### PR TITLE
fix(FX-3505): hide "cancel" button on click, fix analytics event

### DIFF
--- a/src/lib/Components/SearchInput.tests.tsx
+++ b/src/lib/Components/SearchInput.tests.tsx
@@ -80,4 +80,16 @@ describe("SearchInput", () => {
     fireEvent.press(getAllByText("Cancel")[0])
     expect(queryAllByA11yLabel("Clear input button")).toHaveLength(0)
   })
+
+  it('should hide "Cancel" when it is pressed', () => {
+    const { queryAllByA11yLabel, getAllByText, findAllByA11yLabel, getByPlaceholderText } = renderWithWrappersTL(
+      <TestWrapper enableCancelButton />
+    )
+
+    fireEvent.changeText(getByPlaceholderText("Type something..."), "text")
+    expect(findAllByA11yLabel("Cancel")).toBeTruthy()
+
+    fireEvent.press(getAllByText("Cancel")[0])
+    expect(queryAllByA11yLabel("Cancel")).toHaveLength(0)
+  })
 })

--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -74,10 +74,9 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
           >
             <TouchableOpacity
               onPress={() => {
-                ;(ref as RefObject<TextInput>).current?.blur()
-                ;(ref as RefObject<TextInput>).current?.clear()
-                onCancelPress?.()
                 emitInputClearEvent()
+                ;(ref as RefObject<TextInput>).current?.blur()
+                onCancelPress?.()
               }}
               hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}
             >

--- a/src/lib/Scenes/Search2/Search2.tsx
+++ b/src/lib/Scenes/Search2/Search2.tsx
@@ -90,11 +90,6 @@ const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholde
       enableCancelButton
       placeholder={placeholder}
       onChangeText={(text) => {
-        if (text.length === 0) {
-          handleReset()
-          return
-        }
-
         trackEvent({
           action_type: Schema.ActionNames.ARAnalyticsSearchStartedQuery,
           query: text,
@@ -104,7 +99,6 @@ const SearchInput: React.FC<SearchInputProps> = ({ currentRefinement, placeholde
         onReset()
       }}
       onClear={handleReset}
-      onCancelPress={handleReset}
     />
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3505]

### Description
* when clicking on "x", we should clear the entered text in input,  focus remains on input
* when we click on "cancel", the text is cleared, the focus from the input disappears, the "cancel" button is hidden.
* fix track analytics

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- hide search input "cancel" button on click, fix analytics event - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3505]: https://artsyproduct.atlassian.net/browse/FX-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ