### PR TITLE
feat: Order detail: User can see more shipping info for their order [PX-4210]

### DIFF
--- a/src/__generated__/OrderDetailsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsQuery.graphql.ts
@@ -1,11 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-<<<<<<< HEAD
-/* @relayHash fee64609d71acc09143fc4bdb90b3157 */
-=======
-/* @relayHash d1c4320c2c1728f563eb10889ba3197c */
->>>>>>> 5c361e82d3 (generated files)
+/* @relayHash 43c5aeff5bdb6090d0abca7415a1b575 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -105,10 +101,6 @@ fragment OrderDetails_order on CommerceOrder {
   requestedFulfillment {
     __typename
     ... on CommerceShip {
-      __typename
-      name
-    }
-    ... on CommerceShipArta {
       __typename
       name
     }
@@ -278,83 +270,77 @@ v3 = {
   "name": "name",
   "storageKey": null
 },
-v4 = [
-  (v3/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "addressLine1",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "addressLine2",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "country",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "phoneNumber",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "postalCode",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "region",
-    "storageKey": null
-  }
-],
-v5 = [
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine1",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine2",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "country",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phoneNumber",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "postalCode",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "region",
+  "storageKey": null
+},
+v11 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
   }
 ],
-v6 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-<<<<<<< HEAD
-=======
-v6 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
->>>>>>> 5c361e82d3 (generated files)
-v7 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "precision",
@@ -418,13 +404,30 @@ return {
               (v2/*: any*/),
               {
                 "kind": "InlineFragment",
-                "selections": (v4/*: any*/),
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/)
+                ],
                 "type": "CommerceShip",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v4/*: any*/),
+                "selections": [
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/)
+                ],
                 "type": "CommerceShipArta",
                 "abstractKey": null
               }
@@ -433,7 +436,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v5/*: any*/),
+            "args": (v11/*: any*/),
             "concreteType": "CommerceLineItemConnection",
             "kind": "LinkedField",
             "name": "lineItems",
@@ -472,11 +475,11 @@ return {
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v6/*: any*/)
+                              (v12/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -571,7 +574,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v12/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -587,10 +590,7 @@ return {
                             "name": "status",
                             "storageKey": null
                           },
-<<<<<<< HEAD
-                          (v6/*: any*/)
-=======
-                          (v5/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -626,7 +626,6 @@ return {
                             "name": "estimatedDeliveryWindow",
                             "storageKey": null
                           }
->>>>>>> 5c361e82d3 (generated files)
                         ],
                         "storageKey": null
                       },
@@ -645,13 +644,13 @@ return {
                             "name": "displayName",
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v11/*: any*/),
                         "concreteType": "CommerceFulfillmentConnection",
                         "kind": "LinkedField",
                         "name": "fulfillments",
@@ -673,7 +672,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -688,7 +687,7 @@ return {
                                     "name": "estimatedDelivery",
                                     "storageKey": null
                                   },
-                                  (v6/*: any*/)
+                                  (v12/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -707,7 +706,7 @@ return {
             ],
             "storageKey": "lineItems(first:1)"
           },
-          (v6/*: any*/),
+          (v13/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -724,28 +723,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v14/*: any*/),
             "kind": "ScalarField",
             "name": "buyerTotal",
             "storageKey": "buyerTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v14/*: any*/),
             "kind": "ScalarField",
             "name": "taxTotal",
             "storageKey": "taxTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v14/*: any*/),
             "kind": "ScalarField",
             "name": "shippingTotal",
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v7/*: any*/),
+            "args": (v14/*: any*/),
             "kind": "ScalarField",
             "name": "totalListPrice",
             "storageKey": "totalListPrice(precision:2)"
@@ -772,22 +771,18 @@ return {
                 "name": "lastDigits",
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v12/*: any*/)
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v12/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-<<<<<<< HEAD
-    "id": "fee64609d71acc09143fc4bdb90b3157",
-=======
-    "id": "d1c4320c2c1728f563eb10889ba3197c",
->>>>>>> 5c361e82d3 (generated files)
+    "id": "43c5aeff5bdb6090d0abca7415a1b575",
     "metadata": {},
     "name": "OrderDetailsQuery",
     "operationKind": "query",

--- a/src/__generated__/OrderDetailsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsQuery.graphql.ts
@@ -1,7 +1,11 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
+<<<<<<< HEAD
 /* @relayHash fee64609d71acc09143fc4bdb90b3157 */
+=======
+/* @relayHash d1c4320c2c1728f563eb10889ba3197c */
+>>>>>>> 5c361e82d3 (generated files)
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -130,6 +134,7 @@ fragment OrderDetails_order on CommerceOrder {
   ...ArtworkInfoSection_artwork
   ...SummarySection_section
   ...OrderDetailsPayment_order
+  ...TrackOrderSection_section
   ...ShipsToSection_address
   ...SoldBySection_soldBy
 }
@@ -205,6 +210,37 @@ fragment SummarySection_section on CommerceOrder {
         selectedShippingQuote {
           displayName
           id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment TrackOrderSection_section on CommerceOrder {
+  __isCommerceOrder: __typename
+  state
+  lineItems(first: 1) {
+    edges {
+      node {
+        shipment {
+          status
+          trackingUrl
+          trackingNumber
+          deliveryStart
+          deliveryEnd
+          estimatedDeliveryWindow
+          id
+        }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              createdAt
+              trackingId
+              estimatedDelivery
+              id
+            }
+          }
         }
         id
       }
@@ -308,6 +344,16 @@ v6 = {
   "name": "id",
   "storageKey": null
 },
+<<<<<<< HEAD
+=======
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+>>>>>>> 5c361e82d3 (generated files)
 v7 = [
   {
     "kind": "Literal",
@@ -541,7 +587,46 @@ return {
                             "name": "status",
                             "storageKey": null
                           },
+<<<<<<< HEAD
                           (v6/*: any*/)
+=======
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingNumber",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryStart",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryEnd",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "estimatedDeliveryWindow",
+                            "storageKey": null
+                          }
+>>>>>>> 5c361e82d3 (generated files)
                         ],
                         "storageKey": null
                       },
@@ -588,6 +673,14 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
+                                  (v6/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "trackingId",
+                                    "storageKey": null
+                                  },
                                   {
                                     "alias": null,
                                     "args": null,
@@ -614,13 +707,7 @@ return {
             ],
             "storageKey": "lineItems(first:1)"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -696,7 +783,11 @@ return {
     ]
   },
   "params": {
+<<<<<<< HEAD
     "id": "fee64609d71acc09143fc4bdb90b3157",
+=======
+    "id": "d1c4320c2c1728f563eb10889ba3197c",
+>>>>>>> 5c361e82d3 (generated files)
     "metadata": {},
     "name": "OrderDetailsQuery",
     "operationKind": "query",

--- a/src/__generated__/OrderDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsTestsQuery.graphql.ts
@@ -1,11 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-<<<<<<< HEAD
-/* @relayHash 0600489ff0ebffe46be054de734764a8 */
-=======
-/* @relayHash 994c01297ddd1fa1f25179e1bc6e7a87 */
->>>>>>> 5c361e82d3 (generated files)
+/* @relayHash a4aa5614acfbf5403705fd5458f368be */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -101,10 +97,6 @@ fragment OrderDetails_order on CommerceOrder {
   requestedFulfillment {
     __typename
     ... on CommerceShip {
-      __typename
-      name
-    }
-    ... on CommerceShipArta {
       __typename
       name
     }
@@ -267,102 +259,96 @@ v2 = {
   "name": "name",
   "storageKey": null
 },
-v3 = [
-  (v2/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "addressLine1",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "addressLine2",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "city",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "country",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "phoneNumber",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "postalCode",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "region",
-    "storageKey": null
-  }
-],
-v4 = [
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine1",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine2",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "country",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phoneNumber",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "postalCode",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "region",
+  "storageKey": null
+},
+v10 = [
   {
     "kind": "Literal",
     "name": "first",
     "value": 1
   }
 ],
-v5 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-<<<<<<< HEAD
-=======
-v5 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
->>>>>>> 5c361e82d3 (generated files)
-v6 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "precision",
     "value": 2
   }
 ],
-v7 = {
+v14 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v8 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v9 = {
+v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -425,13 +411,30 @@ return {
               (v1/*: any*/),
               {
                 "kind": "InlineFragment",
-                "selections": (v3/*: any*/),
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/)
+                ],
                 "type": "CommerceShip",
                 "abstractKey": null
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v3/*: any*/),
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/)
+                ],
                 "type": "CommerceShipArta",
                 "abstractKey": null
               }
@@ -440,7 +443,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v10/*: any*/),
             "concreteType": "CommerceLineItemConnection",
             "kind": "LinkedField",
             "name": "lineItems",
@@ -479,11 +482,11 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v5/*: any*/)
+                              (v11/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -578,7 +581,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -594,10 +597,7 @@ return {
                             "name": "status",
                             "storageKey": null
                           },
-<<<<<<< HEAD
-                          (v5/*: any*/)
-=======
-                          (v4/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -633,7 +633,6 @@ return {
                             "name": "estimatedDeliveryWindow",
                             "storageKey": null
                           }
->>>>>>> 5c361e82d3 (generated files)
                         ],
                         "storageKey": null
                       },
@@ -652,13 +651,13 @@ return {
                             "name": "displayName",
                             "storageKey": null
                           },
-                          (v5/*: any*/)
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
-                        "args": (v4/*: any*/),
+                        "args": (v10/*: any*/),
                         "concreteType": "CommerceFulfillmentConnection",
                         "kind": "LinkedField",
                         "name": "fulfillments",
@@ -680,7 +679,7 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
-                                  (v5/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -695,7 +694,7 @@ return {
                                     "name": "estimatedDelivery",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -714,7 +713,7 @@ return {
             ],
             "storageKey": "lineItems(first:1)"
           },
-          (v5/*: any*/),
+          (v12/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -731,28 +730,28 @@ return {
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v13/*: any*/),
             "kind": "ScalarField",
             "name": "buyerTotal",
             "storageKey": "buyerTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v13/*: any*/),
             "kind": "ScalarField",
             "name": "taxTotal",
             "storageKey": "taxTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v13/*: any*/),
             "kind": "ScalarField",
             "name": "shippingTotal",
             "storageKey": "shippingTotal(precision:2)"
           },
           {
             "alias": null,
-            "args": (v6/*: any*/),
+            "args": (v13/*: any*/),
             "kind": "ScalarField",
             "name": "totalListPrice",
             "storageKey": "totalListPrice(precision:2)"
@@ -779,22 +778,18 @@ return {
                 "name": "lastDigits",
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v11/*: any*/)
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"order-id\")"
       }
     ]
   },
   "params": {
-<<<<<<< HEAD
-    "id": "0600489ff0ebffe46be054de734764a8",
-=======
-    "id": "994c01297ddd1fa1f25179e1bc6e7a87",
->>>>>>> 5c361e82d3 (generated files)
+    "id": "a4aa5614acfbf5403705fd5458f368be",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "commerceOrder": {
@@ -803,21 +798,21 @@ return {
           "plural": false,
           "type": "CommerceOrder"
         },
-        "commerceOrder.__isCommerceOrder": (v7/*: any*/),
-        "commerceOrder.__typename": (v7/*: any*/),
-        "commerceOrder.buyerTotal": (v8/*: any*/),
-        "commerceOrder.code": (v7/*: any*/),
-        "commerceOrder.createdAt": (v7/*: any*/),
+        "commerceOrder.__isCommerceOrder": (v14/*: any*/),
+        "commerceOrder.__typename": (v14/*: any*/),
+        "commerceOrder.buyerTotal": (v15/*: any*/),
+        "commerceOrder.code": (v14/*: any*/),
+        "commerceOrder.createdAt": (v14/*: any*/),
         "commerceOrder.creditCard": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CreditCard"
         },
-        "commerceOrder.creditCard.brand": (v7/*: any*/),
-        "commerceOrder.creditCard.id": (v9/*: any*/),
-        "commerceOrder.creditCard.lastDigits": (v7/*: any*/),
-        "commerceOrder.id": (v9/*: any*/),
+        "commerceOrder.creditCard.brand": (v14/*: any*/),
+        "commerceOrder.creditCard.id": (v16/*: any*/),
+        "commerceOrder.creditCard.lastDigits": (v14/*: any*/),
+        "commerceOrder.id": (v16/*: any*/),
         "commerceOrder.lineItems": {
           "enumValues": null,
           "nullable": true,
@@ -842,36 +837,36 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "commerceOrder.lineItems.edges.node.artwork.artistNames": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.date": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.artistNames": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.date": (v15/*: any*/),
         "commerceOrder.lineItems.edges.node.artwork.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "dimensions"
         },
-        "commerceOrder.lineItems.edges.node.artwork.dimensions.cm": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.dimensions.in": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.editionOf": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.id": (v9/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.dimensions.cm": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.dimensions.in": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.editionOf": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.id": (v16/*: any*/),
         "commerceOrder.lineItems.edges.node.artwork.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "commerceOrder.lineItems.edges.node.artwork.image.url": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.medium": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.image.url": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.medium": (v15/*: any*/),
         "commerceOrder.lineItems.edges.node.artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "commerceOrder.lineItems.edges.node.artwork.partner.id": (v9/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.partner.name": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.shippingOrigin": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.artwork.title": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.partner.id": (v16/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.partner.name": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.shippingOrigin": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.artwork.title": (v15/*: any*/),
         "commerceOrder.lineItems.edges.node.fulfillments": {
           "enumValues": null,
           "nullable": true,
@@ -890,58 +885,48 @@ return {
           "plural": false,
           "type": "CommerceFulfillment"
         },
-<<<<<<< HEAD
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v9/*: any*/),
-=======
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.createdAt": (v7/*: any*/),
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v9/*: any*/),
-        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.trackingId": (v8/*: any*/),
->>>>>>> 5c361e82d3 (generated files)
-        "commerceOrder.lineItems.edges.node.id": (v9/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.createdAt": (v14/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v16/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.trackingId": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.id": (v16/*: any*/),
         "commerceOrder.lineItems.edges.node.selectedShippingQuote": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceShippingQuote"
         },
-        "commerceOrder.lineItems.edges.node.selectedShippingQuote.displayName": (v7/*: any*/),
-        "commerceOrder.lineItems.edges.node.selectedShippingQuote.id": (v9/*: any*/),
+        "commerceOrder.lineItems.edges.node.selectedShippingQuote.displayName": (v14/*: any*/),
+        "commerceOrder.lineItems.edges.node.selectedShippingQuote.id": (v16/*: any*/),
         "commerceOrder.lineItems.edges.node.shipment": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceShipment"
         },
-<<<<<<< HEAD
-        "commerceOrder.lineItems.edges.node.shipment.id": (v9/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.status": (v8/*: any*/),
-=======
-        "commerceOrder.lineItems.edges.node.shipment.deliveryEnd": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.deliveryStart": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.estimatedDeliveryWindow": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.id": (v9/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.status": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.trackingNumber": (v8/*: any*/),
-        "commerceOrder.lineItems.edges.node.shipment.trackingUrl": (v8/*: any*/),
->>>>>>> 5c361e82d3 (generated files)
+        "commerceOrder.lineItems.edges.node.shipment.deliveryEnd": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.deliveryStart": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.estimatedDeliveryWindow": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.id": (v16/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.status": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingNumber": (v15/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingUrl": (v15/*: any*/),
         "commerceOrder.requestedFulfillment": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceRequestedFulfillmentUnion"
         },
-        "commerceOrder.requestedFulfillment.__typename": (v7/*: any*/),
-        "commerceOrder.requestedFulfillment.addressLine1": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.addressLine2": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.city": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.country": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.name": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.phoneNumber": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.postalCode": (v8/*: any*/),
-        "commerceOrder.requestedFulfillment.region": (v8/*: any*/),
-        "commerceOrder.shippingTotal": (v8/*: any*/),
+        "commerceOrder.requestedFulfillment.__typename": (v14/*: any*/),
+        "commerceOrder.requestedFulfillment.addressLine1": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.addressLine2": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.city": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.country": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.name": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.phoneNumber": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.postalCode": (v15/*: any*/),
+        "commerceOrder.requestedFulfillment.region": (v15/*: any*/),
+        "commerceOrder.shippingTotal": (v15/*: any*/),
         "commerceOrder.state": {
           "enumValues": [
             "ABANDONED",
@@ -956,8 +941,8 @@ return {
           "plural": false,
           "type": "CommerceOrderStateEnum"
         },
-        "commerceOrder.taxTotal": (v8/*: any*/),
-        "commerceOrder.totalListPrice": (v8/*: any*/)
+        "commerceOrder.taxTotal": (v15/*: any*/),
+        "commerceOrder.totalListPrice": (v15/*: any*/)
       }
     },
     "name": "OrderDetailsTestsQuery",

--- a/src/__generated__/OrderDetailsTestsQuery.graphql.ts
+++ b/src/__generated__/OrderDetailsTestsQuery.graphql.ts
@@ -1,7 +1,11 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
+<<<<<<< HEAD
 /* @relayHash 0600489ff0ebffe46be054de734764a8 */
+=======
+/* @relayHash 994c01297ddd1fa1f25179e1bc6e7a87 */
+>>>>>>> 5c361e82d3 (generated files)
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -126,6 +130,7 @@ fragment OrderDetails_order on CommerceOrder {
   ...ArtworkInfoSection_artwork
   ...SummarySection_section
   ...OrderDetailsPayment_order
+  ...TrackOrderSection_section
   ...ShipsToSection_address
   ...SoldBySection_soldBy
 }
@@ -201,6 +206,37 @@ fragment SummarySection_section on CommerceOrder {
         selectedShippingQuote {
           displayName
           id
+        }
+        id
+      }
+    }
+  }
+}
+
+fragment TrackOrderSection_section on CommerceOrder {
+  __isCommerceOrder: __typename
+  state
+  lineItems(first: 1) {
+    edges {
+      node {
+        shipment {
+          status
+          trackingUrl
+          trackingNumber
+          deliveryStart
+          deliveryEnd
+          estimatedDeliveryWindow
+          id
+        }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              createdAt
+              trackingId
+              estimatedDelivery
+              id
+            }
+          }
         }
         id
       }
@@ -297,6 +333,16 @@ v5 = {
   "name": "id",
   "storageKey": null
 },
+<<<<<<< HEAD
+=======
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+>>>>>>> 5c361e82d3 (generated files)
 v6 = [
   {
     "kind": "Literal",
@@ -548,7 +594,46 @@ return {
                             "name": "status",
                             "storageKey": null
                           },
+<<<<<<< HEAD
                           (v5/*: any*/)
+=======
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingNumber",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryStart",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryEnd",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "estimatedDeliveryWindow",
+                            "storageKey": null
+                          }
+>>>>>>> 5c361e82d3 (generated files)
                         ],
                         "storageKey": null
                       },
@@ -595,6 +680,14 @@ return {
                                 "name": "node",
                                 "plural": false,
                                 "selections": [
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "trackingId",
+                                    "storageKey": null
+                                  },
                                   {
                                     "alias": null,
                                     "args": null,
@@ -621,13 +714,7 @@ return {
             ],
             "storageKey": "lineItems(first:1)"
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "createdAt",
-            "storageKey": null
-          },
+          (v5/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -703,7 +790,11 @@ return {
     ]
   },
   "params": {
+<<<<<<< HEAD
     "id": "0600489ff0ebffe46be054de734764a8",
+=======
+    "id": "994c01297ddd1fa1f25179e1bc6e7a87",
+>>>>>>> 5c361e82d3 (generated files)
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "commerceOrder": {
@@ -799,8 +890,15 @@ return {
           "plural": false,
           "type": "CommerceFulfillment"
         },
+<<<<<<< HEAD
         "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v8/*: any*/),
         "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v9/*: any*/),
+=======
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.createdAt": (v7/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v9/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.trackingId": (v8/*: any*/),
+>>>>>>> 5c361e82d3 (generated files)
         "commerceOrder.lineItems.edges.node.id": (v9/*: any*/),
         "commerceOrder.lineItems.edges.node.selectedShippingQuote": {
           "enumValues": null,
@@ -816,8 +914,18 @@ return {
           "plural": false,
           "type": "CommerceShipment"
         },
+<<<<<<< HEAD
         "commerceOrder.lineItems.edges.node.shipment.id": (v9/*: any*/),
         "commerceOrder.lineItems.edges.node.shipment.status": (v8/*: any*/),
+=======
+        "commerceOrder.lineItems.edges.node.shipment.deliveryEnd": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.deliveryStart": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.estimatedDeliveryWindow": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.id": (v9/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.status": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingNumber": (v8/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingUrl": (v8/*: any*/),
+>>>>>>> 5c361e82d3 (generated files)
         "commerceOrder.requestedFulfillment": {
           "enumValues": null,
           "nullable": true,

--- a/src/__generated__/OrderDetails_order.graphql.ts
+++ b/src/__generated__/OrderDetails_order.graphql.ts
@@ -29,7 +29,7 @@ export type OrderDetails_order = {
             } | null;
         } | null> | null;
     } | null;
-    readonly " $fragmentRefs": FragmentRefs<"OrderDetailsHeader_info" | "ArtworkInfoSection_artwork" | "SummarySection_section" | "OrderDetailsPayment_order" | "ShipsToSection_address" | "SoldBySection_soldBy">;
+    readonly " $fragmentRefs": FragmentRefs<"OrderDetailsHeader_info" | "ArtworkInfoSection_artwork" | "SummarySection_section" | "OrderDetailsPayment_order" | "TrackOrderSection_section" | "ShipsToSection_address" | "SoldBySection_soldBy">;
     readonly " $refType": "OrderDetails_order";
 };
 export type OrderDetails_order$data = OrderDetails_order;
@@ -181,6 +181,11 @@ return {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "TrackOrderSection_section"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "ShipsToSection_address"
     },
     {
@@ -193,5 +198,9 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
+<<<<<<< HEAD
 (node as any).hash = 'beff1c9d6c74e128fd07df52975800eb';
+=======
+(node as any).hash = '508f13e5ac0aeca2156c84f1f07245e2';
+>>>>>>> 5c361e82d3 (generated files)
 export default node;

--- a/src/__generated__/OrderDetails_order.graphql.ts
+++ b/src/__generated__/OrderDetails_order.graphql.ts
@@ -9,9 +9,6 @@ export type OrderDetails_order = {
         readonly __typename: "CommerceShip";
         readonly name: string | null;
     } | {
-        readonly __typename: "CommerceShipArta";
-        readonly name: string | null;
-    } | {
         readonly __typename: "CommercePickup";
     } | {
         /*This will never be '%other', but we need some
@@ -54,11 +51,7 @@ v1 = {
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
-},
-v2 = [
-  (v0/*: any*/),
-  (v1/*: any*/)
-];
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -75,14 +68,11 @@ return {
       "selections": [
         {
           "kind": "InlineFragment",
-          "selections": (v2/*: any*/),
+          "selections": [
+            (v0/*: any*/),
+            (v1/*: any*/)
+          ],
           "type": "CommerceShip",
-          "abstractKey": null
-        },
-        {
-          "kind": "InlineFragment",
-          "selections": (v2/*: any*/),
-          "type": "CommerceShipArta",
           "abstractKey": null
         },
         {
@@ -198,9 +188,5 @@ return {
   "abstractKey": "__isCommerceOrder"
 };
 })();
-<<<<<<< HEAD
-(node as any).hash = 'beff1c9d6c74e128fd07df52975800eb';
-=======
 (node as any).hash = '508f13e5ac0aeca2156c84f1f07245e2';
->>>>>>> 5c361e82d3 (generated files)
 export default node;

--- a/src/__generated__/TrackOrderSectionTestsQuery.graphql.ts
+++ b/src/__generated__/TrackOrderSectionTestsQuery.graphql.ts
@@ -1,0 +1,412 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 4d73e28aef4cb359d265716253bb0866 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type TrackOrderSectionTestsQueryVariables = {};
+export type TrackOrderSectionTestsQueryResponse = {
+    readonly commerceOrder: {
+        readonly internalID: string;
+        readonly " $fragmentRefs": FragmentRefs<"TrackOrderSection_section">;
+    } | null;
+};
+export type TrackOrderSectionTestsQuery = {
+    readonly response: TrackOrderSectionTestsQueryResponse;
+    readonly variables: TrackOrderSectionTestsQueryVariables;
+};
+
+
+
+/*
+query TrackOrderSectionTestsQuery {
+  commerceOrder(id: "some-id") {
+    __typename
+    internalID
+    ...TrackOrderSection_section
+    id
+  }
+}
+
+fragment TrackOrderSection_section on CommerceOrder {
+  __isCommerceOrder: __typename
+  state
+  lineItems(first: 1) {
+    edges {
+      node {
+        shipment {
+          status
+          trackingUrl
+          trackingNumber
+          deliveryStart
+          deliveryEnd
+          estimatedDeliveryWindow
+          id
+        }
+        fulfillments(first: 1) {
+          edges {
+            node {
+              createdAt
+              trackingId
+              estimatedDelivery
+              id
+            }
+          }
+        }
+        id
+      }
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "some-id"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "TrackOrderSectionTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "commerceOrder",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "TrackOrderSection_section"
+          }
+        ],
+        "storageKey": "commerceOrder(id:\"some-id\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "TrackOrderSectionTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "commerceOrder",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "kind": "TypeDiscriminator",
+            "abstractKey": "__isCommerceOrder"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "state",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*: any*/),
+            "concreteType": "CommerceLineItemConnection",
+            "kind": "LinkedField",
+            "name": "lineItems",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CommerceLineItemEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CommerceLineItem",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "CommerceShipment",
+                        "kind": "LinkedField",
+                        "name": "shipment",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "status",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "trackingNumber",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryStart",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "deliveryEnd",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "estimatedDeliveryWindow",
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": (v2/*: any*/),
+                        "concreteType": "CommerceFulfillmentConnection",
+                        "kind": "LinkedField",
+                        "name": "fulfillments",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "CommerceFulfillmentEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "CommerceFulfillment",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "createdAt",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "trackingId",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "estimatedDelivery",
+                                    "storageKey": null
+                                  },
+                                  (v3/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": "fulfillments(first:1)"
+                      },
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "lineItems(first:1)"
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": "commerceOrder(id:\"some-id\")"
+      }
+    ]
+  },
+  "params": {
+    "id": "4d73e28aef4cb359d265716253bb0866",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "commerceOrder": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceOrder"
+        },
+        "commerceOrder.__isCommerceOrder": (v4/*: any*/),
+        "commerceOrder.__typename": (v4/*: any*/),
+        "commerceOrder.id": (v5/*: any*/),
+        "commerceOrder.internalID": (v5/*: any*/),
+        "commerceOrder.lineItems": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceLineItemConnection"
+        },
+        "commerceOrder.lineItems.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "CommerceLineItemEdge"
+        },
+        "commerceOrder.lineItems.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceLineItem"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceFulfillmentConnection"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "CommerceFulfillmentEdge"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceFulfillment"
+        },
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.createdAt": (v4/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.estimatedDelivery": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.id": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.fulfillments.edges.node.trackingId": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.id": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceShipment"
+        },
+        "commerceOrder.lineItems.edges.node.shipment.deliveryEnd": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.deliveryStart": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.estimatedDeliveryWindow": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.id": (v5/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.status": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingNumber": (v6/*: any*/),
+        "commerceOrder.lineItems.edges.node.shipment.trackingUrl": (v6/*: any*/),
+        "commerceOrder.state": {
+          "enumValues": [
+            "ABANDONED",
+            "APPROVED",
+            "CANCELED",
+            "FULFILLED",
+            "PENDING",
+            "REFUNDED",
+            "SUBMITTED"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "CommerceOrderStateEnum"
+        }
+      }
+    },
+    "name": "TrackOrderSectionTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+})();
+(node as any).hash = 'ee9d582dd24c59d3fa11cdfe30c28560';
+export default node;

--- a/src/__generated__/TrackOrderSection_section.graphql.ts
+++ b/src/__generated__/TrackOrderSection_section.graphql.ts
@@ -1,0 +1,210 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "PENDING" | "REFUNDED" | "SUBMITTED" | "%future added value";
+export type TrackOrderSection_section = {
+    readonly state: CommerceOrderStateEnum;
+    readonly lineItems: {
+        readonly edges: ReadonlyArray<{
+            readonly node: {
+                readonly shipment: {
+                    readonly status: string | null;
+                    readonly trackingUrl: string | null;
+                    readonly trackingNumber: string | null;
+                    readonly deliveryStart: string | null;
+                    readonly deliveryEnd: string | null;
+                    readonly estimatedDeliveryWindow: string | null;
+                } | null;
+                readonly fulfillments: {
+                    readonly edges: ReadonlyArray<{
+                        readonly node: {
+                            readonly createdAt: string;
+                            readonly trackingId: string | null;
+                            readonly estimatedDelivery: string | null;
+                        } | null;
+                    } | null> | null;
+                } | null;
+            } | null;
+        } | null> | null;
+    } | null;
+    readonly " $refType": "TrackOrderSection_section";
+};
+export type TrackOrderSection_section$data = TrackOrderSection_section;
+export type TrackOrderSection_section$key = {
+    readonly " $data"?: TrackOrderSection_section$data;
+    readonly " $fragmentRefs": FragmentRefs<"TrackOrderSection_section">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "TrackOrderSection_section",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "state",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": (v0/*: any*/),
+      "concreteType": "CommerceLineItemConnection",
+      "kind": "LinkedField",
+      "name": "lineItems",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CommerceLineItemEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "CommerceLineItem",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CommerceShipment",
+                  "kind": "LinkedField",
+                  "name": "shipment",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "status",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "trackingUrl",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "trackingNumber",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "deliveryStart",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "deliveryEnd",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "estimatedDeliveryWindow",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": (v0/*: any*/),
+                  "concreteType": "CommerceFulfillmentConnection",
+                  "kind": "LinkedField",
+                  "name": "fulfillments",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CommerceFulfillmentEdge",
+                      "kind": "LinkedField",
+                      "name": "edges",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "CommerceFulfillment",
+                          "kind": "LinkedField",
+                          "name": "node",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "createdAt",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "trackingId",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "estimatedDelivery",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "fulfillments(first:1)"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "lineItems(first:1)"
+    }
+  ],
+  "type": "CommerceOrder",
+  "abstractKey": "__isCommerceOrder"
+};
+})();
+(node as any).hash = '34b7810a7f523fdbbfb4071c7a2366fd';
+export default node;

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -64,7 +64,7 @@ const OrderDetails: FC<OrderDetailsProps> = ({ order }) => {
     !!partnerName && {
       key: "Sold By",
       title: `Sold by ${partnerName?.name}`,
-      data: [<SoldBySectionFragmentContainer testID="ShipsToSection" soldBy={order} />],
+      data: [<SoldBySectionFragmentContainer soldBy={order} />],
     },
   ])
 

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -29,19 +29,8 @@ export interface SectionListItem {
 
 const OrderDetails: FC<OrderDetailsProps> = ({ order }) => {
   const partnerName = extractNodes(order?.lineItems)?.[0]?.artwork?.partner
-  const fulfillmentType = order.requestedFulfillment?.__typename
-  const isShipping = fulfillmentType === "CommerceShipArta" || fulfillmentType === "CommerceShip"
-
-  const getShippingName = () => {
-    if (
-      order.requestedFulfillment?.__typename === "CommerceShipArta" ||
-      order.requestedFulfillment?.__typename === "CommerceShip"
-    ) {
-      return order?.requestedFulfillment?.name
-    }
-    return null
-  }
-
+  const shippingName =
+    order?.requestedFulfillment?.__typename === "CommerceShip" ? order?.requestedFulfillment.name : null
   const DATA: SectionListItem[] = compact([
     {
       key: "OrderDetailsHeader",
@@ -69,13 +58,13 @@ const OrderDetails: FC<OrderDetailsProps> = ({ order }) => {
     },
     order.requestedFulfillment?.__typename !== "CommercePickup" && {
       key: "ShipTo_Section",
-      title: `Ships to ${getShippingName()}`,
+      title: `Ships to ${shippingName}`,
       data: [<ShipsToSectionFragmentContainer address={order} />],
     },
     !!partnerName && {
-      key: "Sold_By",
+      key: "Sold By",
       title: `Sold by ${partnerName?.name}`,
-      data: [<SoldBySectionFragmentContainer soldBy={order} />],
+      data: [<SoldBySectionFragmentContainer testID="ShipsToSection" soldBy={order} />],
     },
   ])
 
@@ -184,15 +173,10 @@ export const OrderDetailsContainer = createFragmentContainer(OrderDetails, {
           __typename
           name
         }
-        ... on CommerceShipArta {
-          __typename
-          name
-        }
         ... on CommercePickup {
           __typename
         }
       }
-
       lineItems(first: 1) {
         edges {
           node {
@@ -204,7 +188,6 @@ export const OrderDetailsContainer = createFragmentContainer(OrderDetails, {
           }
         }
       }
-
       ...OrderDetailsHeader_info
       ...ArtworkInfoSection_artwork
       ...SummarySection_section

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -7,7 +7,7 @@ import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { compact } from "lodash"
 import { Box, Flex, Separator, Text } from "palette"
-import React from "react"
+import React, { FC } from "react"
 import { SectionList } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { ArtworkInfoSectionFragmentContainer } from "./ArtworkInfoSection"
@@ -16,6 +16,7 @@ import { CreditCardSummaryItemFragmentContainer } from "./OrderDetailsPayment"
 import { ShipsToSectionFragmentContainer } from "./ShipsToSection"
 import { SoldBySectionFragmentContainer } from "./SoldBySection"
 import { SummarySectionFragmentContainer } from "./SummarySection"
+import { TrackOrderSectionFragmentContainer } from "./TrackOrderSection"
 
 export interface OrderDetailsProps {
   order: OrderDetails_order
@@ -26,7 +27,7 @@ export interface SectionListItem {
   data: readonly JSX.Element[]
 }
 
-const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
+const OrderDetails: FC<OrderDetailsProps> = ({ order }) => {
   const partnerName = extractNodes(order?.lineItems)?.[0]?.artwork?.partner
   const fulfillmentType = order.requestedFulfillment?.__typename
   const isShipping = fulfillmentType === "CommerceShipArta" || fulfillmentType === "CommerceShip"
@@ -61,7 +62,12 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
       title: "Payment Method",
       data: [<CreditCardSummaryItemFragmentContainer order={order} />],
     },
-    isShipping && {
+    order.requestedFulfillment?.__typename !== "CommercePickup" && {
+      key: "TrackOrder_Section",
+      title: "Track Order",
+      data: [<TrackOrderSectionFragmentContainer section={order} />],
+    },
+    order.requestedFulfillment?.__typename !== "CommercePickup" && {
       key: "ShipTo_Section",
       title: `Ships to ${getShippingName()}`,
       data: [<ShipsToSectionFragmentContainer address={order} />],
@@ -76,7 +82,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
   return (
     <PageWithSimpleHeader title="Order Details">
       <SectionList
-        initialNumToRender={18}
+        initialNumToRender={21}
         contentContainerStyle={{ paddingHorizontal: 20, marginTop: 20, paddingBottom: 47 }}
         sections={DATA}
         keyExtractor={(item, index) => item.key + index.toString()}
@@ -91,7 +97,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
         renderSectionHeader={({ section: { title, data } }) =>
           title && data ? (
             <Box>
-              <Text mt={20} mb={10} variant="mediumText">
+              <Text mt={20} mb={10} variant="text" weight="medium">
                 {title}
               </Text>
             </Box>
@@ -112,7 +118,7 @@ const OrderDetails: React.FC<OrderDetailsProps> = ({ order }) => {
   )
 }
 
-export const OrderDetailsPlaceholder: React.FC<{}> = () => (
+export const OrderDetailsPlaceholder: FC<{}> = () => (
   <PageWithSimpleHeader title="Order Details">
     <Flex px={2}>
       <Flex flexDirection="row" mt={2}>
@@ -203,13 +209,13 @@ export const OrderDetailsContainer = createFragmentContainer(OrderDetails, {
       ...ArtworkInfoSection_artwork
       ...SummarySection_section
       ...OrderDetailsPayment_order
+      ...TrackOrderSection_section
       ...ShipsToSection_address
       ...SoldBySection_soldBy
     }
   `,
 })
-
-export const OrderDetailsQueryRender: React.FC<{ orderID: string }> = ({ orderID: orderID }) => {
+export const OrderDetailsQueryRender: FC<{ orderID: string }> = ({ orderID: orderID }) => {
   return (
     <QueryRenderer<OrderDetailsQuery>
       environment={defaultEnvironment}

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -1,0 +1,113 @@
+import { TrackOrderSection_section } from "__generated__/TrackOrderSection_section.graphql"
+import { extractNodes } from "lib/utils/extractNodes"
+import { getOrderStatus, OrderState } from "lib/utils/getOrderStatus"
+import { getTrackingUrl } from "lib/utils/getTrackingUrl"
+import { DateTime } from "luxon"
+import { Button, Flex, Text } from "palette"
+import React, { FC } from "react"
+import { Linking } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface Props {
+  section: TrackOrderSection_section
+}
+
+export const TrackOrderSection: FC<Props> = ({ section }) => {
+  if (!section.lineItems) {
+    return null
+  }
+
+  const [lineItem] = extractNodes(section?.lineItems)
+  const { shipment, fulfillments } = lineItem || {}
+  const [fulfillment] = extractNodes(fulfillments)
+  const { estimatedDelivery, createdAt } = fulfillment || {}
+  const trackingUrl = getTrackingUrl(lineItem)
+  const orderStatus = getOrderStatus(section.state as OrderState, lineItem)
+  const deliveredStatus = orderStatus === "delivered"
+
+  return (
+    <Flex flexDirection="row" justifyContent="space-between">
+      <Flex>
+        <Text variant="text" style={{ textTransform: "capitalize" }}>
+          {orderStatus}
+        </Text>
+        {!!shipment?.trackingNumber ? (
+          <Text variant="text" color="black60">
+            Tracking:&nbsp;
+            <Text variant="text" color="black60" weight="medium">
+              {shipment?.trackingNumber}
+            </Text>
+          </Text>
+        ) : (
+          <Text variant="text" color="black60">
+            Traking not available
+          </Text>
+        )}
+        {(!!shipment?.deliveryStart || !!createdAt) && (
+          <Text variant="text" color="black60">
+            Shipped on&nbsp;
+            <Text variant="text" color="black60" weight={!deliveredStatus ? "medium" : "regular"}>
+              {DateTime.fromISO(shipment?.deliveryStart || createdAt).toLocaleString(DateTime.DATE_MED)}
+            </Text>
+          </Text>
+        )}
+        {deliveredStatus && shipment?.deliveryEnd ? (
+          <Text variant="text" color="black60">
+            {"Delivered on "}
+            {DateTime.fromISO(shipment?.deliveryEnd).toLocaleString(DateTime.DATE_MED)}
+          </Text>
+        ) : (
+          <>
+            {!!shipment?.estimatedDeliveryWindow ||
+              (!!estimatedDelivery && (
+                <Text variant="text" color="black60">
+                  Estimated Delivery:&nbsp;
+                  <Text variant="text" color="black60" weight="medium">
+                    {shipment?.estimatedDeliveryWindow ||
+                      DateTime.fromISO(estimatedDelivery).toLocaleString(DateTime.DATE_MED)}
+                  </Text>
+                </Text>
+              ))}
+          </>
+        )}
+        {!!trackingUrl && (
+          <Button mt={2} block variant="primaryBlack" onPress={() => Linking.openURL(trackingUrl)}>
+            View full tracking details
+          </Button>
+        )}
+      </Flex>
+    </Flex>
+  )
+}
+
+export const TrackOrderSectionFragmentContainer = createFragmentContainer(TrackOrderSection, {
+  section: graphql`
+    fragment TrackOrderSection_section on CommerceOrder {
+      state
+      lineItems(first: 1) {
+        edges {
+          node {
+            shipment {
+              status
+              trackingUrl
+              trackingNumber
+              deliveryStart
+              deliveryEnd
+              estimatedDeliveryWindow
+            }
+
+            fulfillments(first: 1) {
+              edges {
+                node {
+                  createdAt
+                  trackingId
+                  estimatedDelivery
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `,
+})

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -100,7 +100,6 @@ export const TrackOrderSectionFragmentContainer = createFragmentContainer(TrackO
               deliveryEnd
               estimatedDeliveryWindow
             }
-
             fulfillments(first: 1) {
               edges {
                 node {

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -51,12 +51,13 @@ export const TrackOrderSection: FC<Props> = ({ section }) => {
             </Text>
           </Text>
         )}
-        {deliveredStatus && shipment?.deliveryEnd ? (
+        {!!deliveredStatus && !!shipment?.deliveryEnd && (
           <Text testID="deliveredStatus" variant="text" color="black60">
             {"Delivered on "}
             {DateTime.fromISO(shipment?.deliveryEnd).toLocaleString(DateTime.DATE_MED)}
           </Text>
-        ) : (
+        )}
+        {!deliveredStatus && (
           <>
             {(!!shipment?.estimatedDeliveryWindow || !!estimatedDelivery) && (
               <Text testID="estimatedDelivery" variant="text" color="black60">

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -40,7 +40,7 @@ export const TrackOrderSection: FC<Props> = ({ section }) => {
           </Text>
         ) : (
           <Text testID="noTrackingNumber" variant="text" color="black60">
-            Traking not available
+            Tracking not available
           </Text>
         )}
         {(!!shipment?.deliveryStart || !!createdAt) && (

--- a/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -28,23 +28,23 @@ export const TrackOrderSection: FC<Props> = ({ section }) => {
   return (
     <Flex flexDirection="row" justifyContent="space-between">
       <Flex>
-        <Text variant="text" style={{ textTransform: "capitalize" }}>
+        <Text testID="orderStatus" variant="text" style={{ textTransform: "capitalize" }}>
           {orderStatus}
         </Text>
         {!!shipment?.trackingNumber ? (
-          <Text variant="text" color="black60">
+          <Text testID="trackingNumber" variant="text" color="black60">
             Tracking:&nbsp;
             <Text variant="text" color="black60" weight="medium">
               {shipment?.trackingNumber}
             </Text>
           </Text>
         ) : (
-          <Text variant="text" color="black60">
+          <Text testID="noTrackingNumber" variant="text" color="black60">
             Traking not available
           </Text>
         )}
         {(!!shipment?.deliveryStart || !!createdAt) && (
-          <Text variant="text" color="black60">
+          <Text testID="shippedOn" variant="text" color="black60">
             Shipped on&nbsp;
             <Text variant="text" color="black60" weight={!deliveredStatus ? "medium" : "regular"}>
               {DateTime.fromISO(shipment?.deliveryStart || createdAt).toLocaleString(DateTime.DATE_MED)}
@@ -52,26 +52,30 @@ export const TrackOrderSection: FC<Props> = ({ section }) => {
           </Text>
         )}
         {deliveredStatus && shipment?.deliveryEnd ? (
-          <Text variant="text" color="black60">
+          <Text testID="deliveredStatus" variant="text" color="black60">
             {"Delivered on "}
             {DateTime.fromISO(shipment?.deliveryEnd).toLocaleString(DateTime.DATE_MED)}
           </Text>
         ) : (
           <>
-            {!!shipment?.estimatedDeliveryWindow ||
-              (!!estimatedDelivery && (
-                <Text variant="text" color="black60">
-                  Estimated Delivery:&nbsp;
+            {(!!shipment?.estimatedDeliveryWindow || !!estimatedDelivery) && (
+              <Text testID="estimatedDelivery" variant="text" color="black60">
+                Estimated Delivery:&nbsp;
+                {!!estimatedDelivery ? (
                   <Text variant="text" color="black60" weight="medium">
-                    {shipment?.estimatedDeliveryWindow ||
-                      DateTime.fromISO(estimatedDelivery).toLocaleString(DateTime.DATE_MED)}
+                    {DateTime.fromISO(estimatedDelivery).toLocaleString(DateTime.DATE_MED)}
                   </Text>
-                </Text>
-              ))}
+                ) : (
+                  <Text variant="text" color="black60" weight="medium">
+                    {shipment?.estimatedDeliveryWindow}
+                  </Text>
+                )}
+              </Text>
+            )}
           </>
         )}
         {!!trackingUrl && (
-          <Button mt={2} block variant="primaryBlack" onPress={() => Linking.openURL(trackingUrl)}>
+          <Button testID="trackingUrl" mt={2} block variant="primaryBlack" onPress={() => Linking.openURL(trackingUrl)}>
             View full tracking details
           </Button>
         )}

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/OrderDetails-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/OrderDetails-tests.tsx
@@ -19,6 +19,7 @@ import { CreditCardSummaryItemFragmentContainer } from "../Components/OrderDetai
 import { ShipsToSectionFragmentContainer } from "../Components/ShipsToSection"
 import { SoldBySectionFragmentContainer } from "../Components/SoldBySection"
 import { SummarySectionFragmentContainer } from "../Components/SummarySection"
+import { TrackOrderSectionFragmentContainer } from "../Components/TrackOrderSection"
 
 jest.unmock("react-relay")
 
@@ -68,6 +69,7 @@ describe(OrderDetailsQueryRender, () => {
     expect(tree.findByType(ArtworkInfoSectionFragmentContainer)).toBeTruthy()
     expect(tree.findByType(SummarySectionFragmentContainer)).toBeTruthy()
     expect(tree.findByType(CreditCardSummaryItemFragmentContainer)).toBeTruthy()
+    expect(tree.findByType(TrackOrderSectionFragmentContainer)).toBeTruthy()
     expect(tree.findByType(ShipsToSectionFragmentContainer)).toBeTruthy()
     expect(tree.findByType(SoldBySectionFragmentContainer)).toBeTruthy()
   })
@@ -78,6 +80,14 @@ describe(OrderDetailsQueryRender, () => {
     mockEnvironmentPayload(mockEnvironment, { CommerceOrder: () => order })
     const sections: SectionListItem[] = tree.findByType(SectionList).props.sections
     expect(sections.filter(({ key }) => key === "ShipTo_Section")).toHaveLength(0)
+  })
+
+  it("not render TrackOrderSection when CommercePickup", () => {
+    const tree = renderWithWrappers(<TestRenderer />).root
+    order.requestedFulfillment.__typename = "CommercePickup"
+    mockEnvironmentPayload(mockEnvironment, { CommerceOrder: () => order })
+    const sections: SectionListItem[] = tree.findByType(SectionList).props.sections
+    expect(sections.filter(({ key }) => key === "TrackOrder_Section")).toHaveLength(0)
   })
 
   it("not render SoldBySection when partnerName null", () => {

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/TrackOrderSection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/TrackOrderSection-tests.tsx
@@ -88,7 +88,7 @@ describe("TrackOrderSection", () => {
 
       expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
       expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Tracking not available")
       expect(extractText(tree.findByProps({ testID: "shippedOn" }))).toContain("Sep 2, 2021")
       expect(extractText(tree.findByProps({ testID: "estimatedDelivery" }))).toContain("Oct 2, 2021")
       expect(extractText(tree.findByProps({ testID: "trackingUrl" }))).toContain("View full tracking details")
@@ -105,7 +105,7 @@ describe("TrackOrderSection", () => {
 
       expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
       expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Tracking not available")
       expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
       expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
       expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)
@@ -152,7 +152,7 @@ describe("TrackOrderSection", () => {
 
       expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("in transit")
       expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Tracking not available")
       expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
       expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
       expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)

--- a/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/TrackOrderSection-tests.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderDetails/__tests__/TrackOrderSection-tests.tsx
@@ -1,0 +1,190 @@
+import { TrackOrderSectionTestsQuery } from "__generated__/TrackOrderSectionTestsQuery.graphql"
+import { extractText } from "lib/tests/extractText"
+import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
+import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { TrackOrderSectionFragmentContainer } from "../Components/TrackOrderSection"
+
+jest.unmock("react-relay")
+
+const CommerceShipOrder = {
+  state: "SUBMITTED",
+  requestedFulfillment: { __typename: "CommerceShip" },
+  lineItems: {
+    edges: [
+      {
+        node: {
+          shipment: null,
+          fulfillments: {
+            edges: [
+              {
+                node: {
+                  createdAt: "2021-09-02T14:51:19+03:00",
+                  trackingId: "1234567890",
+                  estimatedDelivery: "2021-10-02T14:51:19+03:00",
+                },
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+}
+
+const CommerceShipArtaOrder = {
+  state: "APPROVED",
+  requestedFulfillment: { __typename: "CommerceShipArta" },
+  lineItems: {
+    edges: [
+      {
+        node: {
+          shipment: {
+            status: "in_transit",
+            trackingUrl: "https://google.com",
+            trackingNumber: "12345678910",
+            deliveryStart: "2021-10-03T14:51:19+03:00",
+            deliveryEnd: "2021-09-02T14:51:19+03:00",
+            estimatedDeliveryWindow: "on September 20, 2021",
+          },
+          fulfillments: null,
+        },
+      },
+    ],
+  },
+}
+
+describe("TrackOrderSection", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  beforeEach(() => (mockEnvironment = createMockEnvironment()))
+
+  const TestRenderer = () => (
+    <QueryRenderer<TrackOrderSectionTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query TrackOrderSectionTestsQuery @relay_test_operation {
+          commerceOrder(id: "some-id") {
+            internalID
+            ...TrackOrderSection_section
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props }) => {
+        if (props?.commerceOrder) {
+          return <TrackOrderSectionFragmentContainer section={props.commerceOrder} />
+        }
+        return null
+      }}
+    />
+  )
+
+  describe("when CommerceShip", () => {
+    it("renders section", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, { CommerceOrder: () => CommerceShipOrder })
+
+      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
+      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(extractText(tree.findByProps({ testID: "shippedOn" }))).toContain("Sep 2, 2021")
+      expect(extractText(tree.findByProps({ testID: "estimatedDelivery" }))).toContain("Oct 2, 2021")
+      expect(extractText(tree.findByProps({ testID: "trackingUrl" }))).toContain("View full tracking details")
+    })
+
+    it("not renders fields without data", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, {
+        CommerceOrder: () => ({
+          ...CommerceShipOrder,
+          lineItems: { edges: [{ node: { shipment: null, fulfillments: null } }] },
+        }),
+      })
+
+      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
+      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
+      expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
+      expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)
+    })
+  })
+
+  describe("when CommerceShipArta", () => {
+    it("renders section", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, { CommerceOrder: () => CommerceShipArtaOrder })
+
+      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("in transit")
+      expect(extractText(tree.findByProps({ testID: "trackingNumber" }))).toContain("12345678910")
+      expect(tree.findAllByProps({ testID: "noTrackingNumber" })).toHaveLength(0)
+      expect(extractText(tree.findByProps({ testID: "shippedOn" }))).toContain("Oct 3, 2021")
+      expect(extractText(tree.findByProps({ testID: "estimatedDelivery" }))).toContain("on September 20, 2021")
+      expect(extractText(tree.findByProps({ testID: "trackingUrl" }))).toContain("View full tracking details")
+    })
+
+    it("not renders fields without data", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, {
+        CommerceOrder: () => ({
+          ...CommerceShipArtaOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  shipment: {
+                    status: "in_transit",
+                    trackingUrl: null,
+                    trackingNumber: null,
+                    deliveryStart: null,
+                    deliveryEnd: null,
+                    estimatedDeliveryWindow: null,
+                  },
+                  fulfillments: null,
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("in transit")
+      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
+      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe("Traking not available")
+      expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
+      expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
+      expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)
+    })
+
+    it("when delivered", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, {
+        CommerceOrder: () => ({
+          ...CommerceShipArtaOrder,
+          lineItems: {
+            edges: [{ node: { shipment: { status: "completed", deliveryEnd: "2021-09-02T14:51:19+03:00" } } }],
+          },
+        }),
+      })
+
+      expect(extractText(tree.findByProps({ testID: "deliveredStatus" }))).toBe("Delivered on Sep 2, 2021")
+    })
+  })
+
+  describe("when CommercePickup", () => {
+    it("not renders section", () => {
+      const tree = renderWithWrappers(<TestRenderer />).root
+      mockEnvironmentPayload(mockEnvironment, {
+        CommerceOrder: () => ({
+          ...CommerceShipOrder,
+          requestedFulfillment: { __typename: "CommercePickup" },
+          lineItems: { edges: [{ node: { shipment: null, fulfillments: null } }] },
+        }),
+      })
+
+      expect(tree.instance).toBeNull()
+    })
+  })
+})

--- a/src/lib/utils/getTrackingUrl.ts
+++ b/src/lib/utils/getTrackingUrl.ts
@@ -1,10 +1,17 @@
 import { OrderHistoryRow_order } from "__generated__/OrderHistoryRow_order.graphql"
+import { TrackOrderSection_section } from "__generated__/TrackOrderSection_section.graphql"
 
 export type OrderHistoryRowLineItem = NonNullable<
   NonNullable<NonNullable<OrderHistoryRow_order["lineItems"]>["edges"]>[0]
 >["node"]
 
-export function getTrackingUrl(orderLineItem: OrderHistoryRowLineItem): string | undefined {
+export type OrderDetailsTrackOrderSectionLineItem = NonNullable<
+  NonNullable<NonNullable<TrackOrderSection_section["lineItems"]>["edges"]>[0]
+>["node"]
+
+export function getTrackingUrl(
+  orderLineItem: OrderHistoryRowLineItem | OrderDetailsTrackOrderSectionLineItem
+): string | undefined {
   const trackingId = orderLineItem?.fulfillments?.edges?.[0]?.node?.trackingId
   const trackingNumber = orderLineItem?.shipment?.trackingNumber
   const trackingUrl = orderLineItem?.shipment?.trackingUrl


### PR DESCRIPTION
The type of this PR is: **Feature**
Design 🎨  : [Figma](https://www.figma.com/file/J5bIQj4a0l7wYAHnhbVGTp/%5BCollector%5D-Checkout-Shipping?node-id=2826%3A0) 
<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PX-4210]

### Description

This PR is adding a new `TrackOrderSection` to the OrderDetails page and allows users to see tracking and timing info about their order. Also, this PR returns correct bold text for sections titles.

We need to doublecheck backend fields for `Shipped on`, `Estimated Delivery` and `Delivered on` fields in this section. So please, correct this if it's wrong and let me know:point_down:
1. If CommerceShip:
- Shipped on -> `createdAt` on `CommerceFulfillment`
- Estimated Delivery -> `estimatedDelivery` on `CommerceFulfillment`
- if status "delivered" then `Delivered on` -> :question::question::question: on `CommerceFulfillment` (hidding now)
2. If CommerceShipArta:
- Shipped on -> `deliveryStart` on `CommerceShipment`
- Estimated Delivery -> `estimatedDeliveryWindow` on `CommerceShipment`
- if status "delivered" then `Delivered on` -> `deliveryEnd` on `CommerceShipment`
<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Order Details:  added TrackOrderSection - Serge0n

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

**VIDEO:clapper: :**

https://user-images.githubusercontent.com/55637696/134161145-4d65152b-3639-41d8-8aef-2343d37f5621.mov

[PX-4210]: https://artsyproduct.atlassian.net/browse/PX-4210