### PR TITLE
fix: Widget QA Items GRO-722

### DIFF
--- a/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
+++ b/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
@@ -11,7 +11,7 @@ private struct TopArtwork: SwiftUI.View {
         let artworkTitle = artwork.title
         let artworkUrl = artwork.url
         
-        HStack(alignment: .top) {
+        HStack(alignment: .bottom) {
             Image(uiImage: artworkImage)
                 .resizable()
                 .scaledToFit()
@@ -46,16 +46,20 @@ private struct BottomArtwork: SwiftUI.View {
         
         Link(destination: artworkUrl) {
             VStack() {
+                Spacer()
                 Image(uiImage: artworkImage)
                     .resizable()
                     .scaledToFit()
-                Spacer()
-                PrimaryText(name: artistName)
-                    .lineLimit(1)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                SecondaryText(title: artworkTitle)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack() {
+                    PrimaryText(name: artistName)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    SecondaryText(title: artworkTitle)
+                        .lineLimit(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Spacer(minLength: 0)
+                }
+                .frame(height: 45)
             }
         }
     }

--- a/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
+++ b/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
@@ -29,7 +29,7 @@ private struct TopArtwork: SwiftUI.View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(10)
+        .padding(16)
         .background(Color.white)
         .widgetURL(artworkUrl)
     }
@@ -100,7 +100,7 @@ extension FeaturedArtworks {
                         BottomArtwork(artwork: tertiaryArtwork)
                         BottomArtwork(artwork: quaternaryArtwork)
                     }
-                    .padding(10)
+                    .padding(16)
                     .background(Color(white: 0.96))
                     .frame(height: geo.size.height * CGFloat(bottomFactor))
                 }

--- a/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
+++ b/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
@@ -11,11 +11,19 @@ private struct TopArtwork: SwiftUI.View {
         let artworkTitle = artwork.title
         let artworkUrl = artwork.url
         
-        HStack(alignment: .top) {
+        HStack(alignment: .bottom) {
             Image(uiImage: artworkImage)
                 .resizable()
                 .scaledToFit()
+                .padding(.trailing, 10)
             VStack() {
+                HStack() {
+                    Spacer()
+                    Image(uiImage: artsyLogo)
+                        .resizable()
+                        .frame(width: 20, height: 20)
+                }
+                Spacer()
                 PrimaryText(name: artistName)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -23,9 +31,6 @@ private struct TopArtwork: SwiftUI.View {
                     .lineLimit(3)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
-            Image(uiImage: artsyLogo)
-                .resizable()
-                .frame(width: 20, height: 20)
         }
         .padding(10)
         .background(Color.white)

--- a/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
+++ b/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
@@ -32,7 +32,7 @@ private struct TopArtwork: SwiftUI.View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(10)
+        .padding(16)
         .background(Color.white)
         .widgetURL(artworkUrl)
     }
@@ -95,7 +95,7 @@ extension FeaturedArtworks {
                         BottomArtwork(artwork: secondaryArtwork)
                         BottomArtwork(artwork: tertiaryArtwork)
                     }
-                    .padding(10)
+                    .padding(16)
                     .background(Color(white: 0.96))
                     .frame(height: geo.size.height * CGFloat(bottomFactor))
                 }

--- a/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+SmallView.swift
+++ b/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+SmallView.swift
@@ -27,13 +27,12 @@ extension FeaturedArtworks {
                         .resizable()
                         .frame(width: 20, height: 20)
                 }
-                .padding([.top, .leading, .trailing], 10)
                 Spacer()
                 PrimaryText(name: artistName)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding([.bottom, .leading, .trailing], 10)
             }
+            .padding(16)
             .widgetURL(artworkUrl)
             .background(Color.white)
         }

--- a/ArtsyWidget/FullBleed/FullBleed+View.swift
+++ b/ArtsyWidget/FullBleed/FullBleed+View.swift
@@ -41,7 +41,7 @@ extension FullBleed {
                                 .resizable()
                                 .frame(width: 20, height: 20)
                         }
-                        .padding(10)
+                        .padding(16)
                         .background(Color.black)
                     }
                     .widgetURL(artworkUrl)

--- a/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -13,7 +13,7 @@ extension LatestArticles {
             
             VStack() {
                 HStack(alignment: .top) {
-                    Text("ARTSY EDITORIAL")
+                    Text("LATEST ARTICLES")
                         .font(.system(size: 14, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)

--- a/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -14,7 +14,7 @@ extension LatestArticles {
             VStack() {
                 HStack(alignment: .top) {
                     Text("ARTSY EDITORIAL")
-                        .font(.system(size: 14, weight: .bold))
+                        .font(.system(size: 14, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)
                         .resizable()

--- a/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -42,7 +42,7 @@ extension LatestArticles {
                     }
                 }
             }
-            .padding(10)
+            .padding(16)
         }
     }
 }

--- a/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -14,7 +14,7 @@ extension LatestArticles {
             VStack() {
                 HStack(alignment: .top) {
                     Text("ARTSY EDITORIAL")
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: 10, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)
                         .resizable()

--- a/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -13,7 +13,7 @@ extension LatestArticles {
             
             VStack() {
                 HStack(alignment: .top) {
-                    Text("ARTSY EDITORIAL")
+                    Text("LATEST ARTICLES")
                         .font(.system(size: 10, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)

--- a/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -28,11 +28,12 @@ extension LatestArticles {
                                 Image(uiImage: article.image!)
                                     .resizable()
                                     .scaledToFill()
-                                    .frame(width: 48, height: 48, alignment: .top)
+                                    .frame(width: 42, height: 42, alignment: .top)
                                     .clipped()
                                 VStack() {
                                     PrimaryText(name: article.title)
                                         .frame(maxWidth: .infinity, alignment: .leading)
+                                        .lineLimit(2)
                                     SecondaryText(title: article.pubDate)
                                         .frame(maxWidth: .infinity, alignment: .leading)
                                 }

--- a/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -41,7 +41,7 @@ extension LatestArticles {
                     }
                 }
             }
-            .padding(10)
+            .padding(16)
         }
     }
 }

--- a/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
@@ -25,23 +25,23 @@ extension LatestArticles {
                         .scaledToFill()
                         .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
                     VStack() {
-                        HStack() {
+                        Spacer()
+                        HStack(alignment: .top) {
+                            VStack() {
+                                PrimaryText(name: articleTitle, color: .white)
+                                    .lineLimit(2)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                SecondaryText(title: publishedAt, color: .white)
+                                    .lineLimit(1)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            Spacer()
                             Image(uiImage: artsyLogo)
                                 .resizable()
                                 .frame(width: 20, height: 20)
-                                .padding([.leading, .top], 10)
-                            Spacer()
                         }
-                        Spacer()
-                        VStack() {
-                            PrimaryText(name: articleTitle, color: .white)
-                                .lineLimit(2)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                            SecondaryText(title: publishedAt, color: .white)
-                                .lineLimit(1)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                        }
-                        .padding([.leading, .trailing, .bottom], 10)
+                        .padding(10)
+                        .background(Color.black)
                     }
                     .widgetURL(articleUrl)
                 }

--- a/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
@@ -40,7 +40,7 @@ extension LatestArticles {
                                 .resizable()
                                 .frame(width: 20, height: 20)
                         }
-                        .padding(10)
+                        .padding(16)
                         .background(Color.black)
                     }
                     .widgetURL(articleUrl)

--- a/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
@@ -15,7 +15,6 @@ extension LatestArticles {
             let artsyLogo = UIImage(named: "WhiteArtsyLogo")!
             let articleImage = article.image!
             let articleTitle = article.title
-            let publishedAt = article.pubDate
             let articleUrl = article.url!
             
             GeometryReader { geo in
@@ -30,9 +29,6 @@ extension LatestArticles {
                             VStack() {
                                 PrimaryText(name: articleTitle, color: .white)
                                     .lineLimit(2)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                SecondaryText(title: publishedAt, color: .white)
-                                    .lineLimit(1)
                                     .frame(maxWidth: .infinity, alignment: .leading)
                             }
                             Spacer()

--- a/ArtsyWidget/LatestArticles/LatestArticles+Timeline.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+Timeline.swift
@@ -2,26 +2,11 @@ import WidgetKit
 
 extension LatestArticles {
     struct Timeline {
-        static func rotateArticles(articles: [Article]) -> [[Article]] {
-            let initialLineup = articles
-            
-            let nextLineups: [[Article]] = [0, 1, 2, 3].map() { offset in
-                let trailing = Array(initialLineup.suffix(4 - offset))
-                let leading = Array(initialLineup.prefix(offset))
-                
-                return trailing + leading
-            }
-            
-            return nextLineups
-        }
-        
         static func generate(completion: @escaping (WidgetKit.Timeline<Entry>) -> ()) {
             ArticleStore.fetch() { articles in
                 let schedule = Schedule()
-                let rotatedArticles = Timeline.rotateArticles(articles: articles)
-                let updateTimesToArticles = Array(zip(schedule.updateTimes, rotatedArticles))
-                let entries = updateTimesToArticles.map() { (date, articles) in Entry(articles: articles, date: date) }
-                let timeline = WidgetKit.Timeline(entries: entries, policy: .after(schedule.nextUpdate))
+                let entry = Entry(articles: articles, date: Date())
+                let timeline = WidgetKit.Timeline(entries: [entry], policy: .after(schedule.nextUpdate))
                 completion(timeline)
             }
         }


### PR DESCRIPTION
This PR is a series of small updates based on QA feedback. Here's the before/after:

<details>
<summary>before</summary>

![before](https://user-images.githubusercontent.com/79799/146089922-244fe35e-c7f0-4f9a-98cc-8dbdab07091b.png)


</details>

<details>
<summary>after</summary>

![after](https://user-images.githubusercontent.com/79799/146089948-4ff5adea-a527-4267-9461-e8dfff4df8c1.png)


</details>

In terms of the code this is nearly all visual stuff but there is ONE behavior change: the editorial widget no longer rotates through its items as the day goes by. I thought this rotation was a good idea because it would make the widget feel fresh but I failed to consider that each item has a date associated with it.

If you have the large editorial version installed then it starts the day like this:

```
* Article A / Dec 4
* Article B / Dec 3
* Article C / Dec 2
* Article D / Dec 1
```

Newest article on top and then in descending order. As these things rotate you end up with things like this:

```
* Article C / Dec 2
* Article D / Dec 1
* Article A / Dec 4
* Article B / Dec 3
```

So two rotations have happened and now the order is out of wack. Better to just update less often (once a day) and keep the order consistent.

https://artsyproduct.atlassian.net/browse/GRO-722

/cc @artsy/grow-devs @brainbicycle @kathytafel 