### PR TITLE
chore(FX-3677): update the filter counting logic for name input

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -572,7 +572,7 @@ describe("Saved search alert form", () => {
       )
 
       expect(getAllByText("Save Alert")[0]).toBeDisabled()
-      fireEvent.changeText(getByPlaceholderText(`artistName ${bullet} 6 filters`), "new value")
+      fireEvent.changeText(getByPlaceholderText(`artistName ${bullet} 5 filters`), "new value")
       expect(getAllByText("Save Alert")[0]).not.toBeDisabled()
     })
 

--- a/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.tests.ts
@@ -23,6 +23,11 @@ describe("getNamePlaceholder", () => {
       { label: "One", paramName: FilterParamName.materialsTerms, value: "one" },
       { label: "Two", paramName: FilterParamName.materialsTerms, value: "two" },
     ]
-    expect(getNamePlaceholder("artistName", pills)).toBe("artistName • 3 filters")
+    expect(getNamePlaceholder("artistName", pills)).toBe("artistName • 2 filters")
+  })
+
+  it("returns only artist name when pills are empty", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: true })
+    expect(getNamePlaceholder("artistName", [])).toBe("artistName")
   })
 })

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -6,8 +6,14 @@ import { extractPillValue } from "./pillExtractors"
 import { SavedSearchPill } from "./SavedSearchAlertModel"
 
 export const getNamePlaceholder = (artistName: string, pills: SavedSearchPill[]) => {
-  const filtersCountLabel = pills.length > 1 ? "filters" : "filter"
-  return `${artistName} ${bullet} ${pills.length} ${filtersCountLabel}`
+  const filteredPills = pills.filter((pill) => pill.paramName !== FilterParamName.artistIDs)
+  const filtersCountLabel = filteredPills.length > 1 ? "filters" : "filter"
+
+  if (filteredPills.length === 0) {
+    return artistName
+  }
+
+  return `${artistName} ${bullet} ${filteredPills.length} ${filtersCountLabel}`
 }
 
 export const getSearchCriteriaFromPills = (pills: SavedSearchPill[]) => {


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3677]

⚠️ Changes behind `AREnableImprovedAlertsFlow` feature flag

### Acceptance Criteria
* should **not display** "• 1 filter" in name input if no filter is selected and only the artist's name is displayed as a pill (for example, _Banksy_)
* should **display** "• 1 filter" in name input when a user adds a filter (for example, _Banksy • 1 filter_)

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/149120849-b99082d3-8b73-45c2-bed4-3db6dd5357e0.mp4

#### Android
https://user-images.githubusercontent.com/3513494/149122240-8eefe59d-d5e6-408d-a553-6085c4c46f89.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update the filter counting logic for name input - dimatretyak

<!-- end_changelog_updates -->

</details>


[FX-3677]: https://artsyproduct.atlassian.net/browse/FX-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ