### PR TITLE
feat(FX-3521): Disable search pills

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -96,7 +96,7 @@ export const Form: React.FC<FormProps> = (props) => {
         <InputTitle>Filters</InputTitle>
         <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
           {pills.map((pill, index) => (
-            <Pill selected testID="alert-pill" m={0.5} key={`filter-label-${index}`}>
+            <Pill testID="alert-pill" m={0.5} key={`filter-label-${index}`}>
               {pill}
             </Pill>
           ))}

--- a/src/lib/Scenes/Search/Search.tests.tsx
+++ b/src/lib/Scenes/Search/Search.tests.tsx
@@ -146,7 +146,7 @@ describe("Search Screen", () => {
 
   describe("search pills", () => {
     describe("with AREnableImprovedSearchPills enabled", () => {
-      it("are displayed if they have results and when the user has typed the minimum allowed number of characters", () => {
+      it("are displayed when the user has typed the minimum allowed number of characters", () => {
         __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
         const { getByPlaceholderText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
@@ -174,9 +174,54 @@ describe("Search Screen", () => {
 
         expect(queryByText("Top")).toBeTruthy()
         expect(queryByText("Artist")).toBeTruthy()
-        expect(queryByText("Auction")).toBeFalsy()
+        expect(queryByText("Auction")).toBeTruthy()
         expect(queryByText("Gallery")).toBeTruthy()
-        expect(queryByText("Fair")).toBeFalsy()
+        expect(queryByText("Fair")).toBeTruthy()
+      })
+
+      it("have top pill selected and disabled at the same time", () => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
+        const { getByPlaceholderText, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
+        mockEnvironmentPayload(mockEnvironment, {
+          Algolia: () => ({
+            appID: "",
+            apiKey: "",
+            indices: [
+              { name: "Artist_staging", displayName: "Artist" },
+              { name: "Sale_staging", displayName: "Auction" },
+              { name: "Gallery_staging", displayName: "Gallery" },
+              { name: "Fair_staging", displayName: "Fair" },
+            ],
+          }),
+        })
+        const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+        fireEvent(searchInput, "changeText", "Ba")
+        const topPill = getByA11yState({ selected: true, disabled: true })
+        expect(topPill).toHaveTextContent("Top")
+      })
+
+      it("are enabled when they have results", () => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
+        const { getByPlaceholderText, getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
+        mockEnvironmentPayload(mockEnvironment, {
+          Algolia: () => ({
+            appID: "",
+            apiKey: "",
+            indices: [
+              { name: "Artist_staging", displayName: "Artist" },
+              { name: "Sale_staging", displayName: "Auction" },
+              { name: "Gallery_staging", displayName: "Gallery" },
+              { name: "Fair_staging", displayName: "Fair" },
+            ],
+          }),
+        })
+        const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+        fireEvent(searchInput, "changeText", "Ba")
+        const enabledPills = getAllByA11yState({ disabled: false })
+        expect(enabledPills).toHaveLength(3)
+        expect(enabledPills[0]).toHaveTextContent("Artworks")
+        expect(enabledPills[1]).toHaveTextContent("Artist")
+        expect(enabledPills[2]).toHaveTextContent("Gallery")
       })
     })
 

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -93,7 +93,7 @@ export const Search: React.FC<SearchProps> = (props) => {
   const pillsArray = useMemo<PillType[]>(() => {
     if (Array.isArray(indices) && indices.length > 0) {
       const formattedIndices: PillType[] = indices.map((index) => {
-        return { ...index, type: "algolia", disabled: !indicesInfo[index.name]?.hasResults }
+        return { ...index, type: "algolia", disabled: enableImprovedPills && !indicesInfo[index.name]?.hasResults }
       })
 
       return [...pills, ...formattedIndices]

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -92,12 +92,9 @@ export const Search: React.FC<SearchProps> = (props) => {
 
   const pillsArray = useMemo<PillType[]>(() => {
     if (Array.isArray(indices) && indices.length > 0) {
-      const formattedIndices: PillType[] = indices.reduce((acc, index) => {
-        if (!enableImprovedPills || indicesInfo[index.name]?.hasResults) {
-          acc.push({ ...index, type: "algolia" })
-        }
-        return acc
-      }, [])
+      const formattedIndices: PillType[] = indices.map((index) => {
+        return { ...index, type: "algolia", disabled: !indicesInfo[index.name]?.hasResults }
+      })
 
       return [...pills, ...formattedIndices]
     }

--- a/src/lib/Scenes/Search/Search.tsx
+++ b/src/lib/Scenes/Search/Search.tsx
@@ -86,7 +86,7 @@ export const Search: React.FC<SearchProps> = (props) => {
   const { searchClient } = useAlgoliaClient(system?.algolia?.appID!, system?.algolia?.apiKey!)
   const searchInsightsConfigured = useSearchInsightsConfig(system?.algolia?.appID, system?.algolia?.apiKey)
   const indices = system?.algolia?.indices
-  const { indicesInfo, updateIndicesInfo } = useAlgoliaIndices(searchClient, indices)
+  const { loading: indicesInfoLoading, indicesInfo, updateIndicesInfo } = useAlgoliaIndices(searchClient, indices)
   const { trackEvent } = useTracking()
   const enableImprovedPills = useFeatureFlag("AREnableImprovedSearchPills")
 
@@ -218,6 +218,7 @@ export const Search: React.FC<SearchProps> = (props) => {
                 <Box pt={2} pb={1}>
                   <SearchPills
                     ref={searchPillsRef}
+                    loading={indicesInfoLoading}
                     pills={pillsArray}
                     onPillPress={handlePillPress}
                     isSelected={isSelected}

--- a/src/lib/Scenes/Search/components/SearchPills.tests.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tests.tsx
@@ -9,23 +9,35 @@ const pills: PillType[] = [
     name: "first",
     displayName: "First",
     type: "algolia",
+    disabled: false,
   },
   {
     name: "second",
     displayName: "Second",
     type: "algolia",
+    disabled: false,
   },
   {
     name: "third",
     displayName: "Third",
     type: "algolia",
+    disabled: false,
   },
 ]
 
 describe("SearchPills", () => {
   const mockRef = jest.fn()
   const TestRenderer = (props: Partial<SearchPillsProps>) => {
-    return <SearchPills ref={mockRef} pills={pills} onPillPress={jest.fn} isSelected={() => false} {...props} />
+    return (
+      <SearchPills
+        ref={mockRef}
+        loading={false}
+        pills={pills}
+        onPillPress={jest.fn}
+        isSelected={() => false}
+        {...props}
+      />
+    )
   }
 
   it("renders without throwing an error", () => {
@@ -46,6 +58,7 @@ describe("SearchPills", () => {
       type: "algolia",
       name: "second",
       displayName: "Second",
+      disabled: false,
     })
   })
 

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -4,14 +4,14 @@ import { ScrollView } from "react-native"
 import { PillType } from "../types"
 
 export interface SearchPillsProps {
-  loading: boolean
+  loading?: boolean
   pills: PillType[]
   onPillPress: (pill: PillType) => void
   isSelected: (pill: PillType) => boolean
 }
 
 export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props, ref) => {
-  const { loading, pills, onPillPress, isSelected } = props
+  const { loading = false, pills, onPillPress, isSelected } = props
   const space = useSpace()
 
   return (

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -33,9 +33,7 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
           <Pill
             mr={1}
             key={name}
-            accessibilityState={{
-              selected,
-            }}
+            accessibilityState={{ selected, disabled: disabledWithStyles || selected }}
             rounded
             selected={selected}
             disabled={disabledWithStyles || selected}

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -39,7 +39,7 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
             rounded
             selected={selected}
             disabled={disabledWithStyles || selected}
-            disabledStylesEnabled={disabledWithStyles}
+            applyDisabledStyles={disabledWithStyles}
             onPress={() => onPillPress(pill)}
           >
             {displayName}

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -36,7 +36,8 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
             }}
             rounded
             selected={selected}
-            disabled={selected}
+            disabled={pill.disabled || selected}
+            disabledStylesEnabled={pill.disabled}
             onPress={() => onPillPress(pill)}
           >
             {displayName}

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -27,7 +27,7 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
       {pills.map((pill) => {
         const { name, displayName } = pill
         const selected = isSelected(pill)
-        const disabled = (!!pill.disabled || !!loading || !!selected) && pill.name !== "TOP"
+        const disabled = !!pill.disabled || !!loading || !!selected
 
         return (
           <Pill

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -27,17 +27,16 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
       {pills.map((pill) => {
         const { name, displayName } = pill
         const selected = isSelected(pill)
-        const disabledWithStyles = (!!pill.disabled || !!loading) && pill.name !== "TOP"
+        const disabled = (!!pill.disabled || !!loading || !!selected) && pill.name !== "TOP"
 
         return (
           <Pill
             mr={1}
             key={name}
-            accessibilityState={{ selected, disabled: disabledWithStyles || selected }}
+            accessibilityState={{ selected, disabled }}
             rounded
             selected={selected}
-            disabled={disabledWithStyles || selected}
-            applyDisabledStyles={disabledWithStyles}
+            disabled={disabled}
             onPress={() => onPillPress(pill)}
           >
             {displayName}

--- a/src/lib/Scenes/Search/components/SearchPills.tsx
+++ b/src/lib/Scenes/Search/components/SearchPills.tsx
@@ -4,13 +4,14 @@ import { ScrollView } from "react-native"
 import { PillType } from "../types"
 
 export interface SearchPillsProps {
+  loading: boolean
   pills: PillType[]
   onPillPress: (pill: PillType) => void
   isSelected: (pill: PillType) => boolean
 }
 
 export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props, ref) => {
-  const { pills, onPillPress, isSelected } = props
+  const { loading, pills, onPillPress, isSelected } = props
   const space = useSpace()
 
   return (
@@ -26,6 +27,7 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
       {pills.map((pill) => {
         const { name, displayName } = pill
         const selected = isSelected(pill)
+        const disabledWithStyles = (!!pill.disabled || !!loading) && pill.name !== "TOP"
 
         return (
           <Pill
@@ -36,8 +38,8 @@ export const SearchPills = React.forwardRef<ScrollView, SearchPillsProps>((props
             }}
             rounded
             selected={selected}
-            disabled={pill.disabled || selected}
-            disabledStylesEnabled={pill.disabled}
+            disabled={disabledWithStyles || selected}
+            disabledStylesEnabled={disabledWithStyles}
             onPress={() => onPillPress(pill)}
           >
             {displayName}

--- a/src/lib/Scenes/Search/types.ts
+++ b/src/lib/Scenes/Search/types.ts
@@ -13,6 +13,6 @@ export type PillEntityType = "algolia" | "elastic"
 export interface PillType {
   name: string
   displayName: string
-  disabled: boolean
+  disabled?: boolean
   type: PillEntityType
 }

--- a/src/lib/Scenes/Search/types.ts
+++ b/src/lib/Scenes/Search/types.ts
@@ -13,5 +13,6 @@ export type PillEntityType = "algolia" | "elastic"
 export interface PillType {
   name: string
   displayName: string
+  disabled: boolean
   type: PillEntityType
 }

--- a/src/lib/utils/useAlgoliaIndices.ts
+++ b/src/lib/utils/useAlgoliaIndices.ts
@@ -12,6 +12,7 @@ interface IndicesInfo {
 
 export const useAlgoliaIndices = (client: SearchClient | null, indices?: ReadonlyArray<{ name: string }>) => {
   const [indicesInfo, setIndicesInfo] = useState<IndicesInfo>({})
+  const [loading, setLoading] = useState<boolean>(false)
   const lastQuery = useRef<string | null>(null)
 
   const updateIndicesInfo = useCallback(
@@ -29,6 +30,7 @@ export const useAlgoliaIndices = (client: SearchClient | null, indices?: Readonl
         }))
 
         if (!!client) {
+          setLoading(true)
           const indicesResponse = await client.multipleQueries<SearchResponse>(queries)
           if (query === lastQuery.current) {
             const newIndicesInfo = indicesResponse.results.reduce((acc: IndicesInfo, { index, nbHits }) => {
@@ -38,6 +40,7 @@ export const useAlgoliaIndices = (client: SearchClient | null, indices?: Readonl
               return acc
             }, {})
             setIndicesInfo(newIndicesInfo)
+            setLoading(false)
           }
         }
       }
@@ -45,5 +48,5 @@ export const useAlgoliaIndices = (client: SearchClient | null, indices?: Readonl
     [client, indices]
   )
 
-  return { indicesInfo, updateIndicesInfo }
+  return { loading, indicesInfo, updateIndicesInfo }
 }

--- a/src/lib/utils/useAlgoliaIndices.ts
+++ b/src/lib/utils/useAlgoliaIndices.ts
@@ -12,7 +12,7 @@ interface IndicesInfo {
 
 export const useAlgoliaIndices = (client: SearchClient | null, indices?: ReadonlyArray<{ name: string }>) => {
   const [indicesInfo, setIndicesInfo] = useState<IndicesInfo>({})
-  const [loading, setLoading] = useState<boolean>(false)
+  const [loading, setLoading] = useState(false)
   const lastQuery = useRef<string | null>(null)
 
   const updateIndicesInfo = useCallback(

--- a/src/palette/elements/Pill/Pill.stories.tsx
+++ b/src/palette/elements/Pill/Pill.stories.tsx
@@ -32,12 +32,12 @@ storiesOf("Pill", module)
     <List>
       <Pill>Not Selected</Pill>
       <Pill selected>Selected</Pill>
-      <Pill applyDisabledStyles>Disabled</Pill>
+      <Pill disabled>Disabled</Pill>
       <Pill rounded>Not Selected</Pill>
       <Pill rounded selected>
         Selected
       </Pill>
-      <Pill applyDisabledStyles rounded>
+      <Pill disabled rounded>
         Disabled
       </Pill>
     </List>

--- a/src/palette/elements/Pill/Pill.stories.tsx
+++ b/src/palette/elements/Pill/Pill.stories.tsx
@@ -31,10 +31,14 @@ storiesOf("Pill", module)
   .add("Text", () => (
     <List>
       <Pill>Not Selected</Pill>
-      <Pill selected>[NEW]Selected</Pill>
+      <Pill selected>Selected</Pill>
+      <Pill applyDisabledStyles>Disabled</Pill>
       <Pill rounded>Not Selected</Pill>
       <Pill rounded selected>
         Selected
+      </Pill>
+      <Pill applyDisabledStyles rounded>
+        Disabled
       </Pill>
     </List>
   ))

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -164,7 +164,7 @@ const useStyleForState = (state: DisplayState): { textColor: string; borderColor
       break
     case DisplayState.Selected2:
       retval.textColor = color("white100")
-      retval.borderColor = color("white100")
+      retval.borderColor = color("blue100")
       retval.backgroundColor = color("blue100")
       break
     case DisplayState.Enabled:

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -2,6 +2,7 @@ import OpaqueImageView from "lib/Components/OpaqueImageView/OpaqueImageView"
 import { Flex, FlexProps } from "../Flex"
 import { Text, useTextStyleForPalette } from "../Text"
 
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { IconProps, Spacer, useColor } from "palette"
 import React, { ReactNode, useEffect, useState } from "react"
 import { GestureResponderEvent, Pressable, PressableProps } from "react-native"
@@ -28,8 +29,10 @@ export interface PillProps extends FlexProps {
 
 enum DisplayState {
   Enabled = "enabled",
+  Enabled2 = "enabled2",
   Pressed = "pressed",
   Selected = "selected",
+  Selected2 = "selected2",
   Disabled = "disabled",
 }
 
@@ -70,8 +73,12 @@ export const Pill: React.FC<PillProps> = ({
   highlightEnabled = false,
   ...rest
 }) => {
+  const enableImprovedPills = useFeatureFlag("AREnableImprovedSearchPills")
+
   const textStyle = useTextStyleForPalette(size === "xxs" ? "xs" : "sm")
-  const initialDisplayState = selected ? DisplayState.Selected : DisplayState.Enabled
+  const enabledDisplayState = enableImprovedPills ? DisplayState.Enabled2 : DisplayState.Enabled
+  const selectedDisplayState = enableImprovedPills ? DisplayState.Selected2 : DisplayState.Selected
+  const initialDisplayState = selected ? selectedDisplayState : enabledDisplayState
   const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
   const { height, paddingLeft, paddingRight } = getSize(size)
 
@@ -156,11 +163,21 @@ const useStyleForState = (state: DisplayState): { textColor: string; borderColor
       retval.backgroundColor = color("white100")
       break
     case DisplayState.Selected:
+      retval.textColor = color("black100")
+      retval.borderColor = color("black60")
+      retval.backgroundColor = color("white100")
+      break
+    case DisplayState.Selected2:
       retval.textColor = color("white100")
       retval.borderColor = color("white100")
       retval.backgroundColor = color("blue100")
       break
     case DisplayState.Enabled:
+      retval.textColor = color("black100")
+      retval.borderColor = color("black15")
+      retval.backgroundColor = color("white100")
+      break
+    case DisplayState.Enabled2:
       retval.textColor = color("black100")
       retval.borderColor = color("black60")
       retval.backgroundColor = color("white100")

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -23,7 +23,6 @@ export interface PillProps extends FlexProps {
   disabled?: boolean
   selected?: boolean
   imageUrl?: string
-  applyDisabledStyles?: boolean
   highlightEnabled?: boolean
 }
 
@@ -69,7 +68,6 @@ export const Pill: React.FC<PillProps> = ({
   children,
   disabled,
   rounded,
-  applyDisabledStyles = false,
   highlightEnabled = false,
   ...rest
 }) => {
@@ -91,8 +89,8 @@ export const Pill: React.FC<PillProps> = ({
   }, [selected])
 
   useEffect(() => {
-    setInnerDisplayState(applyDisabledStyles ? DisplayState.Disabled : initialDisplayState)
-  }, [applyDisabledStyles])
+    setInnerDisplayState(disabled && !selected ? DisplayState.Disabled : initialDisplayState)
+  }, [disabled])
 
   const iconSpacerMargin = size === "xxs" ? 0.5 : 1
   const iconColor = innerDisplayState === "pressed" ? "blue100" : "black100"

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -28,10 +28,10 @@ export interface PillProps extends FlexProps {
 
 enum DisplayState {
   Enabled = "enabled",
-  Enabled2 = "enabled2",
+  EnabledImprovedFlag = "enabled2",
   Pressed = "pressed",
   Selected = "selected",
-  Selected2 = "selected2",
+  SelectedImprovedFlag = "selected2",
   Disabled = "disabled",
 }
 
@@ -74,8 +74,8 @@ export const Pill: React.FC<PillProps> = ({
   const enableImprovedPills = useFeatureFlag("AREnableImprovedSearchPills")
 
   const textStyle = useTextStyleForPalette(size === "xxs" ? "xs" : "sm")
-  const enabledDisplayState = enableImprovedPills ? DisplayState.Enabled2 : DisplayState.Enabled
-  const selectedDisplayState = enableImprovedPills ? DisplayState.Selected2 : DisplayState.Selected
+  const enabledDisplayState = enableImprovedPills ? DisplayState.EnabledImprovedFlag : DisplayState.Enabled
+  const selectedDisplayState = enableImprovedPills ? DisplayState.SelectedImprovedFlag : DisplayState.Selected
   const standartDisplayState = disabled ? DisplayState.Disabled : enabledDisplayState
   const initialDisplayState = selected ? selectedDisplayState : standartDisplayState
   const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
@@ -162,7 +162,7 @@ const useStyleForState = (state: DisplayState): { textColor: string; borderColor
       retval.borderColor = color("black60")
       retval.backgroundColor = color("white100")
       break
-    case DisplayState.Selected2:
+    case DisplayState.SelectedImprovedFlag:
       retval.textColor = color("white100")
       retval.borderColor = color("blue100")
       retval.backgroundColor = color("blue100")
@@ -172,7 +172,7 @@ const useStyleForState = (state: DisplayState): { textColor: string; borderColor
       retval.borderColor = color("black15")
       retval.backgroundColor = color("white100")
       break
-    case DisplayState.Enabled2:
+    case DisplayState.EnabledImprovedFlag:
       retval.textColor = color("black100")
       retval.borderColor = color("black60")
       retval.backgroundColor = color("white100")

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -76,7 +76,8 @@ export const Pill: React.FC<PillProps> = ({
   const textStyle = useTextStyleForPalette(size === "xxs" ? "xs" : "sm")
   const enabledDisplayState = enableImprovedPills ? DisplayState.Enabled2 : DisplayState.Enabled
   const selectedDisplayState = enableImprovedPills ? DisplayState.Selected2 : DisplayState.Selected
-  const initialDisplayState = selected ? selectedDisplayState : enabledDisplayState
+  const standartDisplayState = disabled ? DisplayState.Disabled : enabledDisplayState
+  const initialDisplayState = selected ? selectedDisplayState : standartDisplayState
   const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
   const { height, paddingLeft, paddingRight } = getSize(size)
 
@@ -86,11 +87,7 @@ export const Pill: React.FC<PillProps> = ({
 
   useEffect(() => {
     setInnerDisplayState(initialDisplayState)
-  }, [selected])
-
-  useEffect(() => {
-    setInnerDisplayState(disabled && !selected ? DisplayState.Disabled : initialDisplayState)
-  }, [disabled])
+  }, [disabled, selected])
 
   const iconSpacerMargin = size === "xxs" ? 0.5 : 1
   const iconColor = innerDisplayState === "pressed" ? "blue100" : "black100"

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -22,6 +22,7 @@ export interface PillProps extends FlexProps {
   disabled?: boolean
   selected?: boolean
   imageUrl?: string
+  disabledStylesEnabled?: boolean
   highlightEnabled?: boolean
 }
 
@@ -64,6 +65,7 @@ export const Pill: React.FC<PillProps> = ({
   children,
   disabled,
   rounded,
+  disabledStylesEnabled = false,
   highlightEnabled = false,
   ...rest
 }) => {
@@ -71,6 +73,7 @@ export const Pill: React.FC<PillProps> = ({
   const initialDisplayState = selected ? DisplayState.Selected : DisplayState.Enabled
   const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
   const { height, paddingLeft, paddingRight } = getSize(size)
+  const color = useColor()
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
@@ -85,7 +88,7 @@ export const Pill: React.FC<PillProps> = ({
   const to = useStyleForState(innerDisplayState)
   return (
     <Spring native to={to} config={config.stiff}>
-      {(springProps: typeof to) => (
+      {() => (
         <Pressable
           disabled={disabled || !onPress}
           onPress={handlePress}
@@ -109,7 +112,7 @@ export const Pill: React.FC<PillProps> = ({
             paddingLeft={paddingLeft}
             paddingRight={paddingRight}
             style={{
-              borderColor: springProps.borderColor,
+              borderColor: disabledStylesEnabled ? color("black30") : color("black60"),
             }}
             {...rest}
           >
@@ -120,7 +123,10 @@ export const Pill: React.FC<PillProps> = ({
               </>
             )}
             {!!imageUrl && <OpaqueImageViewContainer imageURL={imageUrl} />}
-            <AnimatedText numberOfLines={1} style={[textStyle, { color: springProps.textColor }]}>
+            <AnimatedText
+              numberOfLines={1}
+              style={[textStyle, { color: disabledStylesEnabled ? color("black30") : color("black100") }]}
+            >
               {children}
             </AnimatedText>
             {iconPosition === "right" && !!Icon && (


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR resolves [FX-3521]

### Description
It was decided to disable search pills of categories with no results instead of hiding them because we need to avoid user to land on screen and see _no results_ state and flickering pills might be a bad UX. So now pill will be disabled if i has no results or if the query for the information about all pills state is pending.

https://user-images.githubusercontent.com/44819355/140509440-48c998bb-284e-4439-9214-0438df87262e.mp4


Along with that this PR updates Pill view across the app, adds 2 states: active and disabled.

![Screenshot 2021-11-05 at 15 15 30](https://user-images.githubusercontent.com/44819355/140508783-00ad5e3c-6566-4559-a59f-16e4c3225ceb.png)

Changes are available with `AREnableImprovedSearchPills` flag enabled



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add disabled and active states to pill - anastasiapyzhik
- disable search pills when loading and when there is no results - anastasiapyzhik

</details>


[FX-3521]: https://artsyproduct.atlassian.net/browse/FX-3521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ