### PR TITLE
fix(PURCHASE-2670): Don't show the date is not present

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -61,7 +61,8 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
           <Flex ml={2} flex={1}>
             <Text>{artwork.artistNames}</Text>
             <Text color="black60" variant="xs">
-              {artwork.title}, {artwork.date}
+              {artwork.title}
+              {artwork.date && artwork.date.trim() !== "" ? `, ${artwork.date}` : ""}
             </Text>
           </Flex>
           <ChevronIcon color="black100" expanded={isExpanded} initialDirection="down" />


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2670](https://artsyproduct.atlassian.net/browse/PURCHASE-2670)

### Description

The CMS doesn't allow Artworks without `date` but I can't guarantee that behavior from old data, in order to fix the extra comma we do some checks before displaying it.

<!-- Implementation description -->
iOS

<img src="https://user-images.githubusercontent.com/15792853/136018863-e24c84d2-f385-46df-9adc-36a9e64c5764.png" width=240 />

Android

<img src="https://user-images.githubusercontent.com/15792853/136026588-cd1a76c7-a6b3-4c55-aeed-19c87dd4c7e7.png" width=240 />

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- When date is null or "" don't display ", " in the Make Offer Modal

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
