### PR TITLE
feat(NX-3071): Add see details link on initial offer message (inbox)

### DIFF
--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -54,6 +54,7 @@ import { HomeQueryRenderer } from "./Scenes/Home/Home"
 import { MakeOfferModalQueryRenderer } from "./Scenes/Inbox/Components/Conversations/MakeOfferModal"
 import { ConversationNavigator } from "./Scenes/Inbox/ConversationNavigator"
 import { Checkout } from "./Scenes/Inbox/Screens/Checkout"
+import { ConversationDetailsQueryRenderer } from "./Scenes/Inbox/Screens/ConversationDetails"
 import {
   LotsByArtistsYouFollowQueryRenderer,
   LotsByArtistsYouFollowScreenQuery,
@@ -345,6 +346,7 @@ export const modules = defineModules({
   Collection: reactModule(CollectionQueryRenderer, { fullBleed: true }),
   ConsignmentsSubmissionForm: reactModule(ConsignmentsSubmissionForm, {}),
   Conversation: reactModule(Conversation, { onlyShowInTabName: "inbox" }),
+  ConversationDetails: reactModule(ConversationDetailsQueryRenderer),
   Fair: reactModule(FairQueryRenderer, { fullBleed: true }),
   FairMoreInfo: reactModule(FairMoreInfoQueryRenderer),
   FairArticles: reactModule(FairArticlesQueryRenderer),

--- a/src/lib/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
@@ -96,12 +96,14 @@ const IndividualMessage: React.FC<{
 
 export class MessageGroup extends React.Component<MessageGroupProps> {
   render() {
-    const { group } = this.props
+    const { group, conversationId } = this.props
 
     // Events come as a single item in an array
     if (isRelevantEventArray(group)) {
       const onlyEvent = group[0]
-      return <OrderUpdateFragmentContainer event={onlyEvent as any} />
+      return (
+        <OrderUpdateFragmentContainer event={onlyEvent as any} conversationId={conversationId} />
+      )
     }
     if (isMessageArray(group)) {
       const firstItem = group[0]
@@ -109,7 +111,7 @@ export class MessageGroup extends React.Component<MessageGroupProps> {
         <View>
           <TimeSince style={{ alignSelf: "center" }} time={firstItem.createdAt} exact mb={1} />
           {[...group].reverse().map((message: Message_message, messageIndex: number) => {
-            const { subjectItem, conversationId } = this.props
+            const { subjectItem } = this.props
             const messageKey = `message-${messageIndex}`
             return (
               <IndividualMessage

--- a/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -58,7 +58,7 @@ const TestRenderer = () => (
     render={({ props, error }) => {
       if (Boolean(props?.me)) {
         const event = props!.me!.conversation!.orderConnection!.edges![0]!.node!.orderHistory[0]
-        return <OrderUpdate event={event} />
+        return <OrderUpdate event={event} conversationId="12345" />
       } else if (Boolean(error)) {
         console.log(error)
       }
@@ -97,6 +97,7 @@ describe("OrderUpdate with order updates", () => {
     const tree = getWrapper({ __typename: "CommerceOrderStateChangedEvent", state: "APPROVED" })
 
     expect(extractText(tree.root)).toMatch("Offer Accepted")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -108,6 +109,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("Offer Declined")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -119,6 +121,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("Offer Declined")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -130,6 +133,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("Offer Expired")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -140,6 +144,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("You sent an offer")
+    expect(extractText(tree.root)).toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -150,6 +155,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("You sent a counteroffer")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
   })
 
@@ -164,6 +170,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("You received a counteroffer")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(AlertCircleFillIcon)
   })
   it("shows an accepted offer from the partner with pending action", () => {
@@ -177,6 +184,7 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch("Offer Accepted - Pending Action")
+    expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(AlertCircleFillIcon)
   })
 })

--- a/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -1,6 +1,8 @@
 import React from "react"
 
 import { OrderUpdateTestsQuery } from "__generated__/OrderUpdateTestsQuery.graphql"
+import { LinkText } from "lib/Components/Text/LinkText"
+import { navigate } from "lib/navigation/navigate"
 import { extractText } from "lib/tests/extractText"
 import { renderWithWrappers } from "lib/tests/renderWithWrappers"
 import { AlertCircleFillIcon, MoneyFillIcon } from "palette"
@@ -146,6 +148,9 @@ describe("OrderUpdate with order updates", () => {
     expect(extractText(tree.root)).toMatch("You sent an offer")
     expect(extractText(tree.root)).toMatch("See details")
     tree.root.findByType(MoneyFillIcon)
+
+    tree.root.findByType(LinkText).props.onPress()
+    expect(navigate).toHaveBeenCalledWith("/conversation/12345/details")
   })
 
   it("shows a counteroffer offer from the user", () => {

--- a/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/lib/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -1,4 +1,6 @@
 import { OrderUpdate_event } from "__generated__/OrderUpdate_event.graphql"
+import { LinkText } from "lib/Components/Text/LinkText"
+import { navigate } from "lib/navigation/navigate"
 import { AlertCircleFillIcon, Color, Flex, IconProps, MoneyFillIcon, Spacer, Text } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -6,12 +8,14 @@ import { TimeSince } from "./TimeSince"
 
 export interface OrderUpdateProps {
   event: OrderUpdate_event
+  conversationId: string
 }
 
-export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
+export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId }) => {
   let color: Color
   let message: string
   let Icon: React.FC<IconProps> = MoneyFillIcon
+  let action: { label?: string; onPress?: () => void } = {}
 
   if (event.__typename === "CommerceOfferSubmittedEvent") {
     const { offer } = event
@@ -19,6 +23,12 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
     if (offer.fromParticipant === "BUYER") {
       color = "black100"
       message = `You sent ${isCounter ? "a counteroffer" : "an offer"} for ${event.offer.amount}`
+      if (!isCounter) {
+        action = {
+          label: "See details",
+          onPress: () => navigate(`/conversation/${conversationId}/details`),
+        }
+      }
     } else if (offer.fromParticipant === "SELLER") {
       color = "copper100"
       Icon = AlertCircleFillIcon
@@ -59,6 +69,12 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event }) => {
           <Flex flexDirection="column" pl={1}>
             <Text color={color} variant="xs">
               {message}
+              {!!action.label && !!action.onPress && (
+                <>
+                  {". "}
+                  <LinkText onPress={action.onPress}>{action.label}.</LinkText>
+                </>
+              )}
             </Text>
           </Flex>
         </Flex>

--- a/src/lib/navigation/routes.tsx
+++ b/src/lib/navigation/routes.tsx
@@ -165,6 +165,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     new RouteMatcher("/collection/:collectionID", "Collection"),
     new RouteMatcher("/collection/:collectionID/artists", "FullFeaturedArtistList"),
     new RouteMatcher("/conversation/:conversationID", "Conversation"),
+    new RouteMatcher("/conversation/:conversationID/details", "ConversationDetails"),
     new RouteMatcher("/user/conversations/:conversationID", "Conversation"),
     new RouteMatcher("/admin", "Admin"),
     new RouteMatcher("/admin2", "Admin2"),


### PR DESCRIPTION
The type of this PR is: **Feature**

[NX-3071]

### Description

Because users will be pointed to the inbox after making an offer (see [NX-3041](https://artsyproduct.atlassian.net/browse/NX-3041)), we need to make it clear for them where to see the details of the offer. 
- Create conversation details route.
- Allow opening offer order details from the initial offer message.

Twin PR on Force: https://github.com/artsy/force/pull/9292

![image](https://user-images.githubusercontent.com/265560/151798793-fecedce2-baaa-45e5-8fd9-b2d5a7f5a2e5.png)

[Figma file](https://www.figma.com/file/PgmxHwBnoOUS4ybwpK2mTN/Make-Offer-on-all-Eligible-Artworks?node-id=525%3A3575) for reference.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have tested my changes on **iOS** and **Android**.
- [X] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [X] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [X] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add see details link on initial offer message (inbox) - Leandro L

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[NX-3071]: https://artsyproduct.atlassian.net/browse/NX-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ