### PR TITLE
FX-3409 Use react-native-reanimated instead of LayoutAnimation of rea…

### DIFF
--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -1,5 +1,5 @@
 import SearchIcon from "lib/Icons/SearchIcon"
-import { Box, Flex, Input, InputProps, Sans } from "palette"
+import { Box, Flex, Input, INPUT_HEIGHT, InputProps, Sans } from "palette"
 import React, { RefObject, useCallback, useState } from "react"
 import { Dimensions, LayoutChangeEvent, TextInput, TouchableOpacity } from "react-native"
 import Animated from "react-native-reanimated"
@@ -14,15 +14,24 @@ interface SearchInputProps extends InputProps {
 
 export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
   ({ enableCancelButton, onChangeText, onClear, onCancelPress, ...props }, ref) => {
-    const [cancelButtonWidth, setCancelButtonWidth] = useState(0)
+    const [cancelButtonSize, setCancelButtonSize] = useState({ width: 0, height: 0 })
     const animationValue = useAnimatedValue(0)
     const screenWidth = Dimensions.get("window").width
     const inputFullWidth = screenWidth - INPUT_INDENT
-    const shrinkedWidth = inputFullWidth - cancelButtonWidth
+    const shrinkedWidth = inputFullWidth - cancelButtonSize.width
 
-    const handleCancelButtonLayout = useCallback(({ nativeEvent }: LayoutChangeEvent) => {
-      setCancelButtonWidth(nativeEvent.layout.width)
-    }, [])
+    const handleCancelButtonLayout = useCallback(
+      ({
+        nativeEvent: {
+          layout: { width, height },
+        },
+      }: LayoutChangeEvent) => {
+        setCancelButtonSize({ width, height })
+      },
+      []
+    )
+
+    const cancelButtonTopPosition = INPUT_HEIGHT / 2 - cancelButtonSize.height / 2
 
     return (
       <Flex flexDirection="row">
@@ -46,8 +55,8 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
           }}
         />
         {!!enableCancelButton && (
-          <Flex alignItems="center" justifyContent="center" flexDirection="row">
-            <Box onLayout={handleCancelButtonLayout}>
+          <Flex position="relative" alignItems="center" justifyContent="center" flexDirection="row">
+            <Box onLayout={handleCancelButtonLayout} position="absolute" top={cancelButtonTopPosition} right={0}>
               <TouchableOpacity
                 onPress={() => {
                   ;(ref as RefObject<TextInput>).current?.blur()
@@ -56,21 +65,7 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
                 }}
                 hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
               >
-                <Animated.View
-                  style={[
-                    {
-                      opacity: animationValue,
-                      transform: [
-                        {
-                          translateX: animationValue.interpolate({
-                            inputRange: [0, 1],
-                            outputRange: [cancelButtonWidth - INPUT_INDENT, 0],
-                          }),
-                        },
-                      ],
-                    },
-                  ]}
-                >
+                <Animated.View style={[{ opacity: animationValue }]}>
                   <Flex pl={1}>
                     <Sans size="2" color="black60">
                       Cancel

--- a/src/palette/elements/Input/Input.tsx
+++ b/src/palette/elements/Input/Input.tsx
@@ -214,6 +214,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
         <Animated.View
           style={[
             {
+              zIndex: 10,
               width:
                 animationValue && width && shrinkedWidth
                   ? animationValue.interpolate({


### PR DESCRIPTION
…ct-native

The type of this PR is: ** Bugfix**

This PR resolves [FX-3409]

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [ ] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [ ] I have documented any follow-up work that this PR will require, or it does not require any.
- [ ] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [ ] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fixed search cancel button overlapping

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- changed input animation from LayoutAnimation to Animated (Reanimated 2)

<!-- end_changelog_updates -->

</details>


[FX-3409]: https://artsyproduct.atlassian.net/browse/FX-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ