### PR TITLE
feat(TX-168): add Avalara phase 2 feature flag and new tax message

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
@@ -1,3 +1,4 @@
+import { CommercialPartnerInformation_artwork } from "__generated__/CommercialPartnerInformation_artwork.graphql"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { __globalStoreTestUtils__, GlobalStoreProvider } from "lib/store/GlobalStore"
@@ -126,7 +127,7 @@ describe("CommercialPartnerInformation", () => {
   })
 })
 
-const CommercialPartnerInformationArtwork = {
+const CommercialPartnerInformationArtwork: CommercialPartnerInformation_artwork = {
   availability: "for sale",
   isAcquireable: true,
   isForSale: true,
@@ -137,5 +138,5 @@ const CommercialPartnerInformationArtwork = {
     name: "Bob's Gallery",
   },
   priceIncludesTaxDisplay: "VAT included in price",
-  " $refType": null as any,
+  " $refType": "CommercialPartnerInformation_artwork",
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
@@ -1,6 +1,6 @@
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
-import { GlobalStoreProvider } from "lib/store/GlobalStore"
+import { __globalStoreTestUtils__, GlobalStoreProvider } from "lib/store/GlobalStore"
 import { Sans, Theme } from "palette"
 import React from "react"
 import { CommercialPartnerInformation } from "./CommercialPartnerInformation"
@@ -10,10 +10,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <GlobalStoreProvider>
         <Theme>
-          <CommercialPartnerInformation
-            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-            artwork={CommercialPartnerInformationArtwork}
-          />
+          <CommercialPartnerInformation artwork={CommercialPartnerInformationArtwork} />
         </Theme>
       </GlobalStoreProvider>
     )
@@ -29,6 +26,20 @@ describe("CommercialPartnerInformation", () => {
     )
   })
 
+  it("it renders 'Taxes may apply at checkout' instead of 'VAT included in price' when Avalara phase 2 flag is enabled", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableAvalaraPhase2: true })
+    const component = mount(
+      <GlobalStoreProvider>
+        <Theme>
+          <CommercialPartnerInformation artwork={CommercialPartnerInformationArtwork} />
+        </Theme>
+      </GlobalStoreProvider>
+    )
+    expect(component.find(Sans).at(3).render().text()).toMatchInlineSnapshot(
+      `"Taxes may apply at checkout. Learn more."`
+    )
+  })
+
   it("hides shipping info for works from closed auctions", () => {
     const CommercialPartnerInformationArtworkClosedAuction = {
       ...CommercialPartnerInformationArtwork,
@@ -41,7 +52,6 @@ describe("CommercialPartnerInformation", () => {
       <GlobalStoreProvider>
         <Theme>
           <CommercialPartnerInformation
-            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={CommercialPartnerInformationArtworkClosedAuction}
           />
         </Theme>
@@ -63,7 +73,6 @@ describe("CommercialPartnerInformation", () => {
       <GlobalStoreProvider>
         <Theme>
           <CommercialPartnerInformation
-            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={CommercialPartnerInformationArtworkClosedAuction}
           />
         </Theme>
@@ -83,10 +92,7 @@ describe("CommercialPartnerInformation", () => {
     const component = mount(
       <GlobalStoreProvider>
         <Theme>
-          <CommercialPartnerInformation
-            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-            artwork={CommercialPartnerInformationNoEcommerce}
-          />
+          <CommercialPartnerInformation artwork={CommercialPartnerInformationNoEcommerce} />
         </Theme>
       </GlobalStoreProvider>
     )
@@ -107,7 +113,6 @@ describe("CommercialPartnerInformation", () => {
       <GlobalStoreProvider>
         <Theme>
           <CommercialPartnerInformation
-            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
             artwork={CommercialPartnerInformationArtworkClosedAuction}
           />
         </Theme>
@@ -129,5 +134,5 @@ const CommercialPartnerInformationArtwork = {
     name: "Bob's Gallery",
   },
   priceIncludesTaxDisplay: "VAT included in price",
-  " $refType": null,
+  " $refType": null as any,
 }

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
@@ -2,6 +2,7 @@ import { CommercialPartnerInformation_artwork } from "__generated__/CommercialPa
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { __globalStoreTestUtils__, GlobalStoreProvider } from "lib/store/GlobalStore"
+import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import { Sans, Theme } from "palette"
 import React from "react"
 import { CommercialPartnerInformation } from "./CommercialPartnerInformation"
@@ -29,19 +30,11 @@ describe("CommercialPartnerInformation", () => {
 
   it("it renders 'Taxes may apply at checkout' instead of 'VAT included in price' when Avalara phase 2 flag is enabled", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableAvalaraPhase2: true })
-    const component = mount(
-      <GlobalStoreProvider>
-        <Theme>
-          <CommercialPartnerInformation artwork={CommercialPartnerInformationArtwork} />
-        </Theme>
-      </GlobalStoreProvider>
+    const { getByText } = renderWithWrappersTL(
+      <CommercialPartnerInformation artwork={CommercialPartnerInformationArtwork} />
     )
-    expect(component.find(Sans).at(1).render().text()).toMatchInlineSnapshot(
-      `"Taxes may apply at checkout. Learn more."`
-    )
-    expect(component.find(Sans).at(3).render().text()).toMatchInlineSnapshot(
-      `"Ships within the continental USA"`
-    )
+
+    expect(getByText("Taxes may apply at checkout.")).toBeTruthy()
   })
 
   it("hides shipping info for works from closed auctions", () => {

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
@@ -35,8 +35,11 @@ describe("CommercialPartnerInformation", () => {
         </Theme>
       </GlobalStoreProvider>
     )
-    expect(component.find(Sans).at(3).render().text()).toMatchInlineSnapshot(
+    expect(component.find(Sans).at(1).render().text()).toMatchInlineSnapshot(
       `"Taxes may apply at checkout. Learn more."`
+    )
+    expect(component.find(Sans).at(3).render().text()).toMatchInlineSnapshot(
+      `"Ships within the continental USA"`
     )
   })
 

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -1,7 +1,7 @@
 import { CommercialPartnerInformation_artwork } from "__generated__/CommercialPartnerInformation_artwork.graphql"
 import { LinkText } from "lib/Components/Text/LinkText"
 import { navigate } from "lib/navigation/navigate"
-import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
+import { useFeatureFlag } from "lib/store/GlobalStore"
 import { Sans, Spacer } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -10,56 +10,54 @@ interface Props {
   artwork: CommercialPartnerInformation_artwork
 }
 
-export class CommercialPartnerInformation extends React.Component<Props> {
-  render() {
-    const { artwork } = this.props
-    const artworkIsSold = artwork.availability && artwork.availability === "sold"
-    const artworkEcommerceAvailable = artwork.isAcquireable || artwork.isOfferable
-    const showsSellerInfo = artwork.partner && artwork.partner.name
-    const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "From" : "At"
-    const avalaraPhase2 = unsafe_getFeatureFlag("AREnableAvalaraPhase2")
-    return (
-      <>
-        {showsSellerInfo && (
-          <>
-            <Spacer mb={1} />
+export const CommercialPartnerInformation: React.FC<Props> = ({ artwork }) => {
+  const artworkIsSold = artwork.availability && artwork.availability === "sold"
+  const artworkEcommerceAvailable = artwork.isAcquireable || artwork.isOfferable
+  const showsSellerInfo = artwork.partner && artwork.partner.name
+  const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "From" : "At"
+  const avalaraPhase2 = useFeatureFlag("AREnableAvalaraPhase2")
+
+  return (
+    <>
+      {showsSellerInfo && (
+        <>
+          <Spacer mb={1} />
+          <Sans size="3t" color="black60">
+            {availabilityDisplayText} {artwork.partner! /* STRICTNESS_MIGRATION */.name}
+          </Sans>
+          {avalaraPhase2 && (
             <Sans size="3t" color="black60">
-              {availabilityDisplayText} {artwork.partner! /* STRICTNESS_MIGRATION */.name}
+              Taxes may apply at checkout.{" "}
+              <LinkText
+                onPress={() => {
+                  navigate(
+                    "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+                  )
+                }}
+              >
+                Learn more.
+              </LinkText>
             </Sans>
-            {avalaraPhase2 && (
-              <Sans size="3t" color="black60">
-                Taxes may apply at checkout.{" "}
-                <LinkText
-                  onPress={() => {
-                    navigate(
-                      "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
-                    )
-                  }}
-                >
-                  Learn more.
-                </LinkText>
-              </Sans>
-            )}
-            {artworkEcommerceAvailable && !!artwork.shippingOrigin && (
-              <Sans size="3t" color="black60">
-                Ships from {artwork.shippingOrigin}
-              </Sans>
-            )}
-            {artworkEcommerceAvailable && !!artwork.shippingInfo && (
-              <Sans size="3t" color="black60">
-                {artwork.shippingInfo}
-              </Sans>
-            )}
-            {artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && !avalaraPhase2 && (
-              <Sans size="3t" color="black60">
-                {artwork.priceIncludesTaxDisplay}
-              </Sans>
-            )}
-          </>
-        )}
-      </>
-    )
-  }
+          )}
+          {artworkEcommerceAvailable && !!artwork.shippingOrigin && (
+            <Sans size="3t" color="black60">
+              Ships from {artwork.shippingOrigin}
+            </Sans>
+          )}
+          {artworkEcommerceAvailable && !!artwork.shippingInfo && (
+            <Sans size="3t" color="black60">
+              {artwork.shippingInfo}
+            </Sans>
+          )}
+          {artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && !avalaraPhase2 && (
+            <Sans size="3t" color="black60">
+              {artwork.priceIncludesTaxDisplay}
+            </Sans>
+          )}
+        </>
+      )}
+    </>
+  )
 }
 
 export const CommercialPartnerInformationFragmentContainer = createFragmentContainer(

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -23,7 +23,7 @@ export const CommercialPartnerInformation: React.FC<Props> = ({ artwork }) => {
         <>
           <Spacer mb={1} />
           <Sans size="3t" color="black60">
-            {availabilityDisplayText} {artwork.partner! /* STRICTNESS_MIGRATION */.name}
+            {availabilityDisplayText} {artwork.partner!.name}
           </Sans>
           {avalaraPhase2 && (
             <Sans size="3t" color="black60">

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -1,4 +1,7 @@
 import { CommercialPartnerInformation_artwork } from "__generated__/CommercialPartnerInformation_artwork.graphql"
+import { LinkText } from "lib/Components/Text/LinkText"
+import { navigate } from "lib/navigation/navigate"
+import { unsafe_getFeatureFlag } from "lib/store/GlobalStore"
 import { Sans, Spacer } from "palette"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -14,6 +17,7 @@ export class CommercialPartnerInformation extends React.Component<Props> {
     const artworkEcommerceAvailable = artwork.isAcquireable || artwork.isOfferable
     const showsSellerInfo = artwork.partner && artwork.partner.name
     const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "From" : "At"
+    const avalaraPhase2 = unsafe_getFeatureFlag("AREnableAvalaraPhase2")
     return (
       <>
         {showsSellerInfo && (
@@ -32,9 +36,23 @@ export class CommercialPartnerInformation extends React.Component<Props> {
                 {artwork.shippingInfo}
               </Sans>
             )}
-            {artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && (
+            {artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && !avalaraPhase2 && (
               <Sans size="3t" color="black60">
                 {artwork.priceIncludesTaxDisplay}
+              </Sans>
+            )}
+            {avalaraPhase2 && (
+              <Sans size="3t" color="black60">
+                Taxes may apply at checkout.{" "}
+                <LinkText
+                  onPress={() => {
+                    navigate(
+                      "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+                    )
+                  }}
+                >
+                  Learn more.
+                </LinkText>
               </Sans>
             )}
           </>

--- a/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -26,6 +26,20 @@ export class CommercialPartnerInformation extends React.Component<Props> {
             <Sans size="3t" color="black60">
               {availabilityDisplayText} {artwork.partner! /* STRICTNESS_MIGRATION */.name}
             </Sans>
+            {avalaraPhase2 && (
+              <Sans size="3t" color="black60">
+                Taxes may apply at checkout.{" "}
+                <LinkText
+                  onPress={() => {
+                    navigate(
+                      "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
+                    )
+                  }}
+                >
+                  Learn more.
+                </LinkText>
+              </Sans>
+            )}
             {artworkEcommerceAvailable && !!artwork.shippingOrigin && (
               <Sans size="3t" color="black60">
                 Ships from {artwork.shippingOrigin}
@@ -39,20 +53,6 @@ export class CommercialPartnerInformation extends React.Component<Props> {
             {artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && !avalaraPhase2 && (
               <Sans size="3t" color="black60">
                 {artwork.priceIncludesTaxDisplay}
-              </Sans>
-            )}
-            {avalaraPhase2 && (
-              <Sans size="3t" color="black60">
-                Taxes may apply at checkout.{" "}
-                <LinkText
-                  onPress={() => {
-                    navigate(
-                      "https://support.artsy.net/hc/en-us/articles/360047294733-How-is-sales-tax-and-VAT-handled-on-works-listed-with-secure-checkout-"
-                    )
-                  }}
-                >
-                  Learn more.
-                </LinkText>
               </Sans>
             )}
           </>

--- a/src/lib/store/config/features.ts
+++ b/src/lib/store/config/features.ts
@@ -214,6 +214,11 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnablePlaceholderLayoutAnimation",
   },
+  AREnableAvalaraPhase2: {
+    readyForRelease: false,
+    description: "Enable Avalara Phase 2",
+    showInAdminMenu: true,
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [TX-168]

### Description

This PR removes the “VAT included in the price” on some artworks and replaces it with "Taxes may apply at checkout. Learn more" on **all** artworks. 

This update is hidden behind a new "Enable Avalara Phase 2" feature flag. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add Avalara phase 2 feature flag and new tax message on all artworks -rquartararo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

### Before

![Simulator Screen Shot - iPhone 11 Pro - 2022-02-11 at 11 33 56](https://user-images.githubusercontent.com/50849237/153577789-b0586a0a-f68c-4e50-b99b-1c2878c0a5c7.png)

#### After 

![Simulator Screen Shot - iPhone 11 Pro - 2022-02-11 at 11 37 56](https://user-images.githubusercontent.com/50849237/153579267-538c84a7-b50c-4eec-a72f-e5ec3d87b626.png)




[TX-168]: https://artsyproduct.atlassian.net/browse/TX-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ