### PR TITLE
fix: loading modal on MyCollection Add works

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -1,28 +1,27 @@
 import { deleteCollectedArtwork } from "@artsy/cohesion"
+import { useActionSheet } from "@expo/react-native-action-sheet"
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { captureException } from "@sentry/react-native"
 import { MyCollectionArtwork_sharedProps } from "__generated__/MyCollectionArtwork_sharedProps.graphql"
 import { FormikProvider, useFormik } from "formik"
+import LoadingModal from "lib/Components/Modals/LoadingModal"
+import { goBack } from "lib/navigation/navigate"
 import { cleanArtworkPayload, explicitlyClearedFields } from "lib/Scenes/MyCollection/utils/cleanArtworkPayload"
 import { GlobalStore } from "lib/store/GlobalStore"
+import { getConvertedImageUrlFromS3 } from "lib/utils/getConvertedImageUrlFromS3"
+import { isEqual } from "lodash"
 import React, { useEffect, useRef, useState } from "react"
 import { Alert } from "react-native"
 import { useTracking } from "react-tracking"
+import { deleteArtworkImage } from "../../mutations/deleteArtworkImage"
 import { myCollectionAddArtwork } from "../../mutations/myCollectionAddArtwork"
 import { myCollectionDeleteArtwork } from "../../mutations/myCollectionDeleteArtwork"
 import { myCollectionEditArtwork } from "../../mutations/myCollectionEditArtwork"
-import { ArtworkFormValues } from "../../State/MyCollectionArtworkModel"
-import { artworkSchema, validateArtworkSchema } from "./Form/artworkSchema"
-
-import { useActionSheet } from "@expo/react-native-action-sheet"
-import { LoadingIndicator } from "lib/Components/LoadingIndicator"
-import { goBack } from "lib/navigation/navigate"
-import { getConvertedImageUrlFromS3 } from "lib/utils/getConvertedImageUrlFromS3"
-import { isEqual } from "lodash"
-import { deleteArtworkImage } from "../../mutations/deleteArtworkImage"
 import { refreshMyCollection } from "../../MyCollection"
+import { ArtworkFormValues } from "../../State/MyCollectionArtworkModel"
 import { deletedPhotoIDs } from "../../utils/deletedPhotoIDs"
+import { artworkSchema, validateArtworkSchema } from "./Form/artworkSchema"
 import { MyCollectionAdditionalDetailsForm } from "./Screens/MyCollectionArtworkFormAdditionalDetails"
 import { MyCollectionAddPhotos } from "./Screens/MyCollectionArtworkFormAddPhotos"
 import { MyCollectionArtworkFormMain } from "./Screens/MyCollectionArtworkFormMain"
@@ -138,9 +137,13 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
         } else {
           captureException(e)
         }
-        Alert.alert("An error ocurred", typeof e === "string" ? e : undefined)
+        requestAnimationFrame(() => {
+          Alert.alert("An error ocurred", typeof e === "string" ? e : undefined)
+        })
       } finally {
-        setLoading(false)
+        requestAnimationFrame(() => {
+          setLoading(false)
+        })
       }
     },
     validationSchema: artworkSchema,
@@ -234,7 +237,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
             initialParams={{ onHeaderBackButtonPress }}
           />
         </Stack.Navigator>
-        {!!loading && <LoadingIndicator />}
+        <LoadingModal isVisible={loading} />
       </FormikProvider>
     </NavigationContainer>
   )


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2222]

### Description

- Make the loading modal on my collection add works show up in full screen


![Group 10](https://user-images.githubusercontent.com/11945712/146018592-3d007c87-6df6-40e0-bb9f-019df9cb4799.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Make the loading modal on my collection add works show up in full screen - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2222]: https://artsyproduct.atlassian.net/browse/CX-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ