### PR TITLE
fix: checkbox inherit parent flex props

### DIFF
--- a/src/palette/elements/Checkbox/Checkbox.tsx
+++ b/src/palette/elements/Checkbox/Checkbox.tsx
@@ -82,7 +82,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
         onPress?.(event)
       }}
     >
-      <Flex {...restProps}>
+      <Flex {...restProps} flex={1}>
         <Flex flexDirection="row">
           <Flex mt="2px">
             <CssTransition
@@ -94,7 +94,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
             </CssTransition>
           </Flex>
 
-          <Flex justifyContent="center">
+          <Flex justifyContent="center" flex={1}>
             {!!text && (
               <Text variant="md" color={textColor}>
                 {text}


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-2102]

### Description

Text in checkboxes was not respecting parent flex props. This adds flex: 1 to flexes in checkbox.

### Screenshots

<details><summary>Before</summary>

![before](https://user-images.githubusercontent.com/49686530/138749896-330110db-5d11-4df6-b650-48d463e8afff.png)


</details>

<details><summary>After</summary>

![after](https://user-images.githubusercontent.com/49686530/138749843-2ec7bd08-fa43-4aca-92f2-d70400004f6f.png)

</details>


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fix email terms text going off screen - Brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2102]: https://artsyproduct.atlassian.net/browse/CX-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ