### PR TITLE
feat(FX-3321): add debounce to onchangetext requests in improved search

### DIFF
--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, waitFor } from "@testing-library/react-native"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { RecentSearch } from "lib/Scenes/Search/SearchModel"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -64,9 +64,11 @@ describe("Search2 Screen", () => {
     fireEvent.changeText(searchInput, "Ba")
     expect(searchInput).toHaveProp("value", "Ba")
 
-    // Pill should be visible
-    expect(getByText("Artworks")).toBeTruthy()
-    expect(getByText("Artists")).toBeTruthy()
+    // Pills should be visible
+    await waitFor(() => {
+      getByText("Artworks")
+      getByText("Artists")
+    })
   })
 
   it("does not show city guide entrance when on iPad", () => {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3321]

### Description

Add debounce to reduce requests

**Before:**
https://user-images.githubusercontent.com/21178754/133793806-109861ca-e173-41a8-bb6f-e5fb2f873e16.mov

**After:**
https://user-images.githubusercontent.com/21178754/133793900-ba882081-2066-464f-b084-68968a8beb43.mov

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add debounce to reduce requests on improved search - gkartalis

<!-- end_changelog_updates -->

</details>


[FX-3321]: https://artsyproduct.atlassian.net/browse/FX-3321