### PR TITLE
fix: cut off empty states on saves pages #trivial

### DIFF
--- a/src/lib/Scenes/Favorites/FavoriteArtists.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteArtists.tsx
@@ -71,7 +71,6 @@ class Artists extends React.Component<Props, State> {
     if (rows.length === 0) {
       return (
         <StickyTabPageScrollView
-          contentContainerStyle={{ flex: 1 }}
           refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
         >
           <ZeroState

--- a/src/lib/Scenes/Favorites/FavoriteCategories.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteCategories.tsx
@@ -70,7 +70,6 @@ export class Categories extends React.Component<Props, State> {
       return (
         <StickyTabPageScrollView
           refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
-          contentContainerStyle={{ flex: 1 }}
         >
           <ZeroState
             title="You’re not following any categories yet"

--- a/src/lib/Scenes/Favorites/FavoriteShows.tsx
+++ b/src/lib/Scenes/Favorites/FavoriteShows.tsx
@@ -69,7 +69,6 @@ export class Shows extends Component<Props, State> {
       return (
         <StickyTabPageScrollView
           refreshControl={<RefreshControl refreshing={this.state.refreshingFromPull} onRefresh={this.handleRefresh} />}
-          contentContainerStyle={{ flex: 1 }}
         >
           <ZeroState
             title="You haven’t saved any shows yet"


### PR DESCRIPTION
The type of this PR is: **fix**

This PR resolves [CX-2158]

### Description

This is a quick fix for the major layout issue here but there is another bug, the refresh controls are getting rendered too high up on the page so they don't show up when you pull down. Seems to affect here and MyCollection which is also using a refreshControl in StickyTabPageScrollView.

ticket here: https://artsyproduct.atlassian.net/browse/CX-2172

<details><summary>Before</summary>

![saved-shows-before](https://user-images.githubusercontent.com/49686530/142515640-85375dad-c5c4-43e1-aceb-4f19ab238cee.png)
</details>

<details><summary>After</summary>

![saved-shows-after](https://user-images.githubusercontent.com/49686530/142515634-c0ee91b2-753a-410e-9016-a37adc629e5f.png)
</details>

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix empty state layout in saves screens - Brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2158]: https://artsyproduct.atlassian.net/browse/CX-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ