### PR TITLE
refactor(FX-3750): Improved search pills

### DIFF
--- a/src/app/Scenes/Search/RefetchWhenApiKeyExpired.tsx
+++ b/src/app/Scenes/Search/RefetchWhenApiKeyExpired.tsx
@@ -1,13 +1,10 @@
-import { Search_system$key } from "__generated__/Search_system.graphql"
-import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { useEffect } from "react"
 import { connectStateResults, StateResultsProvided } from "react-instantsearch-core"
-import { RefetchFnDynamic } from "react-relay"
 import { isAlgoliaApiKeyExpiredError } from "./helpers"
 import { AlgoliaSearchResult } from "./types"
 
 interface ContainerProps extends StateResultsProvided<AlgoliaSearchResult> {
-  refetch: RefetchFnDynamic<SearchQuery, Search_system$key>
+  refetch: () => void
 }
 
 const Container: React.FC<ContainerProps> = (props) => {
@@ -15,7 +12,7 @@ const Container: React.FC<ContainerProps> = (props) => {
 
   useEffect(() => {
     if (isAlgoliaApiKeyExpiredError(error)) {
-      refetch({}, { fetchPolicy: "network-only" })
+      refetch()
     }
   }, [error?.message])
 

--- a/src/app/Scenes/Search/Search.tests.tsx
+++ b/src/app/Scenes/Search/Search.tests.tsx
@@ -209,106 +209,84 @@ describe("Search Screen", () => {
   })
 
   describe("search pills", () => {
-    describe("with AREnableImprovedSearchPills enabled", () => {
-      it("are displayed when the user has typed the minimum allowed number of characters", async () => {
-        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
-        const { getByPlaceholderText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+    it("are displayed when the user has typed the minimum allowed number of characters", async () => {
+      const { getByPlaceholderText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
-        mockEnvironmentPayload(mockEnvironment, {
-          Query: () => ({
-            system: {
-              algolia: {
-                appID: "",
-                apiKey: "",
-                indices: [
-                  { name: "Artist_staging", displayName: "Artist", key: "artist" },
-                  { name: "Sale_staging", displayName: "Auction", key: "sale" },
-                  { name: "Gallery_staging", displayName: "Gallery", key: "partner_gallery" },
-                  { name: "Fair_staging", displayName: "Fair", key: "fair" },
-                ],
-              },
+      mockEnvironmentPayload(mockEnvironment, {
+        Query: () => ({
+          system: {
+            algolia: {
+              appID: "",
+              apiKey: "",
+              indices: INDICES,
             },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        expect(queryByText("Top")).toBeFalsy()
-        expect(queryByText("Artist")).toBeFalsy()
-        expect(queryByText("Auction")).toBeFalsy()
-        expect(queryByText("Gallery")).toBeFalsy()
-        expect(queryByText("Fair")).toBeFalsy()
-
-        const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
-        fireEvent(searchInput, "changeText", "Ba")
-
-        expect(queryByText("Top")).toBeTruthy()
-        expect(queryByText("Artist")).toBeTruthy()
-        expect(queryByText("Auction")).toBeTruthy()
-        expect(queryByText("Gallery")).toBeTruthy()
-        expect(queryByText("Fair")).toBeTruthy()
+          },
+        }),
       })
 
-      it("have top pill selected and disabled at the same time", async () => {
-        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
-        const { getByPlaceholderText, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
+      await flushPromiseQueue()
 
-        mockEnvironmentPayload(mockEnvironment, {
-          Query: () => ({
-            system: {
-              algolia: {
-                appID: "",
-                apiKey: "",
-                indices: [
-                  { name: "Artist_staging", displayName: "Artist", key: "artist" },
-                  { name: "Sale_staging", displayName: "Auction", key: "sale" },
-                  { name: "Gallery_staging", displayName: "Gallery", key: "partner_gallery" },
-                  { name: "Fair_staging", displayName: "Fair", key: "fair" },
-                ],
-              },
+      expect(queryByText("Top")).toBeFalsy()
+      expect(queryByText("Artist")).toBeFalsy()
+      expect(queryByText("Auction")).toBeFalsy()
+      expect(queryByText("Gallery")).toBeFalsy()
+      expect(queryByText("Fair")).toBeFalsy()
+
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+      fireEvent(searchInput, "changeText", "Ba")
+
+      expect(queryByText("Top")).toBeTruthy()
+      expect(queryByText("Artist")).toBeTruthy()
+      expect(queryByText("Auction")).toBeTruthy()
+      expect(queryByText("Gallery")).toBeTruthy()
+      expect(queryByText("Fair")).toBeTruthy()
+    })
+
+    it("have top pill selected and disabled at the same time", async () => {
+      const { getByPlaceholderText, getByA11yState } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironmentPayload(mockEnvironment, {
+        Query: () => ({
+          system: {
+            algolia: {
+              appID: "",
+              apiKey: "",
+              indices: INDICES,
             },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
-        fireEvent(searchInput, "changeText", "Ba")
-        const topPill = getByA11yState({ selected: true, disabled: true })
-        expect(topPill).toHaveTextContent("Top")
+          },
+        }),
       })
 
-      it("are enabled when they have results", async () => {
-        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImprovedSearchPills: true })
-        const { getByPlaceholderText, UNSAFE_getAllByType } = renderWithWrappersTL(<TestRenderer />)
-        mockEnvironmentPayload(mockEnvironment, {
-          Query: () => ({
-            system: {
-              algolia: {
-                appID: "",
-                apiKey: "",
-                indices: [
-                  { name: "Artist_staging", displayName: "Artist", key: "artist" },
-                  { name: "Sale_staging", displayName: "Auction", key: "sale" },
-                  { name: "Gallery_staging", displayName: "Gallery", key: "partner_gallery" },
-                  { name: "Fair_staging", displayName: "Fair", key: "fair" },
-                ],
-              },
-            },
-          }),
-        })
-        await flushPromiseQueue()
+      await flushPromiseQueue()
 
-        const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
-        fireEvent(searchInput, "changeText", "Ba")
-        const enabledPills = UNSAFE_getAllByType(Pill).filter(
-          (pill) => pill.props.disabled === false
-        )
-        expect(enabledPills).toHaveLength(3)
-        expect(enabledPills[0]).toHaveTextContent("Artworks")
-        expect(enabledPills[1]).toHaveTextContent("Artist")
-        expect(enabledPills[2]).toHaveTextContent("Gallery")
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+      fireEvent(searchInput, "changeText", "Ba")
+      const topPill = getByA11yState({ selected: true, disabled: true })
+      expect(topPill).toHaveTextContent("Top")
+    })
+
+    it("are enabled when they have results", async () => {
+      const { getByPlaceholderText, UNSAFE_getAllByType } = renderWithWrappersTL(<TestRenderer />)
+      mockEnvironmentPayload(mockEnvironment, {
+        Query: () => ({
+          system: {
+            algolia: {
+              appID: "",
+              apiKey: "",
+              indices: INDICES,
+            },
+          },
+        }),
       })
+      await flushPromiseQueue()
+
+      const searchInput = getByPlaceholderText("Search artists, artworks, galleries, etc")
+      fireEvent(searchInput, "changeText", "Ba")
+      const enabledPills = UNSAFE_getAllByType(Pill).filter((pill) => pill.props.disabled === false)
+      expect(enabledPills).toHaveLength(3)
+      expect(enabledPills[0]).toHaveTextContent("Artworks")
+      expect(enabledPills[1]).toHaveTextContent("Artist")
+      expect(enabledPills[2]).toHaveTextContent("Gallery")
     })
 
     it("are displayed when the user has typed the minimum allowed number of characters", async () => {
@@ -319,12 +297,7 @@ describe("Search Screen", () => {
             algolia: {
               appID: "",
               apiKey: "",
-              indices: [
-                { name: "Artist_staging", displayName: "Artist", key: "artist" },
-                { name: "Sale_staging", displayName: "Auction", key: "sale" },
-                { name: "Gallery_staging", displayName: "Gallery", key: "partner_gallery" },
-                { name: "Fair_staging", displayName: "Fair", key: "fair" },
-              ],
+              indices: INDICES,
             },
           },
         }),
@@ -701,3 +674,10 @@ describe("Search Screen", () => {
     `)
   })
 })
+
+const INDICES = [
+  { name: "Artist_staging", displayName: "Artist", key: "artist" },
+  { name: "Sale_staging", displayName: "Auction", key: "sale" },
+  { name: "Gallery_staging", displayName: "Gallery", key: "partner_gallery" },
+  { name: "Fair_staging", displayName: "Fair", key: "fair" },
+]

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -115,7 +115,6 @@ export const Search: FC = () => {
     updateIndicesInfo,
   } = useAlgoliaIndices(searchClient, indices)
   const { trackEvent } = useTracking()
-  const enableImprovedPills = useFeatureFlag("AREnableImprovedSearchPills")
 
   const exampleExperiments = useFeatureFlag("AREnableExampleExperiments")
   const smudgeValue = useExperimentVariant("test-search-smudge")
@@ -139,7 +138,7 @@ export const Search: FC = () => {
         return {
           ...other,
           type: "algolia",
-          disabled: enableImprovedPills && !indicesInfo[name]?.hasResults,
+          disabled: !indicesInfo[name]?.hasResults,
           indexName: name,
         }
       })
@@ -249,7 +248,7 @@ export const Search: FC = () => {
               onTextChange={(value) => {
                 handleResetSearchInput()
 
-                if (enableImprovedPills && value.length >= 2) {
+                if (value.length >= 2) {
                   updateIndicesInfo(value)
                 }
               }}

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -143,6 +143,7 @@ export const Search: FC = () => {
   const { trackEvent } = useTracking()
 
   const exampleExperiments = useFeatureFlag("AREnableExampleExperiments")
+  const enableImprovedSearchPills = useExperimentFlag("eigen-enable-improved-search-pills")
   const smudgeValue = useExperimentVariant("test-search-smudge")
   nonCohesionTracks.experimentVariant(
     "test-search-smudge",
@@ -163,33 +164,33 @@ export const Search: FC = () => {
       return {
         ...other,
         type: "algolia",
-        disabled: !indicesInfo[name]?.hasResults,
+        disabled: enableImprovedSearchPills && !indicesInfo[name]?.hasResults,
         indexName: name,
       }
     })
 
     return [...pills, ...formattedIndices]
-  }, [indices, indicesInfo])
+  }, [indices, indicesInfo, enableImprovedSearchPills])
 
   useEffect(() => {
     /**
      * Refetch up-to-date info about Algolia indices for specified search query
      * when Algolia API key expired and request failed (we get a fresh Algolia API key and send request again)
      */
-    if (searchClient && shouldStartSearching(searchQuery)) {
+    if (enableImprovedSearchPills && searchClient && shouldStartSearching(searchQuery)) {
       updateIndicesInfo(searchQuery)
     }
-  }, [searchClient])
+  }, [searchClient, enableImprovedSearchPills])
 
   const onTextChange = useCallback(
     (value) => {
       handleResetSearchInput()
 
-      if (shouldStartSearching(value)) {
+      if (enableImprovedSearchPills && shouldStartSearching(value)) {
         updateIndicesInfo(value)
       }
     },
-    [searchClient]
+    [searchClient, enableImprovedSearchPills]
   )
 
   if (!searchClient || !searchInsightsConfigured) {

--- a/src/app/Scenes/Search/components/SearchInput.tsx
+++ b/src/app/Scenes/Search/components/SearchInput.tsx
@@ -28,14 +28,14 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   const isImageSearchEnabled = useFeatureFlag("AREnableImageSearch")
   const isAndroid = Platform.OS === "android"
   const navigation = isAndroid ? useNavigation() : null
-  const handleChangeText = useMemo(
-    () =>
-      throttle((value) => {
-        refine(value)
-        onTextChange(value)
-      }, SEARCH_THROTTLE_INTERVAL),
-    []
-  )
+  const handleChangeText = useMemo(() => {
+    console.log("[debug] throttle")
+
+    return throttle((value) => {
+      refine(value)
+      onTextChange(value)
+    }, SEARCH_THROTTLE_INTERVAL)
+  }, [onTextChange])
 
   useEffect(() => {
     if (searchProviderValues.inputRef?.current && isAndroid) {

--- a/src/app/Scenes/Search/components/SearchInput.tsx
+++ b/src/app/Scenes/Search/components/SearchInput.tsx
@@ -28,14 +28,14 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   const isImageSearchEnabled = useFeatureFlag("AREnableImageSearch")
   const isAndroid = Platform.OS === "android"
   const navigation = isAndroid ? useNavigation() : null
-  const handleChangeText = useMemo(() => {
-    console.log("[debug] throttle")
-
-    return throttle((value) => {
-      refine(value)
-      onTextChange(value)
-    }, SEARCH_THROTTLE_INTERVAL)
-  }, [onTextChange])
+  const handleChangeText = useMemo(
+    () =>
+      throttle((value) => {
+        refine(value)
+        onTextChange(value)
+      }, SEARCH_THROTTLE_INTERVAL),
+    [onTextChange]
+  )
 
   useEffect(() => {
     if (searchProviderValues.inputRef?.current && isAndroid) {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -74,11 +74,6 @@ export const features = defineFeatures({
     readyForRelease: false,
     description: "Enable Saved Addresses",
   },
-  AREnableImprovedSearchPills: {
-    readyForRelease: false,
-    description: "Enable improved search pills",
-    echoFlagKey: "AREnableImprovedSearchPills",
-  },
   AREnableTrove: {
     readyForRelease: true,
     description: "Enable Trove in homepage",

--- a/src/app/utils/useAlgoliaIndices.ts
+++ b/src/app/utils/useAlgoliaIndices.ts
@@ -1,6 +1,6 @@
-import { SearchResponse } from "@algolia/client-search"
+import { MultipleQueriesResponse, SearchResponse } from "@algolia/client-search"
 import { SearchClient } from "algoliasearch"
-import { useCallback, useRef, useState } from "react"
+import { useRef, useState } from "react"
 
 interface IndexInfo {
   hasResults: boolean
@@ -10,49 +10,74 @@ interface IndicesInfo {
   [key: string]: IndexInfo
 }
 
-export const useAlgoliaIndices = (
-  client: SearchClient | null,
+export interface IndicesInfoOptions {
+  searchClient: SearchClient | null
   indices?: ReadonlyArray<{ name: string }>
-) => {
+  onError?: (error: Error) => void
+}
+
+export const useAlgoliaIndices = (options: IndicesInfoOptions) => {
+  const { searchClient, indices = [], onError } = options
   const [indicesInfo, setIndicesInfo] = useState<IndicesInfo>({})
   const [loading, setLoading] = useState(false)
   const lastQuery = useRef<string | null>(null)
 
-  const updateIndicesInfo = useCallback(
-    async (query: string) => {
-      lastQuery.current = query
+  const isCurrentQuery = (query: string) => {
+    return lastQuery.current === query
+  }
 
-      if (Array.isArray(indices) && indices.length > 0) {
-        const queries = indices.map((index) => ({
-          indexName: index.name,
-          query,
-          params: {
-            hitsPerPage: 0,
-            analytics: false,
-          },
-        }))
-
-        if (!!client) {
-          setLoading(true)
-          const indicesResponse = await client.multipleQueries<SearchResponse>(queries)
-          if (query === lastQuery.current) {
-            const newIndicesInfo = indicesResponse.results.reduce(
-              (acc: IndicesInfo, { index, nbHits }) => {
-                if (!!index) {
-                  acc[index] = { hasResults: !!nbHits }
-                }
-                return acc
-              },
-              {}
-            )
-            setIndicesInfo(newIndicesInfo)
-            setLoading(false)
-          }
-        }
+  const getIndicesInfo = (response: MultipleQueriesResponse<SearchResponse<{}>>) => {
+    return response.results.reduce((acc: IndicesInfo, { index, nbHits }) => {
+      if (!!index) {
+        acc[index] = { hasResults: !!nbHits }
       }
-    },
-    [client, indices]
-  )
+      return acc
+    }, {})
+  }
+
+  const getQueriesFromIndices = (query: string) => {
+    return indices.map((index) => ({
+      indexName: index.name,
+      query,
+      params: {
+        hitsPerPage: 0,
+        analytics: false,
+      },
+    }))
+  }
+
+  const updateIndicesInfo = async (query: string) => {
+    if (!searchClient) {
+      throw new Error("SearchClient is not specified")
+    }
+
+    if (indices.length === 0) {
+      return
+    }
+
+    lastQuery.current = query
+
+    try {
+      setLoading(true)
+
+      const queries = getQueriesFromIndices(query)
+      const response = await searchClient.multipleQueries<SearchResponse>(queries)
+
+      if (isCurrentQuery(query)) {
+        const updatedIndicesInfo = getIndicesInfo(response)
+        setIndicesInfo(updatedIndicesInfo)
+      }
+    } catch (error) {
+      if (isCurrentQuery(query)) {
+        console.log("[debug] error", error, query)
+        onError?.(error as Error)
+      }
+    } finally {
+      if (isCurrentQuery(query)) {
+        setLoading(false)
+      }
+    }
+  }
 
   return { loading, indicesInfo, updateIndicesInfo }
 }

--- a/src/app/utils/useAlgoliaIndices.ts
+++ b/src/app/utils/useAlgoliaIndices.ts
@@ -12,12 +12,12 @@ interface IndicesInfo {
 
 interface IndicesInfoOptions {
   searchClient: SearchClient | null
-  indices?: ReadonlyArray<{ name: string }>
+  indiceNames: string[]
   onError?: (error: Error) => void
 }
 
 export const useAlgoliaIndices = (options: IndicesInfoOptions) => {
-  const { searchClient, indices = [], onError } = options
+  const { searchClient, indiceNames, onError } = options
   const [indicesInfo, setIndicesInfo] = useState<IndicesInfo>({})
   const [loading, setLoading] = useState(false)
   const queryId = useRef(0)
@@ -32,8 +32,8 @@ export const useAlgoliaIndices = (options: IndicesInfoOptions) => {
   }
 
   const getQueriesFromIndices = (query: string) => {
-    return indices.map((index) => ({
-      indexName: index.name,
+    return indiceNames.map((indiceName) => ({
+      indexName: indiceName,
       query,
       params: {
         hitsPerPage: 0,
@@ -47,7 +47,7 @@ export const useAlgoliaIndices = (options: IndicesInfoOptions) => {
       throw new Error("SearchClient is not specified")
     }
 
-    if (indices.length === 0) {
+    if (indiceNames.length === 0) {
       return
     }
 

--- a/src/app/utils/useAlgoliaIndices.ts
+++ b/src/app/utils/useAlgoliaIndices.ts
@@ -10,7 +10,7 @@ interface IndicesInfo {
   [key: string]: IndexInfo
 }
 
-export interface IndicesInfoOptions {
+interface IndicesInfoOptions {
   searchClient: SearchClient | null
   indices?: ReadonlyArray<{ name: string }>
   onError?: (error: Error) => void
@@ -60,8 +60,6 @@ export const useAlgoliaIndices = (options: IndicesInfoOptions) => {
       const response = await searchClient.multipleQueries<SearchResponse>(queries)
 
       if (currentQueryId === queryId.current) {
-        console.log("[debug] response", new Date().toLocaleTimeString(), query, currentQueryId)
-
         const updatedIndicesInfo = getIndicesInfo(response)
         setIndicesInfo(updatedIndicesInfo)
         setLoading(false)

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -1,9 +1,10 @@
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import { Color } from "palette/Theme"
 import { Flex, FlexProps } from "../Flex"
 import { Text, useTextStyleForPalette } from "../Text"
 
 import { IconProps, Spacer, useColor } from "palette"
-import React, { ReactNode, useEffect, useState } from "react"
+import React, { ReactNode, useState } from "react"
 import { GestureResponderEvent, Pressable, PressableProps } from "react-native"
 import { config } from "react-spring"
 // @ts-ignore
@@ -69,22 +70,27 @@ export const Pill: React.FC<PillProps> = ({
   ...rest
 }) => {
   const textStyle = useTextStyleForPalette(size === "xxs" ? "xs" : "sm")
-  const standartDisplayState = disabled ? DisplayState.Disabled : DisplayState.Enabled
-  const initialDisplayState = selected ? DisplayState.Selected : standartDisplayState
-  const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
+  const [isPressed, setIsPressed] = useState(false)
   const { height, paddingLeft, paddingRight } = getSize(size)
+
+  let displayState = DisplayState.Enabled
+
+  if (isPressed) {
+    displayState = DisplayState.Pressed
+  } else if (selected) {
+    displayState = DisplayState.Selected
+  } else if (disabled) {
+    displayState = DisplayState.Disabled
+  }
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
   }
 
-  useEffect(() => {
-    setInnerDisplayState(initialDisplayState)
-  }, [disabled, selected])
-
   const iconSpacerMargin = size === "xxs" ? 0.5 : 1
-  const iconColor = innerDisplayState === "pressed" ? "blue100" : "black100"
-  const to = useStyleForState(innerDisplayState)
+  const to = useStyleForState(displayState)
+  const iconColor = to.textColor as Color
+
   return (
     <Spring native to={to} config={config.stiff}>
       {(springProps: typeof to) => (
@@ -93,12 +99,12 @@ export const Pill: React.FC<PillProps> = ({
           onPress={handlePress}
           onPressIn={() => {
             if (highlightEnabled) {
-              setInnerDisplayState(DisplayState.Pressed)
+              setIsPressed(true)
             }
           }}
           onPressOut={() => {
             if (highlightEnabled) {
-              setInnerDisplayState(initialDisplayState)
+              setIsPressed(false)
             }
           }}
         >

--- a/src/palette/elements/Pill/Pill.tsx
+++ b/src/palette/elements/Pill/Pill.tsx
@@ -2,7 +2,6 @@ import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { Flex, FlexProps } from "../Flex"
 import { Text, useTextStyleForPalette } from "../Text"
 
-import { useFeatureFlag } from "app/store/GlobalStore"
 import { IconProps, Spacer, useColor } from "palette"
 import React, { ReactNode, useEffect, useState } from "react"
 import { GestureResponderEvent, Pressable, PressableProps } from "react-native"
@@ -28,10 +27,8 @@ export interface PillProps extends FlexProps {
 
 enum DisplayState {
   Enabled = "enabled",
-  EnabledImprovedFlag = "enabled2",
   Pressed = "pressed",
   Selected = "selected",
-  SelectedImprovedFlag = "selected2",
   Disabled = "disabled",
 }
 
@@ -71,17 +68,9 @@ export const Pill: React.FC<PillProps> = ({
   highlightEnabled = false,
   ...rest
 }) => {
-  const enableImprovedPills = useFeatureFlag("AREnableImprovedSearchPills")
-
   const textStyle = useTextStyleForPalette(size === "xxs" ? "xs" : "sm")
-  const enabledDisplayState = enableImprovedPills
-    ? DisplayState.EnabledImprovedFlag
-    : DisplayState.Enabled
-  const selectedDisplayState = enableImprovedPills
-    ? DisplayState.SelectedImprovedFlag
-    : DisplayState.Selected
-  const standartDisplayState = disabled ? DisplayState.Disabled : enabledDisplayState
-  const initialDisplayState = selected ? selectedDisplayState : standartDisplayState
+  const standartDisplayState = disabled ? DisplayState.Disabled : DisplayState.Enabled
+  const initialDisplayState = selected ? DisplayState.Selected : standartDisplayState
   const [innerDisplayState, setInnerDisplayState] = useState(initialDisplayState)
   const { height, paddingLeft, paddingRight } = getSize(size)
 
@@ -164,21 +153,11 @@ const useStyleForState = (
       retval.backgroundColor = color("white100")
       break
     case DisplayState.Selected:
-      retval.textColor = color("black100")
-      retval.borderColor = color("black60")
-      retval.backgroundColor = color("white100")
-      break
-    case DisplayState.SelectedImprovedFlag:
       retval.textColor = color("white100")
       retval.borderColor = color("blue100")
       retval.backgroundColor = color("blue100")
       break
     case DisplayState.Enabled:
-      retval.textColor = color("black100")
-      retval.borderColor = color("black15")
-      retval.backgroundColor = color("white100")
-      break
-    case DisplayState.EnabledImprovedFlag:
       retval.textColor = color("black100")
       retval.borderColor = color("black60")
       retval.backgroundColor = color("white100")


### PR DESCRIPTION
The type of this PR is: **Refactor**
Related PR: #5720
This PR resolves [FX-3750]
Unleash flag: [link](https://unleash.artsy.net/projects/default/features2/eigen-enable-improved-search-pills)

### Description
Currently if search pill doesn't contain results we show _no results_ state [like this](https://github.com/artsy/eigen/pull/5654)

This PR implements checking all algolia indices when typing term and only displaying those having results

### Changes
* update tests
* fix problem with relay cache
* fix problem with displaying loading indicator every time refetch was called
* fix problems for `useAlgoliaIndices` (catch failed responses from algolia, ignore outdated requests to algolia)
* Clean up `AREnableImprovedSearchPills` flag
* Use `eigen-enable-improved-search-pills` flag from Unleash

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/159689126-92b952ee-7304-40a5-9262-0ca7d6e8b094.mp4

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Improved search pills - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3750]: https://artsyproduct.atlassian.net/browse/FX-3750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ