### PR TITLE
bug[swa-278] location autofill result needs two clicks & styling

### DIFF
--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -1,6 +1,6 @@
 import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import { getLocationDetails, getLocationPredictions, SimpleLocation } from "app/utils/googleMaps"
-import { Box, Flex, Input, LocationIcon, Text, Touchable, useSpace } from "palette"
+import { Box, Flex, Input, LocationIcon, Text, useSpace } from "palette"
 import React, { useEffect, useRef, useState } from "react"
 import { FlatList, Image } from "react-native"
 import { Location } from "../validation"

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -112,7 +112,6 @@ export const LocationPredictions = ({
   }
 
   const onLocationSelect = async (item: SimpleLocation) => {
-    console.log("whoop onLocationSelect")
     const { city, state, country } = await getLocationDetails(item)
     onSelect({
       city: city || "",

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -148,13 +148,11 @@ export const LocationPredictions = ({
         }
         renderItem={({ item, index }) => {
           return (
-            <Flex key={index} mb={1}>
-              <Touchable onPress={() => onLocationSelect(item)}>
-                <Flex flexDirection="row" alignItems="center">
-                  <LocationIcon mr={1} />
-                  <Text>{highlightedQuery(item.name)}</Text>
-                </Flex>
-              </Touchable>
+            <Flex key={index} mb={1} onTouchStart={() => onLocationSelect(item)}>
+              <Flex flexDirection="row" alignItems="center">
+                <LocationIcon mr={1} />
+                <Text>{highlightedQuery(item.name)}123</Text>
+              </Flex>
             </Flex>
           )
         }}

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -151,7 +151,7 @@ export const LocationPredictions = ({
             <Flex key={index} mb={1} onTouchStart={() => onLocationSelect(item)}>
               <Flex flexDirection="row" alignItems="center">
                 <LocationIcon mr={1} />
-                <Text>{highlightedQuery(item.name)}123</Text>
+                <Text>{highlightedQuery(item.name)}</Text>
               </Flex>
             </Flex>
           )

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -1,6 +1,6 @@
 import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import { getLocationDetails, getLocationPredictions, SimpleLocation } from "app/utils/googleMaps"
-import { Box, Flex, Input, LocationIcon, Separator, Text, Touchable, useSpace } from "palette"
+import { Box, Flex, Input, LocationIcon, Text, Touchable, useSpace } from "palette"
 import React, { useEffect, useRef, useState } from "react"
 import { FlatList, Image } from "react-native"
 import { Location } from "../validation"
@@ -112,6 +112,7 @@ export const LocationPredictions = ({
   }
 
   const onLocationSelect = async (item: SimpleLocation) => {
+    console.log("whoop onLocationSelect")
     const { city, state, country } = await getLocationDetails(item)
     onSelect({
       city: city || "",
@@ -130,7 +131,7 @@ export const LocationPredictions = ({
         listRef={flatListRef}
         style={{
           flex: 1,
-          padding: space(2),
+          padding: space(1),
           borderStyle: "solid",
           borderColor: "#707070",
           borderWidth: 1,
@@ -152,10 +153,9 @@ export const LocationPredictions = ({
               <Touchable onPress={() => onLocationSelect(item)}>
                 <Flex flexDirection="row" alignItems="center">
                   <LocationIcon mr={1} />
-                  <Text variant="xs">{highlightedQuery(item.name)}</Text>
+                  <Text>{highlightedQuery(item.name)}</Text>
                 </Flex>
               </Touchable>
-              <Separator mt={1} />
             </Flex>
           )
         }}


### PR DESCRIPTION
The type of this PR is: **bug**

Thanks to @kiryl-zubarau for helping with debugging this 🙏
This PR resolves [SWA-278] location autofill result needs two clicks & styling


https://user-images.githubusercontent.com/36475005/156790441-381bc896-e6fd-430a-a6c6-23012496f6e8.mov


### Description

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/master/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/master/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
ⓘ 'User-facing' changes will be published as release notes.
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Rename modal title - patrinoua

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

[SWA-278]: https://artsyproduct.atlassian.net/browse/SWA-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ