### PR TITLE
fix: Prevent Profile screen from crashing without local user profile image

### DIFF
--- a/src/lib/Scenes/MyProfile/MyCollectionAndSavedWorks.tsx
+++ b/src/lib/Scenes/MyProfile/MyCollectionAndSavedWorks.tsx
@@ -21,7 +21,8 @@ export enum Tab {
   savedWorks = "Saved Works",
 }
 
-export const MyCollectionAndSavedWorks: React.FC<{ me: NonNullable<MyCollectionAndSavedWorks_me> }> = ({ me }) => {
+export const MyCollectionAndSavedWorks: React.FC<{ me?: MyCollectionAndSavedWorks_me }> = ({ me }) => {
+  console.log({ ItsMeMeMe: me })
   return (
     <StickyTabPage
       disableBackButtonUpdate
@@ -44,7 +45,7 @@ export const MyCollectionAndSavedWorks: React.FC<{ me: NonNullable<MyCollectionA
 
 export const LOCAL_PROFILE_ICON_PATH_KEY = "LOCAL_PROFILE_ICON_PATH_KEY"
 
-export const MyProfileHeader: React.FC<{ me: NonNullable<MyCollectionAndSavedWorks_me> }> = ({ me }) => {
+export const MyProfileHeader: React.FC<{ me?: MyCollectionAndSavedWorks_me }> = ({ me }) => {
   const color = useColor()
 
   const [showModal, setShowModal] = useState(false)
@@ -68,19 +69,21 @@ export const MyProfileHeader: React.FC<{ me: NonNullable<MyCollectionAndSavedWor
     })
   }, [])
 
-  const userProfileImagePath = localImage?.path || me.icon?.url
+  const userProfileImagePath = localImage?.path || me?.icon?.url
 
   const showIconAndBio = useFeatureFlag("AREnableVisualProfileIconAndBio")
 
   return (
     <>
-      <MyProfileEditFormModalFragmentContainer
-        me={me}
-        visible={showModal}
-        onDismiss={() => setShowModal(false)}
-        setProfileIconLocally={setProfileIconHandler}
-        localImage={localImage}
-      />
+      {!!me && (
+        <MyProfileEditFormModalFragmentContainer
+          me={me}
+          visible={showModal}
+          onDismiss={() => setShowModal(false)}
+          setProfileIconLocally={setProfileIconHandler}
+          localImage={localImage}
+        />
+      )}
       <FancyModalHeader
         rightButtonText="Settings"
         hideBottomDivider

--- a/src/lib/Scenes/MyProfile/MyCollectionAndSavedWorks.tsx
+++ b/src/lib/Scenes/MyProfile/MyCollectionAndSavedWorks.tsx
@@ -22,7 +22,6 @@ export enum Tab {
 }
 
 export const MyCollectionAndSavedWorks: React.FC<{ me?: MyCollectionAndSavedWorks_me }> = ({ me }) => {
-  console.log({ ItsMeMeMe: me })
   return (
     <StickyTabPage
       disableBackButtonUpdate


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2247]

### Description

fix: Handle me being null on Profile screen

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Prevent Profile screen from crashing without local user profile image - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2247]: https://artsyproduct.atlassian.net/browse/CX-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ