### PR TITLE
feat(FX-3739): Add size metric preference in filters

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
@@ -10,6 +10,7 @@ describe("CustomSizeInputs", () => {
         label="Label"
         range={{ min: "*", max: "*" }}
         onChange={jest.fn}
+        selectedMetric="in"
         {...props}
       />
     )

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -1,13 +1,15 @@
+import { Metric } from "lib/Scenes/Search/UserPreferencesModel"
 import { Box, Flex, Input, Join, Spacer, Text, useColor } from "palette"
 import React from "react"
 import { TextStyle } from "react-native"
-import { LOCALIZED_UNIT, Numeric, Range } from "./helpers"
+import { Numeric, Range } from "./helpers"
 
 export interface CustomSizeInputsProps {
   label: string
   range: Range
   active?: boolean
   onChange: (range: Range) => void
+  selectedMetric: Metric
 }
 
 // Helpers
@@ -24,6 +26,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
   range,
   active,
   onChange,
+  selectedMetric,
 }) => {
   const color = useColor()
   const handleInputChange = (field: keyof Range) => (text: string) => {
@@ -50,7 +53,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
             <Input
               keyboardType="number-pad"
               onChangeText={handleInputChange("min")}
-              placeholder={LOCALIZED_UNIT}
+              placeholder={selectedMetric}
               accessibilityLabel={`Minimum ${label} Input`}
               defaultValue={getValue(range.min)}
               inputTextStyle={inputTextStyle}
@@ -63,7 +66,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
             <Input
               keyboardType="number-pad"
               onChangeText={handleInputChange("max")}
-              placeholder={LOCALIZED_UNIT}
+              placeholder={selectedMetric}
               accessibilityLabel={`Maximum ${label} Input`}
               defaultValue={getValue(range.max)}
               inputTextStyle={inputTextStyle}

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -1,4 +1,4 @@
-import { Metric } from "lib/Scenes/Search/UserPreferencesModel"
+import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import { Box, Flex, Input, Join, Spacer, Text, useColor } from "palette"
 import React from "react"
 import { TextStyle } from "react-native"

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
@@ -426,7 +426,7 @@ describe("getCustomValues", () => {
       },
     ]
 
-    expect(getCustomValues(filters)).toEqual({
+    expect(getCustomValues(filters, "in")).toEqual({
       width: {
         min: 5,
         max: 10,
@@ -452,7 +452,7 @@ describe("getCustomValues", () => {
       },
     ]
 
-    expect(getCustomValues(filters)).toEqual({
+    expect(getCustomValues(filters, "in")).toEqual({
       width: {
         min: "*",
         max: 10,

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
@@ -146,7 +146,7 @@ describe("SizesOptionsScreen", () => {
   describe("Metric Radio Buttons", () => {
     it("should convert successfully the predefined sizes and placeholders on metric change", () => {
       __globalStoreTestUtils__?.injectState({
-        userPreferences: { metric: "in" },
+        userPrefs: { metric: "in" },
       })
       const { queryByText, queryAllByText, getByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
 

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { extractText } from "app/tests/extractText"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import React from "react"
@@ -88,14 +89,14 @@ describe("SizesOptionsScreen", () => {
   })
 
   it("single option can be selected", () => {
-    const { getByText, getByA11yState, getByTestId } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, getAllByA11yState, getByTestId } = renderWithWrappersTL(<TestRenderer />)
 
     fireEvent.press(getByText("Small (under 16in)"))
 
     const filters = getFilters(getByTestId("debug"))
     const sizesFilter = getSizesFilterOption(filters)
 
-    expect(getByA11yState({ checked: true })).toHaveTextContent("Small (under 16in)")
+    expect(getAllByA11yState({ checked: true })[0]).toHaveTextContent("Small (under 16in)")
     expect(sizesFilter).toEqual({
       paramName: "sizes",
       displayText: "Small (under 16in)",
@@ -122,15 +123,19 @@ describe("SizesOptionsScreen", () => {
   })
 
   it("correctly select/unselect the same option", () => {
-    const { getByText, queryByA11yState, getByTestId } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryAllByA11yState, getByTestId } = renderWithWrappersTL(<TestRenderer />)
 
     fireEvent.press(getByText("Small (under 16in)"))
+    // ensures that the checked elements are the selected filter and one radio button
+    expect(queryAllByA11yState({ checked: true })).toHaveLength(2)
+
     fireEvent.press(getByText("Small (under 16in)"))
 
     const filters = getFilters(getByTestId("debug"))
     const sizesFilter = getSizesFilterOption(filters)
 
-    expect(queryByA11yState({ checked: true })).toBeFalsy()
+    // ensures that the checked element is one radio button
+    expect(queryAllByA11yState({ checked: true })).toHaveLength(1)
     expect(sizesFilter).toEqual({
       paramName: "sizes",
       displayText: "All",
@@ -138,20 +143,57 @@ describe("SizesOptionsScreen", () => {
     })
   })
 
+  describe("Metric Radio Buttons", () => {
+    it("should convert successfully the predefined sizes and placeholders on metric change", () => {
+      __globalStoreTestUtils__?.injectState({
+        userPreferences: { metric: "in" },
+      })
+      const { queryByText, queryAllByText, getByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
+
+      expect(getByA11yLabel("in")).toBeTruthy()
+      expect(getByA11yLabel("in")).toHaveProp("accessibilityState", { checked: true })
+
+      expect(queryByText("Small (under 16in)")).toBeTruthy()
+      expect(queryByText("Medium (16in – 40in)")).toBeTruthy()
+      expect(queryByText("Large (over 40in)")).toBeTruthy()
+
+      // makes sure that "cm" appears in the screen only once for the radio button
+      expect(queryAllByText("cm")).toHaveLength(1)
+
+      fireEvent.press(getByA11yLabel("cm"))
+
+      expect(getByA11yLabel("in")).toHaveProp("accessibilityState", { checked: false })
+      expect(getByA11yLabel("cm")).toHaveProp("accessibilityState", { checked: true })
+
+      expect(queryByText("Small (under 16in)")).toBeFalsy()
+      expect(queryByText("Medium (16in – 40in)")).toBeFalsy()
+      expect(queryByText("Large (over 40in)")).toBeFalsy()
+
+      expect(queryByText("Small (under 40cm)")).toBeTruthy()
+      expect(queryByText("Medium (40cm – 100cm)")).toBeTruthy()
+      expect(queryByText("Large (over 100cm)")).toBeTruthy()
+
+      // makes sure that "in" appears in the screen only once for the radio button
+      expect(queryAllByText("in")).toHaveLength(1)
+    })
+  })
+
   describe("Custom Size", () => {
     it("should select the custom size option when a custom value is specified", () => {
-      const { getByA11yLabel, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
+      const { getByA11yLabel, getAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
 
       fireEvent.changeText(getByA11yLabel("Minimum Width Input"), "5")
 
-      expect(getByA11yState({ checked: true })).toHaveTextContent("Custom Size")
+      expect(getAllByA11yState({ checked: true })[0]).toHaveTextContent("Custom Size")
     })
 
     it("should clear custom values in filters when the custom size option is unselected", () => {
-      const { getByA11yLabel, getByA11yState, getByTestId } = renderWithWrappersTL(<TestRenderer />)
+      const { getByA11yLabel, getAllByA11yState, getByTestId } = renderWithWrappersTL(
+        <TestRenderer />
+      )
 
       fireEvent.changeText(getByA11yLabel("Minimum Width Input"), "5")
-      fireEvent.press(getByA11yState({ checked: true }))
+      fireEvent.press(getAllByA11yState({ checked: true })[0])
 
       const filters = getFilters(getByTestId("debug"))
       const widthFilter = getWidthFilterOption(filters)
@@ -178,13 +220,14 @@ describe("SizesOptionsScreen", () => {
     })
 
     it("should unselect the custom size option when custom inputs are empty", () => {
-      const { getByA11yLabel, queryByA11yState } = renderWithWrappersTL(<TestRenderer />)
+      const { getByA11yLabel, queryAllByA11yState } = renderWithWrappersTL(<TestRenderer />)
 
       fireEvent.changeText(getByA11yLabel("Minimum Width Input"), "5")
-      expect(queryByA11yState({ checked: true })).toBeTruthy()
+      expect(queryAllByA11yState({ checked: true })[0]).toBeTruthy()
 
       fireEvent.changeText(getByA11yLabel("Minimum Width Input"), "")
-      expect(queryByA11yState({ checked: true })).toBeFalsy()
+      // ensures that the checked element is one radio button
+      expect(queryAllByA11yState({ checked: true })).toHaveLength(1)
     })
 
     it("should keep custom inputs filled in if a predefined value is selected", () => {
@@ -212,7 +255,7 @@ describe("SizesOptionsScreen", () => {
       const sizesFilter = getSizesFilterOption(filters)
       const widthFilter = getWidthFilterOption(filters)
 
-      expect(getAllByA11yState({ checked: true })).toHaveLength(1)
+      expect(getAllByA11yState({ checked: true })).toHaveLength(2)
       expect(sizesFilter).toEqual({
         paramName: "sizes",
         displayText: "All",
@@ -333,7 +376,8 @@ describe("SizesOptionsScreen", () => {
       fireEvent.press(getByText("Small (under 16in)"))
       fireEvent.press(getByText("Clear"))
 
-      expect(queryAllByA11yState({ checked: true })).toHaveLength(0)
+      // only one of unit radio buttons is selected
+      expect(queryAllByA11yState({ checked: true })).toHaveLength(1)
     })
 
     it('should clear selected custom values if "Clear" button is pressed', () => {
@@ -344,7 +388,8 @@ describe("SizesOptionsScreen", () => {
       fireEvent.changeText(getByA11yLabel("Minimum Width Input"), "5")
       fireEvent.press(getByText("Clear"))
 
-      expect(queryAllByA11yState({ checked: true })).toHaveLength(0)
+      // only one of unit radio buttons is selected
+      expect(queryAllByA11yState({ checked: true })).toHaveLength(1)
     })
   })
 })

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -83,15 +83,15 @@ const CUSTOM_SIZE_OPTION_KEYS: Array<keyof CustomSize> = [
 ]
 
 // Helpers
-export const getCustomValues = (options: FilterData[]) => {
+export const getCustomValues = (options: FilterData[], unit: Unit) => {
   return options.reduce((acc, option) => {
     const { min, max } = parseRange(String(option.paramValue))
 
     return {
       ...acc,
       [option.paramName]: {
-        min: localizeDimension(min, "in").value,
-        max: localizeDimension(max, "in").value,
+        min: localizeDimension(min, unit),
+        max: localizeDimension(max, unit),
       },
     }
   }, DEFAULT_CUSTOM_SIZE)
@@ -166,7 +166,9 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const selectedCustomOptions = selectedOptions.filter((option) =>
     CUSTOM_SIZE_OPTION_KEYS.includes(option.paramName as keyof CustomSize)
   )
-  const [customValues, setCustomValues] = useState(getCustomValues(selectedCustomOptions))
+  const [customValues, setCustomValues] = useState(
+    getCustomValues(selectedCustomOptions, localizedUnit)
+  )
   const [customSizeSelected, setCustomSizeSelected] = useState(
     !checkIsEmptyCustomValues(customValues)
   )
@@ -202,8 +204,8 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const selectCustomFiltersAction = (values: CustomSize) => {
     CUSTOM_SIZE_OPTION_KEYS.forEach((paramName) => {
       const value = values[paramName]
-      const localizedMinValue = localizedUnit === "cm" ? toIn(value.min, localizedUnit) : value.min
-      const localizedMaxValue = localizedUnit === "cm" ? toIn(value.max, localizedUnit) : value.max
+      const localizedMinValue = toIn(value.min, localizedUnit)
+      const localizedMaxValue = toIn(value.max, localizedUnit)
       selectFiltersAction({
         displayText: `${value.min}-${value.max}`,
         paramName: paramName as FilterParamName,

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -7,7 +7,7 @@ import { ArtworkFilterNavigationStack } from ".."
 import { FilterData, FilterDisplayName, FilterParamName } from "../ArtworkFilterHelpers"
 import { ArtworksFiltersStore, useSelectedOptionsDisplay } from "../ArtworkFilterStore"
 import { CustomSizeInputs } from "./CustomSizeInputs"
-import { IS_USA, localizeDimension, parseRange, Range, toIn, Unit } from "./helpers"
+import { localizeDimension, parseRange, Range, toIn, Unit } from "./helpers"
 import { MultiSelectOptionScreen } from "./MultiSelectOption"
 import { useMultiSelect } from "./useMultiSelect"
 
@@ -62,7 +62,9 @@ export const USA_SIZE_OPTIONS: FilterData[] = [
   },
 ]
 
-export const SIZES_OPTIONS = IS_USA ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS
+export const getSizeOptions = (unit: Unit) => {
+  return unit === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS
+}
 
 const DEFAULT_CUSTOM_SIZE: CustomSize = {
   width: {
@@ -204,9 +206,9 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const selectCustomFiltersAction = (values: CustomSize) => {
     CUSTOM_SIZE_OPTION_KEYS.forEach((paramName) => {
       const value = values[paramName]
-      const localizedMinValue = toIn(value.min, metric)
-      const localizedMaxValue = toIn(value.max, metric)
-
+      const localizedMinValue = metric === "cm" ? toIn(value.min, metric) : value.min
+      const localizedMaxValue = metric === "cm" ? toIn(value.max, metric) : value.max
+      console.log("localizedMinValue", localizedMinValue)
       selectFiltersAction({
         displayText: `${value.min}-${value.max}`,
         paramName: paramName as FilterParamName,

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -150,10 +150,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
 
   const { localizedUnit } = useLocalizedUnit()
 
-  const [metric, setMetric] = useState(localizedUnit)
-  const [sizesOptions, setSizesOptions] = useState(
-    localizedUnit === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS
-  )
+  const sizesOptions = getSizeOptions(localizedUnit)
 
   const {
     handleSelect,
@@ -178,12 +175,10 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const isActive = isActivePredefinedValues || !checkIsEmptyCustomValues(customValues)
 
   useEffect(() => {
-    setSizesOptions(metric === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS)
     handleCustomInputsChange(customValues)
-  }, [metric])
+  }, [localizedUnit])
 
   const handleMetricChange = (newMetric: "in" | "cm") => {
-    setMetric(newMetric)
     GlobalStore.actions.userPreferences.setMetric(newMetric)
   }
 
@@ -207,8 +202,8 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const selectCustomFiltersAction = (values: CustomSize) => {
     CUSTOM_SIZE_OPTION_KEYS.forEach((paramName) => {
       const value = values[paramName]
-      const localizedMinValue = metric === "cm" ? toIn(value.min, metric) : value.min
-      const localizedMaxValue = metric === "cm" ? toIn(value.max, metric) : value.max
+      const localizedMinValue = localizedUnit === "cm" ? toIn(value.min, localizedUnit) : value.min
+      const localizedMaxValue = localizedUnit === "cm" ? toIn(value.max, localizedUnit) : value.max
       selectFiltersAction({
         displayText: `${value.min}-${value.max}`,
         paramName: paramName as FilterParamName,
@@ -277,7 +272,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
             active={customSizeSelected}
             onChange={handleCustomInputsChange}
             handleMetricChange={handleMetricChange}
-            metric={metric}
+            metric={localizedUnit}
           />
         ) : null
       }

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -115,12 +115,25 @@ const CustomSizeInputsContainer: React.FC<CustomSizeInputsContainerProps> = ({
     onChange({ ...values, [paramName]: range })
   }
 
+  const isCm = metric === "cm"
+  const isIn = metric === "in"
+
   return (
     <Box mx={15} my={2}>
       <Flex flexDirection="row">
-        <RadioButton selected={metric === "cm"} onPress={() => handleMetricChange("cm")} />
+        <RadioButton
+          accessibilityLabel="cm"
+          accessibilityState={{ checked: isCm }}
+          selected={isCm}
+          onPress={() => handleMetricChange("cm")}
+        />
         <Text marginRight="3">cm</Text>
-        <RadioButton selected={metric === "in"} onPress={() => handleMetricChange("in")} />
+        <RadioButton
+          accessibilityLabel="in"
+          accessibilityState={{ checked: isIn }}
+          selected={isIn}
+          onPress={() => handleMetricChange("in")}
+        />
         <Text>in</Text>
       </Flex>
       <Spacer mt={2} />

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -1,6 +1,6 @@
 import { StackScreenProps } from "@react-navigation/stack"
-import { GlobalStore } from "lib/store/GlobalStore"
-import { useLocalizedUnit } from "lib/utils/useLocalizedUnit"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import { Box, Flex, RadioButton, Spacer, Text } from "palette"
 import React, { useEffect, useState } from "react"
 import { ArtworkFilterNavigationStack } from ".."
@@ -155,15 +155,6 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
     localizedUnit === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS
   )
 
-  const handleMetricChange = (newMetric: "in" | "cm") => {
-    setMetric(newMetric)
-    GlobalStore.actions.userPreferences.setMetric(newMetric)
-  }
-
-  useEffect(() => {
-    setSizesOptions(metric === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS)
-  }, [metric])
-
   const {
     handleSelect,
     isSelected,
@@ -185,6 +176,16 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   const [key, setKey] = useState(0)
   const shouldShowCustomInputs = filterType !== "auctionResult"
   const isActive = isActivePredefinedValues || !checkIsEmptyCustomValues(customValues)
+
+  useEffect(() => {
+    setSizesOptions(metric === "in" ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS)
+    handleCustomInputsChange(customValues)
+  }, [metric])
+
+  const handleMetricChange = (newMetric: "in" | "cm") => {
+    setMetric(newMetric)
+    GlobalStore.actions.userPreferences.setMetric(newMetric)
+  }
 
   // Options
   let options: FilterData[] = sizesOptions.map((option) => ({
@@ -208,7 +209,6 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
       const value = values[paramName]
       const localizedMinValue = metric === "cm" ? toIn(value.min, metric) : value.min
       const localizedMaxValue = metric === "cm" ? toIn(value.max, metric) : value.max
-      console.log("localizedMinValue", localizedMinValue)
       selectFiltersAction({
         displayText: `${value.min}-${value.max}`,
         paramName: paramName as FilterParamName,

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -194,7 +194,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   }, [localizedUnit])
 
   const handleMetricChange = (newMetric: Unit) => {
-    GlobalStore.actions.userPreferences.setMetric(newMetric)
+    GlobalStore.actions.userPrefs.setMetric(newMetric)
   }
 
   // Options

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -193,7 +193,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
     handleCustomInputsChange(customValues)
   }, [localizedUnit])
 
-  const handleMetricChange = (newMetric: "in" | "cm") => {
+  const handleMetricChange = (newMetric: Unit) => {
     GlobalStore.actions.userPreferences.setMetric(newMetric)
   }
 

--- a/src/app/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/app/Components/ArtworkFilter/Filters/helpers.ts
@@ -22,7 +22,7 @@ export const localizeDimension = (value: Numeric, unit: Unit): { value: Numeric;
     return { value, unit: "in" }
   }
 
-  if (unit === "cm") {
+  if (IS_USA && unit === "cm") {
     return { value: cmToIn(value), unit: "in" }
   }
 

--- a/src/app/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/app/Components/ArtworkFilter/Filters/helpers.ts
@@ -22,7 +22,7 @@ export const localizeDimension = (value: Numeric, unit: Unit): { value: Numeric;
     return { value, unit: "in" }
   }
 
-  if (IS_USA && unit === "cm") {
+  if (unit === "cm") {
     return { value: cmToIn(value), unit: "in" }
   }
 

--- a/src/app/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/app/Components/ArtworkFilter/Filters/helpers.ts
@@ -13,25 +13,11 @@ const ONE_IN_TO_CM = 2.54
 export const IS_USA = LegacyNativeModules.ARCocoaConstantsModule.CurrentLocale === "en_US"
 export const LOCALIZED_UNIT: Unit = IS_USA ? "in" : "cm"
 
-/**
- * Accepts a value and it's input unit type and returns a localized conversion (or leaves it alone)
- */
-export const localizeDimension = (value: Numeric, unit: Unit): { value: Numeric; unit: Unit } => {
-  // Localize for US (return inches)
-  if (IS_USA && unit === "in") {
-    return { value, unit: "in" }
+export const localizeDimension = (dimension: Numeric, unit: Unit) => {
+  if (unit === "cm") {
+    return inToCm(dimension)
   }
-
-  if (IS_USA && unit === "cm") {
-    return { value: cmToIn(value), unit: "in" }
-  }
-
-  // Localize for rest of world (return centimeters)
-  if (unit === "in") {
-    return { value: inToCm(value), unit: "cm" }
-  }
-
-  return { value, unit: "cm" }
+  return dimension
 }
 
 export const cmToIn = (centimeters: Numeric) => {

--- a/src/app/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/app/Components/ArtworkFilter/Filters/helpers.ts
@@ -2,7 +2,7 @@ import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { isNull, isUndefined, round as __round__ } from "lodash"
 
 export type Numeric = "*" | number
-type Unit = "in" | "cm"
+export type Unit = "in" | "cm"
 
 export interface Range {
   min: Numeric

--- a/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
@@ -9,8 +9,8 @@ import {
 } from "../ArtworkFilterHelpers"
 import { ATTRIBUTION_CLASS_OPTIONS } from "../Filters/AttributionClassOptions"
 import { COLORS_INDEXED_BY_VALUE } from "../Filters/ColorsOptions"
-import { localizeDimension, parsePriceRangeLabel, parseRange } from "../Filters/helpers"
-import { SIZES_OPTIONS } from "../Filters/SizesOptionsScreen"
+import { IS_USA, localizeDimension, parsePriceRangeLabel, parseRange } from "../Filters/helpers"
+import { EUROPE_SIZE_OPTIONS, USA_SIZE_OPTIONS } from "../Filters/SizesOptionsScreen"
 import { WAYS_TO_BUY_OPTIONS } from "../Filters/WaysToBuyOptions"
 import { FALLBACK_SIZE_OPTIONS, shouldExtractValueNamesFromAggregation } from "./constants"
 import { SearchCriteria, SearchCriteriaAttributes } from "./types"
@@ -75,6 +75,7 @@ export const convertSizeToFilterParams = (
 
   if (Array.isArray(sizesValues)) {
     const sizeOptions = sizesValues.map((sizeValue) => {
+      const SIZES_OPTIONS = IS_USA ? USA_SIZE_OPTIONS : EUROPE_SIZE_OPTIONS
       return SIZES_OPTIONS.find((sizeOption) => sizeOption.paramValue === sizeValue)
     })
     const filledSizeOptions = compact(sizeOptions)

--- a/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.ts
@@ -43,7 +43,7 @@ export const convertCustomSizeToFilterParamByName = (paramName: FilterParamName,
   const widthMaxLocalized = localizeDimension(max, "in")
 
   return {
-    displayText: `${widthMinLocalized.value}-${widthMaxLocalized.value}`,
+    displayText: `${widthMinLocalized}-${widthMaxLocalized}`,
     paramValue: `${min}-${max}`,
     paramName,
   }

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -30,6 +30,7 @@ import {
   SavedSearchPill,
 } from "./SavedSearchAlertModel"
 import { SavedSearchStore } from "./SavedSearchStore"
+import { useSavedSearchPills } from "./useSavedSearchPills"
 
 export interface SavedSearchAlertFormProps extends SavedSearchAlertFormPropsBase {
   initialValues: SavedSearchAlertFormValues
@@ -56,7 +57,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const isUpdateForm = !!savedSearchAlertId
   const isEnabledImprovedAlertsFlow = useFeatureFlag("AREnableImprovedAlertsFlow")
   const isFirstRender = useFirstMountState()
-  const savedSearchPills = SavedSearchStore.useStoreState((state) => state.pills)
+  const savedSearchPills = useSavedSearchPills()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
   const hasChangedFilters = SavedSearchStore.useStoreState((state) => state.dirty)
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -39,8 +39,6 @@ const savedSearchModel: SavedSearchModel = {
 
     state.dirty = true
   }),
-
-  // pills: computed((state) => extractPills(state.attributes, state.aggregations)),
 }
 
 export const SavedSearchStore = createContextStore<SavedSearchModel>(

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -3,9 +3,7 @@ import {
   SearchCriteria,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { action, Action, computed, Computed, createContextStore, State } from "easy-peasy"
-import { extractPills } from "./pillExtractors"
-import { SavedSearchPill } from "./SavedSearchAlertModel"
+import { action, Action, createContextStore, State } from "easy-peasy"
 
 interface SavedSearchModel {
   attributes: SearchCriteriaAttributes
@@ -19,8 +17,6 @@ interface SavedSearchModel {
       value: string | number | boolean
     }
   >
-
-  pills: Computed<this, SavedSearchPill[]>
 }
 
 export type SavedSearchState = State<SavedSearchModel>
@@ -44,7 +40,7 @@ const savedSearchModel: SavedSearchModel = {
     state.dirty = true
   }),
 
-  pills: computed((state) => extractPills(state.attributes, state.aggregations)),
+  // pills: computed((state) => extractPills(state.attributes, state.aggregations)),
 }
 
 export const SavedSearchStore = createContextStore<SavedSearchModel>(

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
@@ -51,22 +51,22 @@ describe("extractPillFromAggregation", () => {
 describe("extractSizeLabel", () => {
   it("returns correcly label when full range is specified", () => {
     expect(extractSizeLabel({ prefix: "w", value: "5-10", unit: "in" })).toBe("w: 5-10 in")
-    expect(extractSizeLabel({ prefix: "w", value: "5-10", unit: "cm" })).toBe("w: 5-10 cm")
+    expect(extractSizeLabel({ prefix: "w", value: "5-10", unit: "cm" })).toBe("w: 12.7-25.4 cm")
   })
 
   it("returns correcly label when only min value is specified", () => {
     expect(extractSizeLabel({ prefix: "w", value: "5-*", unit: "in" })).toBe("w: from 5 in")
-    expect(extractSizeLabel({ prefix: "w", value: "5-*", unit: "cm" })).toBe("w: from 5 cm")
+    expect(extractSizeLabel({ prefix: "w", value: "5-*", unit: "cm" })).toBe("w: from 12.7 cm")
   })
 
   it("returns correcly label when only max value is specified", () => {
     expect(extractSizeLabel({ prefix: "w", value: "*-10", unit: "in" })).toBe("w: to 10 in")
-    expect(extractSizeLabel({ prefix: "w", value: "*-10", unit: "cm" })).toBe("w: to 10 cm")
+    expect(extractSizeLabel({ prefix: "w", value: "*-10", unit: "cm" })).toBe("w: to 25.4 cm")
   })
 
   it("returns specified prefix", () => {
     expect(extractSizeLabel({ prefix: "h", value: "5-10", unit: "in" })).toBe("h: 5-10 in")
-    expect(extractSizeLabel({ prefix: "h", value: "5-10", unit: "cm" })).toBe("h: 5-10 cm")
+    expect(extractSizeLabel({ prefix: "h", value: "5-10", unit: "cm" })).toBe("h: 12.7-25.4 cm")
   })
 })
 
@@ -157,9 +157,11 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       sizes: ["SMALL", "LARGE"],
     }
-    const result = extractPills({ attributes, aggregations, unit: "in" })
 
-    expect(result).toEqual([
+    // with unit inches
+    const inResult = extractPills({ attributes, aggregations, unit: "in" })
+
+    expect(inResult).toEqual([
       {
         label: "Small (under 16in)",
         paramName: SearchCriteria.sizes,
@@ -167,6 +169,22 @@ describe("extractPills", () => {
       },
       {
         label: "Large (over 40in)",
+        paramName: SearchCriteria.sizes,
+        value: "LARGE",
+      },
+    ])
+
+    // with unit centimeters
+    const cmResult = extractPills({ attributes, aggregations, unit: "cm" })
+
+    expect(cmResult).toEqual([
+      {
+        label: "Small (under 40cm)",
+        paramName: SearchCriteria.sizes,
+        value: "SMALL",
+      },
+      {
+        label: "Large (over 100cm)",
         paramName: SearchCriteria.sizes,
         value: "LARGE",
       },

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
@@ -50,19 +50,23 @@ describe("extractPillFromAggregation", () => {
 
 describe("extractSizeLabel", () => {
   it("returns correcly label when full range is specified", () => {
-    expect(extractSizeLabel("w", "5-10")).toBe("w: 5-10 in")
+    expect(extractSizeLabel({ prefix: "w", value: "5-10", unit: "in" })).toBe("w: 5-10 in")
+    expect(extractSizeLabel({ prefix: "w", value: "5-10", unit: "cm" })).toBe("w: 5-10 cm")
   })
 
   it("returns correcly label when only min value is specified", () => {
-    expect(extractSizeLabel("w", "5-*")).toBe("w: from 5 in")
+    expect(extractSizeLabel({ prefix: "w", value: "5-*", unit: "in" })).toBe("w: from 5 in")
+    expect(extractSizeLabel({ prefix: "w", value: "5-*", unit: "cm" })).toBe("w: from 5 cm")
   })
 
   it("returns correcly label when only max value is specified", () => {
-    expect(extractSizeLabel("w", "*-10")).toBe("w: to 10 in")
+    expect(extractSizeLabel({ prefix: "w", value: "*-10", unit: "in" })).toBe("w: to 10 in")
+    expect(extractSizeLabel({ prefix: "w", value: "*-10", unit: "cm" })).toBe("w: to 10 cm")
   })
 
   it("returns specified prefix", () => {
-    expect(extractSizeLabel("h", "5-10")).toBe("h: 5-10 in")
+    expect(extractSizeLabel({ prefix: "h", value: "5-10", unit: "in" })).toBe("h: 5-10 in")
+    expect(extractSizeLabel({ prefix: "h", value: "5-10", unit: "cm" })).toBe("h: 5-10 cm")
   })
 })
 
@@ -78,7 +82,7 @@ describe("extractPills", () => {
       colors: ["unknown-color"],
     }
 
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     const pills = [
       {
@@ -131,7 +135,7 @@ describe("extractPills", () => {
       offerable: true,
       atAuction: true,
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     const pills = [
       {
@@ -153,7 +157,7 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       sizes: ["SMALL", "LARGE"],
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -173,7 +177,7 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       majorPeriods: ["2020", "2010"],
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -193,7 +197,7 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       colors: ["pink", "orange", "darkorange"],
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -218,7 +222,7 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       attributionClass: ["unique", "unknown edition"],
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -238,7 +242,7 @@ describe("extractPills", () => {
     const attributes: SearchCriteriaAttributes = {
       priceRange: "1000-1500",
     }
-    const result = extractPills(attributes, aggregations)
+    const result = extractPills({ attributes, aggregations, unit: "in" })
 
     expect(result).toEqual([
       {

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
@@ -71,10 +71,6 @@ export const extractSizeLabel = ({
   const max = localizeDimension(range.max, unit)
   let label
 
-  console.log("[debug] value", value)
-  console.log("[debug] min", min)
-  console.log("[debug] max", max)
-
   if (max === "*") {
     label = `from ${min}`
   } else if (min === "*") {

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
@@ -67,10 +67,13 @@ export const extractSizeLabel = ({
   unit: Unit
 }) => {
   const range = parseRange(value)
-  console.warn(value)
   const min = localizeDimension(range.min, unit)
   const max = localizeDimension(range.max, unit)
   let label
+
+  console.log("[debug] value", value)
+  console.log("[debug] min", min)
+  console.log("[debug] max", max)
 
   if (max === "*") {
     label = `from ${min}`

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
@@ -7,8 +7,7 @@ import {
 import { ATTRIBUTION_CLASS_OPTIONS } from "app/Components/ArtworkFilter/Filters/AttributionClassOptions"
 import { COLORS_INDEXED_BY_VALUE } from "app/Components/ArtworkFilter/Filters/ColorsOptions"
 import {
-  inToCm,
-  Numeric,
+  localizeDimension,
   parsePriceRangeLabel,
   parseRange,
   Unit,
@@ -48,13 +47,6 @@ export const extractPillFromAggregation = (
   }
 
   return []
-}
-
-const localizeDimension = (dimension: Numeric, unit: Unit) => {
-  if (unit === "cm") {
-    return inToCm(dimension)
-  }
-  return dimension
 }
 
 export const extractSizeLabel = ({

--- a/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
+++ b/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
@@ -1,0 +1,16 @@
+import { GlobalStore } from "app/store/GlobalStore"
+import { useMemo } from "react"
+import { extractPills } from "./pillExtractors"
+import { SavedSearchStore } from "./SavedSearchStore"
+
+export const useSavedSearchPills = () => {
+  const userPreferredMetric =
+    GlobalStore.useAppState((state) => state.userPreferences.metric) || "in"
+  const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
+  const aggregations = SavedSearchStore.useStoreState((state) => state.aggregations)
+
+  return useMemo(
+    () => extractPills({ attributes, aggregations, unit: userPreferredMetric }),
+    [attributes, aggregations, userPreferredMetric]
+  )
+}

--- a/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
+++ b/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
@@ -1,16 +1,15 @@
-import { GlobalStore } from "app/store/GlobalStore"
+import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import { useMemo } from "react"
 import { extractPills } from "./pillExtractors"
 import { SavedSearchStore } from "./SavedSearchStore"
 
 export const useSavedSearchPills = () => {
-  const userPreferredMetric =
-    GlobalStore.useAppState((state) => state.userPreferences.metric) || "in"
+  const { localizedUnit } = useLocalizedUnit()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
   const aggregations = SavedSearchStore.useStoreState((state) => state.aggregations)
 
   return useMemo(
-    () => extractPills({ attributes, aggregations, unit: userPreferredMetric }),
-    [attributes, aggregations, userPreferredMetric]
+    () => extractPills({ attributes, aggregations, unit: localizedUnit }),
+    [attributes, aggregations, localizedUnit]
   )
 }

--- a/src/app/utils/useLocalizedUnit.ts
+++ b/src/app/utils/useLocalizedUnit.ts
@@ -3,7 +3,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 
 export const useLocalizedUnit = () => {
   const userPreferredMetric =
-    GlobalStore.useAppState((state) => state.userPreferences.metric) || LOCALIZED_UNIT
+    GlobalStore.useAppState((state) => state.userPrefs.metric) || LOCALIZED_UNIT
 
   return {
     localizedUnit: userPreferredMetric,

--- a/src/app/utils/useLocalizedUnit.ts
+++ b/src/app/utils/useLocalizedUnit.ts
@@ -1,0 +1,11 @@
+import { LOCALIZED_UNIT } from "app/Components/ArtworkFilter/Filters/helpers"
+import { GlobalStore } from "app/store/GlobalStore"
+
+export const useLocalizedUnit = () => {
+  const userPreferredMetric =
+    GlobalStore.useAppState((state) => state.userPreferences.metric) || LOCALIZED_UNIT
+
+  return {
+    localizedUnit: userPreferredMetric,
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3739]

### Description

- Lets user to select preferred metric when selecting size filters
- updated tests

#### Screenshots

|Android|iOS|
|---|---|
|![Screenshot_1645191024](https://user-images.githubusercontent.com/21178754/154691881-4a2a263b-97c5-49ca-931f-2fdb5a9bb31b.png)|![Simulator Screen Shot - iPhone 13 - 2022-02-18 at 14 28 26](https://user-images.githubusercontent.com/21178754/154691842-31905861-ec10-40f1-bb26-59398e0ca22d.png)|

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add size metric preference in filters - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3739]: https://artsyproduct.atlassian.net/browse/FX-3739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ