### PR TITLE
chore(FX-3610): Pass correct owner type to analytics for saved search alerts screen

### DIFF
--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -1,13 +1,10 @@
 import { SavedSearchesListTestsQuery } from "__generated__/SavedSearchesListTestsQuery.graphql"
-import { extractText } from "lib/tests/extractText"
 import { mockEnvironmentPayload } from "lib/tests/mockEnvironmentPayload"
-import { renderWithWrappers } from "lib/tests/renderWithWrappers"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
-import { EmptyMessage } from "./EmptyMessage"
 import { SavedSearchesListContainer as SavedSearchesList } from "./SavedSearchesList"
-import { SavedSearchListItem } from "./SavedSearchListItem"
 
 jest.unmock("react-relay")
 
@@ -42,7 +39,7 @@ describe("SavedSearches", () => {
   }
 
   it("renders correctly", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteriaConnection: () => ({
@@ -65,15 +62,12 @@ describe("SavedSearches", () => {
       }),
     })
 
-    const items = tree.root.findAllByType(SavedSearchListItem)
-
-    expect(items.length).toBe(2)
-    expect(extractText(items[0])).toBe("one")
-    expect(extractText(items[1])).toBe("two")
+    expect(getByText("one")).toBeTruthy()
+    expect(getByText("two")).toBeTruthy()
   })
 
   it("renders an empty message if there are no saved search alerts", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteriaConnection: () => ({
@@ -81,11 +75,11 @@ describe("SavedSearches", () => {
       }),
     })
 
-    expect(tree.root.findAllByType(EmptyMessage)).toHaveLength(1)
+    expect(getByText("You haven’t created any Alerts yet.")).toBeTruthy()
   })
 
-  it("renders an empty message if there is no name for saved search alert", () => {
-    const tree = renderWithWrappers(<TestRenderer />)
+  it("renders the default name placeholder if there is no name for saved search alert", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteriaConnection: () => ({
@@ -108,10 +102,7 @@ describe("SavedSearches", () => {
       }),
     })
 
-    const items = tree.root.findAllByType(SavedSearchListItem)
-
-    expect(items.length).toBe(2)
-    expect(extractText(items[0])).toBe("one")
-    expect(extractText(items[1])).toBe("Untitled Alert")
+    expect(getByText("one")).toBeTruthy()
+    expect(getByText("Untitled Alert")).toBeTruthy()
   })
 })

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -108,7 +108,7 @@ export const SavedSearchesListWrapper: React.FC<SavedSearchesListProps> = (props
     <ProvideScreenTracking
       info={{
         context_screen: Schema.PageNames.SavedSearchList,
-        context_screen_owner_type: OwnerType.savedSearches,
+        context_screen_owner_type: OwnerType.savedSearch,
       }}
     >
       <SavedSearchesList {...props} />


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3610]

### Description
For the screen view on the `SavedSearchList` screen on an app (the list of all Saved Alerts under settings on the app), we fire a pageview with `context_screen_owner_type` = `SavedSearches` where it **should be** `savedSearch`

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Pass correct owner type to analytics for saved search alerts screen - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3610]: https://artsyproduct.atlassian.net/browse/FX-3610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ