### PR TITLE
feat(FX-3335): prevent pill untoggle

### DIFF
--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -110,7 +110,7 @@ interface SearchState {
 const TOP_PILL: PillType = {
   name: "TOP",
   displayName: "Top",
-  type: "global",
+  type: "elastic",
 }
 const ARTWORKS_PILL: PillType = {
   name: "ARTWORK",
@@ -159,10 +159,10 @@ export const Search2: React.FC<Search2Props> = (props) => {
     if (selectedPill.type === "algolia") {
       return <SearchResultsContainer indexName={selectedPill.name} categoryDisplayName={selectedPill.displayName} />
     }
-    if (selectedPill.type === "elastic") {
-      return <SearchArtworksQueryRenderer keyword={searchState.query!} />
+    if (selectedPill.name === TOP_PILL.name) {
+      return <AutosuggestResults query={searchState.query!} />
     }
-    return <AutosuggestResults query={searchState.query!} />
+    return <SearchArtworksQueryRenderer keyword={searchState.query!} />
   }
 
   const shouldStartQuering = !!searchState?.query?.length && searchState?.query.length >= 1

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -162,14 +162,8 @@ export const Search2: React.FC<Search2Props> = (props) => {
   const shouldStartQuering = !!searchState?.query?.length && searchState?.query.length >= 1
 
   const handlePillPress = (pill: PillType) => {
-    let nextSelectedPill: PillType | null = pill
-
-    if (selectedPill?.name === pill.name) {
-      nextSelectedPill = null
-    }
-
     setSearchState((prevState) => ({ ...prevState, page: 1 }))
-    setSelectedPill(nextSelectedPill)
+    setSelectedPill(pill)
   }
 
   const isSelected = (pill: PillType) => {

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -107,12 +107,17 @@ interface SearchState {
   page?: number
 }
 
+const TOP_PILL: PillType = {
+  name: "TOP",
+  displayName: "Top",
+  type: "global",
+}
 const ARTWORKS_PILL: PillType = {
   name: "ARTWORK",
   displayName: "Artworks",
   type: "elastic",
 }
-const pills: PillType[] = [ARTWORKS_PILL]
+const pills: PillType[] = [TOP_PILL, ARTWORKS_PILL]
 
 interface Search2Props {
   relay: RelayRefetchProp
@@ -122,7 +127,7 @@ interface Search2Props {
 export const Search2: React.FC<Search2Props> = (props) => {
   const { system, relay } = props
   const [searchState, setSearchState] = useState<SearchState>({})
-  const [selectedPill, setSelectedPill] = useState<PillType | null>(null)
+  const [selectedPill, setSelectedPill] = useState<PillType>(TOP_PILL)
   const searchProviderValues = useSearchProviderValues(searchState?.query ?? "")
   const { searchClient } = useAlgoliaClient(system?.algolia?.appID!, system?.algolia?.apiKey!)
   const searchInsightsConfigured = useSearchInsightsConfig(system?.algolia?.appID, system?.algolia?.apiKey)
@@ -151,10 +156,10 @@ export const Search2: React.FC<Search2Props> = (props) => {
   }
 
   const renderResults = () => {
-    if (selectedPill?.type === "algolia") {
+    if (selectedPill.type === "algolia") {
       return <SearchResultsContainer indexName={selectedPill.name} categoryDisplayName={selectedPill.displayName} />
     }
-    if (selectedPill?.type === "elastic") {
+    if (selectedPill.type === "elastic") {
       return <SearchArtworksQueryRenderer keyword={searchState.query!} />
     }
     return <AutosuggestResults query={searchState.query!} />
@@ -168,7 +173,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
   }
 
   const isSelected = (pill: PillType) => {
-    return selectedPill?.name === pill.name
+    return selectedPill.name === pill.name
   }
 
   const handleSubmitEditing = () => {
@@ -178,7 +183,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
   }
 
   const handleResetSearchInput = () => {
-    setSelectedPill(null)
+    setSelectedPill(TOP_PILL)
   }
 
   return (
@@ -186,7 +191,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
       <ArtsyKeyboardAvoidingView>
         <InstantSearch
           searchClient={searchClient}
-          indexName={selectedPill?.type === "algolia" ? selectedPill.name : ""}
+          indexName={selectedPill.type === "algolia" ? selectedPill.name : ""}
           searchState={searchState}
           onSearchStateChange={setSearchState}
         >

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -178,7 +178,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
 
   const handleSubmitEditing = () => {
     if (shouldStartQuering) {
-      setSelectedPill(ARTWORKS_PILL)
+      setSelectedPill(TOP_PILL)
     }
   }
 

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -83,6 +83,7 @@ const SearchInput: React.FC<SearchInputProps> = ({
         })
 
         handleChangeText(text)
+        onReset()
       }}
       onSubmitEditing={onSubmitEditing}
       onFocus={() => {

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -120,6 +120,15 @@ describe("Search2 Screen", () => {
     expect(getByA11yState({ selected: true })).toHaveTextContent("Artworks")
   })
 
+  it('The "Top" pill should be selected by default', () => {
+    const { getByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+    fireEvent.changeText(searchInput, "text")
+
+    expect(getByA11yState({ selected: true })).toHaveTextContent("Top")
+  })
+
   it("should not be able to untoggle the same pill", () => {
     const { getByPlaceholderText, getByText, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
     const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -180,6 +180,17 @@ describe("Search2 Screen", () => {
       expect(queryByA11yState({ selected: true })).toBeFalsy()
     })
 
+    it("when the query is changed", () => {
+      const { queryByA11yState, getByPlaceholderText, getByText } = tree
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+      fireEvent(searchInput, "changeText", "12")
+      fireEvent(getByText("Artists"), "press")
+      fireEvent(searchInput, "changeText", "123")
+
+      expect(queryByA11yState({ selected: true })).toBeFalsy()
+    })
+
     it("when clear button is pressed", () => {
       const { queryByA11yState, getByPlaceholderText, getByText, getByA11yLabel } = tree
       const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -120,6 +120,34 @@ describe("Search2 Screen", () => {
     expect(getByA11yState({ selected: true })).toHaveTextContent("Artworks")
   })
 
+  it("should not be able to untoggle the same pill", () => {
+    const { getByPlaceholderText, getByText, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
+    const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Algolia: () => ({
+        appID: "",
+        apiKey: "",
+        indices: [
+          {
+            name: "Artist_staging",
+            displayName: "Artists",
+          },
+          {
+            name: "Gallery_staging",
+            displayName: "Gallery",
+          },
+        ],
+      }),
+    })
+
+    fireEvent(searchInput, "changeText", "prev value")
+    fireEvent(getByText("Artists"), "press")
+    fireEvent(getByText("Artists"), "press")
+
+    expect(getByA11yState({ selected: true })).toHaveTextContent("Artists")
+  })
+
   describe("Reset the state of the pills", () => {
     let tree: RenderAPI
 

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -152,7 +152,6 @@ describe("Search2 Screen", () => {
 
     fireEvent(searchInput, "changeText", "prev value")
     fireEvent(getByText("Artists"), "press")
-    fireEvent(getByText("Artists"), "press")
 
     expect(getByA11yState({ selected: true })).toHaveTextContent("Artists")
   })

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -110,17 +110,17 @@ describe("Search2 Screen", () => {
     expect(queryByA11yState({ selected: true })).toBeFalsy()
   })
 
-  it("selects artworks pill when the search input is submitted", () => {
+  it("selects the top pill when the search input is submitted", () => {
     const { getByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
     const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
 
     fireEvent.changeText(searchInput, "text")
     fireEvent(searchInput, "submitEditing")
 
-    expect(getByA11yState({ selected: true })).toHaveTextContent("Artworks")
+    expect(getByA11yState({ selected: true })).toHaveTextContent("Top")
   })
 
-  it('The "Top" pill should be selected by default', () => {
+  it('the "Top" pill should be selected by default', () => {
     const { getByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
     const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
 
@@ -157,7 +157,7 @@ describe("Search2 Screen", () => {
     expect(getByA11yState({ selected: true })).toHaveTextContent("Artists")
   })
 
-  describe("Reset the state of the pills", () => {
+  describe("the top pill is selected by default", () => {
     let tree: RenderAPI
 
     beforeEach(() => {
@@ -186,7 +186,7 @@ describe("Search2 Screen", () => {
       fireEvent(searchInput, "changeText", "")
       fireEvent(searchInput, "changeText", "new value")
 
-      expect(queryByA11yState({ selected: true })).toBeFalsy()
+      expect(queryByA11yState({ selected: true })).toHaveTextContent("Top")
     })
 
     it("when the query is changed", () => {
@@ -197,7 +197,7 @@ describe("Search2 Screen", () => {
       fireEvent(getByText("Artists"), "press")
       fireEvent(searchInput, "changeText", "123")
 
-      expect(queryByA11yState({ selected: true })).toBeFalsy()
+      expect(queryByA11yState({ selected: true })).toHaveTextContent("Top")
     })
 
     it("when clear button is pressed", () => {
@@ -209,7 +209,7 @@ describe("Search2 Screen", () => {
       fireEvent(getByA11yLabel("Clear input button"), "press")
       fireEvent(searchInput, "changeText", "new value")
 
-      expect(queryByA11yState({ selected: true })).toBeFalsy()
+      expect(queryByA11yState({ selected: true })).toHaveTextContent("Top")
     })
 
     it("when cancel button is pressed", () => {
@@ -222,7 +222,7 @@ describe("Search2 Screen", () => {
       fireEvent(getByText("Cancel"), "press")
       fireEvent(searchInput, "changeText", "new value")
 
-      expect(queryByA11yState({ selected: true })).toBeFalsy()
+      expect(queryByA11yState({ selected: true })).toHaveTextContent("Top")
     })
   })
 })

--- a/src/lib/Scenes/Search2/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search2/components/SearchPills.tsx
@@ -33,6 +33,7 @@ export const SearchPills: React.FC<SearchPillsProps> = (props) => {
             }}
             rounded
             selected={selected}
+            disabled={selected}
             onPress={() => onPillPress(pill)}
           >
             {displayName}

--- a/src/lib/Scenes/Search2/types.ts
+++ b/src/lib/Scenes/Search2/types.ts
@@ -8,7 +8,7 @@ export interface AlgoliaSearchResult {
   __queryID: string
 }
 
-export type PillEntityType = "algolia" | "elastic" | "global"
+export type PillEntityType = "algolia" | "elastic"
 
 export interface PillType {
   name: string

--- a/src/lib/Scenes/Search2/types.ts
+++ b/src/lib/Scenes/Search2/types.ts
@@ -8,7 +8,7 @@ export interface AlgoliaSearchResult {
   __queryID: string
 }
 
-export type PillEntityType = "algolia" | "elastic"
+export type PillEntityType = "algolia" | "elastic" | "global"
 
 export interface PillType {
   name: string

--- a/src/palette/elements/Pill/Pill.stories.tsx
+++ b/src/palette/elements/Pill/Pill.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions"
 import { storiesOf } from "@storybook/react-native"
 import { CheckIcon, CloseIcon } from "palette"
 import React from "react"
@@ -35,5 +36,13 @@ storiesOf("Pill", module)
         Not Selected
       </Pill>
       <Pill rounded>Selected</Pill>
+    </List>
+  ))
+  .add("Miscellaneous", () => (
+    <List>
+      <Pill onPress={() => action("pill tapped")}>Pressable</Pill>
+      <Pill disabled onPress={() => action("pill tapped")}>
+        Pressable (disabled)
+      </Pill>
     </List>
   ))

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -35,6 +35,7 @@ interface PillProps extends FlexProps {
   imageUrl?: string
   icon?: ReactNode
   iconPosition?: "left" | "right"
+  disabled?: boolean
   onPress?: (event: GestureResponderEvent) => void
 }
 
@@ -46,6 +47,7 @@ export const Pill: React.FC<PillProps> = ({
   icon,
   iconPosition = "left",
   imageUrl,
+  disabled,
   onPress,
   ...other
 }) => {
@@ -85,7 +87,11 @@ export const Pill: React.FC<PillProps> = ({
   )
 
   if (onPress) {
-    return <TouchableOpacity onPress={onPress}>{content}</TouchableOpacity>
+    return (
+      <TouchableOpacity disabled={disabled} onPress={onPress}>
+        {content}
+      </TouchableOpacity>
+    )
   }
 
   return content

--- a/src/palette/elements/Pill/__tests__/Pill-tests.tsx
+++ b/src/palette/elements/Pill/__tests__/Pill-tests.tsx
@@ -12,4 +12,17 @@ describe("<Pill />", () => {
     fireEvent.press(getByText("wow"))
     expect(onPress).toHaveBeenCalled()
   })
+
+  it("should not be pressable if disabled is passed", () => {
+    const onPress = jest.fn()
+
+    const { getByText } = renderWithWrappersTL(
+      <Pill disabled onPress={onPress}>
+        Press me
+      </Pill>
+    )
+
+    fireEvent.press(getByText("Press me"))
+    expect(onPress).not.toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3335]

### Description
* The top pill is selected by default
* We can’t untoggle pill, we can only select another one
* We should show the multi-index search (`AutosuggestResults` component) if the query has changed by 1 character (for example, from ab to abc)
* When the user presses the `search` keyboard button, then we need to make the top pill active
* More context you can find in [Slack](https://artsy.slack.com/archives/C9SATFLUU/p1632748608053900)

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/135077960-b93d5adc-aaba-4050-a62e-14e101e262d3.mp4

#### Android
https://user-images.githubusercontent.com/3513494/135078587-688deb96-e30f-4f84-af20-1c87c7665b01.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Prevent search pill untoggle, show the multi-index view when query is changed - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3335]: https://artsyproduct.atlassian.net/browse/FX-3335