### PR TITLE
fix(CX-2015): change margins (py) for action results, home and auction results screens

### DIFF
--- a/src/lib/Components/Lists/AuctionResultListItem.tsx
+++ b/src/lib/Components/Lists/AuctionResultListItem.tsx
@@ -34,7 +34,7 @@ const AuctionResultListItem: React.FC<Props> = ({
 
   return (
     <Touchable underlayColor={color("black5")} onPress={onPress}>
-      <Flex px={withHorizontalPadding ? 2 : 0} flexDirection="row">
+      <Flex px={withHorizontalPadding ? 2 : 0} py={2} flexDirection="row">
         {/* Sale Artwork Thumbnail Image */}
         {!auctionResult.images?.thumbnail?.url ? (
           <Flex

--- a/src/lib/Scenes/AuctionResultsForArtistsYouFollow/AuctionResultsForArtistsYouFollow.tsx
+++ b/src/lib/Scenes/AuctionResultsForArtistsYouFollow/AuctionResultsForArtistsYouFollow.tsx
@@ -99,7 +99,7 @@ export const AuctionResultsForArtistsYouFollow: React.FC<Props> = ({ me, relay }
             )}
             renderItem={({ item }) =>
               item ? (
-                <Flex px={1} py={2}>
+                <Flex px={1}>
                   <AuctionResultListItemFragmentContainer
                     auctionResult={item}
                     showArtistName

--- a/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
+++ b/src/lib/Scenes/Home/Components/AuctionResultsRail.tsx
@@ -39,7 +39,7 @@ const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me } & Props> = ({ t
         horizontal={false}
         initialNumToRender={3}
         ItemSeparatorComponent={() => (
-          <Flex px={2} py={2}>
+          <Flex px={2}>
             <Separator borderColor="black10" />
           </Flex>
         )}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2015]

### Description

<!-- Implementation description -->
Margins are applied to the touchable opacity of 'Action results for artists you follow' items, home and auction results screens, as a result clickable area increased

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Margins are applied to the touchable opacity of 'Action results for artists you follow' items, as a result clickable area increased

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

https://user-images.githubusercontent.com/36167539/146792266-24ef5d9e-f559-43f6-b2ee-b1235bc6a508.mp4

![Android](https://user-images.githubusercontent.com/36167539/146793027-a91c9da4-6793-4121-9c54-0a2b2ceef516.gif)

</details>


[CX-2015]: https://artsyproduct.atlassian.net/browse/CX-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ