### PR TITLE
fix: native push method name mismatch

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -139,12 +139,12 @@ SOFTWARE.
 
 #pragma mark - Native Module: Push Notification Permissions
 
-    emission.APIModule.settingsNotificationPermissionPrompter = ^() {
+    emission.APIModule.directNotificationPermissionPrompter = ^() {
         ARAppNotificationsDelegate *delegate = [[JSDecoupledAppDelegate sharedAppDelegate] remoteNotificationsDelegate];
         [delegate registerForDeviceNotificationsWithApple];
     };
 
-    emission.APIModule.loginNotificationPermissionPrompter = ^() {
+    emission.APIModule.prepromptNotificationPermissionPrompter = ^() {
         ARAppNotificationsDelegate *delegate = [[JSDecoupledAppDelegate sharedAppDelegate] remoteNotificationsDelegate];
         [delegate registerForDeviceNotificationsWithContext:ARAppNotificationsRequestContextOnboarding];
     };

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.h
@@ -20,10 +20,10 @@ typedef void(^ARRelativeURLResolver)(NSString *path, RCTPromiseResolveBlock reso
 
 
 // Just shows the apple dialog, used for explicitly asking permission in settings
-@property (nonatomic, copy, readwrite) ARNotificationPermissionsPrompter settingsNotificationPermissionPrompter;
+@property (nonatomic, copy, readwrite) ARNotificationPermissionsPrompter directNotificationPermissionPrompter;
 
 // Uses some logic to pre-prompt, redirect to settings, and eventually prompt with apple dialog, used on login
-@property (nonatomic, copy, readwrite) ARNotificationPermissionsPrompter loginNotificationPermissionPrompter;
+@property (nonatomic, copy, readwrite) ARNotificationPermissionsPrompter prepromptNotificationPermissionPrompter;
 
 @property (nonatomic, copy, readwrite) ARNotificationReadStatusAssigner notificationReadStatusAssigner;
 

--- a/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
+++ b/emission/Pod/Classes/TemporaryAPI/ARTemporaryAPIModule.m
@@ -7,20 +7,20 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(requestSettingsNotificationPermissions)
+RCT_EXPORT_METHOD(requestDirectNotificationPermissions)
 {
     /* Used in settings screen to directly ask user for push permissions */
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.settingsNotificationPermissionPrompter();
+        self.directNotificationPermissionPrompter();
     });
 }
 
 
-RCT_EXPORT_METHOD(requestLoginNotificationPermissions)
+RCT_EXPORT_METHOD(requestPrepromptNotificationPermissions)
 {
     /* Used on login with some additional logic before requesting permissions */
     dispatch_async(dispatch_get_main_queue(), ^{
-        self.loginNotificationPermissionPrompter();
+        self.prepromptNotificationPermissionPrompter();
     });
 }
 

--- a/src/lib/NativeModules/LegacyNativeModules.tsx
+++ b/src/lib/NativeModules/LegacyNativeModules.tsx
@@ -20,7 +20,7 @@ const noop: any = (name: string) => () => console.warn(`method ${name} doesn't e
 
 interface LegacyNativeModules {
   ARTemporaryAPIModule: {
-    requestLoginNotificationPermissions(): void
+    requestPrepromptNotificationPermissions(): void
     requestDirectNotificationPermissions(): void
     fetchNotificationPermissions(callback: (error: any, result: PushAuthorizationStatus) => void): void
     markNotificationsRead(callback: (error?: Error) => any): void
@@ -122,7 +122,7 @@ export const LegacyNativeModules: LegacyNativeModules =
         },
 
         ARTemporaryAPIModule: {
-          requestLoginNotificationPermissions: noop("requestLoginNotificationPermissions"),
+          requestPrepromptNotificationPermissions: noop("requestPrepromptNotificationPermissions"),
           requestDirectNotificationPermissions: noop("requestDirectNotificationPermissions"),
           fetchNotificationPermissions: noop("fetchNotificationPermissions"),
           markNotificationsRead: noop("markNotificationsRead"),

--- a/src/lib/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
@@ -144,7 +144,7 @@ const handleFinishOnboardingPersonalization = async () => {
   const pushNotificationsPermissionsStatus = await getNotificationPermissionsStatus()
   if (pushNotificationsPermissionsStatus !== PushAuthorizationStatus.Authorized) {
     if (Platform.OS === "ios") {
-      LegacyNativeModules.ARTemporaryAPIModule.requestLoginNotificationPermissions()
+      LegacyNativeModules.ARTemporaryAPIModule.requestPrepromptNotificationPermissions()
     } else {
       setTimeout(() => {
         Alert.alert(

--- a/src/lib/Scenes/Onboarding/OnboardingPersonalization/__tests__/OnboardingPersonalization-tests.tsx
+++ b/src/lib/Scenes/Onboarding/OnboardingPersonalization/__tests__/OnboardingPersonalization-tests.tsx
@@ -78,7 +78,7 @@ describe("OnboardingPersonalizationList", () => {
 
       await flushPromiseQueue()
       expect(__globalStoreTestUtils__?.getCurrentState().auth.onboardingState).toEqual("complete")
-      expect(LegacyNativeModules.ARTemporaryAPIModule.requestLoginNotificationPermissions).toBeCalled()
+      expect(LegacyNativeModules.ARTemporaryAPIModule.requestPrepromptNotificationPermissions).toBeCalled()
     })
   })
 })

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -232,7 +232,7 @@ function getNativeModules(): OurNativeModules {
     },
 
     ARTemporaryAPIModule: {
-      requestLoginNotificationPermissions: jest.fn(),
+      requestPrepromptNotificationPermissions: jest.fn(),
       requestDirectNotificationPermissions: jest.fn(),
       fetchNotificationPermissions: jest.fn(),
       markNotificationsRead: jest.fn(),


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

Fixes a mismatch with push prompt native method name and typescript call.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀
- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Fix push method name mismatch - Brian

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
