### PR TITLE
fix(FX-3278): keep the "show alerts" button disabled when the user selects the same custom price again

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -3,8 +3,10 @@ import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import {
   changedFiltersParams,
+  defaultCommonFilterOptions,
   FilterArray,
   filterArtworksParams,
+  FilterParamName,
   FilterParams,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
@@ -138,8 +140,18 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
     })
   }
 
+  const selectedFilters = selectedFiltersState.filter(({ paramName, paramValue }) => {
+    const isCustomSizeFilter = paramName === FilterParamName.width || paramName === FilterParamName.height
+
+    if (isCustomSizeFilter && paramValue === defaultCommonFilterOptions[paramName]) {
+      return false
+    }
+
+    return true
+  })
+
   const isApplyButtonEnabled =
-    selectedFiltersState.length > 0 || (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
+    selectedFilters.length > 0 || (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
 
   return (
     <NavigationContainer independent>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -3,10 +3,8 @@ import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import {
   changedFiltersParams,
-  defaultCommonFilterOptions,
   FilterArray,
   filterArtworksParams,
-  FilterParamName,
   FilterParams,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
@@ -140,18 +138,8 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
     })
   }
 
-  const selectedFilters = selectedFiltersState.filter(({ paramName, paramValue }) => {
-    const isCustomSizeFilter = paramName === FilterParamName.width || paramName === FilterParamName.height
-
-    if (isCustomSizeFilter && paramValue === defaultCommonFilterOptions[paramName]) {
-      return false
-    }
-
-    return true
-  })
-
   const isApplyButtonEnabled =
-    selectedFilters.length > 0 || (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
+    selectedFiltersState.length > 0 || (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
 
   return (
     <NavigationContainer independent>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -29,6 +29,7 @@ export interface ArtworkFiltersModel {
   setFiltersCountAction: Action<ArtworkFiltersModel, FilterCounts>
   setFilterTypeAction: Action<ArtworkFiltersModel, FilterType>
   setInitialFilterStateAction: Action<ArtworkFiltersModel, FilterArray>
+  setSelectedFiltersAction: Action<ArtworkFiltersModel, FilterArray>
 }
 
 export type ArtworkFiltersState = State<ArtworkFiltersModel>
@@ -134,6 +135,11 @@ export const ArtworkFiltersModel: ArtworkFiltersModel = {
   setInitialFilterStateAction: action((state, payload) => {
     state.appliedFilters = payload
     state.previouslyAppliedFilters = payload
+    state.applyFilters = false
+  }),
+
+  setSelectedFiltersAction: action((state, payload) => {
+    state.selectedFilters = payload
     state.applyFilters = false
   }),
 }

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -162,7 +162,14 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
   }, DEFAULT_CUSTOM_SIZE)
 
   const selectOption = (option: AggregateOption) => {
-    if (option.displayText === CUSTOM_SIZE_OPTION.displayText) {
+    const isCustomSizeOption = option.displayText === CUSTOM_SIZE_OPTION.displayText
+
+    // Don't clear entered values if the custom option is selected again
+    if (shouldShowCustomSize && isCustomSizeOption) {
+      return
+    }
+
+    if (isCustomSizeOption) {
       showCustomSize(true)
       removeSelectedSizeFilters()
     } else {

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -165,6 +165,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
   const selectOption = (option: AggregateOption) => {
     if (option.displayText === CUSTOM_SIZE_OPTION.displayText) {
       showCustomSize(true)
+      restoreCustomPrice()
       selectFiltersAction(defaultOption)
     } else {
       showCustomSize(false)
@@ -175,6 +176,16 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
         paramName: PARAM_NAME,
       })
     }
+  }
+
+  const restoreCustomPrice = () => {
+    CUSTOM_SIZE_OPTION_KEYS.forEach((paramName) => {
+      const sizeFilter = appliedFilters.find((filter) => filter.paramName === paramName)
+
+      if (sizeFilter) {
+        selectFiltersAction(sizeFilter)
+      }
+    })
   }
 
   const resetCustomPrice = () => {

--- a/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SizeOptions.tsx
@@ -164,10 +164,10 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
   const selectOption = (option: AggregateOption) => {
     if (option.displayText === CUSTOM_SIZE_OPTION.displayText) {
       showCustomSize(true)
-      resetSelectedSizeFilters()
+      removeSelectedSizeFilters()
     } else {
       showCustomSize(false)
-      resetCustomPrice()
+      resetCustomSizeFilters()
       selectFiltersAction({
         displayText: option.displayText,
         paramValue: option.paramValue,
@@ -176,7 +176,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
     }
   }
 
-  const resetCustomPrice = () => {
+  const resetCustomSizeFilters = () => {
     CUSTOM_SIZE_OPTION_KEYS.forEach((paramName) => {
       selectFiltersAction({
         displayText: "All",
@@ -186,7 +186,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
     })
   }
 
-  const handleCustomPriceChange = (value: CustomSize) => {
+  const handleCustomSizeChange = (value: CustomSize) => {
     const isEmptyCustomValues = CUSTOM_SIZE_OPTION_KEYS.every((key) => {
       const paramValue = value[key]
       return paramValue.min === "*" && paramValue.max === "*"
@@ -194,7 +194,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
 
     // Populate the custom size filter only when we have at least one specified input
     if (isEmptyCustomValues) {
-      resetSelectedSizeFilters()
+      removeSelectedSizeFilters()
     } else {
       selectCustomSizeFilters(value)
     }
@@ -212,7 +212,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
     })
   }
 
-  const resetSelectedSizeFilters = () => {
+  const removeSelectedSizeFilters = () => {
     const nextSelectedFilters = selectedFilters.filter((filter) => {
       const isSizeFilter = filter.paramName === FilterParamName.dimensionRange
       const isCustomSizeFilter = CUSTOM_SIZE_OPTION_KEYS.includes(filter.paramName as keyof CustomSize)
@@ -237,7 +237,7 @@ export const SizeOptionsScreen: React.FC<SizeOptionsScreenProps> = ({ navigation
               <CustomSizeInput
                 key="custom-size-input"
                 initialValue={customInitialValue}
-                onChange={handleCustomPriceChange}
+                onChange={handleCustomSizeChange}
               />,
             ]
           : []),

--- a/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
+++ b/src/lib/Components/ArtworkFilter/__tests__/ArtworkFiltersStore-tests.tsx
@@ -2205,3 +2205,137 @@ describe("SetFilterCounts", () => {
     })
   })
 })
+
+describe("SetSelectedFiltersAction", () => {
+  it("set the selected filters when the previously selected filters is empty", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+
+    filterArtworksStore.getActions().setSelectedFiltersAction([
+      {
+        displayText: "Artwork Year (Descending)",
+        paramName: FilterParamName.sort,
+        paramValue: "-year",
+      },
+    ])
+
+    expect(filterArtworksStore.getState()).toEqual({
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [
+        {
+          displayText: "Artwork Year (Descending)",
+          paramName: FilterParamName.sort,
+          paramValue: "-year",
+        },
+      ],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    })
+  })
+
+  it("replace the previously selected filters with passed filters", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [
+        {
+          paramName: FilterParamName.artistIDs,
+          paramValue: ["artist-1"],
+          displayText: "Artist 1",
+        },
+      ],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+
+    filterArtworksStore.getActions().setSelectedFiltersAction([
+      {
+        displayText: "Artwork Year (Descending)",
+        paramName: FilterParamName.sort,
+        paramValue: "-year",
+      },
+    ])
+
+    expect(filterArtworksStore.getState()).toEqual({
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [
+        {
+          displayText: "Artwork Year (Descending)",
+          paramName: FilterParamName.sort,
+          paramValue: "-year",
+        },
+      ],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    })
+  })
+
+  it("should reset the selected filters if empty filters are passed", () => {
+    filterState = {
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [
+        {
+          paramName: FilterParamName.artistIDs,
+          paramValue: ["artist-1"],
+          displayText: "Artist 1",
+        },
+      ],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    }
+
+    const filterArtworksStore = getFilterArtworksStore(filterState)
+
+    filterArtworksStore.getActions().setSelectedFiltersAction([])
+
+    expect(filterArtworksStore.getState()).toEqual({
+      applyFilters: false,
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      selectedFilters: [],
+      aggregations: [],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+    })
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3278]

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/135315790-96be0ce3-1364-4e06-8744-0b85aa72857a.mp4

#### After
https://user-images.githubusercontent.com/3513494/135315655-c96a8544-50e9-428c-a4c3-13ee3993c451.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- keep the "show alerts" button disabled when the user selects the custom price again - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3278]: https://artsyproduct.atlassian.net/browse/FX-3278