### PR TITLE
fix: fix tab screen tracking only on first tap

### DIFF
--- a/src/lib/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/lib/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
@@ -60,27 +60,20 @@ interface ConsignmentsHomeQueryRendererProps {
 
 export const ConsignmentsHomeQueryRenderer: React.FC<ConsignmentsHomeQueryRendererProps> = ({ environment }) => {
   return (
-    <ProvideScreenTracking
-      info={{
-        context_screen: Schema.PageNames.Sell,
-        context_screen_owner_type: null,
-      }}
-    >
-      <QueryRenderer<ConsignmentsHomeQuery>
-        environment={environment || defaultEnvironment}
-        variables={{}}
-        query={graphql`
-          query ConsignmentsHomeQuery {
-            targetSupply {
-              ...ConsignmentsHome_targetSupply
-            }
+    <QueryRenderer<ConsignmentsHomeQuery>
+      environment={environment || defaultEnvironment}
+      variables={{}}
+      query={graphql`
+        query ConsignmentsHomeQuery {
+          targetSupply {
+            ...ConsignmentsHome_targetSupply
           }
-        `}
-        render={renderWithPlaceholder({
-          Container: ConsignmentsHomeContainer,
-          renderPlaceholder: () => <ConsignmentsHome isLoading targetSupply={null as any} />,
-        })}
-      />
-    </ProvideScreenTracking>
+        }
+      `}
+      render={renderWithPlaceholder({
+        Container: ConsignmentsHomeContainer,
+        renderPlaceholder: () => <ConsignmentsHome isLoading targetSupply={null as any} />,
+      })}
+    />
   )
 }

--- a/src/lib/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/lib/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
@@ -4,7 +4,6 @@ import { ConsignmentsHomeQuery } from "__generated__/ConsignmentsHomeQuery.graph
 import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { ProvideScreenTracking, Schema } from "lib/utils/track"
 import { Join, Separator } from "palette"
 import React from "react"
 import { ScrollView } from "react-native"

--- a/src/lib/Scenes/Home/Home.tsx
+++ b/src/lib/Scenes/Home/Home.tsx
@@ -501,12 +501,7 @@ export const HomeQueryRenderer: React.FC = () => {
   }, [flash_message])
 
   return (
-    <ProvideScreenTracking
-      info={{
-        context_screen: Schema.PageNames.Home,
-        context_screen_owner_type: null as any,
-      }}
-    >
+    <>
       {/* Avoid rendering when user is logged out, it will fail anyway */}
       {!!userAccessToken && (
         <AboveTheFoldQueryRenderer<HomeAboveTheFoldQuery, HomeBelowTheFoldQuery>
@@ -569,6 +564,6 @@ export const HomeQueryRenderer: React.FC = () => {
           belowTheFoldTimeout={100}
         />
       )}
-    </ProvideScreenTracking>
+    </>
   )
 }

--- a/src/lib/Scenes/MyProfile/MyProfile.tsx
+++ b/src/lib/Scenes/MyProfile/MyProfile.tsx
@@ -1,4 +1,3 @@
-import { OwnerType } from "@artsy/cohesion"
 import { MyProfile_me } from "__generated__/MyProfile_me.graphql"
 import { MyProfileQuery } from "__generated__/MyProfileQuery.graphql"
 import { MenuItem } from "lib/Components/MenuItem"
@@ -9,8 +8,6 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { extractNodes } from "lib/utils/extractNodes"
 import { PlaceholderBox, PlaceholderText } from "lib/utils/placeholders"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { ProvideScreenTrackingWithCohesionSchema } from "lib/utils/track"
-import { screen } from "lib/utils/track/helpers"
 import { times } from "lodash"
 import { Flex, Join, Sans, Separator, Spacer } from "palette"
 import React, { useCallback, useRef, useState } from "react"
@@ -154,21 +151,19 @@ export const MyProfileContainer = createRefetchContainer(
 )
 
 export const MyProfileQueryRenderer: React.FC<{}> = ({}) => (
-  <ProvideScreenTrackingWithCohesionSchema info={screen({ context_screen_owner_type: OwnerType.profile })}>
-    <QueryRenderer<MyProfileQuery>
-      environment={defaultEnvironment}
-      query={graphql`
-        query MyProfileQuery {
-          me @optionalField {
-            ...MyProfile_me
-          }
+  <QueryRenderer<MyProfileQuery>
+    environment={defaultEnvironment}
+    query={graphql`
+      query MyProfileQuery {
+        me @optionalField {
+          ...MyProfile_me
         }
-      `}
-      render={renderWithPlaceholder({
-        Container: MyProfileContainer,
-        renderPlaceholder: () => <MyProfilePlaceholder />,
-      })}
-      variables={{}}
-    />
-  </ProvideScreenTrackingWithCohesionSchema>
+      }
+    `}
+    render={renderWithPlaceholder({
+      Container: MyProfileContainer,
+      renderPlaceholder: () => <MyProfilePlaceholder />,
+    })}
+    variables={{}}
+  />
 )

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -6,7 +6,6 @@ import { __unsafe_switchTab } from "lib/NativeModules/ARScreenPresenterModule"
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { BottomTabType } from "lib/Scenes/BottomTabs/BottomTabType"
 import { GlobalStore, unsafe__getSelectedTab } from "lib/store/GlobalStore"
-import { Schema } from "lib/utils/track"
 import { postEventToProviders } from "lib/utils/track/providers"
 import { Linking, Platform } from "react-native"
 import { matchRoute } from "./routes"
@@ -123,7 +122,7 @@ const tracks = {
         tabScreen = OwnerType.inbox
         break
       case "profile":
-        tabScreen = OwnerType.myCollection
+        tabScreen = OwnerType.profile
         break
       case "search":
         tabScreen = OwnerType.search

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -123,7 +123,7 @@ const tracks = {
         tabScreen = OwnerType.inbox
         break
       case "profile":
-        tabScreen = OwnerType.profile
+        tabScreen = OwnerType.myCollection
         break
       case "search":
         tabScreen = OwnerType.search


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-303]

### Description

Fixes issue causing screen views in our main tabs to only be fired the first time a tab is tapped.

The issue is that our screen tracking by default happens when the screen component mounts. For most screens this is okay but our tabs are lazily mounted so they are not triggering the event on subsequent taps. This pr just removes the typical screen tracking from our tab screens and instead fires the event in the switchTab function. 

#### Before

https://user-images.githubusercontent.com/49686530/135333768-d1f9c694-fdae-4903-94cf-c7845f263e97.mp4


#### After

https://user-images.githubusercontent.com/49686530/135333777-a9e68efa-e944-42cb-aec6-c67b5f953f04.mp4



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix tab screen tracking - Brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-303]: https://artsyproduct.atlassian.net/browse/CX-303