### PR TITLE
feat(cx-2325): Temp fix - Make Header of StickyTabPage scrollable

### DIFF
--- a/src/app/Components/StickyTabPage/StickyTabPageFlatList.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageFlatList.tsx
@@ -1,9 +1,11 @@
 import { useSpace } from "palette"
 import React, { createContext, useContext, useRef, useState } from "react"
-import { FlatList, FlatListProps } from "react-native"
-import Animated from "react-native-reanimated"
+import { FlatListProps } from "react-native"
+import { FlatList as RNGHFlatList } from "react-native-gesture-handler"
+import Animated, { call } from "react-native-reanimated"
 import { useAnimatedValue } from "./reanimatedHelpers"
 import { useStickyTabPageContext } from "./StickyTabPageContext"
+import { StickyTabPageGestureContainerContext } from "./StickyTabPageGestureContainer"
 
 interface FlatListRequiredContext {
   tabIsActive: Animated.Node<number>
@@ -13,7 +15,7 @@ interface FlatListRequiredContext {
 
 export const StickyTabPageFlatListContext = createContext<FlatListRequiredContext>(null as any)
 
-const AnimatedFlatList: typeof FlatList = Animated.createAnimatedComponent(FlatList)
+const AnimatedFlatList: typeof RNGHFlatList = Animated.createAnimatedComponent(RNGHFlatList)
 
 export interface StickyTabSection {
   key: string // must be unique per-tab
@@ -26,7 +28,7 @@ export interface StickyTabFlatListProps
   > {
   data: StickyTabSection[]
   paddingHorizontal?: number
-  innerRef?: React.MutableRefObject<{ getNode(): FlatList<any> } | null>
+  innerRef?: React.MutableRefObject<{ getNode(): RNGHFlatList<any> } | null>
 }
 
 export const StickyTabPageFlatList: React.FC<StickyTabFlatListProps> = (props) => {
@@ -54,7 +56,7 @@ export const StickyTabPageFlatList: React.FC<StickyTabFlatListProps> = (props) =
     scrollOffsetY,
   })
 
-  const flatListRef = useRef<{ getNode(): FlatList<any> }>()
+  const flatListRef = useRef<{ getNode(): RNGHFlatList<any> }>()
 
   const lastIsActive = useAnimatedValue(-1)
 
@@ -95,8 +97,19 @@ export const StickyTabPageFlatList: React.FC<StickyTabFlatListProps> = (props) =
   const [headerDidMount, setHeaderDidMount] = useState(__TEST__)
   const { data, style, ...otherProps } = props
 
+  const { setHeaderHeight: setStickyTabPageGestureContainerContextHeaderHeight } = useContext(
+    StickyTabPageGestureContainerContext
+  )
+
   return (
     <Animated.View style={{ flex: 1, paddingTop: totalStickyHeaderHeight }}>
+      <Animated.Code>
+        {() =>
+          call([staticHeaderHeight], (val) => {
+            setStickyTabPageGestureContainerContextHeaderHeight(val[0])
+          })
+        }
+      </Animated.Code>
       <AnimatedFlatList
         style={[
           {

--- a/src/app/Components/StickyTabPage/StickyTabPageGestureContainer.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageGestureContainer.tsx
@@ -1,0 +1,72 @@
+import React, { createContext, useRef, useState } from "react"
+import { Animated } from "react-native"
+import { FlatList as RNGHFlatList, PanGestureHandler } from "react-native-gesture-handler"
+
+type ListRef = React.MutableRefObject<{ getNode(): RNGHFlatList<any> } | null>
+
+interface GestureContainerContextType {
+  /**
+   * Register the flatlist that contains the content. You need to pass the
+   *  index (from L to R starting from zero). This is so the container can
+   *  know which Ref to perform scroll on
+   */
+  registerListRef: (index: number, listRef: ListRef) => void
+
+  /** Call this when you switch tabs so the container knows which content is in view
+   *  This is how it knows which Flatlist to trigger scroll on
+   */
+  setCurrentContentIndex: (index: number) => void
+
+  /** Provides the header height of the StickyHeader to the container.
+   * This is used to know by how much scroll offset to apply
+   */
+  setHeaderHeight: (index: number) => void
+}
+
+export const StickyTabPageGestureContainerContext = createContext<GestureContainerContextType>({
+  registerListRef: () => null,
+  setCurrentContentIndex: () => null,
+  setHeaderHeight: () => null,
+})
+
+export const StickyTabPageGestureContainer: React.FC<{}> = ({ children }) => {
+  const [currentContentIndex, setCurrentContentIndex] = useState(0)
+  const [headerHeight, setHeaderHeight] = useState(0)
+
+  const registeredListRefs = useRef<Record<number, ListRef>>({})
+
+  const _registerAListRefByIndex = (index: number, listRef: ListRef) => {
+    registeredListRefs.current[index] = listRef
+  }
+
+  const prevValue = useRef(0)
+
+  return (
+    <StickyTabPageGestureContainerContext.Provider
+      value={{
+        registerListRef: (i, r) => _registerAListRefByIndex(i, r),
+        setCurrentContentIndex,
+        setHeaderHeight,
+      }}
+    >
+      <PanGestureHandler
+        onGestureEvent={({ nativeEvent: { translationY } }) => {
+          if (!!registeredListRefs.current) {
+            const params = {
+              offset: 0 > translationY ? headerHeight : -headerHeight,
+              animated: true,
+            }
+            registeredListRefs.current[currentContentIndex]?.current
+              ?.getNode()
+              .scrollToOffset(params)
+            prevValue.current = params.offset
+          }
+        }}
+      >
+        <Animated.View style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+          {children}
+        </Animated.View>
+      </PanGestureHandler>
+    </StickyTabPageGestureContainerContext.Provider>
+  )
+}

--- a/src/app/Components/StickyTabPage/StickyTabPageTabBar.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageTabBar.tsx
@@ -1,7 +1,7 @@
 import { useScreenDimensions } from "app/utils/useScreenDimensions"
 import { Sans } from "palette"
 import { NavigationalTabs } from "palette/elements/Tabs"
-import React, { useEffect, useRef, useState } from "react"
+import React, { useContext, useEffect, useRef, useState } from "react"
 import {
   Animated,
   LayoutRectangle,
@@ -11,6 +11,7 @@ import {
   ViewProps,
 } from "react-native"
 import { useStickyTabPageContext } from "./StickyTabPageContext"
+import { StickyTabPageGestureContainerContext } from "./StickyTabPageGestureContainer"
 
 export const TAB_BAR_HEIGHT = 48
 
@@ -47,12 +48,14 @@ export const StickyTabPageTabBar: React.FC<{
   }, [activeTabIndex.current])
 
   const v3Tabs = tabLabels.map((label, index) => ({ label, superscript: tabSuperscripts[index] }))
+  const gestureContainerContext = useContext(StickyTabPageGestureContainerContext)
   return (
     <NavigationalTabs
       tabs={v3Tabs}
       onTabPress={(label, index) => {
         setActiveTabIndex(index)
         onTabPress?.({ label, index })
+        gestureContainerContext?.setCurrentContentIndex?.(index)
       }}
       activeTab={activeTabIndex.current}
     />

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tsx
@@ -1,9 +1,10 @@
 import { MyCollectionArtworkAbout_artwork$key } from "__generated__/MyCollectionArtworkAbout_artwork.graphql"
 import { MyCollectionArtworkAbout_marketPriceInsights$key } from "__generated__/MyCollectionArtworkAbout_marketPriceInsights.graphql"
+import { StickyTabPageGestureContainerContext } from "app/Components/StickyTabPage/StickyTabPageGestureContainer"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, useTheme } from "palette"
-import React from "react"
+import React, { useContext, useRef } from "react"
 import { useFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 import { MyCollectionArtworkAboutWork } from "./Components/ArtworkAbout/MyCollectionArtworkAboutWork"
@@ -26,10 +27,29 @@ export function MyCollectionArtworkAbout(props: MyCollectionArtworkAboutProps) {
   )
 
   const articles = extractNodes(artwork.artist?.articles)
+
   const Wrapper = props.renderWithoutScrollView ? Flex : StickyTabPageScrollView
+
+  const innerRef = useRef(null)
+
+  const { registerListRef } = useContext(StickyTabPageGestureContainerContext)
+
   return (
-    <Wrapper style={{ paddingHorizontal: space(2) }}>
-      <Flex mt={props.renderWithoutScrollView ? 1 : 2} mb={3}>
+    <Wrapper
+      style={{ paddingHorizontal: space(2) }}
+      showsVerticalScrollIndicator={false}
+      innerRef={props.renderWithoutScrollView ? undefined : innerRef}
+      onLayout={() => {
+        if (
+          registerListRef &&
+          typeof registerListRef === "function" &&
+          !props.renderWithoutScrollView
+        ) {
+          registerListRef(1, innerRef)
+        }
+      }}
+    >
+      <Flex mt={2} mb={3}>
         <MyCollectionArtworkAboutWork artwork={artwork} marketPriceInsights={marketPriceInsights} />
 
         <MyCollectionArtworkPurchaseDetails artwork={artwork} />

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -1,10 +1,11 @@
 import { MyCollectionArtworkInsights_artwork$key } from "__generated__/MyCollectionArtworkInsights_artwork.graphql"
 import { MyCollectionArtworkInsights_marketPriceInsights$key } from "__generated__/MyCollectionArtworkInsights_marketPriceInsights.graphql"
 import { MyCollectionArtworkInsights_me$key } from "__generated__/MyCollectionArtworkInsights_me.graphql"
+import { StickyTabPageGestureContainerContext } from "app/Components/StickyTabPage/StickyTabPageGestureContainer"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { Flex, Spacer } from "palette/elements"
-import React from "react"
+import React, { useContext, useRef } from "react"
 import { useFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 import { MyCollectionArtworkArtistAuctionResults } from "./Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults"
@@ -42,8 +43,19 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
     isP1Artist &&
     Number((marketPriceInsights?.demandRank ?? 0) * 10) >= 9
 
+  const innerRef = useRef(null)
+
+  const { registerListRef } = useContext(StickyTabPageGestureContainerContext)
+
   return (
-    <StickyTabPageScrollView>
+    <StickyTabPageScrollView
+      innerRef={innerRef}
+      onLayout={() => {
+        if (registerListRef && typeof registerListRef === "function") {
+          registerListRef(0, innerRef)
+        }
+      }}
+    >
       <Flex my={3}>
         {!!marketPriceInsights && (
           <>


### PR DESCRIPTION
The type of this PR is: **Bugfix**

<!-- Bugfix/Feature/Enhancement/Documentation -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. [PROJECT-XXXX]
     The Jira integration will turn it into a clickable link for you. -->

This PR resolves [CX-2325]

### Description
- This PR adds a PanGestureHandler around StickyTabPage and triggers an onscroll on the deeply nested FlatList with an offset of the existing headerHeight, thereby making a long staticHeader scroll off the screen when the user attempts to scroll. It behaves similar to how we hide and show BackButton
- Components that want to have this behaviour must explicitly register on the StickyTabPageGestureContainer, therefore the previous/normal StickyTabPage behaviour is maintained
- Switched to Flatlist from 'react-native-gesture-handler' to fix issues where the PanHandler intercepts scroll on the underlying Flatlist


https://user-images.githubusercontent.com/18648835/160426556-a4398f04-0ce8-4f44-8986-4505001bcaf0.mp4


https://user-images.githubusercontent.com/18648835/160428884-7e74123b-1711-4ce1-ae6f-e08741ee8214.mp4


<!-- Implementation description -->

#### follow up
- Leaving CX-2325 in progress. We should implement without the gesture wrapper, when all the blockers are removed

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. CX warmly welcomes any feedback about the list or how it impacts your workflow -->

- [x] I have included screenshots or videos to illustrate my changes, or I have not changed anything that impacts the UI.
- [x] I have tested my changes on **iOS** and **Android**.
- [x] I have added tests/stories for my changes, or my changes don't require testing/stories, or I have included a link to a separate Jira ticket covering the tests.
- [x] I have added a feature flag, or my changes don't require a feature flag. ([How do I add one?](https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md))
- [x] I have documented any follow-up work that this PR will require, or it does not require any.
- [x] I have added an app state migration, or my changes do not require one. ([What are migrations?](https://github.com/artsy/eigen/blob/main/docs/adding_state_migrations.md))
- [x] I have added a changelog entry below or my changes do not require one.

### To the reviewers 👀

- [x] I would like at least one of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Temp fix: Make Header of StickyTabPage scrollable - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
