### PR TITLE
feat(artwork): Add new countdown timer and label for cascading end time interval sales

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -418,14 +418,14 @@
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "ead2477c86563400ffd2577338c6c83ae48aeb5a",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "f8c1197cdd5e93fc4ff721cd4417cad3b2fbd047",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 310
       }
     ],
     "src/app/Scenes/Consignments/fixtures/places.json": [
@@ -532,5 +532,5 @@
       }
     ]
   },
-  "generated_at": "2022-04-06T16:01:01Z"
+  "generated_at": "2022-04-07T14:14:05Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -418,14 +418,14 @@
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "ead2477c86563400ffd2577338c6c83ae48aeb5a",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 298
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "f8c1197cdd5e93fc4ff721cd4417cad3b2fbd047",
         "is_verified": false,
-        "line_number": 310
+        "line_number": 309
       }
     ],
     "src/app/Scenes/Consignments/fixtures/places.json": [
@@ -532,5 +532,5 @@
       }
     ]
   },
-  "generated_at": "2022-04-07T14:14:05Z"
+  "generated_at": "2022-04-07T16:26:41Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -418,14 +418,14 @@
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "ead2477c86563400ffd2577338c6c83ae48aeb5a",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 298
       },
       {
         "type": "Hex High Entropy String",
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "f8c1197cdd5e93fc4ff721cd4417cad3b2fbd047",
         "is_verified": false,
-        "line_number": 302
+        "line_number": 309
       }
     ],
     "src/app/Scenes/Consignments/fixtures/places.json": [
@@ -532,5 +532,5 @@
       }
     ]
   },
-  "generated_at": "2022-03-28T13:30:38Z"
+  "generated_at": "2022-04-06T16:01:01Z"
 }

--- a/Artsy/Eigen.playground/playground.xcworkspace/contents.xcworkspacedata
+++ b/Artsy/Eigen.playground/playground.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/src/app/Components/Bidding/Components/Timer.tests.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tests.tsx
@@ -66,10 +66,10 @@ it("formats the remaining time in '00d  00h  00m  00s'", () => {
   expect(getTimerText(timer)).toEqual("00d  00h  00m  10s")
 })
 
-it("shows 'Ends' when it's an online-only sale with an ending time", () => {
+it("shows 'Closes' when it's an online-only sale with an ending time", () => {
   const timer = renderWithWrappers(<Timer endsAt="2018-05-14T20:00:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toContain("Ends")
+  expect(getTimerLabel(timer)).toContain("Closes")
 })
 
 it("shows 'Live' when the liveStartsAt prop is given", () => {
@@ -140,7 +140,7 @@ it("shows month, date, and hour adjusted for the timezone where the user is", ()
   // Thursday, May 14, 2018 1:00:00.000 PM PDT in LA
   const timer = renderWithWrappers(<Timer endsAt="2018-05-14T20:00:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toEqual("Ends May 14, 1 PM PDT")
+  expect(getTimerLabel(timer)).toEqual("Closes May 14, 1 PM PDT")
 })
 
 it("displays the minutes when the sale does not end on the hour", () => {
@@ -148,11 +148,11 @@ it("displays the minutes when the sale does not end on the hour", () => {
 
   let timer = renderWithWrappers(<Timer endsAt="2018-05-14T20:01:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4:01 PM EDT")
+  expect(getTimerLabel(timer)).toEqual("Closes May 14, 4:01 PM EDT")
 
   timer = renderWithWrappers(<Timer endsAt="2018-05-14T20:30:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4:30 PM EDT")
+  expect(getTimerLabel(timer)).toEqual("Closes May 14, 4:30 PM EDT")
 })
 
 it("omits the minutes when the sale ends on the hour", () => {
@@ -160,7 +160,7 @@ it("omits the minutes when the sale ends on the hour", () => {
 
   const timer = renderWithWrappers(<Timer endsAt="2018-05-14T20:00:00+00:00" />)
 
-  expect(getTimerLabel(timer)).toEqual("Ends May 14, 4 PM EDT")
+  expect(getTimerLabel(timer)).toEqual("Closes May 14, 4 PM EDT")
 })
 
 describe("timer transitions", () => {
@@ -177,7 +177,7 @@ describe("timer transitions", () => {
 
     jest.advanceTimersByTime(1 * SECONDS)
 
-    expect(getMountedTimerLabel(timer)).toContain("Ends")
+    expect(getMountedTimerLabel(timer)).toContain("Closes")
     expect(getMountedTimerText(timer)).toEqual("00d  00h  00m  01s")
   })
 
@@ -223,7 +223,7 @@ describe("timer transitions", () => {
       </Theme>
     )
 
-    expect(getMountedTimerLabel(timer)).toContain("Ends")
+    expect(getMountedTimerLabel(timer)).toContain("Closes")
     expect(getMountedTimerText(timer)).toEqual("00d  00h  00m  01s")
 
     jest.advanceTimersByTime(1 * SECONDS)

--- a/src/app/Components/Bidding/Components/Timer.tests.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tests.tsx
@@ -246,6 +246,7 @@ describe("timer transitions", () => {
 })
 
 describe("Countdown", () => {
+  // 10h 3m
   const duration = moment.duration(36180000)
 
   describe("when the disable cascade feature flag is turned off", () => {

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -124,13 +124,7 @@ export const Countdown: React.FC<CountdownProps> = ({
   return (
     <Flex alignItems="center">
       {cascadingEndTimeFeatureEnabled && cascadingEndTimeInterval ? (
-        <ModernTicker
-          duration={duration}
-          separator="  "
-          size="4t"
-          weight="medium"
-          hasStarted={hasStarted}
-        />
+        <ModernTicker duration={duration} hasStarted={hasStarted} />
       ) : (
         <SimpleTicker duration={duration} separator="  " size="4t" weight="medium" />
       )}
@@ -163,13 +157,13 @@ export const Timer: React.FC<Props> = (props) => {
         CountdownComponent={Countdown}
         onCurrentTickerState={() => {
           const state = currentTimerState(props)
-          const { label, date, hasStarted } = relevantStateData(state, props)
-          return { label, date, state, hasStarted } as any // STRICTNESS_MIGRATION
+          const { label, date } = relevantStateData(state, props)
+          return { label, date, state } as any // STRICTNESS_MIGRATION
         }}
         onNextTickerState={({ state }) => {
           const nextState = nextTimerState(state as AuctionTimerState, props)
-          const { label, date, hasStarted } = relevantStateData(nextState, props)
-          return { state: nextState, label, date, hasStarted } as any // STRICTNESS_MIGRATION
+          const { label, date } = relevantStateData(nextState, props)
+          return { state: nextState, label, date } as any // STRICTNESS_MIGRATION
         }}
       />
     </TimeOffsetProvider>

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -1,5 +1,5 @@
 import { StateManager as CountdownStateManager } from "app/Components/Countdown"
-import { CountdownProps } from "app/Components/Countdown/CountdownTimer"
+import { CountdownTimerProps } from "app/Components/Countdown/CountdownTimer"
 import { ModernTicker, SimpleTicker } from "app/Components/Countdown/Ticker"
 import moment from "moment-timezone"
 import { Flex, Sans } from "palette"
@@ -105,6 +105,11 @@ export function currentTimerState({ isPreview, isClosed, liveStartsAt }: Props) 
   } else {
     return AuctionTimerState.CLOSING
   }
+}
+
+export interface CountdownProps extends CountdownTimerProps {
+  hasStarted?: boolean
+  cascadingEndTimeInterval?: number | null
 }
 
 export const Countdown: React.FC<CountdownProps> = ({

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -118,6 +118,7 @@ export const Countdown: React.FC<CountdownProps> = ({
   hasStarted,
   cascadingEndTimeInterval,
 }) => {
+  console.log("CASACDINGENDTIMINTERVL", cascadingEndTimeInterval)
   return (
     <Flex alignItems="center">
       {cascadingEndTimeInterval ? (
@@ -127,7 +128,6 @@ export const Countdown: React.FC<CountdownProps> = ({
           size="4t"
           weight="medium"
           hasStarted={hasStarted}
-          cascadingEndTimeInterval={cascadingEndTimeInterval}
         />
       ) : (
         <SimpleTicker duration={duration} separator="  " size="4t" weight="medium" />

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -1,6 +1,7 @@
 import { StateManager as CountdownStateManager } from "app/Components/Countdown"
 import { CountdownTimerProps } from "app/Components/Countdown/CountdownTimer"
 import { ModernTicker, SimpleTicker } from "app/Components/Countdown/Ticker"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import moment from "moment-timezone"
 import { Flex, Sans } from "palette"
 import PropTypes from "prop-types"
@@ -118,10 +119,11 @@ export const Countdown: React.FC<CountdownProps> = ({
   hasStarted,
   cascadingEndTimeInterval,
 }) => {
-  console.log("CASACDINGENDTIMINTERVL", cascadingEndTimeInterval)
+  const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerLotPage")
+
   return (
     <Flex alignItems="center">
-      {cascadingEndTimeInterval ? (
+      {cascadingEndTimeFeatureEnabled && cascadingEndTimeInterval ? (
         <ModernTicker
           duration={duration}
           separator="  "

--- a/src/app/Components/Countdown/CountdownTimer.tests.tsx
+++ b/src/app/Components/Countdown/CountdownTimer.tests.tsx
@@ -12,11 +12,11 @@ import { render } from "enzyme"
 import { Flex, Sans, Spacer, Theme } from "palette"
 import React from "react"
 import { LabeledTicker } from "."
-import { CountdownProps, CountdownTimer } from "./CountdownTimer"
+import { CountdownTimer, CountdownTimerProps } from "./CountdownTimer"
 
 const dateString = (m: number) => new Date(m).toISOString()
 
-const CountdownText: React.FC<CountdownProps> = ({ duration, label }) => (
+const CountdownText: React.FC<CountdownTimerProps> = ({ duration, label }) => (
   <Flex justifyContent="center" alignItems="center">
     <LabeledTicker
       renderSeparator={() => <Spacer mr={0.5} />}

--- a/src/app/Components/Countdown/CountdownTimer.tsx
+++ b/src/app/Components/Countdown/CountdownTimer.tsx
@@ -6,14 +6,12 @@ interface Props {
   startAt: string
   endAt: string
   formattedOpeningHours?: string
-  countdownComponent: React.FC<CountdownProps>
+  countdownComponent: React.FC<CountdownTimerProps>
 }
 
-export interface CountdownProps {
+export interface CountdownTimerProps {
   duration: Duration
-  hasStarted?: boolean
   label?: string
-  cascadingEndTimeInterval?: number
 }
 
 enum TimerState {
@@ -57,8 +55,8 @@ export const CountdownTimer: React.FC<Props> = (props: Props) => {
   const onState = () => {
     const state = currentState(props)
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const { label, date, hasStarted } = relevantStateData(state, props)
-    return { state, label, date, hasStarted }
+    const { label, date } = relevantStateData(state, props)
+    return { state, label, date }
   }
   return (
     <CountdownStateManager

--- a/src/app/Components/Countdown/CountdownTimer.tsx
+++ b/src/app/Components/Countdown/CountdownTimer.tsx
@@ -11,7 +11,9 @@ interface Props {
 
 export interface CountdownProps {
   duration: Duration
+  hasStarted?: boolean
   label?: string
+  cascadingEndTimeInterval?: number
 }
 
 enum TimerState {
@@ -55,8 +57,8 @@ export const CountdownTimer: React.FC<Props> = (props: Props) => {
   const onState = () => {
     const state = currentState(props)
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const { label, date } = relevantStateData(state, props)
-    return { state, label, date }
+    const { label, date, hasStarted } = relevantStateData(state, props)
+    return { state, label, date, hasStarted }
   }
   return (
     <CountdownStateManager

--- a/src/app/Components/Countdown/StateManager.tsx
+++ b/src/app/Components/Countdown/StateManager.tsx
@@ -1,5 +1,6 @@
 import React from "react"
-import { CountdownProps } from "./CountdownTimer"
+import { CountdownProps } from "../Bidding/Components/Timer"
+
 import { DurationProvider } from "./DurationProvider"
 
 export interface TickerState {

--- a/src/app/Components/Countdown/StateManager.tsx
+++ b/src/app/Components/Countdown/StateManager.tsx
@@ -5,6 +5,7 @@ import { DurationProvider } from "./DurationProvider"
 export interface TickerState {
   label?: string
   date?: string
+  hasStarted?: boolean
   state: string
 }
 
@@ -25,6 +26,7 @@ export class StateManager extends React.Component<Props, State> {
   static getDerivedStateFromProps(props, state) {
     // If this component receives a new tickerState as props,
     // update to use the new props.
+
     if (props.onCurrentTickerState().date !== state.previousTickerState.date) {
       return {
         tickerState: props.onCurrentTickerState(),
@@ -47,9 +49,8 @@ export class StateManager extends React.Component<Props, State> {
   render() {
     const { CountdownComponent, timeOffsetInMilliseconds, ...props } = this.props
     const {
-      tickerState: { label, date, state },
+      tickerState: { label, date, state, hasStarted },
     } = this.state
-
     return (
       <DurationProvider
         // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -61,6 +62,7 @@ export class StateManager extends React.Component<Props, State> {
           label={label}
           // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           duration={null}
+          hasStarted={hasStarted}
           timerState={state}
           {...props}
         />

--- a/src/app/Components/Countdown/Ticker.tests.tsx
+++ b/src/app/Components/Countdown/Ticker.tests.tsx
@@ -3,7 +3,7 @@ import moment from "moment"
 import { Theme } from "palette"
 import React from "react"
 import { Text } from "react-native"
-import { LabeledTicker, SimpleTicker } from "./Ticker"
+import { LabeledTicker, ModernTicker, SimpleTicker } from "./Ticker"
 
 Date.now = () => 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
 const duration = moment.duration(1000)
@@ -67,5 +67,115 @@ describe("LabeledTicker", () => {
     expect(queryByText("00m")).toBeTruthy()
     expect(queryByText("01s")).toBeTruthy()
     expect(queryAllByText(":")).toHaveLength(3)
+  })
+})
+
+describe("ModernTicker", () => {
+  describe("when the sale has not started", () => {
+    it("renders Bidding Starts Today in blue when start time is < 1 day away", () => {
+      const todayDuration = moment.duration(2000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={todayDuration} separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("Bidding Starts Today")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+
+    it("renders 1 Day Until Bidding Starts in blue when start time is >24 hours but less than 2 days away", () => {
+      // 28 hours
+      const dayDuration = moment.duration(100800000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={dayDuration} separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("1 Day Until Bidding Starts")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+
+    it("renders 4 Days Until Bidding Starts in blue when start time is >2 days away", () => {
+      // 3 days, 23 hours
+      const daysDuration = moment.duration(342000000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={daysDuration} separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("3 Days Until Bidding Starts")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+  })
+
+  describe("when the sale is open", () => {
+    it("renders 3d23h in blue when end time is days away", () => {
+      // 3 days, 23 hours
+      const daysDuration = moment.duration(342000000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={daysDuration} hasStarted separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("3d 23h")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+
+    it("renders 10h3m in blue when end time is hours away", () => {
+      // 10 hours, 3 mins
+      const hoursDuration = moment.duration(36180000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={hoursDuration} hasStarted separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("10h 3m")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+
+    it("renders 45m 30s in red when end time is minutes away", () => {
+      // 45 minutes,  30 seconds
+      const minutesDuration = moment.duration(2730000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={minutesDuration} hasStarted separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("45m 30s")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("red100")
+    })
+
+    it("renders 30s in red when end time is seconds away", () => {
+      // 30 seconds
+      const secondsDuration = moment.duration(30000)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={secondsDuration} hasStarted separator="  " size="5" />
+        </Theme>
+      )
+
+      const timerText = getByText("0m 30s")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("red100")
+    })
   })
 })

--- a/src/app/Components/Countdown/Ticker.tests.tsx
+++ b/src/app/Components/Countdown/Ticker.tests.tsx
@@ -76,7 +76,7 @@ describe("ModernTicker", () => {
       const todayDuration = moment.duration(2000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={todayDuration} separator="  " size="5" />
+          <ModernTicker duration={todayDuration} />
         </Theme>
       )
 
@@ -91,7 +91,7 @@ describe("ModernTicker", () => {
       const dayDuration = moment.duration(100800000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={dayDuration} separator="  " size="5" />
+          <ModernTicker duration={dayDuration} />
         </Theme>
       )
 
@@ -106,7 +106,7 @@ describe("ModernTicker", () => {
       const daysDuration = moment.duration(342000000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={daysDuration} separator="  " size="5" />
+          <ModernTicker duration={daysDuration} />
         </Theme>
       )
 
@@ -123,7 +123,7 @@ describe("ModernTicker", () => {
       const daysDuration = moment.duration(342000000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={daysDuration} hasStarted separator="  " size="5" />
+          <ModernTicker duration={daysDuration} hasStarted />
         </Theme>
       )
 
@@ -138,7 +138,7 @@ describe("ModernTicker", () => {
       const hoursDuration = moment.duration(36180000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={hoursDuration} hasStarted separator="  " size="5" />
+          <ModernTicker duration={hoursDuration} hasStarted />
         </Theme>
       )
 
@@ -153,7 +153,7 @@ describe("ModernTicker", () => {
       const minutesDuration = moment.duration(2730000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={minutesDuration} hasStarted separator="  " size="5" />
+          <ModernTicker duration={minutesDuration} hasStarted />
         </Theme>
       )
 
@@ -168,7 +168,7 @@ describe("ModernTicker", () => {
       const secondsDuration = moment.duration(30000)
       const { getByText } = render(
         <Theme>
-          <ModernTicker duration={secondsDuration} hasStarted separator="  " size="5" />
+          <ModernTicker duration={secondsDuration} hasStarted />
         </Theme>
       )
 

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -87,17 +87,15 @@ export const SimpleTicker: React.FC<SimpleTickerProps> = ({ duration, separator,
 
 interface ModernTickerProps extends SimpleTickerProps {
   hasStarted?: boolean
-  cascadingEndTimeInterval?: number
 }
 
 export const ModernTicker: React.FC<ModernTickerProps> = ({
   duration,
   separator,
-  cascadingEndTimeInterval,
   hasStarted,
   ...rest
 }) => {
-  const timerCopy = getTimerCopy(duration, cascadingEndTimeInterval, hasStarted)
+  const timerCopy = getTimerCopy(duration, hasStarted)
   return (
     <Sans {...rest} color={timerCopy.color}>
       {timerCopy.copy}
@@ -105,13 +103,7 @@ export const ModernTicker: React.FC<ModernTickerProps> = ({
   )
 }
 
-export const getTimerCopy = (
-  duration: Duration,
-  cascadingEndTimeInterval?: number,
-  hasStarted?: boolean
-) => {
-  // const { days, hours, minutes, seconds } = time
-
+export const getTimerCopy = (duration: Duration, hasStarted?: boolean) => {
   const days = duration.asDays()
   const hours = duration.hours()
   const minutes = duration.minutes()
@@ -125,8 +117,6 @@ export const getTimerCopy = (
   let copy = ""
   let color = "blue100"
 
-  const intervalValue = cascadingEndTimeInterval || 60
-
   // // Sale has not yet started
   if (!hasStarted) {
     if (parsedDays < 1) {
@@ -135,18 +125,8 @@ export const getTimerCopy = (
       copy = `${parsedDays} Day${parsedDays > 1 ? "s" : ""} Until Bidding Starts`
     }
   } else {
-    // 2mins or fewer until close
-    if (
-      parsedDays < 1 &&
-      parsedHours < 1 &&
-      ((parsedMinutes === intervalValue / 60 && parsedSeconds === 0) || parsedMinutes < 1)
-    ) {
-      copy = `${parsedMinutes}m ${parsedSeconds}s`
-      color = "red100"
-    }
-
     // More than 24 hours until close
-    else if (parsedDays >= 1) {
+    if (parsedDays >= 1) {
       copy = `${parsedDays}d ${parsedHours}h`
     }
 
@@ -155,9 +135,10 @@ export const getTimerCopy = (
       copy = `${parsedHours}h ${parsedMinutes}m`
     }
 
-    // 2-60 mins until close
-    else if (parsedDays < 1 && parsedHours < 1 && parsedMinutes >= 2) {
+    // <60 mins until close
+    else if (parsedDays < 1 && parsedHours < 1) {
       copy = `${parsedMinutes}m ${parsedSeconds}s`
+      color = "red100"
     }
   }
   return { copy, color }

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -84,3 +84,81 @@ export const SimpleTicker: React.FC<SimpleTickerProps> = ({ duration, separator,
     </Sans>
   )
 }
+
+interface ModernTickerProps extends SimpleTickerProps {
+  hasStarted?: boolean
+  cascadingEndTimeInterval?: number
+}
+
+export const ModernTicker: React.FC<ModernTickerProps> = ({
+  duration,
+  separator,
+  cascadingEndTimeInterval,
+  hasStarted,
+  ...rest
+}) => {
+  const timerCopy = getTimerCopy(duration, cascadingEndTimeInterval, hasStarted)
+  return (
+    <Sans {...rest} color={timerCopy.color}>
+      {timerCopy.copy}
+    </Sans>
+  )
+}
+
+export const getTimerCopy = (
+  duration: Duration,
+  cascadingEndTimeInterval?: number,
+  hasStarted?: boolean
+) => {
+  // const { days, hours, minutes, seconds } = time
+
+  const days = duration.asDays()
+  const hours = duration.hours()
+  const minutes = duration.minutes()
+  const seconds = duration.seconds()
+
+  const parsedDays = parseInt(days.toString(), 10)
+  const parsedHours = parseInt(hours.toString(), 10)
+  const parsedMinutes = parseInt(minutes.toString(), 10)
+  const parsedSeconds = parseInt(seconds.toString(), 10)
+
+  let copy = ""
+  let color = "blue100"
+
+  const intervalValue = cascadingEndTimeInterval || 60
+
+  // // Sale has not yet started
+  if (!hasStarted) {
+    if (parsedDays < 1) {
+      copy = "Bidding Starts Today"
+    } else {
+      copy = `${parsedDays} Day${parsedDays > 1 ? "s" : ""} Until Bidding Starts`
+    }
+  } else {
+    // 2mins or fewer until close
+    if (
+      parsedDays < 1 &&
+      parsedHours < 1 &&
+      ((parsedMinutes === intervalValue / 60 && parsedSeconds === 0) || parsedMinutes < 1)
+    ) {
+      copy = `${parsedMinutes}m ${parsedSeconds}s`
+      color = "red100"
+    }
+
+    // More than 24 hours until close
+    else if (parsedDays >= 1) {
+      copy = `${parsedDays}d ${parsedHours}h`
+    }
+
+    // 1-24 hours until close
+    else if (parsedDays < 1 && parsedHours >= 1) {
+      copy = `${parsedHours}h ${parsedMinutes}m`
+    }
+
+    // 2-60 mins until close
+    else if (parsedDays < 1 && parsedHours < 1 && parsedMinutes >= 2) {
+      copy = `${parsedMinutes}m ${parsedSeconds}s`
+    }
+  }
+  return { copy, color }
+}

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -1,5 +1,5 @@
 import { Duration } from "moment"
-import { Flex, Sans } from "palette"
+import { Flex, Sans, Text } from "palette"
 import React from "react"
 
 interface TimeSectionProps {
@@ -85,25 +85,23 @@ export const SimpleTicker: React.FC<SimpleTickerProps> = ({ duration, separator,
   )
 }
 
-interface ModernTickerProps extends SimpleTickerProps {
+interface ModernTickerProps {
+  duration: Duration
   hasStarted?: boolean
 }
 
-export const ModernTicker: React.FC<ModernTickerProps> = ({
-  duration,
-  separator,
-  hasStarted,
-  ...rest
-}) => {
-  const timerCopy = getTimerCopy(duration, hasStarted)
-  return (
-    <Sans {...rest} color={timerCopy.color}>
-      {timerCopy.copy}
-    </Sans>
-  )
+export const ModernTicker: React.FC<ModernTickerProps> = ({ duration, hasStarted }) => {
+  const timerInfo = getTimerInfo(duration, hasStarted)
+
+  return <Text color={timerInfo.color}>{timerInfo.copy}</Text>
 }
 
-export const getTimerCopy = (duration: Duration, hasStarted?: boolean) => {
+interface TimerInfo {
+  copy: string
+  color: string
+}
+
+export const getTimerInfo = (duration: Duration, hasStarted?: boolean): TimerInfo => {
   const days = duration.asDays()
   const hours = duration.hours()
   const minutes = duration.minutes()

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
@@ -1,9 +1,10 @@
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { Countdown } from "app/Components/Bidding/Components/Timer"
-import { ModernTicker } from "app/Components/Countdown/Ticker"
-import { GlobalStoreProvider } from "app/store/GlobalStore"
+import { ModernTicker, SimpleTicker } from "app/Components/Countdown/Ticker"
+import { __globalStoreTestUtils__, GlobalStoreProvider } from "app/store/GlobalStore"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
+import { before } from "lodash"
 import "moment-timezone"
 import { _test_THEMES, Sans, Theme } from "palette"
 import React from "react"
@@ -319,72 +320,126 @@ describe("CommercialInformation buttons and coundtown timer", () => {
     Date.now = () => dateNow
   })
 
-  it("renders CountDownTimer and BidButton when Artwork is in an auction", () => {
-    const component = mount(
-      <Wrapper>
-        <CommercialInformationTimerWrapper
-          artwork={CommercialInformationArtworkInAuction as any}
-          me={{ identityVerified: false } as any}
-          tracking={{ trackEvent: jest.fn() } as any}
-        />
-      </Wrapper>
-    )
-    expect(component.find(Countdown).length).toEqual(1)
-    expect(component.find(BidButton).length).toEqual(1)
+  describe("when the disable cascading end time feature is off", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerLotPage: false })
+    })
+
+    afterEach(() => jest.clearAllMocks())
+
+    it("renders CountDownTimer and BidButton when Artwork is in an auction", () => {
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationArtworkInAuction as any}
+            me={{ identityVerified: false } as any}
+            tracking={{ trackEvent: jest.fn() } as any}
+          />
+        </Wrapper>
+      )
+      expect(component.find(Countdown).length).toEqual(1)
+      expect(component.find(BidButton).length).toEqual(1)
+    })
+
+    it("renders CountDownTimer with the sale artwork's end time when Artwork is in a cascading end time auction", () => {
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationArtworkInCascadingEndTimeAuction as any}
+            me={{ identityVerified: false } as any}
+            tracking={{ trackEvent: jest.fn() } as any}
+            hasStarted
+          />
+        </Wrapper>
+      )
+
+      expect(component.find(ModernTicker).length).toEqual(1)
+      // This would say 1d 7h if the countdown timer was looking at the sale's end at time (instead of the sale artwork's end at time)
+      expect(component.html()).toInclude("3d 7h")
+      expect(component.find(Countdown).length).toEqual(1)
+      expect(component.find(BidButton).length).toEqual(1)
+    })
+
+    it("doesn't render CountDownTimer, BidButton, or BuyNowButton when artwork is in an auction but sold via buy now", () => {
+      const CommercialInformationSoldArtworkInAuction = {
+        ...CommercialInformationArtworkInAuction,
+        availability: "sold",
+        isAcquireable: false,
+        isForSale: false,
+      }
+
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationSoldArtworkInAuction as any}
+            me={{ identityVerified: false } as any}
+            tracking={{ trackEvent: jest.fn() } as any}
+          />
+        </Wrapper>
+      )
+      expect(component.find(Countdown).length).toEqual(0)
+      expect(component.find(BidButton).length).toEqual(0)
+      expect(component.find(BuyNowButton).length).toEqual(0)
+    })
+
+    it("doesn't render CountDownTimer or BidButton when not in auction", () => {
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationAcquierableArtwork as any}
+            me={{ identityVerified: false } as any}
+          />
+        </Wrapper>
+      )
+      expect(component.find(Countdown).length).toEqual(0)
+      expect(component.find(BidButton).length).toEqual(0)
+      expect(component.find(BuyNowButton).length).toEqual(1)
+    })
+
+    it("renders CountDownTimer with the sale artwork's end time when Artwork is in a cascading end time auction", () => {
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationArtworkInCascadingEndTimeAuction as any}
+            me={{ identityVerified: false } as any}
+            tracking={{ trackEvent: jest.fn() } as any}
+            hasStarted
+          />
+        </Wrapper>
+      )
+      // This would say 1d 7h if the countdown timer was looking at the sale's end at time (instead of the sale artwork's end at time)
+      expect(component.html()).toInclude("3d 7h")
+      expect(component.find(ModernTicker).length).toEqual(1)
+      expect(component.find(Countdown).length).toEqual(1)
+      expect(component.find(BidButton).length).toEqual(1)
+    })
   })
 
-  it("renders CountDownTimer with the sale artwork's end time when Artwork is in a cascading end time auction", () => {
-    const component = mount(
-      <Wrapper>
-        <CommercialInformationTimerWrapper
-          artwork={CommercialInformationArtworkInCascadingEndTimeAuction as any}
-          me={{ identityVerified: false } as any}
-          tracking={{ trackEvent: jest.fn() } as any}
-          hasStarted
-        />
-      </Wrapper>
-    )
-    // This would say 1d 7h if the countdown timer was looking at the sale's end at time (instead of the sale artwork's end at time)
-    expect(component.html()).toInclude("3d 7h")
-    expect(component.find(ModernTicker).length).toEqual(1)
-    expect(component.find(Countdown).length).toEqual(1)
-    expect(component.find(BidButton).length).toEqual(1)
-  })
+  describe("when the disable cascading end time feature is on", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerLotPage: true })
+    })
 
-  it("doesn't render CountDownTimer, BidButton, or BuyNowButton when artwork is in an auction but sold via buy now", () => {
-    const CommercialInformationSoldArtworkInAuction = {
-      ...CommercialInformationArtworkInAuction,
-      availability: "sold",
-      isAcquireable: false,
-      isForSale: false,
-    }
+    afterEach(() => jest.clearAllMocks())
 
-    const component = mount(
-      <Wrapper>
-        <CommercialInformationTimerWrapper
-          artwork={CommercialInformationSoldArtworkInAuction as any}
-          me={{ identityVerified: false } as any}
-          tracking={{ trackEvent: jest.fn() } as any}
-        />
-      </Wrapper>
-    )
-    expect(component.find(Countdown).length).toEqual(0)
-    expect(component.find(BidButton).length).toEqual(0)
-    expect(component.find(BuyNowButton).length).toEqual(0)
-  })
+    it("renders CountDownTimer with the sale's end time even when Artwork is in a cascading end time auction", () => {
+      const component = mount(
+        <Wrapper>
+          <CommercialInformationTimerWrapper
+            artwork={CommercialInformationArtworkInCascadingEndTimeAuction as any}
+            me={{ identityVerified: false } as any}
+            tracking={{ trackEvent: jest.fn() } as any}
+            hasStarted
+          />
+        </Wrapper>
+      )
 
-  it("doesn't render CountDownTimer or BidButton when not in auction", () => {
-    const component = mount(
-      <Wrapper>
-        <CommercialInformationTimerWrapper
-          artwork={CommercialInformationAcquierableArtwork as any}
-          me={{ identityVerified: false } as any}
-        />
-      </Wrapper>
-    )
-    expect(component.find(Countdown).length).toEqual(0)
-    expect(component.find(BidButton).length).toEqual(0)
-    expect(component.find(BuyNowButton).length).toEqual(1)
+      expect(component.find(SimpleTicker).length).toEqual(1)
+      // This would say 03d 07h 00m 00s if the countdown timer was looking at the sale's end at time (instead of the sale artwork's end at time)
+      expect(component.html()).toInclude("01d  07h  58m  00s")
+      expect(component.find(Countdown).length).toEqual(1)
+      expect(component.find(BidButton).length).toEqual(1)
+    })
   })
 })
 

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
@@ -4,7 +4,6 @@ import { ModernTicker, SimpleTicker } from "app/Components/Countdown/Ticker"
 import { __globalStoreTestUtils__, GlobalStoreProvider } from "app/store/GlobalStore"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
-import { before } from "lodash"
 import "moment-timezone"
 import { _test_THEMES, Sans, Theme } from "palette"
 import React from "react"

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
@@ -1,5 +1,6 @@
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { Countdown } from "app/Components/Bidding/Components/Timer"
+import { ModernTicker } from "app/Components/Countdown/Ticker"
 import { GlobalStoreProvider } from "app/store/GlobalStore"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
@@ -121,6 +122,9 @@ describe("CommercialInformation", () => {
         isAuction: true,
         isClosed: true,
       },
+      saleArtwork: {
+        endAt: "2019-08-16T20:20:00+00:00",
+      },
     }
     const component = mount(
       <Wrapper>
@@ -142,6 +146,9 @@ describe("CommercialInformation", () => {
       sale: {
         isAuction: true,
         isClosed: true,
+      },
+      saleArtwork: {
+        endAt: "2019-08-16T20:20:00+00:00",
       },
     }
 
@@ -305,6 +312,13 @@ describe("CommercialInformation", () => {
 })
 
 describe("CommercialInformation buttons and coundtown timer", () => {
+  beforeEach(() => {
+    const dateNow = 1565871720000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
+
+    // Thursday, May 10, 2018 8:22:32.000 PM UTC
+    Date.now = () => dateNow
+  })
+
   it("renders CountDownTimer and BidButton when Artwork is in an auction", () => {
     const component = mount(
       <Wrapper>
@@ -315,6 +329,24 @@ describe("CommercialInformation buttons and coundtown timer", () => {
         />
       </Wrapper>
     )
+    expect(component.find(Countdown).length).toEqual(1)
+    expect(component.find(BidButton).length).toEqual(1)
+  })
+
+  it("renders CountDownTimer with the sale artwork's end time when Artwork is in a cascading end time auction", () => {
+    const component = mount(
+      <Wrapper>
+        <CommercialInformationTimerWrapper
+          artwork={CommercialInformationArtworkInCascadingEndTimeAuction as any}
+          me={{ identityVerified: false } as any}
+          tracking={{ trackEvent: jest.fn() } as any}
+          hasStarted
+        />
+      </Wrapper>
+    )
+    // This would say 1d 7h if the countdown timer was looking at the sale's end at time (instead of the sale artwork's end at time)
+    expect(component.html()).toInclude("3d 7h")
+    expect(component.find(ModernTicker).length).toEqual(1)
     expect(component.find(Countdown).length).toEqual(1)
     expect(component.find(BidButton).length).toEqual(1)
   })
@@ -508,6 +540,39 @@ const CommercialInformationArtworkInAuction = {
     formattedStartDateTime: "Ends Aug 16 at 8:20pm UTC",
   },
   saleArtwork: {
+    increments: [
+      {
+        cents: 11000000,
+        display: "CHF110,000",
+      },
+      {
+        cents: 12000000,
+        display: "CHF120,000",
+      },
+    ],
+  },
+}
+
+const CommercialInformationArtworkInCascadingEndTimeAuction = {
+  ...CommercialInformationArtwork,
+  availability: "for sale",
+  isAcquireable: false,
+  isInAuction: true,
+  sale: {
+    internalId: "internal-id",
+    slug: "my-sale",
+    isClosed: false,
+    isAuction: true,
+    isLiveOpen: false,
+    isPreview: false,
+    startAt: "2019-08-14T19:22:00+00:00",
+    endAt: "2019-08-16T20:20:00+00:00",
+    liveStartAt: null,
+    formattedStartDateTime: "Ends Aug 16 at 8:20pm UTC",
+    cascadingEndTimeInterval: 60,
+  },
+  saleArtwork: {
+    endAt: "2019-08-18T20:20:00+00:00",
     increments: [
       {
         cents: 11000000,

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -9,6 +9,7 @@ import {
 } from "app/Components/Bidding/Components/Timer"
 import { TimeOffsetProvider } from "app/Components/Bidding/Context/TimeOffsetProvider"
 import { StateManager as CountdownStateManager } from "app/Components/Countdown"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import { Schema } from "app/utils/track"
 import { capitalize } from "lodash"
 import { Duration } from "moment"
@@ -46,6 +47,12 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
 
     const { endAt: lotEndAt } = props.artwork.saleArtwork
 
+    const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerLotPage")
+
+    const endsAt =
+      (cascadingEndTimeFeatureEnabled && cascadingEndTimeInterval ? lotEndAt : saleEndAt) ||
+      undefined
+
     return (
       <TimeOffsetProvider>
         <CountdownStateManager
@@ -59,7 +66,7 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
             const { label, date, hasStarted } = relevantStateData(state, {
               liveStartsAt: liveStartsAt || undefined,
               startsAt: startsAt || undefined,
-              endsAt: cascadingEndTimeInterval ? lotEndAt || undefined : saleEndAt || undefined,
+              endsAt,
             })
             return { label, date, state, hasStarted, cascadingEndTimeInterval }
           }}
@@ -70,7 +77,7 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
             const { label, date, hasStarted } = relevantStateData(nextState, {
               liveStartsAt: liveStartsAt || undefined,
               startsAt: startsAt || undefined,
-              endsAt: cascadingEndTimeInterval ? lotEndAt || undefined : saleEndAt || undefined,
+              endsAt,
             })
             return { state: nextState, date, label, hasStarted }
           }}

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -241,6 +241,7 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
             <Countdown
               label={label}
               hasStarted={hasStarted}
+              cascadingEndTimeInterval={sale.cascadingEndTimeInterval}
               // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               duration={duration}
             />

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -34,7 +34,7 @@ interface CommercialInformationProps {
 }
 
 export const CommercialInformationTimerWrapper: React.FC<CommercialInformationProps> = (props) => {
-  if (props.artwork.isInAuction) {
+  if (props.artwork.isInAuction && props.artwork.saleArtwork) {
     const {
       isPreview,
       isClosed,

--- a/src/app/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
+++ b/src/app/Scenes/ViewingRoom/Components/ViewingRoomHeader.tsx
@@ -1,6 +1,6 @@
 import { ViewingRoomHeader_viewingRoom } from "__generated__/ViewingRoomHeader_viewingRoom.graphql"
 import { durationSections } from "app/Components/Countdown"
-import { CountdownProps, CountdownTimer } from "app/Components/Countdown/CountdownTimer"
+import { CountdownTimer, CountdownTimerProps } from "app/Components/Countdown/CountdownTimer"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "app/navigation/navigate"
 import { Box, Flex, Text } from "palette"
@@ -42,7 +42,7 @@ const Overlay = styled(LinearGradient)`
   opacity: 0.15;
 `
 
-const CountdownText: React.FC<CountdownProps> = ({ duration }) => {
+const CountdownText: React.FC<CountdownTimerProps> = ({ duration }) => {
   const separator = "  "
   const sections = durationSections(duration, ["d", "h", "m", "s"])
   return (

--- a/src/app/__fixtures__/ArtworkBidAction.ts
+++ b/src/app/__fixtures__/ArtworkBidAction.ts
@@ -89,6 +89,7 @@ export const ArtworkFromLiveAuctionRegistrationOpen = {
     isClosed: false,
     isRegistrationClosed: false,
     requireIdentityVerification: false,
+    cascadingEndTimeInterval: null,
     liveStartAt: DateTime.fromMillis(Date.now()).minus({ minutes: 1 }).toISO(),
     startAt: DateTime.fromMillis(Date.now()).minus({ minutes: 10 }).toISO(),
     endAt: null,

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -111,6 +111,17 @@ export const features = defineFeatures({
     description: "Allow linking of social accounts on sign up",
     showInAdminMenu: true,
   },
+  ARDisableCascadingEndTimerLotPage: {
+    readyForRelease: false,
+    description: "Enable cascading end times on the lot page",
+    showInAdminMenu: true,
+    echoFlagKey: "ARDisableCascadingEndTimerLotPage",
+  },
+  AREnableImageSearch: {
+    readyForRelease: false,
+    description: "Enable search with image",
+    showInAdminMenu: true,
+  },
   AREnableCollectorProfile: {
     readyForRelease: true,
     description: "Enable collector profile",

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -113,7 +113,7 @@ export const features = defineFeatures({
   },
   ARDisableCascadingEndTimerLotPage: {
     readyForRelease: false,
-    description: "Enable cascading end times on the lot page",
+    description: "Disable cascading end times on the lot page",
     showInAdminMenu: true,
     echoFlagKey: "ARDisableCascadingEndTimerLotPage",
   },

--- a/storybook.json
+++ b/storybook.json
@@ -1,0 +1,3 @@
+{
+  "startStorybook": false
+}


### PR DESCRIPTION
<!-- Use a PR title in the form of 
     `type(thing): what changed`
like:
     `feat(profile): allow editing of profile photo`.
Find some examples in the "conventional commits" summary.
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [BX-210](https://artsyproduct.atlassian.net/browse/BID-210)

### Description

<!-- Some info, Implementation, Before/After shots, follow-up work, etc -->
This PR adds a new timer to cascading end time lots that is formatted differently. This PR also changes the word "Ends" to "Closes" for OO sales that are currently open.

Sale is open and closes in < 2 mins
<img width="244" alt="Screen Shot 2022-04-13 at 12 46 30 PM" src="https://user-images.githubusercontent.com/9466631/163230171-35737a22-bccd-4b5d-8aac-36e9d89a937a.png">

Sale is open and closes in < 60 mins 
<img width="301" alt="Screen Shot 2022-04-07 at 12 21 48 PM" src="https://user-images.githubusercontent.com/9466631/162251397-ae0c3573-f57b-4ca4-a885-35ae15033289.png">

Sale is open and closes in <24 hours and >= 1 hour
<img width="245" alt="Screen Shot 2022-04-13 at 12 35 15 PM" src="https://user-images.githubusercontent.com/9466631/163228234-823a5bb0-70e7-4279-9ed8-445650db1259.png">

Sale is open and closes in >= 24 hours
<img width="225" alt="Screen Shot 2022-04-13 at 12 32 37 PM" src="https://user-images.githubusercontent.com/9466631/163227819-7f123e94-dbdc-44d6-a34a-558e26924289.png">

Sale opens in < 1 day:
<img width="195" alt="Screen Shot 2022-04-13 at 12 28 10 PM" src="https://user-images.githubusercontent.com/9466631/163227022-f1ca966b-a708-42b8-907b-a28080f6f086.png">

Sale opens in >=1 day <2 days
<img width="227" alt="Screen Shot 2022-04-13 at 12 30 46 PM" src="https://user-images.githubusercontent.com/9466631/163227446-a4f8f68e-9d86-4960-b21b-b54f020dba6e.png">

Sale opens in >= 2 days
<img width="246" alt="Screen Shot 2022-04-13 at 12 30 05 PM" src="https://user-images.githubusercontent.com/9466631/163227347-a0abea89-b24f-47f0-9e31-28d9659c3d52.png">

### PR Checklist (tick all before merging)

<!-- 💡 This checklist is experimental. MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->
- [ ] Feature flag around my changes.
- [ ] App state migration.
- [ ] Screenshots/videos of my changes.
- [ ] Tested on **iOS** and **Android**.
- [ ] Tests/stories for my changes.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Display a new countdown on lots that are in sales with cascading end times

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>
