### PR TITLE
[fix]: swa 277/numeric keyboard for inputs in submission flow

### DIFF
--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -55,6 +55,24 @@ describe("ArtworkDetails", () => {
     expect(getByText("All fields are required to submit an artwork.")).toBeTruthy()
   })
 
+  it("renders numeric pad for year and dimensions", async () => {
+    const { getByTestId } = renderWithWrappersTL(<TestRenderer />)
+
+    const inputs = {
+      year: getByTestId("Submission_YearInput"),
+      height: getByTestId("Submission_HeightInput"),
+      width: getByTestId("Submission_WidthInput"),
+      depth: getByTestId("Submission_DepthInput"),
+    }
+
+    await flushPromiseQueue()
+
+    expect(inputs.year.props.keyboardType).toBe("number-pad")
+    expect(inputs.height.props.keyboardType).toBe("number-pad")
+    expect(inputs.width.props.keyboardType).toBe("number-pad")
+    expect(inputs.depth.props.keyboardType).toBe("number-pad")
+  })
+
   describe("createOrUpdateSubmission", () => {
     it("creates new submission when no submission ID passed", async () => {
       await createOrUpdateSubmission(mockFormValues, "")

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -55,7 +55,7 @@ describe("ArtworkDetails", () => {
     expect(getByText("All fields are required to submit an artwork.")).toBeTruthy()
   })
 
-  it("renders numeric pad for year and dimensions", async () => {
+  it("renders numeric-pad for year and decimal-pad for dimension inputs", async () => {
     const { getByTestId } = renderWithWrappersTL(<TestRenderer />)
 
     const inputs = {
@@ -68,9 +68,9 @@ describe("ArtworkDetails", () => {
     await flushPromiseQueue()
 
     expect(inputs.year.props.keyboardType).toBe("number-pad")
-    expect(inputs.height.props.keyboardType).toBe("number-pad")
-    expect(inputs.width.props.keyboardType).toBe("number-pad")
-    expect(inputs.depth.props.keyboardType).toBe("number-pad")
+    expect(inputs.height.props.keyboardType).toBe("decimal-pad")
+    expect(inputs.width.props.keyboardType).toBe("decimal-pad")
+    expect(inputs.depth.props.keyboardType).toBe("decimal-pad")
   })
 
   describe("createOrUpdateSubmission", () => {

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tsx
@@ -37,6 +37,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         testID="Submission_TitleInput"
         value={values.title}
         onChangeText={(e) => setFieldValue("title", e)}
+        accessibilityLabel="Title"
       />
       <StandardSpace />
       <Input
@@ -46,6 +47,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         testID="Submission_YearInput"
         value={values.year}
         onChangeText={(e) => setFieldValue("year", e)}
+        accessibilityLabel="Year"
       />
       <StandardSpace />
       <Input
@@ -54,6 +56,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         testID="Submission_MaterialsInput"
         value={values.medium}
         onChangeText={(e) => setFieldValue("medium", e)}
+        accessibilityLabel="Materials"
       />
       <StandardSpace />
       <Select
@@ -85,17 +88,21 @@ export const ArtworkDetailsForm: React.FC = () => {
             <Box width="48%" mr={1}>
               <Input
                 title="Edition Number"
+                keyboardType="decimal-pad"
                 testID="Submission_EditionNumberInput"
                 value={values.editionNumber}
                 onChangeText={(e) => setFieldValue("editionNumber", e)}
+                accessibilityLabel="Edition Number"
               />
             </Box>
             <Box width="48%">
               <Input
                 title="Edition Size"
+                keyboardType="decimal-pad"
                 testID="Submission_EditionSizeInput"
                 value={values.editionSizeFormatted}
                 onChangeText={(e) => setFieldValue("editionSizeFormatted", e)}
+                accessibilityLabel="Edition Size"
               />
             </Box>
           </Flex>
@@ -122,28 +129,31 @@ export const ArtworkDetailsForm: React.FC = () => {
         <Box width="31%" mr={1}>
           <Input
             title="Height"
-            keyboardType="number-pad"
+            keyboardType="decimal-pad"
             testID="Submission_HeightInput"
             value={values.height}
             onChangeText={(e) => setFieldValue("height", e)}
+            accessibilityLabel="Height"
           />
         </Box>
         <Box width="31%" mr={1}>
           <Input
             title="Width"
-            keyboardType="number-pad"
+            keyboardType="decimal-pad"
             testID="Submission_WidthInput"
             value={values.width}
             onChangeText={(e) => setFieldValue("width", e)}
+            accessibilityLabel="Width"
           />
         </Box>
         <Box width="31%">
           <Input
             title="Depth"
-            keyboardType="number-pad"
+            keyboardType="decimal-pad"
             testID="Submission_DepthInput"
             value={values.depth}
             onChangeText={(e) => setFieldValue("depth", e)}
+            accessibilityLabel="Depth"
           />
         </Box>
       </Flex>

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/ArtworkDetailsForm.tsx
@@ -42,6 +42,7 @@ export const ArtworkDetailsForm: React.FC = () => {
       <Input
         title="Year"
         placeholder="YYYY"
+        keyboardType="number-pad"
         testID="Submission_YearInput"
         value={values.year}
         onChangeText={(e) => setFieldValue("year", e)}
@@ -121,6 +122,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         <Box width="31%" mr={1}>
           <Input
             title="Height"
+            keyboardType="number-pad"
             testID="Submission_HeightInput"
             value={values.height}
             onChangeText={(e) => setFieldValue("height", e)}
@@ -129,6 +131,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         <Box width="31%" mr={1}>
           <Input
             title="Width"
+            keyboardType="number-pad"
             testID="Submission_WidthInput"
             value={values.width}
             onChangeText={(e) => setFieldValue("width", e)}
@@ -137,6 +140,7 @@ export const ArtworkDetailsForm: React.FC = () => {
         <Box width="31%">
           <Input
             title="Depth"
+            keyboardType="number-pad"
             testID="Submission_DepthInput"
             value={values.depth}
             onChangeText={(e) => setFieldValue("depth", e)}

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ContactInformation/ContactInformation.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ContactInformation/ContactInformation.tsx
@@ -77,15 +77,18 @@ export const ContactInformation: React.FC<{
             value={values.userName}
             onBlur={handleBlur("userName")}
             error={touched.userName ? errors.userName : undefined}
+            accessibilityLabel="Name"
           />
           <Spacer mt={4} />
           <Input
             title="Email"
             placeholder="Your Email Address"
+            keyboardType="email-address"
             onChangeText={handleChange("userEmail")}
             value={values.userEmail}
             onBlur={handleBlur("userEmail")}
             error={touched.userEmail ? errors.userEmail : undefined}
+            accessibilityLabel="Email address"
           />
           <Spacer mt={4} />
           <PhoneInput
@@ -98,6 +101,7 @@ export const ContactInformation: React.FC<{
               // do nothing
             }}
             onBlur={handleBlur("userPhone")}
+            accessibilityLabel="Phone number"
           />
           <Spacer mt={6} />
           <CTAButton onPress={handleSubmit} disabled={!isValid}>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [SWA-277]

### Description
This PR turns 4 inputs (for year, width, height, depth) in the new submission flow form into numeric inputs. 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Dev changes
Changes applicable to devs only as the feature behind a flag. 

<!-- end_changelog_updates -->

</details>


[SWA-277]: https://artsyproduct.atlassian.net/browse/SWA-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ