### PR TITLE
feat: pass go back props

### DIFF
--- a/src/lib/Components/ArtsyReactWebView.tests.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tests.tsx
@@ -62,6 +62,19 @@ describe(ArtsyReactWebViewPage, () => {
     tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
     expect(goBack).toHaveBeenCalled()
   })
+  it("calls goBack with props when the close/back button is pressed", () => {
+    const tree = render({
+      backProps: {
+        fromScreen: "BackScreen",
+      },
+    })
+
+    expect(goBack).not.toHaveBeenCalled()
+    tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+    expect(goBack).toHaveBeenCalledWith({
+      fromScreen: "BackScreen",
+    })
+  })
   it("has a progress bar that follows page load events", () => {
     const tree = render()
     const getProgressBar = () => tree.root.findByType(__webViewTestUtils__?.ProgressBar!)

--- a/src/lib/Components/ArtsyReactWebView.tests.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tests.tsx
@@ -65,14 +65,14 @@ describe(ArtsyReactWebViewPage, () => {
   it("calls goBack with props when the close/back button is pressed", () => {
     const tree = render({
       backProps: {
-        fromScreen: "BackScreen",
+        previousScreen: "BackScreen",
       },
     })
 
     expect(goBack).not.toHaveBeenCalled()
     tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
     expect(goBack).toHaveBeenCalledWith({
-      fromScreen: "BackScreen",
+      previousScreen: "BackScreen",
     })
   })
   it("has a progress bar that follows page load events", () => {

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -1,6 +1,6 @@
 import { OwnerType } from "@artsy/cohesion"
 import { addBreadcrumb } from "@sentry/react-native"
-import { BackProps, dismissModal, goBack, navigate } from "lib/navigation/navigate"
+import { dismissModal, goBack, GoBackProps, navigate } from "lib/navigation/navigate"
 import { matchRoute } from "lib/navigation/routes"
 import { BottomTabRoutes } from "lib/Scenes/BottomTabs/bottomTabsConfig"
 import {
@@ -50,7 +50,7 @@ export const ArtsyReactWebViewPage: React.FC<
   {
     url: string
     isPresentedModally?: boolean
-    backProps?: BackProps
+    backProps?: GoBackProps
   } & ArtsyWebViewConfig
 > = ({
   url,

--- a/src/lib/Components/ArtsyReactWebView.tsx
+++ b/src/lib/Components/ArtsyReactWebView.tsx
@@ -1,6 +1,6 @@
 import { OwnerType } from "@artsy/cohesion"
 import { addBreadcrumb } from "@sentry/react-native"
-import { dismissModal, goBack, navigate } from "lib/navigation/navigate"
+import { BackProps, dismissModal, goBack, navigate } from "lib/navigation/navigate"
 import { matchRoute } from "lib/navigation/routes"
 import { BottomTabRoutes } from "lib/Scenes/BottomTabs/bottomTabsConfig"
 import {
@@ -50,6 +50,7 @@ export const ArtsyReactWebViewPage: React.FC<
   {
     url: string
     isPresentedModally?: boolean
+    backProps?: BackProps
   } & ArtsyWebViewConfig
 > = ({
   url,
@@ -59,6 +60,7 @@ export const ArtsyReactWebViewPage: React.FC<
   mimicBrowserBackButton = true,
   useRightCloseButton = false,
   showShareButton,
+  backProps,
 }) => {
   const paddingTop = useScreenDimensions().safeAreaInsets.top
 
@@ -85,11 +87,15 @@ export const ArtsyReactWebViewPage: React.FC<
     }
   }
 
+  const handleGoBack = () => {
+    goBack(backProps)
+  }
+
   const onRightButtonPress = () => {
     if (showShareButton) {
       return handleArticleShare()
     } else if (useRightCloseButton) {
-      return goBack()
+      return handleGoBack()
     }
   }
 
@@ -106,7 +112,7 @@ export const ArtsyReactWebViewPage: React.FC<
                   if (isPresentedModally && !canGoBack) {
                     dismissModal()
                   } else if (!canGoBack) {
-                    goBack()
+                    handleGoBack()
                   } else {
                     ref.current?.goBack()
                   }

--- a/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
+++ b/src/lib/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
@@ -42,7 +42,7 @@ export const ArtworkAttributionClassFAQ: React.FC<Props> = ({ artworkAttribution
               works.
             </Text>
 
-            <Button onPress={goBack} block>
+            <Button onPress={() => goBack()} block>
               OK
             </Button>
           </Join>

--- a/src/lib/Scenes/ArtworkMedium/ArtworkMedium.tsx
+++ b/src/lib/Scenes/ArtworkMedium/ArtworkMedium.tsx
@@ -36,7 +36,7 @@ export const ArtworkMedium: React.FC<Props> = ({ artwork }) => {
               or format used to create the artwork.
             </Text>
 
-            <Button onPress={goBack} block>
+            <Button onPress={() => goBack()} block>
               OK
             </Button>
           </Join>

--- a/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
+++ b/src/lib/Scenes/MyAccount/Components/MyAccountFieldEditScreen.tsx
@@ -84,7 +84,7 @@ export const MyAccountFieldEditScreen = React.forwardRef<
     <ArtsyKeyboardAvoidingView>
       <PageWithSimpleHeader
         left={
-          <TouchableOpacity onPress={goBack}>
+          <TouchableOpacity onPress={() => goBack()}>
             <Text variant="sm" textAlign="left">
               Cancel
             </Text>

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -97,7 +97,13 @@ export const Form: React.FC<FormProps> = (props) => {
       return onUpdateEmailPreferencesPress()
     }
 
-    return navigate("/unsubscribe")
+    return navigate("/unsubscribe", {
+      passProps: {
+        backProps: {
+          fromScreen: "Unsubscribe",
+        },
+      },
+    })
   }
 
   const isArtistPill = (pill: SavedSearchPill) => pill.paramName === SearchCriteria.artistID

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -100,7 +100,7 @@ export const Form: React.FC<FormProps> = (props) => {
     return navigate("/unsubscribe", {
       passProps: {
         backProps: {
-          fromScreen: "Unsubscribe",
+          previousScreen: "Unsubscribe",
         },
       },
     })

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -8,7 +8,7 @@ import { emitSavedSearchRefetchEvent } from "lib/Components/Artist/ArtistArtwork
 import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { Aggregations } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
-import { goBack, navigationEvents } from "lib/navigation/navigate"
+import { BackProps, goBack, navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
@@ -38,13 +38,20 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
   const { userAlertSettings, internalID, ...attributes } = me?.savedSearch ?? {}
 
   const onComplete = () => {
-    goBack()
+    goBack({
+      fromScreen: "EditSavedSearchAlert",
+    })
     emitSavedSearchRefetchEvent()
   }
 
-  const refetch = useCallback(() => {
-    relay.refetch({}, null, null, { force: true })
-  }, [relay])
+  const refetch = useCallback(
+    (backProps: BackProps) => {
+      if (backProps.fromScreen === "Unsubscribe") {
+        relay.refetch({}, null, null, { force: true })
+      }
+    },
+    [relay]
+  )
 
   useEffect(() => {
     navigationEvents.addListener("goBack", refetch)

--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -8,7 +8,7 @@ import { emitSavedSearchRefetchEvent } from "lib/Components/Artist/ArtistArtwork
 import { ArtsyKeyboardAvoidingView } from "lib/Components/ArtsyKeyboardAvoidingView"
 import { Aggregations } from "lib/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { PageWithSimpleHeader } from "lib/Components/PageWithSimpleHeader"
-import { BackProps, goBack, navigationEvents } from "lib/navigation/navigate"
+import { goBack, GoBackProps, navigationEvents } from "lib/navigation/navigate"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
@@ -39,14 +39,14 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
 
   const onComplete = () => {
     goBack({
-      fromScreen: "EditSavedSearchAlert",
+      previousScreen: "EditSavedSearchAlert",
     })
     emitSavedSearchRefetchEvent()
   }
 
   const refetch = useCallback(
-    (backProps: BackProps) => {
-      if (backProps.fromScreen === "Unsubscribe") {
+    (backProps: GoBackProps) => {
+      if (backProps.previousScreen === "Unsubscribe") {
         relay.refetch({}, null, null, { force: true })
       }
     },

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -391,7 +391,7 @@ describe("Saved search alert form", () => {
       expect(navigate).toBeCalledWith("/unsubscribe", {
         passProps: {
           backProps: {
-            fromScreen: "Unsubscribe",
+            previousScreen: "Unsubscribe",
           },
         },
       })

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -388,7 +388,13 @@ describe("Saved search alert form", () => {
 
       fireEvent.press(getByText("Update email preferences"))
 
-      expect(navigate).toBeCalledWith("/unsubscribe")
+      expect(navigate).toBeCalledWith("/unsubscribe", {
+        passProps: {
+          backProps: {
+            fromScreen: "Unsubscribe",
+          },
+        },
+      })
     })
 
     it("should call custom update email preferences handler when it is passed", async () => {

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -1,7 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { SavedSearchesList_me } from "__generated__/SavedSearchesList_me.graphql"
 import { SAVED_SERCHES_PAGE_SIZE } from "lib/Components/constants"
-import { BackProps, navigate, navigationEvents } from "lib/navigation/navigate"
+import { GoBackProps, navigate, navigationEvents } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
@@ -42,8 +42,8 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
   )
 
   useEffect(() => {
-    const onDeleteRefresh = (backProps: BackProps) => {
-      if (backProps.fromScreen === "EditSavedSearchAlert") {
+    const onDeleteRefresh = (backProps: GoBackProps) => {
+      if (backProps.previousScreen === "EditSavedSearchAlert") {
         onRefresh("delete")
       }
     }

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -1,7 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { SavedSearchesList_me } from "__generated__/SavedSearchesList_me.graphql"
 import { SAVED_SERCHES_PAGE_SIZE } from "lib/Components/constants"
-import { navigate, navigationEvents } from "lib/navigation/navigate"
+import { BackProps, navigate, navigationEvents } from "lib/navigation/navigate"
 import { extractNodes } from "lib/utils/extractNodes"
 import { ProvidePlaceholderContext } from "lib/utils/placeholders"
 import { ProvideScreenTracking, Schema } from "lib/utils/track"
@@ -42,7 +42,11 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
   )
 
   useEffect(() => {
-    const onDeleteRefresh = () => onRefresh("delete")
+    const onDeleteRefresh = (backProps: BackProps) => {
+      if (backProps.fromScreen === "EditSavedSearchAlert") {
+        onRefresh("delete")
+      }
+    }
     navigationEvents.addListener("goBack", onDeleteRefresh)
     return () => {
       navigationEvents.removeListener("goBack", onDeleteRefresh)

--- a/src/lib/navigation/BackButton.tsx
+++ b/src/lib/navigation/BackButton.tsx
@@ -36,7 +36,7 @@ export const BackButton: React.FC<{
       }}
     >
       <TouchableOpacity
-        onPress={onPress}
+        onPress={() => onPress()}
         style={{ width: "100%", height: "100%", alignItems: "center", justifyContent: "center" }}
       >
         {showCloseIcon ? (

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -19,14 +19,14 @@ export interface ViewDescriptor extends ViewOptions {
   props: object
 }
 
-export interface BackProps {
-  fromScreen?: string
+export interface GoBackProps {
+  previousScreen?: string
 }
 
 export interface NavigateOptions {
   modal?: boolean
   passProps?: {
-    backProps?: BackProps
+    backProps?: GoBackProps
     [key: string]: any
   }
   replace?: boolean
@@ -167,7 +167,7 @@ export function dismissModal() {
   }
 }
 
-export function goBack(backProps?: BackProps) {
+export function goBack(backProps?: GoBackProps) {
   LegacyNativeModules.ARScreenPresenterModule.goBack(unsafe__getSelectedTab())
   navigationEvents.emit("goBack", backProps)
 }

--- a/src/lib/navigation/navigate.ts
+++ b/src/lib/navigation/navigate.ts
@@ -19,9 +19,16 @@ export interface ViewDescriptor extends ViewOptions {
   props: object
 }
 
+export interface BackProps {
+  fromScreen?: string
+}
+
 export interface NavigateOptions {
   modal?: boolean
-  passProps?: object
+  passProps?: {
+    backProps?: BackProps
+    [key: string]: any
+  }
   replace?: boolean
   // Only when onlyShowInTabName specified
   popToRootTabView?: boolean
@@ -160,9 +167,9 @@ export function dismissModal() {
   }
 }
 
-export function goBack() {
+export function goBack(backProps?: BackProps) {
   LegacyNativeModules.ARScreenPresenterModule.goBack(unsafe__getSelectedTab())
-  navigationEvents.emit("goBack")
+  navigationEvents.emit("goBack", backProps)
 }
 
 export function popParentViewController() {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description
In some situations, it would be useful to pass props for `goBack` method. For example, in this way we can specify which screen the user returned from and perform the logic we need.

This PR adds this feature, and also solves the problem with executing unnecessary network requests for Saved Search Alert Flow when `goBack` event for `navigationEvents` is called (now when this event is called, requests are executed to get a list of all alerts + refetch information for a specific alert)


### Demo
#### Before
In this example, the `SavedSearchesListQuery` query should not be executed, since this data is not used for the current screen

https://user-images.githubusercontent.com/3513494/150771252-39b08e2e-f443-4d87-8d60-d8b39d7b1c5e.mp4

#### After
https://user-images.githubusercontent.com/3513494/150771272-665a2394-96da-4771-8e09-85eb274e93e4.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add ability to pass props for goBack method - dimatretyak

<!-- end_changelog_updates -->

</details>
