### PR TITLE
feat(FX-3145): User can see filter criteria for each alert in list view

### DIFF
--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
@@ -9,17 +9,14 @@ interface SavedSearchListItemProps {
 }
 
 const FALLBACK_TITLE = "Untitled Alert"
-const DISPLAY_PILLS_COUNT = 8
 
 export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) => {
   const { item, onPress } = props
-  const [displayAllFilters, setDisplayAllFilters] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
   const color = useColor()
-  const slicedLabels = item.labels.slice(0, DISPLAY_PILLS_COUNT)
-  const labels = displayAllFilters ? item.labels : slicedLabels
 
-  const toggleDisplayAllFiltersState = () => {
-    setDisplayAllFilters(!displayAllFilters)
+  const toggleExpandFilters = () => {
+    setIsExpanded(!isExpanded)
   }
 
   return (
@@ -31,36 +28,25 @@ export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) =
           </Flex>
           <ChevronIcon direction="right" fill="black60" />
         </Flex>
-        <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
-          {labels.map((entity) => (
-            <Pill m={0.5} key={entity.value}>
-              {entity.value}
-            </Pill>
-          ))}
 
-          {item.labels.length > DISPLAY_PILLS_COUNT && (
-            <Touchable onPress={toggleDisplayAllFiltersState}>
-              <Flex
-                flexDirection="row"
-                m={0.5}
-                height={30}
-                alignItems="center"
-                justifyContent="center"
-                px={1}
-              >
-                <Text variant="xs" underline>
-                  {displayAllFilters ? "Close all filters" : "Show all filters"}
-                </Text>
-                <ChevronIcon
-                  direction={displayAllFilters ? "up" : "down"}
-                  height={15}
-                  mt="2px"
-                  ml={0.5}
-                />
-              </Flex>
-            </Touchable>
-          )}
-        </Flex>
+        <Touchable style={{ alignSelf: "flex-start" }} onPress={toggleExpandFilters}>
+          <Box flexDirection="row" mt={2}>
+            <Text variant="xs" underline>
+              {isExpanded ? "Close all filters" : "Show all filters"}
+            </Text>
+            <ChevronIcon direction={isExpanded ? "up" : "down"} height={16} mt="2px" ml={0.5} />
+          </Box>
+        </Touchable>
+
+        {isExpanded ? (
+          <Flex flexDirection="row" flexWrap="wrap" mt={2} mx={-0.5}>
+            {item.labels.map((entity) => (
+              <Pill m={0.5} key={entity.value}>
+                {entity.value}
+              </Pill>
+            ))}
+          </Flex>
+        ) : null}
       </Box>
     </Touchable>
   )

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
@@ -1,15 +1,17 @@
-import { Box, ChevronIcon, Flex, Text, Touchable, useColor } from "palette"
+import { SavedSearchListItem_item } from "__generated__/SavedSearchListItem_item.graphql"
+import { Box, ChevronIcon, Flex, Pill, Text, Touchable, useColor } from "palette"
 import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 
 interface SavedSearchListItemProps {
-  title: string
+  item: SavedSearchListItem_item
   onPress?: () => void
 }
 
 const FALLBACK_TITLE = "Untitled Alert"
 
 export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) => {
-  const { title, onPress } = props
+  const { item, onPress } = props
   const color = useColor()
 
   return (
@@ -17,11 +19,31 @@ export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) =
       <Box px={2} py={1.5}>
         <Flex flexDirection="row" alignItems="center" justifyContent="space-between">
           <Flex flex={1} flexDirection="row" mr="2">
-            <Text variant="sm">{title ?? FALLBACK_TITLE}</Text>
+            <Text variant="sm">{item.userAlertSettings.name ?? FALLBACK_TITLE}</Text>
           </Flex>
           <ChevronIcon direction="right" fill="black60" />
+        </Flex>
+        <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
+          {item.labels.map((entity) => (
+            <Pill m={0.5} key={entity.value}>
+              {entity.value}
+            </Pill>
+          ))}
         </Flex>
       </Box>
     </Touchable>
   )
 }
+
+export const SavedSearchListItemFragmentContainer = createFragmentContainer(SavedSearchListItem, {
+  item: graphql`
+    fragment SavedSearchListItem_item on SearchCriteria {
+      labels {
+        value
+      }
+      userAlertSettings {
+        name
+      }
+    }
+  `,
+})

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchListItem.tsx
@@ -1,6 +1,6 @@
 import { SavedSearchListItem_item } from "__generated__/SavedSearchListItem_item.graphql"
 import { Box, ChevronIcon, Flex, Pill, Text, Touchable, useColor } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 
 interface SavedSearchListItemProps {
@@ -9,10 +9,18 @@ interface SavedSearchListItemProps {
 }
 
 const FALLBACK_TITLE = "Untitled Alert"
+const DISPLAY_PILLS_COUNT = 8
 
 export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) => {
   const { item, onPress } = props
+  const [displayAllFilters, setDisplayAllFilters] = useState(false)
   const color = useColor()
+  const slicedLabels = item.labels.slice(0, DISPLAY_PILLS_COUNT)
+  const labels = displayAllFilters ? item.labels : slicedLabels
+
+  const toggleDisplayAllFiltersState = () => {
+    setDisplayAllFilters(!displayAllFilters)
+  }
 
   return (
     <Touchable onPress={onPress} underlayColor={color("black5")}>
@@ -24,11 +32,34 @@ export const SavedSearchListItem: React.FC<SavedSearchListItemProps> = (props) =
           <ChevronIcon direction="right" fill="black60" />
         </Flex>
         <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
-          {item.labels.map((entity) => (
+          {labels.map((entity) => (
             <Pill m={0.5} key={entity.value}>
               {entity.value}
             </Pill>
           ))}
+
+          {item.labels.length > DISPLAY_PILLS_COUNT && (
+            <Touchable onPress={toggleDisplayAllFiltersState}>
+              <Flex
+                flexDirection="row"
+                m={0.5}
+                height={30}
+                alignItems="center"
+                justifyContent="center"
+                px={1}
+              >
+                <Text variant="xs" underline>
+                  {displayAllFilters ? "Close all filters" : "Show all filters"}
+                </Text>
+                <ChevronIcon
+                  direction={displayAllFilters ? "up" : "down"}
+                  height={15}
+                  mt="2px"
+                  ml={0.5}
+                />
+              </Flex>
+            </Touchable>
+          )}
         </Flex>
       </Box>
     </Touchable>

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -66,6 +66,42 @@ describe("SavedSearches", () => {
     expect(getByText("two")).toBeTruthy()
   })
 
+  it("renders filter pills", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              labels: [
+                {
+                  value: "Filter pill 1",
+                },
+                {
+                  value: "Filter pill 2",
+                },
+              ],
+            },
+          },
+          {
+            node: {
+              labels: [
+                {
+                  value: "Filter pill 3",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getByText("Filter pill 1")).toBeTruthy()
+    expect(getByText("Filter pill 2")).toBeTruthy()
+    expect(getByText("Filter pill 3")).toBeTruthy()
+  })
+
   it("renders an empty message if there are no saved search alerts", () => {
     const { getByText } = renderWithWrappersTL(<TestRenderer />)
 

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -2,7 +2,6 @@ import { fireEvent } from "@testing-library/react-native"
 import { SavedSearchesListTestsQuery } from "__generated__/SavedSearchesListTestsQuery.graphql"
 import { mockEnvironmentPayload } from "app/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
-import { times } from "lodash"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
@@ -68,7 +67,34 @@ describe("SavedSearches", () => {
     expect(getByText("two")).toBeTruthy()
   })
 
-  it("renders filter pills", () => {
+  it("hides all filters by default", () => {
+    const { queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              labels: [
+                {
+                  value: "Filter pill 1",
+                },
+                {
+                  value: "Filter pill 2",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(queryByText("Show all filters")).toBeTruthy()
+    expect(queryByText("Filter pill 1")).toBeFalsy()
+    expect(queryByText("Filter pill 2")).toBeFalsy()
+  })
+
+  it("renders all filters when `Show all filters` button is pressed", () => {
     const { getByText } = renderWithWrappersTL(<TestRenderer />)
 
     mockEnvironmentPayload(mockEnvironment, {
@@ -86,85 +112,14 @@ describe("SavedSearches", () => {
               ],
             },
           },
-          {
-            node: {
-              labels: [
-                {
-                  value: "Filter pill 3",
-                },
-              ],
-            },
-          },
-        ],
-      }),
-    })
-
-    expect(getByText("Filter pill 1")).toBeTruthy()
-    expect(getByText("Filter pill 2")).toBeTruthy()
-    expect(getByText("Filter pill 3")).toBeTruthy()
-  })
-
-  it("renders only first 8 filter pills", () => {
-    const { queryByText } = renderWithWrappersTL(<TestRenderer />)
-
-    mockEnvironmentPayload(mockEnvironment, {
-      SearchCriteriaConnection: () => ({
-        edges: [
-          {
-            node: {
-              labels: times(10).map((label) => ({
-                value: `Filter pill ${label + 1}`,
-              })),
-            },
-          },
-        ],
-      }),
-    })
-
-    expect(queryByText("Filter pill 8")).toBeTruthy()
-    expect(queryByText("Filter pill 9")).toBeFalsy()
-  })
-
-  it("renders `Show all filters` button if there are more than 8 filters", () => {
-    const { getByText } = renderWithWrappersTL(<TestRenderer />)
-
-    mockEnvironmentPayload(mockEnvironment, {
-      SearchCriteriaConnection: () => ({
-        edges: [
-          {
-            node: {
-              labels: times(10).map((label) => ({
-                value: `Filter pill ${label + 1}`,
-              })),
-            },
-          },
-        ],
-      }),
-    })
-
-    expect(getByText("Show all filters")).toBeTruthy()
-  })
-
-  it("renders `Close all filters` button when all filters are displayed", () => {
-    const { getByText } = renderWithWrappersTL(<TestRenderer />)
-
-    mockEnvironmentPayload(mockEnvironment, {
-      SearchCriteriaConnection: () => ({
-        edges: [
-          {
-            node: {
-              labels: times(10).map((label) => ({
-                value: `Filter pill ${label + 1}`,
-              })),
-            },
-          },
         ],
       }),
     })
 
     fireEvent.press(getByText("Show all filters"))
 
-    expect(getByText("Filter pill 9")).toBeTruthy()
+    expect(getByText("Filter pill 1")).toBeTruthy()
+    expect(getByText("Filter pill 2")).toBeTruthy()
     expect(getByText("Close all filters")).toBeTruthy()
   })
 

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -1,6 +1,8 @@
+import { fireEvent } from "@testing-library/react-native"
 import { SavedSearchesListTestsQuery } from "__generated__/SavedSearchesListTestsQuery.graphql"
 import { mockEnvironmentPayload } from "app/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import { times } from "lodash"
 import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
@@ -100,6 +102,70 @@ describe("SavedSearches", () => {
     expect(getByText("Filter pill 1")).toBeTruthy()
     expect(getByText("Filter pill 2")).toBeTruthy()
     expect(getByText("Filter pill 3")).toBeTruthy()
+  })
+
+  it("renders only first 8 filter pills", () => {
+    const { queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              labels: times(10).map((label) => ({
+                value: `Filter pill ${label + 1}`,
+              })),
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(queryByText("Filter pill 8")).toBeTruthy()
+    expect(queryByText("Filter pill 9")).toBeFalsy()
+  })
+
+  it("renders `Show all filters` button if there are more than 8 filters", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              labels: times(10).map((label) => ({
+                value: `Filter pill ${label + 1}`,
+              })),
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getByText("Show all filters")).toBeTruthy()
+  })
+
+  it("renders `Close all filters` button when all filters are displayed", () => {
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      SearchCriteriaConnection: () => ({
+        edges: [
+          {
+            node: {
+              labels: times(10).map((label) => ({
+                value: `Filter pill ${label + 1}`,
+              })),
+            },
+          },
+        ],
+      }),
+    })
+
+    fireEvent.press(getByText("Show all filters"))
+
+    expect(getByText("Filter pill 9")).toBeTruthy()
+    expect(getByText("Close all filters")).toBeTruthy()
   })
 
   it("renders an empty message if there are no saved search alerts", () => {

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -11,7 +11,7 @@ import { FlatList } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { EmptyMessage } from "./EmptyMessage"
 import { SavedSearchAlertsListPlaceholder } from "./SavedSearchAlertsListPlaceholder"
-import { SavedSearchListItem } from "./SavedSearchListItem"
+import { SavedSearchListItemFragmentContainer } from "./SavedSearchListItem"
 
 interface SavedSearchesListProps {
   me: SavedSearchesList_me
@@ -87,8 +87,8 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
       onRefresh={onRefresh}
       renderItem={({ item }) => {
         return (
-          <SavedSearchListItem
-            title={item.userAlertSettings.name!}
+          <SavedSearchListItemFragmentContainer
+            item={item}
             onPress={() => {
               navigate(`my-profile/saved-search-alerts/${item.internalID}`)
             }}
@@ -136,9 +136,7 @@ export const SavedSearchesListContainer = createPaginationContainer(
           edges {
             node {
               internalID
-              userAlertSettings {
-                name
-              }
+              ...SavedSearchListItem_item
             }
           }
         }

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -92,6 +92,7 @@ export const features = defineFeatures({
     readyForRelease: false,
     description: "Enable improved search pills",
     echoFlagKey: "AREnableImprovedSearchPills",
+    showInAdminMenu: true,
   },
   AREnableTrove: {
     readyForRelease: true,

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -92,7 +92,6 @@ export const features = defineFeatures({
     readyForRelease: false,
     description: "Enable improved search pills",
     echoFlagKey: "AREnableImprovedSearchPills",
-    showInAdminMenu: true,
   },
   AREnableTrove: {
     readyForRelease: true,


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [FX-3145]

### Description
* As a user
* If I visit the "saved alerts" screen
* I see my saved search names
* And below each name, I see the filter criteria used for that saved search

### Acceptance criteria
* ability to expand/collapse filters
* show "Show all filters" button by default
* show “Close all filters” button when filters are expanded
* сlicking “Close all filters” button returns to default state (filters are collapsed, "Show all filters" button is displayed)

### Demo
### iOS
https://user-images.githubusercontent.com/3513494/156553055-a0d0e5d6-4d38-4daa-86f9-d345d0145b17.mp4

### Android
https://user-images.githubusercontent.com/3513494/156553113-8bd721ee-c251-4dfb-abf8-deff8dc20415.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- User can see filter criteria for each alert in list view - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3145]: https://artsyproduct.atlassian.net/browse/FX-3145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ