### PR TITLE
fix: Set source to MY_COLLECTION when submitting an artwork from My Collection

### DIFF
--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/createOrUpdateSubmission.ts
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/ArtworkDetails/utils/createOrUpdateSubmission.ts
@@ -9,6 +9,8 @@ import { limitedEditionValue } from "./rarityOptions"
 
 export type SubmissionInput = CreateSubmissionMutationInput | UpdateSubmissionMutationInput
 
+const DEFAULT_SOURCE = "APP_INBOUND"
+
 export const createOrUpdateSubmission = async (
   values: ArtworkDetailsFormModel,
   submissionId: string
@@ -51,7 +53,7 @@ export const createOrUpdateSubmission = async (
 
   return await createConsignSubmission({
     myCollectionArtworkID: values.myCollectionArtworkID,
-    source: values.source,
+    source: values.source || DEFAULT_SOURCE,
     ...submissionValues,
   } as CreateSubmissionMutationInput)
 }

--- a/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/Mutations/createConsignSubmissionMutation.ts
+++ b/src/app/Scenes/Consignments/Screens/SubmitArtworkOverview/Mutations/createConsignSubmissionMutation.ts
@@ -6,6 +6,8 @@ import { defaultEnvironment } from "app/relay/createEnvironment"
 import { getCurrentEmissionState } from "app/store/GlobalStore"
 import { commitMutation, graphql } from "relay-runtime"
 
+const DEFAULT_SOURCE = "APP_INBOUND"
+
 export const createConsignSubmission = (input: CreateSubmissionMutationInput) => {
   return new Promise<string>((resolve, reject) => {
     commitMutation<createConsignSubmissionMutation>(defaultEnvironment, {
@@ -21,7 +23,7 @@ export const createConsignSubmission = (input: CreateSubmissionMutationInput) =>
       variables: {
         input: {
           ...input,
-          source: "APP_INBOUND",
+          source: input.source || DEFAULT_SOURCE,
           userAgent: getCurrentEmissionState().userAgent,
         },
       },


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [CX-2484]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [ ] Tested on **iOS** and **Android**
- [ ] Screenshots and videos 
- [ ] Added Tests and Stories
- [ ] App state migration
- [ ] Feature flag

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


## Description

Set source to MY_COLLECTION when submitting an artwork from My Collection.