### PR TITLE
fix: failed tests after the release of AREnableSavedSearchToggles flag

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -6,8 +6,11 @@ import { SavedSearchAlertMutationResult } from "lib/Scenes/SavedSearchAlert/Save
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { mockTrackEvent } from "lib/tests/globallyMockedStuff"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import { delay } from "lib/utils/delay"
 import React from "react"
 import { CreateSavedSearchModal, CreateSavedSearchModalProps, tracks } from "./CreateSavedSearchModal"
+
+jest.unmock("react-relay")
 
 const defaultProps: CreateSavedSearchModalProps = {
   visible: true,
@@ -35,6 +38,10 @@ const mockedMutationResult: SavedSearchAlertMutationResult = {
 }
 
 describe("CreateSavedSearchModal", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+  })
+
   const TestRenderer = (props?: Partial<CreateSavedSearchModalProps>) => {
     return (
       <ArtworkFiltersStoreProvider initialData={initialData}>
@@ -60,14 +67,13 @@ describe("CreateSavedSearchModal", () => {
   })
 
   it('should call navigate twice when "My Collection" is enabled', async () => {
-    jest.useFakeTimers()
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableMyCollectionIOS: true })
     const { container, getByText } = renderWithWrappersTL(<TestRenderer />)
 
     container.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult)
     fireEvent.press(getByText("Your alert has been created."))
 
-    jest.runAllTimers()
+    await delay(200)
 
     expect(navigate).toHaveBeenCalledWith("/my-profile/settings", {
       popToRootTabView: true,

--- a/src/lib/Components/PopoverMessage/PopoverMessageProvider.tsx
+++ b/src/lib/Components/PopoverMessage/PopoverMessageProvider.tsx
@@ -1,3 +1,4 @@
+import { delay } from "lib/utils/delay"
 import React, { useCallback, useState } from "react"
 import { useEffect } from "react"
 import { useRef } from "react"
@@ -12,8 +13,6 @@ interface PopoverMessageContextContextValue {
 const SHOW_ANIMATION_VELOCITY = 450
 const HIDE_ANIMATION_VELOCITY = 400
 const REPLACE_ANIMATION_VELOCITY = 350
-
-const delay = (time: number) => new Promise((resolve) => setTimeout(resolve, time))
 
 export const PopoverMessageContext = React.createContext<PopoverMessageContextContextValue>({
   // tslint:disable-next-line:no-empty

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -88,6 +88,8 @@ describe("Saved search alert form", () => {
           searchCriteriaID: "savedSearchAlertId",
           userAlertSettings: {
             name: "something new",
+            email: true,
+            push: true,
           },
         },
       })
@@ -130,6 +132,8 @@ describe("Saved search alert form", () => {
           attributes: createMutationAttributes,
           userAlertSettings: {
             name: "something new",
+            email: true,
+            push: true,
           },
         },
       })
@@ -228,13 +232,6 @@ describe("Saved search alert form", () => {
         },
       })
     })
-  })
-
-  it("should display description by default", () => {
-    const { getByText } = renderWithWrappersTL(<SavedSearchAlertForm {...baseProps} />)
-    const description = getByText("Receive alerts as Push Notifications directly to your device.")
-
-    expect(description).toBeTruthy()
   })
 
   it("should hide description when AREnableSavedSearchToggles is enabled", () => {

--- a/src/lib/utils/delay.ts
+++ b/src/lib/utils/delay.ts
@@ -1,0 +1,1 @@
+export const delay = (time: number) => new Promise((resolve) => setTimeout(resolve, time))


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- failed tests after the release of AREnableSavedSearchToggles flag - dimatretyak

<!-- end_changelog_updates -->

</details>
