### PR TITLE
fix(city guide): selector staying visible

### DIFF
--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -16,7 +16,7 @@ import { Schema, screenTrack, track } from "app/utils/track"
 import { get, isEqual, uniq } from "lodash"
 import { Box, ClassTheme, Flex, Sans } from "palette"
 import React from "react"
-import { Animated, Dimensions, Easing, Image, View } from "react-native"
+import { Animated, Dimensions, Image, View } from "react-native"
 import Config from "react-native-config"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
 // @ts-ignore
@@ -117,15 +117,6 @@ export const ArtsyMapStyleURL = "mapbox://styles/artsyit/cjrb59mjb2tsq2tqxl17pfo
 const DefaultZoomLevel = 11
 const MinZoomLevel = 9
 const MaxZoomLevel = 17.5
-
-const ButtonAnimation = {
-  yDelta: -300,
-  duration: 350,
-  easing: {
-    moveOut: Easing.in(Easing.cubic),
-    moveIn: Easing.out(Easing.cubic),
-  },
-}
 
 enum DrawerPosition {
   open = "open",
@@ -232,24 +223,6 @@ export class GlobalMap extends React.Component<Props, State> {
     // If the relayErrorState changes, emit a new event.
     if (!!relayErrorState !== !!nextProps.relayErrorState) {
       EventEmitter.dispatch("map:error", { relayErrorState: nextProps.relayErrorState })
-    }
-
-    if (nextProps.hideMapButtons !== this.props.hideMapButtons) {
-      if (nextProps.hideMapButtons) {
-        Animated.timing(this.hideButtons, {
-          toValue: 1,
-          duration: ButtonAnimation.duration,
-          easing: ButtonAnimation.easing.moveOut,
-          useNativeDriver: true,
-        }).start()
-      } else {
-        Animated.timing(this.hideButtons, {
-          toValue: 0,
-          duration: ButtonAnimation.duration,
-          easing: ButtonAnimation.easing.moveIn,
-          useNativeDriver: true,
-        }).start()
-      }
     }
   }
 


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [MOPLAT-166]

### Description

Cherry-picking this quick fix from our latest release back to main.

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- city guide city selector stays visible - pavlos

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[MOPLAT-166]: https://artsyproduct.atlassian.net/browse/MOPLAT-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ