### PR TITLE
feat(FX-3614): Update visual design of artwork grid filter menu

### DIFF
--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -29,13 +29,12 @@ import { YearOptionsScreen } from "lib/Components/ArtworkFilter/Filters/YearOpti
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import { Box, Button, Separator } from "palette"
 import React from "react"
 import { View, ViewProps } from "react-native"
 import { useTracking } from "react-tracking"
-import styled from "styled-components/native"
 import { FancyModal } from "../FancyModal/FancyModal"
 import { ArtworkFilterOptionsScreen, FilterModalMode as ArtworkFilterMode } from "./ArtworkFilterOptionsScreen"
+import { ArtworkFilterApplyButton } from "./components/ArtworkFilterApplyButton"
 import { AuctionHouseOptionsScreen } from "./Filters/AuctionHouseOptions"
 import { LocationCitiesOptionsScreen } from "./Filters/LocationCitiesOptions"
 
@@ -147,6 +146,106 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const isApplyButtonEnabled =
     selectedFiltersState.length > 0 || (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
 
+  const handleApplyPress = () => {
+    const appliedFiltersParams = filterArtworksParams(appliedFiltersState, filterTypeState)
+    // TODO: Update to use cohesion
+    switch (mode) {
+      case ArtworkFilterMode.Collection:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.Collection,
+          ownerEntity: OwnerEntityTypes.Collection,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.ArtistArtworks:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.ArtistPage,
+          ownerEntity: OwnerEntityTypes.Artist,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.Fair:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.FairPage,
+          ownerEntity: OwnerEntityTypes.Fair,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.SaleArtworks:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.Auction,
+          ownerEntity: OwnerEntityTypes.Auction,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.Show:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.ShowPage,
+          ownerEntity: OwnerEntityTypes.Show,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.AuctionResults:
+        trackChangeFilters({
+          actionType: ActionType.auctionResultsFilterParamsChanged,
+          screenName: PageNames.ArtistPage,
+          ownerEntity: OwnerEntityTypes.Artist,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+          contextModule: ContextModule.auctionResults,
+        })
+        break
+      case ArtworkFilterMode.Partner:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.PartnerPage,
+          ownerEntity: OwnerEntityTypes.Partner,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.ArtistSeries:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.ArtistSeriesPage,
+          ownerEntity: OwnerEntityTypes.ArtistSeries,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.Gene:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.GenePage,
+          ownerEntity: OwnerEntityTypes.Gene,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+      case ArtworkFilterMode.Search:
+        trackChangeFilters({
+          actionType: ActionType.commercialFilterParamsChanged,
+          screenName: PageNames.Search,
+          ownerEntity: OwnerType.search,
+          artworkQuery: query,
+          currentParams: appliedFiltersParams,
+          changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
+        })
+        break
+    }
+    applyFilters()
+  }
+
   return (
     <NavigationContainer independent>
       <FancyModal
@@ -198,126 +297,9 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             <Stack.Screen name="LocationCitiesOptionsScreen" component={LocationCitiesOptionsScreen} />
           </Stack.Navigator>
 
-          <Separator my={0} />
-
-          <ApplyButtonContainer>
-            <ApplyButton
-              disabled={!isApplyButtonEnabled}
-              onPress={() => {
-                const appliedFiltersParams = filterArtworksParams(appliedFiltersState, filterTypeState)
-                // TODO: Update to use cohesion
-                switch (mode) {
-                  case ArtworkFilterMode.Collection:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.Collection,
-                      ownerEntity: OwnerEntityTypes.Collection,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.ArtistArtworks:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.ArtistPage,
-                      ownerEntity: OwnerEntityTypes.Artist,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.Fair:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.FairPage,
-                      ownerEntity: OwnerEntityTypes.Fair,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.SaleArtworks:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.Auction,
-                      ownerEntity: OwnerEntityTypes.Auction,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.Show:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.ShowPage,
-                      ownerEntity: OwnerEntityTypes.Show,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.AuctionResults:
-                    trackChangeFilters({
-                      actionType: ActionType.auctionResultsFilterParamsChanged,
-                      screenName: PageNames.ArtistPage,
-                      ownerEntity: OwnerEntityTypes.Artist,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                      contextModule: ContextModule.auctionResults,
-                    })
-                    break
-                  case ArtworkFilterMode.Partner:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.PartnerPage,
-                      ownerEntity: OwnerEntityTypes.Partner,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.ArtistSeries:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.ArtistSeriesPage,
-                      ownerEntity: OwnerEntityTypes.ArtistSeries,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.Gene:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.GenePage,
-                      ownerEntity: OwnerEntityTypes.Gene,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                  case ArtworkFilterMode.Search:
-                    trackChangeFilters({
-                      actionType: ActionType.commercialFilterParamsChanged,
-                      screenName: PageNames.Search,
-                      ownerEntity: OwnerType.search,
-                      artworkQuery: query,
-                      currentParams: appliedFiltersParams,
-                      changedParams: changedFiltersParams(appliedFiltersParams, selectedFiltersState),
-                    })
-                    break
-                }
-                applyFilters()
-              }}
-              block
-              width={100}
-              variant="fillDark"
-              size="large"
-            >
-              Show results
-            </ApplyButton>
-          </ApplyButtonContainer>
+          <ArtworkFilterApplyButton disabled={!isApplyButtonEnabled} onPress={handleApplyPress} />
         </View>
       </FancyModal>
     </NavigationContainer>
   )
 }
-
-export const ApplyButton = styled(Button)``
-export const ApplyButtonContainer = styled(Box)`
-  padding: 20px;
-  padding-bottom: 30px;
-`

--- a/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilter.tsx
@@ -26,6 +26,7 @@ import { TimePeriodOptionsScreen } from "lib/Components/ArtworkFilter/Filters/Ti
 import { ViewAsOptionsScreen } from "lib/Components/ArtworkFilter/Filters/ViewAsOptions"
 import { WaysToBuyOptionsScreen } from "lib/Components/ArtworkFilter/Filters/WaysToBuyOptions"
 import { YearOptionsScreen } from "lib/Components/ArtworkFilter/Filters/YearOptions"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
 import { Box, Button, Separator } from "palette"
@@ -101,6 +102,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
 
   const applyFiltersAction = ArtworksFiltersStore.useStoreActions((action) => action.applyFiltersAction)
   const resetFiltersAction = ArtworksFiltersStore.useStoreActions((action) => action.resetFiltersAction)
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   const handleClosingModal = () => {
     resetFiltersAction()
@@ -147,7 +149,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
 
   return (
     <NavigationContainer independent>
-      <FancyModal visible={props.isFilterArtworksModalVisible} onBackgroundPressed={handleClosingModal}>
+      <FancyModal
+        visible={props.isFilterArtworksModalVisible}
+        onBackgroundPressed={handleClosingModal}
+        fullScreen={isEnabledImprovedAlertsFlow}
+      >
         <View style={{ flex: 1 }}>
           <Stack.Navigator
             // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -12,7 +12,7 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import { FilterIcon, Flex, Sans, Separator } from "palette"
+import { FilterIcon, Flex, Sans } from "palette"
 import React, { useMemo } from "react"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
@@ -133,12 +133,12 @@ export const ArtworkFilterOptionsScreen: React.FC<
     <Flex flex={1}>
       <ArtworkFilterOptionsHeader
         title={title}
-        isClearAllButtonEnabled={isClearAllButtonEnabled}
-        onClosePress={handleTappingCloseIcon}
-        onClearAllPress={handleClearAllPress}
+        rightButtonDisabled={!isClearAllButtonEnabled}
+        onLeftButtonPress={handleTappingCloseIcon}
+        onRightButtonPress={handleClearAllPress}
+        rightButtonText="Clear All"
+        useXButton
       />
-
-      <Separator />
 
       <FlatList<FilterDisplayConfig>
         keyExtractor={(_item, index) => String(index)}

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -133,6 +133,31 @@ export const ArtworkFilterOptionsScreen: React.FC<
     closeModal()
   }
 
+  const handleClearAllPress = () => {
+    switch (mode) {
+      case FilterModalMode.Collection:
+        trackClear(PageNames.Collection, OwnerEntityTypes.Collection)
+        break
+      case FilterModalMode.ArtistArtworks:
+        trackClear(PageNames.ArtistPage, OwnerEntityTypes.Artist)
+        break
+      case FilterModalMode.ArtistSeries:
+        trackClear(PageNames.ArtistSeriesPage, OwnerEntityTypes.ArtistSeries)
+        break
+      case "Fair":
+        trackClear(PageNames.FairPage, OwnerEntityTypes.Fair)
+        break
+      case FilterModalMode.Gene:
+        trackClear(PageNames.GenePage, OwnerEntityTypes.Gene)
+        break
+      case FilterModalMode.Search:
+        trackClear(PageNames.Search, OwnerEntityTypes.Search)
+        break
+    }
+
+    clearAllFilters()
+  }
+
   return (
     <Flex style={{ flex: 1 }}>
       <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
@@ -147,33 +172,7 @@ export const ArtworkFilterOptionsScreen: React.FC<
         </Flex>
 
         <Flex position="absolute" right={0} alignItems="flex-end">
-          <ClearAllButton
-            disabled={!isClearAllButtonEnabled}
-            onPress={() => {
-              switch (mode) {
-                case FilterModalMode.Collection:
-                  trackClear(PageNames.Collection, OwnerEntityTypes.Collection)
-                  break
-                case FilterModalMode.ArtistArtworks:
-                  trackClear(PageNames.ArtistPage, OwnerEntityTypes.Artist)
-                  break
-                case FilterModalMode.ArtistSeries:
-                  trackClear(PageNames.ArtistSeriesPage, OwnerEntityTypes.ArtistSeries)
-                  break
-                case "Fair":
-                  trackClear(PageNames.FairPage, OwnerEntityTypes.Fair)
-                  break
-                case FilterModalMode.Gene:
-                  trackClear(PageNames.GenePage, OwnerEntityTypes.Gene)
-                  break
-                case FilterModalMode.Search:
-                  trackClear(PageNames.Search, OwnerEntityTypes.Search)
-                  break
-              }
-
-              clearAllFilters()
-            }}
-          >
+          <ClearAllButton disabled={!isClearAllButtonEnabled} onPress={handleClearAllPress}>
             <Text variant="sm" color={isClearAllButtonEnabled ? "black100" : "black30"}>
               Clear all
             </Text>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -8,49 +8,20 @@ import {
   getUnitedSelectedAndAppliedFilters,
 } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import { ArrowRightIcon, bullet, FilterIcon, Flex, Sans, Separator, Text } from "palette"
+import { FilterIcon, Flex, Sans, Separator } from "palette"
 import React, { useMemo } from "react"
 import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { AnimatedBottomButton } from "../AnimatedBottomButton"
 import { ArtworkFilterNavigationStack } from "./ArtworkFilter"
+import { ArtworkFilterOptionItem } from "./components/ArtworkFilterOptionItem"
 import { ArtworkFilterOptionsHeader } from "./components/ArtworkFilterOptionsHeader"
-
-export type FilterScreen =
-  | "additionalGeneIDs"
-  | "artistIDs"
-  | "artistNationalities"
-  | "artistsIFollow"
-  | "attributionClass"
-  | "categories"
-  | "color"
-  | "colors"
-  | "dimensionRange"
-  | "estimateRange"
-  | "locationCities"
-  | "majorPeriods"
-  | "materialsTerms"
-  | "medium"
-  | "partnerIDs"
-  | "priceRange"
-  | "organizations"
-  | "sizes"
-  | "sort"
-  | "viewAs"
-  | "waysToBuy"
-  | "year"
-
-export interface FilterDisplayConfig {
-  filterType: FilterScreen
-  displayText: string
-  ScreenComponent: keyof ArtworkFilterNavigationStack
-}
+import { FilterDisplayConfig, FilterScreen } from "./types"
 
 export enum FilterModalMode {
   ArtistArtworks = "ArtistArtworks",
@@ -177,24 +148,11 @@ export const ArtworkFilterOptionsScreen: React.FC<
           const selectedFiltersCount = selectedFiltersCounts[item.filterType as FilterParamName]
 
           return (
-            <TouchableRow onPress={() => navigateToNextFilterScreen(item.ScreenComponent)}>
-              <OptionListItem p={2} pr={1.5}>
-                <Flex minWidth="45%">
-                  <Text variant="xs">
-                    {item.displayText}
-                    {!!selectedFiltersCount && (
-                      <Text variant="xs" color="blue100" ml={4}>
-                        {` ${bullet} ${selectedFiltersCount}`}
-                      </Text>
-                    )}
-                  </Text>
-                </Flex>
-
-                <Flex flex={1} flexDirection="row" alignItems="center" justifyContent="flex-end">
-                  <ArrowRightIcon fill="black30" ml={1} />
-                </Flex>
-              </OptionListItem>
-            </TouchableRow>
+            <ArtworkFilterOptionItem
+              item={item}
+              count={selectedFiltersCount}
+              onPress={() => navigateToNextFilterScreen(item.ScreenComponent)}
+            />
           )
         }}
       />
@@ -373,11 +331,6 @@ export const AnimatedArtworkFilterButton: React.FC<AnimatedArtworkFilterButtonPr
     </AnimatedBottomButton>
   )
 }
-
-export const OptionListItem = styled(Flex)`
-  flex-direction: row;
-  justify-content: space-between;
-`
 
 export const filterOptionToDisplayConfigMap: Record<string, FilterDisplayConfig> = {
   additionalGeneIDs: {

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -13,13 +13,14 @@ import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Schema } from "lib/utils/track"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import { ArrowRightIcon, bullet, CloseIcon, FilterIcon, Flex, Sans, Separator, Text, useSpace } from "palette"
+import { ArrowRightIcon, bullet, FilterIcon, Flex, Sans, Separator, Text } from "palette"
 import React, { useMemo } from "react"
-import { FlatList, TouchableOpacity } from "react-native"
+import { FlatList } from "react-native"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { AnimatedBottomButton } from "../AnimatedBottomButton"
 import { ArtworkFilterNavigationStack } from "./ArtworkFilter"
+import { ArtworkFilterOptionsHeader } from "./components/ArtworkFilterOptionsHeader"
 
 export type FilterScreen =
   | "additionalGeneIDs"
@@ -69,7 +70,6 @@ export enum FilterModalMode {
 export const ArtworkFilterOptionsScreen: React.FC<
   StackScreenProps<ArtworkFilterNavigationStack, "FilterOptionsScreen">
 > = ({ navigation, route }) => {
-  const space = useSpace()
   const tracking = useTracking()
   const { closeModal, id, mode, slug, title = "Sort & Filter" } = route.params
 
@@ -159,26 +159,13 @@ export const ArtworkFilterOptionsScreen: React.FC<
   }
 
   return (
-    <Flex style={{ flex: 1 }}>
-      <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
-        <Flex flex={1} alignItems="center">
-          <Text variant="sm">{title}</Text>
-        </Flex>
-
-        <Flex position="absolute" alignItems="flex-start">
-          <CloseIconContainer hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }} onPress={handleTappingCloseIcon}>
-            <CloseIcon fill="black100" />
-          </CloseIconContainer>
-        </Flex>
-
-        <Flex position="absolute" right={0} alignItems="flex-end">
-          <ClearAllButton disabled={!isClearAllButtonEnabled} onPress={handleClearAllPress}>
-            <Text variant="sm" color={isClearAllButtonEnabled ? "black100" : "black30"}>
-              Clear all
-            </Text>
-          </ClearAllButton>
-        </Flex>
-      </Flex>
+    <Flex flex={1}>
+      <ArtworkFilterOptionsHeader
+        title={title}
+        isClearAllButtonEnabled={isClearAllButtonEnabled}
+        onClosePress={handleTappingCloseIcon}
+        onClearAllPress={handleClearAllPress}
+      />
 
       <Separator />
 
@@ -386,14 +373,6 @@ export const AnimatedArtworkFilterButton: React.FC<AnimatedArtworkFilterButtonPr
     </AnimatedBottomButton>
   )
 }
-
-export const CloseIconContainer = styled(TouchableOpacity)`
-  padding: ${themeGet("space.2")}px;
-`
-
-export const ClearAllButton = styled(TouchableOpacity)`
-  padding: ${themeGet("space.2")}px;
-`
 
 export const OptionListItem = styled(Flex)`
   flex-direction: row;

--- a/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
@@ -204,9 +204,9 @@ describe("Filter modal navigation flow", () => {
   })
 
   it("allows users to exit filter modal screen when selecting close icon", () => {
-    const { getByA11yLabel } = renderWithWrappersTL(<MockFilterModalNavigator />)
+    const { getByTestId } = renderWithWrappersTL(<MockFilterModalNavigator />)
 
-    fireEvent.press(getByA11yLabel("Close filter menu"))
+    fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
     expect(closeModalMock).toHaveBeenCalled()
   })

--- a/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
@@ -1,29 +1,21 @@
+import { fireEvent } from "@testing-library/react-native"
 import { FilterModalTestsQuery } from "__generated__/FilterModalTestsQuery.graphql"
-// @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-import { mount } from "enzyme"
 import {
   AnimatedArtworkFilterButton,
-  ApplyButton,
   ArtworkFilterNavigator,
   ArtworkFilterOptionsScreen,
-  ClearAllButton,
-  CloseIconContainer,
   FilterModalMode,
-  OptionListItem,
 } from "lib/Components/ArtworkFilter"
 import { Aggregations, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { TouchableRow } from "lib/Components/TouchableRow"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
 import { GlobalStoreProvider } from "lib/store/GlobalStore"
-import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Sans, Theme } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import { Theme } from "palette"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment } from "relay-test-utils"
 import { closeModalMock, getEssentialProps, MockFilterScreen, navigateMock } from "./FilterTestHelper"
@@ -179,7 +171,7 @@ const MockFilterModalNavigator = ({ initialData = initialState }: { initialData?
 
 describe("Filter modal navigation flow", () => {
   it("allows users to navigate forward to sort screen from filter screen", () => {
-    const filterScreen = renderWithWrappers(
+    const { getByText } = renderWithWrappersTL(
       <ArtworkFiltersStoreProvider>
         <ArtworkFilterOptionsScreen
           {...getEssentialProps({
@@ -189,15 +181,14 @@ describe("Filter modal navigation flow", () => {
       </ArtworkFiltersStoreProvider>
     )
 
-    // the first row item takes users to the Medium navigation route
-    const instance = filterScreen.root.findAllByType(TouchableRow)[0]
+    // the first row item takes users to the Sort navigation route
+    fireEvent.press(getByText("Sort By"))
 
-    act(() => instance.props.onPress())
     expect(navigateMock).toBeCalledWith("SortOptionsScreen")
   })
 
   it("allows users to navigate forward to medium screen from filter screen", () => {
-    const filterScreen = renderWithWrappers(
+    const { getByText } = renderWithWrappersTL(
       <ArtworkFiltersStoreProvider initialData={initialState}>
         <ArtworkFilterOptionsScreen
           {...getEssentialProps({
@@ -207,17 +198,16 @@ describe("Filter modal navigation flow", () => {
       </ArtworkFiltersStoreProvider>
     )
     // the second row item takes users to the Medium navigation route
-    const instance = filterScreen.root.findAllByType(TouchableRow)[2]
-
-    act(() => instance.props.onPress())
+    fireEvent.press(getByText("Medium"))
 
     expect(navigateMock).toBeCalledWith("AdditionalGeneIDsOptionsScreen")
   })
 
   it("allows users to exit filter modal screen when selecting close icon", () => {
-    const filterScreen = mount(<MockFilterModalNavigator />)
+    const { getByA11yLabel } = renderWithWrappersTL(<MockFilterModalNavigator />)
 
-    filterScreen.find(CloseIconContainer).props().onPress()
+    fireEvent.press(getByA11yLabel("Close filter menu"))
+
     expect(closeModalMock).toHaveBeenCalled()
   })
 })
@@ -237,8 +227,9 @@ describe("Filter modal states", () => {
       },
     }
 
-    const filterScreen = mount(<MockFilterScreen initialState={injectedState} />)
-    expect(filterScreen.find(OptionListItem).at(0).text()).toContain("• 1")
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
+
+    expect(getByText("Sort By • 1"))
   })
 
   it("displays the currently selected medium option number on the filter screen", () => {
@@ -261,15 +252,15 @@ describe("Filter modal states", () => {
       },
     }
 
-    const filterScreen = mount(<MockFilterScreen initialState={injectedState} />)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    expect(filterScreen.find(OptionListItem).at(2).text()).toContain("• 1")
+    expect(getByText("Medium • 1")).toBeTruthy()
   })
 
   it("displays the filter screen apply button correctly when no filters are selected", () => {
-    const filterScreen = mount(<MockFilterModalNavigator />)
+    const { getAllByText } = renderWithWrappersTL(<MockFilterModalNavigator />)
 
-    expect(filterScreen.find(ApplyButton).props().disabled).toEqual(true)
+    expect(getAllByText("Show results")[0]).toBeDisabled()
   })
 
   it("displays the filter screen apply button correctly when filters are selected", () => {
@@ -286,16 +277,17 @@ describe("Filter modal states", () => {
       },
     }
 
-    const filterScreen = renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
+    const { getAllByText } = renderWithWrappersTL(<MockFilterModalNavigator initialData={injectedState} />)
 
-    expect(filterScreen.root.findByType(ApplyButton).props.disabled).toEqual(false)
+    expect(getAllByText("Show results")[0]).not.toBeDisabled()
   })
 
   it("does not display default filters numbers on the Filter modal", () => {
-    const filterScreen = mount(<MockFilterScreen initialState={initialState} />)
-    for (let i = 0; i < 3; i++) {
-      expect(filterScreen.find(OptionListItem).at(i).text()).not.toContain("•")
-    }
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={initialState} />)
+
+    expect(getByText("Sort By")).toBeTruthy()
+    expect(getByText("Rarity")).toBeTruthy()
+    expect(getByText("Medium")).toBeTruthy()
   })
 
   it("displays selected filters on the Filter modal", () => {
@@ -322,14 +314,14 @@ describe("Filter modal states", () => {
       },
     }
 
-    const filterScreen = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[0])).toContain("• 1")
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[1])).not.toContain("•")
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[2])).toContain("• 1")
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[3])).toContain("• 1")
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[4])).toContain("• 1")
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[5])).toContain("• 2")
-    expect(filterScreen.root.findAllByType(OptionListItem)).toHaveLength(6)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
+
+    expect(getByText("Sort By • 1")).toBeTruthy()
+    expect(getByText("Rarity")).toBeTruthy()
+    expect(getByText("Medium • 1")).toBeTruthy()
+    expect(getByText("Price • 1")).toBeTruthy()
+    expect(getByText("Ways to Buy • 1")).toBeTruthy()
+    expect(getByText("Time Period • 2")).toBeTruthy()
   })
 })
 
@@ -354,13 +346,13 @@ describe("Clearing filters", () => {
       },
     }
 
-    const filterScreen = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[0])).toContain("• 1")
+    expect(getByText("Sort By • 1"))
 
-    filterScreen.root.findByType(ClearAllButton).props.onPress()
+    fireEvent.press(getByText("Clear All"))
 
-    expect(extractText(filterScreen.root.findAllByType(OptionListItem)[0])).not.toContain("•")
+    expect(getByText("Sort By"))
   })
 
   it("exits the modal when clear all button is pressed", () => {
@@ -377,16 +369,14 @@ describe("Clearing filters", () => {
       },
     }
 
-    const filterModal = mount(<MockFilterModalNavigator initialData={injectedState} />)
+    const { getAllByText, getByText } = renderWithWrappersTL(<MockFilterModalNavigator initialData={injectedState} />)
 
-    expect(filterModal.find(ApplyButton).props().disabled).toEqual(true)
+    expect(getAllByText("Show results")[0]).toBeDisabled()
 
-    filterModal.find(ClearAllButton).at(0).props().onPress()
+    fireEvent.press(getByText("Clear All"))
 
-    filterModal.update()
-
-    expect(filterModal.find(OptionListItem).at(0).text()).not.toContain("•")
-    expect(filterModal.find(OptionListItem).at(1).text()).not.toContain("•")
+    expect(getByText("Sort By")).toBeTruthy()
+    expect(getByText("Rarity")).toBeTruthy()
   })
 })
 
@@ -441,7 +431,7 @@ describe("Applying filters on Artworks", () => {
       },
     }
 
-    renderWithWrappers(<TestRenderer initialData={injectedState} />)
+    renderWithWrappersTL(<TestRenderer initialData={injectedState} />)
 
     mockEnvironmentPayload(env, {
       MarketingCollection: () => ({
@@ -494,13 +484,12 @@ describe("Applying filters on Artworks", () => {
       },
     }
 
-    const filterModal = renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
+    const { getAllByText } = renderWithWrappersTL(<MockFilterModalNavigator initialData={injectedState} />)
 
     mockEnvironmentPayload(env)
 
-    const applyButton = filterModal.root.findByType(ApplyButton)
+    fireEvent.press(getAllByText("Show results")[0])
 
-    applyButton.props.onPress()
     expect(trackEvent).toHaveBeenCalledWith({
       action_type: "commercialFilterParamsChanged",
       changed: JSON.stringify({
@@ -528,22 +517,22 @@ describe("Applying filters on Artworks", () => {
 
 describe("AnimatedArtworkFilterButton", () => {
   it("Shows Sort & Filter when no text prop is available", () => {
-    const tree = renderWithWrappers(
+    const { getByText } = renderWithWrappersTL(
       <ArtworkFiltersStoreProvider>
         <AnimatedArtworkFilterButton isVisible onPress={jest.fn()} />
       </ArtworkFiltersStoreProvider>
     )
 
-    expect(tree.root.findAllByType(Sans)[0].props.children).toEqual("Sort & Filter")
+    expect(getByText("Sort & Filter")).toBeTruthy()
   })
 
   it("Shows text when text prop is available", () => {
-    const tree = renderWithWrappers(
+    const { getByText } = renderWithWrappersTL(
       <ArtworkFiltersStoreProvider>
         <AnimatedArtworkFilterButton text="Filter Text" isVisible onPress={jest.fn()} />
       </ArtworkFiltersStoreProvider>
     )
 
-    expect(tree.root.findAllByType(Sans)[0].props.children).toEqual("Filter Text")
+    expect(getByText("Filter Text")).toBeTruthy()
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/AdditionalGeneIDsOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/AdditionalGeneIDsOptions.tests.tsx
@@ -1,15 +1,11 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
+import { fireEvent } from "@testing-library/react-native"
 import { Aggregations, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { MockFilterScreen } from "lib/Components/ArtworkFilter/FilterTestHelper"
-import { RightButtonContainer } from "lib/Components/FancyModal/FancyModalHeader"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { AdditionalGeneIDsOptionsScreen } from "./AdditionalGeneIDsOptions"
 import { getEssentialProps } from "./helper"
-import { OptionListItem } from "./MultiSelectOption"
 
 const MOCK_AGGREGATIONS: Aggregations = [
   {
@@ -54,27 +50,16 @@ describe("AdditionalGeneIDsOptions Screen", () => {
   }
 
   it("renders the options", () => {
-    const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialData={initialState} />)
+    const { getByText } = renderWithWrappersTL(<MockAdditionalGeneIDsOptionsScreen initialData={initialState} />)
 
-    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(8)
-
-    const items = tree.root.findAllByType(OptionListItem)
-    expect(items.map(extractText)).toEqual([
-      "Prints",
-      "Design",
-      "Sculpture",
-      "Work on Paper",
-      "Painting",
-      "Drawing",
-      "Jewelry",
-      "Photography",
-    ])
-  })
-
-  it("does not display the default text when no filter selected on the filter modal screen", () => {
-    const tree = renderWithWrappers(<MockFilterScreen initialState={initialState} />)
-    const items = tree.root.findAllByType(FilterModalOptionListItem)
-    expect(extractText(items[items.length - 1])).not.toContain("All")
+    expect(getByText("Prints")).toBeTruthy()
+    expect(getByText("Design")).toBeTruthy()
+    expect(getByText("Sculpture")).toBeTruthy()
+    expect(getByText("Work on Paper")).toBeTruthy()
+    expect(getByText("Painting")).toBeTruthy()
+    expect(getByText("Drawing")).toBeTruthy()
+    expect(getByText("Jewelry")).toBeTruthy()
+    expect(getByText("Photography")).toBeTruthy()
   })
 
   it("displays the number of the selected filters on the filter modal screen", () => {
@@ -97,10 +82,9 @@ describe("AdditionalGeneIDsOptions Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
-    const items = tree.root.findAllByType(FilterModalOptionListItem)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    expect(extractText(items[2])).toContain("• 2")
+    expect(getByText("Medium • 2")).toBeTruthy()
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
@@ -123,12 +107,14 @@ describe("AdditionalGeneIDsOptions Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />)
-    const options = tree.root.findAllByType(Check)
+    const { getAllByA11yState } = renderWithWrappersTL(
+      <MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />
+    )
+    const options = getAllByA11yState({ checked: true })
 
-    expect(options[0].props.selected).toBe(true)
-    expect(options[1].props.selected).toBe(false)
-    expect(options[2].props.selected).toBe(true)
+    expect(options).toHaveLength(2)
+    expect(options[0]).toHaveTextContent("Prints")
+    expect(options[1]).toHaveTextContent("Sculpture")
   })
 
   it("clears all when clear button is tapped", () => {
@@ -151,18 +137,14 @@ describe("AdditionalGeneIDsOptions Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />)
-    const options = tree.root.findAllByType(Check)
-    const clear = tree.root.findByType(RightButtonContainer)
+    const { getByText, queryAllByA11yState } = renderWithWrappersTL(
+      <MockAdditionalGeneIDsOptionsScreen initialData={injectedState} />
+    )
 
-    expect(options[0].props.selected).toBe(true)
-    expect(options[1].props.selected).toBe(false)
-    expect(options[2].props.selected).toBe(true)
+    expect(queryAllByA11yState({ checked: true })).toHaveLength(2)
 
-    clear.props.onPress()
+    fireEvent.press(getByText("Clear"))
 
-    expect(options[0].props.selected).toBe(false)
-    expect(options[1].props.selected).toBe(false)
-    expect(options[2].props.selected).toBe(false)
+    expect(queryAllByA11yState({ checked: true })).toHaveLength(0)
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/AttributionClassOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/AttributionClassOptions.tests.tsx
@@ -1,14 +1,10 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { MockFilterScreen } from "lib/Components/ArtworkFilter/FilterTestHelper"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { AttributionClassOptionsScreen } from "./AttributionClassOptions"
 import { getEssentialProps } from "./helper"
-import { OptionListItem } from "./MultiSelectOption"
 
 describe("AttributionClassOptions Screen", () => {
   const MockAttributionClassOptionsScreen = ({ initialData }: { initialData?: ArtworkFiltersState }) => {
@@ -20,29 +16,12 @@ describe("AttributionClassOptions Screen", () => {
   }
 
   it("renders the options", () => {
-    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen />)
-    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4)
-    const items = tree.root.findAllByType(OptionListItem)
-    expect(items.map(extractText)).toEqual(["Unique", "Limited Edition", "Open Edition", "Unknown Edition"])
-  })
+    const { getByText } = renderWithWrappersTL(<MockAttributionClassOptionsScreen />)
 
-  it("does not display the default text when no filter selected on the filter modal screen", () => {
-    const injectedState: ArtworkFiltersState = {
-      selectedFilters: [],
-      appliedFilters: [],
-      previouslyAppliedFilters: [],
-      applyFilters: false,
-      aggregations: [],
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-    }
-
-    const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
-    const items = tree.root.findAllByType(FilterModalOptionListItem)
-    expect(extractText(items[items.length - 1])).not.toContain("All")
+    expect(getByText("Unique")).toBeTruthy()
+    expect(getByText("Limited Edition")).toBeTruthy()
+    expect(getByText("Open Edition")).toBeTruthy()
+    expect(getByText("Unknown Edition")).toBeTruthy()
   })
 
   it("displays all the selected filters on the filter modal screen", () => {
@@ -65,10 +44,9 @@ describe("AttributionClassOptions Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
-    const items = tree.root.findAllByType(FilterModalOptionListItem)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    expect(extractText(items[1])).toContain("• 2")
+    expect(getByText("Rarity • 2")).toBeTruthy()
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
@@ -91,13 +69,13 @@ describe("AttributionClassOptions Screen", () => {
       },
     }
 
-    // TODO: Fix this test
-    const tree = renderWithWrappers(<MockAttributionClassOptionsScreen initialData={injectedState} />)
-    const options = tree.root.findAllByType(Check)
+    const { getAllByA11yState } = renderWithWrappersTL(
+      <MockAttributionClassOptionsScreen initialData={injectedState} />
+    )
+    const options = getAllByA11yState({ checked: true })
 
-    expect(options[0].props.selected).toBe(true)
-    expect(options[1].props.selected).toBe(false)
-    expect(options[2].props.selected).toBe(false)
-    expect(options[3].props.selected).toBe(true)
+    expect(options).toHaveLength(2)
+    expect(options[0]).toHaveTextContent("Unique")
+    expect(options[1]).toHaveTextContent("Unknown Edition")
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -3,6 +3,8 @@ import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { useArtworkFiltersAggregation } from "lib/Components/ArtworkFilter/useArtworkFilters"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { Header } from "lib/Components/Header"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useLayout } from "lib/utils/useLayout"
 import { sortBy } from "lodash"
 import { Flex, useSpace } from "palette"
@@ -40,6 +42,7 @@ interface ColorsOptionsScreenProps extends StackScreenProps<ArtworkFilterNavigat
 export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ navigation }) => {
   const space = useSpace()
   const { layout, handleLayout } = useLayout()
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   const { aggregation } = useArtworkFiltersAggregation({
     paramName: FilterParamName.colors,
@@ -67,12 +70,20 @@ export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ naviga
 
   return (
     <Flex onLayout={handleLayout} flexGrow={1}>
-      <FancyModalHeader
-        onLeftButtonPress={() => navigation.goBack()}
-        {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
-      >
-        {FilterDisplayName.colors}
-      </FancyModalHeader>
+      {isEnabledImprovedAlertsFlow ? (
+        <Header
+          title={FilterDisplayName.colors}
+          onLeftButtonPress={() => navigation.goBack()}
+          {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
+        />
+      ) : (
+        <FancyModalHeader
+          onLeftButtonPress={() => navigation.goBack()}
+          {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}
+        >
+          {FilterDisplayName.colors}
+        </FancyModalHeader>
+      )}
 
       <Flex p={1} flexWrap="wrap" flexDirection="row" justifyContent="flex-start">
         {sortedOptions.map((option, i) => {

--- a/src/lib/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -1,9 +1,9 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { FilterData, FilterDisplayName, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworkFilterBackHeader } from "lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { useArtworkFiltersAggregation } from "lib/Components/ArtworkFilter/useArtworkFilters"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { Header } from "lib/Components/Header"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useLayout } from "lib/utils/useLayout"
 import { sortBy } from "lodash"
@@ -71,7 +71,7 @@ export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ naviga
   return (
     <Flex onLayout={handleLayout} flexGrow={1}>
       {isEnabledImprovedAlertsFlow ? (
-        <Header
+        <ArtworkFilterBackHeader
           title={FilterDisplayName.colors}
           onLeftButtonPress={() => navigation.goBack()}
           {...(isActive ? { rightButtonText: "Clear", onRightButtonPress: handleClear } : {})}

--- a/src/lib/Components/ArtworkFilter/Filters/GalleriesAndInstitutionsOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/GalleriesAndInstitutionsOptions.tests.tsx
@@ -1,10 +1,5 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
-import { OptionListItem as MultiSelectOptionListItem } from "./MultiSelectOption"
-
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "../ArtworkFilterStore"
 import { MockFilterScreen } from "../FilterTestHelper"
@@ -60,12 +55,11 @@ describe("Galleries and Institutions Options Screen", () => {
 
   describe("before any filters are selected", () => {
     it("renders all options present in the aggregation", () => {
-      const tree = renderWithWrappers(<MockGalleriesAndInstitutionsScreen initialData={initialState} />)
+      const { getByText } = renderWithWrappersTL(<MockGalleriesAndInstitutionsScreen initialData={initialState} />)
 
-      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
-
-      const items = tree.root.findAllByType(MultiSelectOptionListItem)
-      expect(items.map(extractText)).toEqual(["Musée Picasso Paris", "Gagosian", "Tate"])
+      expect(getByText("Musée Picasso Paris"))
+      expect(getByText("Gagosian"))
+      expect(getByText("Tate"))
     })
   })
 
@@ -82,25 +76,18 @@ describe("Galleries and Institutions Options Screen", () => {
     }
 
     it("displays the number of the selected filters on the filter modal screen", () => {
-      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={state} />)
 
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Galleries & Institutions"))
-
-      expect(item).not.toBeUndefined()
-      if (item) {
-        expect(extractText(item)).toContain("• 1")
-      }
+      expect(getByText("Galleries & Institutions • 1"))
     })
 
     it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
-      const tree = renderWithWrappers(<MockGalleriesAndInstitutionsScreen initialData={state} />)
+      const { getAllByA11yState } = renderWithWrappersTL(<MockGalleriesAndInstitutionsScreen initialData={state} />)
 
-      const options = tree.root.findAllByType(Check)
+      const options = getAllByA11yState({ checked: true })
 
-      expect(options[0].props.selected).toBe(true)
-      expect(options[1].props.selected).toBe(false)
-      expect(options[2].props.selected).toBe(false)
+      expect(options).toHaveLength(1)
+      expect(options[0]).toHaveTextContent("Musée Picasso Paris")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/LocationCitiesOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/LocationCitiesOptions.tests.tsx
@@ -1,10 +1,5 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
-import { OptionListItem as MultiSelectOptionListItem } from "./MultiSelectOption"
-
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "../ArtworkFilterStore"
 import { MockFilterScreen } from "../FilterTestHelper"
@@ -56,12 +51,11 @@ describe(LocationCitiesOptionsScreen, () => {
 
   describe("no filters are selected", () => {
     it("renders all options present in the aggregation", () => {
-      const tree = renderWithWrappers(<MockLocationCitiesOptionsScreen initialData={initialState} />)
+      const { getByText } = renderWithWrappersTL(<MockLocationCitiesOptionsScreen initialData={initialState} />)
 
-      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
-
-      const items = tree.root.findAllByType(MultiSelectOptionListItem)
-      expect(items.map(extractText)).toEqual(["Paris, France", "London, United Kingdom", "Milan, Italy"])
+      expect(getByText("Paris, France")).toBeTruthy()
+      expect(getByText("London, United Kingdom")).toBeTruthy()
+      expect(getByText("Milan, Italy")).toBeTruthy()
     })
   })
 
@@ -78,25 +72,19 @@ describe(LocationCitiesOptionsScreen, () => {
     }
 
     it("displays the number of the selected filters on the filter modal screen", () => {
-      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={state} />)
 
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Artwork Location"))
-
-      expect(item).not.toBeUndefined()
-      if (item) {
-        expect(extractText(item)).toContain("• 2")
-      }
+      expect(getByText("Artwork Location • 2")).toBeTruthy()
     })
 
     it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
-      const tree = renderWithWrappers(<MockLocationCitiesOptionsScreen initialData={state} />)
+      const { getAllByA11yState } = renderWithWrappersTL(<MockLocationCitiesOptionsScreen initialData={state} />)
 
-      const options = tree.root.findAllByType(Check)
+      const options = getAllByA11yState({ checked: true })
 
-      expect(options[0].props.selected).toBe(true)
-      expect(options[1].props.selected).toBe(false)
-      expect(options[2].props.selected).toBe(true)
+      expect(options).toHaveLength(2)
+      expect(options[0]).toHaveTextContent("Paris, France")
+      expect(options[1]).toHaveTextContent("Milan, Italy")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MaterialsTermsOptions.tests.tsx
@@ -1,10 +1,5 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
-import { OptionListItem as MultiSelectOptionListItem } from "./MultiSelectOption"
-
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "../ArtworkFilterStore"
 import { MockFilterScreen } from "../FilterTestHelper"
@@ -56,12 +51,11 @@ describe("Materials Options Screen", () => {
 
   describe("before any filters are selected", () => {
     it("renders all options present in the aggregation", () => {
-      const tree = renderWithWrappers(<MockMaterialsTermsOptionsScreen initialData={initialState} />)
+      const { getByText } = renderWithWrappersTL(<MockMaterialsTermsOptionsScreen initialData={initialState} />)
 
-      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
-
-      const items = tree.root.findAllByType(MultiSelectOptionListItem)
-      expect(items.map(extractText)).toEqual(["Acrylic", "Canvas", "Metal"])
+      expect(getByText("Acrylic")).toBeTruthy()
+      expect(getByText("Canvas")).toBeTruthy()
+      expect(getByText("Metal")).toBeTruthy()
     })
   })
 
@@ -78,25 +72,17 @@ describe("Materials Options Screen", () => {
     }
 
     it("displays the number of the selected filters on the filter modal screen", () => {
-      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={state} />)
 
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Material"))
-
-      expect(item).not.toBeUndefined()
-      if (item) {
-        expect(extractText(item)).toContain("• 1")
-      }
+      expect(getByText("Material • 1")).toBeTruthy()
     })
 
     it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
-      const tree = renderWithWrappers(<MockMaterialsTermsOptionsScreen initialData={state} />)
+      const { getAllByA11yState } = renderWithWrappersTL(<MockMaterialsTermsOptionsScreen initialData={state} />)
+      const options = getAllByA11yState({ checked: true })
 
-      const options = tree.root.findAllByType(Check)
-
-      expect(options[0].props.selected).toBe(true)
-      expect(options[1].props.selected).toBe(false)
-      expect(options[2].props.selected).toBe(false)
+      expect(options).toHaveLength(1)
+      expect(options[0]).toHaveTextContent("Acrylic")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
@@ -1,8 +1,8 @@
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworkFilterBackHeader } from "lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { Header } from "lib/Components/Header"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Box, CheckIcon, Flex, Separator, Text } from "palette"
 import React from "react"
@@ -48,7 +48,7 @@ export const MultiSelectCheckOptionScreen: React.FC<MultiSelectOptionScreenProps
   return (
     <Flex flexGrow={1}>
       {isEnabledImprovedAlertsFlow ? (
-        <Header title={filterHeaderText} onLeftButtonPress={handleBackNavigation} />
+        <ArtworkFilterBackHeader title={filterHeaderText} onLeftButtonPress={handleBackNavigation} />
       ) : (
         <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
       )}

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
@@ -2,6 +2,8 @@ import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { Header } from "lib/Components/Header"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Box, CheckIcon, Flex, Separator, Text } from "palette"
 import React from "react"
 import { FlatList, TouchableOpacity } from "react-native"
@@ -26,6 +28,7 @@ export const MultiSelectCheckOptionScreen: React.FC<MultiSelectOptionScreenProps
   selectedOptions,
   shouldAddIndent,
 }) => {
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
   const handleBackNavigation = () => {
     navigation.goBack()
   }
@@ -44,7 +47,11 @@ export const MultiSelectCheckOptionScreen: React.FC<MultiSelectOptionScreenProps
 
   return (
     <Flex flexGrow={1}>
-      <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
+      {isEnabledImprovedAlertsFlow ? (
+        <Header title={filterHeaderText} onLeftButtonPress={handleBackNavigation} />
+      ) : (
+        <FancyModalHeader onLeftButtonPress={handleBackNavigation}>{filterHeaderText}</FancyModalHeader>
+      )}
       <Flex mb={120}>
         <FlatList
           initialNumToRender={10}

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -2,8 +2,10 @@ import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
+import { Header } from "lib/Components/Header"
 import { SearchInput } from "lib/Components/SearchInput"
 import { TouchableRow } from "lib/Components/TouchableRow"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, Check, CHECK_SIZE, Flex, Text, useSpace } from "palette"
 import React, { useState } from "react"
@@ -39,6 +41,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 }) => {
   const space = useSpace()
   const { width } = useScreenDimensions()
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
   const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
 
   const handleBackNavigation = () => {
@@ -69,9 +72,18 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 
   return (
     <Flex flexGrow={1}>
-      <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
-        {filterHeaderText}
-      </FancyModalHeader>
+      {isEnabledImprovedAlertsFlow ? (
+        <Header
+          title={filterHeaderText}
+          onLeftButtonPress={handleBackNavigation}
+          onRightButtonPress={rest.onRightButtonPress}
+          rightButtonText={rest.rightButtonText}
+        />
+      ) : (
+        <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
+          {filterHeaderText}
+        </FancyModalHeader>
+      )}
 
       {!!searchable && (
         <>

--- a/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -1,8 +1,8 @@
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworkFilterBackHeader } from "lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
-import { Header } from "lib/Components/Header"
 import { SearchInput } from "lib/Components/SearchInput"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
@@ -73,7 +73,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   return (
     <Flex flexGrow={1}>
       {isEnabledImprovedAlertsFlow ? (
-        <Header
+        <ArtworkFilterBackHeader
           title={filterHeaderText}
           onLeftButtonPress={handleBackNavigation}
           onRightButtonPress={rest.onRightButtonPress}

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -2,7 +2,9 @@ import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
+import { Header } from "lib/Components/Header"
 import { TouchableRow } from "lib/Components/TouchableRow"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Flex, RadioDot, Text } from "palette"
 import React, { Fragment } from "react"
 import { FlatList, ScrollView } from "react-native"
@@ -34,6 +36,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   useScrollView = false,
   ...rest
 }) => {
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
   const handleBackNavigation = () => {
     navigation.goBack()
   }
@@ -51,9 +54,18 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
 
   return (
     <Flex flexGrow={1}>
-      <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
-        {filterHeaderText}
-      </FancyModalHeader>
+      {isEnabledImprovedAlertsFlow ? (
+        <Header
+          title={filterHeaderText}
+          onLeftButtonPress={handleBackNavigation}
+          onRightButtonPress={rest.onRightButtonPress}
+          rightButtonText={rest.rightButtonText}
+        />
+      ) : (
+        <FancyModalHeader onLeftButtonPress={handleBackNavigation} {...rest}>
+          {filterHeaderText}
+        </FancyModalHeader>
+      )}
 
       <Flex flexGrow={1}>
         {useScrollView ? (

--- a/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -1,8 +1,8 @@
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworkFilterBackHeader } from "lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
-import { Header } from "lib/Components/Header"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Flex, RadioDot, Text } from "palette"
@@ -55,7 +55,7 @@ export const SingleSelectOptionScreen: React.FC<SingleSelectOptionScreenProps> =
   return (
     <Flex flexGrow={1}>
       {isEnabledImprovedAlertsFlow ? (
-        <Header
+        <ArtworkFilterBackHeader
           title={filterHeaderText}
           onLeftButtonPress={handleBackNavigation}
           onRightButtonPress={rest.onRightButtonPress}

--- a/src/lib/Components/ArtworkFilter/Filters/TimePeriodOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/TimePeriodOptions.tests.tsx
@@ -1,15 +1,11 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { ArtworkFiltersState } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { MockFilterScreen } from "lib/Components/ArtworkFilter/FilterTestHelper"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { getEssentialProps } from "./helper"
-import { OptionListItem as MultiSelectOptionListItem } from "./MultiSelectOption"
 import { TimePeriodOptionsScreen } from "./TimePeriodOptions"
 
 describe("TimePeriodOptions Screen", () => {
@@ -56,26 +52,18 @@ describe("TimePeriodOptions Screen", () => {
   }
 
   describe("before any filters are selected", () => {
-    it("does not display 'All' in the filter modal screen", () => {
-      const tree = renderWithWrappers(<MockFilterScreen initialState={initialState} />)
+    it("should render name without count label", () => {
+      const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={initialState} />)
 
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Time Period"))
-
-      expect(item).not.toBeUndefined()
-
-      if (item) {
-        expect(extractText(item)).not.toContain("All")
-      }
+      expect(getByText("Time Period")).toBeTruthy()
     })
 
     it("renders all options present in the aggregation", () => {
-      const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialData={initialState} />)
+      const { getByText } = renderWithWrappersTL(<MockTimePeriodOptionsScreen initialData={initialState} />)
 
-      expect(tree.root.findAllByType(MultiSelectOptionListItem)).toHaveLength(3)
-
-      const items = tree.root.findAllByType(MultiSelectOptionListItem)
-      expect(items.map(extractText)).toEqual(["2020–Today", "2010–2019", "In the Year 2000!"])
+      expect(getByText("2020–Today")).toBeTruthy()
+      expect(getByText("2010–2019")).toBeTruthy()
+      expect(getByText("In the Year 2000!")).toBeTruthy()
     })
   })
 
@@ -92,25 +80,17 @@ describe("TimePeriodOptions Screen", () => {
     }
 
     it("displays the number of the selected filters on the filter modal screen", () => {
-      const tree = renderWithWrappers(<MockFilterScreen initialState={state} />)
+      const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={state} />)
 
-      const items = tree.root.findAllByType(FilterModalOptionListItem)
-      const item = items.find((i) => extractText(i).startsWith("Time Period"))
-
-      expect(item).not.toBeUndefined()
-      if (item) {
-        expect(extractText(item)).toContain("• 1")
-      }
+      expect(getByText("Time Period • 1")).toBeTruthy()
     })
 
     it("toggles selected filters 'ON' and unselected filters 'OFF", async () => {
-      const tree = renderWithWrappers(<MockTimePeriodOptionsScreen initialData={state} />)
+      const { getAllByA11yState } = renderWithWrappersTL(<MockTimePeriodOptionsScreen initialData={state} />)
+      const options = getAllByA11yState({ checked: true })
 
-      const options = tree.root.findAllByType(Check)
-
-      expect(options[0].props.selected).toBe(true)
-      expect(options[1].props.selected).toBe(false)
-      expect(options[2].props.selected).toBe(false)
+      expect(options).toHaveLength(1)
+      expect(options[0]).toHaveTextContent("2020–Today")
     })
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/WaysToBuyOptions.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/WaysToBuyOptions.tests.tsx
@@ -1,13 +1,9 @@
-import { OptionListItem as FilterModalOptionListItem } from "lib/Components/ArtworkFilter"
 import { FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { MockFilterScreen } from "lib/Components/ArtworkFilter/FilterTestHelper"
-import { extractText } from "lib/tests/extractText"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Check } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { getEssentialProps } from "./helper"
-import { OptionListItem } from "./MultiSelectOption"
 import { WaysToBuyOptionsScreen } from "./WaysToBuyOptions"
 
 describe("Ways to Buy Options Screen", () => {
@@ -31,22 +27,12 @@ describe("Ways to Buy Options Screen", () => {
   )
 
   it("renders the correct ways to buy options", () => {
-    const tree = renderWithWrappers(<MockWaysToBuyScreen initialData={initialState} />)
+    const { getByText } = renderWithWrappersTL(<MockWaysToBuyScreen initialData={initialState} />)
 
-    expect(tree.root.findAllByType(OptionListItem)).toHaveLength(4)
-
-    const listItems = tree.root.findAllByType(OptionListItem)
-    const firstListItem = listItems[0]
-    expect(extractText(firstListItem)).toBe("Buy Now")
-
-    const secondListItem = listItems[1]
-    expect(extractText(secondListItem)).toBe("Make Offer")
-
-    const thirdListItem = listItems[2]
-    expect(extractText(thirdListItem)).toBe("Bid")
-
-    const fourthListItem = listItems[3]
-    expect(extractText(fourthListItem)).toBe("Inquire")
+    expect(getByText("Buy Now")).toBeTruthy()
+    expect(getByText("Make Offer")).toBeTruthy()
+    expect(getByText("Bid")).toBeTruthy()
+    expect(getByText("Inquire")).toBeTruthy()
   })
 
   it("does not display the default text when no filter selected on the filter modal screen", () => {
@@ -63,11 +49,9 @@ describe("Ways to Buy Options Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    const waysToBuyListItem = tree.root.findAllByType(FilterModalOptionListItem)[1]
-
-    expect(extractText(waysToBuyListItem)).not.toContain("All")
+    expect(getByText("Ways to Buy")).toBeTruthy()
   })
 
   it("displays the number of the selected filters on the filter modal screen", () => {
@@ -100,9 +84,9 @@ describe("Ways to Buy Options Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockFilterScreen initialState={injectedState} />)
+    const { getByText } = renderWithWrappersTL(<MockFilterScreen initialState={injectedState} />)
 
-    expect(extractText(tree.root)).toContain("• 3")
+    expect(getByText("Ways to Buy • 3")).toBeTruthy()
   })
 
   it("toggles selected filters 'ON' and unselected filters 'OFF", () => {
@@ -125,16 +109,11 @@ describe("Ways to Buy Options Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockWaysToBuyScreen initialData={injectedState} />)
-    const options = tree.root.findAllByType(Check)
+    const { getAllByA11yState } = renderWithWrappersTL(<MockWaysToBuyScreen initialData={injectedState} />)
+    const options = getAllByA11yState({ checked: true })
 
-    expect(options[0].props.selected).toBe(true)
-
-    expect(options[1].props.selected).toBe(false)
-
-    expect(options[2].props.selected).toBe(false)
-
-    expect(options[3].props.selected).toBe(false)
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent("Buy Now")
   })
 
   it("it toggles applied filters 'ON' and unapplied filters 'OFF", () => {
@@ -163,15 +142,10 @@ describe("Ways to Buy Options Screen", () => {
       },
     }
 
-    const tree = renderWithWrappers(<MockWaysToBuyScreen initialData={injectedState} />)
-    const options = tree.root.findAllByType(Check)
+    const { getAllByA11yState } = renderWithWrappersTL(<MockWaysToBuyScreen initialData={injectedState} />)
+    const options = getAllByA11yState({ checked: true })
 
-    expect(options[0].props.selected).toBe(false)
-
-    expect(options[1].props.selected).toBe(false)
-
-    expect(options[2].props.selected).toBe(false)
-
-    expect(options[3].props.selected).toBe(true)
+    expect(options).toHaveLength(1)
+    expect(options[0]).toHaveTextContent("Inquire")
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/YearOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/YearOptions.tsx
@@ -3,9 +3,9 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { ArtworkFilterNavigationStack } from "lib/Components/ArtworkFilter"
 import { aggregationForFilter, FilterData, FilterParamName } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { ArtworkFilterBackHeader } from "lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { CircleWithBorder } from "lib/Components/CircleWithBorder/CircleWithBorder"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
-import { Header } from "lib/Components/Header"
 import { TouchableRow } from "lib/Components/TouchableRow"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
@@ -95,7 +95,7 @@ export const YearOptionsScreen: React.FC<YearOptionsScreenProps> = ({ navigation
   return (
     <Flex flexGrow={1}>
       {isEnabledImprovedAlertsFlow ? (
-        <Header title="Year created" onLeftButtonPress={navigation.goBack} />
+        <ArtworkFilterBackHeader title="Year created" onLeftButtonPress={navigation.goBack} />
       ) : (
         <FancyModalHeader onLeftButtonPress={navigation.goBack}>Year created</FancyModalHeader>
       )}

--- a/src/lib/Components/ArtworkFilter/Filters/YearOptions.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/YearOptions.tsx
@@ -5,7 +5,9 @@ import { aggregationForFilter, FilterData, FilterParamName } from "lib/Component
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { CircleWithBorder } from "lib/Components/CircleWithBorder/CircleWithBorder"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { Header } from "lib/Components/Header"
 import { TouchableRow } from "lib/Components/TouchableRow"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { useScreenDimensions } from "lib/utils/useScreenDimensions"
 import { Box, CheckIcon, Flex, Separator, Text, useColor } from "palette"
 import React, { useState } from "react"
@@ -23,6 +25,7 @@ export const ALLOW_EMPTY_CREATED_DATES_FILTER: FilterData = {
 export const YearOptionsScreen: React.FC<YearOptionsScreenProps> = ({ navigation }) => {
   const color = useColor()
   const screenWidth = useScreenDimensions().width
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFilters = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
@@ -91,7 +94,11 @@ export const YearOptionsScreen: React.FC<YearOptionsScreenProps> = ({ navigation
 
   return (
     <Flex flexGrow={1}>
-      <FancyModalHeader onLeftButtonPress={navigation.goBack}>Year created</FancyModalHeader>
+      {isEnabledImprovedAlertsFlow ? (
+        <Header title="Year created" onLeftButtonPress={navigation.goBack} />
+      ) : (
+        <FancyModalHeader onLeftButtonPress={navigation.goBack}>Year created</FancyModalHeader>
+      )}
       <Flex flexGrow={1} py={2}>
         <YearText variant="xs" mb={15} mx={2}>
           {sliderValues[0]} – {sliderValues[1]}

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
@@ -1,0 +1,40 @@
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { ArtworkFilterApplyButton, ArtworkFilterApplyButtonProps } from "./ArtworkFilterApplyButton"
+
+const defaultProps: ArtworkFilterApplyButtonProps = {
+  disabled: false,
+  onPress: jest.fn,
+}
+
+describe("ArtworkFilterApplyButton", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+  })
+
+  const TestWrapper = (props?: Partial<ArtworkFilterApplyButtonProps>) => {
+    return <ArtworkFilterApplyButton {...defaultProps} {...props} />
+  }
+
+  it("cannot press if disabled prop is passed", () => {
+    const onPressMock = jest.fn()
+    const { getAllByText } = renderWithWrappersTL(<TestWrapper disabled />)
+    const button = getAllByText("Apply Filters")[0]
+
+    fireEvent.press(button)
+
+    expect(button).toBeDisabled()
+    expect(onPressMock).not.toBeCalled()
+  })
+
+  it('should call "onPress" handle when it is pressed', () => {
+    const onPressMock = jest.fn()
+    const { getAllByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
+
+    fireEvent.press(getAllByText("Apply Filters")[0])
+
+    expect(onPressMock).toBeCalled()
+  })
+})

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -38,7 +38,7 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
   return (
     <>
       <Separator my={0} />
-      <Box p={2} pb={3}>
+      <Box p={2} pb={30}>
         <Button disabled={disabled} onPress={onPress} block width={100} variant="fillDark" size="large">
           Show results
         </Button>

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -1,0 +1,48 @@
+import { useFeatureFlag } from "lib/store/GlobalStore"
+import { Box, Button, Separator, useColor } from "palette"
+import React from "react"
+
+export interface ArtworkFilterApplyButtonProps {
+  disabled: boolean
+  onPress: () => void
+}
+
+export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
+  const { disabled, onPress } = props
+  const color = useColor()
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
+
+  if (isEnabledImprovedAlertsFlow) {
+    return (
+      <Box
+        p={2}
+        backgroundColor="white"
+        style={{
+          shadowColor: color("black100"),
+          shadowOffset: {
+            width: 0,
+            height: 7,
+          },
+          shadowOpacity: 0.1,
+          shadowRadius: 12,
+          elevation: 12,
+        }}
+      >
+        <Button disabled={disabled} onPress={onPress} block width={100} variant="fillDark" size="large">
+          Apply Filters
+        </Button>
+      </Box>
+    )
+  }
+
+  return (
+    <>
+      <Separator my={0} />
+      <Box p={2} pb={3}>
+        <Button disabled={disabled} onPress={onPress} block width={100} variant="fillDark" size="large">
+          Show results
+        </Button>
+      </Box>
+    </>
+  )
+}

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader.tests.tsx
@@ -1,27 +1,23 @@
 import { fireEvent } from "@testing-library/react-native"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { Header, HeaderProps } from "./Header"
+import { ArtworkFilterBackHeader, ArtworkFilterBackHeaderProps } from "./ArtworkFilterBackHeader"
 
-const defaultProps: HeaderProps = {
+const defaultProps: ArtworkFilterBackHeaderProps = {
+  title: "Title",
   onLeftButtonPress: jest.fn,
 }
 
-describe("Header", () => {
-  const TestRenderer = (props?: Partial<HeaderProps>) => {
-    return <Header {...defaultProps} {...props} />
+describe("ArtworkFilterBackHeader", () => {
+  const TestRenderer = (props?: Partial<ArtworkFilterBackHeaderProps>) => {
+    return <ArtworkFilterBackHeader {...defaultProps} {...props} />
   }
 
   it("renders without throwing an error", () => {
-    const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, getByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
 
+    expect(getByText("Title")).toBeTruthy()
     expect(getByA11yLabel("Header back button")).toBeTruthy()
-  })
-
-  it("should render passed title", () => {
-    const { getByText } = renderWithWrappersTL(<TestRenderer title="Custom Title" />)
-
-    expect(getByText("Custom Title")).toBeTruthy()
   })
 
   it('should call "onLeftButtonPress" handler when left button is pressed', () => {

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterBackHeader.tsx
@@ -2,15 +2,15 @@ import { ArrowLeftIcon, Box, Separator, Text, useTheme } from "palette"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 
-export interface HeaderProps {
-  title?: string
+export interface ArtworkFilterBackHeaderProps {
+  title: string
   rightButtonText?: string
   rightButtonAccessibilityLabel?: string
   onLeftButtonPress: () => void
   onRightButtonPress?: () => void
 }
 
-export const Header: React.FC<HeaderProps> = (props) => {
+export const ArtworkFilterBackHeader: React.FC<ArtworkFilterBackHeaderProps> = (props) => {
   const {
     title,
     rightButtonText,
@@ -31,13 +31,11 @@ export const Header: React.FC<HeaderProps> = (props) => {
         >
           <ArrowLeftIcon fill="black100" />
         </TouchableOpacity>
-        {!!title && (
-          <Box flex={1} ml={1} mr={2}>
-            <Text variant="md" numberOfLines={2} lineHeight={18}>
-              {title}
-            </Text>
-          </Box>
-        )}
+        <Box flex={1} ml={1} mr={2}>
+          <Text variant="md" numberOfLines={2} lineHeight={18}>
+            {title}
+          </Text>
+        </Box>
         {!!onRightButtonPress && !!rightButtonText && (
           <TouchableOpacity
             onPress={onRightButtonPress}

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tests.tsx
@@ -1,0 +1,46 @@
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { ArtworkFilterOptionItem, ArtworkFilterOptionItemProps } from "./ArtworkFilterOptionItem"
+
+const defaultProps: ArtworkFilterOptionItemProps = {
+  item: {
+    filterType: "attributionClass",
+    displayText: "Rarity",
+    ScreenComponent: "AttributionClassOptionsScreen",
+  },
+  count: 0,
+  onPress: jest.fn,
+}
+
+describe("ArtworkFilterOptionItem", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+  })
+
+  const TestWrapper = (props?: Partial<ArtworkFilterOptionItemProps>) => {
+    return <ArtworkFilterOptionItem {...defaultProps} {...props} />
+  }
+
+  it("should render item label", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper />)
+
+    expect(getByText("Rarity"))
+  })
+
+  it("should render count label if it is passed", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper count={3} />)
+
+    expect(getByText("Rarity • 3"))
+  })
+
+  it('should call "onPress" handler when item is pressed', () => {
+    const onPressMock = jest.fn()
+    const { getByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
+
+    fireEvent.press(getByText("Rarity"))
+
+    expect(onPressMock).toBeCalled()
+  })
+})

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
@@ -1,9 +1,10 @@
 import { TouchableRow } from "lib/Components/TouchableRow"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { ArrowRightIcon, bullet, Flex, Text } from "palette"
 import React from "react"
 import { FilterDisplayConfig } from "../types"
 
-interface ArtworkFilterOptionItemProps {
+export interface ArtworkFilterOptionItemProps {
   item: FilterDisplayConfig
   count?: number
   onPress: () => void
@@ -11,6 +12,24 @@ interface ArtworkFilterOptionItemProps {
 
 export const ArtworkFilterOptionItem: React.FC<ArtworkFilterOptionItemProps> = (props) => {
   const { item, count, onPress } = props
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
+
+  if (isEnabledImprovedAlertsFlow) {
+    return (
+      <TouchableRow onPress={onPress}>
+        <Flex flexDirection="row" alignItems="center" justifyContent="space-between" p={2}>
+          <Flex flex={1}>
+            <Text variant="md">
+              {item.displayText}
+              {!!count && <Text color="blue100">{` ${bullet} ${count}`}</Text>}
+            </Text>
+          </Flex>
+
+          <ArrowRightIcon fill="black100" ml={1} />
+        </Flex>
+      </TouchableRow>
+    )
+  }
 
   return (
     <TouchableRow onPress={onPress}>

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
@@ -1,0 +1,35 @@
+import { TouchableRow } from "lib/Components/TouchableRow"
+import { ArrowRightIcon, bullet, Flex, Text } from "palette"
+import React from "react"
+import { FilterDisplayConfig } from "../types"
+
+interface ArtworkFilterOptionItemProps {
+  item: FilterDisplayConfig
+  count?: number
+  onPress: () => void
+}
+
+export const ArtworkFilterOptionItem: React.FC<ArtworkFilterOptionItemProps> = (props) => {
+  const { item, count, onPress } = props
+
+  return (
+    <TouchableRow onPress={onPress}>
+      <Flex flexDirection="row" justifyContent="space-between" p={2} pr={1.5}>
+        <Flex minWidth="45%">
+          <Text variant="xs">
+            {item.displayText}
+            {!!count && (
+              <Text variant="xs" color="blue100" ml={4}>
+                {` ${bullet} ${count}`}
+              </Text>
+            )}
+          </Text>
+        </Flex>
+
+        <Flex flex={1} flexDirection="row" alignItems="center" justifyContent="flex-end">
+          <ArrowRightIcon fill="black30" ml={1} />
+        </Flex>
+      </Flex>
+    </TouchableRow>
+  )
+}

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionItem.tsx
@@ -21,7 +21,7 @@ export const ArtworkFilterOptionItem: React.FC<ArtworkFilterOptionItemProps> = (
           <Flex flex={1}>
             <Text variant="md">
               {item.displayText}
-              {!!count && <Text color="blue100">{` ${bullet} ${count}`}</Text>}
+              {!!count && <Text variant="md" color="blue100">{` ${bullet} ${count}`}</Text>}
             </Text>
           </Flex>
 

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tests.tsx
@@ -6,9 +6,9 @@ import { ArtworkFilterOptionsHeader, ArtworkFilterOptionsHeaderProps } from "./A
 
 const defaultProps: ArtworkFilterOptionsHeaderProps = {
   title: "Title",
-  isClearAllButtonEnabled: true,
-  onClosePress: jest.fn,
-  onClearAllPress: jest.fn,
+  rightButtonDisabled: false,
+  onLeftButtonPress: jest.fn,
+  onRightButtonPress: jest.fn,
 }
 
 describe("ArtworkFilterOptionsHeader", () => {
@@ -26,27 +26,41 @@ describe("ArtworkFilterOptionsHeader", () => {
     expect(getByText("Custom Title")).toBeTruthy()
   })
 
-  it('should disable "Clear All" button when isClearAllButtonEnabled prop is false', () => {
-    const { getByText } = renderWithWrappersTL(<TestWrapper isClearAllButtonEnabled={false} />)
+  it("should render passed rightButtonText prop", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper rightButtonText="Custom Right Button Text" />)
 
-    expect(getByText("Clear All")).toBeDisabled()
+    expect(getByText("Custom Right Button Text")).toBeTruthy()
   })
 
-  it('should call "onClosePress" handler when back button is pressed', () => {
-    const onClosePressMock = jest.fn()
-    const { getByTestId } = renderWithWrappersTL(<TestWrapper onClosePress={onClosePressMock} />)
+  it('should hide right button if "onRightButtonPress" is not passed', () => {
+    const { queryByText } = renderWithWrappersTL(
+      <TestWrapper onRightButtonPress={undefined} rightButtonText="Right Button" />
+    )
+
+    expect(queryByText("Right Button")).toBeFalsy()
+  })
+
+  it("should disable right button when rightButtonDisabled prop is true", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper rightButtonDisabled />)
+
+    expect(getByText("Clear")).toBeDisabled()
+  })
+
+  it('should call "onLeftButtonPress" handler when back button is pressed', () => {
+    const onLeftButtonPressMock = jest.fn()
+    const { getByTestId } = renderWithWrappersTL(<TestWrapper onLeftButtonPress={onLeftButtonPressMock} />)
 
     fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
-    expect(onClosePressMock).toBeCalled()
+    expect(onLeftButtonPressMock).toBeCalled()
   })
 
-  it('should call "onClearAllPress" handler when clear all is pressed', () => {
-    const onClearAllPressMock = jest.fn()
-    const { getByText } = renderWithWrappersTL(<TestWrapper onClearAllPress={onClearAllPressMock} />)
+  it('should call "onRightButtonPress" handler when clear all is pressed', () => {
+    const onRightButtonPressMock = jest.fn()
+    const { getByText } = renderWithWrappersTL(<TestWrapper onRightButtonPress={onRightButtonPressMock} />)
 
-    fireEvent.press(getByText("Clear All"))
+    fireEvent.press(getByText("Clear"))
 
-    expect(onClearAllPressMock).toBeCalled()
+    expect(onRightButtonPressMock).toBeCalled()
   })
 })

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tests.tsx
@@ -1,0 +1,52 @@
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { ArtworkFilterOptionsHeader, ArtworkFilterOptionsHeaderProps } from "./ArtworkFilterOptionsHeader"
+
+const defaultProps: ArtworkFilterOptionsHeaderProps = {
+  title: "Title",
+  isClearAllButtonEnabled: true,
+  onClosePress: jest.fn,
+  onClearAllPress: jest.fn,
+}
+
+describe("ArtworkFilterOptionsHeader", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+  })
+
+  const TestWrapper = (props?: Partial<ArtworkFilterOptionsHeaderProps>) => {
+    return <ArtworkFilterOptionsHeader {...defaultProps} {...props} />
+  }
+
+  it("should render title", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper title="Custom Title" />)
+
+    expect(getByText("Custom Title")).toBeTruthy()
+  })
+
+  it('should disable "Clear All" button when isClearAllButtonEnabled prop is false', () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper isClearAllButtonEnabled={false} />)
+
+    expect(getByText("Clear All")).toBeDisabled()
+  })
+
+  it('should call "onClosePress" handler when back button is pressed', () => {
+    const onClosePressMock = jest.fn()
+    const { getByTestId } = renderWithWrappersTL(<TestWrapper onClosePress={onClosePressMock} />)
+
+    fireEvent.press(getByTestId("fancy-modal-header-left-button"))
+
+    expect(onClosePressMock).toBeCalled()
+  })
+
+  it('should call "onClearAllPress" handler when clear all is pressed', () => {
+    const onClearAllPressMock = jest.fn()
+    const { getByText } = renderWithWrappersTL(<TestWrapper onClearAllPress={onClearAllPressMock} />)
+
+    fireEvent.press(getByText("Clear All"))
+
+    expect(onClearAllPressMock).toBeCalled()
+  })
+})

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
@@ -1,8 +1,10 @@
-import { CloseIcon, Flex, Text, useSpace } from "palette"
+import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { useFeatureFlag } from "lib/store/GlobalStore"
+import { Box, CloseIcon, Flex, Text, useSpace } from "palette"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 
-interface ArtworkFilterOptionsHeaderProps {
+export interface ArtworkFilterOptionsHeaderProps {
   title: string
   isClearAllButtonEnabled: boolean
   onClosePress: () => void
@@ -12,6 +14,27 @@ interface ArtworkFilterOptionsHeaderProps {
 export const ArtworkFilterOptionsHeader: React.FC<ArtworkFilterOptionsHeaderProps> = (props) => {
   const { title, isClearAllButtonEnabled, onClosePress, onClearAllPress } = props
   const space = useSpace()
+  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
+
+  if (isEnabledImprovedAlertsFlow) {
+    return (
+      <Box>
+        <FancyModalHeader hideBottomDivider onLeftButtonPress={onClosePress} />
+        <Flex flexDirection="row" alignItems="center" justifyContent="space-between" p={2} pt={1}>
+          <Text variant="lg">{title}</Text>
+          <TouchableOpacity disabled={!isClearAllButtonEnabled} onPress={onClearAllPress}>
+            <Text
+              variant="sm"
+              style={{ textDecorationLine: "underline" }}
+              color={isClearAllButtonEnabled ? "black100" : "black30"}
+            >
+              Clear All
+            </Text>
+          </TouchableOpacity>
+        </Flex>
+      </Box>
+    )
+  }
 
   return (
     <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
@@ -32,7 +55,7 @@ export const ArtworkFilterOptionsHeader: React.FC<ArtworkFilterOptionsHeaderProp
       <Flex position="absolute" right={0} alignItems="flex-end">
         <TouchableOpacity style={{ padding: space(2) }} disabled={!isClearAllButtonEnabled} onPress={onClearAllPress}>
           <Text variant="sm" color={isClearAllButtonEnabled ? "black100" : "black30"}>
-            Clear all
+            Clear All
           </Text>
         </TouchableOpacity>
       </Flex>

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
@@ -1,65 +1,59 @@
-import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
+import { FancyModalHeader, FancyModalHeaderProps } from "lib/Components/FancyModal/FancyModalHeader"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, CloseIcon, Flex, Text, useSpace } from "palette"
+import { Box, Flex, Separator, Text } from "palette"
 import React from "react"
 import { TouchableOpacity } from "react-native"
 
-export interface ArtworkFilterOptionsHeaderProps {
+export interface ArtworkFilterOptionsHeaderProps extends FancyModalHeaderProps {
   title: string
-  isClearAllButtonEnabled: boolean
-  onClosePress: () => void
-  onClearAllPress: () => void
+  onLeftButtonPress: () => void
 }
 
 export const ArtworkFilterOptionsHeader: React.FC<ArtworkFilterOptionsHeaderProps> = (props) => {
-  const { title, isClearAllButtonEnabled, onClosePress, onClearAllPress } = props
-  const space = useSpace()
+  const {
+    title,
+    rightButtonDisabled,
+    rightButtonText = "Clear",
+    onLeftButtonPress,
+    onRightButtonPress,
+    useXButton,
+    ...other
+  } = props
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   if (isEnabledImprovedAlertsFlow) {
     return (
       <Box>
-        <FancyModalHeader hideBottomDivider onLeftButtonPress={onClosePress} />
+        <FancyModalHeader hideBottomDivider onLeftButtonPress={onLeftButtonPress} {...other} />
         <Flex flexDirection="row" alignItems="center" justifyContent="space-between" p={2} pt={1}>
           <Text variant="lg">{title}</Text>
-          <TouchableOpacity disabled={!isClearAllButtonEnabled} onPress={onClearAllPress}>
-            <Text
-              variant="sm"
-              style={{ textDecorationLine: "underline" }}
-              color={isClearAllButtonEnabled ? "black100" : "black30"}
-            >
-              Clear All
-            </Text>
-          </TouchableOpacity>
+          {!!onRightButtonPress && (
+            <TouchableOpacity disabled={rightButtonDisabled} onPress={onRightButtonPress}>
+              <Text
+                variant="sm"
+                style={{ textDecorationLine: "underline" }}
+                color={rightButtonDisabled ? "black30" : "black100"}
+              >
+                {rightButtonText}
+              </Text>
+            </TouchableOpacity>
+          )}
         </Flex>
+        <Separator />
       </Box>
     )
   }
 
   return (
-    <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
-      <Flex flex={1} alignItems="center">
-        <Text variant="sm">{title}</Text>
-      </Flex>
-
-      <Flex position="absolute" alignItems="flex-start">
-        <TouchableOpacity
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          style={{ padding: space(2) }}
-          onPress={onClosePress}
-          accessibilityLabel="Close filter menu"
-        >
-          <CloseIcon fill="black100" />
-        </TouchableOpacity>
-      </Flex>
-
-      <Flex position="absolute" right={0} alignItems="flex-end">
-        <TouchableOpacity style={{ padding: space(2) }} disabled={!isClearAllButtonEnabled} onPress={onClearAllPress}>
-          <Text variant="sm" color={isClearAllButtonEnabled ? "black100" : "black30"}>
-            Clear All
-          </Text>
-        </TouchableOpacity>
-      </Flex>
-    </Flex>
+    <FancyModalHeader
+      onLeftButtonPress={onLeftButtonPress}
+      rightButtonText={rightButtonText}
+      onRightButtonPress={onRightButtonPress}
+      rightButtonDisabled={rightButtonDisabled}
+      useXButton={useXButton}
+      {...other}
+    >
+      {title}
+    </FancyModalHeader>
   )
 }

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
@@ -1,0 +1,41 @@
+import { CloseIcon, Flex, Text, useSpace } from "palette"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+
+interface ArtworkFilterOptionsHeaderProps {
+  title: string
+  isClearAllButtonEnabled: boolean
+  onClosePress: () => void
+  onClearAllPress: () => void
+}
+
+export const ArtworkFilterOptionsHeader: React.FC<ArtworkFilterOptionsHeaderProps> = (props) => {
+  const { title, isClearAllButtonEnabled, onClosePress, onClearAllPress } = props
+  const space = useSpace()
+
+  return (
+    <Flex flexGrow={0} flexDirection="row" justifyContent="space-between" alignItems="center" height={space(6)}>
+      <Flex flex={1} alignItems="center">
+        <Text variant="sm">{title}</Text>
+      </Flex>
+
+      <Flex position="absolute" alignItems="flex-start">
+        <TouchableOpacity
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          style={{ padding: space(2) }}
+          onPress={onClosePress}
+        >
+          <CloseIcon fill="black100" />
+        </TouchableOpacity>
+      </Flex>
+
+      <Flex position="absolute" right={0} alignItems="flex-end">
+        <TouchableOpacity style={{ padding: space(2) }} disabled={!isClearAllButtonEnabled} onPress={onClearAllPress}>
+          <Text variant="sm" color={isClearAllButtonEnabled ? "black100" : "black30"}>
+            Clear all
+          </Text>
+        </TouchableOpacity>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterOptionsHeader.tsx
@@ -47,6 +47,7 @@ export const ArtworkFilterOptionsHeader: React.FC<ArtworkFilterOptionsHeaderProp
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           style={{ padding: space(2) }}
           onPress={onClosePress}
+          accessibilityLabel="Close filter menu"
         >
           <CloseIcon fill="black100" />
         </TouchableOpacity>

--- a/src/lib/Components/ArtworkFilter/types.ts
+++ b/src/lib/Components/ArtworkFilter/types.ts
@@ -1,0 +1,31 @@
+import { ArtworkFilterNavigationStack } from "./ArtworkFilter"
+
+export type FilterScreen =
+  | "additionalGeneIDs"
+  | "artistIDs"
+  | "artistNationalities"
+  | "artistsIFollow"
+  | "attributionClass"
+  | "categories"
+  | "color"
+  | "colors"
+  | "dimensionRange"
+  | "estimateRange"
+  | "locationCities"
+  | "majorPeriods"
+  | "materialsTerms"
+  | "medium"
+  | "partnerIDs"
+  | "priceRange"
+  | "organizations"
+  | "sizes"
+  | "sort"
+  | "viewAs"
+  | "waysToBuy"
+  | "year"
+
+export interface FilterDisplayConfig {
+  filterType: FilterScreen
+  displayText: string
+  ScreenComponent: keyof ArtworkFilterNavigationStack
+}

--- a/src/lib/Components/Gene/GeneArtworks.tests.tsx
+++ b/src/lib/Components/Gene/GeneArtworks.tests.tsx
@@ -1,17 +1,10 @@
+import { fireEvent } from "@testing-library/react-native"
 import { GeneArtworksTestsQuery } from "__generated__/GeneArtworksTestsQuery.graphql"
-import { ApplyButton } from "lib/Components/ArtworkFilter"
-import { ArtworksFilterHeader } from "lib/Components/ArtworkGrids/ArtworksFilterHeader"
-import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
-import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
-import { TouchableRow } from "lib/Components/TouchableRow"
-import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Message, TouchableHighlightColor } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { GeneArtworksPaginationContainer } from "./GeneArtworks"
 
@@ -65,19 +58,19 @@ describe("GeneArtworks", () => {
   }
 
   it("renders without throwing an error", () => {
-    renderWithWrappers(<TestRenderer />)
+    renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment)
   })
 
   it("renders filter header", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment)
 
-    expect(tree.root.findAllByType(ArtworksFilterHeader)).toHaveLength(1)
+    expect(getByText("Sort & Filter")).toBeTruthy()
   })
 
   it("renders artworks grid", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
         return {
@@ -88,11 +81,12 @@ describe("GeneArtworks", () => {
       },
     })
 
-    expect(tree.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(1)
+    // Find by artwork title
+    expect(getByText("title-1")).toBeTruthy()
   })
 
   it("renders empty artworks grid view", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText, getAllByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
         return {
@@ -104,11 +98,10 @@ describe("GeneArtworks", () => {
     })
 
     // Change sort filter
-    act(() => tree.root.findByType(TouchableHighlightColor).props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[0].props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[1].props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[1].props.onPress())
-    act(() => tree.root.findByType(ApplyButton).props.onPress())
+    fireEvent.press(getByText("Sort & Filter"))
+    fireEvent.press(getByText("Sort By"))
+    fireEvent.press(getByText("Recently Added"))
+    fireEvent.press(getAllByText("Show results")[0])
 
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
@@ -120,11 +113,11 @@ describe("GeneArtworks", () => {
       },
     })
 
-    expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
+    expect(getByText(/No results found/)).toBeTruthy()
   })
 
   it("renders empty message when artworks is empty", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       Gene() {
         return {
@@ -136,10 +129,8 @@ describe("GeneArtworks", () => {
         }
       },
     })
+    const emptyMessage = "There aren’t any works available in the category at this time."
 
-    expect(tree.root.findAllByType(Message)).toHaveLength(1)
-    expect(extractText(tree.root.findByType(Message))).toEqual(
-      "There aren’t any works available in the category at this time."
-    )
+    expect(getByText(emptyMessage)).toBeTruthy()
   })
 })

--- a/src/lib/Components/Header.tests.tsx
+++ b/src/lib/Components/Header.tests.tsx
@@ -1,0 +1,54 @@
+import { fireEvent } from "@testing-library/react-native"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React from "react"
+import { Header, HeaderProps } from "./Header"
+
+const defaultProps: HeaderProps = {
+  onLeftButtonPress: jest.fn,
+}
+
+describe("Header", () => {
+  const TestRenderer = (props?: Partial<HeaderProps>) => {
+    return <Header {...defaultProps} {...props} />
+  }
+
+  it("renders without throwing an error", () => {
+    const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
+
+    expect(getByA11yLabel("Header back button")).toBeTruthy()
+  })
+
+  it("should render passed title", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer title="Custom Title" />)
+
+    expect(getByText("Custom Title")).toBeTruthy()
+  })
+
+  it('should call "onLeftButtonPress" handler when left button is pressed', () => {
+    const onLeftButtonPressMock = jest.fn()
+    const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer onLeftButtonPress={onLeftButtonPressMock} />)
+
+    fireEvent.press(getByA11yLabel("Header back button"))
+
+    expect(onLeftButtonPressMock).toBeCalled()
+  })
+
+  it("should render right button if all required props are passed", () => {
+    const { getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer rightButtonText="Right button" onRightButtonPress={jest.fn} />
+    )
+
+    expect(getByA11yLabel("Header right button")).toBeTruthy()
+  })
+
+  it('should call "onRightButtonPress" handler when right button is pressed', () => {
+    const onRightButtonPressMock = jest.fn()
+    const { getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer rightButtonText="Right button" onRightButtonPress={onRightButtonPressMock} />
+    )
+
+    fireEvent.press(getByA11yLabel("Header right button"))
+
+    expect(onRightButtonPressMock).toBeCalled()
+  })
+})

--- a/src/lib/Components/Header.tsx
+++ b/src/lib/Components/Header.tsx
@@ -1,0 +1,56 @@
+import { ArrowLeftIcon, Box, Separator, Text, useTheme } from "palette"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+
+export interface HeaderProps {
+  title?: string
+  rightButtonText?: string
+  rightButtonAccessibilityLabel?: string
+  onLeftButtonPress: () => void
+  onRightButtonPress?: () => void
+}
+
+export const Header: React.FC<HeaderProps> = (props) => {
+  const {
+    title,
+    rightButtonText,
+    rightButtonAccessibilityLabel = "Header right button",
+    onLeftButtonPress,
+    onRightButtonPress,
+  } = props
+  const { space } = useTheme()
+
+  return (
+    <>
+      <Box flexDirection="row" alignItems="center" justifyContent="space-between" height={space(6)} px={2}>
+        <TouchableOpacity
+          onPress={onLeftButtonPress}
+          hitSlop={{ top: space(1), bottom: space(1), left: space(1), right: space(1) }}
+          accessibilityLabel="Header back button"
+          style={{ paddingRight: space(0.5) }}
+        >
+          <ArrowLeftIcon fill="black100" />
+        </TouchableOpacity>
+        {!!title && (
+          <Box flex={1} ml={1} mr={2}>
+            <Text variant="md" numberOfLines={2} lineHeight={18}>
+              {title}
+            </Text>
+          </Box>
+        )}
+        {!!onRightButtonPress && !!rightButtonText && (
+          <TouchableOpacity
+            onPress={onRightButtonPress}
+            hitSlop={{ top: space(1), bottom: space(1), left: space(1), right: space(1) }}
+            accessibilityLabel={rightButtonAccessibilityLabel}
+          >
+            <Text variant="sm" style={{ textDecorationLine: "underline" }}>
+              {rightButtonText}
+            </Text>
+          </TouchableOpacity>
+        )}
+      </Box>
+      <Separator />
+    </>
+  )
+}

--- a/src/lib/Components/Tag/TagArtworks.tests.tsx
+++ b/src/lib/Components/Tag/TagArtworks.tests.tsx
@@ -1,17 +1,10 @@
+import { fireEvent } from "@testing-library/react-native"
 import { TagArtworksTestsQuery } from "__generated__/TagArtworksTestsQuery.graphql"
-import { ApplyButton } from "lib/Components/ArtworkFilter"
-import { ArtworksFilterHeader } from "lib/Components/ArtworkGrids/ArtworksFilterHeader"
-import { FilteredArtworkGridZeroState } from "lib/Components/ArtworkGrids/FilteredArtworkGridZeroState"
-import { InfiniteScrollArtworksGridContainer } from "lib/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
-import { TouchableRow } from "lib/Components/TouchableRow"
-import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
-import { Message, TouchableHighlightColor } from "palette"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { TagArtworksPaginationContainer } from "./TagArtworks"
 
@@ -61,19 +54,19 @@ describe("TagArtworks", () => {
   }
 
   it("renders without throwing an error", () => {
-    renderWithWrappers(<TestRenderer />)
+    renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment)
   })
 
   it("renders filter header", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment)
 
-    expect(tree.root.findAllByType(ArtworksFilterHeader)).toHaveLength(1)
+    expect(getByText("Sort & Filter")).toBeTruthy()
   })
 
   it("renders artworks grid", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
         return {
@@ -84,11 +77,12 @@ describe("TagArtworks", () => {
       },
     })
 
-    expect(tree.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(1)
+    // Find by artwork title
+    expect(getByText("title-1")).toBeTruthy()
   })
 
   it("renders empty artworks grid view", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText, getAllByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
         return {
@@ -100,11 +94,10 @@ describe("TagArtworks", () => {
     })
 
     // Change sort filter
-    act(() => tree.root.findByType(TouchableHighlightColor).props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[0].props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[1].props.onPress())
-    act(() => tree.root.findAllByType(TouchableRow)[1].props.onPress())
-    act(() => tree.root.findByType(ApplyButton).props.onPress())
+    fireEvent.press(getByText("Sort & Filter"))
+    fireEvent.press(getByText("Sort By"))
+    fireEvent.press(getByText("Recently Added"))
+    fireEvent.press(getAllByText("Show results")[0])
 
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {
@@ -116,11 +109,11 @@ describe("TagArtworks", () => {
       },
     })
 
-    expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
+    expect(getByText(/No results found/)).toBeTruthy()
   })
 
   it("renders empty message when artworks is empty", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
     mockEnvironmentPayload(environment, {
       Tag() {
         return {
@@ -132,10 +125,8 @@ describe("TagArtworks", () => {
         }
       },
     })
+    const emptyMessage = "There aren’t any works available in the tag at this time."
 
-    expect(tree.root.findAllByType(Message)).toHaveLength(1)
-    expect(extractText(tree.root.findByType(Message))).toEqual(
-      "There aren’t any works available in the tag at this time."
-    )
+    expect(getByText(emptyMessage)).toBeTruthy()
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3614]

### Acceptance Criteria
* Update the visual design to match the spec in [Figma](https://www.figma.com/file/zbEFZqjKgKquZwtU8U44j9/Alerts?node-id=3321%3A6866)
* Only the "Apply Filters" button should be displayed at the bottom (without “Create Alert“ button)
* Artwork grid filter menu should open at full height
* Top header on the filters screen (for example, Materials, Medium, Sort By) should match the spec in [Figma](https://www.figma.com/file/zG9cduJdOaTQAw886QcOwn/Filters?node-id=2737%3A11807)
* Updated design should be displayed on all screens, not just for artist artworks


### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/145037815-e3412871-36f7-4605-b7a7-b43bc2b66929.mp4

#### Android
https://user-images.githubusercontent.com/3513494/145037969-141e45ee-3295-4ede-b871-89d640d9770c.mp4

|| iOS | Android |
|-|-|-|
|Sort & Filter|![Simulator Screen Shot - iPhone 8 - 2021-12-07 at 16 33 13](https://user-images.githubusercontent.com/3513494/145040489-93b2bcdc-59be-4610-b0d0-852ef6262cbf.png)|![photo_2021-12-07 16 37 35](https://user-images.githubusercontent.com/3513494/145040746-d49d4a7a-bc3f-4c6d-9a5e-7c4ee822fd4f.jpeg)|
|Sort & Filter with selected filters|![Simulator Screen Shot - iPhone 8 - 2021-12-07 at 16 33 21](https://user-images.githubusercontent.com/3513494/145040539-a9c8409c-9dc4-4282-a74a-c98ae1857dc8.png)|![photo_2021-12-07 16 37 35 (1)](https://user-images.githubusercontent.com/3513494/145040805-b0f23adb-899d-451d-9ff7-03d730c75331.jpeg)|
|Medium filter|![Simulator Screen Shot - iPhone 8 - 2021-12-07 at 16 35 19](https://user-images.githubusercontent.com/3513494/145040599-237179b6-a15d-4e14-ad94-423c47272001.png)|![photo_2021-12-07 16 37 34](https://user-images.githubusercontent.com/3513494/145040845-686b4bae-d31f-4089-8eef-e222c03dba45.jpeg)|
|Medium filter with selected values|![Simulator Screen Shot - iPhone 8 - 2021-12-07 at 16 33 37](https://user-images.githubusercontent.com/3513494/145040640-3e5725e7-8a36-4dff-991b-9640da3b8698.png)|![photo_2021-12-07 16 37 36](https://user-images.githubusercontent.com/3513494/145040878-15faa8ad-0d74-43e5-9980-616c57279aca.jpeg)|
|Material filter (with search box)|![Simulator Screen Shot - iPhone 8 - 2021-12-07 at 16 35 58](https://user-images.githubusercontent.com/3513494/145040698-076c8dde-799f-4e27-acc8-99ab62bab1c6.png)|![photo_2021-12-07 16 37 32](https://user-images.githubusercontent.com/3513494/145040921-4b2bdf89-df58-465f-a320-17c6273cb93d.jpeg)|

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Update visual design of artwork grid filter menu - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3614]: https://artsyproduct.atlassian.net/browse/FX-3614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ