### PR TITLE
feat(PURCHASE-2966): navigate to view offer in order history

### DIFF
--- a/src/lib/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/lib/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -19,7 +19,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const trackingUrl = getTrackingUrl(lineItem)
   const orderStatus = getOrderStatus(order.state as OrderState, lineItem)
   const orderIsInactive = orderStatus === "canceled" || orderStatus === "refunded"
-  const isViewOfferButton = orderStatus === "pending" && order?.mode === "OFFER"
+  const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
   return (
     <Flex width="100%" data-test-id="order-container">
@@ -79,10 +79,18 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
           <Button
             block
             variant="fillGray"
-            onPress={() => navigate(`/user/purchases/${order.internalID}`)}
+            onPress={
+              isViewOffer
+                ? () =>
+                    navigate(`/orders/${order.internalID}`, {
+                      modal: true,
+                      passProps: { orderID: order.internalID, title: "Make Offer" },
+                    })
+                : () => navigate(`/user/purchases/${order.internalID}`)
+            }
             data-test-id="view-order-button"
           >
-            {isViewOfferButton ? "View Offer" : "View Order"}
+            {isViewOffer ? "View Offer" : "View Order"}
           </Button>
         )}
       </Box>


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [PURCHASE-2966]

### Description

If an order is an "offer" and is "pending", the "View Offer" button on the order history screen will navigate to the offer modal, instead of navigating to the order details. 

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Make offer modal is now accessible from the order history screen for pending orders. -rquartararo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

#### Screen recording 

https://user-images.githubusercontent.com/50849237/136199905-f864b385-7934-4c3d-9ebb-d39ade1e2634.mp4




[PURCHASE-2966]: https://artsyproduct.atlassian.net/browse/PURCHASE-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ