### PR TITLE
fix: (CX-2149) Add Work and Browse for you buttons are placed to the center. 

### DIFF
--- a/src/lib/Components/States/ZeroState.tsx
+++ b/src/lib/Components/States/ZeroState.tsx
@@ -12,7 +12,7 @@ interface ZeroStateProps {
 export const ZeroState = (props: ZeroStateProps) => {
   const color = useColor()
   return (
-    <Flex py="4" px="2" justifyContent="center" style={{ height: "100%" }}>
+    <Flex flex={1} py="6" px="2" justifyContent="center">
       <Flex minHeight={30}>
         {!!props.title && (
           <>

--- a/src/lib/Scenes/Favorites/FavoriteArtworks.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteArtworks.tsx
@@ -76,7 +76,6 @@ export class SavedWorks extends Component<Props, State> {
       return (
         <StickyTabPageScrollView
           refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
-          contentContainerStyle={{ flex: 1 }}
         >
           <ZeroState
             title="You haven’t saved any works yet"


### PR DESCRIPTION
The type of this PR is: Bugfix

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2149]

### Description

This PR fixes the `Add work` and `Browse works for you` buttons in my collection screen getting misplaced. 
This was because the header component is getting more content in it and the screen is not following flex rules

|Before|After|
|---|---|
|<img width="415" alt="Screenshot 2021-11-04 at 12 25 53" src="https://user-images.githubusercontent.com/17421923/140308735-20093f57-baee-44f2-8ade-86ad2f4e9c33.png">|<img width="416" alt="Screenshot 2021-11-04 at 12 22 08" src="https://user-images.githubusercontent.com/17421923/140308774-749d2665-9501-4a39-8676-fd9640ce120f.png">|
|<img width="348" alt="Screenshot 2021-11-04 at 12 36 57" src="https://user-images.githubusercontent.com/17421923/140310173-6f807dc7-441c-47ce-b2e1-e9e99cf4f92e.png">|<img width="345" alt="Screenshot 2021-11-04 at 13 01 27" src="https://user-images.githubusercontent.com/17421923/140310205-41a04e93-8c2d-4e5d-9545-295db6e2b863.png">|

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add works and Browe works button are placed at the center of the MyCollection screen - sam

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2149]: https://artsyproduct.atlassian.net/browse/CX-2149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ