### PR TITLE
fix: Broken back navigation

### DIFF
--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -227,17 +227,23 @@ const InnerPageWrapper: React.FC<PageWrapperProps> = ({
 // provide the tracking context so pages can use `useTracking` all the time
 @track()
 class PageWrapper extends React.Component<PageWrapperProps> {
-  render() {
-    const props = {
+  pageProps: PageWrapperProps
+
+  constructor(props: PageWrapperProps) {
+    super(props)
+    this.pageProps = {
       ...this.props,
       viewProps: {
         ...this.props.viewProps,
         ...propsStore.getPropsForModule(this.props.moduleName),
       },
     }
+  }
+
+  render() {
     return (
       <AppProviders>
-        <InnerPageWrapper {...props} />
+        <InnerPageWrapper {...this.pageProps} />
       </AppProviders>
     )
   }


### PR DESCRIPTION
**This is a long description for very few lines of code, but it was fun to debug 😄**

The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2285]

### Issue description
**Reproduction**
1. Open the app
2. Select an artwork (**Artwork X**)
3. Scroll down to the end of the page to see related artworks
4. Select an artwork (**Artwork Y**)
5. Press back

**Expected result**
Get back to **Artwork X** screen 🍾

**Actual result**
User lands on **Artwork Y** screen 😲
(video below)


### How I debugged the issue
**What I noticed**
When I press the back button, the screen is already loaded with the **Artwork Y** Content without any loading at all. Usually, there should be some loading even if its props are cached in the relay store.

**My theory (might be right or might be wrong and might be both right and wrong at the same time 😵‍💫)**
The screen could be actually getting rendered on the background 🤔

**How can I confirm my theory?**
Obviously, I will write some console.logs 😄. I will add one at the top of the artwork screen render block and see if **by navigating to one artwork screen to an other, we are going to get the same number of console.logs** (in a perfect world, it should be just one `console.log` and there will be no re-render but yeah, let's be honest, this is not the case)

**Output**
```
/* I navigate to artwork X */
render artwork screen X// console.log("render artwork screen X")
render artwork screen X// console.log("render artwork screen X")
/* I navigate to artwork Y */
render artwork screen Y// console.log("render artwork screen Y")
render artwork screen Y// console.log("render artwork screen Y")
render artwork screen X// console.log("render artwork screen X")
render artwork screen X// console.log("render artwork screen X")
```

![EasygoingGrayAntipodesgreenparakeet-max-1mb](https://user-images.githubusercontent.com/11945712/151403125-a7f426cb-9cc7-4445-bdd4-77ad1698e7a4.gif)

We got **double** `console.log` when navigating to **Artwork Y** screen. by navigating to **Artwork Z** we even got more!
```
/* I navigate to artwork Z */
render artwork screen Z// console.log("render artwork screen Z")
render artwork screen Z// console.log("render artwork screen Z")
render artwork screen Y// console.log("render artwork screen Y")
render artwork screen Y// console.log("render artwork screen Y")
render artwork screen X// console.log("render artwork screen X")
render artwork screen X// console.log("render artwork screen X")
```

<img width="588" alt="Screenshot 2022-01-27 at 17 41 37" src="https://user-images.githubusercontent.com/11945712/151403672-222d5f1e-30e3-4a7d-aead-145553d6f4a4.png">

**Yeah** kind of... there is one way to be sure, and that's our `PageWrapper` inside `Appregistry.tsx` since that's our highest HOC. Again, how can I confirm it?
![consolelog-consolelog-everywhere](https://user-images.githubusercontent.com/11945712/151404472-d1c1afec-c74d-4806-9e68-403f54aa1236.jpeg)

<img width="868" alt="Screenshot 2022-01-27 at 17 44 51" src="https://user-images.githubusercontent.com/11945712/151404605-c6e6e610-c838-4076-bcd2-46601ea77f93.png">

And here I noticed that this is not optimized and the props better would better live inside a reference as so
```
class PageWrapper extends React.Component<PageWrapperProps> {
  pageProps: PageWrapperProps

  constructor(props: PageWrapperProps) {
    super(props)
    this.pageProps = {
      ...this.props,
      viewProps: {
        ...this.props.viewProps,
        ...propsStore.getPropsForModule(this.props.moduleName),
      },
    }
  }
...
```

### How I should have debugged the issue
Probably [Dichotomic search](https://en.wikipedia.org/wiki/Dichotomic_search) using:
- [Git-bisect](https://git-scm.com/docs/git-bisect)
or
- simpler and better IMO in this case: just installing old builds from Testflight until I find the first broken build (it was **7.1.3 2021.12.10.6**), then checking when it got broken in git history

**Before**

https://user-images.githubusercontent.com/11945712/151406848-ff184fa3-5c48-4ed3-83f6-2a378a978672.mov

**After**

https://user-images.githubusercontent.com/11945712/151406887-7195dc81-c69b-414a-9de7-267bf8cd1439.mov


<!-- Implementation description -->



### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix back navigation on iOS - mounir

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2285]: https://artsyproduct.atlassian.net/browse/CX-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ