### PR TITLE
feat: Convert Adjust universal links GRO-419

### DIFF
--- a/Artsy/App/ARAppActivityContinuationDelegate.m
+++ b/Artsy/App/ARAppActivityContinuationDelegate.m
@@ -6,6 +6,7 @@
 
 #import <CoreSpotlight/CoreSpotlight.h>
 #import <Emission/AREmission.h>
+#import <Adjust/Adjust.h>
 
 static  NSString *SailthruLinkDomain = @"link.artsy.net";
 
@@ -36,7 +37,17 @@ static  NSString *SailthruLinkDomain = @"link.artsy.net";
 
         // Show the screen they clicked on
         if ([[ARUserManager sharedManager] hasExistingAccount]) {
-            [[AREmission sharedInstance] navigate:[decodedURL absoluteString]];
+            NSURL *convertedUrl = [Adjust convertUniversalLink:decodedURL scheme:@"artsy"];
+            if (convertedUrl) {
+                [Adjust appWillOpenUrl:decodedURL];
+                
+                // ensure the path includes our quirk of needing three slashes
+                NSString *convertedPath = [convertedUrl absoluteString];
+                NSString *fixedPath = [convertedPath stringByReplacingOccurrencesOfString:@"artsy://" withString:@"artsy:///"];
+                [[AREmission sharedInstance] navigate:fixedPath];
+            } else {
+                [[AREmission sharedInstance] navigate:[decodedURL absoluteString]];
+            }
         }
     });
     return YES;


### PR DESCRIPTION
After lots of trial and error @brainbicycle and I were able to figure out that we need to convert the Adjust universal links to match our quirky schema. What you see here does that conversion: either the link is not an Adjust link and we skip to the else branch or it is and Adjust link and we do some converting.

We tested this via the simulator and commands like this:

```
$ xcrun simctl openurl booted "https://wvxa.adj.st/artwork/ray-parker-number-6?adj_t=n4sw6qk&adj_campaign=best-campaign&adj_adgroup=awesome-group&adj_creative=super-creative&adj_label=jon-test"
$ xcrun simctl openurl booted "https://www.artsy.net/artist/kaws"
```

https://artsyproduct.atlassian.net/browse/GRO-419

/cc @artsy/grow-devs