### PR TITLE
feat(FX-3675): update analytics tracking for saved search

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -31,6 +31,8 @@ interface ArtworksGridProps extends InfiniteScrollGridProps {
   relay: RelayPaginationProp
 }
 
+type FilterModalOpenedFrom = "sortAndFilter" | "createAlert"
+
 const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) => {
   const tracking = useTracking()
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
@@ -38,8 +40,8 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
   const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
 
-  const openFilterArtworksModal = (isOpenedFromSortAndFilterButton = true) => {
-    if (isOpenedFromSortAndFilterButton) {
+  const openFilterArtworksModal = (openedFrom: FilterModalOpenedFrom) => {
+    if (openedFrom === "sortAndFilter") {
       tracking.trackEvent({
         action_name: "filter",
         context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
@@ -62,6 +64,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
       context_screen_owner_slug: artist.slug,
       action_type: Schema.ActionTypes.Tap,
     })
+
     handleCloseFilterArtworksModal()
   }
 
@@ -86,7 +89,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
 }
 
 interface ArtistArtworksContainerProps {
-  openFilterModal: (isOpenedFromSortAndFilterButton?: boolean) => void
+  openFilterModal: (openedFrom: FilterModalOpenedFrom) => void
 }
 
 const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContainerProps> = ({
@@ -151,7 +154,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
     setJSX(
       <Box backgroundColor="white">
         <ArtworksFilterHeader
-          onFilterPress={openFilterModal}
+          onFilterPress={() => openFilterModal("sortAndFilter")}
           selectedFiltersCount={appliedFiltersCount}
           childrenPosition={isEnabledImprovedAlertsFlow ? "left" : "right"}
         >
@@ -159,7 +162,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             <SavedSearchButtonV2
               artistId={artist.internalID}
               artistSlug={artist.slug}
-              onPress={() => openFilterModal(false)}
+              onPress={() => openFilterModal("createAlert")}
             />
           ) : (
             !!shouldShowSavedSearchButton && (

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -153,7 +153,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           childrenPosition={isEnabledImprovedAlertsFlow ? "left" : "right"}
         >
           {isEnabledImprovedAlertsFlow ? (
-            <SavedSearchButtonV2 onPress={openFilterModal} />
+            <SavedSearchButtonV2 artistId={artist.internalID} artistSlug={artist.slug} onPress={openFilterModal} />
           ) : (
             !!shouldShowSavedSearchButton && (
               <SavedSearchButtonQueryRenderer

--- a/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -38,15 +38,18 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
   const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
   const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
 
-  const openFilterArtworksModal = () => {
-    tracking.trackEvent({
-      action_name: "filter",
-      context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
-      context_screen: Schema.PageNames.ArtistPage,
-      context_screen_owner_id: artist.id,
-      context_screen_owner_slug: artist.slug,
-      action_type: Schema.ActionTypes.Tap,
-    })
+  const openFilterArtworksModal = (isOpenedFromSortAndFilterButton = true) => {
+    if (isOpenedFromSortAndFilterButton) {
+      tracking.trackEvent({
+        action_name: "filter",
+        context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
+        context_screen: Schema.PageNames.ArtistPage,
+        context_screen_owner_id: artist.id,
+        context_screen_owner_slug: artist.slug,
+        action_type: Schema.ActionTypes.Tap,
+      })
+    }
+
     handleOpenFilterArtworksModal()
   }
 
@@ -83,7 +86,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({ artist, relay, ...props }) 
 }
 
 interface ArtistArtworksContainerProps {
-  openFilterModal: () => void
+  openFilterModal: (isOpenedFromSortAndFilterButton?: boolean) => void
 }
 
 const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContainerProps> = ({
@@ -153,7 +156,11 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
           childrenPosition={isEnabledImprovedAlertsFlow ? "left" : "right"}
         >
           {isEnabledImprovedAlertsFlow ? (
-            <SavedSearchButtonV2 artistId={artist.internalID} artistSlug={artist.slug} onPress={openFilterModal} />
+            <SavedSearchButtonV2
+              artistId={artist.internalID}
+              artistSlug={artist.slug}
+              onPress={() => openFilterModal(false)}
+            />
           ) : (
             !!shouldShowSavedSearchButton && (
               <SavedSearchButtonQueryRenderer

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tests.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tests.tsx
@@ -1,11 +1,12 @@
 import { fireEvent } from "@testing-library/react-native"
+import { mockTrackEvent } from "lib/tests/globallyMockedStuff"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { SavedSearchButtonV2, SavedSearchButtonV2Props } from "./SavedSearchButtonV2"
 
 describe("SavedSearchButtonV2", () => {
   const TestWrapper = (props: Partial<SavedSearchButtonV2Props>) => {
-    return <SavedSearchButtonV2 onPress={jest.fn} {...props} />
+    return <SavedSearchButtonV2 onPress={jest.fn} artistId="artistId" artistSlug="artistSlug" {...props} />
   }
 
   it("renders without error", () => {
@@ -19,5 +20,19 @@ describe("SavedSearchButtonV2", () => {
     fireEvent.press(getByText("Create Alert"))
 
     expect(onPressMock).toBeCalled()
+  })
+
+  it("should correctly track event", () => {
+    const { getByText } = renderWithWrappersTL(<TestWrapper />)
+
+    fireEvent.press(getByText("Create Alert"))
+
+    expect(mockTrackEvent).toBeCalledWith({
+      action: "tappedCreateAlert",
+      context_screen_owner_type: "artist",
+      context_screen_owner_id: "artistId",
+      context_screen_owner_slug: "artistSlug",
+      context_module: "artworkGrid",
+    })
   })
 })

--- a/src/lib/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
@@ -1,18 +1,28 @@
+import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { BellIcon, Box, Flex, Text, TouchableHighlightColor } from "palette"
 import React from "react"
+import { useTracking } from "react-tracking"
 
 export interface SavedSearchButtonV2Props {
+  artistId: string
+  artistSlug: string
   onPress: () => void
 }
 
 export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) => {
-  const { onPress } = props
+  const { artistId, artistSlug, onPress } = props
+  const tracking = useTracking()
+
+  const handlePress = () => {
+    onPress()
+    tracking.trackEvent(tracks.tappedCreateAlert(artistId, artistSlug))
+  }
 
   return (
     <Box>
       <TouchableHighlightColor
         haptic
-        onPress={onPress}
+        onPress={handlePress}
         render={({ color }) => (
           <Flex flexDirection="row" alignItems="center">
             <Box backgroundColor="white">
@@ -26,4 +36,14 @@ export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) =
       />
     </Box>
   )
+}
+
+export const tracks = {
+  tappedCreateAlert: (artistId: string, artistSlug: string): TappedCreateAlert => ({
+    action: ActionType.tappedCreateAlert,
+    context_screen_owner_type: OwnerType.artist,
+    context_screen_owner_id: artistId,
+    context_screen_owner_slug: artistSlug,
+    context_module: ContextModule.artworkGrid,
+  }),
 }

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -334,6 +334,6 @@ export const tracks = {
     context_screen_owner_type: OwnerType.artist,
     context_screen_owner_id: artistId,
     context_screen_owner_slug: artistSlug,
-    context_module: "filterScreen", // TODO: Use ContextModule.filterScreen
+    context_module: ContextModule.filterScreen,
   }),
 }

--- a/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/lib/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -1,4 +1,4 @@
-import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import {
@@ -249,6 +249,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
     applyFilters()
   }
 
+  const handleCreateAlertPress = () => {
+    setIsCreateAlertModalVisible(true)
+    tracking.trackEvent(tracks.tappedCreateAlert(id!, name!))
+  }
+
   return (
     <NavigationContainer independent>
       <FancyModal
@@ -303,7 +308,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
           <ArtworkFilterApplyButton
             disabled={!isApplyButtonEnabled}
             onPress={handleApplyPress}
-            onCreateAlertPress={() => setIsCreateAlertModalVisible(true)}
+            onCreateAlertPress={handleCreateAlertPress}
             shouldShowCreateAlertButton={shouldShowCreateAlertButton}
           />
 
@@ -321,4 +326,14 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
       </FancyModal>
     </NavigationContainer>
   )
+}
+
+export const tracks = {
+  tappedCreateAlert: (artistId: string, artistSlug: string): TappedCreateAlert => ({
+    action: ActionType.tappedCreateAlert,
+    context_screen_owner_type: OwnerType.artist,
+    context_screen_owner_id: artistId,
+    context_screen_owner_slug: artistSlug,
+    context_module: "filterScreen", // TODO: Use ContextModule.filterScreen
+  }),
 }


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3675]

### Description
* we should track the same events `tappedCreateAlert` and `toggledSavedSearch` in improved alerts flow
* `tappedCreateAlert` event should be tracked when the user clicks the "Create Alert" button on artist **artworks grid** with the following values:
  * `action: "tappedCreateAlert"`
  * `context_screen_owner_type: "artist"`
  * `context_screen_owner_id: "artist id"`
  * `context_screen_owner_slug: "artist slug"`
  * `context_module: "artworkGrid"`
* `tappedCreateAlert` event should be tracked when the user clicks "Create Alert" button on **Sort & Filter** menu with the following values:
  * `action: "tappedCreateAlert"`
  * `context_screen_owner_type: "artist"`
  * `context_screen_owner_id: "artist id"`
  * `context_screen_owner_slug: "artist slug"`
  * `context_module: "filterScreen"`
* we **shouldn’t fire** the tap events filter when user clicks "Create Alert" button from the artwork grid

### Demo
https://user-images.githubusercontent.com/3513494/148744778-b29cd44b-ee93-4861-a0d2-6411e4b50192.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Update analytics tracking for saved search - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3675]: https://artsyproduct.atlassian.net/browse/FX-3675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ