### PR TITLE
fix: crash for alerts flow on android

### DIFF
--- a/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -45,8 +45,8 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
   }
 
   const refetch = useCallback(
-    (backProps: GoBackProps) => {
-      if (backProps.previousScreen === "Unsubscribe") {
+    (backProps?: GoBackProps) => {
+      if (backProps?.previousScreen === "Unsubscribe") {
         relay.refetch({}, null, null, { force: true })
       }
     },

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -42,8 +42,8 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
   )
 
   useEffect(() => {
-    const onDeleteRefresh = (backProps: GoBackProps) => {
-      if (backProps.previousScreen === "EditSavedSearchAlert") {
+    const onDeleteRefresh = (backProps?: GoBackProps) => {
+      if (backProps?.previousScreen === "EditSavedSearchAlert") {
         onRefresh("delete")
       }
     }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

### Description
Due to the added changes in PR #6072, there was a crash on `Alerts List` screen on Android. Release version (7.1.7) is **not affected**

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fix crash for alerts flow on android - dimatretyak

<!-- end_changelog_updates -->

</details>
