### PR TITLE
fix: rename prop for button animated text

### DIFF
--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -156,7 +156,7 @@ export const Button: React.FC<ButtonProps> = ({
                 <VisibleTextContainer>
                   {iconPosition === "left" && iconBox}
                   <AnimatedText
-                    size={size === "small" ? "xs" : "sm"}
+                    variant={size === "small" ? "xs" : "sm"}
                     style={{ color: springProps.textColor, textDecorationLine: springProps.textDecorationLine }}
                   >
                     {children}


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1974]

### Description

We renamed text props from size -> variant as part of paletteV3 migration, missed one spot in Button component which was leading to the issues we were seeing. 

## Screen shots 

<details><summary>Before</summary>

![text-cutoff-before](https://user-images.githubusercontent.com/49686530/134718402-dbfa4726-0065-4589-a16d-91d98e395559.png)

</details>

<details>
<summary>After</summary>

![text-cutoff-after](https://user-images.githubusercontent.com/49686530/134718411-a15ee689-9d5d-4366-a73d-873ebc563fcc.png)


</details>




### PR Checklist (tick all before merging)

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix text cutoff in small buttons - brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1974]: https://artsyproduct.atlassian.net/browse/CX-1974