### PR TITLE
fix: enable save & continue button after photo deletion

### DIFF
--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/UploadPhotos/UploadPhotosForm.tsx
@@ -87,10 +87,11 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
           p.errorMessage = ""
         })
       }
-      setFieldValue("photos", filteredPhotos)
+
       GlobalStore.actions.artworkSubmission.submission.setPhotos({
-        photos: [...filteredPhotos],
+        photos: filteredPhotos,
       })
+      setFieldValue("photos", filteredPhotos)
     } catch (error) {
       photo.error = true
       photo.errorMessage = "Photo could not be deleted"


### PR DESCRIPTION
The type of this PR is: **BugFix**

This PR resolves [SWA-287]

### Description
This PR fixes the problem that after deleting a photo in the Upload Photos step, the Save & Continue button becomes disabled. 

#### Videos 
https://user-images.githubusercontent.com/42584148/156786411-c4af53d4-f78f-4208-b63d-7cd285a287e0.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[SWA-287]: https://artsyproduct.atlassian.net/browse/SWA-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ