### PR TITLE
feat(CX-2382): refresh My Collection when submitting an artwork via SWA flow

### DIFF
--- a/src/app/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/app/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
@@ -26,6 +26,7 @@ export const ConsignmentsHome: React.FC<Props> = ({ targetSupply, isLoading }) =
   const tracking = useTracking()
   const handleConsignPress = (tappedConsignArgs: TappedConsignArgs) => {
     tracking.trackEvent(tappedConsign(tappedConsignArgs))
+    GlobalStore.actions.artworkSubmission.submission.resetSessionStateAll()
     const route = "/collections/my-collection/artworks/new/submissions/new"
     navigate(route)
   }

--- a/src/app/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
+++ b/src/app/Scenes/Consignments/ConsignmentsHome/ConsignmentsHome.tsx
@@ -32,7 +32,7 @@ export const ConsignmentsHome: React.FC<Props> = ({ targetSupply, isLoading }) =
 
   useEffect(() => {
     return () => {
-      GlobalStore.actions.artworkSubmission.submission.resetSessionState()
+      GlobalStore.actions.artworkSubmission.submission.resetSessionStateAll()
     }
   }, [])
 

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkSubmitted.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkSubmitted.tsx
@@ -1,5 +1,6 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { navigate } from "app/navigation/navigate"
+import { GlobalStore } from "app/store/GlobalStore"
 import { Box, Button, Flex, Spacer, Text } from "palette"
 import { ArtsyLogoHeader } from "palette/elements/Header/ArtsyLogoHeader"
 import React from "react"
@@ -34,6 +35,7 @@ export const ArtworkSubmittedScreen: React.FC<ArtworkSubmittedScreenNavigationPr
           haptic
           maxWidth={540}
           onPress={() => {
+            GlobalStore.actions.artworkSubmission.submission.resetSessionStateAll()
             navigation.replace("SubmitArtworkScreen")
           }}
         >

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/State/SubmissionModel.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/State/SubmissionModel.tsx
@@ -14,6 +14,7 @@ export interface ArtworkSubmissionModel {
   photos: PhotosFormModel
   setPhotos: Action<ArtworkSubmissionModel, PhotosFormModel>
   setUtmParams: Action<ArtworkSubmissionModel, ConsignmentsSubmissionUtmParams>
+  resetSessionStateAll: Action<ArtworkSubmissionModel>
   resetSessionState: Action<ArtworkSubmissionModel>
 }
 
@@ -44,6 +45,10 @@ export const getSubmissionModel = (): SubmissionModel => ({
       }
     }),
     resetSessionState: action((state) => {
+      state.submissionId = ""
+      state.artworkDetails = artworkDetailsEmptyInitialValues
+    }),
+    resetSessionStateAll: action((state) => {
       state.submissionId = ""
       state.artworkDetails = artworkDetailsEmptyInitialValues
       state.photos = photosEmptyInitialValues

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/SubmitArtworkOverview.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/SubmitArtworkOverview.tsx
@@ -2,6 +2,7 @@ import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, StackScreenProps } from "@react-navigation/stack"
 import { BackButton } from "app/navigation/BackButton"
 import { goBack } from "app/navigation/navigate"
+import { refreshMyCollection } from "app/Scenes/MyCollection/MyCollection"
 import { CollapsibleMenuItem, Flex, Join, Separator, Spacer } from "palette"
 import React, { useRef, useState } from "react"
 import { ScrollView } from "react-native"
@@ -47,6 +48,7 @@ export const SubmitArtworkScreen: React.FC<SubmitArtworkScreenNavigationProps> =
       Content: (
         <ContactInformationQueryRenderer
           handlePress={() => {
+            refreshMyCollection()
             navigation.navigate("ArtworkSubmittedScreen")
           }}
         />

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/validation.ts
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/validation.ts
@@ -7,12 +7,12 @@ export interface PhotosFormModel {
 export interface Photo {
   id?: string
   geminiToken?: string
-  height: number
+  height?: number
   isDefault?: boolean
   imageURL?: string
   internalID?: string
   path?: string
-  width: number
+  width?: number
   imageVersions?: string[]
   loading?: boolean
   error?: boolean

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/validation.ts
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/validation.ts
@@ -7,12 +7,12 @@ export interface PhotosFormModel {
 export interface Photo {
   id?: string
   geminiToken?: string
-  height?: number
+  height: number
   isDefault?: boolean
   imageURL?: string
   internalID?: string
   path?: string
-  width?: number
+  width: number
   imageVersions?: string[]
   loading?: boolean
   error?: boolean

--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -1,4 +1,6 @@
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import { Photo } from "app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/validation"
+import { GlobalStore } from "app/store/GlobalStore"
 import { LocalImage, retrieveLocalImages } from "app/utils/LocalImageStore"
 import { Flex, NoImageIcon, useColor } from "palette"
 import React, { useEffect, useState } from "react"
@@ -21,6 +23,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
 }) => {
   const color = useColor()
   const [localImage, setLocalImage] = useState<LocalImage | null>(null)
+  const [localImageConsignments, setLocalImageConsignments] = useState<Photo | null>(null)
 
   useEffect(() => {
     retrieveLocalImages(artworkSlug).then((images) => {
@@ -28,6 +31,12 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
         setLocalImage(images[0])
       }
     })
+  }, [])
+  const { photos } = GlobalStore.useAppState((state) => state.artworkSubmission.submission.photos)
+  useEffect(() => {
+    if (photos !== null && photos.length > 0) {
+      setLocalImageConsignments(photos[0])
+    }
   }, [])
 
   const renderImage = () => {
@@ -53,6 +62,20 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           }}
           resizeMode="contain"
           source={{ uri: localImage.path }}
+        />
+      )
+    } else if (localImageConsignments) {
+      return (
+        <RNImage
+          testID="Image-Local"
+          style={{
+            width: imageWidth,
+            height: (imageWidth / localImageConsignments.width) * localImageConsignments.height,
+          }}
+          resizeMode="contain"
+          source={{
+            uri: localImageConsignments.path,
+          }}
         />
       )
     } else {

--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -70,7 +70,9 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           testID="Image-Local"
           style={{
             width: imageWidth,
-            height: (imageWidth / localImageConsignments.width) * localImageConsignments.height,
+            height:
+              (imageWidth / (localImageConsignments.width || 120)) *
+              (localImageConsignments.height || 120),
           }}
           resizeMode="contain"
           source={{


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2382]

### Description

Added refreshMyCollection method to my collection when submitting artworks with SWA. When refreshing I am checking GlobalSore, if the artwork is present, I display it. It is done, because after submission artworks are now available immediately. Similar to what we have when editing an artwork in My Collection.

iOS, Upload of one artwork
https://user-images.githubusercontent.com/36167539/155393951-01e90569-b916-431f-a072-34879d7c3519.mp4

iOS (the video is too long, including only screenshot), the look of My Collection after uploading two artworks in a row
![Simulator Screen Shot - iPhone 12 mini - 2022-02-23 at 20 11 10](https://user-images.githubusercontent.com/36167539/155394153-8cb04dea-0cc6-470b-8294-b90f317dc9a6.png)


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- added refresh to my collection when submitting artworks with SWA -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
