### PR TITLE
fix(FX-3599): useRawURL of images that come from articles algolia

### DIFF
--- a/src/lib/Scenes/Search/components/SearchResultImage.tsx
+++ b/src/lib/Scenes/Search/components/SearchResultImage.tsx
@@ -11,6 +11,7 @@ export const SearchResultImage: React.FC<{ imageURL: string | null; resultType: 
 
   return (
     <OpaqueImageView
+      useRawURL={resultType === "Article"}
       imageURL={imageURL}
       style={{
         width: IMAGE_SIZE,


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3599]

### Description

In eigen in order to render images (more specifically to render the algolia list items) we use the [`OpaqueImageView` component](https://github.com/artsy/eigen/blob/2d141d230e406eae3f0b5b741500914044a54930/src/lib/Scenes/Search/components/SearchResultImage.tsx#L6).

In positron when we index articles we index `image_url` like [that](https://github.com/artsy/positron/blob/86d00affde2f84f1af1f88bc302ba4879553996c/src/api/apps/articles/model/distribute.coffee#L135) and we use the [crop function](https://github.com/artsy/positron/blob/86d00affde2f84f1af1f88bc302ba4879553996c/src/api/apps/articles/model/distribute.coffee#L167-L169) which creates the url for the article to be indexed (structures the url in order to fetch it from gemini) and the result is something like this:   https://d7hftxdivxxvm.cloudfront.net/?resize_to=fill&width=70&height=70&quality=95&src=http%3A%2F%2Fstatic.artsy.net/additional_images/53c57724726169092b540000/large.jpg

In eigen afterwards we render a blank photo because we try to recreate the link via gemini with this function [`imageUrl`](https://github.com/artsy/eigen/blob/2d141d230e406eae3f0b5b741500914044a54930/src/lib/Components/OpaqueImageView/OpaqueImageView.tsx#L106-L123) and the result is a link of this form which is not a link that doesn't exist (?)

on photos that don't render:
https://d7hftxdivxxvm.cloudfront.net/?height=180&quality=80&resize_to=fill&src=https%3A%2F%2Fd2v80f5yrouhh2.cloudfront.net%2F_R1DXkBBPeEtiJY4xh4NUA%2Flarge.jpg&width=180

and in photos that render
https://d7hftxdivxxvm.cloudfront.net/?height=180&quality=80&resize_to=fill&src=https%3A%2F%2Fd2v80f5yrouhh2.cloudfront.net%2FspajNM1flkg36F0Kgh1pPA%2Flarge.jpg&width=180

(second one is still not okay since it messes up the link again but it exists in geminy)

For this reason OpaqueImageView has a property called useRawURL<boolean> that handles these cases so the suggested change would be something like this inside eigen

add useRawURL={resultType === "Artcle"}

and this will let us see all the images coming from articles

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- algolia article images now consistently appear under articles pill - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3599]: https://artsyproduct.atlassian.net/browse/FX-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ