### PR TITLE
fix: wrong script directory

### DIFF
--- a/scripts/setup-distribute
+++ b/scripts/setup-distribute
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 if [ "$(uname)" == "Darwin" ]; then # MacOS
-    ./setup-distribute-macos
+    ./scripts/setup-distribute-macos
 else # Assume Linux
-    ./setup-distribute-linux
+    ./scripts/setup-distribute-linux
 fi


### PR DESCRIPTION
Co-authored-by: Sultan Al-Maari <sultan.al-maari@artsymail.com>
Co-authored-by: Adam Butler <ab@adam-butler.com>

The type of this PR is: **fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->


This PR is a follow-up on https://github.com/artsy/eigen/pull/6082

### Description
the `setup-distribute-macos` and `setup-distribute-linux` directories were not the right ones and this was resulting in the issue below. The fix was simply to update those imports 

<img width="1111" alt="Screenshot 2022-01-26 at 11 56 48" src="https://user-images.githubusercontent.com/11945712/151151165-383d388a-9555-412b-a8a9-e75d7b40289d.png">


#nochangelog