### PR TITLE
feat(FX-3634): Allow to update search criteria attributes from saved alerts screen

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -61,7 +61,7 @@ export const Form: React.FC<FormProps> = (props) => {
   }
 
   // Enable "Save Alert" button if the user has removed the filters or changed data
-  if (isEnabledImprovedAlertsFlow && !isEditMode && (hasChangedFilters || dirty)) {
+  if (isEnabledImprovedAlertsFlow && (hasChangedFilters || dirty)) {
     isSaveAlertButtonDisabled = false
   }
 

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -139,17 +139,12 @@ export const Form: React.FC<FormProps> = (props) => {
                 m={0.5}
                 key={`filter-label-${index}`}
                 iconPosition="right"
-                // this is to make the pills removable only on create alert screen
-                {...(!isEditMode
-                  ? {
-                      onPress: () => {
-                        if (!isArtistPill(pill)) {
-                          onRemovePill(pill)
-                        }
-                      },
-                      Icon: isArtistPill(pill) ? undefined : RemoveIcon,
-                    }
-                  : {})}
+                onPress={() => {
+                  if (!isArtistPill(pill)) {
+                    onRemovePill(pill)
+                  }
+                }}
+                Icon={isArtistPill(pill) ? undefined : RemoveIcon}
               >
                 {pill.label}
               </Pill>

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, waitFor } from "@testing-library/react-native"
 import * as savedSearchButton from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { goBack, navigate } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
 import { mockFetchNotificationPermissions } from "lib/tests/mockFetchNotificationPermissions"
@@ -167,6 +168,41 @@ describe("EditSavedSearchAlert", () => {
     })
 
     expect(getAllByA11yState({ selected: false })).toHaveLength(1)
+  })
+
+  it("should pass updated criteria to update mutation when pills are removed", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+    const { getByText, getAllByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteria: () => searchCriteria,
+      Me: () => meMocked,
+    })
+    mockEnvironmentPayload(mockEnvironment, {
+      Artist: () => ({
+        internalID: "artistID",
+      }),
+      FilterArtworksConnection: () => filterArtworks,
+    })
+
+    fireEvent.press(getByText("Lithograph"))
+    fireEvent.press(getAllByText("Save Alert")[0])
+
+    await waitFor(() => {
+      const operation = mockEnvironment.mock.getMostRecentOperation()
+      expect(operation.request.variables.input).toEqual({
+        searchCriteriaID: "savedSearchAlertId",
+        attributes: {
+          artistID: "artistID",
+          materialsTerms: ["paper"],
+        },
+        userAlertSettings: {
+          name: "unique-name",
+          push: true,
+          email: true,
+        },
+      })
+    })
   })
 })
 

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -560,6 +560,16 @@ describe("Saved search alert form", () => {
       fireEvent(getByA11yLabel("Email Alerts Toggler"), "valueChange", false)
       expect(getAllByText("Save Alert")[0]).not.toBeDisabled()
     })
+
+    it("should be enabled if filters are changed in edit mode", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
+      const { getByText, getAllByText } = renderWithWrappersTL(
+        <SavedSearchAlertForm {...baseProps} savedSearchAlertId="savedSearchAlertId" />
+      )
+
+      fireEvent.press(getByText("Limited Edition"))
+      expect(getAllByText("Save Alert")[0]).toBeEnabled()
+    })
   })
 
   describe("Create Alert Form", () => {

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -562,13 +562,14 @@ describe("Saved search alert form", () => {
     })
 
     it("should be enabled if filters are changed in edit mode", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
       const { getByText, getAllByText } = renderWithWrappersTL(
         <SavedSearchAlertForm {...baseProps} savedSearchAlertId="savedSearchAlertId" />
       )
 
+      expect(getAllByText("Save Alert")[0]).toBeDisabled()
       fireEvent.press(getByText("Limited Edition"))
-      expect(getAllByText("Save Alert")[0]).toBeEnabled()
+      expect(getAllByText("Save Alert")[0]).not.toBeDisabled()
     })
   })
 

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -563,9 +563,7 @@ describe("Saved search alert form", () => {
 
     it("should be enabled if filters are changed in edit mode", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
-      const { getByText, getAllByText } = renderWithWrappersTL(
-        <SavedSearchAlertForm {...baseProps} savedSearchAlertId="savedSearchAlertId" />
-      )
+      const { getByText, getAllByText } = renderWithWrappersTL(<TestRenderer savedSearchAlertId="savedSearchAlertId" />)
 
       expect(getAllByText("Save Alert")[0]).toBeDisabled()
       fireEvent.press(getByText("Limited Edition"))

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -92,7 +92,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         }
 
         if (isUpdateForm) {
-          const criteria = isEnabledImprovedAlertsFlow ? clearedAttributes : null
+          const criteria = isEnabledImprovedAlertsFlow ? clearedAttributes : undefined
 
           const response = await updateSavedSearchAlert(savedSearchAlertId!, userAlertSettings, criteria)
           tracking.trackEvent(tracks.editedSavedSearch(savedSearchAlertId!, initialValues, values))

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -80,6 +80,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
       try {
         let result: SavedSearchAlertMutationResult
+        const clearedAttributes = clearDefaultAttributes(attributes)
 
         /**
          * We perform the mutation only if
@@ -91,7 +92,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         }
 
         if (isUpdateForm) {
-          const criteria = isEnabledImprovedAlertsFlow ? getSearchCriteriaFromPills(pills) : null
+          const criteria = isEnabledImprovedAlertsFlow ? clearedAttributes : null
 
           const response = await updateSavedSearchAlert(savedSearchAlertId!, userAlertSettings, criteria)
           tracking.trackEvent(tracks.editedSavedSearch(savedSearchAlertId!, initialValues, values))
@@ -100,7 +101,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
             id: response.updateSavedSearch?.savedSearchOrErrors.internalID!,
           }
         } else {
-          const clearedAttributes = clearDefaultAttributes(attributes)
           const response = await createSavedSearchAlert(userAlertSettings, clearedAttributes)
 
           result = {

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -91,7 +91,9 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         }
 
         if (isUpdateForm) {
-          const response = await updateSavedSearchAlert(userAlertSettings, savedSearchAlertId!)
+          const criteria = isEnabledImprovedAlertsFlow ? getSearchCriteriaFromPills(pills) : null
+
+          const response = await updateSavedSearchAlert(savedSearchAlertId!, userAlertSettings, criteria)
           tracking.trackEvent(tracks.editedSavedSearch(savedSearchAlertId!, initialValues, values))
 
           result = {

--- a/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -1,15 +1,28 @@
 import {
   updateSavedSearchAlertMutation,
   updateSavedSearchAlertMutationResponse,
+  updateSavedSearchAlertMutationVariables,
 } from "__generated__/updateSavedSearchAlertMutation.graphql"
+import { SearchCriteriaAttributes } from "lib/Components/ArtworkFilter/SavedSearch/types"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 
 export const updateSavedSearchAlert = (
+  savedSearchAlertId: string,
   userAlertSettings: SavedSearchAlertFormValues,
-  savedSearchAlertId: string
+  attributes: SearchCriteriaAttributes | null
 ): Promise<updateSavedSearchAlertMutationResponse> => {
+  const input: updateSavedSearchAlertMutationVariables["input"] = {
+    searchCriteriaID: savedSearchAlertId,
+    userAlertSettings,
+  }
+
+  // Pass immediately to input when the AREnableImprovedAlertsFlow flag is released
+  if (!!attributes) {
+    input.attributes = attributes
+  }
+
   return new Promise((resolve, reject) => {
     commitMutation<updateSavedSearchAlertMutation>(defaultEnvironment, {
       mutation: graphql`
@@ -27,10 +40,7 @@ export const updateSavedSearchAlert = (
         }
       `,
       variables: {
-        input: {
-          searchCriteriaID: savedSearchAlertId,
-          userAlertSettings,
-        },
+        input,
       },
       onCompleted: (response) => {
         resolve(response)

--- a/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/lib/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -11,7 +11,7 @@ import { SavedSearchAlertFormValues } from "../SavedSearchAlertModel"
 export const updateSavedSearchAlert = (
   savedSearchAlertId: string,
   userAlertSettings: SavedSearchAlertFormValues,
-  attributes: SearchCriteriaAttributes | null
+  attributes?: SearchCriteriaAttributes
 ): Promise<updateSavedSearchAlertMutationResponse> => {
   const input: updateSavedSearchAlertMutationVariables["input"] = {
     searchCriteriaID: savedSearchAlertId,


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3634]

### Description
Currently, when making changes in a saved alert, we can update only name, email and push. We need to make changes and add the ability to update search criteria attributes on the edit saved search alert screen

### Acceptance Criteria
* As a collector
* When I’m on the edit alert screen
* And I remove a non-default filter
* And I click Save Alert
* Then my alert is updated to the desired criteria

### Demo
####  A user tries to update an alert to match a new one
##### iOS
https://user-images.githubusercontent.com/3513494/150136271-b7d6e1f7-8388-4cbc-b0f9-cbf3875fd9d8.mp4

##### Android
https://user-images.githubusercontent.com/3513494/150138195-08e953e0-a4eb-4a38-a57c-a6a47c53ae2e.mp4

####  A user tries to update an alert to match a pre-existing one
https://user-images.githubusercontent.com/3513494/150136496-f0083b45-099e-4c18-bc21-92ac71748941.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Allow to update search criteria attributes from saved alerts screen - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3634]: https://artsyproduct.atlassian.net/browse/FX-3634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ