### PR TITLE
fix(FX-3409): search input animation

### DIFF
--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -7,7 +7,7 @@ import { useAnimatedValue } from "./StickyTabPage/reanimatedHelpers"
 
 const MX = 2
 
-interface SearchInputProps extends InputProps {
+export interface SearchInputProps extends InputProps {
   mx?: SpacingUnitV2 | SpacingUnitV3
   enableCancelButton?: boolean
   onCancelPress?: () => void

--- a/src/lib/Components/__tests__/SearchInput-tests.tsx
+++ b/src/lib/Components/__tests__/SearchInput-tests.tsx
@@ -1,0 +1,68 @@
+import { fireEvent } from "@testing-library/react-native"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { TextInput } from "react-native"
+import Animated, { Easing } from "react-native-reanimated"
+import { SearchInput, SearchInputProps } from "../SearchInput"
+
+describe("SearchInput", () => {
+  const onCancelPressMock = jest.fn()
+  const animatedTimingSpy = jest.spyOn(Animated, "timing")
+
+  const TestWrapper = (props: SearchInputProps) => {
+    const ref = { current: null as null | TextInput }
+    return <SearchInput ref={ref} onCancelPress={onCancelPressMock} placeholder="Type something..." {...props} />
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders input", () => {
+    const { getByPlaceholderText } = renderWithWrappersTL(<TestWrapper />)
+    expect(getByPlaceholderText("Type something...")).toBeDefined()
+  })
+
+  it(`calls "Animated.timing" with value 1 when focusing the input`, () => {
+    const { getByPlaceholderText } = renderWithWrappersTL(<TestWrapper enableCancelButton />)
+    fireEvent(getByPlaceholderText("Type something..."), "focus")
+    expect(animatedTimingSpy).toHaveBeenCalledTimes(1)
+    expect(animatedTimingSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        duration: 180,
+        easing: Easing.ease,
+        toValue: 1,
+      })
+    )
+  })
+
+  it(`calls "Animated.timing" with value 0 when blurring the input`, () => {
+    const { getByPlaceholderText } = renderWithWrappersTL(<TestWrapper enableCancelButton />)
+    fireEvent(getByPlaceholderText("Type something..."), "blur")
+    expect(animatedTimingSpy).toHaveBeenCalledTimes(1)
+    expect(animatedTimingSpy.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        duration: 180,
+        easing: Easing.ease,
+        toValue: 0,
+      })
+    )
+  })
+
+  it(`doesn't render "Cancel" button when "enableCancelButton" is not passed`, () => {
+    const { queryAllByText } = renderWithWrappersTL(<TestWrapper />)
+    // Cancel text is wrapped by Sans and Animated.Text so we get 2 elements here
+    expect(queryAllByText("Cancel")).toHaveLength(0)
+  })
+
+  it(`renders "Cancel" button when "enableCancelButton" is passed`, () => {
+    const { getAllByText } = renderWithWrappersTL(<TestWrapper enableCancelButton />)
+    expect(getAllByText("Cancel")[0]).toBeDefined()
+  })
+
+  it(`calls passed "onCancelPress" callback when pressing on "Cancel" button`, () => {
+    const { getAllByText } = renderWithWrappersTL(<TestWrapper enableCancelButton />)
+    fireEvent.press(getAllByText("Cancel")[0])
+    expect(onCancelPressMock).toHaveBeenCalled()
+  })
+})

--- a/src/lib/Scenes/Search/__tests__/Search-tests.tsx
+++ b/src/lib/Scenes/Search/__tests__/Search-tests.tsx
@@ -84,15 +84,6 @@ describe("The Search page", () => {
     expect(tree.root.findAllByType(AutosuggestResults)).toHaveLength(0)
   })
 
-  it(`shows the cancel button when the input focues`, () => {
-    const tree = renderWithWrappers(<TestWrapper />)
-    expect(extractText(tree.root)).not.toContain("Cancel")
-    act(() => {
-      tree.root.findByType(TextInput).props.onFocus()
-    })
-    expect(extractText(tree.root)).toContain("Cancel")
-  })
-
   it(`passes the query to the AutosuggestResults when the query.length is >= 2`, async () => {
     const tree = renderWithWrappers(<TestWrapper />)
 

--- a/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
+++ b/src/lib/Scenes/Search2/__tests__/Search2-tests.tsx
@@ -91,17 +91,6 @@ describe("Search2 Screen", () => {
     expect(getByText("Explore art on view")).toBeTruthy()
   })
 
-  it("shows the cancel button when the input focuses", () => {
-    const { queryByText, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
-
-    expect(queryByText("Cancel")).toBeFalsy()
-
-    const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
-
-    fireEvent(searchInput, "focus")
-    expect(queryByText("Cancel")).toBeTruthy()
-  })
-
   it('the "Top" pill should be selected by default', () => {
     const { getByA11yState, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
     const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
@@ -231,13 +220,13 @@ describe("Search2 Screen", () => {
     })
 
     it("when cancel button is pressed", () => {
-      const { queryByA11yState, getByPlaceholderText, getByText } = tree
+      const { queryByA11yState, getByPlaceholderText, getByText, getAllByText } = tree
       const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
 
       fireEvent(searchInput, "changeText", "prev value")
       fireEvent(getByText("Artists"), "press")
       fireEvent(searchInput, "focus")
-      fireEvent(getByText("Cancel"), "press")
+      fireEvent(getAllByText("Cancel")[0], "press")
       fireEvent(searchInput, "changeText", "new value")
 
       expect(queryByA11yState({ selected: true })).toHaveTextContent("Top")


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-3409]

### Description

In the current implementation _Cancel_ button is overlapping input when getting back from the result page. This is specific for Android bug since `LayoutAnimation` feature is experimental on Android

This fixes the issue by changing the animation implementation for search input component from `LayoutAnimation` to `Animated`

### Demo

#### Before
https://user-images.githubusercontent.com/44819355/136564940-b7358c0e-c4dc-47ba-af75-89280f10a4d7.mp4


#### After
https://user-images.githubusercontent.com/44819355/136565574-3babde87-e0ef-4cbf-aec4-65e5108fc444.mp4



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests for my changes, or my changes don't require testing, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- fixed search cancel button overlapping - anastasiapyzhik

#### Dev changes

- changed search input animation from LayoutAnimation to Animated (Reanimated 2) - anastasiapyzhik

<!-- end_changelog_updates -->

</details>


[FX-3409]: https://artsyproduct.atlassian.net/browse/FX-3409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ