### PR TITLE
fix: Input with limit

### DIFF
--- a/src/palette/elements/Input/Input.stories.tsx
+++ b/src/palette/elements/Input/Input.stories.tsx
@@ -20,9 +20,9 @@ storiesOf("Input", module)
       <Input title="Disabled" disabled />
       <Input placeholder="I'm a placeholder" />
       <Input title="full text" value="Wow this is a long text, I wonder if I can read the whole thing!" />
-      <Input title="Text with limit" maxLength={100} />
+      <Input title="Text with limit" maxLength={100} showLimit />
       <Input title="Text area" multiline />
-      <Input title="Text area with limit" multiline maxLength={150} />
+      <Input title="Text area with limit" multiline maxLength={150} showLimit />
     </List>
   ))
   .add("Multiple placeholders", () => {

--- a/src/palette/elements/Input/Input.tsx
+++ b/src/palette/elements/Input/Input.tsx
@@ -38,6 +38,7 @@ export interface InputProps extends Omit<TextInputProps, "placeholder"> {
   title?: string
   multiline?: boolean
   maxLength?: number
+  showLimit?: boolean
   /**
    * The placeholder can be an array of string, specifically for android, because of a bug.
    * On ios, the longest string will always be picked, as ios can add ellipsis.
@@ -90,6 +91,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
       placeholder,
       multiline,
       maxLength,
+      showLimit,
       ...rest
     },
     ref
@@ -213,7 +215,7 @@ export const Input = React.forwardRef<TextInput, InputProps>(
       <Flex flexGrow={1} style={containerStyle}>
         <Flex flexDirection="row" alignItems="center">
           <InputTitle required={required}>{title}</InputTitle>
-          {!!maxLength && (
+          {!!maxLength && !!showLimit && (
             <Text color="black60" variant="xs" marginLeft="auto" mr={0.5}>
               {maxLength - value.length}
             </Text>


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [[Slack discussion](https://artsy.slack.com/archives/C01B2P6LJUU/p1635959068347300)]

### Description

This PR is a bug fix for the displayed limit of the Input components with props `maxLength`. t's a follow up of #5699

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/17421923/140291860-d2ed9c33-ee2e-45c8-881c-927539863f2b.png)|![image](https://user-images.githubusercontent.com/17421923/140291721-4579aec3-3f18-423c-a2d9-4b9e046d7dae.png)|


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Limit will not show for the Input components unless `showLimit` prop is passed - sam

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
