### PR TITLE
feat(FX-3240): horizontal scroll back to top whenever query changes

### DIFF
--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -11,7 +11,7 @@ import { useAlgoliaClient } from "lib/utils/useAlgoliaClient"
 import { useSearchInsightsConfig } from "lib/utils/useSearchInsightsConfig"
 import { throttle } from "lodash"
 import { Box, Flex, Spacer } from "palette"
-import React, { useMemo, useState } from "react"
+import React, { useMemo, useRef, useState } from "react"
 import {
   Configure,
   connectInfiniteHits,
@@ -118,6 +118,7 @@ interface Search2Props {
 
 export const Search2: React.FC<Search2Props> = (props) => {
   const { system, relay } = props
+  const searchPillsRef = useRef<ScrollView>(null)
   const [searchState, setSearchState] = useState<SearchState>({})
   const [selectedPill, setSelectedPill] = useState<PillType>(TOP_PILL)
   const searchProviderValues = useSearchProviderValues(searchState?.query ?? "")
@@ -170,6 +171,7 @@ export const Search2: React.FC<Search2Props> = (props) => {
   }
 
   const handleResetSearchInput = () => {
+    searchPillsRef?.current?.scrollTo({ x: 0, y: 0, animated: true })
     setSelectedPill(TOP_PILL)
   }
 
@@ -194,7 +196,12 @@ export const Search2: React.FC<Search2Props> = (props) => {
             {!!shouldStartQuering ? (
               <>
                 <Box pt={2} pb={1}>
-                  <SearchPills pills={pillsArray} onPillPress={handlePillPress} isSelected={isSelected} />
+                  <SearchPills
+                    ref={searchPillsRef}
+                    pills={pillsArray}
+                    onPillPress={handlePillPress}
+                    isSelected={isSelected}
+                  />
                 </Box>
                 {renderResults()}
               </>

--- a/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/SearchPills-tests.tsx
@@ -23,8 +23,9 @@ const pills: PillType[] = [
 ]
 
 describe("SearchPills", () => {
+  const mockRef = jest.fn()
   const TestRenderer = (props: Partial<SearchPillsProps>) => {
-    return <SearchPills pills={pills} onPillPress={jest.fn} isSelected={() => false} {...props} />
+    return <SearchPills ref={mockRef} pills={pills} onPillPress={jest.fn} isSelected={() => false} {...props} />
   }
 
   it("renders without throwing an error", () => {

--- a/src/lib/Scenes/Search2/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search2/components/SearchPills.tsx
@@ -7,14 +7,18 @@ export interface SearchPillsProps {
   pills: PillType[]
   onPillPress: (pill: PillType) => void
   isSelected: (pill: PillType) => boolean
+  ref: React.Ref<ScrollView>
 }
 
-export const SearchPills: React.FC<SearchPillsProps> = (props) => {
+export const SearchPills: React.FC<SearchPillsProps> = React.forwardRef((props, ref) => {
   const { pills, onPillPress, isSelected } = props
   const space = useSpace()
 
   return (
     <ScrollView
+      accessible
+      accessibilityLabel="pill scrollview"
+      ref={ref}
       horizontal
       contentContainerStyle={{ paddingHorizontal: space(2) }}
       showsHorizontalScrollIndicator={false}
@@ -42,4 +46,4 @@ export const SearchPills: React.FC<SearchPillsProps> = (props) => {
       })}
     </ScrollView>
   )
-}
+})


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3240]

### Description

Whenever the user changes the query scroll pill view to top

|Android|iOS|
|---|---|
| https://user-images.githubusercontent.com/21178754/136178676-bf75d1d1-de31-4d33-9f23-9225a5f4b9b5.mov | https://user-images.githubusercontent.com/21178754/136178019-c64254be-1204-4e9a-b84a-c9e9d425870a.mp4 |

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- horizontal scroll back to top whenever query changes on new search - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
