### PR TITLE
feat(FX-3667):  Applying rounding when converting a value from cm to in

### DIFF
--- a/src/lib/Components/ArtworkFilter/Filters/helpers.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.tests.tsx
@@ -39,6 +39,12 @@ describe("cmToIn", () => {
     expect(cmToIn(199)).toBe(78.35)
   })
 
+  it("should correctly convert from centimeters to inches when the shouldRound param is set to false", () => {
+    expect(cmToIn(1, false)).toBe(0.39370078740157477)
+    expect(cmToIn(100, false)).toBe(39.37007874015748)
+    expect(cmToIn(199, false)).toBe(78.34645669291338)
+  })
+
   it('should return "*" if it is passed', () => {
     expect(cmToIn("*")).toBe("*")
   })

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.tests.tsx
@@ -1,4 +1,4 @@
-import { parseRange } from "./helpers"
+import { cmToIn, inToCm, parseRange } from "./helpers"
 
 describe("parseRange", () => {
   it("parses a default range string", () => {
@@ -29,5 +29,43 @@ describe("parseRange", () => {
     expect(parseRange("0-*")).toEqual({ min: 0, max: "*" })
     expect(parseRange("*-0")).toEqual({ min: "*", max: 0 })
     expect(parseRange("0-0")).toEqual({ min: 0, max: 0 })
+  })
+})
+
+describe("cmToIn", () => {
+  it("should correctly convert from centimeters to inches", () => {
+    expect(cmToIn(1)).toBe(0.39)
+    expect(cmToIn(100)).toBe(39.37)
+    expect(cmToIn(199)).toBe(78.35)
+  })
+
+  it('should return "*" if it is passed', () => {
+    expect(cmToIn("*")).toBe("*")
+  })
+})
+
+describe("inToCm", () => {
+  it("should correctly convert from inches to centimeters", () => {
+    expect(inToCm(1)).toBe(2.54)
+    expect(inToCm(10)).toBe(25.4)
+    expect(inToCm(10.12345)).toBe(25.71)
+    expect(inToCm(10.6789)).toBe(27.12)
+    expect(inToCm(45)).toBe(114.3)
+    expect(inToCm(50)).toBe(127)
+    expect(inToCm(99)).toBe(251.46)
+  })
+
+  it("should correctly convert from inches to centimeters when the shouldRound param is set to false", () => {
+    expect(inToCm(1, false)).toBe(2.54)
+    expect(inToCm(10, false)).toBe(25.4)
+    expect(inToCm(10.12345, false)).toBe(25.713563)
+    expect(inToCm(10.6789, false)).toBe(27.124406)
+    expect(inToCm(45, false)).toBe(114.3)
+    expect(inToCm(50, false)).toBe(127)
+    expect(inToCm(99, false)).toBe(251.46)
+  })
+
+  it('should return "*" if it is passed', () => {
+    expect(inToCm("*")).toBe("*")
   })
 })

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -39,7 +39,7 @@ export const cmToIn = (centimeters: Numeric) => {
     return centimeters
   }
 
-  return centimeters / ONE_IN_TO_CM
+  return round(centimeters / ONE_IN_TO_CM)
 }
 
 export const inToCm = (inches: Numeric, shouldRound: boolean = true) => {

--- a/src/lib/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/lib/Components/ArtworkFilter/Filters/helpers.ts
@@ -34,12 +34,18 @@ export const localizeDimension = (value: Numeric, unit: Unit): { value: Numeric;
   return { value, unit: "cm" }
 }
 
-export const cmToIn = (centimeters: Numeric) => {
+export const cmToIn = (centimeters: Numeric, shouldRound: boolean = true) => {
   if (centimeters === "*") {
     return centimeters
   }
 
-  return round(centimeters / ONE_IN_TO_CM)
+  const inches = centimeters / ONE_IN_TO_CM
+
+  if (shouldRound) {
+    return round(inches)
+  }
+
+  return inches
 }
 
 export const inToCm = (inches: Numeric, shouldRound: boolean = true) => {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3667]

### Context
If the user specifies the same custom size values for Force and Eigen, they will be converted to inches differently. In turn, this can add problems when working with saved search alerts

#### Force
* width: 100 - 199 cm -> 39.37 - 78.35 in
* height: 200 - 299 cm -> 78.74 - 117.72 in

#### Eigen
* width: 100 - 199 cm -> 39.37007874015748 - 78.34645669291338 in
* height: 200 - 299 cm -> 78.74015748031496 - 117.71653543307086 in

### Acceptance Criteria
* Values from cm to in should be converted equally to Force and to Eigen

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Applying rounding when converting a value from cm to in - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3667]: https://artsyproduct.atlassian.net/browse/FX-3667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ