### PR TITLE
feat(FX-3576): Create link for user to view/update email preferences

### DIFF
--- a/src/__generated__/CreateSavedSearchAlertScreenRefetchQuery.graphql.ts
+++ b/src/__generated__/CreateSavedSearchAlertScreenRefetchQuery.graphql.ts
@@ -1,0 +1,103 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash e01d9128f1dbf7abcaac41f6f7f9b87f */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CreateSavedSearchAlertScreenRefetchQueryVariables = {};
+export type CreateSavedSearchAlertScreenRefetchQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"CreateSavedSearchAlertScreen_me">;
+    } | null;
+};
+export type CreateSavedSearchAlertScreenRefetchQuery = {
+    readonly response: CreateSavedSearchAlertScreenRefetchQueryResponse;
+    readonly variables: CreateSavedSearchAlertScreenRefetchQueryVariables;
+};
+
+
+
+/*
+query CreateSavedSearchAlertScreenRefetchQuery {
+  me {
+    ...CreateSavedSearchAlertScreen_me
+    id
+  }
+}
+
+fragment CreateSavedSearchAlertScreen_me on Me {
+  emailFrequency
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CreateSavedSearchAlertScreenRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "CreateSavedSearchAlertScreen_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "CreateSavedSearchAlertScreenRefetchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "e01d9128f1dbf7abcaac41f6f7f9b87f",
+    "metadata": {},
+    "name": "CreateSavedSearchAlertScreenRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+(node as any).hash = '90158348c2a8c52bddbfc9bb9b904937';
+export default node;

--- a/src/__generated__/CreateSavedSearchAlertScreen_me.graphql.ts
+++ b/src/__generated__/CreateSavedSearchAlertScreen_me.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CreateSavedSearchAlertScreen_me = {
+    readonly emailFrequency: string | null;
+    readonly " $refType": "CreateSavedSearchAlertScreen_me";
+};
+export type CreateSavedSearchAlertScreen_me$data = CreateSavedSearchAlertScreen_me;
+export type CreateSavedSearchAlertScreen_me$key = {
+    readonly " $data"?: CreateSavedSearchAlertScreen_me$data;
+    readonly " $fragmentRefs": FragmentRefs<"CreateSavedSearchAlertScreen_me">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "CreateSavedSearchAlertScreen_me",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "emailFrequency",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = 'ae0ddf16ad30d3c62fecdb063de9bc62';
+export default node;

--- a/src/__generated__/CreateSavedSearchAlertTestsQuery.graphql.ts
+++ b/src/__generated__/CreateSavedSearchAlertTestsQuery.graphql.ts
@@ -1,0 +1,124 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash 952339cebec96492825e0beb0857324d */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CreateSavedSearchAlertTestsQueryVariables = {};
+export type CreateSavedSearchAlertTestsQueryResponse = {
+    readonly me: {
+        readonly " $fragmentRefs": FragmentRefs<"CreateSavedSearchAlertScreen_me">;
+    } | null;
+};
+export type CreateSavedSearchAlertTestsQuery = {
+    readonly response: CreateSavedSearchAlertTestsQueryResponse;
+    readonly variables: CreateSavedSearchAlertTestsQueryVariables;
+};
+
+
+
+/*
+query CreateSavedSearchAlertTestsQuery {
+  me {
+    ...CreateSavedSearchAlertScreen_me
+    id
+  }
+}
+
+fragment CreateSavedSearchAlertScreen_me on Me {
+  emailFrequency
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CreateSavedSearchAlertTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "CreateSavedSearchAlertScreen_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "CreateSavedSearchAlertTestsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "952339cebec96492825e0beb0857324d",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.emailFrequency": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "String"
+        },
+        "me.id": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ID"
+        }
+      }
+    },
+    "name": "CreateSavedSearchAlertTestsQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+(node as any).hash = '5cec524a39eb01adf1ff1221a283af08';
+export default node;

--- a/src/__generated__/SavedSearchButtonQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash d93b72524739eb524d1f4cd9509ced17 */
+/* @relayHash e552a44d1b7a5e472daa646e5135e5ed */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -48,8 +48,12 @@ query SavedSearchButtonQuery(
   }
 }
 
-fragment SavedSearchButton_me_1ff8oJ on Me {
+fragment CreateSavedSearchAlertScreen_me on Me {
   emailFrequency
+}
+
+fragment SavedSearchButton_me_1ff8oJ on Me {
+  ...CreateSavedSearchAlertScreen_me
   savedSearch(criteria: $criteria) {
     internalID
   }
@@ -150,7 +154,7 @@ return {
     ]
   },
   "params": {
-    "id": "d93b72524739eb524d1f4cd9509ced17",
+    "id": "e552a44d1b7a5e472daa646e5135e5ed",
     "metadata": {},
     "name": "SavedSearchButtonQuery",
     "operationKind": "query",

--- a/src/__generated__/SavedSearchButtonRefetchQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonRefetchQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 463b1fbf7d68e7e303caf9e2c8db9f7f */
+/* @relayHash b7bcaeb8d504648efd11bc1a8721ff27 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -48,8 +48,12 @@ query SavedSearchButtonRefetchQuery(
   }
 }
 
-fragment SavedSearchButton_me_1ff8oJ on Me {
+fragment CreateSavedSearchAlertScreen_me on Me {
   emailFrequency
+}
+
+fragment SavedSearchButton_me_1ff8oJ on Me {
+  ...CreateSavedSearchAlertScreen_me
   savedSearch(criteria: $criteria) {
     internalID
   }
@@ -150,7 +154,7 @@ return {
     ]
   },
   "params": {
-    "id": "463b1fbf7d68e7e303caf9e2c8db9f7f",
+    "id": "b7bcaeb8d504648efd11bc1a8721ff27",
     "metadata": {},
     "name": "SavedSearchButtonRefetchQuery",
     "operationKind": "query",

--- a/src/__generated__/SavedSearchButtonTestsQuery.graphql.ts
+++ b/src/__generated__/SavedSearchButtonTestsQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 84e5e8e39c313b093d4b14e50e6c5ae1 */
+/* @relayHash 33418cc4ff4324fe9b73521bb2b40f29 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -48,8 +48,12 @@ query SavedSearchButtonTestsQuery(
   }
 }
 
-fragment SavedSearchButton_me_1ff8oJ on Me {
+fragment CreateSavedSearchAlertScreen_me on Me {
   emailFrequency
+}
+
+fragment SavedSearchButton_me_1ff8oJ on Me {
+  ...CreateSavedSearchAlertScreen_me
   savedSearch(criteria: $criteria) {
     internalID
   }
@@ -156,7 +160,7 @@ return {
     ]
   },
   "params": {
-    "id": "84e5e8e39c313b093d4b14e50e6c5ae1",
+    "id": "33418cc4ff4324fe9b73521bb2b40f29",
     "metadata": {
       "relayTestingSelectionTypeInfo": {
         "me": {

--- a/src/__generated__/SavedSearchButton_me.graphql.ts
+++ b/src/__generated__/SavedSearchButton_me.graphql.ts
@@ -5,10 +5,10 @@
 import { ReaderFragment } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
 export type SavedSearchButton_me = {
-    readonly emailFrequency: string | null;
     readonly savedSearch: {
         readonly internalID: string;
     } | null;
+    readonly " $fragmentRefs": FragmentRefs<"CreateSavedSearchAlertScreen_me">;
     readonly " $refType": "SavedSearchButton_me";
 };
 export type SavedSearchButton_me$data = SavedSearchButton_me;
@@ -33,13 +33,6 @@ const node: ReaderFragment = {
   "selections": [
     {
       "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "emailFrequency",
-      "storageKey": null
-    },
-    {
-      "alias": null,
       "args": [
         {
           "kind": "Variable",
@@ -61,10 +54,15 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "CreateSavedSearchAlertScreen_me"
     }
   ],
   "type": "Me",
   "abstractKey": null
 };
-(node as any).hash = '363a20ebbd1cde9877929cbdf07203e0';
+(node as any).hash = '61f2d525eb7e1a835209d936083651d6';
 export default node;

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tests.tsx
@@ -134,7 +134,7 @@ describe("SavedSearchButton", () => {
   it("should navigate to the saved search alerts list when popover is pressed", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete(mockedMutationResult))
+    act(() => tree.root.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult))
     act(() => tree.root.findByType(PopoverMessage).props.onPress())
 
     expect(navigate).toHaveBeenCalledWith("/my-profile/settings", {
@@ -144,13 +144,14 @@ describe("SavedSearchButton", () => {
   })
 
   it('should call navigate twice when "My Collection" is enabled', async () => {
+    jest.useFakeTimers()
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableMyCollectionIOS: true })
     const tree = renderWithWrappers(<TestRenderer />)
 
-    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete(mockedMutationResult))
+    act(() => tree.root.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult))
     act(() => tree.root.findByType(PopoverMessage).props.onPress())
 
-    await new Promise((r) => setTimeout(r, 100))
+    jest.runAllTimers()
 
     expect(navigate).toHaveBeenCalledWith("/my-profile/settings", {
       popToRootTabView: true,
@@ -162,7 +163,7 @@ describe("SavedSearchButton", () => {
   it("tracks clicks when the create alert button is pressed", async () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
-    act(() => tree.root.findByType(CreateSavedSearchAlert).props.onComplete(mockedMutationResult))
+    act(() => tree.root.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult))
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       tracks.toggleSavedSearch(true, "artistID", "artistSlug", "savedSearchAlertId")

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -133,6 +133,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
         aggregations={aggregations}
         userAllowsEmails={me?.emailFrequency !== "none"}
         refetch={refetch}
+        isLoading={loading || refetching}
         onClosePress={handleCloseForm}
         onComplete={handleComplete}
       />

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -129,11 +129,12 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
         artistId={artistId}
         artistName={artistName}
         visible={visibleForm}
-        onClosePress={handleCloseForm}
-        onComplete={handleComplete}
         filters={filters}
         aggregations={aggregations}
         userAllowsEmails={me?.emailFrequency !== "none"}
+        refetch={refetch}
+        onClosePress={handleCloseForm}
+        onComplete={handleComplete}
       />
     </Box>
   )

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -11,6 +11,7 @@ import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { useEnableMyCollection } from "lib/Scenes/MyCollection/MyCollection"
 import { CreateSavedSearchAlert } from "lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
 import {
+  CreateSavedSearchAlertParams,
   SavedSearchAlertFormPropsBase,
   SavedSearchAlertMutationResult,
 } from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
@@ -111,6 +112,16 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
     }
   }, [refetch])
 
+  const params: CreateSavedSearchAlertParams = {
+    artistId,
+    artistName,
+    filters,
+    aggregations,
+    me,
+    onClosePress: handleCloseForm,
+    onComplete: handleComplete,
+  }
+
   return (
     <Box>
       <Button
@@ -125,18 +136,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
       >
         Create Alert
       </Button>
-      <CreateSavedSearchAlert
-        artistId={artistId}
-        artistName={artistName}
-        visible={visibleForm}
-        filters={filters}
-        aggregations={aggregations}
-        userAllowsEmails={me?.emailFrequency !== "none"}
-        refetch={refetch}
-        isLoading={loading || refetching}
-        onClosePress={handleCloseForm}
-        onComplete={handleComplete}
-      />
+      <CreateSavedSearchAlert visible={visibleForm} params={params} />
     </Box>
   )
 }
@@ -146,7 +146,7 @@ export const SavedSearchButtonRefetchContainer = createRefetchContainer(
   {
     me: graphql`
       fragment SavedSearchButton_me on Me @argumentDefinitions(criteria: { type: "SearchCriteriaAttributes" }) {
-        emailFrequency
+        ...CreateSavedSearchAlertScreen_me
         savedSearch(criteria: $criteria) {
           internalID
         }

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButton.tsx
@@ -15,7 +15,7 @@ import {
   SavedSearchAlertMutationResult,
 } from "lib/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { BellIcon, Box, Button } from "palette"
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -55,7 +55,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
   const popover = usePopoverMessage()
   const isSavedSearch = !!me?.savedSearch?.internalID
 
-  const refetch = () => {
+  const refetch = useCallback(() => {
     setRefetching(true)
     relay.refetch(
       { criteria },
@@ -65,7 +65,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
       },
       { force: true }
     )
-  }
+  }, [criteria])
 
   const handleOpenForm = () => setVisibleForm(true)
   const handleCloseForm = () => setVisibleForm(false)
@@ -109,7 +109,7 @@ export const SavedSearchButton: React.FC<SavedSearchButtonProps> = ({
     return () => {
       savedSearchEvents.removeListener("refetch", refetch)
     }
-  }, [])
+  }, [refetch])
 
   return (
     <Box>
@@ -162,7 +162,7 @@ export const SavedSearchButtonRefetchContainer = createRefetchContainer(
 
 export const SavedSearchButtonQueryRenderer: React.FC<SavedSearchButtonQueryRendererProps> = (props) => {
   const { filters, artistId } = props
-  const criteria = getSearchCriteriaFromFilters(artistId, filters)
+  const criteria = useMemo(() => getSearchCriteriaFromFilters(artistId, filters), [artistId, filters])
 
   return (
     <QueryRenderer<SavedSearchButtonQuery>

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,9 +1,9 @@
 import { useFormikContext } from "formik"
 import { navigate } from "lib/navigation/navigate"
-import { useFeatureFlag, useIsStaging } from "lib/store/GlobalStore"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Box, Button, Flex, Input, InputTitle, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
-import { LayoutAnimation, Linking } from "react-native"
+import { LayoutAnimation } from "react-native"
 import { getNamePlaceholder } from "../helpers"
 import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 import { SavedSearchAlertSwitch } from "./SavedSearchAlertSwitch"
@@ -39,9 +39,7 @@ export const Form: React.FC<FormProps> = (props) => {
     handleChange,
   } = useFormikContext<SavedSearchAlertFormValues>()
   const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
-  const isStaging = useIsStaging()
   const namePlaceholder = getNamePlaceholder(artistName, pills)
-  const emailPreferencesLink = isStaging ? "https://staging.artsy.net/unsubscribe" : "https://artsy.net/unsubscribe"
   let isSaveAlertButtonDisabled = false
 
   // Сhanges have been made by the user
@@ -121,7 +119,7 @@ export const Form: React.FC<FormProps> = (props) => {
           <SavedSearchAlertSwitch label="Email Alerts" onChange={handleToggleEmailNotification} active={values.email} />
           {!!values.email && (
             <Text
-              onPress={() => Linking.openURL(emailPreferencesLink)}
+              onPress={() => navigate("/unsubscribe")}
               variant="xs"
               color="black60"
               style={{ textDecorationLine: "underline" }}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,6 +1,6 @@
 import { useFormikContext } from "formik"
 import { navigate } from "lib/navigation/navigate"
-import { useFeatureFlag } from "lib/store/GlobalStore"
+import { useFeatureFlag, useIsStaging } from "lib/store/GlobalStore"
 import { Box, Button, Flex, Input, InputTitle, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
 import { LayoutAnimation, Linking } from "react-native"
@@ -39,7 +39,9 @@ export const Form: React.FC<FormProps> = (props) => {
     handleChange,
   } = useFormikContext<SavedSearchAlertFormValues>()
   const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
+  const isStaging = useIsStaging()
   const namePlaceholder = getNamePlaceholder(artistName, pills)
+  const emailPreferencesLink = isStaging ? "https://staging.artsy.net/unsubscribe" : "https://artsy.net/unsubscribe"
   let isSaveAlertButtonDisabled = false
 
   // Сhanges have been made by the user
@@ -119,7 +121,7 @@ export const Form: React.FC<FormProps> = (props) => {
           <SavedSearchAlertSwitch label="Email Alerts" onChange={handleToggleEmailNotification} active={values.email} />
           {!!values.email && (
             <Text
-              onPress={() => Linking.openURL("https://staging.artsy.net/unsubscribe")}
+              onPress={() => Linking.openURL(emailPreferencesLink)}
               variant="xs"
               color="black60"
               style={{ textDecorationLine: "underline" }}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from "formik"
 import { navigate } from "lib/navigation/navigate"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, Button, Flex, Input, InputTitle, Pill, Sans, Spacer, Text, Touchable } from "palette"
+import { Box, Button, Flex, Input, InputTitle, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
 import { LayoutAnimation } from "react-native"
 import { getNamePlaceholder } from "../helpers"
@@ -85,11 +85,9 @@ export const Form: React.FC<FormProps> = (props) => {
     <Box>
       {!isEditMode && (
         <Box mb={4}>
-          <Sans size="8">Create an Alert</Sans>
+          <Text variant="lg">Create an Alert</Text>
           {!enableSavedSearchToggles && (
-            <Sans size="3t" mt={1}>
-              Receive alerts as Push Notifications directly to your device.
-            </Sans>
+            <Text mt={1}>Receive alerts as Push Notifications directly to your device.</Text>
           )}
         </Box>
       )}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -13,6 +13,7 @@ interface FormProps {
   savedSearchAlertId?: string
   artistId: string
   artistName: string
+  isLoading?: boolean
   onDeletePress?: () => void
   onSubmitPress?: () => void
   onUpdateEmailPreferencesPress: () => void
@@ -26,6 +27,7 @@ export const Form: React.FC<FormProps> = (props) => {
     artistId,
     artistName,
     savedSearchAlertId,
+    isLoading,
     onDeletePress,
     onSubmitPress,
     onUpdateEmailPreferencesPress,
@@ -148,7 +150,7 @@ export const Form: React.FC<FormProps> = (props) => {
         <Button
           testID="save-alert-button"
           disabled={isSaveAlertButtonDisabled}
-          loading={isSubmitting}
+          loading={isSubmitting || isLoading}
           size="large"
           block
           onPress={onSubmitPress}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -15,6 +15,7 @@ interface FormProps {
   artistName: string
   onDeletePress?: () => void
   onSubmitPress?: () => void
+  onUpdateEmailPreferencesPress: () => void
   onTogglePushNotification: (enabled: boolean) => void
   onToggleEmailNotification: (enabled: boolean) => void
 }
@@ -27,6 +28,7 @@ export const Form: React.FC<FormProps> = (props) => {
     savedSearchAlertId,
     onDeletePress,
     onSubmitPress,
+    onUpdateEmailPreferencesPress,
     onTogglePushNotification,
     onToggleEmailNotification,
   } = props
@@ -131,7 +133,7 @@ export const Form: React.FC<FormProps> = (props) => {
           <SavedSearchAlertSwitch label="Email Alerts" onChange={handleToggleEmailNotification} active={values.email} />
           {!!values.email && (
             <Text
-              onPress={() => navigate("/unsubscribe")}
+              onPress={onUpdateEmailPreferencesPress}
               variant="xs"
               color="black60"
               style={{ textDecorationLine: "underline" }}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,7 +1,7 @@
 import { useFormikContext } from "formik"
 import { navigate } from "lib/navigation/navigate"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, Button, Flex, Input, InputTitle, Pill, Spacer, Text, Touchable } from "palette"
+import { Box, Button, Flex, Input, InputTitle, Pill, Sans, Spacer, Text, Touchable } from "palette"
 import React from "react"
 import { LayoutAnimation } from "react-native"
 import { getNamePlaceholder } from "../helpers"
@@ -40,17 +40,18 @@ export const Form: React.FC<FormProps> = (props) => {
   } = useFormikContext<SavedSearchAlertFormValues>()
   const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
   const namePlaceholder = getNamePlaceholder(artistName, pills)
+  const isEditMode = !!savedSearchAlertId
   let isSaveAlertButtonDisabled = false
 
   // Сhanges have been made by the user
-  if (!!savedSearchAlertId && !dirty) {
+  if (isEditMode && !dirty) {
     isSaveAlertButtonDisabled = true
   }
 
   // If the saved search alert doesn't have a name, a user can click the save button without any changes.
   // This situation is possible if a user created an alert in Saved Search V1,
   // since we didn't have the opportunity to specify custom name for the alert
-  if (!!savedSearchAlertId && !dirty && values.name.length === 0) {
+  if (isEditMode && !dirty && values.name.length === 0) {
     isSaveAlertButtonDisabled = false
   }
 
@@ -70,6 +71,17 @@ export const Form: React.FC<FormProps> = (props) => {
 
   return (
     <Box>
+      {!isEditMode && (
+        <Box mb={4}>
+          <Sans size="8">Create an Alert</Sans>
+          {!enableSavedSearchToggles && (
+            <Sans size="3t" mt={1}>
+              Receive alerts as Push Notifications directly to your device.
+            </Sans>
+          )}
+        </Box>
+      )}
+
       <Box mb={2}>
         <Input
           title="Name"
@@ -82,7 +94,7 @@ export const Form: React.FC<FormProps> = (props) => {
           maxLength={75}
         />
       </Box>
-      {!!savedSearchAlertId && (
+      {!!isEditMode && (
         <Box mb={2} height={40} justifyContent="center" alignItems="center">
           <Touchable
             haptic
@@ -130,25 +142,31 @@ export const Form: React.FC<FormProps> = (props) => {
           )}
         </>
       )}
-      <Spacer mt={5} />
-      <Button
-        testID="save-alert-button"
-        disabled={isSaveAlertButtonDisabled}
-        loading={isSubmitting}
-        size="large"
-        block
-        onPress={onSubmitPress}
-      >
-        Save Alert
-      </Button>
-      {!!savedSearchAlertId && (
-        <>
-          <Spacer mt={2} />
-          <Button testID="delete-alert-button" variant="outline" size="large" block onPress={onDeletePress}>
-            Delete Alert
-          </Button>
-        </>
-      )}
+      <Box mt={5}>
+        <Button
+          testID="save-alert-button"
+          disabled={isSaveAlertButtonDisabled}
+          loading={isSubmitting}
+          size="large"
+          block
+          onPress={onSubmitPress}
+        >
+          Save Alert
+        </Button>
+        {!!isEditMode && (
+          <>
+            <Spacer mt={2} />
+            <Button testID="delete-alert-button" variant="outline" size="large" block onPress={onDeletePress}>
+              Delete Alert
+            </Button>
+          </>
+        )}
+        {!isEditMode && (
+          <Text variant="sm" color="black60" textAlign="center" my={2}>
+            You will be able to access all your Saved Alerts in your Profile.
+          </Text>
+        )}
+      </Box>
     </Box>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -16,7 +16,7 @@ interface FormProps {
   isLoading?: boolean
   onDeletePress?: () => void
   onSubmitPress?: () => void
-  onUpdateEmailPreferencesPress: () => void
+  onUpdateEmailPreferencesPress?: () => void
   onTogglePushNotification: (enabled: boolean) => void
   onToggleEmailNotification: (enabled: boolean) => void
 }
@@ -71,6 +71,14 @@ export const Form: React.FC<FormProps> = (props) => {
     })
 
     onToggleEmailNotification(value)
+  }
+
+  const handleUpdateEmailPreferencesPress = () => {
+    if (onUpdateEmailPreferencesPress) {
+      return onUpdateEmailPreferencesPress()
+    }
+
+    return navigate("/unsubscribe")
   }
 
   return (
@@ -135,7 +143,7 @@ export const Form: React.FC<FormProps> = (props) => {
           <SavedSearchAlertSwitch label="Email Alerts" onChange={handleToggleEmailNotification} active={values.email} />
           {!!values.email && (
             <Text
-              onPress={onUpdateEmailPreferencesPress}
+              onPress={handleUpdateEmailPreferencesPress}
               variant="xs"
               color="black60"
               style={{ textDecorationLine: "underline" }}

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -3,6 +3,7 @@ import { navigate } from "lib/navigation/navigate"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Box, Button, Flex, Input, InputTitle, Pill, Spacer, Text, Touchable } from "palette"
 import React from "react"
+import { LayoutAnimation, Linking } from "react-native"
 import { getNamePlaceholder } from "../helpers"
 import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 import { SavedSearchAlertSwitch } from "./SavedSearchAlertSwitch"
@@ -58,6 +59,15 @@ export const Form: React.FC<FormProps> = (props) => {
     isSaveAlertButtonDisabled = true
   }
 
+  const handleToggleEmailNotification = (value: boolean) => {
+    LayoutAnimation.configureNext({
+      ...LayoutAnimation.Presets.easeInEaseOut,
+      duration: 300,
+    })
+
+    onToggleEmailNotification(value)
+  }
+
   return (
     <Box>
       <Box mb={2}>
@@ -104,13 +114,23 @@ export const Form: React.FC<FormProps> = (props) => {
       </Box>
       {!!enableSavedSearchToggles && (
         <>
-          <SavedSearchAlertSwitch label="Email Alerts" onChange={onToggleEmailNotification} active={values.email} />
-          <Spacer mt={2} />
           <SavedSearchAlertSwitch label="Mobile Alerts" onChange={onTogglePushNotification} active={values.push} />
           <Spacer mt={2} />
+          <SavedSearchAlertSwitch label="Email Alerts" onChange={handleToggleEmailNotification} active={values.email} />
+          {!!values.email && (
+            <Text
+              onPress={() => Linking.openURL("https://staging.artsy.net/unsubscribe")}
+              variant="xs"
+              color="black60"
+              style={{ textDecorationLine: "underline" }}
+              mt={1}
+            >
+              Update email preferences
+            </Text>
+          )}
         </>
       )}
-      <Spacer mt={4} />
+      <Spacer mt={5} />
       <Button
         testID="save-alert-button"
         disabled={isSaveAlertButtonDisabled}

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, waitFor } from "@testing-library/react-native"
+import { CreateSavedSearchAlertTestsQuery } from "__generated__/CreateSavedSearchAlertTestsQuery.graphql"
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
@@ -8,14 +9,14 @@ import { mockFetchNotificationPermissions } from "lib/tests/mockFetchNotificatio
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { PushAuthorizationStatus } from "lib/utils/PushNotification"
 import React from "react"
+import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
 import { CreateSavedSearchAlert } from "./CreateSavedSearchAlert"
 import { CreateSavedSearchAlertProps } from "./SavedSearchAlertModel"
 
 jest.unmock("react-relay")
 
-const defaultProps: CreateSavedSearchAlertProps = {
-  visible: true,
+const defaultParams: CreateSavedSearchAlertProps["params"] = {
   filters: [
     {
       displayText: "Bid",
@@ -26,7 +27,6 @@ const defaultProps: CreateSavedSearchAlertProps = {
   aggregations: [],
   artistId: "artistID",
   artistName: "artistName",
-  userAllowsEmails: true,
   onComplete: jest.fn(),
   onClosePress: jest.fn(),
 }
@@ -40,17 +40,55 @@ describe("CreateSavedSearchAlert", () => {
     notificationPermissions.mockClear()
   })
 
+  const TestRenderer = (props: Partial<CreateSavedSearchAlertProps>) => {
+    return (
+      <QueryRenderer<CreateSavedSearchAlertTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query CreateSavedSearchAlertTestsQuery @relay_test_operation {
+            me {
+              ...CreateSavedSearchAlertScreen_me
+            }
+          }
+        `}
+        render={({ props: relayProps }) => (
+          <CreateSavedSearchAlert
+            visible
+            params={{
+              ...defaultParams,
+              // @ts-ignore
+              me: relayProps?.me,
+            }}
+            {...props}
+          />
+        )}
+        variables={{}}
+      />
+    )
+  }
+
+  const renderAndExecuteQuery = (props?: Partial<CreateSavedSearchAlertProps>) => {
+    const render = renderWithWrappersTL(<TestRenderer {...props} />)
+
+    mockEnvironmentPayload(mockEnvironment)
+
+    return render
+  }
+
   it("renders without throwing an error", () => {
-    const { getAllByTestId } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
+    const { getAllByTestId } = renderAndExecuteQuery()
 
     expect(getAllByTestId("alert-pill").map(extractText)).toEqual(["Bid"])
   })
 
   it("should call onClosePress handler when the close button is pressed", () => {
     const onCloseMock = jest.fn()
-    const { getByTestId } = renderWithWrappersTL(
-      <CreateSavedSearchAlert {...defaultProps} onClosePress={onCloseMock} />
-    )
+    const { getByTestId } = renderAndExecuteQuery({
+      params: {
+        ...defaultParams,
+        onClosePress: onCloseMock,
+      },
+    })
 
     fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
@@ -61,14 +99,20 @@ describe("CreateSavedSearchAlert", () => {
     notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Authorized))
     const onCompleteMock = jest.fn()
 
-    const { getByTestId } = renderWithWrappersTL(
-      <CreateSavedSearchAlert {...defaultProps} onComplete={onCompleteMock} />
-    )
+    const { getByTestId } = renderAndExecuteQuery({
+      params: {
+        ...defaultParams,
+        onComplete: onCompleteMock,
+      },
+    })
 
     fireEvent.changeText(getByTestId("alert-input-name"), "something new")
     fireEvent.press(getByTestId("save-alert-button"))
 
     await waitFor(() => {
+      const operation = mockEnvironment.mock.getMostRecentOperation()
+
+      expect(operation.request.node.operation.name).toBe("createSavedSearchAlertMutation")
       mockEnvironmentPayload(mockEnvironment, {
         SearchCriteria: () => ({
           internalID: "internalID",
@@ -89,7 +133,7 @@ describe("CreateSavedSearchAlert", () => {
     it("the push notification is enabled by default when push permissions are enabled", async () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Authorized))
 
-      const { findAllByA11yState } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
+      const { findAllByA11yState } = renderAndExecuteQuery()
       const toggles = await findAllByA11yState({ selected: true })
 
       expect(toggles).toHaveLength(2)
@@ -98,7 +142,7 @@ describe("CreateSavedSearchAlert", () => {
     it("the push notification is disabled by default when push permissions are denied", async () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Denied))
 
-      const { findAllByA11yState } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
+      const { findAllByA11yState } = renderAndExecuteQuery()
       const toggles = await findAllByA11yState({ selected: false })
 
       expect(toggles).toHaveLength(1)
@@ -107,18 +151,7 @@ describe("CreateSavedSearchAlert", () => {
     it("the push notification is disabled by default when push permissions are not determined", async () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.NotDetermined))
 
-      const { findAllByA11yState } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
-      const toggles = await findAllByA11yState({ selected: false })
-
-      expect(toggles).toHaveLength(1)
-    })
-
-    it("the email notification is disabled by default if a user has not allowed email notifications", async () => {
-      notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Authorized))
-
-      const { findAllByA11yState } = renderWithWrappersTL(
-        <CreateSavedSearchAlert {...defaultProps} userAllowsEmails={false} />
-      )
+      const { findAllByA11yState } = renderAndExecuteQuery()
       const toggles = await findAllByA11yState({ selected: false })
 
       expect(toggles).toHaveLength(1)

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -45,21 +45,6 @@ describe("CreateSavedSearchAlert", () => {
     expect(getAllByTestId("alert-pill").map(extractText)).toEqual(["Bid"])
   })
 
-  it("should display description by default", () => {
-    const { getByText } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
-    const description = getByText("Receive alerts as Push Notifications directly to your device.")
-
-    expect(description).toBeTruthy()
-  })
-
-  it("should hide description when AREnableSavedSearchToggles is enabled", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchToggles: true })
-    const { queryByText } = renderWithWrappersTL(<CreateSavedSearchAlert {...defaultProps} />)
-    const description = queryByText("Receive alerts as Push Notifications directly to your device.")
-
-    expect(description).toBeFalsy()
-  })
-
   it("should call onClosePress handler when the close button is pressed", () => {
     const onCloseMock = jest.fn()
     const { getByTestId } = renderWithWrappersTL(

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -78,9 +78,6 @@ describe("CreateSavedSearchAlert", () => {
     // CreateSavedSearchAlertTestsQuery
     mockEnvironmentPayload(mockEnvironment, mockResolvers)
 
-    // Refetch query
-    mockEnvironmentPayload(mockEnvironment, mockResolvers)
-
     return render
   }
 
@@ -143,6 +140,10 @@ describe("CreateSavedSearchAlert", () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Authorized))
 
       const { findAllByA11yState } = renderAndExecuteQuery()
+
+      // Refetch query
+      mockEnvironmentPayload(mockEnvironment)
+
       const toggles = await findAllByA11yState({ selected: true })
 
       expect(toggles).toHaveLength(2)
@@ -152,6 +153,10 @@ describe("CreateSavedSearchAlert", () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Denied))
 
       const { findAllByA11yState } = renderAndExecuteQuery()
+
+      // Refetch query
+      mockEnvironmentPayload(mockEnvironment)
+
       const toggles = await findAllByA11yState({ selected: false })
 
       expect(toggles).toHaveLength(1)
@@ -168,15 +173,16 @@ describe("CreateSavedSearchAlert", () => {
 
     it("the email notification is disabled by default if a user has not allowed email notifications", async () => {
       notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Authorized))
+      const mockResolver = {
+        Me: () => ({
+          emailFrequency: "none",
+        }),
+      }
 
-      const { findAllByA11yState } = renderAndExecuteQuery(
-        {},
-        {
-          Me: () => ({
-            emailFrequency: "none",
-          }),
-        }
-      )
+      const { findAllByA11yState } = renderAndExecuteQuery({}, mockResolver)
+
+      // Refetch query
+      mockEnvironmentPayload(mockEnvironment, mockResolver)
 
       const toggles = await findAllByA11yState({ selected: false })
 

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -9,7 +9,8 @@ import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { PushAuthorizationStatus } from "lib/utils/PushNotification"
 import React from "react"
 import { createMockEnvironment } from "relay-test-utils"
-import { CreateSavedSearchAlert, CreateSavedSearchAlertProps } from "./CreateSavedSearchAlert"
+import { CreateSavedSearchAlert } from "./CreateSavedSearchAlert"
+import { CreateSavedSearchAlertProps } from "./SavedSearchAlertModel"
 
 jest.unmock("react-relay")
 

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -10,7 +10,7 @@ import { EmailPreferencesScreen } from "./screens/EmailPreferencesScreen"
 const Stack = createStackNavigator<CreateSavedSearchAlertNavigationStack>()
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
-  const { visible, ...screenParams } = props
+  const { visible, params } = props
 
   return (
     <NavigationContainer independent>
@@ -29,7 +29,7 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
             <Stack.Screen
               name="CreateSavedSearchAlert"
               component={CreateSavedSearchAlertScreen}
-              initialParams={screenParams}
+              initialParams={params}
             />
             <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
           </Stack.Navigator>

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,55 +1,40 @@
-import { Aggregations, FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { NavigationContainer } from "@react-navigation/native"
+import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
-import useAppState from "lib/utils/useAppState"
-import React, { useCallback, useEffect, useState } from "react"
-import { SavedSearchAlertForm } from "./SavedSearchAlertForm"
-import { SavedSearchAlertFormPropsBase, SavedSearchAlertMutationResult } from "./SavedSearchAlertModel"
+import { Box } from "palette"
+import React from "react"
+import { CreateSavedSearchAlertNavigationStack, CreateSavedSearchAlertProps } from "./SavedSearchAlertModel"
+import { CreateSavedSearchAlertScreen } from "./screens/CreateSavedSearchAlertScreen"
+import { EmailPreferencesScreen } from "./screens/EmailPreferencesScreen"
 
-export interface CreateSavedSearchAlertProps extends SavedSearchAlertFormPropsBase {
-  visible: boolean
-  filters: FilterData[]
-  aggregations: Aggregations
-  userAllowsEmails: boolean
-  onClosePress: () => void
-  onComplete: (response: SavedSearchAlertMutationResult) => void
-}
+const Stack = createStackNavigator<CreateSavedSearchAlertNavigationStack>()
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
-  const { visible, filters, aggregations, onClosePress, onComplete, ...other } = props
-  const [enablePushNotifications, setEnablePushNotifications] = useState(true)
-
-  const getPermissionStatus = async () => {
-    const status = await getNotificationPermissionsStatus()
-    setEnablePushNotifications(status === PushAuthorizationStatus.Authorized)
-  }
-
-  const onForeground = useCallback(() => {
-    getPermissionStatus()
-  }, [])
-
-  useAppState({ onForeground })
-
-  useEffect(() => {
-    getPermissionStatus()
-  }, [])
-
-  const handleComplete = async (result: SavedSearchAlertMutationResult) => {
-    onComplete(result)
-  }
+  const { visible, ...screenParams } = props
 
   return (
-    <FancyModal visible={visible} fullScreen>
-      <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
-      <SavedSearchAlertForm
-        initialValues={{ name: "", email: props.userAllowsEmails, push: enablePushNotifications }}
-        aggregations={aggregations}
-        filters={filters}
-        onComplete={handleComplete}
-        contentContainerStyle={{ paddingTop: 0 }}
-        {...other}
-      />
-    </FancyModal>
+    <NavigationContainer independent>
+      <FancyModal visible={visible} fullScreen>
+        <Box flex={1}>
+          <Stack.Navigator
+            // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
+            detachInactiveScreens={false}
+            screenOptions={{
+              ...TransitionPresets.SlideFromRightIOS,
+              headerShown: false,
+              safeAreaInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+              cardStyle: { backgroundColor: "white" },
+            }}
+          >
+            <Stack.Screen
+              name="CreateSavedSearchAlert"
+              component={CreateSavedSearchAlertScreen}
+              initialParams={screenParams}
+            />
+            <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
+          </Stack.Navigator>
+        </Box>
+      </FancyModal>
+    </NavigationContainer>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,12 +1,9 @@
 import { Aggregations, FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModal } from "lib/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { useFeatureFlag } from "lib/store/GlobalStore"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
 import useAppState from "lib/utils/useAppState"
-import { Sans, Spacer, Text, useTheme } from "palette"
 import React, { useCallback, useEffect, useState } from "react"
-import { ScrollView } from "react-native"
 import { SavedSearchAlertForm } from "./SavedSearchAlertForm"
 import { SavedSearchAlertFormPropsBase, SavedSearchAlertMutationResult } from "./SavedSearchAlertModel"
 
@@ -21,9 +18,7 @@ export interface CreateSavedSearchAlertProps extends SavedSearchAlertFormPropsBa
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
   const { visible, filters, aggregations, onClosePress, onComplete, ...other } = props
-  const { space } = useTheme()
   const [enablePushNotifications, setEnablePushNotifications] = useState(true)
-  const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
 
   const getPermissionStatus = async () => {
     const status = await getNotificationPermissionsStatus()
@@ -47,29 +42,13 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
   return (
     <FancyModal visible={visible} fullScreen>
       <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
-      <ScrollView
-        keyboardDismissMode="on-drag"
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(2) }}
-      >
-        <Sans size="8">Create an Alert</Sans>
-        {!enableSavedSearchToggles && (
-          <Sans size="3t" mt={1}>
-            Receive alerts as Push Notifications directly to your device.
-          </Sans>
-        )}
-        <Spacer mt={4} />
-        <SavedSearchAlertForm
-          initialValues={{ name: "", email: props.userAllowsEmails, push: enablePushNotifications }}
-          aggregations={aggregations}
-          filters={filters}
-          onComplete={handleComplete}
-          {...other}
-        />
-        <Text variant="sm" color="black60" textAlign="center" my={2}>
-          You will be able to access all your Saved Alerts in your Profile.
-        </Text>
-      </ScrollView>
+      <SavedSearchAlertForm
+        initialValues={{ name: "", email: props.userAllowsEmails, push: enablePushNotifications }}
+        aggregations={aggregations}
+        filters={filters}
+        onComplete={handleComplete}
+        {...other}
+      />
     </FancyModal>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -47,6 +47,7 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
         aggregations={aggregations}
         filters={filters}
         onComplete={handleComplete}
+        contentContainerStyle={{ paddingTop: 0 }}
         {...other}
       />
     </FancyModal>

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -13,9 +13,7 @@ import { goBack } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
-import { useTheme } from "palette"
 import React from "react"
-import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { EditSavedSearchFormPlaceholder } from "./Components/EditSavedSearchAlertPlaceholder"
 import { SavedSearchAlertQueryRenderer } from "./SavedSearchAlert"
@@ -34,7 +32,6 @@ interface EditSavedSearchAlertProps {
 
 export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props) => {
   const { me, artist, artworksConnection, savedSearchAlertId } = props
-  const { space } = useTheme()
   const aggregations = (artworksConnection.aggregations ?? []) as Aggregations
   const { userAlertSettings, ...savedSearchCriteria } = me?.savedSearch ?? {}
   const filters = convertSavedSearchCriteriaToFilterParams(
@@ -57,27 +54,21 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
     >
       <ArtsyKeyboardAvoidingView>
         <PageWithSimpleHeader title="Edit your Alert">
-          <ScrollView
-            keyboardDismissMode="on-drag"
-            keyboardShouldPersistTaps="handled"
-            contentContainerStyle={{ padding: space(2) }}
-          >
-            <SavedSearchAlertForm
-              initialValues={{
-                name: userAlertSettings?.name ?? "",
-                email: userAlertSettings?.email ?? false,
-                push: userAlertSettings?.push ?? false,
-              }}
-              artistId={artist.internalID}
-              artistName={artist.name!}
-              filters={filters}
-              aggregations={aggregations}
-              savedSearchAlertId={savedSearchAlertId}
-              userAllowsEmails={me?.emailFrequency !== "none"}
-              onComplete={onComplete}
-              onDeleteComplete={onComplete}
-            />
-          </ScrollView>
+          <SavedSearchAlertForm
+            initialValues={{
+              name: userAlertSettings?.name ?? "",
+              email: userAlertSettings?.email ?? false,
+              push: userAlertSettings?.push ?? false,
+            }}
+            artistId={artist.internalID}
+            artistName={artist.name!}
+            filters={filters}
+            aggregations={aggregations}
+            savedSearchAlertId={savedSearchAlertId}
+            userAllowsEmails={me?.emailFrequency !== "none"}
+            onComplete={onComplete}
+            onDeleteComplete={onComplete}
+          />
         </PageWithSimpleHeader>
       </ArtsyKeyboardAvoidingView>
     </ProvideScreenTracking>

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, waitFor } from "@testing-library/react-native"
 import { Aggregations, FilterData, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractText } from "lib/tests/extractText"
@@ -373,6 +374,25 @@ describe("Saved search alert form", () => {
 
       await fireEvent(getByA11yLabel("Email Alerts Toggler"), "valueChange", false)
       expect(queryByText("Update email preferences")).toBeFalsy()
+    })
+
+    it("should call navigate handler when update preferences is pressed", async () => {
+      const { getByText } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+
+      fireEvent.press(getByText("Update email preferences"))
+
+      expect(navigate).toBeCalledWith("/unsubscribe")
+    })
+
+    it("should call custom update email preferences handler when it is passed", async () => {
+      const onUpdateEmailPreferencesMock = jest.fn()
+      const { getByText } = renderWithWrappersTL(
+        <SavedSearchAlertForm {...baseProps} onUpdateEmailPreferencesPress={onUpdateEmailPreferencesMock} />
+      )
+
+      fireEvent.press(getByText("Update email preferences"))
+
+      expect(onUpdateEmailPreferencesMock).toBeCalled()
     })
 
     describe("Allow to send emails modal", () => {

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -215,6 +215,21 @@ describe("Saved search alert form", () => {
     })
   })
 
+  it("should display description by default", () => {
+    const { getByText } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+    const description = getByText("Receive alerts as Push Notifications directly to your device.")
+
+    expect(description).toBeTruthy()
+  })
+
+  it("should hide description when AREnableSavedSearchToggles is enabled", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchToggles: true })
+    const { queryByText } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+    const description = queryByText("Receive alerts as Push Notifications directly to your device.")
+
+    expect(description).toBeFalsy()
+  })
+
   it("should hide notification toggles if AREnableSavedSearchToggles is disabled", async () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableSavedSearchToggles: false })
     const { queryByText } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -351,6 +351,15 @@ describe("Saved search alert form", () => {
       expect(queryAllByA11yState({ selected: true })).toHaveLength(1)
     })
 
+    it("should display email update preferences link only when email alerts toggle is enabled", async () => {
+      const { queryByText, getByA11yLabel } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+
+      expect(queryByText("Update email preferences")).toBeTruthy()
+
+      await fireEvent(getByA11yLabel("Email Alerts Toggler"), "valueChange", false)
+      expect(queryByText("Update email preferences")).toBeFalsy()
+    })
+
     describe("Allow to send emails modal", () => {
       it("should display the modal when the user enables email alerts", async () => {
         const { getByA11yLabel } = renderWithWrappersTL(

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -26,6 +26,7 @@ export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase
   savedSearchAlertId?: string
   userAllowsEmails: boolean
   contentContainerStyle?: StyleProp<ViewStyle>
+  onUpdateEmailPreferencesPress: () => void
   onComplete?: (result: SavedSearchAlertMutationResult) => void
   onDeleteComplete?: () => void
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -26,7 +26,7 @@ export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase
   savedSearchAlertId?: string
   userAllowsEmails: boolean
   contentContainerStyle?: StyleProp<ViewStyle>
-  onUpdateEmailPreferencesPress: () => void
+  onUpdateEmailPreferencesPress?: () => void
   onComplete?: (result: SavedSearchAlertMutationResult) => void
   onDeleteComplete?: () => void
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -6,7 +6,7 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
 import { Dialog, quoteLeft, quoteRight, useTheme } from "palette"
 import React, { useEffect, useState } from "react"
-import { Alert, AlertButton, Linking, Platform, ScrollView } from "react-native"
+import { Alert, AlertButton, Linking, Platform, ScrollView, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { Form } from "./Components/Form"
 import { extractPills, getNamePlaceholder } from "./helpers"
@@ -25,6 +25,7 @@ export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase
   initialValues: SavedSearchAlertFormValues
   savedSearchAlertId?: string
   userAllowsEmails: boolean
+  contentContainerStyle?: StyleProp<ViewStyle>
   onComplete?: (result: SavedSearchAlertMutationResult) => void
   onDeleteComplete?: () => void
 }
@@ -38,6 +39,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
     artistId,
     artistName,
     userAllowsEmails,
+    contentContainerStyle,
     onComplete,
     onDeleteComplete,
     ...other
@@ -254,7 +256,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       <ScrollView
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ padding: space(2), paddingTop: 0 }}
+        contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
       >
         <Form
           pills={pills}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -4,9 +4,9 @@ import { getSearchCriteriaFromFilters } from "lib/Components/ArtworkFilter/Saved
 import { LegacyNativeModules } from "lib/NativeModules/LegacyNativeModules"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
-import { Dialog, quoteLeft, quoteRight } from "palette"
+import { Dialog, quoteLeft, quoteRight, useTheme } from "palette"
 import React, { useEffect, useState } from "react"
-import { Alert, AlertButton, Linking, Platform } from "react-native"
+import { Alert, AlertButton, Linking, Platform, ScrollView } from "react-native"
 import { useTracking } from "react-tracking"
 import { Form } from "./Components/Form"
 import { extractPills, getNamePlaceholder } from "./helpers"
@@ -45,6 +45,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const isUpdateForm = !!savedSearchAlertId
   const pills = extractPills(filters, aggregations)
   const tracking = useTracking()
+  const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
   const [shouldShowEmailWarning, setShouldShowEmailWarning] = useState(!userAllowsEmails)
   const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
@@ -250,17 +251,23 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   return (
     <FormikProvider value={formik}>
-      <Form
-        pills={pills}
-        savedSearchAlertId={savedSearchAlertId}
-        artistId={artistId}
-        artistName={artistName}
-        onDeletePress={handleDeletePress}
-        onSubmitPress={handleSubmit}
-        onTogglePushNotification={handleTogglePushNotification}
-        onToggleEmailNotification={handleToggleEmailNotification}
-        {...other}
-      />
+      <ScrollView
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ padding: space(2), paddingTop: 0 }}
+      >
+        <Form
+          pills={pills}
+          savedSearchAlertId={savedSearchAlertId}
+          artistId={artistId}
+          artistName={artistName}
+          onDeletePress={handleDeletePress}
+          onSubmitPress={handleSubmit}
+          onTogglePushNotification={handleTogglePushNotification}
+          onToggleEmailNotification={handleToggleEmailNotification}
+          {...other}
+        />
+      </ScrollView>
       {!!savedSearchAlertId && (
         <Dialog
           isVisible={visibleDeleteDialog}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -29,6 +29,7 @@ export interface CreateSavedSearchAlertScreenProps extends SavedSearchAlertFormP
   filters: FilterData[]
   aggregations: Aggregations
   userAllowsEmails: boolean
+  refetch: () => void
   onClosePress: () => void
   onComplete: (response: SavedSearchAlertMutationResult) => void
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -23,3 +23,23 @@ export interface SavedSearchAlertUserAlertSettings {
   email?: boolean
   push?: boolean
 }
+
+// Navigation
+export interface CreateSavedSearchAlertScreenProps extends SavedSearchAlertFormPropsBase {
+  filters: FilterData[]
+  aggregations: Aggregations
+  userAllowsEmails: boolean
+  onClosePress: () => void
+  onComplete: (response: SavedSearchAlertMutationResult) => void
+}
+
+export interface CreateSavedSearchAlertProps extends CreateSavedSearchAlertScreenProps {
+  visible: boolean
+}
+
+// This needs to be a `type` rather than an `interface`
+// tslint:disable-next-line:interface-over-type-literal
+export type CreateSavedSearchAlertNavigationStack = {
+  CreateSavedSearchAlert: CreateSavedSearchAlertProps
+  EmailPreferences: undefined
+}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -1,3 +1,4 @@
+import { SavedSearchButton_me } from "__generated__/SavedSearchButton_me.graphql"
 import { Aggregations, FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 
 export interface SavedSearchAlertFormValues {
@@ -26,22 +27,22 @@ export interface SavedSearchAlertUserAlertSettings {
 }
 
 // Navigation
-export interface CreateSavedSearchAlertScreenProps extends SavedSearchAlertFormPropsBase {
+export interface CreateSavedSearchAlertParams extends SavedSearchAlertFormPropsBase {
+  me?: SavedSearchButton_me | null
   filters: FilterData[]
   aggregations: Aggregations
-  userAllowsEmails: boolean
-  refetch: () => void
   onClosePress: () => void
   onComplete: (response: SavedSearchAlertMutationResult) => void
 }
 
-export interface CreateSavedSearchAlertProps extends CreateSavedSearchAlertScreenProps {
+export interface CreateSavedSearchAlertProps {
   visible: boolean
+  params: CreateSavedSearchAlertParams
 }
 
 // This needs to be a `type` rather than an `interface`
 // tslint:disable-next-line:interface-over-type-literal
 export type CreateSavedSearchAlertNavigationStack = {
-  CreateSavedSearchAlert: CreateSavedSearchAlertProps
+  CreateSavedSearchAlert: CreateSavedSearchAlertParams
   EmailPreferences: undefined
 }

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -11,6 +11,7 @@ export interface SavedSearchAlertFormPropsBase {
   aggregations: Aggregations
   artistId: string
   artistName: string
+  isLoading?: boolean
 }
 
 export interface SavedSearchAlertMutationResult {

--- a/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
@@ -1,19 +1,29 @@
-import { StackScreenProps } from "@react-navigation/stack"
+import { useFocusEffect } from "@react-navigation/core"
+import { StackNavigationProp, StackScreenProps } from "@react-navigation/stack"
+import { CreateSavedSearchAlertScreen_me } from "__generated__/CreateSavedSearchAlertScreen_me.graphql"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
 import useAppState from "lib/utils/useAppState"
 import { Box } from "palette"
 import React, { useCallback, useEffect, useState } from "react"
+import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { SavedSearchAlertForm } from "../SavedSearchAlertForm"
-import { CreateSavedSearchAlertNavigationStack } from "../SavedSearchAlertModel"
+import { CreateSavedSearchAlertNavigationStack, CreateSavedSearchAlertParams } from "../SavedSearchAlertModel"
 import { SavedSearchAlertMutationResult } from "../SavedSearchAlertModel"
 
 type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "CreateSavedSearchAlert">
 
-export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
-  const { navigation, route } = props
-  const { filters, aggregations, onComplete, onClosePress, refetch, ...other } = route.params
+type ContentProps = Omit<CreateSavedSearchAlertParams, "me" | "onClosePress"> & {
+  navigation: StackNavigationProp<CreateSavedSearchAlertNavigationStack, "CreateSavedSearchAlert">
+  relay: RelayRefetchProp
+  me?: CreateSavedSearchAlertScreen_me | null
+}
+
+const Content: React.FC<ContentProps> = (props) => {
+  const { navigation, relay, me, filters, aggregations, onComplete, ...other } = props
   const [enablePushNotifications, setEnablePushNotifications] = useState(true)
+  const [refetching, setRefetching] = useState(false)
+  const userAllowsEmails = me?.emailFrequency !== "none"
 
   const getPermissionStatus = async () => {
     const status = await getNotificationPermissionsStatus()
@@ -24,12 +34,24 @@ export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
     getPermissionStatus()
   }, [])
 
-  const handleComplete = async (result: SavedSearchAlertMutationResult) => {
+  const handleComplete = (result: SavedSearchAlertMutationResult) => {
     onComplete(result)
   }
 
   const handleUpdateEmailPreferencesPress = () => {
     navigation.navigate("EmailPreferences")
+  }
+
+  const refetch = () => {
+    setRefetching(true)
+    relay.refetch(
+      {},
+      null,
+      () => {
+        setRefetching(false)
+      },
+      { force: true }
+    )
   }
 
   useAppState({ onForeground })
@@ -38,18 +60,55 @@ export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
     getPermissionStatus()
   }, [])
 
+  useFocusEffect(
+    useCallback(() => {
+      refetch()
+    }, [])
+  )
+
   return (
     <Box flex={1}>
-      <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
       <SavedSearchAlertForm
-        initialValues={{ name: "", email: route.params.userAllowsEmails, push: enablePushNotifications }}
+        initialValues={{ name: "", email: userAllowsEmails, push: enablePushNotifications }}
         aggregations={aggregations}
         filters={filters}
         onComplete={handleComplete}
         contentContainerStyle={{ paddingTop: 0 }}
+        userAllowsEmails={userAllowsEmails}
+        isLoading={refetching}
         onUpdateEmailPreferencesPress={handleUpdateEmailPreferencesPress}
         {...other}
       />
+    </Box>
+  )
+}
+
+const ContentRefetchContainer = createRefetchContainer(
+  Content,
+  {
+    me: graphql`
+      fragment CreateSavedSearchAlertScreen_me on Me {
+        emailFrequency
+      }
+    `,
+  },
+  graphql`
+    query CreateSavedSearchAlertScreenRefetchQuery {
+      me {
+        ...CreateSavedSearchAlertScreen_me
+      }
+    }
+  `
+)
+
+export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
+  const { route, navigation } = props
+  const { me, onClosePress, ...other } = route.params
+
+  return (
+    <Box flex={1}>
+      <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
+      <ContentRefetchContainer navigation={navigation} me={me} {...other} />
     </Box>
   )
 }

--- a/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
@@ -2,6 +2,7 @@ import { useFocusEffect } from "@react-navigation/core"
 import { StackNavigationProp, StackScreenProps } from "@react-navigation/stack"
 import { CreateSavedSearchAlertScreen_me } from "__generated__/CreateSavedSearchAlertScreen_me.graphql"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
 import useAppState from "lib/utils/useAppState"
 import { Box } from "palette"
@@ -23,6 +24,7 @@ const Content: React.FC<ContentProps> = (props) => {
   const { navigation, relay, me, filters, aggregations, onComplete, ...other } = props
   const [enablePushNotifications, setEnablePushNotifications] = useState(true)
   const [refetching, setRefetching] = useState(false)
+  const enableSavedSearchToggles = useFeatureFlag("AREnableSavedSearchToggles")
   const userAllowsEmails = me?.emailFrequency !== "none"
 
   const getPermissionStatus = async () => {
@@ -60,10 +62,13 @@ const Content: React.FC<ContentProps> = (props) => {
     getPermissionStatus()
   }, [])
 
+  // make refetch only when toggles are displayed
   useFocusEffect(
     useCallback(() => {
-      refetch()
-    }, [])
+      if (enableSavedSearchToggles) {
+        refetch()
+      }
+    }, [enableSavedSearchToggles])
   )
 
   return (

--- a/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
@@ -1,0 +1,55 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { getNotificationPermissionsStatus, PushAuthorizationStatus } from "lib/utils/PushNotification"
+import useAppState from "lib/utils/useAppState"
+import { Box } from "palette"
+import React, { useCallback, useEffect, useState } from "react"
+import { SavedSearchAlertForm } from "../SavedSearchAlertForm"
+import { CreateSavedSearchAlertNavigationStack } from "../SavedSearchAlertModel"
+import { SavedSearchAlertMutationResult } from "../SavedSearchAlertModel"
+
+type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "CreateSavedSearchAlert">
+
+export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
+  const { navigation, route } = props
+  const { filters, aggregations, onComplete, onClosePress, ...other } = route.params
+  const [enablePushNotifications, setEnablePushNotifications] = useState(true)
+
+  const getPermissionStatus = async () => {
+    const status = await getNotificationPermissionsStatus()
+    setEnablePushNotifications(status === PushAuthorizationStatus.Authorized)
+  }
+
+  const onForeground = useCallback(() => {
+    getPermissionStatus()
+  }, [])
+
+  const handleComplete = async (result: SavedSearchAlertMutationResult) => {
+    onComplete(result)
+  }
+
+  const handleUpdateEmailPreferencesPress = () => {
+    navigation.navigate("EmailPreferences")
+  }
+
+  useAppState({ onForeground })
+
+  useEffect(() => {
+    getPermissionStatus()
+  }, [])
+
+  return (
+    <Box flex={1}>
+      <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
+      <SavedSearchAlertForm
+        initialValues={{ name: "", email: route.params.userAllowsEmails, push: enablePushNotifications }}
+        aggregations={aggregations}
+        filters={filters}
+        onComplete={handleComplete}
+        contentContainerStyle={{ paddingTop: 0 }}
+        onUpdateEmailPreferencesPress={handleUpdateEmailPreferencesPress}
+        {...other}
+      />
+    </Box>
+  )
+}

--- a/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/screens/CreateSavedSearchAlertScreen.tsx
@@ -12,7 +12,7 @@ type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "CreateSave
 
 export const CreateSavedSearchAlertScreen: React.FC<Props> = (props) => {
   const { navigation, route } = props
-  const { filters, aggregations, onComplete, onClosePress, ...other } = route.params
+  const { filters, aggregations, onComplete, onClosePress, refetch, ...other } = route.params
   const [enablePushNotifications, setEnablePushNotifications] = useState(true)
 
   const getPermissionStatus = async () => {

--- a/src/lib/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen.tsx
@@ -1,0 +1,22 @@
+import { StackScreenProps } from "@react-navigation/stack"
+import { ArtsyReactWebView } from "lib/Components/ArtsyReactWebView"
+import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { Box } from "palette"
+import React from "react"
+import { CreateSavedSearchAlertNavigationStack } from "../SavedSearchAlertModel"
+
+type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "EmailPreferences">
+
+export const EmailPreferencesScreen: React.FC<Props> = (props) => {
+  const { navigation } = props
+  const handleLeftButtonPress = () => {
+    navigation.goBack()
+  }
+
+  return (
+    <Box flex={1}>
+      <FancyModalHeader hideBottomDivider onLeftButtonPress={handleLeftButtonPress} />
+      <ArtsyReactWebView url="/unsubscribe" />
+    </Box>
+  )
+}

--- a/src/lib/navigation/routes.tests.tsx
+++ b/src/lib/navigation/routes.tests.tsx
@@ -693,6 +693,18 @@ describe("artsy.net routes", () => {
     `)
   })
 
+  it("routes to Email Preferences", () => {
+    expect(matchRoute("/unsubscribe")).toMatchInlineSnapshot(`
+      Object {
+        "module": "ReactWebView",
+        "params": Object {
+          "url": "/unsubscribe",
+        },
+        "type": "match",
+      }
+    `)
+  })
+
   it("routes to Favorites", () => {
     expect(matchRoute("/favorites")).toMatchInlineSnapshot(`
       Object {

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -221,6 +221,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     webViewRoute("/terms"),
     webViewRoute("/buy-now-feature-faq"),
     webViewRoute("/buyer-guarantee"),
+    webViewRoute("/unsubscribe"),
 
     new RouteMatcher("/city-bmw-list/:citySlug", "CityBMWList"),
     new RouteMatcher("/make-offer/:artworkID", "MakeOfferModal"),


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3576]

⚠️ Changes behind a feature flag

### Acceptance Criteria
- “Update email preferences” button should be displayed only when  the “Email Alerts” toggle is on
- The button directs user to web view (see below screenshot) with the 4 email preference options
- We should to get the up-to-date status of "email preferences" every time a user opens the “create an alert” view (Only for Create Alert Flow)
- This is where a link should live
  - Edit flow: SETTINGS > SAVED ALERTS > click any ALERT > under the email toggle
  - Create flow: ARTIST > Specify some filters > click “Create an alert” button  > under the email toggle

### Demo
#### Create flow - iOS
https://user-images.githubusercontent.com/3513494/143445357-2fc89063-1baa-4f10-b97e-95a6e56fdebf.mp4

#### Update flow  - iOS
https://user-images.githubusercontent.com/3513494/143445381-92bb3abc-73b6-462b-866d-59b9e9f47316.mp4

#### Create flow - Android
https://user-images.githubusercontent.com/3513494/143445559-83dc4b06-dd3f-4da1-a45e-dcb329379e06.mp4

#### Update flow - Android
https://user-images.githubusercontent.com/3513494/143445569-7f37677e-65e3-4221-a5fe-6578c771d1a6.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Create link for user to view/update email preferences - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3576]: https://artsyproduct.atlassian.net/browse/FX-3576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ