### PR TITLE
feat(FX-3613): Add "Create alert" button within Artist screen's artwork grid filter menu

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -75,6 +75,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
           exitModal={handleCloseFilterArtworksModal}
           closeModal={closeFilterArtworksModal}
           mode={FilterModalMode.ArtistArtworks}
+          shouldShowCreateAlertButton
         />
       </StickyTabPageScrollView>
     </ArtworkFiltersStoreProvider>

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -70,13 +70,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   return (
     <ArtworkFiltersStoreProvider>
       <StickyTabPageScrollView>
-        <ArtistArtworksContainer
-          {...props}
-          artist={artist}
-          relay={relay}
-          openFilterModal={openFilterArtworksModal}
-          openCreateAlertModal={handleOpenCreateAlertModal}
-        />
+        <ArtistArtworksContainer {...props} artist={artist} relay={relay} openFilterModal={openFilterArtworksModal} />
         <ArtworkFilterNavigator
           {...props}
           id={artist.internalID}
@@ -84,6 +78,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
           visible={isFilterArtworksModalVisible}
           exitModal={handleCloseFilterArtworksModal}
           closeModal={closeFilterArtworksModal}
+          openCreateAlertModal={handleOpenCreateAlertModal}
           mode={FilterModalMode.ArtistArtworks}
         />
         {!!isEnabledImprovedAlertsFlow && (
@@ -102,7 +97,6 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
 
 interface ArtistArtworksContainerProps {
   openFilterModal: () => void
-  openCreateAlertModal: () => void
 }
 
 const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContainerProps> = ({
@@ -110,7 +104,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   relay,
   searchCriteria,
   openFilterModal,
-  openCreateAlertModal,
   ...props
 }) => {
   const tracking = useTracking()
@@ -173,7 +166,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           childrenPosition={isEnabledImprovedAlertsFlow ? "left" : "right"}
         >
           {isEnabledImprovedAlertsFlow ? (
-            <SavedSearchButtonV2 onPress={openCreateAlertModal} />
+            <SavedSearchButtonV2 onPress={openFilterModal} />
           ) : (
             !!shouldShowSavedSearchButton && (
               <SavedSearchButtonQueryRenderer

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -22,7 +22,6 @@ import { Box, Spacer } from "palette"
 import React, { useContext, useEffect, useMemo, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
-import { CreateSavedSearchModal } from "./CreateSavedSearchModal"
 import { SavedSearchButtonQueryRenderer } from "./SavedSearchButton"
 import { SavedSearchButtonV2 } from "./SavedSearchButtonV2"
 
@@ -34,14 +33,10 @@ interface ArtworksGridProps extends InfiniteScrollGridProps {
 
 const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) => {
   const tracking = useTracking()
-  const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
   const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
   const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
-  const handleOpenCreateAlertModal = () => setIsCreateAlertModalVisible(true)
-  const handleCloseCreateAlertModal = () => setIsCreateAlertModalVisible(false)
 
   const openFilterArtworksModal = () => {
     tracking.trackEvent({
@@ -76,20 +71,11 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
           id={artist.internalID}
           slug={artist.slug}
           visible={isFilterArtworksModalVisible}
+          name={artist.name ?? ""}
           exitModal={handleCloseFilterArtworksModal}
           closeModal={closeFilterArtworksModal}
-          openCreateAlertModal={handleOpenCreateAlertModal}
           mode={FilterModalMode.ArtistArtworks}
         />
-        {!!isEnabledImprovedAlertsFlow && (
-          <CreateSavedSearchModal
-            visible={isCreateAlertModalVisible}
-            artistId={artist.internalID}
-            artistName={artist.name ?? ""}
-            artistSlug={artist.slug}
-            closeModal={handleCloseCreateAlertModal}
-          />
-        )}
       </StickyTabPageScrollView>
     </ArtworkFiltersStoreProvider>
   )

--- a/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -18,10 +18,11 @@ export interface CreateSavedSearchModalProps {
   artistName: string
   artistSlug: string
   closeModal: () => void
+  onComplete?: () => void
 }
 
 export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (props) => {
-  const { visible, artistId, artistName, artistSlug, closeModal } = props
+  const { visible, artistId, artistName, artistSlug, closeModal, onComplete } = props
   const tracking = useTracking()
   const popover = usePopoverMessage()
   const shouldDisplayMyCollection = useEnableMyCollection()
@@ -32,6 +33,7 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
     tracking.trackEvent(tracks.toggleSavedSearch(true, artistId, artistSlug, result.id))
     closeModal()
+    onComplete?.()
 
     popover.show({
       title: "Your alert has been created.",

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -51,6 +51,7 @@ interface ArtworkFilterProps extends ViewProps {
   name?: string
   title?: string
   query?: string
+  shouldShowCreateAlertButton?: boolean
 }
 
 interface ArtworkFilterOptionsScreenParams {
@@ -95,7 +96,7 @@ const Stack = createStackNavigator<ArtworkFilterNavigationStack>()
 
 export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const tracking = useTracking()
-  const { id, mode, slug, name, query, closeModal, exitModal } = props
+  const { id, mode, slug, name, query, shouldShowCreateAlertButton, closeModal, exitModal } = props
   const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
@@ -305,6 +306,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             disabled={!isApplyButtonEnabled}
             onPress={handleApplyPress}
             onCreateAlertPress={() => setIsCreateAlertModalVisible(true)}
+            shouldShowCreateAlertButton={shouldShowCreateAlertButton}
           />
 
           {!!isEnabledImprovedAlertsFlow && (

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -29,9 +29,10 @@ import { YearOptionsScreen } from "lib/Components/ArtworkFilter/Filters/YearOpti
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "lib/utils/track/schema"
 import _ from "lodash"
-import React from "react"
+import React, { useState } from "react"
 import { View, ViewProps } from "react-native"
 import { useTracking } from "react-tracking"
+import { CreateSavedSearchModal } from "../Artist/ArtistArtworks/CreateSavedSearchModal"
 import { FancyModal } from "../FancyModal/FancyModal"
 import { ArtworkFilterOptionsScreen, FilterModalMode as ArtworkFilterMode } from "./ArtworkFilterOptionsScreen"
 import { ArtworkFilterApplyButton } from "./components/ArtworkFilterApplyButton"
@@ -47,6 +48,7 @@ interface ArtworkFilterProps extends ViewProps {
   visible: boolean
   mode: ArtworkFilterMode
   slug?: string
+  name?: string
   title?: string
   query?: string
 }
@@ -93,7 +95,8 @@ const Stack = createStackNavigator<ArtworkFilterNavigationStack>()
 
 export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const tracking = useTracking()
-  const { id, mode, slug, query, closeModal, exitModal, openCreateAlertModal } = props
+  const { id, mode, slug, name, query, closeModal, exitModal } = props
+  const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
@@ -301,8 +304,18 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
           <ArtworkFilterApplyButton
             disabled={!isApplyButtonEnabled}
             onPress={handleApplyPress}
-            onCreateAlertPress={openCreateAlertModal}
+            onCreateAlertPress={() => setIsCreateAlertModalVisible(true)}
           />
+
+          {!!isEnabledImprovedAlertsFlow && (
+            <CreateSavedSearchModal
+              visible={isCreateAlertModalVisible}
+              artistId={id!}
+              artistName={name!}
+              artistSlug={slug!}
+              closeModal={() => setIsCreateAlertModalVisible(false)}
+            />
+          )}
         </View>
       </FancyModal>
     </NavigationContainer>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -41,6 +41,7 @@ import { LocationCitiesOptionsScreen } from "./Filters/LocationCitiesOptions"
 interface ArtworkFilterProps extends ViewProps {
   closeModal?: () => void
   exitModal?: () => void
+  openCreateAlertModal?: () => void
   id?: string
   initiallyAppliedFilters?: FilterArray
   visible: boolean
@@ -92,7 +93,7 @@ const Stack = createStackNavigator<ArtworkFilterNavigationStack>()
 
 export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const tracking = useTracking()
-  const { exitModal, id, mode, slug, closeModal, query } = props
+  const { id, mode, slug, query, closeModal, exitModal, openCreateAlertModal } = props
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
@@ -300,7 +301,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
           <ArtworkFilterApplyButton
             disabled={!isApplyButtonEnabled}
             onPress={handleApplyPress}
-            onCreateAlertPress={handleApplyPress}
+            onCreateAlertPress={openCreateAlertModal}
           />
         </View>
       </FancyModal>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -297,7 +297,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             <Stack.Screen name="LocationCitiesOptionsScreen" component={LocationCitiesOptionsScreen} />
           </Stack.Navigator>
 
-          <ArtworkFilterApplyButton disabled={!isApplyButtonEnabled} onPress={handleApplyPress} />
+          <ArtworkFilterApplyButton
+            disabled={!isApplyButtonEnabled}
+            onPress={handleApplyPress}
+            onCreateAlertPress={handleApplyPress}
+          />
         </View>
       </FancyModal>
     </NavigationContainer>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -314,6 +314,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
               artistName={name!}
               artistSlug={slug!}
               closeModal={() => setIsCreateAlertModalVisible(false)}
+              onComplete={exitModal}
             />
           )}
         </View>

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -211,65 +211,64 @@ export const getStaticFilterOptionsByMode = (
   }
 }
 
-export const getFilterScreenSortByMode = (
-  mode: FilterModalMode,
-  localFilterOptions: ArtworkFiltersModel["filterOptions"]
-) => (left: FilterDisplayConfig, right: FilterDisplayConfig): number => {
-  let sortOrder: FilterScreen[] = []
+export const getFilterScreenSortByMode =
+  (mode: FilterModalMode, localFilterOptions: ArtworkFiltersModel["filterOptions"]) =>
+  (left: FilterDisplayConfig, right: FilterDisplayConfig): number => {
+    let sortOrder: FilterScreen[] = []
 
-  // Filter order is based on frequency of use for a given page
-  switch (mode) {
-    case FilterModalMode.Collection:
-      sortOrder = CollectionFiltersSorted
-      break
-    case FilterModalMode.ArtistArtworks:
-      sortOrder = ArtistArtworksFiltersSorted
-      break
-    case FilterModalMode.ArtistSeries:
-      sortOrder = ArtistSeriesFiltersSorted
-      break
-    case FilterModalMode.Artworks:
-      sortOrder = ArtworksFiltersSorted
-      break
-    case FilterModalMode.Search:
-      sortOrder = ArtworksFiltersSorted
-      break
-    case FilterModalMode.Show:
-      sortOrder = ShowFiltersSorted
-      break
-    case FilterModalMode.Fair:
-      sortOrder = FairFiltersSorted
-      break
-    case FilterModalMode.SaleArtworks:
-      sortOrder = SaleArtworksFiltersSorted
-      break
-    case FilterModalMode.AuctionResults:
-      sortOrder = AuctionResultsFiltersSorted
-      break
-    case FilterModalMode.Partner:
-      sortOrder = PartnerFiltersSorted
-      break
-    case FilterModalMode.Gene:
-      sortOrder = TagAndGeneFiltersSorted
-      break
-    case FilterModalMode.Tag:
-      sortOrder = TagAndGeneFiltersSorted
-      break
-    case FilterModalMode.Custom:
-      sortOrder = (localFilterOptions ?? []).map((f) => f.filterType)
-      break
-    default:
-      assertNever(mode)
-  }
+    // Filter order is based on frequency of use for a given page
+    switch (mode) {
+      case FilterModalMode.Collection:
+        sortOrder = CollectionFiltersSorted
+        break
+      case FilterModalMode.ArtistArtworks:
+        sortOrder = ArtistArtworksFiltersSorted
+        break
+      case FilterModalMode.ArtistSeries:
+        sortOrder = ArtistSeriesFiltersSorted
+        break
+      case FilterModalMode.Artworks:
+        sortOrder = ArtworksFiltersSorted
+        break
+      case FilterModalMode.Search:
+        sortOrder = ArtworksFiltersSorted
+        break
+      case FilterModalMode.Show:
+        sortOrder = ShowFiltersSorted
+        break
+      case FilterModalMode.Fair:
+        sortOrder = FairFiltersSorted
+        break
+      case FilterModalMode.SaleArtworks:
+        sortOrder = SaleArtworksFiltersSorted
+        break
+      case FilterModalMode.AuctionResults:
+        sortOrder = AuctionResultsFiltersSorted
+        break
+      case FilterModalMode.Partner:
+        sortOrder = PartnerFiltersSorted
+        break
+      case FilterModalMode.Gene:
+        sortOrder = TagAndGeneFiltersSorted
+        break
+      case FilterModalMode.Tag:
+        sortOrder = TagAndGeneFiltersSorted
+        break
+      case FilterModalMode.Custom:
+        sortOrder = (localFilterOptions ?? []).map((f) => f.filterType)
+        break
+      default:
+        assertNever(mode)
+    }
 
-  const leftParam = left.filterType
-  const rightParam = right.filterType
-  if (sortOrder.indexOf(leftParam) < sortOrder.indexOf(rightParam)) {
-    return -1
-  } else {
-    return 1
+    const leftParam = left.filterType
+    const rightParam = right.filterType
+    if (sortOrder.indexOf(leftParam) < sortOrder.indexOf(rightParam)) {
+      return -1
+    } else {
+      return 1
+    }
   }
-}
 
 export const FilterArtworkButton = styled(Flex)`
   background-color: ${themeGet("colors.black100")};

--- a/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
@@ -10,7 +10,7 @@ import { Aggregations, FilterParamName } from "lib/Components/ArtworkFilter/Artw
 import { ArtworkFiltersState, ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import { CollectionFixture } from "lib/Scenes/Collection/Components/__fixtures__/CollectionFixture"
 import { CollectionArtworksFragmentContainer } from "lib/Scenes/Collection/Screens/CollectionArtworks"
-import { GlobalStoreProvider } from "lib/store/GlobalStore"
+import { __globalStoreTestUtils__, GlobalStoreProvider } from "lib/store/GlobalStore"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { Theme } from "palette"
@@ -148,7 +148,13 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-const MockFilterModalNavigator = ({ initialData = initialState }: { initialData?: ArtworkFiltersState }) => (
+const MockFilterModalNavigator = ({
+  initialData = initialState,
+  shouldShowCreateAlertButton,
+}: {
+  initialData?: ArtworkFiltersState
+  shouldShowCreateAlertButton?: boolean
+}) => (
   <GlobalStoreProvider>
     <Theme>
       <ArtworkFiltersStoreProvider initialData={initialData}>
@@ -161,6 +167,7 @@ const MockFilterModalNavigator = ({ initialData = initialState }: { initialData?
           id="abc123"
           slug="some-artist"
           visible
+          shouldShowCreateAlertButton={shouldShowCreateAlertButton}
         />
       </ArtworkFiltersStoreProvider>
     </Theme>
@@ -532,5 +539,23 @@ describe("AnimatedArtworkFilterButton", () => {
     )
 
     expect(getByText("Filter Text")).toBeTruthy()
+  })
+})
+
+describe("Saved Search Flow", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+  })
+
+  it('should hide "Create Alert" button by default', () => {
+    const { queryByText } = renderWithWrappersTL(<MockFilterModalNavigator />)
+
+    expect(queryByText("Create Alert")).toBeFalsy()
+  })
+
+  it('should show "Create Alert" button when shouldShowCreateAlertButton prop is passed', () => {
+    const { getByText } = renderWithWrappersTL(<MockFilterModalNavigator shouldShowCreateAlertButton />)
+
+    expect(getByText("Create Alert")).toBeTruthy()
   })
 })

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
@@ -6,6 +6,7 @@ import { ArtworkFilterApplyButton, ArtworkFilterApplyButtonProps } from "./Artwo
 
 const defaultProps: ArtworkFilterApplyButtonProps = {
   disabled: false,
+  onCreateAlertPress: jest.fn(),
   onPress: jest.fn,
 }
 
@@ -20,8 +21,8 @@ describe("ArtworkFilterApplyButton", () => {
 
   it("cannot press if disabled prop is passed", () => {
     const onPressMock = jest.fn()
-    const { getAllByText } = renderWithWrappersTL(<TestWrapper disabled />)
-    const button = getAllByText("Apply Filters")[0]
+    const { getByText } = renderWithWrappersTL(<TestWrapper disabled />)
+    const button = getByText("Apply Filters")
 
     fireEvent.press(button)
 
@@ -31,10 +32,19 @@ describe("ArtworkFilterApplyButton", () => {
 
   it('should call "onPress" handle when it is pressed', () => {
     const onPressMock = jest.fn()
-    const { getAllByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
+    const { getByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
 
-    fireEvent.press(getAllByText("Apply Filters")[0])
+    fireEvent.press(getByText("Apply Filters"))
 
     expect(onPressMock).toBeCalled()
+  })
+
+  it('should call "onCreateAlertPress" handler when "Create Alert" is pressed', () => {
+    const onCreateAlertPressMock = jest.fn()
+    const { getByText } = renderWithWrappersTL(<TestWrapper onCreateAlertPress={onCreateAlertPressMock} />)
+
+    fireEvent.press(getByText("Create Alert"))
+
+    expect(onCreateAlertPressMock).toBeCalled()
   })
 })

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
@@ -6,7 +6,7 @@ import { ArtworkFilterApplyButton, ArtworkFilterApplyButtonProps } from "./Artwo
 
 const defaultProps: ArtworkFilterApplyButtonProps = {
   disabled: false,
-  onCreateAlertPress: jest.fn(),
+  onCreateAlertPress: jest.fn,
   onPress: jest.fn,
 }
 
@@ -39,9 +39,17 @@ describe("ArtworkFilterApplyButton", () => {
     expect(onPressMock).toBeCalled()
   })
 
+  it('should show "Create Alert" button only when shouldShowCreateAlertButton prop is specified', () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper shouldShowCreateAlertButton />)
+
+    expect(getByText("Create Alert")).toBeTruthy()
+  })
+
   it('should call "onCreateAlertPress" handler when "Create Alert" is pressed', () => {
     const onCreateAlertPressMock = jest.fn()
-    const { getByText } = renderWithWrappersTL(<TestWrapper onCreateAlertPress={onCreateAlertPressMock} />)
+    const { getByText } = renderWithWrappersTL(
+      <TestWrapper shouldShowCreateAlertButton onCreateAlertPress={onCreateAlertPressMock} />
+    )
 
     fireEvent.press(getByText("Create Alert"))
 

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
@@ -30,7 +30,7 @@ describe("ArtworkFilterApplyButton", () => {
     expect(onPressMock).not.toBeCalled()
   })
 
-  it('should call "onPress" handle when it is pressed', () => {
+  it('should call "onPress" handler when it is pressed', () => {
     const onPressMock = jest.fn()
     const { getByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
 

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -7,6 +7,7 @@ export interface ArtworkFilterApplyButtonProps {
   disabled: boolean
   onCreateAlertPress?: () => void
   onPress: () => void
+  shouldShowCreateAlertButton?: boolean
 }
 
 interface Button {
@@ -44,7 +45,7 @@ const InnerButton: React.FC<Button> = (props) => {
 }
 
 export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
-  const { disabled, onCreateAlertPress, onPress } = props
+  const { disabled, shouldShowCreateAlertButton, onCreateAlertPress, onPress } = props
   const color = useColor()
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
@@ -65,12 +66,16 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
         }}
       >
         <Box height={50} borderRadius={50} px={1} backgroundColor="black100" flexDirection="row" alignItems="center">
-          <InnerButton
-            label="Create Alert"
-            icon={<BellIcon fill="white100" width="15px" height="15px" mr={1} />}
-            onPress={onCreateAlertPress}
-          />
-          <Box width="1" height={20} backgroundColor="white100" mx={1} />
+          {!!shouldShowCreateAlertButton && (
+            <>
+              <InnerButton
+                label="Create Alert"
+                icon={<BellIcon fill="white100" width="15px" height="15px" mr={1} />}
+                onPress={onCreateAlertPress}
+              />
+              <Box width="1" height={20} backgroundColor="white100" mx={1} />
+            </>
+          )}
           <InnerButton disabled={disabled} label="Apply Filters" onPress={onPress} />
         </Box>
       </Box>

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -5,7 +5,7 @@ import { TouchableOpacity, ViewStyle } from "react-native"
 
 export interface ArtworkFilterApplyButtonProps {
   disabled: boolean
-  onCreateAlertPress: () => void
+  onCreateAlertPress?: () => void
   onPress: () => void
 }
 
@@ -14,7 +14,7 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
   const color = useColor()
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
-  if (isEnabledImprovedAlertsFlow) {
+  if (isEnabledImprovedAlertsFlow && onCreateAlertPress) {
     const buttonContainerStyle: ViewStyle = {
       flex: 1,
     }

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -1,18 +1,30 @@
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import { Box, Button, Separator, useColor } from "palette"
+import { BellIcon, Box, Button, Separator, Text, useColor } from "palette"
 import React from "react"
+import { TouchableOpacity, ViewStyle } from "react-native"
 
 export interface ArtworkFilterApplyButtonProps {
   disabled: boolean
+  onCreateAlertPress: () => void
   onPress: () => void
 }
 
 export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
-  const { disabled, onPress } = props
+  const { disabled, onCreateAlertPress, onPress } = props
   const color = useColor()
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   if (isEnabledImprovedAlertsFlow) {
+    const buttonContainerStyle: ViewStyle = {
+      flex: 1,
+    }
+    const buttonStyle: ViewStyle = {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+    }
+
     return (
       <Box
         p={2}
@@ -28,9 +40,30 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
           elevation: 12,
         }}
       >
-        <Button disabled={disabled} onPress={onPress} block width={100} variant="fillDark" size="large">
-          Apply Filters
-        </Button>
+        <Box height={50} borderRadius={50} px={1} backgroundColor="black100" flexDirection="row" alignItems="center">
+          <TouchableOpacity onPress={onCreateAlertPress} style={buttonContainerStyle}>
+            <Box style={buttonStyle}>
+              <BellIcon fill="white100" width="15px" height="15px" mr={1} />
+              <Text variant="xs" color="white100" lineHeight={14}>
+                Create Alert
+              </Text>
+            </Box>
+          </TouchableOpacity>
+
+          <Box width="1" height={20} backgroundColor="white100" mx={1} />
+
+          <TouchableOpacity
+            onPress={onPress}
+            style={[buttonContainerStyle, disabled && { opacity: 0.6 }]}
+            disabled={disabled}
+          >
+            <Box style={buttonStyle}>
+              <Text variant="xs" color="white100" lineHeight={14}>
+                Apply Filters
+              </Text>
+            </Box>
+          </TouchableOpacity>
+        </Box>
       </Box>
     )
   }

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -1,12 +1,46 @@
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { BellIcon, Box, Button, Separator, Text, useColor } from "palette"
-import React from "react"
-import { TouchableOpacity, ViewStyle } from "react-native"
+import React, { ReactNode, useState } from "react"
+import { Pressable } from "react-native"
 
 export interface ArtworkFilterApplyButtonProps {
   disabled: boolean
   onCreateAlertPress?: () => void
   onPress: () => void
+}
+
+interface Button {
+  label: string
+  disabled?: boolean
+  icon?: ReactNode
+  onPress: () => void
+}
+
+const InnerButton: React.FC<Button> = (props) => {
+  const { label, disabled, icon, onPress } = props
+  const [isPressed, setIsPressed] = useState(false)
+
+  return (
+    <Pressable
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      onPress={onPress}
+      disabled={disabled}
+      style={{ flex: 1, opacity: disabled ? 0.4 : 1 }}
+    >
+      <Box flex={1} flexDirection="row" alignItems="center" justifyContent="center">
+        {icon}
+        <Text
+          variant="xs"
+          color="white100"
+          lineHeight={14}
+          style={{ textDecorationLine: isPressed ? "underline" : "none" }}
+        >
+          {label}
+        </Text>
+      </Box>
+    </Pressable>
+  )
 }
 
 export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
@@ -15,16 +49,6 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
 
   if (isEnabledImprovedAlertsFlow && onCreateAlertPress) {
-    const buttonContainerStyle: ViewStyle = {
-      flex: 1,
-    }
-    const buttonStyle: ViewStyle = {
-      flex: 1,
-      flexDirection: "row",
-      alignItems: "center",
-      justifyContent: "center",
-    }
-
     return (
       <Box
         p={2}
@@ -41,28 +65,13 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
         }}
       >
         <Box height={50} borderRadius={50} px={1} backgroundColor="black100" flexDirection="row" alignItems="center">
-          <TouchableOpacity onPress={onCreateAlertPress} style={buttonContainerStyle}>
-            <Box style={buttonStyle}>
-              <BellIcon fill="white100" width="15px" height="15px" mr={1} />
-              <Text variant="xs" color="white100" lineHeight={14}>
-                Create Alert
-              </Text>
-            </Box>
-          </TouchableOpacity>
-
+          <InnerButton
+            label="Create Alert"
+            icon={<BellIcon fill="white100" width="15px" height="15px" mr={1} />}
+            onPress={onCreateAlertPress}
+          />
           <Box width="1" height={20} backgroundColor="white100" mx={1} />
-
-          <TouchableOpacity
-            onPress={onPress}
-            style={[buttonContainerStyle, disabled && { opacity: 0.4 }]}
-            disabled={disabled}
-          >
-            <Box style={buttonStyle}>
-              <Text variant="xs" color="white100" lineHeight={14}>
-                Apply Filters
-              </Text>
-            </Box>
-          </TouchableOpacity>
+          <InnerButton disabled={disabled} label="Apply Filters" onPress={onPress} />
         </Box>
       </Box>
     )

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -54,7 +54,7 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
 
           <TouchableOpacity
             onPress={onPress}
-            style={[buttonContainerStyle, disabled && { opacity: 0.6 }]}
+            style={[buttonContainerStyle, disabled && { opacity: 0.4 }]}
             disabled={disabled}
           >
             <Box style={buttonStyle}>

--- a/src/lib/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainerV2.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainerV2.tsx
@@ -3,6 +3,7 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { captureMessage } from "@sentry/react-native"
 import { CreateSavedSearchContentContainerV2_me } from "__generated__/CreateSavedSearchContentContainerV2_me.graphql"
 import { CreateSavedSearchContentContainerV2Query } from "__generated__/CreateSavedSearchContentContainerV2Query.graphql"
+import { getUnitedSelectedAndAppliedFilters } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
 import {
   getAllowedFiltersForSavedSearchInput,
@@ -11,7 +12,7 @@ import {
 import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { useFeatureFlag } from "lib/store/GlobalStore"
-import React, { useCallback, useMemo, useRef, useState } from "react"
+import React, { useCallback, useRef, useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { CreateSavedSearchContent } from "../Components/CreateSavedSearchContent"
 import {
@@ -108,10 +109,11 @@ export const CreateSavedSearchAlertContentQueryRenderer: React.FC<CreateSavedSea
   props
 ) => {
   const { artistId } = props
-  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const aggregations = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
-  const filters = useMemo(() => getAllowedFiltersForSavedSearchInput(appliedFilters), [appliedFilters])
-  const criteria = useMemo(() => getSearchCriteriaFromFilters(artistId, filters), [artistId, filters])
+  const filterState = ArtworksFiltersStore.useStoreState((state) => state)
+  const unitedFilters = getUnitedSelectedAndAppliedFilters(filterState)
+  const filters = getAllowedFiltersForSavedSearchInput(unitedFilters)
+  const criteria = getSearchCriteriaFromFilters(artistId, filters)
 
   return (
     <QueryRenderer<CreateSavedSearchContentContainerV2Query>


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3613]

### Context
Under a feature flag, enable new behavior for the “Create alert” trigger on the Artist screen’s artwork grid.

### Acceptance Criteria
* Create alert button on the grid opens up the filter menu (just like clicking Filter + Sort)
* New button is visible within the filter menu for creating an alert with the “selected” and “applied” filters set (next to Apply).
* Changes must be under feature flag

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.


### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/144844715-cab69bab-743a-4ae1-9c41-3bf34ba1b737.mp4

#### Android
https://user-images.githubusercontent.com/3513494/144844788-243e96db-ea36-435d-97e4-516e0beaf5db.mp4

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add "Create alert" button within Artist screen's artwork grid filter menu - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3613]: https://artsyproduct.atlassian.net/browse/FX-3613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ