### PR TITLE
Bugfix(CX-1943): Fix Navigational Tabs width update on Tablets when device is rotated

### DIFF
--- a/src/palette/elements/Tabs/ContentTabs.tsx
+++ b/src/palette/elements/Tabs/ContentTabs.tsx
@@ -20,13 +20,9 @@ export const ContentTabs: React.FC<TabsProps> = ({ onTabPress, activeTab, tabs }
             onLayout={(e) => {
               const layout = e.nativeEvent.layout
               setTabLayouts((layouts) => {
-                // update layouts only once per tab
                 const result = layouts.slice(0)
-                if (!result[index]) {
-                  result[index] = layout
-                  return result
-                }
-                return layouts
+                result[index] = layout
+                return result
               })
             }}
             onPress={() => {

--- a/src/palette/elements/Tabs/NavigationalTabs.tsx
+++ b/src/palette/elements/Tabs/NavigationalTabs.tsx
@@ -27,13 +27,9 @@ export const NavigationalTabs: React.FC<TabsProps> = ({ onTabPress, activeTab, t
               onLayout={(e) => {
                 const layout = e.nativeEvent.layout
                 setTabLayouts((layouts) => {
-                  // update layouts only once per tab
                   const result = layouts.slice(0)
-                  if (!result[index]) {
-                    result[index] = layout
-                    return result
-                  }
-                  return layouts
+                  result[index] = layout
+                  return result
                 })
               }}
             />

--- a/src/palette/elements/Tabs/StepTabs.tsx
+++ b/src/palette/elements/Tabs/StepTabs.tsx
@@ -33,13 +33,9 @@ export const StepTabs: React.FC<TabsProps> = ({ onTabPress, activeTab, tabs }) =
               onLayout={(e) => {
                 const layout = e.nativeEvent.layout
                 setTabLayouts((layouts) => {
-                  // update layouts only once per tab
                   const result = layouts.slice(0)
-                  if (!result[index]) {
-                    result[index] = layout
-                    return result
-                  }
-                  return layouts
+                  result[index] = layout
+                  return result
                 })
               }}
             >


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-1943]

### Description



https://user-images.githubusercontent.com/18648835/133807751-e018e722-2078-4ee6-bc75-087b2e51d135.mp4


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix Navigational Tabs width update on Tablets when device is rotated - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1943]: https://artsyproduct.atlassian.net/browse/CX-1943