### PR TITLE
fix: location auto complete dropdown logic

### DIFF
--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tests.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tests.tsx
@@ -1,10 +1,10 @@
 import { fireEvent } from "@testing-library/react-native"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import React from "react"
 import { RelayEnvironmentProvider } from "react-relay"
-import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
 import { LocationAutocomplete } from "./LocationAutocomplete"
 
@@ -44,8 +44,22 @@ describe("ArtworkDetailsForm", () => {
       const { getByTestId } = renderWithWrappersTL(<TestRenderer />)
       const locationInput = getByTestId("Submission_LocationInput")
 
-      act(() => fireEvent.changeText(locationInput, "berlin"))
+      fireEvent.changeText(locationInput, "berlin")
       expect(locationInput.props.value).toBe("berlin")
+    })
+
+    it("displays a message when no location is found", async () => {
+      const { getByText, getByTestId } = renderWithWrappersTL(<TestRenderer />)
+
+      const locationInput = getByTestId("Submission_LocationInput")
+      fireEvent.changeText(locationInput, "there is no such a location")
+
+      await flushPromiseQueue()
+
+      const locationNotFoundMessage = getByText(
+        "Please try searching again with a different spelling."
+      )
+      expect(locationNotFoundMessage).toBeTruthy()
     })
   })
 })

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -70,7 +70,7 @@ export const LocationAutocomplete: React.FC<Props> = ({ initialLocation, onChang
         value={locationValue}
       />
       <LocationPredictions
-        locationValue={locationValue}
+        selectedLocation={selectedLocation}
         predictions={predictions}
         query={query}
         onSelect={setSelectedLocation}
@@ -84,9 +84,9 @@ export const LocationPredictions = ({
   predictions,
   query,
   onSelect,
-  locationValue,
+  selectedLocation,
 }: {
-  locationValue: string
+  selectedLocation: Location | null
   predictions: SimpleLocation[]
   query?: string
   onSelect: (loc: Location) => void
@@ -122,7 +122,7 @@ export const LocationPredictions = ({
     })
   }
 
-  if (locationValue.length < MIN_LENGTH) {
+  if (selectedLocation || !predictions.length) {
     return null
   }
 

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/Components/LocationAutocomplete.tsx
@@ -122,7 +122,7 @@ export const LocationPredictions = ({
     })
   }
 
-  if (selectedLocation || !predictions.length) {
+  if (selectedLocation || !query || query.length < MIN_LENGTH) {
     return null
   }
 


### PR DESCRIPTION
The type of this PR is: **Bugfix**

This PR resolves [SWA-318]

### Description
In the app submission flow, when a location is selected from the suggested dropdown list, the suggestion box is still rendered with ‘Please try searching again with a different spelling’ message. (see the 'before' video below). 

This is caused by a recent change we have introduced in [this PR](https://github.com/artsy/eigen/commit/3f48bc410abcb0b473bdc39715e2c958194359fd?diff=split). The problem is caused by the fact that the logic returning null from the `LocationPredictions` component is updated from: 

```
 if (!predictions.length) {
    return null
}
```

to 

```
if (locationValue.length < MIN_LENGTH) {
    return null
}
```

This PR updates this logic by: 
- passing the selectedLocation from `LocationAutocomplete` to `LocationPredictions`
- updating the above logic to `if (selectedLocation || !query || query.length < MIN_LENGTH) return null `

With this logic, location predictions box will not be rendered when there's a selected location or the search query is less than 3 characters. 

### Video
#### Before 
https://user-images.githubusercontent.com/42584148/159885472-d91c36df-6658-4d20-94d0-1cdc49178c47.mp4


#### After
https://user-images.githubusercontent.com/42584148/159893246-c7b18bf9-e5da-46dd-98c5-34b90f144c6d.mp4

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[SWA-318]: https://artsyproduct.atlassian.net/browse/SWA-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ