### PR TITLE
feature: User on gallery detail page on eigen sees marquee

### DIFF
--- a/CHANGELOG/android-changelog.md
+++ b/CHANGELOG/android-changelog.md
@@ -8,6 +8,7 @@
   - Dev changes:
     - Do not save the changelog update date - mounir
     - Track link tap and AuctionResultsForYou Screen - kizito
+    - Add black owned marquee to partner page - lily
 
 <!-- DO NOT CHANGE -->
 

--- a/CHANGELOG/ios-changelog.md
+++ b/CHANGELOG/ios-changelog.md
@@ -8,6 +8,7 @@
   - Dev changes:
     - Do not save the changelog update date - mounir
     - Track link tap and AuctionResultsForYou Screen - kizito
+    - Add black owned marquee to partner page - lily
 
 <!-- DO NOT CHANGE -->
 

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "react-native-scrollable-tab-view": "1.0.0",
     "react-native-share": "7.3.6",
     "react-native-svg": "9.13.3",
+    "react-native-text-ticker": "1.14.0",
     "react-native-view-shot": "3.1.2",
     "react-native-webview": "11.3.1",
     "react-relay": "12.0.0",

--- a/src/app/Components/Marquee.tsx
+++ b/src/app/Components/Marquee.tsx
@@ -1,0 +1,33 @@
+import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
+import { Box, BoxProps } from "palette/elements/Box/Box"
+import { Text } from "palette/elements/Text/Text"
+import React from "react"
+import { Easing } from "react-native"
+import TextTicker from "react-native-text-ticker"
+
+export interface MarqueeProps extends BoxProps {
+  speed?: number
+  textVariant?: TextVariant
+  marqueeText: string
+}
+
+export const Marquee: React.FC<MarqueeProps> = ({
+  marqueeText,
+  textVariant = "sm",
+  speed = 15000,
+}) => {
+  return (
+    <TextTicker duration={speed} repeatSpacer={0} loop easing={Easing.linear}>
+      {Array.from(Array(10)).map((_, i) => (
+        <Box key={i} flexDirection="row" bg="black100" py={0.5}>
+          <Text variant={textVariant} px={2} color="white100">
+            {marqueeText}
+          </Text>
+          <Text variant={textVariant} px={2} color="white100">
+            •
+          </Text>
+        </Box>
+      ))}
+    </TextTicker>
+  )
+}

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
@@ -74,6 +74,20 @@ describe("PartnerHeader", () => {
 
     expect(extractText(tree.root.findByType(Button))).toContain("Follow")
   })
+
+  it("renders the Black Owned marquee if the gallery has the 'Black Owned' category", async () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          partner: BlackOwnedPartnerHeaderFixture,
+        },
+      })
+    })
+
+    expect(extractText(tree.root)).toContain("Black Owned")
+  })
 })
 
 const PartnerHeaderFixture = {
@@ -90,6 +104,26 @@ const PartnerHeaderFixture = {
     internalID: "5159da629a60832439000035",
     isFollowed: false,
   },
+  categories: [],
+  internalID: "4d8b92c44eb68a1b2c0004cb",
+  slug: "gagosian",
+}
+
+const BlackOwnedPartnerHeaderFixture = {
+  " $refType": null,
+  name: "Gagosian",
+  counts: {
+    eligibleArtworks: 1231,
+  },
+  profile: {
+    counts: {
+      follows: 136999,
+    },
+    id: "UHJvZmlsZTo1MTU5ZGE2MjlhNjA4MzI0MzkwMDAwMzU=",
+    internalID: "5159da629a60832439000035",
+    isFollowed: false,
+  },
+  categories: [{ name: "Black Owned" }],
   internalID: "4d8b92c44eb68a1b2c0004cb",
   slug: "gagosian",
 }

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tsx
@@ -1,4 +1,5 @@
 import { PartnerHeader_partner } from "__generated__/PartnerHeader_partner.graphql"
+import { Marquee } from "app/Components/Marquee"
 import { Stack } from "app/Components/Stack"
 import { formatLargeNumberOfItems } from "app/utils/formatLargeNumberOfItems"
 import { Box, Flex, Sans } from "palette"
@@ -10,27 +11,31 @@ const PartnerHeader: React.FC<{
   partner: PartnerHeader_partner
 }> = ({ partner }) => {
   const eligibleArtworks = partner.counts?.eligibleArtworks ?? 0
+  const isBlackOwned = true
 
   return (
-    <Box px={2} pb={1} pt={6}>
-      <Sans mb={1} size="8">
-        {partner.name}
-      </Sans>
-      <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-        <Stack spacing={0.5}>
-          {!!eligibleArtworks && (
-            <Sans size="3t">
-              {!!eligibleArtworks && formatLargeNumberOfItems(eligibleArtworks, "work", "works")}
-            </Sans>
+    <>
+      <Box px={2} pb={1} pt={6}>
+        <Sans mb={1} size="8">
+          {partner.name}
+        </Sans>
+        <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+          <Stack spacing={0.5}>
+            {!!eligibleArtworks && (
+              <Sans size="3t">
+                {!!eligibleArtworks && formatLargeNumberOfItems(eligibleArtworks, "work", "works")}
+              </Sans>
+            )}
+          </Stack>
+          {!!partner.profile && (
+            <Flex flexGrow={0} flexShrink={0}>
+              <FollowButton partner={partner} />
+            </Flex>
           )}
-        </Stack>
-        {!!partner.profile && (
-          <Flex flexGrow={0} flexShrink={0}>
-            <FollowButton partner={partner} />
-          </Flex>
-        )}
-      </Flex>
-    </Box>
+        </Flex>
+      </Box>
+      {isBlackOwned && <Marquee marqueeText="Black Owned" />}
+    </>
   )
 }
 
@@ -40,6 +45,9 @@ export const PartnerHeaderContainer = createFragmentContainer(PartnerHeader, {
       name
       profile {
         # Only fetch something so we can see if the profile exists.
+        name
+      }
+      categories {
         name
       }
       counts {

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tsx
@@ -11,7 +11,7 @@ const PartnerHeader: React.FC<{
   partner: PartnerHeader_partner
 }> = ({ partner }) => {
   const eligibleArtworks = partner.counts?.eligibleArtworks ?? 0
-  const isBlackOwned = true
+  const isBlackOwned = partner.categories!.filter((c) => c && c.name === "Black Owned").length > 0
 
   return (
     <>

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -1,16 +1,15 @@
 import { Partner_partner } from "__generated__/Partner_partner.graphql"
 import { PartnerQuery } from "__generated__/PartnerQuery.graphql"
-import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
-import { HeaderTabsGridPlaceholder } from "lib/Components/HeaderTabGridPlaceholder"
-import { RetryErrorBoundaryLegacy } from "lib/Components/RetryErrorBoundary"
-import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
-import { defaultEnvironment } from "lib/relay/createEnvironment"
-import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
-import { Schema, screenTrack } from "lib/utils/track"
+import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
+import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
+import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
+import { defaultEnvironment } from "app/relay/createEnvironment"
+import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
+import { Schema, screenTrack } from "app/utils/track"
 import { Separator } from "palette"
 import React from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
-import { Marquee } from "./Components/Marquee"
 import { PartnerArtworkFragmentContainer as PartnerArtwork } from "./Components/PartnerArtwork"
 import { PartnerHeaderContainer as PartnerHeader } from "./Components/PartnerHeader"
 import { PartnerOverviewFragmentContainer as PartnerOverview } from "./Components/PartnerOverview"
@@ -31,14 +30,13 @@ interface Props {
 class Partner extends React.Component<Props> {
   render() {
     const { partner } = this.props
-    const { partnerType, displayFullPartnerPage, categories } = partner
-    const isBlackOwned = categories!.filter((c) => c && c.name === "Black Owned").length > 0
+    const { partnerType, displayFullPartnerPage } = partner
 
     if (!displayFullPartnerPage && partnerType !== "Brand") {
       return (
         <>
           <PartnerHeader partner={partner} />
-          {isBlackOwned ? <Marquee marqueeText="Black Owned" /> : <Separator my={2} />}
+          <Separator my={2} />
           <PartnerSubscriberBanner partner={partner} />
         </>
       )
@@ -49,7 +47,6 @@ class Partner extends React.Component<Props> {
         staticHeaderContent={
           <>
             <PartnerHeader partner={partner} />
-            <Marquee marqueeText="Black Owned" />
           </>
         }
         tabs={[
@@ -86,9 +83,6 @@ export const PartnerContainer = createRefetchContainer(
         slug
         partnerType
         displayFullPartnerPage
-        categories {
-          name
-        }
         profile {
           id
           isFollowed

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -1,15 +1,16 @@
 import { Partner_partner } from "__generated__/Partner_partner.graphql"
 import { PartnerQuery } from "__generated__/PartnerQuery.graphql"
-import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
-import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
-import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
-import { defaultEnvironment } from "app/relay/createEnvironment"
-import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import { Schema, screenTrack } from "app/utils/track"
+import { ArtworkFiltersStoreProvider } from "lib/Components/ArtworkFilter/ArtworkFilterStore"
+import { HeaderTabsGridPlaceholder } from "lib/Components/HeaderTabGridPlaceholder"
+import { RetryErrorBoundaryLegacy } from "lib/Components/RetryErrorBoundary"
+import { StickyTabPage } from "lib/Components/StickyTabPage/StickyTabPage"
+import { defaultEnvironment } from "lib/relay/createEnvironment"
+import { renderWithPlaceholder } from "lib/utils/renderWithPlaceholder"
+import { Schema, screenTrack } from "lib/utils/track"
 import { Separator } from "palette"
 import React from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
+import { Marquee } from "./Components/Marquee"
 import { PartnerArtworkFragmentContainer as PartnerArtwork } from "./Components/PartnerArtwork"
 import { PartnerHeaderContainer as PartnerHeader } from "./Components/PartnerHeader"
 import { PartnerOverviewFragmentContainer as PartnerOverview } from "./Components/PartnerOverview"
@@ -30,13 +31,14 @@ interface Props {
 class Partner extends React.Component<Props> {
   render() {
     const { partner } = this.props
-    const { partnerType, displayFullPartnerPage } = partner
+    const { partnerType, displayFullPartnerPage, categories } = partner
+    const isBlackOwned = categories!.filter((c) => c && c.name === "Black Owned").length > 0
 
     if (!displayFullPartnerPage && partnerType !== "Brand") {
       return (
         <>
           <PartnerHeader partner={partner} />
-          <Separator my={2} />
+          {isBlackOwned ? <Marquee marqueeText="Black Owned" /> : <Separator my={2} />}
           <PartnerSubscriberBanner partner={partner} />
         </>
       )
@@ -44,7 +46,12 @@ class Partner extends React.Component<Props> {
 
     return (
       <StickyTabPage
-        staticHeaderContent={<PartnerHeader partner={partner} />}
+        staticHeaderContent={
+          <>
+            <PartnerHeader partner={partner} />
+            <Marquee marqueeText="Black Owned" />
+          </>
+        }
         tabs={[
           {
             title: "Overview",
@@ -79,6 +86,9 @@ export const PartnerContainer = createRefetchContainer(
         slug
         partnerType
         displayFullPartnerPage
+        categories {
+          name
+        }
         profile {
           id
           isFollowed

--- a/yarn.lock
+++ b/yarn.lock
@@ -16643,6 +16643,11 @@ react-native-swipe-gestures@^1.0.4:
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
 
+react-native-text-ticker@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/react-native-text-ticker/-/react-native-text-ticker-1.14.0.tgz#dc537d2c587efc18ef19db9a85dc678a28aa8c57"
+  integrity sha512-8TNGTcW43dfnCqIuXVA7F1Ny8SKGrw0pIrNS5nM7eda+6AsuPTZh3JQ2CwmSRYfsrlnS4QFrpyo5ykpI8nvtCw==
+
 react-native-view-shot@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.1.2.tgz#8c8e84c67a4bc8b603e697dbbd59dbc9b4f84825"


### PR DESCRIPTION
[GRO-820](https://artsyproduct.atlassian.net/browse/GRO-820)

This implements the scrolling marquee on the eigen partner page. I used `react-native-text-ticker` to accomplish this, after I tried and failed to do it without an external library. Speed/font/spacing can be adjusted if needed.

https://user-images.githubusercontent.com/5643895/155397365-3b035641-c9f8-4cba-aad8-bd82edae4601.mov


