### PR TITLE
chore: different approach for navigating back on editing photos

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -54,9 +54,7 @@ export type ArtworkFormScreen = {
     onDelete(): void
     onHeaderBackButtonPress(): void
   }
-  AddPhotos: {
-    onHeaderBackButtonPress(): void
-  }
+  AddPhotos: undefined
 }
 
 export type MyCollectionArtworkFormProps = { onSuccess: () => void } & (
@@ -169,10 +167,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
 
   const onHeaderBackButtonPress = () => {
     const currentRoute = navContainerRef.current?.getCurrentRoute()
-    const isFirstScreen =
-      (props.mode === "edit" && currentRoute?.name !== "AddPhotos") ||
-      !currentRoute?.name ||
-      currentRoute?.name === "ArtworkFormArtist"
+    const isFirstScreen = props.mode === "edit" || !currentRoute?.name || currentRoute?.name === "ArtworkFormArtist"
 
     // clear and exit the form if we're on the first screen
     if (isFirstScreen) {
@@ -215,11 +210,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
             component={MyCollectionArtworkFormMain}
             initialParams={{ onDelete, clearForm, mode: props.mode, onHeaderBackButtonPress }}
           />
-          <Stack.Screen
-            name="AddPhotos"
-            component={MyCollectionAddPhotos}
-            initialParams={{ onHeaderBackButtonPress }}
-          />
+          <Stack.Screen name="AddPhotos" component={MyCollectionAddPhotos} />
         </Stack.Navigator>
         <LoadingModal isVisible={loading} />
       </FormikProvider>

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tests.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tests.tsx
@@ -1,4 +1,3 @@
-import { Route } from "@react-navigation/native"
 import { FancyModalHeader } from "lib/Components/FancyModal/FancyModalHeader"
 import { __globalStoreTestUtils__, GlobalStore } from "lib/store/GlobalStore"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
@@ -30,19 +29,7 @@ describe("MyCollectionAddPhotos", () => {
     })
 
     const mockNav = jest.fn()
-    const mockRoute: Route<
-      "AddPhotos",
-      {
-        onHeaderBackButtonPress(): void
-      }
-    > = {
-      key: "AddPhotos",
-      name: "AddPhotos",
-      params: {
-        onHeaderBackButtonPress: jest.fn(),
-      },
-    }
-    mockAddPhotos = <MyCollectionAddPhotos navigation={mockNav as any} route={mockRoute} />
+    mockAddPhotos = <MyCollectionAddPhotos navigation={mockNav as any} route={{} as any} />
   })
 
   it("updates header with correct label based on number of photos selected", () => {
@@ -69,19 +56,7 @@ describe("MyCollectionAddPhotos", () => {
 
   it("triggers action on add photo button click", () => {
     const mockNav = jest.fn()
-    const mockRoute: Route<
-      "AddPhotos",
-      {
-        onHeaderBackButtonPress(): void
-      }
-    > = {
-      key: "AddPhotos",
-      name: "AddPhotos",
-      params: {
-        onHeaderBackButtonPress: jest.fn(),
-      },
-    }
-    const wrapper = renderWithWrappers(<MyCollectionAddPhotos navigation={mockNav as any} route={mockRoute} />)
+    const wrapper = renderWithWrappers(<MyCollectionAddPhotos navigation={mockNav as any} route={{} as any} />)
     wrapper.root.findByType(tests.AddPhotosButton).findByType(TouchableOpacity).props.onPress()
     expect(showPhotoActionSheet).toHaveBeenCalled()
   })
@@ -90,19 +65,7 @@ describe("MyCollectionAddPhotos", () => {
     const spy = jest.fn()
     GlobalStore.actions.myCollection.artwork.removePhoto = spy as any
     const mockNav = jest.fn()
-    const mockRoute: Route<
-      "AddPhotos",
-      {
-        onHeaderBackButtonPress(): void
-      }
-    > = {
-      key: "AddPhotos",
-      name: "AddPhotos",
-      params: {
-        onHeaderBackButtonPress: jest.fn(),
-      },
-    }
-    const wrapper = renderWithWrappers(<MyCollectionAddPhotos navigation={mockNav as any} route={mockRoute} />)
+    const wrapper = renderWithWrappers(<MyCollectionAddPhotos navigation={mockNav as any} route={{} as any} />)
     wrapper.root.findAllByType(tests.DeletePhotoButton)[0].findByType(TouchableOpacity).props.onPress()
     expect(spy).toHaveBeenCalledWith({ path: "photo/1" })
   })

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tsx
@@ -15,7 +15,7 @@ import { ArtworkFormScreen } from "../MyCollectionArtworkForm"
 
 const MARGIN = 20
 
-export const MyCollectionAddPhotos: React.FC<StackScreenProps<ArtworkFormScreen, "AddPhotos">> = ({ route }) => {
+export const MyCollectionAddPhotos: React.FC<StackScreenProps<ArtworkFormScreen, "AddPhotos">> = ({ navigation }) => {
   const formValues = GlobalStore.useAppState((state) => state.myCollection.artwork.sessionState.formValues)
   const { photos } = formValues
   const { width: screenWidth } = useScreenDimensions()
@@ -38,9 +38,7 @@ export const MyCollectionAddPhotos: React.FC<StackScreenProps<ArtworkFormScreen,
 
   return (
     <>
-      <NavHeader onLeftButtonPress={() => route.params.onHeaderBackButtonPress()}>
-        Photos {!!photos.length && `(${photos.length})`}
-      </NavHeader>
+      <NavHeader onLeftButtonPress={navigation.goBack}>Photos {!!photos.length && `(${photos.length})`}</NavHeader>
       <ScrollView>
         <Flex flexDirection="row" flexWrap="wrap" my="2">
           {rows.map((row, i) => (

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -144,7 +144,7 @@ export const MyCollectionArtworkFormMain: React.FC<StackScreenProps<ArtworkFormS
                 artworkActions.addPhotos(photos)
               })
             } else {
-              navigation.navigate("AddPhotos", { onHeaderBackButtonPress: route.params.onHeaderBackButtonPress })
+              navigation.navigate("AddPhotos")
             }
           }}
         />


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2254]

### Description

Follow-up on https://github.com/artsy/eigen/pull/5978
- Use `navigation.goBack()` to navigate back from the Add Photos screen
- This approach would help us avoid nested ternary operations and keep the code easier to understand

https://user-images.githubusercontent.com/11945712/148214317-3c2aa77c-9d9b-433b-af6c-1da67b75b57a.mov



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- refactor navigating back logic on google photos - mounir

<!-- end_changelog_updates -->

</details>


[CX-2254]: https://artsyproduct.atlassian.net/browse/CX-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ