### PR TITLE
feat: Explanatory banner for empty Collector Profile 

### DIFF
--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -104,7 +104,7 @@ const MyCollection: React.FC<{
 
   const hasBeenShownBanner = async () => {
     const hasSeen = await AsyncStorage.getItem(HAS_SEEN_MY_COLLECTION_NEW_WORKS_BANNER)
-    const shouldShowConsignments = showSessionVisualClue("ArtworkSubmissionBanner")
+    const shouldShowConsignments = showSessionVisualClue("ArtworkSubmissionMessage")
     return {
       hasSeenBanner: hasSeen === "true",
       shouldShowConsignments: shouldShowConsignments === true,
@@ -164,7 +164,7 @@ const MyCollection: React.FC<{
                 title="Artwork added to My Collection"
                 text="The artwork you submitted for sale has been automatically added."
                 showCloseButton
-                onClose={() => removeClue("ArtworkSubmissionBanner")}
+                onClose={() => removeClue("ArtworkSubmissionMessage")}
               />
             )}
           </Flex>

--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
@@ -106,7 +106,7 @@ describe("MyProfileHeaderMyCollectionAndSavedWorks", () => {
       it("Get displayed if at least one of the fields is empty,", async () => {
         beforeEach(() => {
           __globalStoreTestUtils__?.injectFeatureFlags({
-            ARShowCollectorProfileExplanatoryBanner: false,
+            AREnableCompleteProfileMessage: false,
           })
         })
         const { findByText } = getWrapper({
@@ -126,7 +126,7 @@ describe("MyProfileHeaderMyCollectionAndSavedWorks", () => {
       it("Doesnt get displayed if none of fields are empty", async () => {
         beforeEach(() => {
           __globalStoreTestUtils__?.injectFeatureFlags({
-            ARShowCollectorProfileExplanatoryBanner: false,
+            AREnableCompleteProfileMessage: false,
           })
         })
         const { queryByText } = getWrapper({

--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
@@ -102,8 +102,8 @@ describe("MyProfileHeaderMyCollectionAndSavedWorks", () => {
       expect(await findByText("My Bio")).toBeTruthy()
     })
 
-    describe("Explanatory banner", () => {
-      it("Get displayed if at least one of the fields is empty,", async () => {
+    describe("Complete Profile Message", () => {
+      it("does get displayed if at least one of the fields is empty", async () => {
         beforeEach(() => {
           __globalStoreTestUtils__?.injectFeatureFlags({
             AREnableCompleteProfileMessage: false,
@@ -123,7 +123,7 @@ describe("MyProfileHeaderMyCollectionAndSavedWorks", () => {
         expect(await findByText("Why complete your Colletor Profile?")).toBeTruthy()
       })
 
-      it("Doesnt get displayed if none of fields are empty", async () => {
+      it("doesn't get displayed if the profile is completed", async () => {
         beforeEach(() => {
           __globalStoreTestUtils__?.injectFeatureFlags({
             AREnableCompleteProfileMessage: false,

--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
@@ -102,6 +102,48 @@ describe("MyProfileHeaderMyCollectionAndSavedWorks", () => {
       expect(await findByText("My Bio")).toBeTruthy()
     })
 
+    describe("Explanatory banner", () => {
+      it("Get displayed if at least one of the fields is empty,", async () => {
+        beforeEach(() => {
+          __globalStoreTestUtils__?.injectFeatureFlags({
+            ARShowCollectorProfileExplanatoryBanner: false,
+          })
+        })
+        const { findByText } = getWrapper({
+          Me: () => ({
+            name: "My Name",
+            profession: null,
+            bio: "some-bio",
+            icon: "icon",
+            otherRelevantPositions: "something",
+          }),
+        })
+
+        await flushPromiseQueue()
+        expect(await findByText("Why complete your Colletor Profile?")).toBeTruthy()
+      })
+
+      it("Doesnt get displayed if none of fields are empty", async () => {
+        beforeEach(() => {
+          __globalStoreTestUtils__?.injectFeatureFlags({
+            ARShowCollectorProfileExplanatoryBanner: false,
+          })
+        })
+        const { queryByText } = getWrapper({
+          Me: () => ({
+            name: "My Name",
+            profession: "some-profession",
+            bio: "some-bio",
+            icon: "some-icon",
+            otherRelevantPositions: "something",
+          }),
+        })
+
+        await flushPromiseQueue()
+        expect(await queryByText("Why complete your Colletor Profile?")).toBeFalsy()
+      })
+    })
+
     it("Renders Icon", async () => {
       const localImage: LocalImage = {
         path: "some/my/profile/path",

--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
@@ -7,12 +7,13 @@ import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { navigate } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
-import { useFeatureFlag } from "app/store/GlobalStore"
+import { setVisualClueAsSeen, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import {
   Avatar,
+  Banner,
   Box,
   BriefcaseIcon,
   Button,
@@ -24,7 +25,7 @@ import {
   Text,
   useColor,
 } from "palette"
-import React, { useContext } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import { createRefetchContainer, QueryRenderer } from "react-relay"
 import { graphql } from "relay-runtime"
 import { FavoriteArtworksQueryRenderer } from "../Favorites/FavoriteArtworks"
@@ -71,10 +72,29 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeaderMyCollectionAndSaved
   const navigation = useNavigation()
 
   const showCollectorProfile = useFeatureFlag("AREnableCollectorProfile")
+  const showCollectorProfileExplanatoryBannerFeatureFlag = useFeatureFlag(
+    "ARShowCollectorProfileExplanatoryBanner"
+  )
+  const { showVisualClue } = useVisualClue()
+
+  const [showCollectorProfileExplanatoryBanner, setShowCollectorProfileExplanatoryBanner] =
+    useState(showVisualClue("CollectorProfileExplanatoryBanner"))
 
   const { localImage } = useContext(MyProfileContext)
 
   const userProfileImagePath = localImage || me?.icon?.url
+
+  const collectorProfileIsNotComplete =
+    !me.bio || !me.icon || !me.profession || !me.otherRelevantPositions
+
+  useEffect(() => {
+    setVisualClueAsSeen("CollectorProfileExplanatoryBanner")
+  }, [])
+
+  const showBanner =
+    showCollectorProfileExplanatoryBannerFeatureFlag &&
+    collectorProfileIsNotComplete &&
+    showCollectorProfileExplanatoryBanner
 
   return (
     <>
@@ -85,6 +105,18 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeaderMyCollectionAndSaved
           navigate("/my-profile/settings")
         }}
       />
+      {showBanner && (
+        <Banner
+          title="Why complete your Colletor Profile?"
+          text="A complete profile helps you build a relationship with sellers. Select “Edit Profile” to see which details are shared when you contact sellers."
+          showCloseButton
+          containerStyle={{ mb: 2, backgroundColor: color("black5") }}
+          titleStyle={{ variant: "xs", color: color("black100") }}
+          bodyTextStyle={{ variant: "xs", color: color("black60") }}
+          onClose={() => setShowCollectorProfileExplanatoryBanner(false)}
+        />
+      )}
+
       <Flex flexDirection="row" alignItems="center" px={2}>
         <Box
           height="99"

--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
@@ -13,13 +13,13 @@ import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import {
   Avatar,
-  Banner,
   Box,
   BriefcaseIcon,
   Button,
   Flex,
   Join,
   MapPinIcon,
+  Message,
   MuseumIcon,
   Spacer,
   Text,
@@ -70,31 +70,30 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeaderMyCollectionAndSaved
 }) => {
   const color = useColor()
   const navigation = useNavigation()
-
-  const showCollectorProfile = useFeatureFlag("AREnableCollectorProfile")
-  const showCollectorProfileExplanatoryBannerFeatureFlag = useFeatureFlag(
-    "ARShowCollectorProfileExplanatoryBanner"
-  )
   const { showVisualClue } = useVisualClue()
 
-  const [showCollectorProfileExplanatoryBanner, setShowCollectorProfileExplanatoryBanner] =
-    useState(showVisualClue("CollectorProfileExplanatoryBanner"))
+  const showCollectorProfile = useFeatureFlag("AREnableCollectorProfile")
+  const enableCompleteProfileMessage = useFeatureFlag("AREnableCompleteProfileMessage")
 
   const { localImage } = useContext(MyProfileContext)
 
   const userProfileImagePath = localImage || me?.icon?.url
 
-  const collectorProfileIsNotComplete =
-    !me.bio || !me.icon || !me.profession || !me.otherRelevantPositions
+  const [showCompleteCollectorProfileMessage, setShowCompleteCollectorProfileMessage] = useState(
+    showVisualClue("CompleteCollectorProfileMessage")
+  )
 
   useEffect(() => {
-    setVisualClueAsSeen("CollectorProfileExplanatoryBanner")
+    setVisualClueAsSeen("CompleteCollectorProfileMessage")
   }, [])
 
-  const showBanner =
-    showCollectorProfileExplanatoryBannerFeatureFlag &&
-    collectorProfileIsNotComplete &&
-    showCollectorProfileExplanatoryBanner
+  const isCollectorProfileCompleted =
+    me.bio && me.icon && me.profession && me.otherRelevantPositions
+
+  const showCompleteProfileMessage =
+    enableCompleteProfileMessage &&
+    !isCollectorProfileCompleted &&
+    showCompleteCollectorProfileMessage
 
   return (
     <>
@@ -105,16 +104,16 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeaderMyCollectionAndSaved
           navigate("/my-profile/settings")
         }}
       />
-      {showBanner && (
-        <Banner
-          title="Why complete your Colletor Profile?"
-          text="A complete profile helps you build a relationship with sellers. Select “Edit Profile” to see which details are shared when you contact sellers."
-          showCloseButton
-          containerStyle={{ mb: 2, backgroundColor: color("black5") }}
-          titleStyle={{ variant: "xs", color: color("black100") }}
-          bodyTextStyle={{ variant: "xs", color: color("black60") }}
-          onClose={() => setShowCollectorProfileExplanatoryBanner(false)}
-        />
+      {showCompleteProfileMessage && (
+        <Flex mb={2}>
+          <Message
+            variant="default"
+            title="Why complete your Colletor Profile?"
+            text="A complete profile helps you build a relationship with sellers. Select “Edit Profile” to see which details are shared when you contact sellers."
+            showCloseButton
+            onClose={() => setShowCompleteCollectorProfileMessage(false)}
+          />
+        </Flex>
       )}
 
       <Flex flexDirection="row" alignItems="center" px={2}>
@@ -129,7 +128,7 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeaderMyCollectionAndSaved
           {!!userProfileImagePath ? (
             <Avatar src={userProfileImagePath} size="md" />
           ) : (
-            <Image source={require("../../../../images/profile_placeholder_avatar.webp")} />
+            <Image source={require("@images/profile_placeholder_avatar.webp")} />
           )}
         </Box>
         <Box px={2} flexShrink={1}>

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
@@ -42,7 +42,7 @@ export const ContactInformation: React.FC<{
         trackEvent(consignmentSubmittedEvent(updatedSubmissionId, formValues.userEmail, userID))
 
         GlobalStore.actions.artworkSubmission.submission.resetSessionState()
-        addClue("ArtworkSubmissionBanner")
+        addClue("ArtworkSubmissionMessage")
         handlePress(submissionId)
       }
     } catch (error) {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -189,9 +189,9 @@ export const features = defineFeatures({
     description: "Conversational Buy Now",
     showInAdminMenu: true,
   },
-  ARShowCollectorProfileExplanatoryBanner: {
+  AREnableCompleteProfileMessage: {
     readyForRelease: true,
-    description: "Show Collector Profile Explanatory Banner",
+    description: "Anable Collector Profile Complete Message",
     showInAdminMenu: true,
   },
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -191,7 +191,7 @@ export const features = defineFeatures({
   },
   AREnableCompleteProfileMessage: {
     readyForRelease: true,
-    description: "Anable Collector Profile Complete Message",
+    description: "Enable Collector Profile Complete Message",
     showInAdminMenu: true,
   },
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -189,6 +189,11 @@ export const features = defineFeatures({
     description: "Conversational Buy Now",
     showInAdminMenu: true,
   },
+  ARShowCollectorProfileExplanatoryBanner: {
+    readyForRelease: true,
+    description: "Show Collector Profile Explanatory Banner",
+    showInAdminMenu: true,
+  },
 })
 
 export interface DevToggleDescriptor {

--- a/src/app/store/config/visualClues.ts
+++ b/src/app/store/config/visualClues.ts
@@ -21,4 +21,7 @@ export const visualClues = defineVisualClues({
   ArtworkSubmissionBanner: {
     description: "The banner shown after artwork submission with SWA flow",
   },
+  CollectorProfileExplanatoryBanner: {
+    description: "The banner shown if the collector profile is empty",
+  },
 })

--- a/src/app/store/config/visualClues.ts
+++ b/src/app/store/config/visualClues.ts
@@ -18,10 +18,10 @@ export const visualClues = defineVisualClues({
   // ExampleClueName: {
   //   description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
   // },
-  ArtworkSubmissionBanner: {
-    description: "The banner shown after artwork submission with SWA flow",
+  ArtworkSubmissionMessage: {
+    description: "The message shown after artwork submission with SWA flow",
   },
-  CollectorProfileExplanatoryBanner: {
-    description: "The banner shown if the collector profile is empty",
+  CompleteCollectorProfileMessage: {
+    description: "The message shown if the collector profile is incomplete",
   },
 })


### PR DESCRIPTION
<!-- Use a PR title in the form of 
     `type(thing): what changed`
like:
     `feat(profile): allow editing of profile photo`.
Find some examples in the "conventional commits" summary.
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [CX-2473]

### Description

The PR added an explanatory banner at the top of the Collector Profile screen. It will appear for all the users, new and existing, as long as they have an empty profile and haven’t added any information.

![image](https://user-images.githubusercontent.com/17421923/161978978-2ed1a07d-770c-4e16-b22c-9e67b21ce5dc.png)

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->
- [x] Feature flag around my changes.
- [ ] App state migration.
- [x] Screenshots/videos of my changes.
- [x] Tested on **iOS** and **Android**.
- [x] Tests/stories for my changes.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Explanatory banner for empty Collector Profile - sam

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[CX-2473]: https://artsyproduct.atlassian.net/browse/CX-2473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ