### PR TITLE
feat(Wrap): tests and better api for Wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "react-fps": "1.0.6",
     "react-instantsearch-core": "6.16.0",
     "react-instantsearch-native": "6.16.0",
+    "react-nanny": "2.12.0",
     "react-native": "0.63.3",
     "react-native-appboy-sdk": "1.30.0",
     "react-native-bootsplash": "3.2.0",

--- a/src/app/utils/Wrap.tests.tsx
+++ b/src/app/utils/Wrap.tests.tsx
@@ -1,0 +1,75 @@
+import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import React from "react"
+import { Text, View } from "react-native"
+import { Wrap } from "./Wrap"
+
+describe("Wrap", () => {
+  const TestComp = ({ force }: { force: boolean }) => (
+    <Wrap if={force}>
+      <View testID="wrapper-view">
+        <Wrap.Content>
+          <Text testID="inner-text">wow</Text>
+        </Wrap.Content>
+      </View>
+    </Wrap>
+  )
+
+  it("renders transparently when not wrapping", async () => {
+    const { queryByTestId } = renderWithWrappersTL(<TestComp force={false} />)
+    expect(queryByTestId("wrapper-view")).toBeFalsy()
+    expect(queryByTestId("inner-text")).toBeTruthy()
+  })
+
+  it("renders transparently when wrapping", async () => {
+    const { queryByTestId } = renderWithWrappersTL(<TestComp force />)
+
+    expect(queryByTestId("wrapper-view")).toBeTruthy()
+    expect(queryByTestId("inner-text")).toBeTruthy()
+  })
+
+  describe("edge cases", () => {
+    it("doesn't allow zero Wrap.Content", async () => {
+      expect(() =>
+        renderWithWrappersTL(
+          <Wrap if={false}>
+            <Text testID="inner-text">wow</Text>
+          </Wrap>
+        )
+      ).toThrowError("Wrap.Content is required")
+    })
+
+    it("doesn't allow more than exactly one Wrap.Content", async () => {
+      expect(() =>
+        renderWithWrappersTL(
+          <Wrap if={false}>
+            <View testID="wrapper-view">
+              <Wrap.Content>
+                <Text testID="inner-text">wow</Text>
+              </Wrap.Content>
+              <Wrap.Content>
+                <Text testID="inner-text-2">wow2</Text>
+              </Wrap.Content>
+            </View>
+          </Wrap>
+        )
+      ).toThrowError("You can't have more than one Wrap.Content")
+    })
+
+    it("doesn't allow more than exactly one Wrap.Content even if wrapped", async () => {
+      expect(() =>
+        renderWithWrappersTL(
+          <Wrap if={false}>
+            <View testID="wrapper-view">
+              <Wrap.Content>
+                <Text testID="inner-text">wow</Text>
+                <Wrap.Content>
+                  <Text testID="inner-text-2">wow2</Text>
+                </Wrap.Content>
+              </Wrap.Content>
+            </View>
+          </Wrap>
+        )
+      ).toThrowError("You can't have more than one Wrap.Content")
+    })
+  })
+})

--- a/src/app/utils/Wrap.tsx
+++ b/src/app/utils/Wrap.tsx
@@ -11,15 +11,15 @@ export const Wrap = ({ if: condition, children }: WrapProps) => {
     return <>{children}</>
   }
 
-  const wrapContentChilden = getChildrenByTypeDeep(children, Wrap.Content)
-  if (wrapContentChilden.length === 0) {
+  const wrapContentChildren = getChildrenByTypeDeep(children, Wrap.Content)
+  if (wrapContentChildren.length === 0) {
     throw new Error("Wrap.Content is required")
   }
-  if (wrapContentChilden.length > 1) {
+  if (wrapContentChildren.length > 1) {
     throw new Error("You can't have more than one Wrap.Content")
   }
 
-  const actualWrapContent = wrapContentChilden[0]
+  const actualWrapContent = wrapContentChildren[0]
   return <>{actualWrapContent}</>
 }
 

--- a/src/app/utils/Wrap.tsx
+++ b/src/app/utils/Wrap.tsx
@@ -1,10 +1,26 @@
-import React, { FC, ReactNode } from "react"
+import React, { ReactNode } from "react"
+import { getChildrenByTypeDeep } from "react-nanny"
 
 interface WrapProps {
   if: boolean
-  with: (children: ReactNode) => JSX.Element
+  children?: ReactNode
 }
 
-export const Wrap: FC<WrapProps> = ({ if: condition, with: wrapper, children }) => {
-  return condition ? wrapper(children) : <>{children}</>
+export const Wrap = ({ if: condition, children }: WrapProps) => {
+  if (condition) {
+    return <>{children}</>
+  }
+
+  const wrapContentChilden = getChildrenByTypeDeep(children, Wrap.Content)
+  if (wrapContentChilden.length === 0) {
+    throw new Error("Wrap.Content is required")
+  }
+  if (wrapContentChilden.length > 1) {
+    throw new Error("You can't have more than one Wrap.Content")
+  }
+
+  const actualWrapContent = wrapContentChilden[0]
+  return <>{actualWrapContent}</>
 }
+
+Wrap.Content = ({ children }: { children?: ReactNode }) => <>{children}</>

--- a/src/palette/elements/Button/Button.stories.tsx
+++ b/src/palette/elements/Button/Button.stories.tsx
@@ -69,17 +69,14 @@ storiesOf("Button", module)
     <DataList
       data={variants}
       renderItem={({ item: variant }) => (
-        <Wrap
-          if={variant === "outlineLight" || variant === "fillLight"}
-          with={(c) => (
-            <Flex backgroundColor="black100" p={10}>
-              {c}
-            </Flex>
-          )}
-        >
-          <Button variant={variant} onPress={() => action(`tapped ${variant}`)}>
-            {variant}
-          </Button>
+        <Wrap if={variant === "outlineLight" || variant === "fillLight"}>
+          <Flex backgroundColor="black100" p={10}>
+            <Wrap.Content>
+              <Button variant={variant} onPress={() => action(`tapped ${variant}`)}>
+                {variant}
+              </Button>
+            </Wrap.Content>
+          </Flex>
         </Wrap>
       )}
     />
@@ -98,17 +95,14 @@ storiesOf("Button", module)
     <DataList
       data={variants}
       renderItem={({ item: variant }) => (
-        <Wrap
-          if={variant === "outlineLight"}
-          with={(c) => (
-            <Flex backgroundColor="black100" p={10}>
-              {c}
-            </Flex>
-          )}
-        >
-          <Button variant={variant} disabled onPress={() => action(`tapped ${variant}`)}>
-            {variant}
-          </Button>
+        <Wrap if={variant === "outlineLight"}>
+          <Flex backgroundColor="black100" p={10}>
+            <Wrap.Content>
+              <Button variant={variant} disabled onPress={() => action(`tapped ${variant}`)}>
+                {variant}
+              </Button>
+            </Wrap.Content>
+          </Flex>
         </Wrap>
       )}
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -16499,6 +16499,11 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-nanny@2.12.0:
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.12.0.tgz#8ee7d20319f81131fc1be50ddf3197f286a81dde"
+  integrity sha512-oQ3Mo2oBPVELl96IHc43zVsCJUt8BYoEXoeBtPJzTfTTVezQx3/CRZZ+4Ck6TITxawRTUiOcU8v7EPaGpDk01A==
+
 react-native-appboy-sdk@1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/react-native-appboy-sdk/-/react-native-appboy-sdk-1.30.0.tgz#ccebdcb297c887d30bd7fb75afab88022e243884"


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves []

### Description

`Wrap` is a helper component we have, and I changed its "api" to be a bit more clear. Also I added tests

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
#nochangelog
#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
