### PR TITLE
chore: set default metric on clear all filters

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -60,7 +60,7 @@ export const getArtworkFiltersModel = (): ArtworkFiltersModel => ({
     total: null,
     followedArtists: null,
   },
-  sizeMetric: LOCALIZED_UNIT,
+  sizeMetric: unsafe_getLocalizedUnit() || LOCALIZED_UNIT,
 
   /**
    * Store actions

--- a/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -1,4 +1,5 @@
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
+import { unsafe_getLocalizedUnit } from "app/store/GlobalStore"
 import { assignDeep } from "app/store/persistence"
 import { Action, action, createContextStore, State } from "easy-peasy"
 import { filter, find, isEqual, unionBy } from "lodash"
@@ -126,6 +127,7 @@ export const getArtworkFiltersModel = (): ArtworkFiltersModel => ({
     state.selectedFilters = []
     state.previouslyAppliedFilters = []
     state.applyFilters = true
+    state.sizeMetric = unsafe_getLocalizedUnit() || LOCALIZED_UNIT
   }),
 
   setAggregationsAction: action((state, payload) => {

--- a/src/app/Components/ArtworkFilter/ArtworkFiltersStore.tests.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFiltersStore.tests.tsx
@@ -1066,7 +1066,7 @@ describe("clearFiltersZeroState", () => {
         total: null,
         followedArtists: null,
       },
-      sizeMetric: "cm",
+      sizeMetric: "in",
     })
   })
 
@@ -1101,7 +1101,7 @@ describe("clearFiltersZeroState", () => {
         total: null,
         followedArtists: null,
       },
-      sizeMetric: "cm",
+      sizeMetric: "in",
     })
   })
 })

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -1,5 +1,6 @@
 import { StackScreenProps } from "@react-navigation/stack"
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
+import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import { Box, Flex, RadioButton, Spacer, Text } from "palette"
 import React, { useEffect, useState } from "react"
 import { ArtworkFilterNavigationStack } from ".."
@@ -159,6 +160,8 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
     (state) => state.selectFiltersAction
   )
 
+  const { localizedUnit } = useLocalizedUnit()
+
   const setSelectedMetric = ArtworksFiltersStore.useStoreActions((state) => state.setSizeMetric)
   const selectedMetric = ArtworksFiltersStore.useStoreState((state) => state.sizeMetric)
 
@@ -269,6 +272,7 @@ export const SizesOptionsScreen: React.FC<SizesOptionsScreenProps> = ({ navigati
   }
 
   const handleClear = () => {
+    setSelectedMetric(localizedUnit)
     clearPredefinedValues()
     clearCustomSizeValues()
     setCustomValues(DEFAULT_CUSTOM_SIZE)


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [FX-3739]

### Description

Fixes for FX-3739:

- Set default metric on clear all filters button press

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [x] Tested on **iOS** and **Android**
- [ ] Screenshots and videos 
- [ ] Added Tests and Stories
- [ ] App state migration
- [ ] Feature flag

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- set default size metric on clear all filters button press - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[FX-3739]: https://artsyproduct.atlassian.net/browse/FX-3739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ