### PR TITLE
fix: Improve performance of artwork form metric change

### DIFF
--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
@@ -2,14 +2,20 @@ import { useArtworkForm } from "lib/Scenes/MyCollection/Screens/ArtworkForm/Form
 import { Metric } from "lib/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "lib/store/GlobalStore"
 import { Flex, Input, RadioButton, Spacer, Text } from "palette"
-import React from "react"
+import React, { useState } from "react"
 
 export const Dimensions: React.FC = () => {
   const { formik } = useArtworkForm()
 
+  const [localMetric, setLocalMetric] = useState(formik.values.metric)
+
   const handleMetricChange = (unit: Metric) => {
-    GlobalStore.actions.userPrefs.setMetric(unit)
-    formik.handleChange("metric")(unit)
+    setLocalMetric(unit)
+
+    requestAnimationFrame(() => {
+      formik.handleChange("metric")(unit)
+      GlobalStore.actions.userPrefs.setMetric(unit)
+    })
   }
 
   return (
@@ -19,15 +25,9 @@ export const Dimensions: React.FC = () => {
       </Flex>
       <Spacer mt={1} mb={0.3} />
       <Flex flexDirection="row">
-        <RadioButton
-          selected={formik.values.metric === "cm"}
-          onPress={() => handleMetricChange("cm")}
-        />
+        <RadioButton selected={localMetric === "cm"} onPress={() => handleMetricChange("cm")} />
         <Text marginRight="3">cm</Text>
-        <RadioButton
-          selected={formik.values.metric === "in"}
-          onPress={() => handleMetricChange("in")}
-        />
+        <RadioButton selected={localMetric === "in"} onPress={() => handleMetricChange("in")} />
         <Text>in</Text>
       </Flex>
       <Spacer my={1} />

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
@@ -3,6 +3,7 @@ import { Metric } from "lib/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "lib/store/GlobalStore"
 import { Flex, Input, RadioButton, Spacer, Text } from "palette"
 import React, { useState } from "react"
+import { TouchableWithoutFeedback } from "react-native-gesture-handler"
 
 export const Dimensions: React.FC = () => {
   const { formik } = useArtworkForm()
@@ -26,10 +27,18 @@ export const Dimensions: React.FC = () => {
       </Flex>
       <Spacer mt={1} mb={0.3} />
       <Flex flexDirection="row">
-        <RadioButton selected={localMetric === "cm"} onPress={() => handleMetricChange("cm")} />
-        <Text marginRight="3">cm</Text>
-        <RadioButton selected={localMetric === "in"} onPress={() => handleMetricChange("in")} />
-        <Text>in</Text>
+        <TouchableWithoutFeedback onPress={() => handleMetricChange("cm")}>
+          <Flex flexDirection="row">
+            <RadioButton selected={localMetric === "cm"} />
+            <Text marginRight="3">cm</Text>
+          </Flex>
+        </TouchableWithoutFeedback>
+        <TouchableWithoutFeedback onPress={() => handleMetricChange("in")}>
+          <Flex flexDirection="row">
+            <RadioButton selected={localMetric === "in"} />
+            <Text>in</Text>
+          </Flex>
+        </TouchableWithoutFeedback>
       </Flex>
       <Spacer my={1} />
       <Flex flexDirection="row">

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
@@ -7,6 +7,7 @@ import React, { useState } from "react"
 export const Dimensions: React.FC = () => {
   const { formik } = useArtworkForm()
 
+  // Using a local state to improve performance
   const [localMetric, setLocalMetric] = useState(formik.values.metric)
 
   const handleMetricChange = (unit: Metric) => {

--- a/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/lib/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -141,8 +141,8 @@ export const MyCollectionArtworkFormMain: React.FC<
               enableSearch={false}
               showTitleLabel={false}
               onSelectValue={(value) => {
-                GlobalStore.actions.userPrefs.setCurrency(value as Currency)
                 formik.handleChange("pricePaidCurrency")(value)
+                GlobalStore.actions.userPrefs.setCurrency(value as Currency)
               }}
               testID="CurrencyPicker"
             />

--- a/src/palette/elements/Radio/RadioButton.tsx
+++ b/src/palette/elements/Radio/RadioButton.tsx
@@ -1,6 +1,8 @@
 import { themeGet } from "@styled-system/theme-get"
+import { CssTransition } from "lib/Components/Bidding/Components/Animation/CssTransition"
+import { Flex, FlexProps } from "lib/Components/Bidding/Elements/Flex"
 import { Text, useTheme } from "palette"
-import React, { useState } from "react"
+import React from "react"
 import {
   PixelRatio,
   StyleSheet,
@@ -9,11 +11,8 @@ import {
 } from "react-native"
 import styled from "styled-components/native"
 
-import { CssTransition } from "lib/Components/Bidding/Components/Animation/CssTransition"
-import { Flex, FlexProps } from "lib/Components/Bidding/Elements/Flex"
-
 const RADIOBUTTON_SIZE = 20
-const DURATION = 250
+const DURATION = 150
 
 export interface RadioButtonProps extends TouchableWithoutFeedbackProps, FlexProps {
   selected?: boolean
@@ -25,7 +24,7 @@ export interface RadioButtonProps extends TouchableWithoutFeedbackProps, FlexPro
 }
 
 export const RadioButton: React.FC<RadioButtonProps> = ({
-  selected: selectedProp,
+  selected,
   disabled,
   error,
   onPress,
@@ -39,9 +38,6 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 
   const fontScale = PixelRatio.getFontScale()
   const radioButtonSize = RADIOBUTTON_SIZE * fontScale
-
-  const [selected, setSelected] = useState(selectedProp)
-  const isSelected = selectedProp ?? selected
 
   const defaultRadioButtonStyle = {
     backgroundColor: color("white100"),
@@ -71,7 +67,7 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
 
   const radioButtonStyle = disabled
     ? disabledRadioButtonStyle
-    : radioButtonStyles[error ? "error" : "default"][isSelected ? "selected" : "notSelected"]
+    : radioButtonStyles[error ? "error" : "default"][selected ? "selected" : "notSelected"]
 
   const textColor = error ? color("red100") : disabled ? color("black30") : color("black100")
   const subtitleColor = error ? color("red100") : color("black30")
@@ -83,7 +79,6 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
           return
         }
 
-        setSelected(!selected)
         onPress?.(event)
       }}
     >
@@ -96,10 +91,10 @@ export const RadioButton: React.FC<RadioButtonProps> = ({
                 { marginRight: space("1") * fontScale },
                 radioButtonStyle,
               ]}
-              animate={["backgroundColor", "borderColor"]}
+              animate={["borderColor"]}
               duration={DURATION}
             >
-              {!!isSelected &&
+              {!!selected &&
                 (!!disabled ? (
                   <DisabledDot size={radioButtonSize} />
                 ) : (


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2315]

### Description

This PR improves the artwork form metric change performance.

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Improve artwork form metric change performance - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2315]: https://artsyproduct.atlassian.net/browse/CX-2315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ