### PR TITLE
chore(FX-3731): Saved Alerts copy updates

### DIFF
--- a/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/lib/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -30,7 +30,7 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
 
     popover.show({
       title: "Your alert has been created.",
-      message: "You can edit your alerts with your Profile.",
+      message: "Edit your alerts in your profile, in Settings.",
       onPress: async () => {
         const options: NavigateOptions = {
           popToRootTabView: true,

--- a/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/FilterModal.tests.tsx
@@ -273,7 +273,7 @@ describe("Filter modal states", () => {
   it("displays the filter screen apply button correctly when no filters are selected", () => {
     const { getByText } = renderWithWrappersTL(<MockFilterModalNavigator />)
 
-    expect(getByText("Apply Filters")).toBeDisabled()
+    expect(getByText("Show Results")).toBeDisabled()
   })
 
   it("displays the filter screen apply button correctly when filters are selected", () => {
@@ -294,7 +294,7 @@ describe("Filter modal states", () => {
       <MockFilterModalNavigator initialData={injectedState} />
     )
 
-    expect(getByText("Apply Filters")).not.toBeDisabled()
+    expect(getByText("Show Results")).not.toBeDisabled()
   })
 
   it("does not display default filters numbers on the Filter modal", () => {
@@ -402,7 +402,7 @@ describe("Clearing filters", () => {
       <MockFilterModalNavigator initialData={injectedState} />
     )
 
-    expect(getByText("Apply Filters")).toBeDisabled()
+    expect(getByText("Show Results")).toBeDisabled()
 
     fireEvent.press(getByText("Clear All"))
 
@@ -537,7 +537,7 @@ describe("Applying filters on Artworks", () => {
 
     mockEnvironmentPayload(env)
 
-    fireEvent.press(getByText("Apply Filters"))
+    fireEvent.press(getByText("Show Results"))
 
     expect(trackEvent).toHaveBeenCalledWith({
       action_type: "commercialFilterParamsChanged",

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tests.tsx
@@ -18,7 +18,7 @@ describe("ArtworkFilterApplyButton", () => {
   it("cannot press if disabled prop is passed", () => {
     const onPressMock = jest.fn()
     const { getByText } = renderWithWrappersTL(<TestWrapper disabled />)
-    const button = getByText("Apply Filters")
+    const button = getByText("Show Results")
 
     fireEvent.press(button)
 
@@ -30,7 +30,7 @@ describe("ArtworkFilterApplyButton", () => {
     const onPressMock = jest.fn()
     const { getByText } = renderWithWrappersTL(<TestWrapper onPress={onPressMock} />)
 
-    fireEvent.press(getByText("Apply Filters"))
+    fireEvent.press(getByText("Show Results"))
 
     expect(onPressMock).toBeCalled()
   })

--- a/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/lib/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -88,7 +88,7 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
                 <Box width="1" height={20} backgroundColor="white100" mx={1} />
               </>
             )}
-            <InnerButton disabled={disabled} label="Apply Filters" onPress={onPress} />
+            <InnerButton disabled={disabled} label="Show Results" onPress={onPress} />
           </Box>
         </Box>
       </SafeAreaView>

--- a/src/lib/Components/Gene/GeneArtworks.tests.tsx
+++ b/src/lib/Components/Gene/GeneArtworks.tests.tsx
@@ -102,7 +102,7 @@ describe("GeneArtworks", () => {
     fireEvent.press(getByText("Sort & Filter"))
     fireEvent.press(getByText("Sort By"))
     fireEvent.press(getByText("Recently Added"))
-    fireEvent.press(getByText("Apply Filters"))
+    fireEvent.press(getByText("Show Results"))
 
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {

--- a/src/lib/Components/Tag/TagArtworks.tests.tsx
+++ b/src/lib/Components/Tag/TagArtworks.tests.tsx
@@ -98,7 +98,7 @@ describe("TagArtworks", () => {
     fireEvent.press(getByText("Sort & Filter"))
     fireEvent.press(getByText("Sort By"))
     fireEvent.press(getByText("Recently Added"))
-    fireEvent.press(getByText("Apply Filters"))
+    fireEvent.press(getByText("Show Results"))
 
     mockEnvironmentPayload(environment, {
       FilterArtworksConnection() {

--- a/src/lib/Scenes/MyCollection/MyCollection.tests.tsx
+++ b/src/lib/Scenes/MyCollection/MyCollection.tests.tsx
@@ -153,7 +153,7 @@ const applyFilter = async (renderApi: RenderAPI, filterName: string, filterOptio
   act(() => fireEvent.press(renderApi.getByTestId("sort-and-filter-button")))
   act(() => fireEvent.press(renderApi.getByText(filterName)))
   act(() => fireEvent.press(renderApi.getByText(filterOption)))
-  act(() => fireEvent.press(renderApi.getByText("Apply Filters")))
+  act(() => fireEvent.press(renderApi.getByText("Show Results")))
 }
 
 const mockArtworkConnection = {

--- a/src/lib/Scenes/Sale/Sale.tests.tsx
+++ b/src/lib/Scenes/Sale/Sale.tests.tsx
@@ -33,7 +33,6 @@ describe("Sale", () => {
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedAlertsFlow: false })
   })
 
   afterEach(() => {

--- a/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -110,7 +110,7 @@ export const Form: React.FC<FormProps> = (props) => {
     <Box>
       {!isEditMode && (
         <Text variant="lg" mb={4}>
-          Create an Alert
+          Create Alert
         </Text>
       )}
 
@@ -187,7 +187,7 @@ export const Form: React.FC<FormProps> = (props) => {
       {!!shouldShowEmailWarning && (
         <Box backgroundColor="orange10" my={1} p={2}>
           <Text variant="xs" color="orange150">
-            Your email frequency is set to None
+            Change your email frequency
           </Text>
           <Text variant="xs" mt={0.5}>
             To receive Email Alerts, please update your email preferences.
@@ -232,7 +232,7 @@ export const Form: React.FC<FormProps> = (props) => {
         )}
         {!isEditMode && (
           <Text variant="sm" color="black60" textAlign="center" my={2}>
-            You will be able to access all your Saved Alerts in your Profile.
+            Access all your saved alerts in your profile.
           </Text>
         )}
       </Box>

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -250,7 +250,7 @@ describe("Saved search alert form", () => {
       <TestRenderer savedSearchAlertId="savedSearchAlertId" userAllowsEmails={false} />
     )
 
-    expect(getByText("Your email frequency is set to None")).toBeTruthy()
+    expect(getByText("Change your email frequency")).toBeTruthy()
     expect(getByText("To receive Email Alerts, please update your email preferences.")).toBeTruthy()
   })
 
@@ -647,7 +647,7 @@ describe("Saved search alert form", () => {
 
       it('should call create mutation when "Replace" button is pressed', async () => {
         // @ts-ignore
-        spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Replace" button
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[2].onPress()) // Click "Replace" button
 
         const { getAllByText } = renderWithWrappersTL(<TestRenderer />)
 
@@ -694,7 +694,10 @@ describe("Saved search alert form", () => {
         })
       })
 
-      it("should display a warning message if there is a duplicate", async () => {
+      it("should display a warning message if there is a duplicate and user is able to view duplicate alert", async () => {
+        // @ts-ignore
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "View Duplicate" button
+
         const { getAllByText, getByText } = renderWithWrappersTL(
           <TestRenderer savedSearchAlertId="savedSearchAlertId" />
         )
@@ -710,11 +713,13 @@ describe("Saved search alert form", () => {
         mockEnvironmentPayload(mockEnvironment)
 
         await waitFor(() => expect(spyAlert.mock.calls[0][0]).toBe("Duplicate Alert"))
+
+        expect(navigate).toBeCalledWith("/my-profile/saved-search-alerts/internalID-1")
       })
 
       it('should call update mutation when "Replace" button is pressed', async () => {
         // @ts-ignore
-        spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Replace" button
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[2].onPress()) // Click "Replace" button
 
         const { getAllByText, getByText } = renderWithWrappersTL(
           <TestRenderer savedSearchAlertId="savedSearchAlertId" />

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -647,7 +647,7 @@ describe("Saved search alert form", () => {
 
       it('should call create mutation when "Replace" button is pressed', async () => {
         // @ts-ignore
-        spyAlert.mockImplementation((_title, _message, buttons) => buttons[2].onPress()) // Click "Replace" button
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
 
         const { getAllByText } = renderWithWrappersTL(<TestRenderer />)
 
@@ -719,7 +719,7 @@ describe("Saved search alert form", () => {
 
       it('should call update mutation when "Replace" button is pressed', async () => {
         // @ts-ignore
-        spyAlert.mockImplementation((_title, _message, buttons) => buttons[2].onPress()) // Click "Replace" button
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
 
         const { getAllByText, getByText } = renderWithWrappersTL(
           <TestRenderer savedSearchAlertId="savedSearchAlertId" />

--- a/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/lib/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -4,6 +4,7 @@ import {
   SearchCriteria,
   SearchCriteriaAttributes,
 } from "lib/Components/ArtworkFilter/SavedSearch/types"
+import { goBack, navigate } from "lib/navigation/navigate"
 import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Dialog, quoteLeft, quoteRight, useTheme } from "palette"
 import React, { useEffect, useState } from "react"
@@ -96,7 +97,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       try {
         const clearedAttributes = clearDefaultAttributes(attributes)
         const submitHandler = isUpdateForm ? handleUpdateAlert : handleCreateAlert
-        let duplicateSavedSearchId = null
+        let duplicateSavedSearchId: string | undefined
 
         /**
          * We perform the mutation only if
@@ -120,6 +121,10 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
           showWarningMessageForDuplicateAlert({
             onReplacePress: () => {
               submitHandler(userAlertSettings, clearedAttributes)
+            },
+            onViewDuplicatePress: () => {
+              goBack()
+              navigate(`/my-profile/saved-search-alerts/${duplicateSavedSearchId}`)
             },
           })
           return
@@ -274,7 +279,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         <Dialog
           isVisible={visibleDeleteDialog}
           title="Delete Alert"
-          detail="Once deleted, you will no longer receive notifications for these filter criteria."
+          detail="You will no longer receive notifications for artworks matching the criteria in this alert."
           primaryCta={{
             text: "Delete",
             onPress: () => {
@@ -283,7 +288,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
             },
           }}
           secondaryCta={{
-            text: "Cancel",
+            text: "Keep Alert",
             onPress: () => {
               setVisibleDeleteDialog(false)
             },

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -120,16 +120,16 @@ export const showWarningMessageForDuplicateAlert = ({
     "You already have a saved alert with these filters. Do you want to replace it?",
     [
       {
-        text: "Cancel",
+        onPress: onReplacePress,
+        style: "destructive",
+        text: "Replace",
       },
       {
         onPress: onViewDuplicatePress,
         text: "View Duplicate",
       },
       {
-        onPress: onReplacePress,
-        style: "destructive",
-        text: "Replace",
+        text: "Cancel",
       },
     ]
   )

--- a/src/lib/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/lib/Scenes/SavedSearchAlert/helpers.ts
@@ -110,15 +110,21 @@ export const clearDefaultAttributes = (attributes: SearchCriteriaAttributes) => 
 
 export const showWarningMessageForDuplicateAlert = ({
   onReplacePress,
+  onViewDuplicatePress,
 }: {
   onReplacePress: () => void
+  onViewDuplicatePress: () => void
 }) => {
   Alert.alert(
     "Duplicate Alert",
-    "You already have a Saved Alert with these filters. Do you want to replace it?",
+    "You already have a saved alert with these filters. Do you want to replace it?",
     [
       {
         text: "Cancel",
+      },
+      {
+        onPress: onViewDuplicatePress,
+        text: "View Duplicate",
       },
       {
         onPress: onReplacePress,

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
@@ -1,5 +1,5 @@
 import { navigate } from "lib/navigation/navigate"
-import { Box, Button, Flex, Spacer, Text } from "palette"
+import { Box, Button, Flex, quoteLeft, quoteRight, Spacer, Text } from "palette"
 import React from "react"
 import { ScrollView } from "react-native"
 
@@ -9,12 +9,11 @@ export const EmptyMessage: React.FC = () => {
       <Flex px={2} py={4} justifyContent="center" alignItems="center" height="100%">
         <Box maxWidth="80%" alignItems="center">
           <Text variant="md" textAlign="center">
-            You haven’t created any Alerts yet.
+            Create an alert to get notified about new works.
           </Text>
           <Spacer mb={1} />
           <Text textAlign="center" variant="xs" color="black60">
-            Filter for the artworks you love on an Artist Page and tap ‘Create Alert’ to be notified
-            when new works are added to Artsy.
+            {`Search for an artist, use the filters to define the artwork you want, and select ${quoteLeft}Create Alert.${quoteRight}`}
           </Text>
           <Spacer mb={2} />
           <Button onPress={() => navigate("/")}>Explore Artists</Button>

--- a/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/lib/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -75,7 +75,7 @@ describe("SavedSearches", () => {
       }),
     })
 
-    expect(getByText("You haven’t created any Alerts yet.")).toBeTruthy()
+    expect(getByText("Create an alert to get notified about new works.")).toBeTruthy()
   })
 
   it("renders the default name placeholder if there is no name for saved search alert", () => {


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3731]

### Description

The purpose of this pr is to update the Alert Flow copies in the app and adding a View Duplicate button in the Duplicate alert prompt, in order collectors to be able to view with one press of a button the duplicate alert.

#### Screenshots 
|Screenshots||||
|--|--|--|--|
|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 14 26](https://user-images.githubusercontent.com/21178754/153245507-1bac53e1-0277-4cee-b02f-f18945b4b3be.png)|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 14 21](https://user-images.githubusercontent.com/21178754/153245510-a5b36da8-2ad4-4eef-b629-db305d92f20c.png)|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 28 57](https://user-images.githubusercontent.com/21178754/153245477-0052c51c-ea71-4a1e-8b49-d6710f106f00.png)|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 24 08](https://user-images.githubusercontent.com/21178754/153245486-3642780f-4f0a-48ee-9a18-59c82614f0de.png)|
|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 14 56](https://user-images.githubusercontent.com/21178754/153245495-fc32d64f-5690-4dfc-be59-a3c10eeee94c.png)|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 15 34](https://user-images.githubusercontent.com/21178754/153245490-ed3e715c-5f41-4eac-bb32-bdc10f1b2ff2.png)|![Simulator Screen Shot - iPhone 13 mini - 2022-02-09 at 17 34 34](https://user-images.githubusercontent.com/21178754/153246128-68384e5c-2d33-43c4-91d5-257479d49d3e.png)|

#### Video

![Simulator Screen Recording - iPhone 13 mini - 2022-02-09 at 17 37 32](https://user-images.githubusercontent.com/21178754/153246812-cac5703a-2b00-4767-972a-42ab0ab2f8d4.gif)



<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- saved alert copy updates and add view duplicate alert button - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>


[FX-3671]: https://artsyproduct.atlassian.net/browse/FX-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-3731]: https://artsyproduct.atlassian.net/browse/FX-3731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ