### PR TITLE
chore(FX-3523): copy change filter on searchableartworkgrid

### DIFF
--- a/src/lib/Components/ArtworkGrids/FilterHeader2.tests.tsx
+++ b/src/lib/Components/ArtworkGrids/FilterHeader2.tests.tsx
@@ -1,0 +1,34 @@
+import { fireEvent } from "@testing-library/react-native"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { ArtworksFilterHeader } from "./FilterHeader2"
+
+describe("ArtistSeriesFilterHeader", () => {
+  const onPress = jest.fn()
+
+  it("renders without throwing an error and shows correct artworks count", () => {
+    const { getByText } = renderWithWrappersTL(
+      <ArtworksFilterHeader selectedFiltersCount={3} onFilterPress={onPress} />
+    )
+
+    expect(getByText("Sort & Filter")).toBeTruthy()
+    expect(getByText(" • 3")).toBeTruthy()
+  })
+
+  it("should call `onFilterPress` when `sort & filter` button is pressed", () => {
+    const { getByText } = renderWithWrappersTL(
+      <ArtworksFilterHeader selectedFiltersCount={3} onFilterPress={onPress} />
+    )
+
+    fireEvent.press(getByText("Sort & Filter"))
+    expect(onPress).toBeCalled()
+  })
+
+  it("Should render the custom title text if passed as prop", () => {
+    const { getByText } = renderWithWrappersTL(
+      <ArtworksFilterHeader selectedFiltersCount={3} onFilterPress={onPress} title="Custom title" />
+    )
+
+    expect(getByText("Custom title")).toBeTruthy()
+  })
+})

--- a/src/lib/Components/ArtworkGrids/FilterHeader2.tsx
+++ b/src/lib/Components/ArtworkGrids/FilterHeader2.tsx
@@ -5,12 +5,14 @@ interface FilterHeaderProps {
   children?: React.ReactNode
   onFilterPress: () => void
   selectedFiltersCount: number
+  title?: string
 }
 
 export const ArtworksFilterHeader: React.FC<FilterHeaderProps> = ({
   children,
   onFilterPress,
   selectedFiltersCount,
+  title,
 }) => {
   return (
     <Flex flexDirection="row" height={28} my={1} px={2} justifyContent="space-between" alignItems="center">
@@ -21,7 +23,7 @@ export const ArtworksFilterHeader: React.FC<FilterHeaderProps> = ({
           <Flex flex={1} flexDirection="row" alignItems="center">
             <FilterIcon fill={color} width="20px" height="20px" />
             <Text variant="xs" numberOfLines={1} color={color} ml={0.5}>
-              Sort & Filter
+              {title ?? "Sort & Filter"}
             </Text>
             {selectedFiltersCount > 0 && (
               <Text variant="xs" color="blue100">

--- a/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
+++ b/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
@@ -83,7 +83,11 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
         closeModal={handleCloseFilterArtworksModal}
         mode={FilterModalMode.Search}
       />
-      <ArtworksFilterHeader selectedFiltersCount={appliedFiltersCount} onFilterPress={handleOpenFilterArtworksModal} />
+      <ArtworksFilterHeader
+        title="Filter"
+        selectedFiltersCount={appliedFiltersCount}
+        onFilterPress={handleOpenFilterArtworksModal}
+      />
       <Separator />
       {artworksCount === 0 ? (
         <Box mb="80px" pt={6}>


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3523]

### Description

This pr changes the label of the Filter Button under SearchableArtworkGrid from `Sort & Filter` to `Filter` since we don't provide a sorting functionality on artwork grids with keyword search yet.

- Add title optional prop to `FilterHeader2` component that resolves to "Sort & Filter" when not passed
- Pass title = "Filter" when on Searchable Artwork Grid under mobile search

more context here [slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1635781485373200)

|Before|After|
|---|---|
|![simulator_screenshot_B09A9E0A-2239-4E16-A6CF-46E12F772FBF](https://user-images.githubusercontent.com/21178754/139709749-e5f66750-e119-47fd-a541-cf992d393fed.png)|![Simulator Screen Shot - iPhone 8 - 2021-11-01 at 17 52 28](https://user-images.githubusercontent.com/21178754/139709501-e40d5186-a873-4cdb-b97f-8e43b5714fc3.png)|

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- change filter title under searchable artworks grid - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3523]: https://artsyproduct.atlassian.net/browse/FX-3523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ