### PR TITLE
feat(FX-3526): enable the Sort By option for the Artworks pill when feature flag is enabled

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -9,6 +9,7 @@ import {
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { TouchableRow } from "lib/Components/TouchableRow"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
@@ -216,6 +217,8 @@ export const ArtworkFilterOptionsScreen: React.FC<
 }
 
 export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
+  const enableSortFilter = useFeatureFlag("AREnableSortFilterForArtworksPill")
+
   switch (mode) {
     case FilterModalMode.SaleArtworks:
       return [
@@ -233,7 +236,16 @@ export const getStaticFilterOptionsByMode = (mode: FilterModalMode) => {
         filterOptionToDisplayConfigMap.organizations,
       ]
 
+    // TODO: Remove the entire case block when AREnableSortFilterForArtworksPill flag is released
     case FilterModalMode.Search:
+      if (enableSortFilter) {
+        return [
+          filterOptionToDisplayConfigMap.sort,
+          filterOptionToDisplayConfigMap.waysToBuy,
+          filterOptionToDisplayConfigMap.attributionClass,
+        ]
+      }
+
       return [filterOptionToDisplayConfigMap.waysToBuy, filterOptionToDisplayConfigMap.attributionClass]
 
     default:

--- a/src/lib/Scenes/Search2/SearchArtworksGrid.tests.tsx
+++ b/src/lib/Scenes/Search2/SearchArtworksGrid.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react-native"
 import { SearchArtworksGridTestsQuery } from "__generated__/SearchArtworksGridTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { mockTrackEvent } from "lib/tests/globallyMockedStuff"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
@@ -81,5 +82,22 @@ describe("SearchArtworksGrid", () => {
           },
         ]
       `)
+  })
+
+  it('should display "Filter" label by default', () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(environment)
+
+    expect(getByText("Filter")).toBeTruthy()
+  })
+
+  it('should display "Sort & Filter" label when AREnableSortFilterForArtworksPill flag is enabled', () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSortFilterForArtworksPill: true })
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(environment)
+
+    expect(getByText("Sort & Filter")).toBeTruthy()
   })
 })

--- a/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
+++ b/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
@@ -6,6 +6,7 @@ import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids
 import { OwnerType } from "@artsy/cohesion"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { ArtworksFilterHeader } from "lib/Components/ArtworkGrids/FilterHeader2"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import { Box, quoteLeft, quoteRight, Separator, Text, useTheme } from "palette"
@@ -30,6 +31,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
   const { trackEvent } = useTracking()
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
   const setFiltersCountAction = ArtworksFiltersStore.useStoreActions((state) => state.setFiltersCountAction)
+  const enableSortFilter = useFeatureFlag("AREnableSortFilterForArtworksPill")
 
   const handleCloseFilterArtworksModal = (withFiltersApplying: boolean = false) => {
     if (!withFiltersApplying) {
@@ -86,7 +88,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
         mode={FilterModalMode.Search}
       />
       <ArtworksFilterHeader
-        title="Filter"
+        title={enableSortFilter ? "Sort & Filter" : "Filter"}
         selectedFiltersCount={appliedFiltersCount}
         onFilterPress={handleOpenFilterArtworksModal}
       />

--- a/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
+++ b/src/lib/Scenes/Search2/SearchArtworksGrid.tsx
@@ -88,7 +88,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
         mode={FilterModalMode.Search}
       />
       <ArtworksFilterHeader
-        title={enableSortFilter ? "Sort & Filter" : "Filter"}
+        {...!enableSortFilter && { title: "Filter" }}
         selectedFiltersCount={appliedFiltersCount}
         onFilterPress={handleOpenFilterArtworksModal}
       />

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -186,6 +186,11 @@ export const features = defineFeatures({
     description: "Enable Split.io A/B testing",
     showInAdminMenu: true,
   },
+  AREnableSortFilterForArtworksPill: {
+    readyForRelease: false,
+    description: "Enable sort filter for artworks pill",
+    showInAdminMenu: true,
+  },
 })
 
 export interface DevToggleDescriptor {

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -187,9 +187,10 @@ export const features = defineFeatures({
     showInAdminMenu: true,
   },
   AREnableSortFilterForArtworksPill: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable sort filter for artworks pill",
     showInAdminMenu: true,
+    echoFlagKey: "AREnableSortFilterForArtworksPill",
   },
 })
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3526]

⚠️ Changes behind a feature flag

### Description
* As a user
* When I open the improved search screen
* And when the feature flag is enabled
* And when I press the "sort & filter" button on the artworks pill
* I see the Sort By option and I can specify a sort filter

### Acceptance criteria
* Changes are available under the feature flag
* if feature flag is **enabled**, display **Sort & Filter** label
* if feature flag is **disabled**, display **Filter** label
* Changes should be behind a feature flag

### Useful links
* [Slack](https://artsy.slack.com/archives/C9SATFLUU/p1635860066395500)
 
### Demo
#### Before
https://user-images.githubusercontent.com/3513494/139913321-74d8425e-f388-4bb9-b851-b57b5a6ca84d.mp4

#### After
https://user-images.githubusercontent.com/3513494/139913352-c0fc8ab1-5476-440d-8af7-f456d7b4fd3a.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Enable the Sort By option for the Artworks pill when feature flag is enabled - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3526]: https://artsyproduct.atlassian.net/browse/FX-3526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ