### PR TITLE
fix(CX-1929): home page spacing fix

### DIFF
--- a/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
+++ b/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
@@ -6,14 +6,19 @@ import { SectionTitle } from "lib/Components/SectionTitle"
 import { navigate } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { Flex, Separator } from "palette"
-import React, { useImperativeHandle, useRef } from "react"
+import React, { useEffect, useImperativeHandle, useRef } from "react"
 import { FlatList, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { RailScrollProps } from "./types"
 
-const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & RailScrollProps> = (props) => {
-  const { me, scrollRef } = props
+interface Props {
+  onHide?: () => void
+  onShow?: () => void
+}
+
+const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & RailScrollProps & Props> = (props) => {
+  const { me, scrollRef, onHide, onShow } = props
   const { trackEvent } = useTracking()
   const auctionResultsByFollowedArtists = extractNodes(me?.auctionResultsByFollowedArtists)
   const listRef = useRef<FlatList<any>>()
@@ -25,6 +30,11 @@ const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & RailScrollPro
   useImperativeHandle(scrollRef, () => ({
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
+
+  // Checks to see if rail is being rendered and hides / shows the separator accordingly
+  useEffect(() => {
+    auctionResultsByFollowedArtists?.length ? onShow?.() : onHide?.()
+  }, [auctionResultsByFollowedArtists])
 
   if (!auctionResultsByFollowedArtists?.length) {
     return null

--- a/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
+++ b/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
@@ -31,12 +31,13 @@ const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & RailScrollPro
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
-  // Checks to see if rail is being rendered and hides / shows the separator accordingly
+  const hasAuctionResults = auctionResultsByFollowedArtists?.length
+
   useEffect(() => {
-    auctionResultsByFollowedArtists?.length ? onShow?.() : onHide?.()
+    hasAuctionResults ? onShow?.() : onHide?.()
   }, [auctionResultsByFollowedArtists])
 
-  if (!auctionResultsByFollowedArtists?.length) {
+  if (!hasAuctionResults) {
     return null
   }
 

--- a/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
+++ b/src/lib/Scenes/Home/Components/SaleArtworksHomeRail.tsx
@@ -21,12 +21,13 @@ interface Props {
 
 export const SaleArtworksHomeRail: React.FC<Props> = ({ me, relay, onShow, onHide }) => {
   const artworks = extractNodes(me?.lotsByFollowedArtistsConnection)
+  const hasArtworks = artworks?.length
 
   useEffect(() => {
-    artworks.length ? onShow?.() : onHide?.()
-  }, [artworks.length])
+    hasArtworks ? onShow?.() : onHide?.()
+  }, [hasArtworks])
 
-  if (!artworks?.length) {
+  if (!hasArtworks) {
     return null
   }
 

--- a/src/lib/Scenes/Home/Components/SalesRail.tsx
+++ b/src/lib/Scenes/Home/Components/SalesRail.tsx
@@ -46,12 +46,13 @@ const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
-  // Checks to see if the artworks rail is being rendered and hides the separator accordingly
-  useEffect(() => {
-    salesModule.results?.length ? onShow?.() : onHide?.()
-  }, [salesModule.results])
+  const hasSales = salesModule.results?.length
 
-  if (!salesModule.results?.length) {
+  useEffect(() => {
+    hasSales ? onShow?.() : onHide?.()
+  }, [hasSales])
+
+  if (!hasSales) {
     return null
   }
 

--- a/src/lib/Scenes/Home/Components/SalesRail.tsx
+++ b/src/lib/Scenes/Home/Components/SalesRail.tsx
@@ -24,7 +24,6 @@ import { RailScrollProps } from "./types"
 
 interface Props {
   salesModule: SalesRail_salesModule
-  artworkRails: Array<{ type: string; data: object } | null>
   onHide?: () => void
   onShow?: () => void
 }
@@ -32,7 +31,7 @@ interface Props {
 type Sale = SalesRail_salesModule["results"][0]
 
 const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
-  const { scrollRef, salesModule, onHide, onShow, artworkRails } = props
+  const { scrollRef, salesModule, onHide, onShow } = props
   const listRef = useRef<FlatList<any>>()
   const tracking = useTracking()
   const allowV3 = usePaletteFlagStore((state) => state.allowV3)
@@ -49,8 +48,8 @@ const SalesRail: React.FC<Props & RailScrollProps> = (props) => {
 
   // Checks to see if the artworks rail is being rendered and hides the separator accordingly
   useEffect(() => {
-    artworkRails.length ? onShow?.() : onHide?.()
-  }, [artworkRails.length])
+    salesModule.results?.length ? onShow?.() : onHide?.()
+  }, [salesModule.results])
 
   if (!salesModule.results?.length) {
     return null

--- a/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
@@ -1,16 +1,14 @@
+import { SalesRail_salesModule } from "__generated__/SalesRail_salesModule.graphql"
+import { CardRailCard } from "lib/Components/Home/CardRailCard"
+import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
+import { SectionTitle } from "lib/Components/SectionTitle"
+import { navigate } from "lib/navigation/navigate"
+import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { cloneDeep } from "lodash"
 import { first, last } from "lodash"
 import React from "react"
 import "react-native"
-
-import { SalesRail_salesModule } from "__generated__/SalesRail_salesModule.graphql"
-import { extractText } from "lib/tests/extractText"
-
-import { CardRailCard } from "lib/Components/Home/CardRailCard"
-import ImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
-import { SectionTitle } from "lib/Components/SectionTitle"
-import { navigate } from "lib/navigation/navigate"
 import { useTracking } from "react-tracking"
 import HomeAnalytics from "../../homeAnalytics"
 import { SalesRailFragmentContainer } from "../SalesRail"
@@ -56,9 +54,17 @@ const salesModule: Omit<SalesRail_salesModule, " $refType"> = {
   ],
 }
 
+const artworksRails: Array<{ type: string; data: object } | null> = []
+
 it("doesn't throw when rendered", () => {
   expect(() =>
-    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />)
+    renderWithWrappers(
+      <SalesRailFragmentContainer
+        salesModule={salesModule as any}
+        scrollRef={mockScrollRef}
+        artworkRails={artworksRails}
+      />
+    )
   ).not.toThrow()
 })
 
@@ -69,7 +75,13 @@ it("looks correct when rendered with sales missing artworks", () => {
     result.saleArtworksConnection.edges = []
   })
   expect(() =>
-    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesCopy as any} scrollRef={mockScrollRef} />)
+    renderWithWrappers(
+      <SalesRailFragmentContainer
+        salesModule={salesCopy as any}
+        scrollRef={mockScrollRef}
+        artworkRails={artworksRails}
+      />
+    )
   ).not.toThrow()
 })
 
@@ -80,7 +92,11 @@ describe("image handling", () => {
     // @ts-ignore
     sale!.saleArtworksConnection!.edges = edges
     return renderWithWrappers(
-      <SalesRailFragmentContainer salesModule={{ results: [sale] } as any} scrollRef={mockScrollRef} />
+      <SalesRailFragmentContainer
+        salesModule={{ results: [sale] } as any}
+        scrollRef={mockScrollRef}
+        artworkRails={artworksRails}
+      />
     )
   }
 
@@ -121,7 +137,11 @@ describe("image handling", () => {
 
 it("renders the correct subtitle based on auction type", async () => {
   const tree = renderWithWrappers(
-    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
+    <SalesRailFragmentContainer
+      salesModule={salesModule as any}
+      scrollRef={mockScrollRef}
+      artworkRails={artworksRails}
+    />
   )
   const subtitles = tree.root.findAllByProps({ "data-test-id": "sale-subtitle" })
   // Timed sale
@@ -134,7 +154,11 @@ it("renders the correct subtitle based on auction type", async () => {
 
 it("routes to live URL if present, otherwise href", () => {
   const tree = renderWithWrappers(
-    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
+    <SalesRailFragmentContainer
+      salesModule={salesModule as any}
+      scrollRef={mockScrollRef}
+      artworkRails={artworksRails}
+    />
   )
   // Timed sale
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -157,7 +181,11 @@ describe("analytics", () => {
 
   it("tracks auction header taps", () => {
     const tree = renderWithWrappers(
-      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
+      <SalesRailFragmentContainer
+        salesModule={salesModule as any}
+        scrollRef={mockScrollRef}
+        artworkRails={artworksRails}
+      />
     )
     tree.root.findByType(SectionTitle as any).props.onPress()
     expect(trackEvent).toHaveBeenCalledWith(HomeAnalytics.auctionHeaderTapEvent())
@@ -165,7 +193,11 @@ describe("analytics", () => {
 
   it("tracks auction thumbnail taps", () => {
     const tree = renderWithWrappers(
-      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
+      <SalesRailFragmentContainer
+        salesModule={salesModule as any}
+        scrollRef={mockScrollRef}
+        artworkRails={artworksRails}
+      />
     )
     const cards = tree.root.findAllByType(CardRailCard)
     cards[0].props.onPress()

--- a/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
+++ b/src/lib/Scenes/Home/Components/__tests__/SalesRail-tests.tsx
@@ -54,17 +54,9 @@ const salesModule: Omit<SalesRail_salesModule, " $refType"> = {
   ],
 }
 
-const artworksRails: Array<{ type: string; data: object } | null> = []
-
 it("doesn't throw when rendered", () => {
   expect(() =>
-    renderWithWrappers(
-      <SalesRailFragmentContainer
-        salesModule={salesModule as any}
-        scrollRef={mockScrollRef}
-        artworkRails={artworksRails}
-      />
-    )
+    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />)
   ).not.toThrow()
 })
 
@@ -75,13 +67,7 @@ it("looks correct when rendered with sales missing artworks", () => {
     result.saleArtworksConnection.edges = []
   })
   expect(() =>
-    renderWithWrappers(
-      <SalesRailFragmentContainer
-        salesModule={salesCopy as any}
-        scrollRef={mockScrollRef}
-        artworkRails={artworksRails}
-      />
-    )
+    renderWithWrappers(<SalesRailFragmentContainer salesModule={salesCopy as any} scrollRef={mockScrollRef} />)
   ).not.toThrow()
 })
 
@@ -92,11 +78,7 @@ describe("image handling", () => {
     // @ts-ignore
     sale!.saleArtworksConnection!.edges = edges
     return renderWithWrappers(
-      <SalesRailFragmentContainer
-        salesModule={{ results: [sale] } as any}
-        scrollRef={mockScrollRef}
-        artworkRails={artworksRails}
-      />
+      <SalesRailFragmentContainer salesModule={{ results: [sale] } as any} scrollRef={mockScrollRef} />
     )
   }
 
@@ -137,11 +119,7 @@ describe("image handling", () => {
 
 it("renders the correct subtitle based on auction type", async () => {
   const tree = renderWithWrappers(
-    <SalesRailFragmentContainer
-      salesModule={salesModule as any}
-      scrollRef={mockScrollRef}
-      artworkRails={artworksRails}
-    />
+    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
   )
   const subtitles = tree.root.findAllByProps({ "data-test-id": "sale-subtitle" })
   // Timed sale
@@ -154,11 +132,7 @@ it("renders the correct subtitle based on auction type", async () => {
 
 it("routes to live URL if present, otherwise href", () => {
   const tree = renderWithWrappers(
-    <SalesRailFragmentContainer
-      salesModule={salesModule as any}
-      scrollRef={mockScrollRef}
-      artworkRails={artworksRails}
-    />
+    <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
   )
   // Timed sale
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -181,11 +155,7 @@ describe("analytics", () => {
 
   it("tracks auction header taps", () => {
     const tree = renderWithWrappers(
-      <SalesRailFragmentContainer
-        salesModule={salesModule as any}
-        scrollRef={mockScrollRef}
-        artworkRails={artworksRails}
-      />
+      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     )
     tree.root.findByType(SectionTitle as any).props.onPress()
     expect(trackEvent).toHaveBeenCalledWith(HomeAnalytics.auctionHeaderTapEvent())
@@ -193,11 +163,7 @@ describe("analytics", () => {
 
   it("tracks auction thumbnail taps", () => {
     const tree = renderWithWrappers(
-      <SalesRailFragmentContainer
-        salesModule={salesModule as any}
-        scrollRef={mockScrollRef}
-        artworkRails={artworksRails}
-      />
+      <SalesRailFragmentContainer salesModule={salesModule as any} scrollRef={mockScrollRef} />
     )
     const cards = tree.root.findAllByType(CardRailCard)
     cards[0].props.onPress()

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -164,7 +164,6 @@ const Home = (props: Props) => {
                 case "sales":
                   return (
                     <SalesRailFragmentContainer
-                      artworkRails={artworkRails}
                       salesModule={item.data}
                       scrollRef={scrollRefs.current[index]}
                       onShow={() => separators.updateProps("leading", { hideSeparator: false })}

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -50,7 +50,6 @@ interface Props extends ViewProps {
 
 const Home = (props: Props) => {
   const { homePageAbove, homePageBelow, meAbove, meBelow, articlesConnection, featured, loading } = props
-
   const artworkModules = (homePageAbove?.artworkModules || []).concat(homePageBelow?.artworkModules || [])
   const salesModule = homePageAbove?.salesModule
   const collectionsModule = homePageBelow?.marketingCollectionsModule
@@ -82,6 +81,7 @@ const Home = (props: Props) => {
   Ordering is defined in https://www.notion.so/artsy/App-Home-Screen-4841255ded3f47c9bcdb73185ee3f335.
   Please make sure to keep this page in sync with the home screen.
   */
+
   const rowData = compact([
     // Above-the-fold modules (make sure to include enough modules in the above-the-fold query to cover the whole screen.)
     artworkRails[0],
@@ -162,7 +162,15 @@ const Home = (props: Props) => {
                 case "fairs":
                   return <FairsRailFragmentContainer fairsModule={item.data} scrollRef={scrollRefs.current[index]} />
                 case "sales":
-                  return <SalesRailFragmentContainer salesModule={item.data} scrollRef={scrollRefs.current[index]} />
+                  return (
+                    <SalesRailFragmentContainer
+                      artworkRails={artworkRails}
+                      salesModule={item.data}
+                      scrollRef={scrollRefs.current[index]}
+                      onShow={() => separators.updateProps("leading", { hideSeparator: false })}
+                      onHide={() => separators.updateProps("leading", { hideSeparator: true })}
+                    />
+                  )
                 case "collections":
                   return (
                     <CollectionsRailFragmentContainer
@@ -174,7 +182,12 @@ const Home = (props: Props) => {
                   return featured ? <ViewingRoomsHomeRail featured={featured} /> : <></>
                 case "auction-results":
                   return meBelow ? (
-                    <AuctionResultsRailFragmentContainer me={meBelow} scrollRef={scrollRefs.current[index]} />
+                    <AuctionResultsRailFragmentContainer
+                      me={meBelow}
+                      scrollRef={scrollRefs.current[index]}
+                      onShow={() => separators.updateProps("leading", { hideSeparator: false })}
+                      onHide={() => separators.updateProps("leading", { hideSeparator: true })}
+                    />
                   ) : (
                     <></>
                   )

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -172,6 +172,7 @@ const Home = (props: Props) => {
                     />
                   )
                 case "collections":
+                  separators.updateProps("leading", { hideSeparator: false })
                   return (
                     <CollectionsRailFragmentContainer
                       collectionsModule={item.data}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1929]

### Description

This PR fixes the spacing issues between rails on the home page, specifically when a new user does not have all of the rails yet.  

Note: make a new account to test. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Spacing issues between home page rails is fixed - rquartararo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

#### Screen recording

https://user-images.githubusercontent.com/50849237/133589242-1ddc6c02-0afc-4838-8151-e38f8d443372.mp4

 


[CX-1929]: https://artsyproduct.atlassian.net/browse/CX-1929