### PR TITLE
chore: add `force: true` for load more on sale screen

### DIFF
--- a/src/app/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/SaleLotsList.tsx
@@ -131,6 +131,12 @@ export const SaleLotsList: React.FC<Props> = ({
     })
   }
 
+  const handleLoadMore: RelayPaginationProp["loadMore"] = (pageSize, callback) => {
+    relay.loadMore(pageSize, callback, { force: true })
+
+    return null
+  }
+
   if (unfilteredSaleArtworksConnection?.counts?.total === 0) {
     return null
   }
@@ -155,7 +161,7 @@ export const SaleLotsList: React.FC<Props> = ({
         <SaleArtworkListContainer
           connection={saleArtworksConnection.saleArtworksConnection!}
           hasMore={relay.hasMore}
-          loadMore={relay.loadMore}
+          loadMore={handleLoadMore}
           isLoading={relay.isLoading}
           contextScreenOwnerType={OwnerType.sale}
           contextScreenOwnerId={saleID}
@@ -169,7 +175,7 @@ export const SaleLotsList: React.FC<Props> = ({
             contextScreenOwnerId={saleID}
             contextScreenOwnerSlug={saleSlug}
             hasMore={relay.hasMore}
-            loadMore={relay.loadMore}
+            loadMore={handleLoadMore}
             isLoading={relay.isLoading}
             showLotLabel
             hidePartner


### PR DESCRIPTION
Related PRs: #6558, #6534

### Description
The auction team [has raised a problem](https://artsy.slack.com/archives/C02MU3DB3/p1648496726378999) that incorrect bids were displayed on the Sale page. The problem was due to the fact that data from Relay Cache was displayed

This PR contains small additions for PR #6534

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/162430765-ac32488a-8dbc-4c60-a91e-d715db2f9a6b.mp4

#### After
https://user-images.githubusercontent.com/3513494/162430776-aff6731e-47ac-4628-9e92-4675db64cbb7.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [x] Tested on **iOS** and **Android**
- [x] Screenshots and videos 
- [ ] Added Tests and Stories
- [ ] App state migration
- [ ] Feature flag

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add `force: true` for load more on sale screen - dimatretyak

<!-- end_changelog_updates -->

</details>
