### PR TITLE
fix: give my collection auction results some space #trivial

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults.tsx
@@ -51,10 +51,14 @@ const MyCollectionArtworkArtistAuctionResults: React.FC<MyCollectionArtworkArtis
           data={auctionResults}
           keyExtractor={(item) => item.id}
           renderItem={({ item }) => (
-            <AuctionResultFragmentContainer
-              auctionResult={item}
-              onPress={() => navigate(`/artist/${props?.artwork?.artist?.slug!}/auction-result/${item.internalID}`)}
-            />
+            <>
+              <Spacer mt="1" />
+              <AuctionResultFragmentContainer
+                auctionResult={item}
+                onPress={() => navigate(`/artist/${props?.artwork?.artist?.slug!}/auction-result/${item.internalID}`)}
+              />
+              <Spacer mb="1" />
+            </>
           )}
           ListHeaderComponent={() => (
             <Flex px={2}>


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-1975]

### Description

Adds a top and bottom spacer to auction results in My Collection. 


## Screenshots

<details><summary>Before</summary>

![auction-result-spacing-before](https://user-images.githubusercontent.com/49686530/134721423-764e5782-a0ad-426b-9694-e97857f58d0f.png)

</details>

<details><summary>After</summary>

![auction-result-spacing-after](https://user-images.githubusercontent.com/49686530/134721432-2e223346-5de3-4c17-9e16-492a8265adf2.png)

</details>

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix spacing in my collection auction results - Brian

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-1975]: https://artsyproduct.atlassian.net/browse/CX-1975