### PR TITLE
fix: use weak self in city guide, fix memory leak

### DIFF
--- a/Artsy/App/ARAppDelegate+Emission.m
+++ b/Artsy/App/ARAppDelegate+Emission.m
@@ -28,7 +28,6 @@
 #import <Emission/ARTemporaryAPIModule.h>
 #import <Emission/AREventsModule.h>
 #import <Emission/ARTakeCameraPhotoModule.h>
-#import "AREigenMapContainerViewController.h"
 #import <SDWebImage/SDImageCache.h>
 
 #import <React/RCTUtils.h>

--- a/Artsy/View_Controllers/Util/ARNavigationController.m
+++ b/Artsy/View_Controllers/Util/ARNavigationController.m
@@ -14,7 +14,6 @@
 #import "ARNavigationController.h"
 #import "ARMenuAwareViewController.h"
 #import "ARScrollNavigationChief.h"
-#import "AREigenMapContainerViewController.h"
 #import "ARBackButton.h"
 
 #import "ARMacros.h"

--- a/HACKS.md
+++ b/HACKS.md
@@ -263,3 +263,15 @@ React native is not able to convert js functions so this is passed as null to th
 See what can be converted: https://github.com/facebook/react-native/blob/main/React/Base/RCTConvert.h
 
 PropsStore allows us to temporarily hold on the props and reinject them back into the destination view or module.
+
+# `Map` manual prop update in `PageWrapper`
+
+#### When can we remove this:
+
+We should see if it is still necessary when we remove the old native navigation on iOS. To check: go into City Guide, leave, enter again and then try to change the city. If it works without this code it can be removed.
+If it is still an issue with old native navigation gone this can either be removed when we remove or rebuild City Guide or if we change how props are saved in PageWrapper.
+
+#### Explanation/Context:
+
+City Guide is a mixture of native components and react components, prop updates from the native side are not updating the component on the react native side without this manual check and update. See the PR here for the change in the AppRegistry:
+https://github.com/artsy/eigen/pull/6348

--- a/emission/Pod/Classes/ViewControllers/ARMapContainerViewController.m
+++ b/emission/Pod/Classes/ViewControllers/ARMapContainerViewController.m
@@ -147,9 +147,9 @@ const CGFloat MARGIN = 10;
     [[NSNotificationCenter defaultCenter] addObserverForName:@"ARLocalDiscoveryCityGotScrollView" object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
         if (!wself.scrollableTabView) {
             UIScrollView *foundScrollView = FindCityScrollView(wself.cityVC.view);
-            self.scrollableTabView = FindParentScrollView(foundScrollView);
+            wself.scrollableTabView = FindParentScrollView(foundScrollView);
         }
-        BOOL isDrawerOpen = [self.bottomSheetVC.drawerPosition isEqualToPosition:PulleyPosition.open];
+        BOOL isDrawerOpen = [wself.bottomSheetVC.drawerPosition isEqualToPosition:PulleyPosition.open];
         RecurseThroughScrollViewsSettingScrollEnabled(wself.scrollableTabView.superview, isDrawerOpen);
     }];
 

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -227,7 +227,21 @@ class PageWrapper extends React.Component<PageWrapperProps> {
 
   constructor(props: PageWrapperProps) {
     super(props)
-    this.pageProps = {
+    this.pageProps = this.savePageProps()
+  }
+
+  componentDidUpdate() {
+    if (this.props.moduleName === "Map") {
+      // workaround for City Guide. DO NOT USE FOR OTHER THINGS!
+      // basically, only for the city guide component, we recreate the pageprops fresh.
+      // thats because of the funky way the native and RN components in city guide are set up.
+      // if we dont refresh them, then the city guide does not change cities from the dropdown.
+      this.pageProps = this.savePageProps()
+    }
+  }
+
+  savePageProps() {
+    return {
       ...this.props,
       viewProps: {
         ...this.props.viewProps,


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MOPLAT-162]

### Description

There were 2 issues here, 1 was that there was a memory leak causing multiple `AREigenMapContainerViewController`s to be created and stay in memory, this would cause react components contained within to get out of sync. The other was that after we started saving props in the PageWrapper prop updates from the native side were not getting propagated to react native. 

- Fixes a memory leak causing citySelection not to work on subsequent entries to cityGuide
- Adds a workaround for prop updates from native side not updating RN side in PageWrapper

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-  Fixes city not updating in city guide - Pavlos, Brian, Angela, Sultan

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[MOPLAT-162]: https://artsyproduct.atlassian.net/browse/MOPLAT-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ