### PR TITLE
fix(NX-3119): broken conversations for Collectors without a name

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Message.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Message.tsx
@@ -145,7 +145,6 @@ export default createFragmentContainer(Message, {
       isFromUser
       isFirstMessage
       from {
-        name
         email
       }
       attachments {

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -194,14 +194,11 @@ export default createPaginationContainer(
         id
         internalID
         from {
-          name
           email
         }
         to {
           name
         }
-        initialMessage
-        lastMessageID
         orderConnection(first: 10, participantType: BUYER) {
           edges {
             node {


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [NX-3119]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

SSO for Google got broken in Force for a while so we ended up with Collectors without a name being registered, that was causing some issues since we are receiving `null` in a GraphQL field that is required.

This PR removes unnecessary props from GraphQL in Conversations that were breaking the UI for these particular collectors.

cc @artsy/negotiate-devs 

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [x] Tested on **iOS** and **Android**
- [ ] Screenshots and videos 
- [x] Added Tests and Stories
- [x] App state migration
- [x] Feature flag

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[NX-3119]: https://artsyproduct.atlassian.net/browse/NX-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ