### PR TITLE
Disable edit artwork coming from SWA

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -88,7 +88,7 @@ describe("My Collection Artwork", () => {
     })
 
     describe("when submission is in progress", () => {
-      it("hides the edit button when the artwork has consignmentSubmission prop", async () => {
+      it("hides the edit button when the artwork is coming from a submission", async () => {
         const { findByText } = renderWithHookWrappersTL(
           <MyCollectionArtworkQueryRenderer
             artworkSlug="random-slug"

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -66,29 +66,6 @@ describe("My Collection Artwork", () => {
       mockEnvironment = createMockEnvironment()
     })
 
-    describe("when submission is not in progress", () => {
-      it("shows the edit button", async () => {
-        const { findByText } = renderWithHookWrappersTL(
-          <MyCollectionArtworkQueryRenderer
-            artworkSlug="random-slug"
-            artistInternalID="internal-id"
-            medium="medium"
-          />,
-          mockEnvironment
-        )
-
-        mockEnvironmentPayload(mockEnvironment, {
-          Artwork: () => ({
-            consignmentSubmission: {
-              inProgress: false,
-            },
-          }),
-        })
-
-        expect(await findByText("Edit")).toBeTruthy()
-      })
-    })
-
     describe("when there is no submission", () => {
       it("shows the edit button", async () => {
         const { findByText } = renderWithHookWrappersTL(
@@ -111,7 +88,7 @@ describe("My Collection Artwork", () => {
     })
 
     describe("when submission is in progress", () => {
-      it("hides the edit button", async () => {
+      it("hides the edit button when the artwork has consignmentSubmission prop", async () => {
         const { findByText } = renderWithHookWrappersTL(
           <MyCollectionArtworkQueryRenderer
             artworkSlug="random-slug"
@@ -123,9 +100,7 @@ describe("My Collection Artwork", () => {
 
         mockEnvironmentPayload(mockEnvironment, {
           Artwork: () => ({
-            consignmentSubmission: {
-              inProgress: true,
-            },
+            consignmentSubmission: "some-consignmentSubmission",
           }),
         })
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -70,8 +70,6 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
     })
   }, [data.artwork])
 
-  const displayEditButton = !data.artwork.consignmentSubmission?.inProgress
-
   const tabs = compact([
     {
       title: Tab.insights,
@@ -99,7 +97,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
       <FancyModalHeader
         onLeftButtonPress={goBack}
         rightButtonText="Edit"
-        onRightButtonPress={displayEditButton ? handleEdit : undefined}
+        onRightButtonPress={!data.artwork.consignmentSubmission ? handleEdit : undefined}
         hideBottomDivider
       />
       <StickyTabPage

--- a/src/app/Scenes/MyCollection/Screens/Artwork/OldMyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/OldMyCollectionArtwork.tsx
@@ -45,8 +45,6 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
   const isInProgress = artwork.consignmentSubmission?.inProgress
   const isSold = artwork.consignmentSubmission?.isSold
 
-  const displayEditButton = !isInProgress
-
   return (
     <ProvideScreenTrackingWithCohesionSchema
       info={screen({
@@ -58,7 +56,7 @@ export const MyCollectionArtwork: React.FC<MyCollectionArtworkProps> = ({
       <ScrollView>
         <FancyModalHeader
           onRightButtonPress={
-            displayEditButton
+            !artwork.consignmentSubmission
               ? () => {
                   trackEvent(tracks.editCollectedArtwork(artwork.internalID, artwork.slug))
                   GlobalStore.actions.myCollection.artwork.startEditingArtwork(artwork as any)

--- a/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
@@ -56,7 +56,7 @@ describe("MyCollectionArtworkFullDetails", () => {
         }),
       })
 
-      expect(wrapper.root.findByType(FancyModalHeader).props.rightButtonText).toBeUndefined()
+      expect(wrapper.root.findByType(FancyModalHeader).props.onRightButtonPress).toBeUndefined()
     })
 
     it("tracks an analytics event on edit button presed", () => {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
@@ -48,12 +48,23 @@ describe("MyCollectionArtworkFullDetails", () => {
     jest.clearAllMocks()
   })
 
-  describe("edit button pressed", () => {
-    it("tracks an analytics event", () => {
+  describe("edit button", () => {
+    it("hide edit button if the artwork has consignmentSubmission prop", () => {
+      const wrapper = getWrapper({
+        Artwork: () => ({
+          consignmentSubmission: "someConsignmentSubmission",
+        }),
+      })
+
+      expect(wrapper.root.findByType(FancyModalHeader).props.rightButtonText).toBeUndefined()
+    })
+
+    it("tracks an analytics event on edit button presed", () => {
       const wrapper = getWrapper({
         Artwork: () => ({
           internalID: "someInternalId",
           slug: "someSlug",
+          consignmentSubmission: null,
         }),
       })
       GlobalStore.actions.myCollection.artwork.startEditingArtwork = jest.fn() as any

--- a/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tests.tsx
@@ -49,7 +49,7 @@ describe("MyCollectionArtworkFullDetails", () => {
   })
 
   describe("edit button", () => {
-    it("hide edit button if the artwork has consignmentSubmission prop", () => {
+    it("hide edit button if the artwork is coming from a submission", () => {
       const wrapper = getWrapper({
         Artwork: () => ({
           consignmentSubmission: "someConsignmentSubmission",

--- a/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tsx
@@ -17,25 +17,36 @@ const MyCollectionArtworkFullDetails: React.FC<{
   artwork: MyCollectionArtworkFullDetails_artwork
 }> = (props) => {
   const { trackEvent } = useTracking()
+
+  const MyCollectionArtworkFullDetailsHeader = () => {
+    if (!props.artwork.consignmentSubmission) {
+      return (
+        <FancyModalHeader
+          rightButtonText="Edit"
+          onRightButtonPress={() => {
+            trackEvent(tracks.editCollectedArtwork(props.artwork.internalID, props.artwork.slug))
+            GlobalStore.actions.myCollection.artwork.startEditingArtwork(props.artwork as any)
+            navigate(`my-collection/artworks/${props.artwork.internalID}/edit`, {
+              passProps: {
+                mode: "edit",
+                artwork: props.artwork,
+                onSuccess: popParentViewController,
+                onDelete: popToRoot,
+              },
+            })
+          }}
+        >
+          Artwork Details
+        </FancyModalHeader>
+      )
+    } else {
+      return <FancyModalHeader>Artwork Details</FancyModalHeader>
+    }
+  }
+
   return (
     <Flex>
-      <FancyModalHeader
-        rightButtonText="Edit"
-        onRightButtonPress={() => {
-          trackEvent(tracks.editCollectedArtwork(props.artwork.internalID, props.artwork.slug))
-          GlobalStore.actions.myCollection.artwork.startEditingArtwork(props.artwork as any)
-          navigate(`my-collection/artworks/${props.artwork.internalID}/edit`, {
-            passProps: {
-              mode: "edit",
-              artwork: props.artwork,
-              onSuccess: popParentViewController,
-              onDelete: popToRoot,
-            },
-          })
-        }}
-      >
-        Artwork Details
-      </FancyModalHeader>
+      <MyCollectionArtworkFullDetailsHeader />
       <Spacer my={0.5} />
       <MyCollectionArtworkMetaFragmentContainer artwork={props.artwork} viewAll />
     </Flex>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkFullDetails/MyCollectionArtworkFullDetails.tsx
@@ -7,7 +7,7 @@ import { defaultEnvironment } from "app/relay/createEnvironment"
 import { GlobalStore } from "app/store/GlobalStore"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { Flex, Spacer } from "palette"
-import React from "react"
+import React, { useCallback } from "react"
 import { ActivityIndicator } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -18,35 +18,27 @@ const MyCollectionArtworkFullDetails: React.FC<{
 }> = (props) => {
   const { trackEvent } = useTracking()
 
-  const MyCollectionArtworkFullDetailsHeader = () => {
-    if (!props.artwork.consignmentSubmission) {
-      return (
-        <FancyModalHeader
-          rightButtonText="Edit"
-          onRightButtonPress={() => {
-            trackEvent(tracks.editCollectedArtwork(props.artwork.internalID, props.artwork.slug))
-            GlobalStore.actions.myCollection.artwork.startEditingArtwork(props.artwork as any)
-            navigate(`my-collection/artworks/${props.artwork.internalID}/edit`, {
-              passProps: {
-                mode: "edit",
-                artwork: props.artwork,
-                onSuccess: popParentViewController,
-                onDelete: popToRoot,
-              },
-            })
-          }}
-        >
-          Artwork Details
-        </FancyModalHeader>
-      )
-    } else {
-      return <FancyModalHeader>Artwork Details</FancyModalHeader>
-    }
-  }
+  const handleEdit = useCallback(() => {
+    trackEvent(tracks.editCollectedArtwork(props.artwork.internalID, props.artwork.slug))
+    GlobalStore.actions.myCollection.artwork.startEditingArtwork(props.artwork as any)
+    navigate(`my-collection/artworks/${props.artwork.internalID}/edit`, {
+      passProps: {
+        mode: "edit",
+        artwork: props.artwork,
+        onSuccess: popParentViewController,
+        onDelete: popToRoot,
+      },
+    })
+  }, [props.artwork])
 
   return (
     <Flex>
-      <MyCollectionArtworkFullDetailsHeader />
+      <FancyModalHeader
+        rightButtonText="Edit"
+        onRightButtonPress={!props.artwork.consignmentSubmission ? handleEdit : undefined}
+      >
+        Artwork Details
+      </FancyModalHeader>
       <Spacer my={0.5} />
       <MyCollectionArtworkMetaFragmentContainer artwork={props.artwork} viewAll />
     </Flex>


### PR DESCRIPTION
The type of this PR is: Feature

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2348]

### Description

Disable edit option for artwork in my collection coming from SWA

|Artwork not from SWA| Artwork from SWA|
|---|---|
|![image](https://user-images.githubusercontent.com/17421923/158828293-022160ad-b46d-4843-8dec-6b10eb13c7be.png)|![image](https://user-images.githubusercontent.com/17421923/158828048-d524bc88-7ce9-472e-aedc-455b83e83b75.png)|


<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Disable edit option for artwork in my collection coming from SWA - sam

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2348]: https://artsyproduct.atlassian.net/browse/CX-2348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ