### PR TITLE
feat(FX-3615): Display artist name as pill in create/edit alert forms

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -49,6 +49,20 @@ describe("Saved search alert form", () => {
     ])
   })
 
+  it("should display the artist name as a pill if AREnableImprovedAlertsFlow is enabled", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+    const { getAllByTestId } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
+
+    expect(getAllByTestId("alert-pill").map(extractText)).toEqual([
+      "artistName",
+      "Limited Edition",
+      "Tate Ward Auctions",
+      "New York, NY, USA",
+      "Photography",
+      "Prints",
+    ])
+  })
+
   it(`should render "Delete Alert" button when the savedSearchAlertId is passed`, () => {
     const { getAllByTestId } = renderWithWrappersTL(
       <SavedSearchAlertForm {...baseProps} savedSearchAlertId="savedSearchAlertId" />

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -47,9 +47,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   } = props
   const isUpdateForm = !!savedSearchAlertId
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
-  const pills = isEnabledImprovedAlertsFlow
-    ? [artistName, ...extractPills(filters, aggregations)]
-    : extractPills(filters, aggregations)
+  const pillsFromFilters = extractPills(filters, aggregations)
+  const pills = isEnabledImprovedAlertsFlow ? [artistName, ...pillsFromFilters] : pillsFromFilters
   const tracking = useTracking()
   const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -46,7 +46,10 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
     ...other
   } = props
   const isUpdateForm = !!savedSearchAlertId
-  const pills = extractPills(filters, aggregations)
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
+  const pills = isEnabledImprovedAlertsFlow
+    ? [artistName, ...extractPills(filters, aggregations)]
+    : extractPills(filters, aggregations)
   const tracking = useTracking()
   const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)

--- a/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
@@ -138,6 +138,6 @@ describe("getNamePlaceholder", () => {
 
   it("returns the correct number of filters when artist pill is shown", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
-    expect(getNamePlaceholder("artistName", ["artistName", "one", "two"])).toBe("artistName • 2 filters")
+    expect(getNamePlaceholder("artistName", ["artistName", "one", "two"])).toBe("artistName • 3 filters")
   })
 })

--- a/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
@@ -1,4 +1,5 @@
 import { Aggregations, FilterData, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractPillFromAggregation, extractPills, extractSizeLabel, getNamePlaceholder } from "./helpers"
 
 describe("extractPillFromAggregation", () => {
@@ -133,5 +134,10 @@ describe("getNamePlaceholder", () => {
 
   it("returns the plural form for the filter label", () => {
     expect(getNamePlaceholder("artistName", ["one", "two"])).toBe("artistName • 2 filters")
+  })
+
+  it("returns the correct number of filters when artist pill is shown", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+    expect(getNamePlaceholder("artistName", ["artistName", "one", "two"])).toBe("artistName • 2 filters")
   })
 })

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -7,7 +7,6 @@ import {
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { LOCALIZED_UNIT, parseRange } from "lib/Components/ArtworkFilter/Filters/helpers"
 import { shouldExtractValueNamesFromAggregation } from "lib/Components/ArtworkFilter/SavedSearch/constants"
-import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import { compact, flatten, keyBy } from "lodash"
 import { bullet } from "palette"
 

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -7,6 +7,7 @@ import {
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { LOCALIZED_UNIT, parseRange } from "lib/Components/ArtworkFilter/Filters/helpers"
 import { shouldExtractValueNamesFromAggregation } from "lib/Components/ArtworkFilter/SavedSearch/constants"
+import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import { compact, flatten, keyBy } from "lodash"
 import { bullet } from "palette"
 
@@ -74,5 +75,7 @@ export const extractPills = (filters: FilterArray, aggregations: Aggregations) =
 
 export const getNamePlaceholder = (artistName: string, pills: string[]) => {
   const filtersCountLabel = pills.length > 1 ? "filters" : "filter"
-  return `${artistName} ${bullet} ${pills.length} ${filtersCountLabel}`
+  const isEnabledImprovedAlertsFlow = unsafe_getFeatureFlag("AREnableImprovedAlertsFlow")
+  const filtersCount = isEnabledImprovedAlertsFlow ? pills.length - 1 : pills.length
+  return `${artistName} ${bullet} ${filtersCount} ${filtersCountLabel}`
 }

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -75,7 +75,5 @@ export const extractPills = (filters: FilterArray, aggregations: Aggregations) =
 
 export const getNamePlaceholder = (artistName: string, pills: string[]) => {
   const filtersCountLabel = pills.length > 1 ? "filters" : "filter"
-  const isEnabledImprovedAlertsFlow = unsafe_getFeatureFlag("AREnableImprovedAlertsFlow")
-  const filtersCount = isEnabledImprovedAlertsFlow ? pills.length - 1 : pills.length
-  return `${artistName} ${bullet} ${filtersCount} ${filtersCountLabel}`
+  return `${artistName} ${bullet} ${pills.length} ${filtersCountLabel}`
 }


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3615]

### Description

⚠️ This work is behind `AREnableImprovedAlertsFlow` feature flag

- renders artist pill in create/edit alert forms
- artist pill is not editable
- matches visual ac's in [figma](https://www.figma.com/file/zbEFZqjKgKquZwtU8U44j9/Alerts?node-id=3147%3A7315)

### Screenshots

|Android|iOS|
|---|---|
|![Screenshot_1638435636](https://user-images.githubusercontent.com/21178754/144390452-5df58adf-f8a6-43b0-a951-76231758beed.png)|![Simulator Screen Shot - iPhone 8 - 2021-12-02 at 09 55 29](https://user-images.githubusercontent.com/21178754/144389966-1c5af052-7cda-443c-b768-fe36d5ca8a08.png)|
|![Screenshot_1638435612](https://user-images.githubusercontent.com/21178754/144390456-680207f8-cf6c-4526-8163-7dbb87494177.png)|![Simulator Screen Shot - iPhone 8 - 2021-12-02 at 09 54 37](https://user-images.githubusercontent.com/21178754/144389973-71ac3d0c-4ada-47f4-bb37-35a4636175c8.png)|
|![Screenshot_1638435598](https://user-images.githubusercontent.com/21178754/144390459-80db833e-1dcc-465a-9615-f8afe70542ac.png)|![Simulator Screen Shot - iPhone 8 - 2021-12-02 at 09 54 10](https://user-images.githubusercontent.com/21178754/144389976-4a6e623a-3693-4ff8-987e-2c9866da3d37.png)|

### Resolved

- [x] Waiting to resolve [this question](https://artsy.slack.com/archives/C9SATFLUU/p1638359765126000) with design before this is ready for review

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- display artist name as pill in create/edit alert forms - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3615]: https://artsyproduct.atlassian.net/browse/FX-3615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ