### PR TITLE
fix(FX-3658): prevent crashes coming from simple-markdown

### DIFF
--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -46,8 +46,11 @@ export const ReadMore = React.memo(
       ...(type === "show" && {
         list: {
           ...basicRules.paragraph,
-          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-          react: (node, output, state) => {
+          react: (
+            node: SimpleMarkdown.SingleASTNode,
+            output: SimpleMarkdown.Output<React.ReactNode>,
+            state: SimpleMarkdown.State
+          ) => {
             return (
               <TextComponent {...textProps} color={color || "black100"} key={state.key}>
                 {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}
@@ -59,8 +62,11 @@ export const ReadMore = React.memo(
       }),
       paragraph: {
         ...basicRules.paragraph,
-        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-        react: (node, output, state) => {
+        react: (
+          node: SimpleMarkdown.SingleASTNode,
+          output: SimpleMarkdown.Output<React.ReactNode>,
+          state: SimpleMarkdown.State
+        ) => {
           return (
             <TextComponent {...textProps} color={color || "black100"} key={state.key}>
               {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -18,6 +18,7 @@ interface Props {
   color?: ResponsiveValue<Color>
   textStyle?: "sans" | "new"
   testID?: string
+  type?: "show"
 }
 
 export const ReadMore = React.memo(
@@ -30,7 +31,9 @@ export const ReadMore = React.memo(
     contextModule,
     textStyle = "sans",
     testID,
+    type,
   }: Props) => {
+    console.warn(content)
     const [isExpanded, setIsExpanded] = useState(false)
     const tracking = useTracking()
     const useNewTextStyles = textStyle === "new"
@@ -41,6 +44,20 @@ export const ReadMore = React.memo(
     const textProps: SansProps | PaletteTextProps = textStyle === "new" ? { variant: "xs" } : { size: "3" }
     const rules = {
       ...basicRules,
+      ...(type === "show" && {
+        list: {
+          ...basicRules.paragraph,
+          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+          react: (node, output, state) => {
+            return (
+              <TextComponent {...textProps} color={color || "black100"} key={state.key}>
+                {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}
+                {output(node.content, state)}
+              </TextComponent>
+            )
+          },
+        },
+      }),
       paragraph: {
         ...basicRules.paragraph,
         // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏

--- a/src/lib/Components/ReadMore.tsx
+++ b/src/lib/Components/ReadMore.tsx
@@ -33,7 +33,6 @@ export const ReadMore = React.memo(
     testID,
     type,
   }: Props) => {
-    console.warn(content)
     const [isExpanded, setIsExpanded] = useState(false)
     const tracking = useTracking()
     const useNewTextStyles = textStyle === "new"

--- a/src/lib/Scenes/Show/Screens/ShowMoreInfo.tsx
+++ b/src/lib/Scenes/Show/Screens/ShowMoreInfo.tsx
@@ -89,7 +89,7 @@ export const ShowMoreInfo: React.FC<ShowMoreInfoProps> = ({ show }) => {
                 <Text variant="sm" mb={0.5}>
                   Press Release
                 </Text>
-                <ReadMore content={show.pressRelease} textStyle="new" maxChars={500} />
+                <ReadMore type="show" content={show.pressRelease} textStyle="new" maxChars={500} />
               </Box>
             ),
           },

--- a/src/palette/elements/EntityHeader/EntityHeader.tsx
+++ b/src/palette/elements/EntityHeader/EntityHeader.tsx
@@ -37,7 +37,7 @@ export const EntityHeader: React.FC<EntityHeaderProps> = ({
     </Sans>
   )
 
-  const headerMeta = meta && (
+  const headerMeta = !!meta && (
     <Sans ellipsizeMode="tail" numberOfLines={1} size="2" color="black60" style={{ flexShrink: 1 }}>
       {meta}
     </Sans>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3658]

### Description

In some cases the `simple-markdown` library that we are using splits a paragraph that starts with `-` in every punctuation symbol that it finds as a list item. See the issue that I opened in [here](https://github.com/Khan/simple-markdown/issues/112).

Our partners are uploading the `pressRelease` content in our cms as plain text but we render it as markdown.

With this [temporary solution](https://github.com/artsy/eigen/pull/5912/files#diff-8ca64f781dac935a68794d70fcf1963028dc4cd2ec1f96156771232436a6ed8cR46-R59) if the `ReadMore` component is under shows we resolve lists to paragraphs (I doubt that any of our partners upload markdown lists under there.)

While fixing that found a bonus bug ([fixed here](https://github.com/artsy/eigen/pull/5912/files#r770783177)) that was also crashing the app due to text being rendered outside a `<Text/>` component

### Steps to reproduce and QA:

#### 1st issue
- Log in the app
- Go to search 
- type `(RE)Collections`
- press the `show` pill 
- click `(RE)Collections`
- scroll and press the `More Info` button
- the app should NOT crash anymore

#### 2nd issue (bonus bugfix)
try every step in the above list but search for `ARTephemera`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix markdown rendering issue that caused app to crash - gkartalis

<!-- end_changelog_updates -->

</details>


[FX-3658]: https://artsyproduct.atlassian.net/browse/FX-3658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ