### PR TITLE
feat(FX-3699): Show a warning message on edit alert screen if a user has set email frequency to None

### DIFF
--- a/src/__generated__/EditSavedSearchAlertQuery.graphql.ts
+++ b/src/__generated__/EditSavedSearchAlertQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 79caa0c330d4c63b9272ec4f52ac8cf6 */
+/* @relayHash a3abe9edb6a85abc6f9aa6a8923d86d0 */
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
@@ -9,6 +9,9 @@ export type EditSavedSearchAlertQueryVariables = {
     artistID: string;
 };
 export type EditSavedSearchAlertQueryResponse = {
+    readonly user: {
+        readonly " $fragmentRefs": FragmentRefs<"EditSavedSearchAlert_user">;
+    } | null;
     readonly artist: {
         readonly " $fragmentRefs": FragmentRefs<"EditSavedSearchAlert_artist">;
     } | null;
@@ -27,6 +30,10 @@ export type EditSavedSearchAlertQuery = {
 query EditSavedSearchAlertQuery(
   $artistID: String!
 ) {
+  user: me {
+    ...EditSavedSearchAlert_user
+    id
+  }
   artist(id: $artistID) {
     ...EditSavedSearchAlert_artist
     id
@@ -51,6 +58,10 @@ fragment EditSavedSearchAlert_artworksConnection on FilterArtworksConnection {
       value
     }
   }
+}
+
+fragment EditSavedSearchAlert_user on Me {
+  emailFrequency
 }
 */
 
@@ -97,14 +108,14 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 };
 return {
@@ -114,6 +125,22 @@ return {
     "metadata": null,
     "name": "EditSavedSearchAlertQuery",
     "selections": [
+      {
+        "alias": "user",
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "EditSavedSearchAlert_user"
+          }
+        ],
+        "storageKey": null
+      },
       {
         "alias": null,
         "args": (v1/*: any*/),
@@ -157,6 +184,25 @@ return {
     "name": "EditSavedSearchAlertQuery",
     "selections": [
       {
+        "alias": "user",
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
         "alias": null,
         "args": (v1/*: any*/),
         "concreteType": "Artist",
@@ -171,8 +217,8 @@ return {
             "name": "internalID",
             "storageKey": null
           },
-          (v3/*: any*/),
-          (v4/*: any*/)
+          (v4/*: any*/),
+          (v3/*: any*/)
         ],
         "storageKey": null
       },
@@ -214,7 +260,7 @@ return {
                     "name": "count",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
+                  (v4/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -228,14 +274,14 @@ return {
             ],
             "storageKey": null
           },
-          (v4/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "id": "79caa0c330d4c63b9272ec4f52ac8cf6",
+    "id": "a3abe9edb6a85abc6f9aa6a8923d86d0",
     "metadata": {},
     "name": "EditSavedSearchAlertQuery",
     "operationKind": "query",
@@ -243,5 +289,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'b7ba8ea3f6d77b3e8cb1436877763543';
+(node as any).hash = 'bc62a42de7d55f8e498e65ed1723ee63';
 export default node;

--- a/src/__generated__/EditSavedSearchAlertRefetchQuery.graphql.ts
+++ b/src/__generated__/EditSavedSearchAlertRefetchQuery.graphql.ts
@@ -1,0 +1,103 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+/* @relayHash fb9f84c5e8aa1c472b0037446b577514 */
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type EditSavedSearchAlertRefetchQueryVariables = {};
+export type EditSavedSearchAlertRefetchQueryResponse = {
+    readonly user: {
+        readonly " $fragmentRefs": FragmentRefs<"EditSavedSearchAlert_user">;
+    } | null;
+};
+export type EditSavedSearchAlertRefetchQuery = {
+    readonly response: EditSavedSearchAlertRefetchQueryResponse;
+    readonly variables: EditSavedSearchAlertRefetchQueryVariables;
+};
+
+
+
+/*
+query EditSavedSearchAlertRefetchQuery {
+  user: me {
+    ...EditSavedSearchAlert_user
+    id
+  }
+}
+
+fragment EditSavedSearchAlert_user on Me {
+  emailFrequency
+}
+*/
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EditSavedSearchAlertRefetchQuery",
+    "selections": [
+      {
+        "alias": "user",
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "EditSavedSearchAlert_user"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "EditSavedSearchAlertRefetchQuery",
+    "selections": [
+      {
+        "alias": "user",
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "emailFrequency",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "id": "fb9f84c5e8aa1c472b0037446b577514",
+    "metadata": {},
+    "name": "EditSavedSearchAlertRefetchQuery",
+    "operationKind": "query",
+    "text": null
+  }
+};
+(node as any).hash = '30499e96f2556b1fdcd85174653166a9';
+export default node;

--- a/src/__generated__/EditSavedSearchAlert_user.graphql.ts
+++ b/src/__generated__/EditSavedSearchAlert_user.graphql.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type EditSavedSearchAlert_user = {
+    readonly emailFrequency: string | null;
+    readonly " $refType": "EditSavedSearchAlert_user";
+};
+export type EditSavedSearchAlert_user$data = EditSavedSearchAlert_user;
+export type EditSavedSearchAlert_user$key = {
+    readonly " $data"?: EditSavedSearchAlert_user$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"EditSavedSearchAlert_user">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "EditSavedSearchAlert_user",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "emailFrequency",
+      "storageKey": null
+    }
+  ],
+  "type": "Me",
+  "abstractKey": null
+};
+(node as any).hash = '11a9b12a83b821f9819a3d182ac81a2c';
+export default node;

--- a/src/__generated__/SavedSearchAlertQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertQuery.graphql.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @ts-nocheck
-/* @relayHash 001b65e4542f3c0b892b9011ad9cc803 */
+/* @relayHash 434cba45d49bc25f7ba25349a7f27b5d */
 
 import { ConcreteRequest } from "relay-runtime";
 export type SavedSearchAlertQueryVariables = {
@@ -9,7 +9,6 @@ export type SavedSearchAlertQueryVariables = {
 };
 export type SavedSearchAlertQueryResponse = {
     readonly me: {
-        readonly emailFrequency: string | null;
         readonly savedSearch: {
             readonly internalID: string;
             readonly acquireable: boolean | null;
@@ -49,7 +48,6 @@ query SavedSearchAlertQuery(
   $savedSearchAlertId: ID!
 ) {
   me {
-    emailFrequency
     savedSearch(id: $savedSearchAlertId) {
       internalID
       acquireable
@@ -89,13 +87,6 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "emailFrequency",
-  "storageKey": null
-},
-v2 = {
   "alias": null,
   "args": [
     {
@@ -285,8 +276,7 @@ return {
         "name": "me",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
-          (v2/*: any*/)
+          (v1/*: any*/)
         ],
         "storageKey": null
       }
@@ -309,7 +299,6 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
-          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -323,7 +312,7 @@ return {
     ]
   },
   "params": {
-    "id": "001b65e4542f3c0b892b9011ad9cc803",
+    "id": "434cba45d49bc25f7ba25349a7f27b5d",
     "metadata": {},
     "name": "SavedSearchAlertQuery",
     "operationKind": "query",
@@ -331,5 +320,5 @@ return {
   }
 };
 })();
-(node as any).hash = 'f9113a2201aa52e9c5c28056815ad9d0';
+(node as any).hash = 'ef8b45a2d729f9b791d4983d0b1a40e6';
 export default node;

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -28,6 +28,7 @@ interface FormProps {
   isLoading?: boolean
   isPreviouslySaved?: boolean
   hasChangedFilters?: boolean
+  shouldShowEmailWarning?: boolean
   onDeletePress?: () => void
   onSubmitPress?: () => void
   onUpdateEmailPreferencesPress?: () => void
@@ -45,6 +46,7 @@ export const Form: React.FC<FormProps> = (props) => {
     isLoading,
     isPreviouslySaved,
     hasChangedFilters,
+    shouldShowEmailWarning,
     onDeletePress,
     onSubmitPress,
     onUpdateEmailPreferencesPress,
@@ -178,6 +180,16 @@ export const Form: React.FC<FormProps> = (props) => {
         onChange={handleToggleEmailNotification}
         active={values.email}
       />
+      {!!shouldShowEmailWarning && (
+        <Box backgroundColor="orange10" my={1} p={2}>
+          <Text variant="xs" color="orange150">
+            Your email frequency is set to None
+          </Text>
+          <Text variant="xs" mt={0.5}>
+            To receive Email Alerts, please update your email preferences.
+          </Text>
+        </Box>
+      )}
       {!!values.email && (
         <Text
           onPress={handleUpdateEmailPreferencesPress}

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -36,10 +36,10 @@ describe("EditSavedSearchAlert", () => {
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteria: () => searchCriteria,
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     expect(getAllByTestId("alert-pill").map(extractText)).toEqual(["Lithograph", "Paper"])
@@ -51,10 +51,10 @@ describe("EditSavedSearchAlert", () => {
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteria: () => searchCriteria,
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     fireEvent.changeText(getByTestId("alert-input-name"), "something new")
@@ -79,13 +79,13 @@ describe("EditSavedSearchAlert", () => {
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteria: () => searchCriteria,
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       Artist: () => ({
         internalID: "artistID",
       }),
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     fireEvent.press(getByTestId("view-artworks-button"))
@@ -102,10 +102,10 @@ describe("EditSavedSearchAlert", () => {
 
     mockEnvironmentPayload(mockEnvironment, {
       SearchCriteria: () => searchCriteria,
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     expect(getAllByA11yState({ selected: true })).toHaveLength(2)
@@ -123,10 +123,10 @@ describe("EditSavedSearchAlert", () => {
           push: false,
         },
       }),
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     expect(getAllByA11yState({ selected: false })).toHaveLength(2)
@@ -143,10 +143,10 @@ describe("EditSavedSearchAlert", () => {
           push: false,
         },
       }),
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     expect(getAllByA11yState({ selected: false })).toHaveLength(1)
@@ -163,10 +163,10 @@ describe("EditSavedSearchAlert", () => {
           email: false,
         },
       }),
-      Me: () => meMocked,
     })
     mockEnvironmentPayload(mockEnvironment, {
       FilterArtworksConnection: () => filterArtworks,
+      Me: () => meMocked,
     })
 
     expect(getAllByA11yState({ selected: false })).toHaveLength(1)

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -1,18 +1,19 @@
 import { OwnerType } from "@artsy/cohesion"
 import { EditSavedSearchAlert_artist } from "__generated__/EditSavedSearchAlert_artist.graphql"
 import { EditSavedSearchAlert_artworksConnection } from "__generated__/EditSavedSearchAlert_artworksConnection.graphql"
+import { EditSavedSearchAlert_user } from "__generated__/EditSavedSearchAlert_user.graphql"
 import { EditSavedSearchAlertQuery } from "__generated__/EditSavedSearchAlertQuery.graphql"
 import { SavedSearchAlertQueryResponse } from "__generated__/SavedSearchAlertQuery.graphql"
 import { emitSavedSearchRefetchEvent } from "lib/Components/Artist/ArtistArtworks/SavedSearchButton"
 import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { Aggregations } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
-import { goBack } from "lib/navigation/navigate"
+import { goBack, navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
-import React from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import React, { useCallback, useEffect } from "react"
+import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 import { EditSavedSearchFormPlaceholder } from "./Components/EditSavedSearchAlertPlaceholder"
 import { SavedSearchAlertQueryRenderer } from "./SavedSearchAlert"
 import { SavedSearchAlertForm } from "./SavedSearchAlertForm"
@@ -24,13 +25,15 @@ interface EditSavedSearchAlertBaseProps {
 
 interface EditSavedSearchAlertProps {
   me: SavedSearchAlertQueryResponse["me"]
+  user: EditSavedSearchAlert_user
   artist: EditSavedSearchAlert_artist
   savedSearchAlertId: string
   artworksConnection: EditSavedSearchAlert_artworksConnection
+  relay: RelayRefetchProp
 }
 
 export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props) => {
-  const { me, artist, artworksConnection, savedSearchAlertId } = props
+  const { me, user, artist, artworksConnection, savedSearchAlertId, relay } = props
   const aggregations = (artworksConnection.aggregations ?? []) as Aggregations
   const { userAlertSettings, internalID, ...attributes } = me?.savedSearch ?? {}
 
@@ -38,6 +41,18 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
     goBack()
     emitSavedSearchRefetchEvent()
   }
+
+  const refetch = useCallback(() => {
+    relay.refetch({}, null, null, { force: true })
+  }, [relay])
+
+  useEffect(() => {
+    navigationEvents.addListener("goBack", refetch)
+
+    return () => {
+      navigationEvents.removeListener("goBack", refetch)
+    }
+  }, [])
 
   return (
     <ProvideScreenTracking
@@ -59,7 +74,7 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
               artistId={artist.internalID}
               artistName={artist.name!}
               savedSearchAlertId={savedSearchAlertId}
-              userAllowsEmails={me?.emailFrequency !== "none"}
+              userAllowsEmails={user?.emailFrequency !== "none"}
               onComplete={onComplete}
               onDeleteComplete={onComplete}
             />
@@ -70,26 +85,41 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
   )
 }
 
-export const EditSavedSearchAlertFragmentContainer = createFragmentContainer(EditSavedSearchAlert, {
-  artist: graphql`
-    fragment EditSavedSearchAlert_artist on Artist {
-      internalID
-      name
-    }
-  `,
-  artworksConnection: graphql`
-    fragment EditSavedSearchAlert_artworksConnection on FilterArtworksConnection {
-      aggregations {
-        slice
-        counts {
-          count
-          name
-          value
+export const EditSavedSearchAlertRefetchContainer = createRefetchContainer(
+  EditSavedSearchAlert,
+  {
+    user: graphql`
+      fragment EditSavedSearchAlert_user on Me {
+        emailFrequency
+      }
+    `,
+    artist: graphql`
+      fragment EditSavedSearchAlert_artist on Artist {
+        internalID
+        name
+      }
+    `,
+    artworksConnection: graphql`
+      fragment EditSavedSearchAlert_artworksConnection on FilterArtworksConnection {
+        aggregations {
+          slice
+          counts {
+            count
+            name
+            value
+          }
         }
       }
+    `,
+  },
+  graphql`
+    query EditSavedSearchAlertRefetchQuery {
+      user: me {
+        ...EditSavedSearchAlert_user
+      }
     }
-  `,
-})
+  `
+)
 
 export const EditSavedSearchAlertQueryRenderer: React.FC<EditSavedSearchAlertBaseProps> = (
   props
@@ -105,6 +135,9 @@ export const EditSavedSearchAlertQueryRenderer: React.FC<EditSavedSearchAlertBas
             environment={defaultEnvironment}
             query={graphql`
               query EditSavedSearchAlertQuery($artistID: String!) {
+                user: me {
+                  ...EditSavedSearchAlert_user
+                }
                 artist(id: $artistID) {
                   ...EditSavedSearchAlert_artist
                 }
@@ -119,7 +152,7 @@ export const EditSavedSearchAlertQueryRenderer: React.FC<EditSavedSearchAlertBas
             `}
             variables={{ artistID: relayProps.me?.savedSearch?.artistID! }}
             render={renderWithPlaceholder({
-              Container: EditSavedSearchAlertFragmentContainer,
+              Container: EditSavedSearchAlertRefetchContainer,
               renderPlaceholder: () => <EditSavedSearchFormPlaceholder />,
               initialProps: { savedSearchAlertId, ...relayProps },
             })}

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
@@ -24,7 +24,6 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
       query={graphql`
         query SavedSearchAlertQuery($savedSearchAlertId: ID!) {
           me {
-            emailFrequency
             savedSearch(id: $savedSearchAlertId) {
               internalID
               acquireable

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -245,6 +245,15 @@ describe("Saved search alert form", () => {
     })
   })
 
+  it("should show a warning message if a user has set email frequency to None in update mode", async () => {
+    const { getByText } = renderWithWrappersTL(
+      <TestRenderer savedSearchAlertId="savedSearchAlertId" userAllowsEmails={false} />
+    )
+
+    expect(getByText("Your email frequency is set to None")).toBeTruthy()
+    expect(getByText("To receive Email Alerts, please update your email preferences.")).toBeTruthy()
+  })
+
   describe("Notification toggles", () => {
     const notificationPermissionsMock = mockFetchNotificationPermissions(false)
 

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -65,7 +65,9 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const tracking = useTracking()
   const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
-  const [shouldShowEmailWarning, setShouldShowEmailWarning] = useState(!userAllowsEmails)
+  const [shouldShowEmailSubscriptionWarning, setShouldShowEmailSubscriptionWarning] = useState(
+    !userAllowsEmails
+  )
   const formik = useFormik<SavedSearchAlertFormValues>({
     initialValues,
     initialErrors: {},
@@ -136,7 +138,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   }, [initialValues.email])
 
   useEffect(() => {
-    setShouldShowEmailWarning(!userAllowsEmails)
+    setShouldShowEmailSubscriptionWarning(!userAllowsEmails)
   }, [userAllowsEmails])
 
   const handleTogglePushNotification = async (enabled: boolean) => {
@@ -154,7 +156,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   const handleToggleEmailNotification = (enabled: boolean) => {
     // Show the modal only when the user is opted out of email and changes the "email alerts" toggle from off to on state
-    if (shouldShowEmailWarning && !initialValues.email && enabled) {
+    if (shouldShowEmailSubscriptionWarning && !initialValues.email && enabled) {
       const title = "Artsy would like to send you email notifications"
       const description = `After clicking ${quoteLeft}Save Alert${quoteRight}, you are opting in to receive alert notifications via email. You can update your email preferences by clicking into any alert listed in your profile tab and clicking ${quoteLeft}Update email preferences${quoteRight} underneath the ${quoteLeft}Email Alerts${quoteRight} toggle`
 
@@ -163,7 +165,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         {
           text: "Accept",
           onPress: () => {
-            setShouldShowEmailWarning(false)
+            setShouldShowEmailSubscriptionWarning(false)
             formik.setFieldValue("email", enabled)
           },
         },
@@ -195,6 +197,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
     })
   }
 
+  const shouldShowEmailWarning = !!savedSearchAlertId && !!initialValues.email && !userAllowsEmails
+
   return (
     <FormikProvider value={formik}>
       <ScrollView
@@ -213,6 +217,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
           onTogglePushNotification={handleTogglePushNotification}
           onToggleEmailNotification={handleToggleEmailNotification}
           onRemovePill={handleRemovePill}
+          shouldShowEmailWarning={shouldShowEmailWarning}
           {...other}
         />
       </ScrollView>

--- a/src/palette/Theme.tsx
+++ b/src/palette/Theme.tsx
@@ -21,7 +21,14 @@ import {
 
 type SpacingUnitV3 = `${SpacingUnitV3Numbers}`
 export type SpacingUnit = SpacingUnitV2 | SpacingUnitV3
-export type Color = ColorV3BeforeDevPurple | "devpurple" | "yellow100" | "yellow30" | "yellow10" // yellows are temporary, until we add them to palette-tokens
+export type Color =
+  | ColorV3BeforeDevPurple
+  | "devpurple"
+  | "yellow100"
+  | "yellow30"
+  | "yellow10"
+  | "orange10"
+  | "orange100" // yellows and orange are temporary, until we add them to palette-tokens
 export { SpacingUnitV2, SpacingUnitV3 }
 export { TextVariantV3 }
 
@@ -98,6 +105,8 @@ const fixColorV3 = (
   ourColors.yellow100 = "#A85F00"
   ourColors.yellow30 = "#FAE7BA"
   ourColors.yellow10 = "#F6EFE5"
+  ourColors.orange10 = "#FCF7F3"
+  ourColors.orange150 = "#A8501C"
   return colors as any
 }
 


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3699]

### Description
There may be a situation when the user previously created a saved search alert and enabled "Email Alerts" toggle, but later set "Email Preferences" to "None". And it would be useful to warn the user about this on edit alert screen

### Acceptance Criteria
* A warning message is displayed on the edit alert screen if:
  * "Email Alerts" toggle **enabled**
  * "Email Preferences" are set to "**None**"
* A warning message should be placed **between** "Email Alerts" toggle and "update email preferences" button
* Colors for the message
  * background color: `orange10 = #FCF7F3`
  * text color: `orange150 = #A8501C`

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/150392140-6904ef4c-181e-4332-b4bc-25e49ee6a058.mp4

#### Android
https://user-images.githubusercontent.com/3513494/150394688-ce644be6-061f-45db-a7d5-b51827ed7b93.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Show a warning message on edit alert screen if a user has set email frequency to None - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3699]: https://artsyproduct.atlassian.net/browse/FX-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ