### PR TITLE
fix(SWA-198): submissions without photos

### DIFF
--- a/src/lib/Scenes/Consignments/Screens/Overview-uploading.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview-uploading.tests.tsx
@@ -13,6 +13,7 @@ import { updateConsignmentSubmission } from "../Submission/updateConsignmentSubm
 jest.mock("../Submission/uploadPhotoToGemini", () => ({ uploadImageAndPassToGemini: jest.fn() }))
 import { uploadImageAndPassToGemini } from "../Submission/uploadPhotoToGemini"
 
+const mockUploadImageAndPassToGemini = uploadImageAndPassToGemini as jest.Mock
 const nav = {} as any
 const route = {} as any
 
@@ -58,6 +59,23 @@ it("calls update submission when submitting a non-draft version", () => {
 
   overview.submitFinalSubmission()
   expect(updateConsignmentSubmission).toBeCalledWith({ state: "SUBMITTED", submissionID: "123" })
+})
+
+it("if image uploadin failed", async () => {
+  mockUploadImageAndPassToGemini.mockRejectedValue("UploadImageError")
+  const overview = new Overview({
+    nav,
+    route,
+    setup: { submissionID: 1, photos: [{ image: { path: "/a/b/c.webp" }, uploaded: false }] },
+    params: {},
+  })
+  overview.setState = jest.fn()
+  overview.showUploadFailureAlert = jest.fn()
+
+  await overview.updateLocalStateAndMetaphysics()
+
+  expect(overview.showUploadFailureAlert).toHaveBeenCalled()
+  expect(overview.showUploadFailureAlert).toHaveBeenCalledWith("UploadImageError")
 })
 
 it("passes utm params when submitting", () => {

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -145,9 +145,9 @@ export class Overview extends React.Component<Props, State> {
         updateConsignmentSubmission({ ...this.state, utmSource, utmTerm, utmMedium })
       } else if (this.state.artist) {
         const submissionID = await createConsignmentSubmission(this.state)
-        this.setState({ submissionID }, async () => {
+        this.setState({ submissionID }, () => {
           this.submissionDraftCreated()
-          await this.uploadPhotosIfNeeded()
+          this.updateLocalStateAndMetaphysics()
         })
       }
     } catch (error: any) {

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -279,7 +279,7 @@ export class Overview extends React.Component<Props, State> {
       this.state.metadata.height &&
       this.state.metadata.width &&
       this.state.editionScreenViewed &&
-      this.state.photos?.length! > 0
+      this.state.photos?.filter((photo) => photo.uploaded).length! > 0
     )
 
   render() {

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -136,21 +136,22 @@ export class Overview extends React.Component<Props, State> {
   updateLocalStateAndMetaphysics = async () => {
     this.saveStateToLocalStorage()
 
-    if (this.state.submissionID) {
-      try {
+    try {
+      if (this.state.submissionID) {
         await this.uploadPhotosIfNeeded()
         const utmSource = this.props.params.utm_source
         const utmMedium = this.props.params.utm_medium
         const utmTerm = this.props.params.utm_term
         updateConsignmentSubmission({ ...this.state, utmSource, utmTerm, utmMedium })
-      } catch (error: any) {
-        this.showUploadFailureAlert(error)
+      } else if (this.state.artist) {
+        const submissionID = await createConsignmentSubmission(this.state)
+        this.setState({ submissionID }, async () => {
+          this.submissionDraftCreated()
+          await this.uploadPhotosIfNeeded()
+        })
       }
-    } else if (this.state.artist) {
-      const submissionID = await createConsignmentSubmission(this.state)
-      this.setState({ submissionID }, () => {
-        this.submissionDraftCreated()
-      })
+    } catch (error: any) {
+      this.showUploadFailureAlert(error)
     }
   }
 

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -285,6 +285,7 @@ export class Overview extends React.Component<Props, State> {
   render() {
     // See https://github.com/artsy/convection/blob/master/app/models/submission.rb for list
     const canSubmit = this.canSubmit()
+    const isPhotoLoading = this.state.photos?.some((photo) => photo.uploading)
 
     const isPad = Dimensions.get("window").width > 700
 
@@ -342,8 +343,9 @@ export class Overview extends React.Component<Props, State> {
             <Button
               maxWidth={540}
               block
+              loading={isPhotoLoading}
               onPress={this.state.hasLoaded && canSubmit ? this.submitFinalSubmission : undefined}
-              disabled={!canSubmit}
+              disabled={isPhotoLoading || !canSubmit}
               haptic
             >
               Next

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -279,13 +279,16 @@ export class Overview extends React.Component<Props, State> {
       this.state.metadata.height &&
       this.state.metadata.width &&
       this.state.editionScreenViewed &&
-      this.state.photos?.filter((photo) => photo.uploaded).length! > 0
+      this.state.photos?.filter((photo) => photo.uploaded).length! > 0 &&
+      !this.isPhotoLoading()
     )
+
+  isPhotoLoading = () => this.state.photos?.some((photo) => photo.uploading)
 
   render() {
     // See https://github.com/artsy/convection/blob/master/app/models/submission.rb for list
     const canSubmit = this.canSubmit()
-    const isPhotoLoading = this.state.photos?.some((photo) => photo.uploading)
+    const isPhotoLoading = this.isPhotoLoading()
 
     const isPad = Dimensions.get("window").width > 700
 
@@ -345,8 +348,9 @@ export class Overview extends React.Component<Props, State> {
               block
               loading={isPhotoLoading}
               onPress={this.state.hasLoaded && canSubmit ? this.submitFinalSubmission : undefined}
-              disabled={isPhotoLoading || !canSubmit}
+              disabled={!canSubmit}
               haptic
+              testID="consignments-next-button"
             >
               Next
             </Button>

--- a/src/lib/Scenes/Consignments/Screens/Overview.tsx
+++ b/src/lib/Scenes/Consignments/Screens/Overview.tsx
@@ -163,6 +163,9 @@ export class Overview extends React.Component<Props, State> {
         {
           text: "Cancel",
           style: "cancel",
+          onPress: () => {
+            this.setState({ photos: this.state.photos?.filter((photo) => photo.uploaded) })
+          },
         },
         {
           text: "Retry",


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [SWA-198]

### Description

This PR fixes some cases when consign submission may be submitted without photos

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [X] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [X] I have tested my changes on **iOS** and **Android**.
- [X] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [X] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [X] I have documented any follow-up work that this PR will require, or it does not require any.
- [X] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [X] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix submission's photos saving 

<!-- end_changelog_updates -->

</details>


https://user-images.githubusercontent.com/79979820/152800069-8fcc9715-a9a0-4e80-98a9-1fc3ae045126.mov


[SWA-198]: https://artsyproduct.atlassian.net/browse/SWA-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ