### PR TITLE
fix(CX-2122): fix broken ref handling

### DIFF
--- a/src/lib/Components/SearchInput.tsx
+++ b/src/lib/Components/SearchInput.tsx
@@ -1,6 +1,6 @@
 import SearchIcon from "lib/Icons/SearchIcon"
 import { emitInputClearEvent, Flex, Input, InputProps, Sans, SpacingUnitV2, SpacingUnitV3, useSpace } from "palette"
-import React, { RefObject } from "react"
+import React, { useImperativeHandle, useRef } from "react"
 import { TextInput, TouchableOpacity, useWindowDimensions } from "react-native"
 import Animated, { Easing } from "react-native-reanimated"
 import { useAnimatedValue } from "./StickyTabPage/reanimatedHelpers"
@@ -14,12 +14,16 @@ export interface SearchInputProps extends InputProps {
 }
 
 export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
-  ({ enableCancelButton, onChangeText, onClear, onCancelPress, mx = MX, ...props }, ref) => {
+  (
+    { enableCancelButton, onChangeText, onClear, onCancelPress, mx = MX, ...props },
+    ref: React.Ref<Partial<TextInput>>
+  ) => {
     const cancelWidth = useAnimatedValue(0)
     const animationValue = useAnimatedValue(0)
     const space = useSpace()
     const width = useWindowDimensions().width - space(mx) * 2
     const inputWidth = Animated.sub(width, cancelWidth)
+    const inputRef = useRef<TextInput>(null)
 
     const animateTo = (toValue: 1 | 0) => {
       Animated.timing(animationValue, {
@@ -28,6 +32,8 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
         duration: 180,
       }).start()
     }
+
+    useImperativeHandle(ref, () => inputRef?.current ?? {})
 
     return (
       <Flex flexDirection="row">
@@ -42,14 +48,14 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
           }}
         >
           <Input
-            ref={ref}
+            ref={inputRef}
             icon={<SearchIcon width={18} height={18} />}
             autoCorrect={false}
             enableClearButton
             returnKeyType="search"
             onClear={() => {
               onClear?.()
-              ;(ref as RefObject<TextInput>).current?.focus()
+              inputRef?.current?.focus()
             }}
             onChangeText={onChangeText}
             {...props}
@@ -75,7 +81,7 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
             <TouchableOpacity
               onPress={() => {
                 emitInputClearEvent()
-                ;(ref as RefObject<TextInput>).current?.blur()
+                inputRef?.current?.blur()
                 onCancelPress?.()
               }}
               hitSlop={{ bottom: 40, right: 40, left: 0, top: 40 }}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2122]

### Description

The error happening before was caused by a typecast assuring the ref was present and wrongly typecasting it to `RefObject<T>` when the real type is `Ref<T>` and the latter doesn't expose any methods.

This PR addresses an error when calling forwarded refs methods, like focus, blur, these values are not present if you omit the ref from the place you're using the component causing the issue described in Sentry when you for example tap in the clear button of the SearchInput of the onboarding flow.
When we need to call exposed functions from forwarded refs the recommended pattern is to use `useImperativeHandle` to use, focus, blur, etc.

https://user-images.githubusercontent.com/15792853/139397144-dc974371-0529-4fcc-a4e9-198a3abfb63c.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fixes ref on SearchInput usage - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2122]: https://artsyproduct.atlassian.net/browse/CX-2122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ