### PR TITLE
chore: set my collection ffs to readyForRelease to true

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -154,7 +154,7 @@ export const features = defineFeatures({
     showInAdminMenu: true,
   },
   ARShowConsignmentsInMyCollection: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Show consignments in My Collection",
     showInAdminMenu: true,
   },
@@ -163,13 +163,13 @@ export const features = defineFeatures({
     description: "Enable placeholder layout animation",
   },
   AREnableNewMyCollectionArtwork: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable new my collection artwork page",
     showInAdminMenu: true,
     echoFlagKey: "AREnablePlaceholderLayoutAnimation",
   },
   AREnableShowOnlySubmittedMyCollectionArtworkFilter: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable Show Only Submitted MyCollection Artwork Filter",
     showInAdminMenu: true,
   },
@@ -184,22 +184,22 @@ export const features = defineFeatures({
     showInAdminMenu: true,
   },
   ARShowRequestPriceEstimateBanner: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Show request price estimate banner",
     showInAdminMenu: true,
   },
   ARShowDemandIndexHints: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Show demand index hints",
     showInAdminMenu: true,
   },
   AREnablePriceEstimateRange: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable My Collection Price Estimate Range",
     showInAdminMenu: true,
   },
   AREnableMyCollectionComparableWorks: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable My Collection Comparable Works",
     showInAdminMenu: true,
   },


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

### Description

This PR sets the ffs `readyForRelease` to true.
Blocked by https://github.com/artsy/echo/pull/216

<!-- Implementation description -->

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [ ] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- set my collection ffs to readyForRelease to true - mounir

<!-- end_changelog_updates -->

</details>
