### PR TITLE
feat(FX-3509): fetch notification settings for saved search alert

### DIFF
--- a/src/__generated__/SavedSearchAlertQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 08207471bf58838f6c895837c8384c38 */
+/* @relayHash 05eb8e2e23339f454dfd7de5ff955054 */
 
 import { ConcreteRequest } from "relay-runtime";
 export type SavedSearchAlertQueryVariables = {
@@ -28,6 +28,8 @@ export type SavedSearchAlertQueryResponse = {
             readonly priceRange: string | null;
             readonly userAlertSettings: {
                 readonly name: string | null;
+                readonly email: boolean;
+                readonly push: boolean;
             };
             readonly width: string | null;
         } | null;
@@ -64,6 +66,8 @@ query SavedSearchAlertQuery(
       priceRange
       userAlertSettings {
         name
+        email
+        push
       }
       width
     }
@@ -220,6 +224,20 @@ v1 = {
           "kind": "ScalarField",
           "name": "name",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "email",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "push",
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -285,7 +303,7 @@ return {
     ]
   },
   "params": {
-    "id": "08207471bf58838f6c895837c8384c38",
+    "id": "05eb8e2e23339f454dfd7de5ff955054",
     "metadata": {},
     "name": "SavedSearchAlertQuery",
     "operationKind": "query",
@@ -293,5 +311,5 @@ return {
   }
 };
 })();
-(node as any).hash = '339d772e996883602600d50b4ecf22bc';
+(node as any).hash = '454a8920df824a5f25c488c90faac491';
 export default node;

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from "@testing-library/react-native"
 import * as savedSearchButton from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { goBack, navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { mockFetchNotificationPermissions } from "lib/tests/mockFetchNotificationPermissions"
@@ -90,6 +91,83 @@ describe("EditSavedSearchAlert", () => {
       },
     })
   })
+
+  describe("When AREnableSavedSearchToggles is enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchToggles: true })
+    })
+
+    it("should render two toggles are enabled", async () => {
+      const { getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        SearchCriteria: () => searchCriteria,
+      })
+      mockEnvironmentPayload(mockEnvironment, {
+        FilterArtworksConnection: () => filterArtworks,
+      })
+
+      expect(getAllByA11yState({ selected: true })).toHaveLength(2)
+    })
+
+    it("should render two toggles are disabled", async () => {
+      const { getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        SearchCriteria: () => ({
+          ...searchCriteria,
+          userAlertSettings: {
+            ...searchCriteria.userAlertSettings,
+            email: false,
+            push: false,
+          },
+        }),
+      })
+      mockEnvironmentPayload(mockEnvironment, {
+        FilterArtworksConnection: () => filterArtworks,
+      })
+
+      expect(getAllByA11yState({ selected: false })).toHaveLength(2)
+    })
+
+    it("should render push toggle is enabled, email toggle is disabled", async () => {
+      const { getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        SearchCriteria: () => ({
+          ...searchCriteria,
+          userAlertSettings: {
+            ...searchCriteria.userAlertSettings,
+            push: false,
+          },
+        }),
+      })
+      mockEnvironmentPayload(mockEnvironment, {
+        FilterArtworksConnection: () => filterArtworks,
+      })
+
+      expect(getAllByA11yState({ selected: false })).toHaveLength(1)
+    })
+
+    it("should render email toggle is enabled, push toggle is disabled", async () => {
+      const { getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        SearchCriteria: () => ({
+          ...searchCriteria,
+          userAlertSettings: {
+            ...searchCriteria.userAlertSettings,
+            email: false,
+          },
+        }),
+      })
+      mockEnvironmentPayload(mockEnvironment, {
+        FilterArtworksConnection: () => filterArtworks,
+      })
+
+      expect(getAllByA11yState({ selected: false })).toHaveLength(1)
+    })
+  })
 })
 
 const searchCriteria = {
@@ -111,6 +189,8 @@ const searchCriteria = {
   width: null,
   userAlertSettings: {
     name: "unique-name",
+    push: true,
+    email: true,
   },
 }
 

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -65,8 +65,8 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
             <SavedSearchAlertForm
               initialValues={{
                 name: userAlertSettings?.name ?? "",
-                email: true,
-                push: true,
+                email: userAlertSettings?.email ?? false,
+                push: userAlertSettings?.push ?? false,
               }}
               artistId={artist.internalID}
               artistName={artist.name!}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
@@ -41,6 +41,8 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
               priceRange
               userAlertSettings {
                 name
+                email
+                push
               }
               width
             }


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3509]

### Description
* As a user
* When I open edit saved search screen
* I see previously saved notification settings

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/138500818-a905784c-32d5-4d84-a10c-f9b7f2f64294.mp4

#### Android
https://user-images.githubusercontent.com/3513494/138501420-ec2ab181-136d-43ca-9184-80dea937a5cc.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Show previously saved notification settings on edit saved search screen - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3509]: https://artsyproduct.atlassian.net/browse/FX-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ