### PR TITLE
chore: disable build-test-js on beta builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -610,6 +610,8 @@ workflows:
                 - app_store_submission
                 - play_store_submission
                 - update-changelog
+                - beta-android
+                - beta-ios
       - horizon/block:
           context: horizon
           project_id: 37


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves []

### Description
Whenever we are trying to build a beta - we run the `build-test-js` workflow and we don't really need it. The reason behind that is this workflow already runs on every PR and runs on main as well. This will save us about 15 minutes for andoid and for android as well

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [ ] Tested on **iOS** and **Android**
- [ ] Screenshots and videos 
- [ ] Added Tests and Stories
- [ ] App state migration
- [ ] Feature flag

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- disable build-test-js on beta builds - mounir

<!-- end_changelog_updates -->

</details>
