### PR TITLE
chore: add script to execute example algolia location-based queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "@types/luxon": "2.0.9",
     "@types/moment-timezone": "0.5.30",
     "@types/node": "14.17.34",
+    "@types/node-fetch": "2.6.1",
     "@types/qs": "6.9.7",
     "@types/query-string": "5.0.1",
     "@types/react": "17.0.39",

--- a/scripts/algolia-example-galleries-near-me.ts
+++ b/scripts/algolia-example-galleries-near-me.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env yarn ts-node
+
+/**
+ * example location-based queries against Algolia
+ */
+
+declare var process: {
+  argv: string[]
+  env: {
+    ALGOLIA_API_KEY: string
+    ALGOLIA_APP_ID: string
+  }
+  exit(code: number): void
+}
+
+interface GalleryHit {
+  partner: {
+    name: string
+    href: string
+  }
+  _geoloc: {
+    lat: number
+    lng: number
+  }
+}
+
+import algoliasearch from "algoliasearch"
+import fetch from "node-fetch"
+import cities from "../data/cityDataSortedByDisplayPreference.json"
+
+const main = async () => {
+  const { ALGOLIA_API_KEY, ALGOLIA_APP_ID } = process.env
+  const client = algoliasearch(ALGOLIA_APP_ID!, ALGOLIA_API_KEY!)
+
+  const lng = process.argv[3]
+  const citySlugOrLat = process.argv[2]
+  const city = cities.find((c) => c.slug === citySlugOrLat)
+
+  let options
+
+  if (lng) {
+    options = {
+      aroundLatLng: `${citySlugOrLat}, ${lng}`,
+      aroundRadius: 100000,
+    }
+  } else if (city) {
+    const { coordinates } = city
+    options = {
+      aroundLatLng: `${coordinates.lat}, ${coordinates.lng}`,
+      aroundRadius: 100000,
+    }
+  } else {
+    const response = await fetch("https://api.ipify.org")
+    const ipAddress = await response.text()
+    console.log("Your IP Address is:", ipAddress)
+    options = {
+      aroundRadius: 100000,
+      aroundLatLngViaIP: true,
+      headers: {
+        "X-Forwarded-For": ipAddress,
+      },
+    }
+  }
+
+  const galleryIndex = client.initIndex("PartnerLocation_staging")
+  const results = await galleryIndex.search<GalleryHit>("", options)
+  const { hits, nbHits } = results
+  console.log("Total: %s galleries\n", nbHits)
+
+  console.log("Closest %s gallery locations:", hits.length)
+  hits.forEach((hit) => {
+    console.log(
+      "- %s (%s, %s) -- https://artsy.net%s",
+      hit.partner.name,
+      hit._geoloc.lat,
+      hit._geoloc.lng,
+      hit.partner.href
+    )
+  })
+}
+
+main().catch(console.error)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3746,6 +3746,14 @@
   dependencies:
     moment-timezone "*"
 
+"@types/node-fetch@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.1.tgz#8f127c50481db65886800ef496f20bbf15518975"
+  integrity sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*", "@types/node@14.17.34", "@types/node@>= 8":
   version "14.17.34"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.34.tgz#fe4b38b3f07617c0fa31ae923fca9249641038f0"


### PR DESCRIPTION
Search for gallery locations within 100km of either:
- Your current IP address
- An Artsy recognized city slug
- Specific coordinates

```bash
$ ./scripts/algolia-example-galleries-near-me.ts

$ ./scripts/algolia-example-galleries-near-me.ts los-angeles-ca-usa

$ ./scripts/algolia-example-galleries-near-me.ts 48.1351, 11.5820
```

Jira: [FX-3852](https://artsyproduct.atlassian.net/browse/FX-3852)

cc/ @dimatretyak @erikdstock 