### PR TITLE
feat(tracking): moving the top-level tracking to the AppProviders

### DIFF
--- a/patches/@types+react-relay+11.0.3.patch
+++ b/patches/@types+react-relay+11.0.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@types/react-relay/relay-hooks/RelayEnvironmentProvider.react.d.ts b/node_modules/@types/react-relay/relay-hooks/RelayEnvironmentProvider.react.d.ts
+index 585fa73..b9c564c 100755
+--- a/node_modules/@types/react-relay/relay-hooks/RelayEnvironmentProvider.react.d.ts
++++ b/node_modules/@types/react-relay/relay-hooks/RelayEnvironmentProvider.react.d.ts
+@@ -2,7 +2,7 @@ import { ProviderProps, ReactElement, ReactNode } from 'react';
+ import { IEnvironment, RelayContext } from 'relay-runtime';
+ 
+ export interface Props {
+-    children: ReactNode;
++    children?: ReactNode;
+     environment: IEnvironment;
+ }
+ 

--- a/src/lib/AndroidApp.tsx
+++ b/src/lib/AndroidApp.tsx
@@ -1,7 +1,7 @@
 import { GoogleSignin } from "@react-native-google-signin/google-signin"
 import { GlobalStore } from "lib/store/GlobalStore"
 import { AdminMenuWrapper } from "lib/utils/AdminMenuWrapper"
-import { addTrackingProvider, track } from "lib/utils/track"
+import { addTrackingProvider } from "lib/utils/track"
 import {
   SEGMENT_TRACKING_PROVIDER,
   SegmentTrackingProvider,
@@ -35,7 +35,7 @@ if (UIManager.setLayoutAnimationEnabledExperimental) {
   UIManager.setLayoutAnimationEnabledExperimental(true)
 }
 
-const Main: React.FC<{}> = track()(({}) => {
+const Main: React.FC = () => {
   useEffect(() => {
     GoogleSignin.configure({
       webClientId: "673710093763-hbj813nj4h3h183c4ildmu8vvqc0ek4h.apps.googleusercontent.com",
@@ -104,7 +104,7 @@ const Main: React.FC<{}> = track()(({}) => {
       <BottomTabsNavigator />
     </ModalStack>
   )
-})
+}
 
 export const App = () => (
   <AppProviders>

--- a/src/lib/AppProviders.tsx
+++ b/src/lib/AppProviders.tsx
@@ -1,6 +1,6 @@
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { Theme } from "palette"
-import React, { ReactNode } from "react"
+import React, { ComponentClass, FC, ReactNode } from "react"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { RelayEnvironmentProvider } from "react-relay"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
@@ -10,6 +10,7 @@ import { ToastProvider } from "./Components/Toast/toastHook"
 import { defaultEnvironment } from "./relay/createEnvironment"
 import { GlobalStoreProvider } from "./store/GlobalStore"
 import { ProvideScreenDimensions } from "./utils/useScreenDimensions"
+import { combineProviders } from "./utils/combineProviders"
 
 export const AppProviders = ({ children }: { children: ReactNode }) => {
   return (

--- a/src/lib/AppProviders.tsx
+++ b/src/lib/AppProviders.tsx
@@ -1,6 +1,6 @@
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { Theme } from "palette"
-import React, { ComponentClass, FC, ReactNode } from "react"
+import React, { Component, ComponentClass, FC, ReactNode } from "react"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { RelayEnvironmentProvider } from "react-relay"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
@@ -11,31 +11,41 @@ import { defaultEnvironment } from "./relay/createEnvironment"
 import { GlobalStoreProvider } from "./store/GlobalStore"
 import { ProvideScreenDimensions } from "./utils/useScreenDimensions"
 import { combineProviders } from "./utils/combineProviders"
+import track from "react-tracking"
 
-export const AppProviders = ({ children }: { children: ReactNode }) => {
-  return (
-    <SafeAreaProvider>
-      <ProvideScreenDimensions>
-        <GlobalStoreProvider>
-          <RelayEnvironmentProvider environment={defaultEnvironment}>
-            <Theme>
-              <RetryErrorBoundary>
-                <ActionSheetProvider>
-                  <PopoverMessageProvider>
-                    <_FancyModalPageWrapper>
-                      <ToastProvider>
-                        {/*  */}
-                        {children}
-                        {/*  */}
-                      </ToastProvider>
-                    </_FancyModalPageWrapper>
-                  </PopoverMessageProvider>
-                </ActionSheetProvider>
-              </RetryErrorBoundary>
-            </Theme>
-          </RelayEnvironmentProvider>
-        </GlobalStoreProvider>
-      </ProvideScreenDimensions>
-    </SafeAreaProvider>
+export const AppProviders = ({ children }: { children?: ReactNode }) =>
+  combineProviders(
+    [
+      // order matters here, be careful!
+      // if Provider A is using another Provider B, then A needs to appear below B.
+      TrackingProvider,
+      SafeAreaProvider,
+      ProvideScreenDimensions, // uses: SafeAreaProvider
+      GlobalStoreProvider,
+      RelayDefaultEnvProvider,
+      Theme,
+      RetryErrorBoundary,
+      ActionSheetProvider,
+      PopoverMessageProvider,
+      _FancyModalPageWrapper,
+      ToastProvider, // uses: GlobalStoreProvider
+    ],
+    children
   )
+
+// Providers with preset props
+
+// relay needs the default environment
+const RelayDefaultEnvProvider: FC = (props) => (
+  <RelayEnvironmentProvider environment={defaultEnvironment} {...props} />
+)
+
+// react-track has no provider, we make one using the decorator and a class wrapper
+const TrackingProvider: FC = (props) => <PureWrapper {...props} />
+
+@track()
+class PureWrapper extends Component {
+  render() {
+    return this.props.children
+  }
 }

--- a/src/lib/AppProviders.tsx
+++ b/src/lib/AppProviders.tsx
@@ -1,6 +1,6 @@
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { Theme } from "palette"
-import React, { Component, ComponentClass, FC, ReactNode } from "react"
+import React, { Component, FC, ReactNode } from "react"
 import { SafeAreaProvider } from "react-native-safe-area-context"
 import { RelayEnvironmentProvider } from "react-relay"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
@@ -9,9 +9,9 @@ import { RetryErrorBoundary } from "./Components/RetryErrorBoundary"
 import { ToastProvider } from "./Components/Toast/toastHook"
 import { defaultEnvironment } from "./relay/createEnvironment"
 import { GlobalStoreProvider } from "./store/GlobalStore"
-import { ProvideScreenDimensions } from "./utils/useScreenDimensions"
 import { combineProviders } from "./utils/combineProviders"
-import track from "react-tracking"
+import { track } from "./utils/track"
+import { ProvideScreenDimensions } from "./utils/useScreenDimensions"
 
 export const AppProviders = ({ children }: { children?: ReactNode }) =>
   combineProviders(

--- a/src/lib/AppRegistry.tsx
+++ b/src/lib/AppRegistry.tsx
@@ -110,7 +110,7 @@ import { GlobalStore, useSelectedTab } from "./store/GlobalStore"
 import { propsStore } from "./store/PropsStore"
 import { AdminMenu } from "./utils/AdminMenu"
 import { useInitializeQueryPrefetching } from "./utils/queryPrefetching"
-import { addTrackingProvider, Schema, screenTrack, track } from "./utils/track"
+import { addTrackingProvider, Schema, screenTrack } from "./utils/track"
 import { ConsoleTrackingProvider } from "./utils/track/ConsoleTrackingProvider"
 import {
   SEGMENT_TRACKING_PROVIDER,
@@ -223,7 +223,6 @@ const InnerPageWrapper: React.FC<PageWrapperProps> = ({
   )
 }
 
-@track()
 class PageWrapper extends React.Component<PageWrapperProps> {
   pageProps: PageWrapperProps
 
@@ -446,7 +445,7 @@ for (const moduleName of Object.keys(modules)) {
   }
 }
 
-const Main: React.FC<{}> = track()(({}) => {
+const Main: React.FC = () => {
   usePreferredThemeTracking()
   useScreenReaderTracking()
   useFreshInstallTracking()
@@ -483,7 +482,7 @@ const Main: React.FC<{}> = track()(({}) => {
   }
 
   return <BottomTabsNavigator />
-})
+}
 
 if (Platform.OS === "ios") {
   register("Artsy", Main, { fullBleed: true, isMainView: true, moduleName: "Artsy" })

--- a/src/lib/Components/RetryErrorBoundary.tsx
+++ b/src/lib/Components/RetryErrorBoundary.tsx
@@ -1,5 +1,5 @@
 import { captureMessage } from "@sentry/react-native"
-import React, { FC } from "react"
+import React, { FC, ReactNode } from "react"
 import { LoadFailureView } from "./LoadFailureView"
 
 enum ErrorState {
@@ -46,6 +46,7 @@ export class RetryErrorBoundaryLegacy extends React.Component<Props, State> {
 // Taken from https://relay.dev/docs/guided-tour/rendering/error-states/#when-using-uselazyloadquery
 interface RetryErrorBoundaryProps {
   failureView?: FC<{ error: Error; retry: () => void }>
+  children: ReactNode
 }
 interface RetryErrorBoundaryState {
   error: Error | null

--- a/src/lib/utils/combineProviders.tests.tsx
+++ b/src/lib/utils/combineProviders.tests.tsx
@@ -1,0 +1,42 @@
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
+import React, { ReactNode } from "react"
+import { View } from "react-native"
+import { combineProviders } from "./combineProviders"
+
+const Child = () => <View testID="child" />
+const ProviderA = (props: any) => <View testID="A" {...props} />
+const ProviderB = (props: any) => <View testID="B" {...props} />
+const ProviderCSpecial = (props: { needed: string }) => <View testID="C" {...props} />
+const ProviderC = (props: any) => <ProviderCSpecial needed="special" {...props} />
+
+describe("combineProviders", () => {
+  it("works", () => {
+    const Providers = ({ children }: { children?: ReactNode }) =>
+      combineProviders([ProviderA, ProviderB, ProviderC], children)
+
+    const { toJSON } = renderWithWrappersTL(
+      <Providers>
+        <Child />
+      </Providers>
+    )
+
+    expect(toJSON()).toMatchInlineSnapshot(`
+      <View
+        testID="A"
+      >
+        <View
+          testID="B"
+        >
+          <View
+            needed="special"
+            testID="C"
+          >
+            <View
+              testID="child"
+            />
+          </View>
+        </View>
+      </View>
+    `)
+  })
+})

--- a/src/lib/utils/combineProviders.tsx
+++ b/src/lib/utils/combineProviders.tsx
@@ -2,5 +2,35 @@ import React, { ComponentClass, FC, ReactNode } from "react"
 
 type ProviderList = Array<FC | ComponentClass<{ children: ReactNode }>>
 
+/**
+ * This function can takes a list of Providers and returns
+ * one Provider that contains all of them.
+ * It's used to provide a cleaner way to combine multiple Providers.
+ *
+ * Usage:
+ * const AppProviders = ({children}) => combineProviders(
+ *   [
+ *     ProviderA,
+ *     ProviderB,
+ *     ProviderC,
+ *   ],
+ *   children
+ * )
+ *
+ * This will be the same as writing the following:
+ * const AppProviders = ({children}) => (
+ *   <ProviderA>
+ *     <ProviderB>
+ *       <ProviderC>
+ *         {children}
+ *       </ProviderC>
+ *     </ProviderB>
+ *   </ProviderA>
+ * )
+ *
+ * @param list A list of Providers.
+ * @param children The children that will be wrapped.
+ * @returns A Provider that includes all the Providers from `list`.
+ */
 export const combineProviders = (list: ProviderList, children: ReactNode) =>
   list.reduceRight((acc, Provider) => <Provider>{acc}</Provider>, <>{children}</>)

--- a/src/lib/utils/combineProviders.tsx
+++ b/src/lib/utils/combineProviders.tsx
@@ -1,0 +1,6 @@
+import React, { ComponentClass, FC, ReactNode } from "react"
+
+type ProviderList = Array<FC | ComponentClass<{ children: ReactNode }>>
+
+export const combineProviders = (list: ProviderList, children: ReactNode) =>
+  list.reduceRight((acc, Provider) => <Provider>{acc}</Provider>, <>{children}</>)


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description

This PR is moving the tracking to the AppProviders, and also adds a little helper function to list Providers in a nicer, flatter way. It also allows for Providers that need props, like the relay and the tracking one.

⚠️  Since this has broken before, I would appreciate if at least one of the reviewers runs the app to verify the events fire. I tested it on ios and it seems to be firing, but a second verification would be nice. Also, the android emulator is giving me attitude today, and I cant make it work right now. The changes should be fine there, but again I would like it if one of you runs this on android to verify. ⚠️ 
The way to verify is to enable the analytics inspector dev toggle from the admin menu. then click around and toasts should pop up with all your actions. If you do run it, comment, so we know that someone did run it. Thank you.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [ ] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- move tracking to Providers [NEEDS QA] - pavlos

<!-- end_changelog_updates -->

</details>
