### PR TITLE
feat(colors): support new color filtering options

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
@@ -25,14 +25,14 @@ describe("Colors options screen", () => {
           value: "black-and-white",
         },
         {
-          name: "Dark Orange",
+          name: "Orange",
           count: 513,
-          value: "darkorange",
+          value: "orange",
         },
         {
-          name: "Light Blue",
+          name: "Blue",
           count: 277,
-          value: "lightblue",
+          value: "blue",
         },
         {
           name: "Yellow",

--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
@@ -157,9 +157,9 @@ describe("Colors options screen", () => {
       const selectedOptions = selectedColorOptions(tree)
       expect(selectedOptions).toHaveLength(3)
       expect(selectedOptions.map((option) => option.props.name)).toEqual([
-        aggregation!.counts[0].name,
+        aggregation!.counts[1].name,
         aggregation!.counts[3].name,
-        aggregation!.counts[4].name,
+        aggregation!.counts[2].name,
       ])
     })
 

--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -16,7 +16,8 @@ import React from "react"
 import { ColorsSwatch } from "./ColorsSwatch"
 import { useMultiSelect } from "./useMultiSelect"
 
-export const COLORS = [
+// TODO: delete after all artworks are reindexed to use new colors only
+const OLD_COLORS = [
   {
     value: "black-and-white",
     name: "Black and White",
@@ -37,9 +38,26 @@ export const COLORS = [
   { value: "darkgreen", name: "Dark Green", backgroundColor: "#004600", foregroundColor: "#fff" },
 ] as const
 
-type Color = typeof COLORS[number]
+export const COLORS = [
+  { value: "red", name: "Red", backgroundColor: "#BB392D", foregroundColor: "#fff" },
+  { value: "orange", name: "Orange", backgroundColor: "#EA6B1F", foregroundColor: "#000" },
+  { value: "yellow", name: "Yellow", backgroundColor: "#E2B929", foregroundColor: "#000" },
+  { value: "green", name: "Green", backgroundColor: "#00674A", foregroundColor: "#fff" },
+  { value: "blue", name: "Blue", backgroundColor: "#0A1AB4", foregroundColor: "#fff" },
+  { value: "purple", name: "Purple", backgroundColor: "#7B3D91", foregroundColor: "#fff" },
+  {
+    value: "black-and-white",
+    name: "Black and White",
+    backgroundColor: "#000",
+    foregroundColor: "#f00",
+  },
+  { value: "gray", name: "Gray", backgroundColor: "#C2C2C2", foregroundColor: "#000" },
+  { value: "pink", name: "Pink", backgroundColor: "#E1ADCD", foregroundColor: "#000" },
+] as const
 
-export const COLORS_INDEXED_BY_VALUE = COLORS.reduce(
+type Color = typeof COLORS[number] | typeof OLD_COLORS[number]
+
+export const COLORS_INDEXED_BY_VALUE = [...COLORS, ...OLD_COLORS].reduce(
   (acc: Record<string, Color>, color) => ({ ...acc, [color.value]: color }),
   {}
 )
@@ -70,7 +88,7 @@ export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ naviga
 
   // Sort according to order of COLORS constant
   const sortedOptions = sortBy(options, (option) => {
-    return COLORS.findIndex(({ value }) => value === option.paramValue)
+    return [...COLORS, ...OLD_COLORS].findIndex(({ value }) => value === option.paramValue)
   })
 
   const { handleSelect, isSelected, handleClear, isActive } = useMultiSelect({

--- a/src/app/Components/ArtworkFilter/Filters/ColorsSwatch.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsSwatch.tests.tsx
@@ -10,7 +10,7 @@ describe("Colors swatch", () => {
         width={30}
         backgroundColor="black"
         foregroundColor="#fff"
-        name="darkblue"
+        name="blue"
         selected
       />
     )
@@ -22,7 +22,7 @@ describe("Colors swatch", () => {
         width={30}
         backgroundColor="black"
         foregroundColor="#fff"
-        name="darkblue"
+        name="blue"
         selected={false}
       />
     )
@@ -31,16 +31,16 @@ describe("Colors swatch", () => {
   })
 
   it("has correct background color for passed in color", () => {
-    const darkblue = renderWithWrappers(
+    const blue = renderWithWrappers(
       <ColorsSwatch
         width={30}
         backgroundColor="#435EA9"
         foregroundColor="#fff"
-        name="darkblue"
+        name="blue"
         selected
       />
     )
-    const darkBlueView = darkblue.root.findAllByType(Box)[1]
+    const darkBlueView = blue.root.findAllByType(Box)[1]
     expect(darkBlueView.props.bg).toMatch("#435EA9")
 
     const blackAndWhite = renderWithWrappers(
@@ -61,7 +61,7 @@ describe("Colors swatch", () => {
         width={30}
         backgroundColor="#F1572C"
         foregroundColor="#fff"
-        name="darkorange"
+        name="orange"
         selected={false}
       />
     )

--- a/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.tests.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/convertersToFilterParams.tests.ts
@@ -185,8 +185,8 @@ describe("convertColorsToFilterParam", () => {
       colors: [
         {
           count: 11359,
-          name: "gold",
-          value: "gold",
+          name: "yellow",
+          value: "yellow",
         },
         {
           count: 406,
@@ -196,13 +196,13 @@ describe("convertColorsToFilterParam", () => {
       ],
     }
     const criteria: SearchCriteriaAttributes = {
-      colors: ["gold", "red"],
+      colors: ["yellow", "red"],
       additionalGeneIDs: ["prints"],
     }
 
     expect(convertColorsToFilterParam(criteria, aggregation)).toEqual({
-      displayText: "Gold, Red",
-      paramValue: ["gold", "red"],
+      displayText: "Yellow, Red",
+      paramValue: ["yellow", "red"],
       paramName: FilterParamName.colors,
     })
   })
@@ -212,8 +212,8 @@ describe("convertColorsToFilterParam", () => {
       colors: [
         {
           count: 13,
-          name: "violet",
-          value: "violet",
+          name: "purple",
+          value: "purple",
         },
         {
           count: 83,
@@ -223,12 +223,12 @@ describe("convertColorsToFilterParam", () => {
       ],
     }
     const criteria: SearchCriteriaAttributes = {
-      colors: ["pink", "violet", "deep-purple"],
+      colors: ["pink", "purple", "deep-purple"],
     }
 
     expect(convertColorsToFilterParam(criteria, aggregation)).toEqual({
-      displayText: "Pink, Violet",
-      paramValue: ["pink", "violet"],
+      displayText: "Pink, Purple",
+      paramValue: ["pink", "purple"],
       paramName: FilterParamName.colors,
     })
   })
@@ -470,13 +470,13 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
         counts: [
           {
             count: 11359,
-            name: "gold",
-            value: "gold",
+            name: "yellow",
+            value: "yellow",
           },
           {
             count: 7211,
-            name: "lightblue",
-            value: "lightblue",
+            name: "blue",
+            value: "blue",
           },
           {
             count: 406,
@@ -491,7 +491,7 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       additionalGeneIDs: ["prints"],
       atAuction: true,
       attributionClass: ["unknown edition", "open edition"],
-      colors: ["gold", "red"],
+      colors: ["yellow", "red"],
       sizes: ["MEDIUM"],
       inquireableOnly: null,
       locationCities: ["New York, NY, USA"],
@@ -514,8 +514,8 @@ describe("convertSavedSearchCriteriaToFilterParams", () => {
       paramName: FilterParamName.sizes,
     })
     expect(result).toContainEqual({
-      displayText: "Gold, Red",
-      paramValue: ["gold", "red"],
+      displayText: "Yellow, Red",
+      paramValue: ["yellow", "red"],
       paramName: FilterParamName.colors,
     })
     expect(result).toContainEqual({

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
@@ -191,7 +191,7 @@ describe("extractPills", () => {
 
   it("should correctly extract color pills", () => {
     const attributes: SearchCriteriaAttributes = {
-      colors: ["pink", "orange", "darkorange"],
+      colors: ["pink", "orange", "red"],
     }
     const result = extractPills(attributes, aggregations)
 
@@ -207,9 +207,9 @@ describe("extractPills", () => {
         value: "orange",
       },
       {
-        label: "Dark Orange",
+        label: "Red",
         paramName: SearchCriteria.colors,
-        value: "darkorange",
+        value: "red",
       },
     ])
   })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3719]

### Description

- Adds support for the new colors, while retaining support for old colors, so that this can safely be rolled out during our interim period of indexing both sets of color names
- Once usage of older versions of Eigen drops low enough and we've reindexed all production artworks to new color names only, we can come back and drop support for the `OLD_COLORS` list here

We made some decisions above `foregroundColors` for the new swatches, which determines the color of the check mark in the selected state:

|iOS|Android|
|--|--|
|<img width="400" alt="selected" src="https://user-images.githubusercontent.com/140521/156212001-a831c29f-da6c-4c79-9803-a08d7c1165fa.png">|<img width="300" alt="selected" src="https://user-images.githubusercontent.com/21178754/156214573-0f17ef7a-3a53-4834-8057-9e5deac134e5.png">|

Note above that the new colors appear before the old colors, and there is some potential temporary redundancy (blue vs dark blue).


<!-- Implementation description -->


### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Enable support for filtering new color names - roop

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3719]: https://artsyproduct.atlassian.net/browse/FX-3719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ