### PR TITLE
feat: Add an Extra Large Widget GRO-777

### DIFF
--- a/ArtsyWidget/FullBleed/FullBleed+View.swift
+++ b/ArtsyWidget/FullBleed/FullBleed+View.swift
@@ -4,7 +4,13 @@ import WidgetKit
 
 extension FullBleed {
     struct View: SwiftUI.View {
-        static let supportedFamilies: [WidgetFamily] = [.systemLarge]
+        static var supportedFamilies: [WidgetFamily] {
+            if #available(iOSApplicationExtension 15.0, *) {
+                return [.systemLarge, .systemExtraLarge]
+            } else {
+                return [.systemLarge]
+            }
+        }
         
         let entry: Entry
         


### PR DESCRIPTION
We had a call with Apple where they encouraged us to add an Extra Large version of the widget so I did it:

![884CDCE3-35D0-46CB-804D-02DDA8865643_1_102_o](https://user-images.githubusercontent.com/79799/152039188-b2341fac-07ab-4e64-a880-b79561ea47d4.jpeg)

I got lucky there with the artwork being a great fit for that aspect ratio, they don't always cooperate so nicely. Here's an example from the add screen:

![9BB2CA4A-7EB1-46B2-A215-F76D77DE9BDF_1_102_o](https://user-images.githubusercontent.com/79799/152039319-dc7df1e1-a0ff-4a60-b346-e2e92fdce8a0.jpeg)

I'm good with this but open to ideas...

https://artsyproduct.atlassian.net/browse/GRO-777

/cc @artsy/grow-devs @jpoczik @pvinis @brainbicycle 

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

#### iOS user-facing changes

- Add an extra large widget - Jon

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>