### PR TITLE
fix: Editorial widget broken with dark mode GRO-727

### DIFF
--- a/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -12,8 +12,9 @@ extension LatestArticles {
             let articles = entry.articles
             
             VStack() {
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     Text("LATEST ARTICLES")
+                        .foregroundColor(.black)
                         .font(.system(size: 14, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)
@@ -24,7 +25,7 @@ extension LatestArticles {
                 VStack() {
                     ForEach(articles, id: \.url) { article in
                         Link(destination: article.url!) {
-                            HStack(alignment: .top) {
+                            HStack(alignment: .center) {
                                 Image(uiImage: article.image!)
                                     .resizable()
                                     .scaledToFill()
@@ -43,6 +44,7 @@ extension LatestArticles {
                 }
             }
             .padding(16)
+            .background(Color.white)
         }
     }
 }

--- a/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -12,8 +12,9 @@ extension LatestArticles {
             let articles = entry.articles[0...1]
             
             VStack() {
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     Text("LATEST ARTICLES")
+                        .foregroundColor(.black)
                         .font(.system(size: 10, weight: .medium))
                     Spacer()
                     Image(uiImage: artsyLogo)
@@ -24,7 +25,7 @@ extension LatestArticles {
                 VStack() {
                     ForEach(articles, id: \.url) { article in
                         Link(destination: article.url!) {
-                            HStack(alignment: .top) {
+                            HStack(alignment: .center) {
                                 Image(uiImage: article.image!)
                                     .resizable()
                                     .scaledToFill()
@@ -43,6 +44,7 @@ extension LatestArticles {
                 }
             }
             .padding(16)
+            .background(Color.white)
         }
     }
 }


### PR DESCRIPTION
I don't run dark mode on any of my devices so I had a bit of a blind spot here - luckily @kathytafel noticed it! What was happening was that only for the medium and large editorial widget views I never set a background color. That meant that when a user switched to dark mode then the view was all busted looking. Here's some pictures:

<details>
<summary>before (dark mode)</summary>

![before-dark](https://user-images.githubusercontent.com/79799/146584329-301c446a-dd42-403f-be3f-9138b1c5aac4.png)


</details>

<details>
<summary>before (light mode)</summary>

![before-light](https://user-images.githubusercontent.com/79799/146584349-9b8863e6-b237-4b0f-a1df-13af83f325e5.png)


</details>

<details>
<summary>after</summary>

![after](https://user-images.githubusercontent.com/79799/146584373-af309c1a-d44a-4eb3-8179-a883a4ae5098.png)


</details>

I was also chatting with @damassi about some improvements to the layout of the editorial widget, namely vertically centering some text so that's in here too.

https://artsyproduct.atlassian.net/browse/GRO-727

/cc @artsy/grow-devs