### PR TITLE
fix(FX-3278): Artworks Size filters custom size doesn't behave as expected

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -90,7 +90,7 @@ const ListItem = ({
   const selected = item.displayText === selectedOption.displayText
 
   return (
-    <TouchableRow onPress={() => onSelect(item)}>
+    <TouchableRow accessibilityState={{ selected }} onPress={() => onSelect(item)}>
       <OptionListItem>
         <InnerOptionListItem px={withExtraPadding && item.displayText !== "All" ? 3 : 2}>
           <Text color="black100" variant="caption">

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -91,7 +91,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.width.min === "*" || state.width.min === 0 ? undefined : String(state.width.min)}
           keyboardType="number-pad"
           onChangeText={handleChange("width")("min")}
-          testID="minimum-width-input"
+          accessibilityLabel="Minimum width input"
         />
 
         <Text mx={2}>to</Text>
@@ -101,7 +101,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.width.max === "*" ? undefined : String(state.width.max)}
           keyboardType="number-pad"
           onChangeText={handleChange("width")("max")}
-          testID="maximum-width-input"
+          accessibilityLabel="Maximum width input"
         />
       </Flex>
 
@@ -117,7 +117,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.height.min === "*" || state.height.min === 0 ? undefined : String(state.height.min)}
           keyboardType="number-pad"
           onChangeText={handleChange("height")("min")}
-          testID="minimum-height-input"
+          accessibilityLabel="Minimum height input"
         />
 
         <Text mx={2}>to</Text>
@@ -127,7 +127,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.height.max === "*" ? undefined : String(state.height.max)}
           keyboardType="number-pad"
           onChangeText={handleChange("height")("max")}
-          testID="maximum-height-input"
+          accessibilityLabel="Maximum height input"
         />
       </Flex>
     </Flex>

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -138,9 +138,11 @@ interface SizeOptionsScreenProps extends StackScreenProps<ArtworkFilterNavigatio
 
 export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation }) => {
   const selectFiltersAction = ArtworksFiltersStore.useStoreActions((state) => state.selectFiltersAction)
+  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find((option) => option.paramName === PARAM_NAME)!
+  const appliedOption = appliedFilters.find((option) => option.paramName === PARAM_NAME) ?? DEFAULT_SIZE_OPTION
   const selectedCustomOptions = selectedOptions.filter((option) =>
     CUSTOM_SIZE_OPTION_KEYS.includes(option.paramName as keyof CustomSize)
   )
@@ -162,7 +164,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
   const selectOption = (option: AggregateOption) => {
     if (option.displayText === CUSTOM_SIZE_OPTION.displayText) {
       showCustomSize(true)
-      selectFiltersAction(DEFAULT_SIZE_OPTION)
+      selectFiltersAction(appliedOption)
     } else {
       showCustomSize(false)
       resetCustomPrice()
@@ -191,7 +193,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
     })
 
     if (isEmptyCustomValues) {
-      selectFiltersAction(DEFAULT_SIZE_OPTION)
+      selectFiltersAction(appliedOption)
     } else {
       selectFiltersAction(CUSTOM_SIZE_OPTION)
     }

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -193,7 +193,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
       return paramValue.min === "*" && paramValue.max === "*"
     })
 
-    // Populate the custom size filter only when we have at least one filled input
+    // Populate the custom size filter only when we have at least one specified input
     if (isEmptyCustomValues) {
       selectFiltersAction(defaultOption)
     } else {

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -91,6 +91,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.width.min === "*" || state.width.min === 0 ? undefined : String(state.width.min)}
           keyboardType="number-pad"
           onChangeText={handleChange("width")("min")}
+          testID="minimum-width-input"
         />
 
         <Text mx={2}>to</Text>
@@ -100,6 +101,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.width.max === "*" ? undefined : String(state.width.max)}
           keyboardType="number-pad"
           onChangeText={handleChange("width")("max")}
+          testID="maximum-width-input"
         />
       </Flex>
 
@@ -115,6 +117,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.height.min === "*" || state.height.min === 0 ? undefined : String(state.height.min)}
           keyboardType="number-pad"
           onChangeText={handleChange("height")("min")}
+          testID="minimum-height-input"
         />
 
         <Text mx={2}>to</Text>
@@ -124,6 +127,7 @@ const CustomSizeInput: React.FC<CustomSizeInputProps> = ({ initialValue, onChang
           defaultValue={state.height.max === "*" ? undefined : String(state.height.max)}
           keyboardType="number-pad"
           onChangeText={handleChange("height")("max")}
+          testID="maximum-height-input"
         />
       </Flex>
     </Flex>

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -142,12 +142,13 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
 
   const selectedOptions = useSelectedOptionsDisplay()
   const selectedOption = selectedOptions.find((option) => option.paramName === PARAM_NAME)!
-  const appliedOption = appliedFilters.find((option) => option.paramName === PARAM_NAME) ?? DEFAULT_SIZE_OPTION
+  const appliedOption = appliedFilters.find((option) => option.paramName === PARAM_NAME)
+  const defaultOption = appliedOption ?? DEFAULT_SIZE_OPTION
   const selectedCustomOptions = selectedOptions.filter((option) =>
     CUSTOM_SIZE_OPTION_KEYS.includes(option.paramName as keyof CustomSize)
   )
-
-  const [shouldShowCustomSize, showCustomSize] = useState(selectedOption.displayText === CUSTOM_SIZE_OPTION.displayText)
+  const isCustomSize = selectedOption.displayText === CUSTOM_SIZE_OPTION.displayText
+  const [shouldShowCustomSize, showCustomSize] = useState(isCustomSize)
 
   const customInitialValue = selectedCustomOptions.reduce((acc, option) => {
     const { min, max } = parseRange(String(option.paramValue))
@@ -164,7 +165,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
   const selectOption = (option: AggregateOption) => {
     if (option.displayText === CUSTOM_SIZE_OPTION.displayText) {
       showCustomSize(true)
-      selectFiltersAction(appliedOption)
+      selectFiltersAction(defaultOption)
     } else {
       showCustomSize(false)
       resetCustomPrice()
@@ -192,8 +193,9 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
       return paramValue.min === "*" && paramValue.max === "*"
     })
 
+    // Populate the custom size filter only when we have at least one filled input
     if (isEmptyCustomValues) {
-      selectFiltersAction(appliedOption)
+      selectFiltersAction(defaultOption)
     } else {
       selectFiltersAction(CUSTOM_SIZE_OPTION)
     }

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
@@ -102,7 +102,7 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
+      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -119,7 +119,7 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("maximum-width-input"), 10)
+      fireEvent.changeText(getByTestId("maximum-width-input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -136,8 +136,8 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
-      fireEvent.changeText(getByTestId("maximum-width-input"), 10)
+      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
+      fireEvent.changeText(getByTestId("maximum-width-input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -154,7 +154,7 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-height-input"), 5)
+      fireEvent.changeText(getByTestId("minimum-height-input"), "5")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -171,7 +171,7 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
+      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -188,8 +188,8 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-height-input"), 5)
-      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
+      fireEvent.changeText(getByTestId("minimum-height-input"), "5")
+      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -206,8 +206,8 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
-      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
+      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
+      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -224,14 +224,14 @@ describe("SizeOptions", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
+      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
 
       const prevFilters = getFilters(getByTestId("debug"))
       const prevSizeFilter = getSizeFilterOption(prevFilters)
 
       expect(prevSizeFilter?.paramValue).toBe("0-*")
 
-      fireEvent.changeText(getByTestId("minimum-width-input"), "*")
+      fireEvent.changeText(getByTestId("minimum-width-input"), "")
 
       const currentFilters = getFilters(getByTestId("debug"))
       const currentSizeFilter = getSizeFilterOption(currentFilters)

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
@@ -99,10 +99,10 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if only minimum width is specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "5")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -116,10 +116,10 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if only maximum width is specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("maximum-width-input"), "10")
+      fireEvent.changeText(getByA11yLabel("Maximum width input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -133,11 +133,11 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if minimum and maximum width are specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
-      fireEvent.changeText(getByTestId("maximum-width-input"), "10")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "5")
+      fireEvent.changeText(getByA11yLabel("Maximum width input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -151,10 +151,10 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if only minimum height is specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-height-input"), "5")
+      fireEvent.changeText(getByA11yLabel("Minimum height input"), "5")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -168,10 +168,10 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if only maximum height is specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
+      fireEvent.changeText(getByA11yLabel("Maximum height input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -185,11 +185,11 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if maximum and maximum height are specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-height-input"), "5")
-      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
+      fireEvent.changeText(getByA11yLabel("Minimum height input"), "5")
+      fireEvent.changeText(getByA11yLabel("Maximum height input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -203,11 +203,11 @@ describe("SizeOptions", () => {
     })
 
     it("returns the custom filter option if minimum width and the maximum height are specified", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
-      fireEvent.changeText(getByTestId("maximum-height-input"), "10")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "5")
+      fireEvent.changeText(getByA11yLabel("Maximum height input"), "10")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)
@@ -221,17 +221,17 @@ describe("SizeOptions", () => {
     })
 
     it("returns the default filter option if nothing is specified in width or height", () => {
-      const { getByTestId, getByText } = getTree()
+      const { getByTestId, getByA11yLabel, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "5")
 
       const prevFilters = getFilters(getByTestId("debug"))
       const prevSizeFilter = getSizeFilterOption(prevFilters)
 
       expect(prevSizeFilter?.paramValue).toBe("0-*")
 
-      fireEvent.changeText(getByTestId("minimum-width-input"), "")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "")
 
       const currentFilters = getFilters(getByTestId("debug"))
       const currentSizeFilter = getSizeFilterOption(currentFilters)
@@ -245,7 +245,7 @@ describe("SizeOptions", () => {
         paramValue: "*-16.0",
         paramName: FilterParamName.size,
       }
-      const { getByTestId, getByText } = getTree({
+      const { getByTestId, getByA11yLabel, getByText } = getTree({
         initialData: {
           ...INITIAL_DATA,
           appliedFilters: [option],
@@ -254,8 +254,8 @@ describe("SizeOptions", () => {
       })
 
       fireEvent.press(getByText("Custom Size"))
-      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
-      fireEvent.changeText(getByTestId("minimum-width-input"), "")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "5")
+      fireEvent.changeText(getByA11yLabel("Minimum width input"), "")
 
       const filters = getFilters(getByTestId("debug"))
       const sizeFilter = getSizeFilterOption(filters)

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
@@ -1,5 +1,6 @@
 import { fireEvent } from "@testing-library/react-native"
 import { FilterArray, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { Text } from "palette"
@@ -236,6 +237,31 @@ describe("SizeOptions", () => {
       const currentSizeFilter = getSizeFilterOption(currentFilters)
 
       expect(currentSizeFilter?.paramValue).toBe("*-*")
+    })
+
+    it("returns the previously applied filter option if the invalid custom values are entered", () => {
+      const option: FilterData = {
+        displayText: "Small (under 40cm)",
+        paramValue: "*-16.0",
+        paramName: FilterParamName.size,
+      }
+      const { getByTestId, getByText } = getTree({
+        initialData: {
+          ...INITIAL_DATA,
+          appliedFilters: [option],
+          previouslyAppliedFilters: [option],
+        },
+      })
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-width-input"), "5")
+      fireEvent.changeText(getByTestId("minimum-width-input"), "")
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Small (under 40cm)")
+      expect(sizeFilter?.paramValue).toBe("*-16.0")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
@@ -1,18 +1,36 @@
-import { FilterData, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { Input } from "lib/Components/Input/Input"
-import { TouchableRow } from "lib/Components/TouchableRow"
+import { fireEvent } from "@testing-library/react-native"
+import { FilterArray, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { Text } from "palette"
 import React from "react"
-import { act, ReactTestRenderer } from "react-test-renderer"
+import { ReactTestInstance } from "react-test-renderer"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider, useSelectedOptionsDisplay } from "../../ArtworkFilterStore"
 import { SizeOptionsScreen } from "../SizeOptions"
 import { getEssentialProps } from "./helper"
 
-type Key = FilterParamName.dimensionRange | FilterParamName.width | FilterParamName.height
+// Helpers
+const getFilters = (element: ReactTestInstance) => {
+  return JSON.parse(extractText(element)) as FilterArray
+}
 
-describe("SizeOptionsNew", () => {
+const getFilterOptionByName = (filters: FilterArray, filterName: FilterParamName) => {
+  return filters.find((filter) => filter.paramName === filterName)
+}
+
+const getSizeFilterOption = (filters: FilterArray) => {
+  return getFilterOptionByName(filters, FilterParamName.size)
+}
+
+const getWidthFilterOption = (filters: FilterArray) => {
+  return getFilterOptionByName(filters, FilterParamName.width)
+}
+
+const getHeightFilterOption = (filters: FilterArray) => {
+  return getFilterOptionByName(filters, FilterParamName.height)
+}
+
+describe("SizeOptions", () => {
   const INITIAL_DATA: ArtworkFiltersState = {
     selectedFilters: [],
     appliedFilters: [],
@@ -30,198 +48,194 @@ describe("SizeOptionsNew", () => {
     const selected = useSelectedOptionsDisplay()
     return (
       <>
-        <Text>{JSON.stringify(selected)}</Text>
+        <Text testID="debug">{JSON.stringify(selected)}</Text>
         <SizeOptionsScreen {...getEssentialProps()} />
       </>
     )
   }
 
   const getTree = ({ initialData = INITIAL_DATA }: { initialData?: ArtworkFiltersState } = {}) => {
-    return renderWithWrappers(
+    return renderWithWrappersTL(
       <ArtworkFiltersStoreProvider initialData={initialData}>
         <MockPriceRangeOptionsScreen />
       </ArtworkFiltersStoreProvider>
     )
   }
 
-  const getData = (tree: ReactTestRenderer): Record<Key, FilterData> => {
-    return JSON.parse(extractText(tree.root.findAllByType(Text)[0]))
-      .filter(({ paramName }: FilterData) => {
-        return (
-          paramName === FilterParamName.dimensionRange ||
-          paramName === FilterParamName.width ||
-          paramName === FilterParamName.height
-        )
-      })
-      .reduce(
-        (acc: Record<Key, FilterData>, filterData: FilterData) => ({
-          ...acc,
-          [filterData.paramName]: filterData,
-        }),
-        {}
-      )
-  }
-
   it("renders the options", () => {
-    const tree = getTree()
-    const text = extractText(tree.root)
+    const { getByText } = getTree()
 
-    expect(text).toContain("All")
-    expect(text).toContain("Small (under 16in)")
-    expect(text).toContain("Medium (16in – 40in)")
-    expect(text).toContain("Large (over 40in)")
-    expect(text).toContain("Custom Size")
+    expect(getByText("All")).toBeTruthy()
+    expect(getByText("Small (under 16in)")).toBeTruthy()
+    expect(getByText("Medium (16in – 40in)")).toBeTruthy()
+    expect(getByText("Large (over 40in)")).toBeTruthy()
+    expect(getByText("Custom Size")).toBeTruthy()
   })
 
   it("selects an option", () => {
-    const tree = getTree()
+    const { getByText, getByA11yState } = getTree()
 
-    const options = tree.root.findAllByType(TouchableRow)
+    fireEvent.press(getByText("Small (under 16in)"))
 
-    expect(getData(tree).dimensionRange).toEqual({
-      paramName: "dimensionRange",
-      displayText: "All",
-      paramValue: "*-*",
-    })
-
-    act(() => {
-      options[1].props.onPress()
-    })
-
-    expect(getData(tree).dimensionRange).toEqual({
-      paramName: "dimensionRange",
-      displayText: "Small (under 16in)",
-      paramValue: "*-16.0",
-    })
+    expect(extractText(getByA11yState({ selected: true }))).toBe("Small (under 16in)")
   })
 
-  it("selects a custom size range", () => {
-    const tree = getTree()
+  describe("Custom Size", () => {
+    it("returns the default filter option if width and height are not entered", () => {
+      const { getByTestId, getByText } = getTree()
 
-    const options = tree.root.findAllByType(TouchableRow)
+      fireEvent.press(getByText("Custom Size"))
 
-    expect(getData(tree).dimensionRange).toEqual({
-      paramName: "dimensionRange",
-      displayText: "All",
-      paramValue: "*-*",
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getWidthFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("All")
+      expect(sizeFilter?.paramValue).toBe("*-*")
+      expect(widthFilter).toBeUndefined()
+      expect(heightFilter).toBeUndefined()
     })
 
-    act(() => {
-      // Displays the custom range inputs
-      options[4].props.onPress()
+    it("returns the custom filter option if only minimum width is entered", () => {
+      const { getByTestId, getByText } = getTree()
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(widthFilter?.paramValue).toBe("5-*")
+      expect(heightFilter).toBeUndefined()
     })
 
-    const dimensionRange = {
-      displayText: "Custom Size",
-      paramValue: "0-*",
-      paramName: "dimensionRange",
-    }
+    it("returns the custom filter option if only maximum width is entered", () => {
+      const { getByTestId, getByText } = getTree()
 
-    expect(getData(tree).dimensionRange).toEqual(dimensionRange)
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("maximum-width-input"), 10)
 
-    const [minWidthInput, maxWidthInput, minHeightInput, maxHeightInput] = tree.root.findAllByType(Input)
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
 
-    act(() => {
-      minWidthInput.props.onChangeText("10")
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(widthFilter?.paramValue).toBe("*-10")
+      expect(heightFilter).toBeUndefined()
     })
 
-    expect(getData(tree)).toEqual({
-      dimensionRange,
-      width: {
-        displayText: "10-*",
-        paramName: "width",
-        paramValue: "10-*",
-      },
+    it("returns the custom filter option if minimum and maximum width are entered", () => {
+      const { getByTestId, getByText } = getTree()
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
+      fireEvent.changeText(getByTestId("maximum-width-input"), 10)
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(widthFilter?.paramValue).toBe("5-10")
+      expect(heightFilter).toBeUndefined()
     })
 
-    act(() => {
-      maxWidthInput.props.onChangeText("200")
+    it("returns the custom filter option if only minimum height is entered", () => {
+      const { getByTestId, getByText } = getTree()
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-height-input"), 5)
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(heightFilter?.paramValue).toBe("5-*")
+      expect(widthFilter).toBeUndefined()
     })
 
-    const width = {
-      displayText: "10-200",
-      paramName: "width",
-      paramValue: "10-200",
-    }
+    it("returns the custom filter option if only maximum height is entered", () => {
+      const { getByTestId, getByText } = getTree()
 
-    expect(getData(tree)).toEqual({ dimensionRange, width })
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
 
-    act(() => {
-      minHeightInput.props.onChangeText("33")
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(heightFilter?.paramValue).toBe("*-10")
+      expect(widthFilter).toBeUndefined()
     })
 
-    expect(getData(tree)).toEqual({
-      dimensionRange,
-      width,
-      height: {
-        displayText: "33-*",
-        paramName: "height",
-        paramValue: "33-*",
-      },
+    it("returns the custom filter option if maximum and maximum height are entered", () => {
+      const { getByTestId, getByText } = getTree()
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-height-input"), 5)
+      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(heightFilter?.paramValue).toBe("5-10")
+      expect(widthFilter).toBeUndefined()
     })
 
-    act(() => {
-      maxHeightInput.props.onChangeText("101.2")
+    it("returns the custom filter option if minimum width and the maximum height are entered", () => {
+      const { getByTestId, getByText } = getTree()
+
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
+      fireEvent.changeText(getByTestId("maximum-height-input"), 10)
+
+      const filters = getFilters(getByTestId("debug"))
+      const sizeFilter = getSizeFilterOption(filters)
+      const widthFilter = getWidthFilterOption(filters)
+      const heightFilter = getHeightFilterOption(filters)
+
+      expect(sizeFilter?.displayText).toBe("Custom Size")
+      expect(sizeFilter?.paramValue).toBe("0-*")
+      expect(widthFilter?.paramValue).toBe("5-*")
+      expect(heightFilter?.paramValue).toBe("*-10")
     })
 
-    expect(getData(tree)).toEqual({
-      dimensionRange,
-      width,
-      height: {
-        displayText: "33-101.2",
-        paramName: "height",
-        paramValue: "33-101.2",
-      },
-    })
-  })
+    it("returns the default filter option if nothing is entered in width or height", () => {
+      const { getByTestId, getByText } = getTree()
 
-  it("selects a custom size range", () => {
-    const tree = getTree()
+      fireEvent.press(getByText("Custom Size"))
+      fireEvent.changeText(getByTestId("minimum-width-input"), 5)
 
-    const options = tree.root.findAllByType(TouchableRow)
+      const prevFilters = getFilters(getByTestId("debug"))
+      const prevSizeFilter = getSizeFilterOption(prevFilters)
 
-    expect(getData(tree).dimensionRange).toEqual({
-      paramName: "dimensionRange",
-      displayText: "All",
-      paramValue: "*-*",
-    })
+      expect(prevSizeFilter?.paramValue).toBe("0-*")
 
-    act(() => {
-      // Displays the custom range inputs
-      options[4].props.onPress()
-    })
+      fireEvent.changeText(getByTestId("minimum-width-input"), "*")
 
-    const [minWidthInput, maxWidthInput] = tree.root.findAllByType(Input)
+      const currentFilters = getFilters(getByTestId("debug"))
+      const currentSizeFilter = getSizeFilterOption(currentFilters)
 
-    act(() => {
-      minWidthInput.props.onChangeText("10")
-      maxWidthInput.props.onChangeText("200")
-    })
-
-    expect(getData(tree)).toEqual({
-      dimensionRange: {
-        displayText: "Custom Size",
-        paramValue: "0-*",
-        paramName: "dimensionRange",
-      },
-      width: {
-        displayText: "10-200",
-        paramName: "width",
-        paramValue: "10-200",
-      },
-    })
-
-    act(() => {
-      // Toggle to a preset size bucket
-      options[3].props.onPress()
-    })
-
-    expect(getData(tree)).toEqual({
-      dimensionRange: {
-        displayText: "Large (over 40in)",
-        paramName: "dimensionRange",
-        paramValue: "40.0-*",
-      },
+      expect(currentSizeFilter?.paramValue).toBe("*-*")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/__tests__/SizeOptions-tests.tsx
@@ -82,7 +82,7 @@ describe("SizeOptions", () => {
   })
 
   describe("Custom Size", () => {
-    it("returns the default filter option if width and height are not entered", () => {
+    it("returns the default filter option if width and height are not specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -98,7 +98,7 @@ describe("SizeOptions", () => {
       expect(heightFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if only minimum width is entered", () => {
+    it("returns the custom filter option if only minimum width is specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -115,7 +115,7 @@ describe("SizeOptions", () => {
       expect(heightFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if only maximum width is entered", () => {
+    it("returns the custom filter option if only maximum width is specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -132,7 +132,7 @@ describe("SizeOptions", () => {
       expect(heightFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if minimum and maximum width are entered", () => {
+    it("returns the custom filter option if minimum and maximum width are specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -150,7 +150,7 @@ describe("SizeOptions", () => {
       expect(heightFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if only minimum height is entered", () => {
+    it("returns the custom filter option if only minimum height is specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -167,7 +167,7 @@ describe("SizeOptions", () => {
       expect(widthFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if only maximum height is entered", () => {
+    it("returns the custom filter option if only maximum height is specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -184,7 +184,7 @@ describe("SizeOptions", () => {
       expect(widthFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if maximum and maximum height are entered", () => {
+    it("returns the custom filter option if maximum and maximum height are specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -202,7 +202,7 @@ describe("SizeOptions", () => {
       expect(widthFilter).toBeUndefined()
     })
 
-    it("returns the custom filter option if minimum width and the maximum height are entered", () => {
+    it("returns the custom filter option if minimum width and the maximum height are specified", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -220,7 +220,7 @@ describe("SizeOptions", () => {
       expect(heightFilter?.paramValue).toBe("*-10")
     })
 
-    it("returns the default filter option if nothing is entered in width or height", () => {
+    it("returns the default filter option if nothing is specified in width or height", () => {
       const { getByTestId, getByText } = getTree()
 
       fireEvent.press(getByText("Custom Size"))
@@ -239,7 +239,7 @@ describe("SizeOptions", () => {
       expect(currentSizeFilter?.paramValue).toBe("*-*")
     })
 
-    it("returns the previously applied filter option if the invalid custom values are entered", () => {
+    it("returns the previously applied filter option if the invalid custom values are specified", () => {
       const option: FilterData = {
         displayText: "Small (under 40cm)",
         paramValue: "*-16.0",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3278]

### Description
* Populate the custom size filter only when we have at least one filled input
* Shouldn't let the user press `Show Results` button unless the custom height and width is specified

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/134040129-f88fdbc7-3b6d-4fa2-880b-b7084a501a25.mp4

#### Android
https://user-images.githubusercontent.com/3513494/134044392-10ef1d78-a846-484a-9c1e-9e4bd5623af4.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fix custom size filter behaviour - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3278]: https://artsyproduct.atlassian.net/browse/FX-3278