### PR TITLE
feat(FX-3326): select artworks pill when search button is clicked

### DIFF
--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -38,11 +38,12 @@ interface SearchInputProps {
   placeholder: string
   currentRefinement: string
   refine: (value: string) => any
+  onSubmitEditing: () => void
 }
 
 const SEARCH_THROTTLE_INTERVAL = 500
 
-const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholder, refine }) => {
+const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholder, refine, onSubmitEditing }) => {
   const { trackEvent } = useTracking()
   const searchProviderValues = useSearchProviderValues(currentRefinement)
 
@@ -64,6 +65,7 @@ const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholde
       enableCancelButton
       placeholder={placeholder}
       onChangeText={handleChangeText}
+      onSubmitEditing={onSubmitEditing}
       onFocus={() => {
         trackEvent({
           action_type: Schema.ActionNames.ARAnalyticsSearchStartedQuery,
@@ -88,7 +90,8 @@ interface SearchState {
   page?: number
 }
 
-const pills: PillType[] = [{ name: "ARTWORK", displayName: "Artworks" }]
+const ARTWORKS_PILL: PillType = { name: "ARTWORK", displayName: "Artworks" }
+const pills: PillType[] = [ARTWORKS_PILL]
 
 interface Search2Props {
   relay: RelayRefetchProp
@@ -152,6 +155,16 @@ export const Search2: React.FC<Search2Props> = (props) => {
     return selectedAlgoliaIndex === name || elasticSearchEntity === name
   }
 
+  const handleSubmitEditing = () => {
+    if (shouldStartQuering) {
+      const { displayName, name } = ARTWORKS_PILL
+
+      setSelectedAlgoliaIndex("")
+      setActivePillDisplayName(displayName)
+      setElasticSearchEntity(name)
+    }
+  }
+
   return (
     <SearchContext.Provider value={searchProviderValues}>
       <ArtsyKeyboardAvoidingView>
@@ -164,7 +177,10 @@ export const Search2: React.FC<Search2Props> = (props) => {
           <Configure clickAnalytics />
           <RefetchWhenApiKeyExpiredContainer relay={relay} />
           <Flex p={2} pb={1}>
-            <SearchInputContainer placeholder="Search artists, artworks, galleries, etc" />
+            <SearchInputContainer
+              placeholder="Search artists, artworks, galleries, etc"
+              onSubmitEditing={handleSubmitEditing}
+            />
           </Flex>
           {!!shouldStartQuering ? (
             <>

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -100,4 +100,23 @@ describe("Search2 Screen", () => {
     fireEvent(searchInput, "focus")
     expect(queryByText("Cancel")).toBeTruthy()
   })
+
+  it("selects artworks pill only when the user has typed the minimum allowed number of characters", () => {
+    const { queryByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+    fireEvent(searchInput, "submitEditing")
+
+    expect(queryByA11yState({ selected: true })).toBeFalsy()
+  })
+
+  it("selects artworks pill when the search input is submitted", () => {
+    const { getByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+    fireEvent.changeText(searchInput, "text")
+    fireEvent(searchInput, "submitEditing")
+
+    expect(getByA11yState({ selected: true })).toHaveTextContent("Artworks")
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3326]

### Description
When the user clicks on the "search" button, we need to make the artwork tablet active and show the search results for this pill

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/134339894-0ef07bf3-5af4-4f04-87c4-3a9fb430e86e.mp4

#### Android
https://user-images.githubusercontent.com/3513494/134340822-1fdd46d8-8e02-406f-bdb4-0dc7ef22b180.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Select artworks pill when search button is clicked - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3326]: https://artsyproduct.atlassian.net/browse/FX-3326