### PR TITLE
feat(cx-2439): Restrict showing request price estimate banner for D-Index less than nine

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -37,7 +37,10 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
 
   const isP1Artist = artwork.artist?.targetSupply?.isP1
 
-  const showPriceEstimateBanner = useFeatureFlag("ARShowRequestPriceEstimateBanner") && isP1Artist
+  const showPriceEstimateBanner =
+    useFeatureFlag("ARShowRequestPriceEstimateBanner") &&
+    isP1Artist &&
+    Number((marketPriceInsights?.demandRank ?? 0) * 10) >= 9
 
   return (
     <StickyTabPageScrollView>
@@ -104,6 +107,7 @@ const artworkFragment = graphql`
 
 const marketPriceInsightsFragment = graphql`
   fragment MyCollectionArtworkInsights_marketPriceInsights on MarketPriceInsights {
+    demandRank
     ...MyCollectionArtworkDemandIndex_marketPriceInsights
     ...MyCollectionArtworkArtistMarket_marketPriceInsights
     ...RequestForPriceEstimateBanner_marketPriceInsights


### PR DESCRIPTION
The type of this PR is: **Enhancement**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2439]

### Description

<!-- Implementation description -->

- We want to show the Request For Price Estimate Banner only for Artworks with D-Index of >= 9


<table>
  <tr>
    <td><b>D-Index >= 9</b></td>
     <td><b>D-Index < 9</b></td>
  </tr>
  <tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/18648835/159527866-fefee120-726d-496e-be44-8aab9b32112d.png"></td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/18648835/159527885-cf94b545-9f5e-4fd3-9c3f-5a66ca2b688e.png"></td>
  </tr>
 </table>

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Restrict showing request price estimate banner for D-Index less than nine - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2439]: https://artsyproduct.atlassian.net/browse/CX-2439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ