### PR TITLE
fix: correct scroll to top of search list for android

### DIFF
--- a/src/lib/Scenes/Search2/SearchResults.tsx
+++ b/src/lib/Scenes/Search2/SearchResults.tsx
@@ -55,11 +55,12 @@ export const SearchResults: React.FC<SearchResultsProps> = ({
   const space = useSpace()
 
   useEffect(() => {
-    flatListRef.current?.scrollToOffset({ offset: 1, animated: true })
-  }, [searchState.query, indexName])
+    requestAnimationFrame(() => {
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: true })
+    })
+  }, [indexName])
 
   // When we get the first search results, we hide the loading placeholder
-
   useEffect(() => {
     // Skips the initial mount
     if (didMountRef.current) {


### PR DESCRIPTION
The type of this PR is: **Enhancement**

### Demo
https://user-images.githubusercontent.com/3513494/135088299-bed8c470-c30f-4379-9899-7be092f78cad.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Correct scroll to top of search list for android - dimatretyak

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
