### PR TITLE
fix(FX-3586): Keep recent searches if log in to the same account

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -379,7 +379,7 @@
         "filename": "src/lib/store/AuthModel.tests.ts",
         "hashed_secret": "bb21216b09d3be2d9e40beab38ae57af2b11d081",
         "is_verified": false,
-        "line_number": 228
+        "line_number": 266
       }
     ],
     "src/lib/utils/PushNotification.tests.ts": [
@@ -422,5 +422,5 @@
       }
     ]
   },
-  "generated_at": "2021-11-08T16:11:46Z"
+  "generated_at": "2021-11-19T12:50:15Z"
 }

--- a/src/lib/Scenes/Search/SearchModel.tsx
+++ b/src/lib/Scenes/Search/SearchModel.tsx
@@ -14,6 +14,7 @@ export interface SearchModel {
   recentSearches: RecentSearch[]
   addRecentSearch: Action<SearchModel, RecentSearch>
   deleteRecentSearch: Action<SearchModel, AutosuggestResult>
+  clearRecentSearches: Action<SearchModel>
 }
 
 export const getSearchModel = (): SearchModel => ({
@@ -32,6 +33,9 @@ export const getSearchModel = (): SearchModel => ({
     state.recentSearches = state.recentSearches.filter(
       (recentSearch: RecentSearch) => recentSearch.props.href !== payload.href
     )
+  }),
+  clearRecentSearches: action((state) => {
+    state.recentSearches = []
   }),
 })
 

--- a/src/lib/store/AuthModel.tests.ts
+++ b/src/lib/store/AuthModel.tests.ts
@@ -199,6 +199,44 @@ describe("AuthModel", () => {
       })
       expect(result).toBe(false)
     })
+
+    it("does not clear recent searches if user id has not changed after the previous session", async () => {
+      const clearRecentSearchesSpy = jest.spyOn(GlobalStore.actions.search, "clearRecentSearches")
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userID: null,
+          previousSessionUserID: "my-user-id",
+        },
+      })
+      mockFetchJsonOnce({ access_token: "my-access-token" }, 201)
+      mockFetchJsonOnce({
+        id: "my-user-id",
+      })
+      await GlobalStore.actions.auth.signIn({
+        email: "user@example.com",
+        password: "hunter2",
+      })
+      expect(clearRecentSearchesSpy).not.toHaveBeenCalled()
+    })
+
+    it("clears recent searches if user id has changed after the previous session", async () => {
+      const clearRecentSearchesSpy = jest.spyOn(GlobalStore.actions.search, "clearRecentSearches")
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userID: null,
+          previousSessionUserID: "prev-user-id",
+        },
+      })
+      mockFetchJsonOnce({ access_token: "my-access-token" }, 201)
+      mockFetchJsonOnce({
+        id: "my-user-id",
+      })
+      await GlobalStore.actions.auth.signIn({
+        email: "user@example.com",
+        password: "hunter2",
+      })
+      expect(clearRecentSearchesSpy).toHaveBeenCalled()
+    })
   })
 
   describe("signUp", () => {

--- a/src/lib/store/GlobalStoreModel.ts
+++ b/src/lib/store/GlobalStoreModel.ts
@@ -63,9 +63,15 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
     return result
   }),
   signOut: thunk(async (actions, _, store) => {
+    const {
+      config: existingConfig,
+      search,
+      auth: { userID },
+    } = store.getState()
+
     // keep existing config state
-    const existingConfig = store.getState().config
     const config = sanitize(existingConfig) as typeof existingConfig
+
     const signOutGoogle = async () => {
       try {
         await GoogleSignin.revokeAccess()
@@ -81,7 +87,7 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
       await signOutGoogle(),
       CookieManager.clearAll(),
       RelayCache.clearAll(),
-      actions.reset({ config }),
+      actions.reset({ config, search, auth: { previousSessionUserID: userID } }),
     ])
   }),
   didRehydrate: thunkOn(

--- a/src/lib/store/migration.tests.ts
+++ b/src/lib/store/migration.tests.ts
@@ -386,3 +386,23 @@ describe("AddExperimentsModel migration", () => {
     expect(migratedState.config.experiments).toEqual({})
   })
 })
+
+describe("App version Versions.AddPreviousSessionUserID", () => {
+  const migrationToTest = Versions.AddPreviousSessionUserID
+  it("adds previousSessionUserID", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    }) as any
+
+    expect("previousSessionUserID" in previousState.auth).toBe(false)
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect("previousSessionUserID" in migratedState.auth).toBe(true)
+    expect(migratedState.auth.previousSessionUserID).toEqual(null)
+  })
+})

--- a/src/lib/store/migration.ts
+++ b/src/lib/store/migration.ts
@@ -25,9 +25,10 @@ export const Versions = {
   PendingPushNotification: 13,
   CopyIOSNativeSessionAuthToTS: 14,
   AddExperimentsModel: 15,
+  AddPreviousSessionUserID: 16,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddExperimentsModel
+export const CURRENT_APP_VERSION = Versions.AddPreviousSessionUserID
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -106,6 +107,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.AddExperimentsModel]: (state) => {
     state.config.experiments = {}
+  },
+  [Versions.AddPreviousSessionUserID]: (state) => {
+    state.auth.previousSessionUserID = null
   },
 }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [FX-3586]

### Description

Currently if user is logged out and back into the app they can't see their recent searches.
This PR keeps recent searches in async storage after log out and only removes them if previous user and newly logged in one are not the same.

#### Demo

https://user-images.githubusercontent.com/44819355/142632808-7954e2e0-bb7c-4bfa-b497-500d12b62cf6.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- keep recent searches after log out - anastasiapyzhik

<!-- end_changelog_updates -->

</details>


[FX-3586]: https://artsyproduct.atlassian.net/browse/FX-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ