### PR TITLE
[fix]: Rarity validation in Submission flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0",
+  "version": "1.2.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.1.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -7,8 +7,7 @@ import { createMockEnvironment } from "relay-test-utils"
 import { createConsignSubmission, updateConsignSubmission } from "../Mutations"
 import { ArtworkDetails } from "./ArtworkDetails"
 import { createOrUpdateSubmission } from "./utils/createOrUpdateSubmission"
-import { limitedEditionValue } from "./utils/rarityOptions"
-import { ArtworkDetailsFormModel } from "./validation"
+import { mockFormValues } from "./utils/testUtils"
 
 jest.mock(
   "lib/Scenes/Consignments/Screens/SubmitArtworkOverview/Mutations/createConsignSubmissionMutation",
@@ -51,38 +50,13 @@ describe("ArtworkDetails", () => {
     })
 
     it("creates new submission", async () => {
-      await createOrUpdateSubmission(mockSubmissionForm, "")
+      await createOrUpdateSubmission(mockFormValues, "")
       expect(createConsignSubmissionMock).toHaveBeenCalled()
     })
 
     it("updates existing submission when ID passed", async () => {
-      await createOrUpdateSubmission(mockSubmissionForm, "12345")
+      await createOrUpdateSubmission(mockFormValues, "12345")
       expect(updateConsignSubmissionMock).toHaveBeenCalled()
     })
   })
 })
-
-export const mockSubmissionForm: ArtworkDetailsFormModel = {
-  artist: "123",
-  artistId: "200",
-  title: "hello",
-  year: "2000",
-  medium: "oil",
-  attributionClass: limitedEditionValue,
-  editionNumber: "1",
-  editionSizeFormatted: "1",
-  dimensionsMetric: "in",
-  height: "2",
-  width: "2",
-  depth: "2",
-  provenance: "found",
-  state: "DRAFT",
-  utmMedium: "",
-  utmSource: "",
-  utmTerm: "",
-  location: {
-    city: "London",
-    state: "England",
-    country: "UK",
-  },
-}

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -1,8 +1,11 @@
+import { fireEvent } from "@testing-library/react-native"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { RelayEnvironmentProvider } from "react-relay"
+import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { createConsignSubmission, updateConsignSubmission } from "../Mutations"
 import { ArtworkDetails } from "./ArtworkDetails"
@@ -43,20 +46,94 @@ describe("ArtworkDetails", () => {
 
   afterEach(() => jest.clearAllMocks())
 
-  describe("ArtworkDetails", () => {
-    it("renders correct explanation for form fields", () => {
-      const { getByText } = renderWithWrappersTL(<TestRenderer />)
-      expect(getByText("All fields are required to submit an artwork.")).toBeTruthy()
-    })
+  it("renders correct explanation for form fields", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+    expect(getByText("All fields are required to submit an artwork.")).toBeTruthy()
+  })
 
-    it("creates new submission", async () => {
+  describe("createOrUpdateSubmission", () => {
+    it("creates new submission when no submission ID passed", async () => {
       await createOrUpdateSubmission(mockFormValues, "")
       expect(createConsignSubmissionMock).toHaveBeenCalled()
     })
 
-    it("updates existing submission when ID passed", async () => {
+    it("updates existing submission when submission ID passed", async () => {
       await createOrUpdateSubmission(mockFormValues, "12345")
       expect(updateConsignSubmissionMock).toHaveBeenCalled()
+    })
+  })
+
+  describe("Save & Continue button", () => {
+    it("disabled when a required field is missing", async () => {
+      const { getByTestId, UNSAFE_getByProps } = renderWithWrappersTL(<TestRenderer />)
+
+      const SaveButton = UNSAFE_getByProps({
+        testID: "Submission_ArtworkDetails_Button",
+      })
+
+      const inputs = {
+        title: getByTestId("Submission_TitleInput"),
+        year: getByTestId("Submission_YearInput"),
+        material: getByTestId("Submission_MaterialsInput"),
+        height: getByTestId("Submission_HeightInput"),
+        width: getByTestId("Submission_WidthInput"),
+        depth: getByTestId("Submission_DepthInput"),
+        provenance: getByTestId("Submission_ProvenanceInput"),
+      }
+
+      await flushPromiseQueue()
+
+      // title missing
+      act(() => fireEvent.changeText(inputs.title, ""))
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // year missing
+      act(() => {
+        fireEvent.changeText(inputs.year, "")
+        fireEvent.changeText(inputs.title, "someTitle")
+      })
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // material missing
+      act(() => {
+        fireEvent.changeText(inputs.material, "")
+        fireEvent.changeText(inputs.year, "1999")
+      })
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // height missing
+      act(() => {
+        fireEvent.changeText(inputs.height, "")
+        fireEvent.changeText(inputs.material, "oil on c")
+      })
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // width missing
+      act(() => {
+        fireEvent.changeText(inputs.width, "")
+        fireEvent.changeText(inputs.height, "123")
+      })
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // depth missing
+      act(() => {
+        fireEvent.changeText(inputs.depth, "")
+        fireEvent.changeText(inputs.width, "123")
+      })
+
+      expect(SaveButton.props.disabled).toBe(true)
+
+      // provenance missing
+      act(() => {
+        fireEvent.changeText(inputs.provenance, "")
+        fireEvent.changeText(inputs.depth, "123")
+      })
+
+      expect(SaveButton.props.disabled).toBe(true)
+
+      act(() => {
+        fireEvent.changeText(inputs.provenance, "found it")
+      })
     })
   })
 })

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, waitFor } from "@testing-library/react-native"
+import { fireEvent } from "@testing-library/react-native"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { RelayEnvironmentProvider } from "react-relay"
@@ -63,7 +64,7 @@ describe("ArtworkDetailsForm", () => {
     })
 
     describe("validation", () => {
-      it("keeps Save & Continue button disabled until required fields validated", async () => {
+      it("keeps Save & Continue button disabled until all required fields validated", async () => {
         const { getByTestId, UNSAFE_getByProps } = renderWithWrappersTL(<TestRenderer />)
 
         const SaveButton = UNSAFE_getByProps({
@@ -80,63 +81,59 @@ describe("ArtworkDetailsForm", () => {
           provenance: getByTestId("Submission_ProvenanceInput"),
         }
 
+        await flushPromiseQueue()
+
         // title missing
-        await waitFor(() => act(() => fireEvent.changeText(inputs.title, "")))
+        act(() => fireEvent.changeText(inputs.title, ""))
         expect(SaveButton.props.disabled).toBe(true)
 
         // year missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.year, "")
-            fireEvent.changeText(inputs.title, "someTitle")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.year, "")
+          fireEvent.changeText(inputs.title, "someTitle")
         })
         expect(SaveButton.props.disabled).toBe(true)
 
         // material missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.material, "")
-            fireEvent.changeText(inputs.year, "1999")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.material, "")
+          fireEvent.changeText(inputs.year, "1999")
         })
         expect(SaveButton.props.disabled).toBe(true)
 
         // height missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.height, "")
-            fireEvent.changeText(inputs.material, "oil on c")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.height, "")
+          fireEvent.changeText(inputs.material, "oil on c")
         })
         expect(SaveButton.props.disabled).toBe(true)
 
         // width missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.width, "")
-            fireEvent.changeText(inputs.height, "123")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.width, "")
+          fireEvent.changeText(inputs.height, "123")
         })
         expect(SaveButton.props.disabled).toBe(true)
 
         // depth missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.depth, "")
-            fireEvent.changeText(inputs.width, "123")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.depth, "")
+          fireEvent.changeText(inputs.width, "123")
         })
+
         expect(SaveButton.props.disabled).toBe(true)
 
         // provenance missing
-        await waitFor(() => {
-          act(() => {
-            fireEvent.changeText(inputs.provenance, "")
-            fireEvent.changeText(inputs.depth, "123")
-          })
+        act(() => {
+          fireEvent.changeText(inputs.provenance, "")
+          fireEvent.changeText(inputs.depth, "123")
         })
+
         expect(SaveButton.props.disabled).toBe(true)
+
+        act(() => {
+          fireEvent.changeText(inputs.provenance, "found it")
+        })
       })
     })
   })

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -1,15 +1,13 @@
-import { fireEvent } from "@testing-library/react-native"
 import { defaultEnvironment } from "lib/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
-import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { RelayEnvironmentProvider } from "react-relay"
-import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { createConsignSubmission, updateConsignSubmission } from "../Mutations"
 import { ArtworkDetails } from "./ArtworkDetails"
 import { createOrUpdateSubmission } from "./utils/createOrUpdateSubmission"
+import { limitedEditionValue } from "./utils/rarityOptions"
 import { ArtworkDetailsFormModel } from "./validation"
 
 jest.mock(
@@ -32,7 +30,7 @@ const createConsignSubmissionMock = createConsignSubmission as jest.Mock
 const updateConsignSubmissionMock = updateConsignSubmission as jest.Mock
 const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
 
-describe("ArtworkDetailsForm", () => {
+describe("ArtworkDetails", () => {
   const TestRenderer = () => (
     <RelayEnvironmentProvider environment={mockEnvironment}>
       <ArtworkDetails handlePress={jest.fn()} />
@@ -42,8 +40,9 @@ describe("ArtworkDetailsForm", () => {
   beforeEach(() => {
     ;(createConsignSubmissionMock as jest.Mock).mockClear()
     ;(updateConsignSubmissionMock as jest.Mock).mockClear()
-    mockEnvironment.mockClear()
   })
+
+  afterEach(() => jest.clearAllMocks())
 
   describe("ArtworkDetails", () => {
     it("renders correct explanation for form fields", () => {
@@ -51,90 +50,14 @@ describe("ArtworkDetailsForm", () => {
       expect(getByText("All fields are required to submit an artwork.")).toBeTruthy()
     })
 
-    describe("createOrUpdateSubmission", () => {
-      it("creates new submission", async () => {
-        await createOrUpdateSubmission(mockSubmissionForm, "")
-        expect(createConsignSubmissionMock).toHaveBeenCalled()
-      })
-
-      it("updates existing submission when ID passed", async () => {
-        await createOrUpdateSubmission(mockSubmissionForm, "12345")
-        expect(updateConsignSubmissionMock).toHaveBeenCalled()
-      })
+    it("creates new submission", async () => {
+      await createOrUpdateSubmission(mockSubmissionForm, "")
+      expect(createConsignSubmissionMock).toHaveBeenCalled()
     })
 
-    describe("validation", () => {
-      it("keeps Save & Continue button disabled until all required fields validated", async () => {
-        const { getByTestId, UNSAFE_getByProps } = renderWithWrappersTL(<TestRenderer />)
-
-        const SaveButton = UNSAFE_getByProps({
-          testID: "Submission_ArtworkDetails_Button",
-        })
-
-        const inputs = {
-          title: getByTestId("Submission_TitleInput"),
-          year: getByTestId("Submission_YearInput"),
-          material: getByTestId("Submission_MaterialsInput"),
-          height: getByTestId("Submission_HeightInput"),
-          width: getByTestId("Submission_WidthInput"),
-          depth: getByTestId("Submission_DepthInput"),
-          provenance: getByTestId("Submission_ProvenanceInput"),
-        }
-
-        await flushPromiseQueue()
-
-        // title missing
-        act(() => fireEvent.changeText(inputs.title, ""))
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // year missing
-        act(() => {
-          fireEvent.changeText(inputs.year, "")
-          fireEvent.changeText(inputs.title, "someTitle")
-        })
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // material missing
-        act(() => {
-          fireEvent.changeText(inputs.material, "")
-          fireEvent.changeText(inputs.year, "1999")
-        })
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // height missing
-        act(() => {
-          fireEvent.changeText(inputs.height, "")
-          fireEvent.changeText(inputs.material, "oil on c")
-        })
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // width missing
-        act(() => {
-          fireEvent.changeText(inputs.width, "")
-          fireEvent.changeText(inputs.height, "123")
-        })
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // depth missing
-        act(() => {
-          fireEvent.changeText(inputs.depth, "")
-          fireEvent.changeText(inputs.width, "123")
-        })
-
-        expect(SaveButton.props.disabled).toBe(true)
-
-        // provenance missing
-        act(() => {
-          fireEvent.changeText(inputs.provenance, "")
-          fireEvent.changeText(inputs.depth, "123")
-        })
-
-        expect(SaveButton.props.disabled).toBe(true)
-
-        act(() => {
-          fireEvent.changeText(inputs.provenance, "found it")
-        })
-      })
+    it("updates existing submission when ID passed", async () => {
+      await createOrUpdateSubmission(mockSubmissionForm, "12345")
+      expect(updateConsignSubmissionMock).toHaveBeenCalled()
     })
   })
 })
@@ -145,7 +68,7 @@ export const mockSubmissionForm: ArtworkDetailsFormModel = {
   title: "hello",
   year: "2000",
   medium: "oil",
-  attributionClass: null,
+  attributionClass: limitedEditionValue,
   editionNumber: "1",
   editionSizeFormatted: "1",
   dimensionsMetric: "in",

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
@@ -1,95 +1,30 @@
-import { fireEvent } from "@testing-library/react-native"
-import { ConsignmentAttributionClass } from "__generated__/createConsignmentSubmissionMutation.graphql"
-import { Formik } from "formik"
+import { useFormikContext } from "formik"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
-import { CTAButton } from "palette"
 import React from "react"
-import { act } from "react-test-renderer"
 import { mockSubmissionForm } from "./ArtworkDetails.tests"
 import { ArtworkDetailsForm } from "./ArtworkDetailsForm"
-import { limitedEditionValue } from "./utils/rarityOptions"
-import { artworkDetailsValidationSchema } from "./validation"
-import { ArtworkDetailsFormModel } from "./validation"
 
 jest.unmock("react-relay")
+jest.mock("formik")
 
-const ArtworkDetailsFormTestRenderer: React.FC<{
-  attributionClass?: ConsignmentAttributionClass | null
-}> = ({ attributionClass }) => {
-  return (
-    <Formik<ArtworkDetailsFormModel>
-      initialValues={{
-        ...mockSubmissionForm,
-        attributionClass: attributionClass ? attributionClass : null,
-      }}
-      onSubmit={jest.fn()}
-      validationSchema={artworkDetailsValidationSchema}
-      validateOnMount
-    >
-      {({ isValid }) => (
-        <>
-          <ArtworkDetailsForm />
-          <CTAButton
-            disabled={!isValid}
-            onPress={jest.fn()}
-            testID="Submission_ArtworkDetails_Button"
-          >
-            Save & Continue
-          </CTAButton>
-        </>
-      )}
-    </Formik>
-  )
-}
+const useFormikContextMock = useFormikContext as jest.Mock
 
 describe("ArtworkDetailsForm", () => {
-  it("mutates typed input values", () => {
-    const { getByTestId } = renderWithWrappersTL(<ArtworkDetailsFormTestRenderer />)
-
-    const inputs = {
-      title: getByTestId("Submission_TitleInput"),
-      year: getByTestId("Submission_YearInput"),
-      material: getByTestId("Submission_MaterialsInput"),
-      height: getByTestId("Submission_HeightInput"),
-      width: getByTestId("Submission_WidthInput"),
-      depth: getByTestId("Submission_DepthInput"),
-      provenance: getByTestId("Submission_ProvenanceInput"),
-      location: getByTestId("Submission_LocationInput"),
-    }
-
-    act(() => {
-      fireEvent.changeText(inputs.title, "caspar d.")
-      fireEvent.changeText(inputs.year, "0001")
-      fireEvent.changeText(inputs.material, "litho graph")
-      fireEvent.changeText(inputs.height, "1256")
-      fireEvent.changeText(inputs.width, "1398")
-      fireEvent.changeText(inputs.depth, "3")
-      fireEvent.changeText(inputs.provenance, "found")
-      fireEvent.changeText(inputs.location, "somewhere")
-    })
-
-    expect(inputs.title.props.value).toBe("caspar d.")
-    expect(inputs.year.props.value).toBe("0001")
-    expect(inputs.material.props.value).toBe("litho graph")
-    expect(inputs.height.props.value).toBe("1256")
-    expect(inputs.width.props.value).toBe("1398")
-    expect(inputs.depth.props.value).toBe("3")
-    expect(inputs.provenance.props.value).toBe("found")
-    expect(inputs.location.props.value).toBe("somewhere")
+  beforeEach(() => {
+    useFormikContextMock.mockImplementation(() => ({
+      handleSubmit: jest.fn(),
+      handleChange: jest.fn(),
+      setFieldValue: jest.fn(),
+      errors: {},
+      values: mockSubmissionForm,
+    }))
   })
 
-  it("when rarity is limited edition, renders additional inputs for edition number and size", () => {
-    const { getByTestId } = renderWithWrappersTL(
-      <ArtworkDetailsFormTestRenderer attributionClass={limitedEditionValue} />
-    )
+  afterEach(() => jest.clearAllMocks())
 
-    const inputs = {
-      editionNumber: getByTestId("Submission_EditionNumberInput"),
-      editionSize: getByTestId("Submission_EditionSizeInput"),
-    }
-
-    expect(inputs.editionNumber).toBeTruthy()
-    expect(inputs.editionSize).toBeTruthy()
+  it("Validation", async () => {
+    const { findByText } = renderWithWrappersTL(<ArtworkDetailsForm />)
+    expect(findByText("hello")).toBeTruthy()
   })
 })

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
@@ -28,3 +28,77 @@ describe("ArtworkDetailsForm", () => {
     expect(findByText("hello")).toBeTruthy()
   })
 })
+
+// describe("validation", () => {
+//   it("keeps Save & Continue button disabled until all required fields validated", async () => {
+//     const { getByTestId, UNSAFE_getByProps } = renderWithWrappersTL(<TestRenderer />)
+
+//     const SaveButton = UNSAFE_getByProps({
+//       testID: "Submission_ArtworkDetails_Button",
+//     })
+
+//     const inputs = {
+//       title: getByTestId("Submission_TitleInput"),
+//       year: getByTestId("Submission_YearInput"),
+//       material: getByTestId("Submission_MaterialsInput"),
+//       height: getByTestId("Submission_HeightInput"),
+//       width: getByTestId("Submission_WidthInput"),
+//       depth: getByTestId("Submission_DepthInput"),
+//       provenance: getByTestId("Submission_ProvenanceInput"),
+//     }
+
+//     await flushPromiseQueue()
+
+//     // title missing
+//     act(() => fireEvent.changeText(inputs.title, ""))
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // year missing
+//     act(() => {
+//       fireEvent.changeText(inputs.year, "")
+//       fireEvent.changeText(inputs.title, "someTitle")
+//     })
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // material missing
+//     act(() => {
+//       fireEvent.changeText(inputs.material, "")
+//       fireEvent.changeText(inputs.year, "1999")
+//     })
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // height missing
+//     act(() => {
+//       fireEvent.changeText(inputs.height, "")
+//       fireEvent.changeText(inputs.material, "oil on c")
+//     })
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // width missing
+//     act(() => {
+//       fireEvent.changeText(inputs.width, "")
+//       fireEvent.changeText(inputs.height, "123")
+//     })
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // depth missing
+//     act(() => {
+//       fireEvent.changeText(inputs.depth, "")
+//       fireEvent.changeText(inputs.width, "123")
+//     })
+
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     // provenance missing
+//     act(() => {
+//       fireEvent.changeText(inputs.provenance, "")
+//       fireEvent.changeText(inputs.depth, "123")
+//     })
+
+//     expect(SaveButton.props.disabled).toBe(true)
+
+//     act(() => {
+//       fireEvent.changeText(inputs.provenance, "found it")
+//     })
+//   })
+// })

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
@@ -2,8 +2,8 @@ import { useFormikContext } from "formik"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
-import { mockSubmissionForm } from "./ArtworkDetails.tests"
 import { ArtworkDetailsForm } from "./ArtworkDetailsForm"
+import { mockFormValues } from "./utils/testUtils"
 
 jest.unmock("react-relay")
 jest.mock("formik")
@@ -17,7 +17,7 @@ describe("ArtworkDetailsForm", () => {
       handleChange: jest.fn(),
       setFieldValue: jest.fn(),
       errors: {},
-      values: mockSubmissionForm,
+      values: mockFormValues,
     }))
   })
 

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tests.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from "formik"
 import { __globalStoreTestUtils__ } from "lib/store/GlobalStore"
+import { flushPromiseQueue } from "lib/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "lib/tests/renderWithWrappers"
 import React from "react"
 import { ArtworkDetailsForm } from "./ArtworkDetailsForm"
@@ -21,84 +22,29 @@ describe("ArtworkDetailsForm", () => {
     }))
   })
 
-  afterEach(() => jest.clearAllMocks())
+  afterEach(async () => {
+    jest.clearAllMocks()
+    await flushPromiseQueue()
+  })
 
-  it("Validation", async () => {
+  it("correctly displays formik values in form", () => {
     const { findByText } = renderWithWrappersTL(<ArtworkDetailsForm />)
     expect(findByText("hello")).toBeTruthy()
+    expect(findByText("Caspar David Friedrich")).toBeTruthy()
+    expect(findByText("oil on canvas")).toBeTruthy()
+    expect(findByText("found")).toBeTruthy()
+    expect(findByText("London")).toBeTruthy()
+  })
+
+  it("when rarity is limited edition, renders additional inputs for edition number and size", () => {
+    const { getByTestId } = renderWithWrappersTL(<ArtworkDetailsForm />)
+
+    const inputs = {
+      editionNumber: getByTestId("Submission_EditionNumberInput"),
+      editionSize: getByTestId("Submission_EditionSizeInput"),
+    }
+
+    expect(inputs.editionNumber).toBeTruthy()
+    expect(inputs.editionSize).toBeTruthy()
   })
 })
-
-// describe("validation", () => {
-//   it("keeps Save & Continue button disabled until all required fields validated", async () => {
-//     const { getByTestId, UNSAFE_getByProps } = renderWithWrappersTL(<TestRenderer />)
-
-//     const SaveButton = UNSAFE_getByProps({
-//       testID: "Submission_ArtworkDetails_Button",
-//     })
-
-//     const inputs = {
-//       title: getByTestId("Submission_TitleInput"),
-//       year: getByTestId("Submission_YearInput"),
-//       material: getByTestId("Submission_MaterialsInput"),
-//       height: getByTestId("Submission_HeightInput"),
-//       width: getByTestId("Submission_WidthInput"),
-//       depth: getByTestId("Submission_DepthInput"),
-//       provenance: getByTestId("Submission_ProvenanceInput"),
-//     }
-
-//     await flushPromiseQueue()
-
-//     // title missing
-//     act(() => fireEvent.changeText(inputs.title, ""))
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // year missing
-//     act(() => {
-//       fireEvent.changeText(inputs.year, "")
-//       fireEvent.changeText(inputs.title, "someTitle")
-//     })
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // material missing
-//     act(() => {
-//       fireEvent.changeText(inputs.material, "")
-//       fireEvent.changeText(inputs.year, "1999")
-//     })
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // height missing
-//     act(() => {
-//       fireEvent.changeText(inputs.height, "")
-//       fireEvent.changeText(inputs.material, "oil on c")
-//     })
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // width missing
-//     act(() => {
-//       fireEvent.changeText(inputs.width, "")
-//       fireEvent.changeText(inputs.height, "123")
-//     })
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // depth missing
-//     act(() => {
-//       fireEvent.changeText(inputs.depth, "")
-//       fireEvent.changeText(inputs.width, "123")
-//     })
-
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     // provenance missing
-//     act(() => {
-//       fireEvent.changeText(inputs.provenance, "")
-//       fireEvent.changeText(inputs.depth, "123")
-//     })
-
-//     expect(SaveButton.props.disabled).toBe(true)
-
-//     act(() => {
-//       fireEvent.changeText(inputs.provenance, "found it")
-//     })
-//   })
-// })

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/testUtils.ts
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/testUtils.ts
@@ -1,0 +1,27 @@
+import { ArtworkDetailsFormModel } from "../validation"
+import { limitedEditionValue } from "./rarityOptions"
+
+export const mockFormValues: ArtworkDetailsFormModel = {
+  artist: "123",
+  artistId: "200",
+  title: "hello",
+  year: "2000",
+  medium: "oil",
+  attributionClass: limitedEditionValue,
+  editionNumber: "1",
+  editionSizeFormatted: "1",
+  dimensionsMetric: "in",
+  height: "2",
+  width: "2",
+  depth: "2",
+  provenance: "found",
+  state: "DRAFT",
+  utmMedium: "",
+  utmSource: "",
+  utmTerm: "",
+  location: {
+    city: "London",
+    state: "England",
+    country: "UK",
+  },
+}

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/testUtils.ts
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/testUtils.ts
@@ -2,11 +2,11 @@ import { ArtworkDetailsFormModel } from "../validation"
 import { limitedEditionValue } from "./rarityOptions"
 
 export const mockFormValues: ArtworkDetailsFormModel = {
-  artist: "123",
+  artist: "Caspar David Friedrich",
   artistId: "200",
   title: "hello",
   year: "2000",
-  medium: "oil",
+  medium: "oil on canvas",
   attributionClass: limitedEditionValue,
   editionNumber: "1",
   editionSizeFormatted: "1",

--- a/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/validation.ts
+++ b/src/lib/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/validation.ts
@@ -3,6 +3,7 @@ import {
   ConsignmentSubmissionStateAggregation,
 } from "__generated__/createConsignmentSubmissionMutation.graphql"
 import * as Yup from "yup"
+import { limitedEditionValue } from "./utils/rarityOptions"
 
 export interface Location {
   city: string
@@ -65,11 +66,11 @@ export const artworkDetailsValidationSchema = Yup.object().shape({
   medium: Yup.string().required().trim(),
   attributionClass: Yup.string().required(),
   editionNumber: Yup.string().when("attributionClass", {
-    is: "limited edition",
+    is: limitedEditionValue,
     then: Yup.string().required().trim(),
   }),
   editionSizeFormatted: Yup.string().when("attributionClass", {
-    is: "limited edition",
+    is: limitedEditionValue,
     then: Yup.string().required().trim(),
   }),
   dimensionsMetric: Yup.string().required(),


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [[SWA-249](https://artsyproduct.atlassian.net/browse/SWA-249)]

### Description
This PR fixes the form validation in Artwork details step of submission flow. The bug is that when rarity field is selected as limited_edition, we should expect user to type in edition size and number before enabling the save button. 

#### Videos
https://user-images.githubusercontent.com/42584148/155077812-a4ead876-08a0-4517-9cf4-cfe24915b462.mp4



### PR Checklist (tick all before merging)
- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Dev changes
This feature is behind a feature flag, so the changes applicable only to developer for now. 

</details>
