### PR TITLE
chore(FX-3322): split search pills into separated component

### DIFF
--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -9,7 +9,7 @@ import { ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { Schema } from "lib/utils/track"
 import { useAlgoliaClient } from "lib/utils/useAlgoliaClient"
 import { useSearchInsightsConfig } from "lib/utils/useSearchInsightsConfig"
-import { Flex, Pill, Spacer } from "palette"
+import { Box, Flex, Pill, Spacer, useSpace } from "palette"
 import React, { useMemo, useState } from "react"
 import {
   Configure,
@@ -91,6 +91,7 @@ interface Search2Props {
 
 export const Search2: React.FC<Search2Props> = (props) => {
   const { system, relay } = props
+  const space = useSpace()
   const [searchState, setSearchState] = useState<SearchState>({})
   const [selectedAlgoliaIndex, setSelectedAlgoliaIndex] = useState("")
   const [elasticSearchEntity, setElasticSearchEntity] = useState("")
@@ -157,8 +158,12 @@ export const Search2: React.FC<Search2Props> = (props) => {
           </Flex>
           {!!shouldStartQuering ? (
             <>
-              <Flex p={2} pb={1}>
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+              <Box pt={2} pb={1}>
+                <ScrollView
+                  horizontal
+                  contentContainerStyle={{ paddingHorizontal: space(2) }}
+                  showsHorizontalScrollIndicator={false}
+                >
                   {pillsArray.map((pill) => {
                     const { name, displayName } = pill
                     return (
@@ -174,7 +179,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
                     )
                   })}
                 </ScrollView>
-              </Flex>
+              </Box>
               {renderResults(activePillDisplayName)}
             </>
           ) : (

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -9,7 +9,7 @@ import { ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { Schema } from "lib/utils/track"
 import { useAlgoliaClient } from "lib/utils/useAlgoliaClient"
 import { useSearchInsightsConfig } from "lib/utils/useSearchInsightsConfig"
-import { Box, Flex, Pill, Spacer, useSpace } from "palette"
+import { Box, Flex, Spacer } from "palette"
 import React, { useMemo, useState } from "react"
 import {
   Configure,
@@ -26,10 +26,12 @@ import { AutosuggestResults } from "../Search/AutosuggestResults"
 import { CityGuideCTA } from "../Search/CityGuideCTA"
 import { RecentSearches } from "../Search/RecentSearches"
 import { SearchContext, useSearchProviderValues } from "../Search/SearchContext"
+import { SearchPills } from "./components/SearchPills"
 import { SearchPlaceholder } from "./components/SearchPlaceholder"
 import { RefetchWhenApiKeyExpiredContainer } from "./containers/RefetchWhenApiKeyExpired"
 import { SearchArtworksQueryRenderer } from "./containers/SearchArtworksContainer"
 import { SearchResults } from "./SearchResults"
+import { PillType } from "./types"
 
 interface SearchInputProps {
   placeholder: string
@@ -77,11 +79,6 @@ interface SearchState {
   page?: number
 }
 
-interface PillType {
-  name: string
-  displayName: string
-}
-
 const pills: PillType[] = [{ name: "ARTWORK", displayName: "Artworks" }]
 
 interface Search2Props {
@@ -91,7 +88,6 @@ interface Search2Props {
 
 export const Search2: React.FC<Search2Props> = (props) => {
   const { system, relay } = props
-  const space = useSpace()
   const [searchState, setSearchState] = useState<SearchState>({})
   const [selectedAlgoliaIndex, setSelectedAlgoliaIndex] = useState("")
   const [elasticSearchEntity, setElasticSearchEntity] = useState("")
@@ -142,6 +138,11 @@ export const Search2: React.FC<Search2Props> = (props) => {
     setSelectedAlgoliaIndex(selectedAlgoliaIndex === name ? "" : name)
   }
 
+  const isSelected = (pill: PillType) => {
+    const { name } = pill
+    return selectedAlgoliaIndex === name || elasticSearchEntity === name
+  }
+
   return (
     <SearchContext.Provider value={searchProviderValues}>
       <ArtsyKeyboardAvoidingView>
@@ -159,26 +160,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
           {!!shouldStartQuering ? (
             <>
               <Box pt={2} pb={1}>
-                <ScrollView
-                  horizontal
-                  contentContainerStyle={{ paddingHorizontal: space(2) }}
-                  showsHorizontalScrollIndicator={false}
-                >
-                  {pillsArray.map((pill) => {
-                    const { name, displayName } = pill
-                    return (
-                      <Pill
-                        mr={1}
-                        key={name}
-                        rounded
-                        selected={selectedAlgoliaIndex === name || elasticSearchEntity === name}
-                        onPress={() => handlePillPress(pill)}
-                      >
-                        {displayName}
-                      </Pill>
-                    )
-                  })}
-                </ScrollView>
+                <SearchPills pills={pillsArray} onPillPress={handlePillPress} isSelected={isSelected} />
               </Box>
               {renderResults(activePillDisplayName)}
             </>

--- a/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
@@ -1,0 +1,54 @@
+import { fireEvent } from "@testing-library/react-native"
+import { extractText } from "lib/tests/extractText"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { SearchPills, SearchPillsProps } from "../components/SearchPills"
+import { PillType } from "../types"
+
+const pills: PillType[] = [
+  {
+    name: "first",
+    displayName: "First",
+  },
+  {
+    name: "second",
+    displayName: "Second",
+  },
+  {
+    name: "third",
+    displayName: "Third",
+  },
+]
+
+describe("SearchPills", () => {
+  const TestRenderer = (props: Partial<SearchPillsProps>) => {
+    return <SearchPills pills={pills} onPillPress={jest.fn} isSelected={() => false} {...props} />
+  }
+
+  it("renders without throwing an error", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    expect(getByText("First")).toBeTruthy()
+    expect(getByText("Second")).toBeTruthy()
+    expect(getByText("Third")).toBeTruthy()
+  })
+
+  it('should call "onPillPress" handler when the pill is pressed', () => {
+    const onPillPressMock = jest.fn()
+    const { getByText } = renderWithWrappersTL(<TestRenderer onPillPress={onPillPressMock} />)
+
+    fireEvent.press(getByText("Second"))
+
+    expect(onPillPressMock).toBeCalledWith({
+      name: "second",
+      displayName: "Second",
+    })
+  })
+
+  it("the selected pill must be displayed correctly", () => {
+    const isSelected = (pill: PillType) => pill.name === "second"
+    const { getByA11yState } = renderWithWrappersTL(<TestRenderer isSelected={isSelected} />)
+
+    expect(extractText(getByA11yState({ selected: true }))).toBe("Second")
+  })
+})

--- a/src/lib/Scenes/Search2/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search2/components/SearchPills.tsx
@@ -1,0 +1,43 @@
+import { Pill, useSpace } from "palette"
+import React from "react"
+import { ScrollView } from "react-native"
+import { PillType } from "../types"
+
+export interface SearchPillsProps {
+  pills: PillType[]
+  onPillPress: (pill: PillType) => void
+  isSelected: (pill: PillType) => boolean
+}
+
+export const SearchPills: React.FC<SearchPillsProps> = (props) => {
+  const { pills, onPillPress, isSelected } = props
+  const space = useSpace()
+
+  return (
+    <ScrollView
+      horizontal
+      contentContainerStyle={{ paddingHorizontal: space(2) }}
+      showsHorizontalScrollIndicator={false}
+    >
+      {pills.map((pill) => {
+        const { name, displayName } = pill
+        const selected = isSelected(pill)
+
+        return (
+          <Pill
+            mr={1}
+            key={name}
+            accessibilityState={{
+              selected,
+            }}
+            rounded
+            selected={selected}
+            onPress={() => onPillPress(pill)}
+          >
+            {displayName}
+          </Pill>
+        )
+      })}
+    </ScrollView>
+  )
+}

--- a/src/lib/Scenes/Search2/types.ts
+++ b/src/lib/Scenes/Search2/types.ts
@@ -7,3 +7,8 @@ export interface AlgoliaSearchResult {
   __position: number
   __queryID: string
 }
+
+export interface PillType {
+  name: string
+  displayName: string
+}


### PR DESCRIPTION
The type of this PR is: **Refactor, Chore**

This PR resolves [FX-3322]

### Demo
https://user-images.githubusercontent.com/3513494/133794596-c0524f4c-914d-4d8a-8f91-d856451b598f.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Split search pill into separated component - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3322]: https://artsyproduct.atlassian.net/browse/FX-3322