### PR TITLE
fix(PURCHASE-2833): overlapping text on lot statuses

### DIFF
--- a/src/lib/Scenes/MyBids/Components/ActiveLotStanding.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLotStanding.tsx
@@ -44,8 +44,8 @@ export const ActiveLotStanding = ({ saleArtwork }: { saleArtwork: ActiveLotStand
       <TouchableOpacity onPress={() => handleLotTap()} style={{ marginHorizontal: 0, width: "100%" }}>
         <Flex flexDirection="row" justifyContent="space-between">
           <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen} />
-          <Flex flexDirection="column">
-            <Flex flexDirection="row" justifyContent="flex-end">
+          <Flex>
+            <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
               <Text variant="xs" color="black60">
                 {" "}

--- a/src/lib/Scenes/MyBids/Components/ActiveLotStanding.tsx
+++ b/src/lib/Scenes/MyBids/Components/ActiveLotStanding.tsx
@@ -42,26 +42,29 @@ export const ActiveLotStanding = ({ saleArtwork }: { saleArtwork: ActiveLotStand
   return (
     saleArtwork && (
       <TouchableOpacity onPress={() => handleLotTap()} style={{ marginHorizontal: 0, width: "100%" }}>
-        <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen}>
-          <Flex flexDirection="row" justifyContent="flex-end">
-            <Text variant="xs">{sellingPrice}</Text>
-            <Text variant="xs" color="black60">
-              {" "}
-              {displayBidCount()}
-            </Text>
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen} />
+          <Flex flexDirection="column">
+            <Flex flexDirection="row" justifyContent="flex-end">
+              <Text variant="xs">{sellingPrice}</Text>
+              <Text variant="xs" color="black60">
+                {" "}
+                {displayBidCount()}
+              </Text>
+            </Flex>
+            <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
+              {!timelySale.isLAI &&
+              saleArtwork?.isHighestBidder &&
+              saleArtwork?.lotState?.reserveStatus === "ReserveNotMet" ? (
+                <ReserveNotMet />
+              ) : saleArtwork?.isHighestBidder ? (
+                <HighestBid />
+              ) : (
+                <Outbid />
+              )}
+            </Flex>
           </Flex>
-          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-            {!timelySale.isLAI &&
-            saleArtwork?.isHighestBidder &&
-            saleArtwork?.lotState?.reserveStatus === "ReserveNotMet" ? (
-              <ReserveNotMet />
-            ) : saleArtwork?.isHighestBidder ? (
-              <HighestBid />
-            ) : (
-              <Outbid />
-            )}
-          </Flex>
-        </Lot>
+        </Flex>
       </TouchableOpacity>
     )
   )

--- a/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
@@ -68,10 +68,10 @@ export const ClosedLotStanding = ({
       <Flex flexDirection="row" justifyContent="space-between">
         <Lot saleArtwork={saleArtwork!} subtitle={subtitle} ArtworkBadge={Badge} />
         <Flex flexDirection="column">
-          <Flex flexDirection="row">
+          <Flex flexDirection="row" justifyContent="flex-end">
             <Text variant="xs">{sellingPrice}</Text>
           </Flex>
-          <Flex flexDirection="row" alignItems="center">
+          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
             <Result />
           </Flex>
         </Flex>

--- a/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
@@ -67,8 +67,8 @@ export const ClosedLotStanding = ({
     <TouchableOpacity onPress={() => handleLotTap()} style={{ marginHorizontal: 0, width: "100%" }}>
       <Flex flexDirection="row" justifyContent="space-between">
         <Lot saleArtwork={saleArtwork!} subtitle={subtitle} ArtworkBadge={Badge} />
-        <Flex flexDirection="column">
-          <Flex flexDirection="row" justifyContent="flex-end">
+        <Flex>
+          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
             <Text variant="xs">{sellingPrice}</Text>
           </Flex>
           <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">

--- a/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
+++ b/src/lib/Scenes/MyBids/Components/ClosedLotStanding.tsx
@@ -65,14 +65,17 @@ export const ClosedLotStanding = ({
 
   return (
     <TouchableOpacity onPress={() => handleLotTap()} style={{ marginHorizontal: 0, width: "100%" }}>
-      <Lot saleArtwork={saleArtwork!} subtitle={subtitle} ArtworkBadge={Badge}>
-        <Flex flexDirection="row">
-          <Text variant="xs">{sellingPrice}</Text>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Lot saleArtwork={saleArtwork!} subtitle={subtitle} ArtworkBadge={Badge} />
+        <Flex flexDirection="column">
+          <Flex flexDirection="row">
+            <Text variant="xs">{sellingPrice}</Text>
+          </Flex>
+          <Flex flexDirection="row" alignItems="center">
+            <Result />
+          </Flex>
         </Flex>
-        <Flex flexDirection="row" alignItems="center">
-          <Result />
-        </Flex>
-      </Lot>
+      </Flex>
     </TouchableOpacity>
   )
 }

--- a/src/lib/Scenes/MyBids/Components/Lot.tsx
+++ b/src/lib/Scenes/MyBids/Components/Lot.tsx
@@ -18,34 +18,28 @@ class Lot extends React.Component<Props> {
     const { saleArtwork, subtitle, children, ArtworkBadge, isSmallScreen } = this.props
 
     return (
-      <Flex flexDirection="row">
-        <Flex width="50%">
-          <Flex flexDirection="row">
-            <Flex mr={isSmallScreen! ? 0.5 : 1}>
-              <OpaqueImageView
-                width={50}
-                height={50}
-                style={{ borderRadius: 2, overflow: "hidden" }}
-                imageURL={saleArtwork?.artwork?.image?.url}
-              />
-              {!!ArtworkBadge && (
-                <Box position="absolute" top={-2} left={-5}>
-                  {<ArtworkBadge />}
-                </Box>
-              )}
-            </Flex>
-
-            <Flex alignItems="baseline">
-              <Text variant="xs" numberOfLines={2}>
-                {saleArtwork?.artwork?.artistNames}
-              </Text>
-              <Text variant="xs" color="black60" numberOfLines={1}>
-                {subtitle ? subtitle : !!saleArtwork.lotLabel && `Lot ${saleArtwork.lotLabel}`}
-              </Text>
-            </Flex>
-          </Flex>
+      <Flex flexDirection="row" width="50%" paddingRight={2}>
+        <Flex mr={isSmallScreen! ? 0.5 : 1}>
+          <OpaqueImageView
+            width={50}
+            height={50}
+            style={{ borderRadius: 2, overflow: "hidden" }}
+            imageURL={saleArtwork?.artwork?.image?.url}
+          />
+          {!!ArtworkBadge && (
+            <Box position="absolute" top={-2} left={-5}>
+              {<ArtworkBadge />}
+            </Box>
+          )}
         </Flex>
-
+        <Flex alignItems="baseline">
+          <Text variant="xs" numberOfLines={2}>
+            {saleArtwork?.artwork?.artistNames}
+          </Text>
+          <Text variant="xs" color="black60" numberOfLines={1}>
+            {subtitle ? subtitle : !!saleArtwork.lotLabel && `Lot ${saleArtwork.lotLabel}`}
+          </Text>
+        </Flex>
         <Flex width="50%" alignItems="flex-end">
           {children}
         </Flex>

--- a/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
@@ -43,20 +43,23 @@ export const WatchedLot: React.FC<WatchedLotProps> = ({ saleArtwork }) => {
 
   return (
     <TouchableOpacity style={{ marginHorizontal: 0, width: "100%" }} onPress={handleLotTap}>
-      <Lot saleArtwork={saleArtwork!} isSmallScreen={isSmallScreen}>
-        <Flex flexDirection="row" justifyContent="flex-end">
-          <Text variant="xs">{sellingPrice}</Text>
-          {!!bidCount && (
-            <Text variant="xs" color="black60">
-              {" "}
-              {displayBidCount()}
-            </Text>
-          )}
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Lot saleArtwork={saleArtwork!} isSmallScreen={isSmallScreen} />
+        <Flex flexDirection="column">
+          <Flex flexDirection="row" justifyContent="flex-end">
+            <Text variant="xs">{sellingPrice}</Text>
+            {!!bidCount && (
+              <Text variant="xs" color="black60">
+                {" "}
+                {displayBidCount()}
+              </Text>
+            )}
+          </Flex>
+          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
+            <Watching />
+          </Flex>
         </Flex>
-        <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-          <Watching />
-        </Flex>
-      </Lot>
+      </Flex>
     </TouchableOpacity>
   )
 }

--- a/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
+++ b/src/lib/Scenes/MyBids/Components/WatchedLot.tsx
@@ -45,8 +45,8 @@ export const WatchedLot: React.FC<WatchedLotProps> = ({ saleArtwork }) => {
     <TouchableOpacity style={{ marginHorizontal: 0, width: "100%" }} onPress={handleLotTap}>
       <Flex flexDirection="row" justifyContent="space-between">
         <Lot saleArtwork={saleArtwork!} isSmallScreen={isSmallScreen} />
-        <Flex flexDirection="column">
-          <Flex flexDirection="row" justifyContent="flex-end">
+        <Flex>
+          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
             <Text variant="xs">{sellingPrice}</Text>
             {!!bidCount && (
               <Text variant="xs" color="black60">

--- a/src/lib/Scenes/Sale/Components/SaleActiveBidItem.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleActiveBidItem.tsx
@@ -27,8 +27,8 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
       >
         <Flex flexDirection="row" justifyContent="space-between">
           <LotFragmentContainer saleArtwork={saleArtwork} />
-          <Flex flexDirection="column">
-            <Flex flexDirection="row" justifyContent="flex-end">
+          <Flex>
+            <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
               <Text variant="xs" color="black60">
                 {" "}

--- a/src/lib/Scenes/Sale/Components/SaleActiveBidItem.tsx
+++ b/src/lib/Scenes/Sale/Components/SaleActiveBidItem.tsx
@@ -25,26 +25,29 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
       <TouchableOpacity
         onPress={() => lotStanding?.saleArtwork?.artwork?.href && navigate(lotStanding.saleArtwork.artwork.href)}
       >
-        <LotFragmentContainer saleArtwork={saleArtwork}>
-          <Flex flexDirection="row">
-            <Text variant="xs">{sellingPrice}</Text>
-            <Text variant="xs" color="black60">
-              {" "}
-              ({bidCount} {bidCount === 1 ? "bid" : "bids"})
-            </Text>
+        <Flex flexDirection="row" justifyContent="space-between">
+          <LotFragmentContainer saleArtwork={saleArtwork} />
+          <Flex flexDirection="column">
+            <Flex flexDirection="row" justifyContent="flex-end">
+              <Text variant="xs">{sellingPrice}</Text>
+              <Text variant="xs" color="black60">
+                {" "}
+                ({bidCount} {bidCount === 1 ? "bid" : "bids"})
+              </Text>
+            </Flex>
+            <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
+              {!isLAI &&
+              lotStanding?.activeBid?.isWinning &&
+              lotStanding?.saleArtwork?.reserveStatus === "ReserveNotMet" ? (
+                <ReserveNotMet />
+              ) : lotStanding?.activeBid?.isWinning ? (
+                <HighestBid />
+              ) : (
+                <Outbid />
+              )}
+            </Flex>
           </Flex>
-          <Flex flexDirection="row" alignItems="center">
-            {!isLAI &&
-            lotStanding?.activeBid?.isWinning &&
-            lotStanding?.saleArtwork?.reserveStatus === "ReserveNotMet" ? (
-              <ReserveNotMet />
-            ) : lotStanding?.activeBid?.isWinning ? (
-              <HighestBid />
-            ) : (
-              <Outbid />
-            )}
-          </Flex>
-        </LotFragmentContainer>
+        </Flex>
       </TouchableOpacity>
     )
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2833]

### Description

This PR resolves the overlapping artist and bid price text on the lot statuses when the artist name and/or bid price is too long. 

**New behaviour**: If the artist name is very long, it will move to the next line, and if it exceeds the second line it will ellipsis. I did this by refactoring the flexboxes. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Lot status text no longer overlaps when text is too long -rquartararo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

#### Screenshots Before
<img width="315" alt="Bug5155676_Screenshot_2021-07-17_at_2 47 53_PM" src="https://user-images.githubusercontent.com/50849237/134893313-5cb18f59-6467-4cdb-aeec-3ef8b609751e.png">

#### Screenshots After
![Simulator Screen Shot - iPhone 12 mini - 2021-09-27 at 11 54 21](https://user-images.githubusercontent.com/50849237/134892474-ca22aff6-05ff-47ea-be45-2f1293850d7c.png)

![Simulator Screen Shot - iPhone 12 mini - 2021-09-27 at 11 54 32](https://user-images.githubusercontent.com/50849237/134892487-eb79d5dd-8d25-4e61-b442-17de3ab01bb7.png)




[PURCHASE-2833]: https://artsyproduct.atlassian.net/browse/PURCHASE-2833