### PR TITLE
fix: conversation messages and event order

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -15,21 +15,26 @@ interface Props {
 export const ConversationCTA: React.FC<Props> = ({ conversation, show }) => {
   const liveArtwork = conversation?.items?.[0]?.liveArtwork
 
-  const artwork = liveArtwork?.__typename === "Artwork" ? liveArtwork : null
-  const artworkID = artwork?.internalID
-  const isOfferableFromInquiry = artwork?.isOfferableFromInquiry
+  if (liveArtwork?.__typename !== "Artwork") {
+    return null
+  }
+
+  const artworkID = liveArtwork?.internalID
+  const isOfferableFromInquiry = liveArtwork?.isOfferableFromInquiry
 
   let CTA: JSX.Element | null = null
 
   const inquiryCheckoutEnabled = unsafe_getFeatureFlag("AROptionsInquiryCheckout")
 
-  if (inquiryCheckoutEnabled && isOfferableFromInquiry) {
+  if (inquiryCheckoutEnabled) {
     // artworkID is guaranteed to be present if `isOfferableFromInquiry` was present.
     const conversationID = conversation.conversationID!
 
     const activeOrder = extractNodes(conversation.activeOrders)[0]
     if (!activeOrder) {
-      CTA = <OpenInquiryModalButton artworkID={artworkID!} conversationID={conversationID} />
+      if (isOfferableFromInquiry) {
+        CTA = <OpenInquiryModalButton artworkID={artworkID!} conversationID={conversationID} />
+      }
     } else {
       const { lastTransactionFailed, state, lastOffer } = activeOrder
 

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
@@ -244,7 +244,7 @@ describe("messages with order updates", () => {
   })
 
   // We fetch all order updates but only paginated messages, so this is to avoid a smooshed list of updates at the top.
-  it("does not show order updates before the currently-available messages", () => {
+  it("shows order updates before the currently-available messages", () => {
     const beforeLastMessageTime = "2020-03-18T02:58:37.699Z"
     const beforeLastMessageTime2 = "2020-03-18T02:59:37.699Z"
     const lastMessageTime = "2020-03-19T01:58:37.699Z"
@@ -257,6 +257,7 @@ describe("messages with order updates", () => {
           __typename: "CommerceOfferSubmittedEvent",
           offer: {
             respondsTo: null,
+            amount: 10,
           },
           createdAt: beforeLastMessageTime,
         },
@@ -265,6 +266,8 @@ describe("messages with order updates", () => {
           offer: {
             respondsTo: {},
             fromParticipant: "SELLER",
+            offerAmountChanged: true,
+            amount: 11,
           },
           createdAt: beforeLastMessageTime2,
         },
@@ -272,14 +275,15 @@ describe("messages with order updates", () => {
           __typename: "CommerceOfferSubmittedEvent",
           offer: {
             respondsTo: {},
-            fromParticipant: "Buyer",
+            fromParticipant: "BUYER",
+            amount: 12,
           },
           createdAt: afterLastMessageTime,
         },
       ],
     })
-    expect(extractText(tree.root)).toContain("You sent a counteroffer for")
-    expect(extractText(tree.root)).not.toContain("You sent an offer for")
-    expect(extractText(tree.root)).not.toContain("You received a counteroffer for")
+    expect(extractText(tree.root)).toContain("You sent an offer for 10")
+    expect(extractText(tree.root)).toContain("You received a counteroffer for 11")
+    expect(extractText(tree.root)).toContain("You sent a counteroffer for 12")
   })
 })

--- a/src/app/Scenes/Inbox/Components/Conversations/utils/groupConversationItems.ts
+++ b/src/app/Scenes/Inbox/Components/Conversations/utils/groupConversationItems.ts
@@ -24,7 +24,6 @@ export const groupConversationItems = <T extends ConversationItem>(items: T[]): 
     const lastCreatedAt = moment(lastItem?.createdAt as string)
     const currentCreatedAt = moment(currentItem?.createdAt as string)
     const sameDay = lastCreatedAt.isSame(currentCreatedAt, "day")
-
     const today = currentCreatedAt.isSame(moment(), "day")
 
     const isMessage = (message: ConversationItem) => message.__typename === "Message"


### PR DESCRIPTION
The type of this PR is: **Bugfix**

[NX-3102]

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

### Description

When the conversation starts from Make Offer we don't see events being rendered in the conversation, like the message `You sent an Offer of $XXX`.
Another fix included is to show the conversation CTA to interact with counter offers given conversations starting from Make Offer.
There are some open questions like messages and events that are not grouped at the same time to render but are not related to the scope of this PR.

Here the first 2 conversations started from Make Offer flow, the last one started from Inquiry.
https://user-images.githubusercontent.com/15792853/157627846-625c227b-e669-4ed9-95e2-f41b5633fb1e.mov

Before (Conversation started from MO given counter-offer)
![image](https://user-images.githubusercontent.com/15792853/157643751-2897a97d-042f-44f6-93fe-3786e3ef553a.png)

After (Conversation started from MO given counter-offer)
<img width="415" alt="image" src="https://user-images.githubusercontent.com/15792853/157644210-1cb9401d-bbf3-41ef-b1ab-2526958965fd.png">

cc @artsy/negotiate-devs 

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fix events/ctas not rendered in conversation when not from inquiry - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[NX-3102]: https://artsyproduct.atlassian.net/browse/NX-3102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ