### PR TITLE
feat(FX-3325): Update the display of size filter labels for saved search M2

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/__tests__/helpers-tests.ts
+++ b/src/lib/Scenes/SavedSearchAlert/__tests__/helpers-tests.ts
@@ -1,5 +1,5 @@
 import { Aggregations, FilterData, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { extractPillFromAggregation, extractPills, getNamePlaceholder } from "../helpers"
+import { extractPillFromAggregation, extractPills, extractSizeLabel, getNamePlaceholder } from "../helpers"
 
 describe("extractPillFromAggregation", () => {
   it("returns pills", () => {
@@ -36,6 +36,24 @@ describe("extractPillFromAggregation", () => {
   })
 })
 
+describe("extractSizeLabel", () => {
+  it("returns correcly label when full range is specified", () => {
+    expect(extractSizeLabel("w", "5-10")).toBe("w: 5-10 in")
+  })
+
+  it("returns correcly label when only min value is specified", () => {
+    expect(extractSizeLabel("w", "5-*")).toBe("w: from 5 in")
+  })
+
+  it("returns correcly label when only max value is specified", () => {
+    expect(extractSizeLabel("w", "*-10")).toBe("w: to 10 in")
+  })
+
+  it("returns specified prefix", () => {
+    expect(extractSizeLabel("h", "5-10")).toBe("h: 5-10 in")
+  })
+})
+
 describe("extractPills", () => {
   it("should correctly extract pills", () => {
     const filters: FilterData[] = [
@@ -59,10 +77,29 @@ describe("extractPills", () => {
         paramValue: true,
         paramName: FilterParamName.waysToBuyMakeOffer,
       },
+      {
+        displayText: "5-10",
+        paramValue: "5-10",
+        paramName: FilterParamName.width,
+      },
+      {
+        displayText: "15-*",
+        paramValue: "15-*",
+        paramName: FilterParamName.height,
+      },
     ]
     const result = extractPills(filters, aggregations)
 
-    expect(result).toEqual(["Acrylic", "Canvas", "$5,000–10,000", "Limited Edition", "Open Edition", "Make Offer"])
+    expect(result).toEqual([
+      "Acrylic",
+      "Canvas",
+      "$5,000–10,000",
+      "Limited Edition",
+      "Open Edition",
+      "Make Offer",
+      "w: 5-10 in",
+      "h: from 15 in",
+    ])
   })
 })
 

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -1,11 +1,11 @@
 import {
   aggregationForFilter,
   Aggregations,
-  extractCustomSizeLabel,
   FilterArray,
   FilterData,
   FilterParamName,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { LOCALIZED_UNIT, parseRange } from "lib/Components/ArtworkFilter/Filters/helpers"
 import { shouldExtractValueNamesFromAggregation } from "lib/Components/ArtworkFilter/SavedSearch/constants"
 import { compact, flatten, keyBy } from "lodash"
 import { bullet } from "palette"
@@ -25,27 +25,35 @@ export const extractPillFromAggregation = (filter: FilterData, aggregations: Agg
   return []
 }
 
-export const extractSizePill = (filters: FilterArray) => {
-  const label = extractCustomSizeLabel(filters)
+export const extractSizeLabel = (prefix: string, value: string) => {
+  const { min, max } = parseRange(value)
+  let label
 
-  if (label) {
-    return label
+  if (max === "*") {
+    label = `from ${min}`
+  } else if (min === "*") {
+    label = `to ${max}`
+  } else {
+    label = `${min}-${max}`
   }
 
-  return filters.find((filter) => filter.paramName === FilterParamName.dimensionRange)?.displayText
+  return `${prefix}: ${label} ${LOCALIZED_UNIT}`
 }
 
 export const extractPills = (filters: FilterArray, aggregations: Aggregations) => {
   const pills = filters.map((filter) => {
     const { paramName, paramValue, displayText } = filter
 
-    if (paramName === FilterParamName.dimensionRange) {
-      return extractSizePill(filters)
+    if (paramName === FilterParamName.dimensionRange && displayText === "Custom Size") {
+      return null
     }
 
-    // We skip width and height, since we extracted them in extractSizePill
-    if (paramName === FilterParamName.width || paramName === FilterParamName.height) {
-      return
+    if (paramName === FilterParamName.width) {
+      return extractSizeLabel("w", displayText)
+    }
+
+    if (paramName === FilterParamName.height) {
+      return extractSizeLabel("h", displayText)
     }
 
     // Extract label from aggregations


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3325]
More context you can find in [Slack](https://artsy.slack.com/archives/C9SATFLUU/p1632216208334400)

### Examples
#### Example 1
* Values
  * minimum width `5`
  * minimum height `10`
  * maximum height `15`
* Labels
  * `w: from 5 in` or `w: from 5 cm`
  * `h: 10-15 in` or `h: 10-15 cm`

#### Example 2
* Values
  * minimum width `5`
  * maximum width `10`
  * minimum height `15`
  * maximum height `20`
* Label
  * `w: 5-10 in` or `w: 5-10 cm`
  * `h: 15-20 in` or `h: 15-20 cm`

#### Example 3
* Values
  * minimum width `5`
  * minimum height `15`
* Label
  * `w: from 5 in` or `w: from 5 cm`
  * `h: from 15 in` or `h: from 15 cm`

#### Example 4
* Values
  * maximum width `5`
  * maximum height `15`
* Label
  * `w: to 5 in` or `w: to 5 cm`
  * `h: to 15 in` or `h: to 15 cm`

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/134199053-8fb78eb6-692e-4136-8875-eea2430a6098.mp4

#### Android
https://user-images.githubusercontent.com/3513494/134201340-07c7c207-aa87-481c-8f4c-da3fa3e1e556.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Update the display of size filter labels for saved search M2 - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3325]: https://artsyproduct.atlassian.net/browse/FX-3325