### PR TITLE
fix: render logic of buttons given offerable artwork

### DIFF
--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tests.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tests.tsx
@@ -303,4 +303,19 @@ describe("CommercialButtons", () => {
     })
     expect(commercialButtons.find(Button).length).toEqual(0)
   })
+
+  it("renders both Make Offer and Contact Gallery buttons when isOfferable and isInquiriable", async () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isOfferable: true,
+      isForSale: false,
+      isInquireable: true,
+      isPriceHidden: false,
+    }
+    const commercialButtons = await relayComponent({
+      artwork,
+    })
+    expect(commercialButtons.find(Button).at(0).text()).toContain("Make offer")
+    expect(commercialButtons.find(Button).at(1).text()).toContain("Contact gallery")
+  })
 })

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -92,11 +92,33 @@ export class CommercialButtons extends React.Component<CommercialButtonProps> {
       )
     } else if (isOfferable) {
       return (
-        <MakeOfferButtonFragmentContainer
-          artwork={artwork}
-          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-          editionSetID={this.props.editionSetID}
-        />
+        <>
+          <MakeOfferButtonFragmentContainer
+            artwork={artwork}
+            // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+            editionSetID={this.props.editionSetID}
+          />
+          {isInquireable && <Spacer my={0.5} />}
+          {isInquireable && !newFirstInquiry && (
+            <Button
+              onPress={() => this.handleInquiry()}
+              size="large"
+              variant="outline"
+              block
+              width={100}
+              haptic
+            >
+              {InquiryOptions.ContactGallery}
+            </Button>
+          )}
+          {isInquireable && newFirstInquiry && (
+            <InquiryButtonsFragmentContainer
+              artwork={artwork}
+              editionSetID={this.props.editionSetID}
+              variant="outline"
+            />
+          )}
+        </>
       )
     } else if (isInquireable && !newFirstInquiry) {
       return (

--- a/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/lib/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -23,7 +23,7 @@ export interface InquiryButtonsState {
   modalIsVisible: boolean
 }
 
-const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork }) => {
+const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, variant }) => {
   const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
   const [notificationVisibility, setNotificationVisibility] = useState(false)
@@ -48,6 +48,7 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork }) => {
           trackEvent(tracks.trackTappedContactGallery(artwork.slug, artwork.internalID))
           dispatchAction(InquiryOptions.ContactGallery)
         }}
+        variant={variant}
         size="large"
         block
         width={100}


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

### Description

This PR addresses a bug when we have the offerable feature flag on in Gravity, we never had the situation where artwork is offerable and inquiriable with buttons appearing at the same time, `Make offer` and `Contact Gallery`.

This is a bugfix so we would touch anything else here, but we had a [ticket](https://artsyproduct.atlassian.net/browse/NX-3083) before the bug news that is going to address the refactor of this component, especially this if/else mess.

https://user-images.githubusercontent.com/15792853/154026154-1acd6426-9f46-4cf3-bc03-7f906a7a1479.mov

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- enable commercial buttons to show make offer and contact gallery at same time - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
