### PR TITLE
feat(FX-3327, FX-3330): Keep selected pill as one entity, Reset the state of the search pills

### DIFF
--- a/src/lib/Components/Input/Input.tsx
+++ b/src/lib/Components/Input/Input.tsx
@@ -283,6 +283,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
                       localClear()
                     }}
                     hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
+                    accessibilityLabel="Clear input button"
                   >
                     <XCircleIcon fill="black30" />
                   </TouchableOpacity>

--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -6,10 +6,11 @@ import { Input, InputProps } from "./Input/Input"
 
 interface SearchInputProps extends InputProps {
   enableCancelButton?: boolean
+  onCancelPress?: () => void
 }
 
 export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
-  ({ enableCancelButton, onChangeText, onClear, ...props }, ref) => {
+  ({ enableCancelButton, onChangeText, onClear, onCancelPress, ...props }, ref) => {
     const [inputFocused, setInputFocused] = useState(false)
 
     return (
@@ -45,6 +46,7 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
                 onPress={() => {
                   ;(ref as RefObject<TextInput>).current?.blur()
                   ;(ref as RefObject<TextInput>).current?.clear()
+                  onCancelPress?.()
                 }}
                 hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
               >

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -57,6 +57,10 @@ const SearchInput: React.FC<SearchInputProps> = ({
   const handleChangeText = useMemo(() => throttle(refine, SEARCH_THROTTLE_INTERVAL), [])
 
   const handleReset = () => {
+    trackEvent({
+      action_type: Schema.ActionNames.ARAnalyticsSearchCleared,
+    })
+
     refine("")
     handleChangeText.cancel()
     onReset()
@@ -68,15 +72,15 @@ const SearchInput: React.FC<SearchInputProps> = ({
       enableCancelButton
       placeholder={placeholder}
       onChangeText={(text) => {
-        trackEvent({
-          action_type: Schema.ActionNames.ARAnalyticsSearchStartedQuery,
-          query: text,
-        })
-
         if (text.length === 0) {
           handleReset()
           return
         }
+
+        trackEvent({
+          action_type: Schema.ActionNames.ARAnalyticsSearchStartedQuery,
+          query: text,
+        })
 
         handleChangeText(text)
       }}
@@ -87,12 +91,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
           currentRefinement,
         })
       }}
-      onClear={() => {
-        trackEvent({
-          action_type: Schema.ActionNames.ARAnalyticsSearchCleared,
-        })
-        handleReset()
-      }}
+      onClear={handleReset}
       onCancelPress={handleReset}
     />
   )

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -192,7 +192,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
       <ArtsyKeyboardAvoidingView>
         <InstantSearch
           searchClient={searchClient}
-          indexName={selectedPill?.name ?? ""}
+          indexName={selectedPill?.type === "algolia" ? selectedPill.name : ""}
           searchState={searchState}
           onSearchStateChange={setSearchState}
         >

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -39,11 +39,18 @@ interface SearchInputProps {
   currentRefinement: string
   refine: (value: string) => any
   onSubmitEditing: () => void
+  onReset: () => void
 }
 
 const SEARCH_THROTTLE_INTERVAL = 500
 
-const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholder, refine, onSubmitEditing }) => {
+const SearchInput: React.FC<SearchInputProps> = ({
+  currentRefinement,
+  placeholder,
+  refine,
+  onSubmitEditing,
+  onReset,
+}) => {
   const { trackEvent } = useTracking()
   const searchProviderValues = useSearchProviderValues(currentRefinement)
 
@@ -55,6 +62,10 @@ const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholde
           action_type: Schema.ActionNames.ARAnalyticsSearchStartedQuery,
           query: queryText,
         })
+
+        if (queryText.length === 0) {
+          onReset()
+        }
       }, SEARCH_THROTTLE_INTERVAL),
     []
   )
@@ -76,6 +87,10 @@ const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholde
         trackEvent({
           action_type: Schema.ActionNames.ARAnalyticsSearchCleared,
         })
+        onReset()
+      }}
+      onCancelPress={() => {
+        handleChangeText("")
       }}
     />
   )
@@ -166,6 +181,10 @@ export const Search2: React.FC<Search2Props> = (props) => {
     }
   }
 
+  const handleResetSearchInput = () => {
+    setSelectedPill(null)
+  }
+
   return (
     <SearchContext.Provider value={searchProviderValues}>
       <ArtsyKeyboardAvoidingView>
@@ -181,6 +200,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
             <SearchInputContainer
               placeholder="Search artists, artworks, galleries, etc"
               onSubmitEditing={handleSubmitEditing}
+              onReset={handleResetSearchInput}
             />
           </Flex>
           {!!shouldStartQuering ? (

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -23,7 +23,10 @@ const banksy: RecentSearch = {
 jest.unmock("react-relay")
 jest.mock("lodash", () => ({
   ...jest.requireActual("lodash"),
-  throttle: jest.fn((fn) => fn),
+  throttle: jest.fn((fn) => {
+    fn.cancel = jest.fn()
+    return fn
+  }),
 }))
 jest.mock("lib/utils/hardware", () => ({
   isPad: jest.fn(),

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -21,13 +21,6 @@ const banksy: RecentSearch = {
 }
 
 jest.unmock("react-relay")
-jest.mock("lodash", () => ({
-  ...jest.requireActual("lodash"),
-  throttle: jest.fn((fn) => {
-    fn.cancel = jest.fn()
-    return fn
-  }),
-}))
 jest.mock("lib/utils/hardware", () => ({
   isPad: jest.fn(),
 }))
@@ -147,7 +140,7 @@ describe("Search2 Screen", () => {
       })
     })
 
-    it("returns", () => {
+    it("when search query is empty", () => {
       const { queryByA11yState, getByPlaceholderText, getByText } = tree
       const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
 

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from "@testing-library/react-native"
+import { fireEvent, RenderAPI, waitFor } from "@testing-library/react-native"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { RecentSearch } from "lib/Scenes/Search/SearchModel"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -21,6 +21,10 @@ const banksy: RecentSearch = {
 }
 
 jest.unmock("react-relay")
+jest.mock("lodash", () => ({
+  ...jest.requireActual("lodash"),
+  throttle: jest.fn((fn) => fn),
+}))
 jest.mock("lib/utils/hardware", () => ({
   isPad: jest.fn(),
 }))
@@ -118,5 +122,63 @@ describe("Search2 Screen", () => {
     fireEvent(searchInput, "submitEditing")
 
     expect(getByA11yState({ selected: true })).toHaveTextContent("Artworks")
+  })
+
+  describe("Reset the state of the pills", () => {
+    let tree: RenderAPI
+
+    beforeEach(() => {
+      tree = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        Algolia: () => ({
+          appID: "",
+          apiKey: "",
+          indices: [
+            {
+              name: "Artist_staging",
+              displayName: "Artists",
+            },
+          ],
+        }),
+      })
+    })
+
+    it("returns", () => {
+      const { queryByA11yState, getByPlaceholderText, getByText } = tree
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+      fireEvent(searchInput, "changeText", "prev value")
+      fireEvent(getByText("Artists"), "press")
+      fireEvent(searchInput, "changeText", "")
+      fireEvent(searchInput, "changeText", "new value")
+
+      expect(queryByA11yState({ selected: true })).toBeFalsy()
+    })
+
+    it("when clear button is pressed", () => {
+      const { queryByA11yState, getByPlaceholderText, getByText, getByA11yLabel } = tree
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+      fireEvent(searchInput, "changeText", "prev value")
+      fireEvent(getByText("Artists"), "press")
+      fireEvent(getByA11yLabel("Clear input button"), "press")
+      fireEvent(searchInput, "changeText", "new value")
+
+      expect(queryByA11yState({ selected: true })).toBeFalsy()
+    })
+
+    it("when cancel button is pressed", () => {
+      const { queryByA11yState, getByPlaceholderText, getByText } = tree
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+      fireEvent(searchInput, "changeText", "prev value")
+      fireEvent(getByText("Artists"), "press")
+      fireEvent(searchInput, "focus")
+      fireEvent(getByText("Cancel"), "press")
+      fireEvent(searchInput, "changeText", "new value")
+
+      expect(queryByA11yState({ selected: true })).toBeFalsy()
+    })
   })
 })

--- a/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
@@ -1,5 +1,4 @@
 import { fireEvent } from "@testing-library/react-native"
-import { extractText } from "lib/tests/extractText"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { SearchPills, SearchPillsProps } from "../components/SearchPills"
@@ -9,14 +8,17 @@ const pills: PillType[] = [
   {
     name: "first",
     displayName: "First",
+    type: "algolia",
   },
   {
     name: "second",
     displayName: "Second",
+    type: "algolia",
   },
   {
     name: "third",
     displayName: "Third",
+    type: "algolia",
   },
 ]
 
@@ -40,6 +42,7 @@ describe("SearchPills", () => {
     fireEvent.press(getByText("Second"))
 
     expect(onPillPressMock).toBeCalledWith({
+      type: "algolia",
       name: "second",
       displayName: "Second",
     })
@@ -49,6 +52,6 @@ describe("SearchPills", () => {
     const isSelected = (pill: PillType) => pill.name === "second"
     const { getByA11yState } = renderWithWrappersTL(<TestRenderer isSelected={isSelected} />)
 
-    expect(extractText(getByA11yState({ selected: true }))).toBe("Second")
+    expect(getByA11yState({ selected: true })).toHaveTextContent("Second")
   })
 })

--- a/src/lib/Scenes/Search2/types.ts
+++ b/src/lib/Scenes/Search2/types.ts
@@ -8,7 +8,10 @@ export interface AlgoliaSearchResult {
   __queryID: string
 }
 
+export type PillEntityType = "algolia" | "elastic"
+
 export interface PillType {
   name: string
   displayName: string
+  type: PillEntityType
 }

--- a/src/lib/utils/useAlgoliaClient.ts
+++ b/src/lib/utils/useAlgoliaClient.ts
@@ -12,8 +12,9 @@ export const useAlgoliaClient = (appID: string, apiKey: string, options?: Algoli
       // @ts-ignore
       search(requests) {
         const isEmptyIndexName = requests.every((request) => request.indexName.length === 0)
+        const isEmptyQueryName = requests.every((request) => request.params?.query?.length === 0)
 
-        if (isEmptyIndexName) {
+        if (isEmptyIndexName || isEmptyQueryName) {
           return Promise.resolve({
             results: requests.map(() => ({
               hits: [],


### PR DESCRIPTION
The type of this PR is: **Refactor**, **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3327], [FX-3330]


### Description
* As a user when I 
  * delete my search term 
  * press `x` input button 
  * press `cancel` button
* I want to be able to start a search from scratch without any pill selected. 

### Selected pill shape
```javascript
{
  type: "elastic" | "algolia",
  displayName: string,
  name: string
}
```


### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/134516874-340a67b2-7b45-4363-970e-50b4b29e42c8.mp4

#### Android
https://user-images.githubusercontent.com/3513494/134525365-85ad5e1a-8c57-4c76-b118-bd0e73654fc5.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Reset the state of the pills when the search query is cleared/empty - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Keep selected search pill as one entity - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3327]: https://artsyproduct.atlassian.net/browse/FX-3327

[FX-3330]: https://artsyproduct.atlassian.net/browse/FX-3330