### PR TITLE
fix(FX-3587): Multi select option checkbox

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -4,10 +4,14 @@ import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
 import { SearchInput } from "lib/Components/SearchInput"
 import { TouchableRow } from "lib/Components/TouchableRow"
-import { Box, Check, Flex, Text } from "palette"
+import { useScreenDimensions } from "lib/utils/useScreenDimensions"
+import { Box, Check, CHECK_SIZE, Flex, Text, useSpace } from "palette"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
 import styled from "styled-components/native"
+
+const OPTIONS_MARGIN_LEFT = 0.5
+const OPTION_PADDING = 15
 
 interface MultiSelectOptionScreenProps extends FancyModalHeaderProps {
   navigation: StackNavigationProp<ParamListBase>
@@ -33,6 +37,10 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   noResultsLabel = "No results",
   ...rest
 }) => {
+  const space = useSpace()
+  const { width } = useScreenDimensions()
+  const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
+
   const handleBackNavigation = () => {
     navigation.goBack()
   }
@@ -89,7 +97,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
             const selected = itemIsSelected(item)
 
             return (
-              <Box ml={0.5}>
+              <Box ml={OPTIONS_MARGIN_LEFT}>
                 <TouchableRow
                   onPress={() => {
                     const currentParamValue = item.paramValue as boolean
@@ -100,9 +108,11 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
                   accessibilityState={{ checked: selected }}
                 >
                   <OptionListItem>
-                    <Text variant="xs" color="black100">
-                      {item.displayText}
-                    </Text>
+                    <Box maxWidth={optionTextMaxWidth}>
+                      <Text variant="xs" color="black100">
+                        {item.displayText}
+                      </Text>
+                    </Box>
 
                     <Check selected={selected} disabled={disabled} />
                   </OptionListItem>
@@ -120,6 +130,6 @@ export const OptionListItem = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
   flex-grow: 1;
-  align-items: flex-end;
-  padding: 15px;
+  align-items: flex-start;
+  padding: ${OPTION_PADDING}px;
 `

--- a/src/palette/elements/Checkbox/Check.tsx
+++ b/src/palette/elements/Checkbox/Check.tsx
@@ -4,6 +4,8 @@ import styled, { css } from "styled-components/native"
 import { CheckIcon } from "../../svgs/CheckIcon"
 import { Box } from "../Box"
 
+export const CHECK_SIZE = 22
+
 const CHECK_MODES = {
   default: {
     resting: css`
@@ -54,8 +56,8 @@ export const Check: React.FC<CheckProps> = ({ disabled, selected, ...rest }) => 
 }
 
 const Container = styled(Box)<CheckProps>`
-  width: 22px;
-  height: 22px;
+  width: ${CHECK_SIZE}px;
+  height: ${CHECK_SIZE}px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-3587]

### Description

When I get on artworks filters
and go to some multi select options filter
which has some option with text long enough to reach the checkbox on the right
I see that the checkbox is shifted and not aligned with the others

We should prevent checkboxes from being misaligned
#### Demo

|Before|After|
|---|---|
|![Screenshot_20211116-114438_Artsy](https://user-images.githubusercontent.com/44819355/141973160-74aa7041-5fa2-41fb-b61f-c701426ecca6.jpg)|![Screenshot_20211116-135925_Artsy](https://user-images.githubusercontent.com/44819355/141973633-8b5ddaca-8675-4370-8719-b98b40fac824.jpg)|



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fix multi select filter option layout - anastasiapyzhik

<!-- end_changelog_updates -->

</details>


[FX-3587]: https://artsyproduct.atlassian.net/browse/FX-3587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ