### PR TITLE
Adds black owned banner to partner page

### DIFF
--- a/CHANGELOG/android-changelog.md
+++ b/CHANGELOG/android-changelog.md
@@ -8,6 +8,7 @@
   - Dev changes:
     - Do not save the changelog update date - mounir
     - Track link tap and AuctionResultsForYou Screen - kizito
+    - Add black owned banner to partner page - lily
 
 <!-- DO NOT CHANGE -->
 

--- a/CHANGELOG/ios-changelog.md
+++ b/CHANGELOG/ios-changelog.md
@@ -8,6 +8,7 @@
   - Dev changes:
     - Do not save the changelog update date - mounir
     - Track link tap and AuctionResultsForYou Screen - kizito
+    - Add black owned banner to partner page - lily
 
 <!-- DO NOT CHANGE -->
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -675,6 +675,8 @@ PODS:
     - Sentry (= 7.9.0)
   - RNShare (7.3.6):
     - React-Core
+  - RNSplit (0.0.1):
+    - React
   - RNSVG (9.13.3):
     - React
   - SDWebImage (5.8.3):
@@ -844,6 +846,7 @@ DEPENDENCIES:
   - RNScreens (from `node_modules/react-native-screens`)
   - "RNSentry (from `node_modules/@sentry/react-native`)"
   - RNShare (from `node_modules/react-native-share`)
+  - "RNSplit (from `node_modules/@splitsoftware/splitio-react-native`)"
   - RNSVG (from `node_modules/react-native-svg`)
   - SDWebImage (= 5.8.3)
   - Segment-Adjust (= 3.1.4)
@@ -859,14 +862,7 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
-  trunk:
+  https://cdn.cocoapods.org/:
     - Adjust
     - AFNetworkActivityLogger
     - AFNetworking
@@ -941,6 +937,13 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:
@@ -1143,7 +1146,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   EDColor: 91d127cd67d7c1d3862846fb11ef4b3851151bfa
   Emission: ce472ad11d5dcd1e332938722aef6e97945e4efb
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -1172,7 +1175,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
-  glog: 5337263514dd6f09803962437687240c5dc39aa4
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20

--- a/src/app/Components/PartnerBanner.tsx
+++ b/src/app/Components/PartnerBanner.tsx
@@ -1,0 +1,30 @@
+import { TextVariant } from "@artsy/palette-tokens/dist/typography/v3"
+import { BoxProps, Flex, Text } from "palette"
+import React from "react"
+
+export interface PartnerBannerProps extends BoxProps {
+  textVariant?: TextVariant
+  bannerText: string
+}
+
+export const PartnerBanner: React.FC<PartnerBannerProps> = ({ bannerText, textVariant = "xs" }) => {
+  return (
+    <Flex flexDirection="row" justifyContent="space-around" bg="black10" py={0.5}>
+      <Text variant={textVariant} color="black100">
+        •
+      </Text>
+      <Text variant={textVariant} color="black100">
+        {bannerText}
+      </Text>
+      <Text variant={textVariant} color="black100">
+        •
+      </Text>
+      <Text variant={textVariant} color="black100">
+        {bannerText}
+      </Text>
+      <Text variant={textVariant} color="black100">
+        •
+      </Text>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
@@ -74,6 +74,20 @@ describe("PartnerHeader", () => {
 
     expect(extractText(tree.root.findByType(Button))).toContain("Follow")
   })
+
+  it("renders the Black Owned marquee if the gallery has the 'Black Owned' category", async () => {
+    const tree = renderWithWrappers(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation({
+        errors: [],
+        data: {
+          partner: BlackOwnedPartnerHeaderFixture,
+        },
+      })
+    })
+
+    expect(extractText(tree.root)).toContain("Black Owned")
+  })
 })
 
 const PartnerHeaderFixture = {
@@ -90,6 +104,26 @@ const PartnerHeaderFixture = {
     internalID: "5159da629a60832439000035",
     isFollowed: false,
   },
+  categories: [],
+  internalID: "4d8b92c44eb68a1b2c0004cb",
+  slug: "gagosian",
+}
+
+const BlackOwnedPartnerHeaderFixture = {
+  " $refType": null,
+  name: "Gagosian",
+  counts: {
+    eligibleArtworks: 1231,
+  },
+  profile: {
+    counts: {
+      follows: 136999,
+    },
+    id: "UHJvZmlsZTo1MTU5ZGE2MjlhNjA4MzI0MzkwMDAwMzU=",
+    internalID: "5159da629a60832439000035",
+    isFollowed: false,
+  },
+  categories: [{ name: "Black Owned" }],
   internalID: "4d8b92c44eb68a1b2c0004cb",
   slug: "gagosian",
 }

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tsx
@@ -11,7 +11,15 @@ const PartnerHeader: React.FC<{
   partner: PartnerHeader_partner
 }> = ({ partner }) => {
   const eligibleArtworks = partner.counts?.eligibleArtworks ?? 0
-  const isBlackOwned = partner.categories!.filter((c) => c && c.name === "Black Owned").length > 0
+
+  const galleryBadges = ["Black Owned", "Women Owned"]
+
+  const eligibleCategories = (partner.categories || []).filter(Boolean)
+
+  const categoryNames: string[] = eligibleCategories.map((category) => category?.name || "")
+  const firstEligibleBadgeName: string | undefined = galleryBadges.find((badge) =>
+    categoryNames.includes(badge)
+  )
 
   return (
     <>
@@ -34,7 +42,7 @@ const PartnerHeader: React.FC<{
           )}
         </Flex>
       </Box>
-      {isBlackOwned && <PartnerBanner bannerText="Black Owned" />}
+      {firstEligibleBadgeName && <PartnerBanner bannerText={firstEligibleBadgeName} />}
     </>
   )
 }

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tsx
@@ -1,4 +1,5 @@
 import { PartnerHeader_partner } from "__generated__/PartnerHeader_partner.graphql"
+import { PartnerBanner } from "app/Components/PartnerBanner"
 import { Stack } from "app/Components/Stack"
 import { formatLargeNumberOfItems } from "app/utils/formatLargeNumberOfItems"
 import { Box, Flex, Sans } from "palette"
@@ -10,27 +11,31 @@ const PartnerHeader: React.FC<{
   partner: PartnerHeader_partner
 }> = ({ partner }) => {
   const eligibleArtworks = partner.counts?.eligibleArtworks ?? 0
+  const isBlackOwned = partner.categories!.filter((c) => c && c.name === "Black Owned").length > 0
 
   return (
-    <Box px={2} pb={1} pt={6}>
-      <Sans mb={1} size="8">
-        {partner.name}
-      </Sans>
-      <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-        <Stack spacing={0.5}>
-          {!!eligibleArtworks && (
-            <Sans size="3t">
-              {!!eligibleArtworks && formatLargeNumberOfItems(eligibleArtworks, "work", "works")}
-            </Sans>
+    <>
+      <Box px={2} pb={1} pt={6}>
+        <Sans mb={1} size="8">
+          {partner.name}
+        </Sans>
+        <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+          <Stack spacing={0.5}>
+            {!!eligibleArtworks && (
+              <Sans size="3t">
+                {!!eligibleArtworks && formatLargeNumberOfItems(eligibleArtworks, "work", "works")}
+              </Sans>
+            )}
+          </Stack>
+          {!!partner.profile && (
+            <Flex flexGrow={0} flexShrink={0}>
+              <FollowButton partner={partner} />
+            </Flex>
           )}
-        </Stack>
-        {!!partner.profile && (
-          <Flex flexGrow={0} flexShrink={0}>
-            <FollowButton partner={partner} />
-          </Flex>
-        )}
-      </Flex>
-    </Box>
+        </Flex>
+      </Box>
+      {isBlackOwned && <PartnerBanner bannerText="Black Owned" />}
+    </>
   )
 }
 
@@ -40,6 +45,9 @@ export const PartnerHeaderContainer = createFragmentContainer(PartnerHeader, {
       name
       profile {
         # Only fetch something so we can see if the profile exists.
+        name
+      }
+      categories {
         name
       }
       counts {


### PR DESCRIPTION
This is a followup to [GRO-820](https://artsyproduct.atlassian.net/browse/GRO-820). Design decided that a static banner was preferable to [an animated marquee](https://github.com/artsy/eigen/pull/6305) so I reimplemented the feature here.

<img width="440" alt="Screen Shot 2022-04-05 at 12 43 23 PM" src="https://user-images.githubusercontent.com/5643895/161805668-2662f8c4-f0b7-4d1b-b3cb-dbc8c6b6eab3.png">
