### PR TITLE
fix(MOPLAT-213): partial revert of #6386, add back auction web view

### DIFF
--- a/Artsy.xcodeproj/project.pbxproj
+++ b/Artsy.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		49BA7E141655ABE600C06572 /* ARAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 49BA7E131655ABE600C06572 /* ARAppDelegate.m */; };
 		49EC62181778AF100020D648 /* PartnerShow.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EC62171778AF100020D648 /* PartnerShow.m */; };
 		49EF164716C568EA00460BD7 /* Profile.m in Sources */ = {isa = PBXBuildFile; fileRef = 49EF164616C568EA00460BD7 /* Profile.m */; };
+		5102616F1BBE8324002AB8BB /* ARAuctionWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5102616E1BBE8324002AB8BB /* ARAuctionWebViewController.m */; };
+		510261711BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 510261701BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m */; };
 		5108A7BC1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5108A7BB1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m */; };
 		512AB35B1BD7C7A100F92B9A /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 512AB35A1BD7C7A100F92B9A /* CoreSpotlight.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		512AB35C1BD7C82F00F92B9A /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06E44EB8170235D8001B2EBF /* MessageUI.framework */; };
@@ -705,6 +707,9 @@
 		49EC62171778AF100020D648 /* PartnerShow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PartnerShow.m; sourceTree = "<group>"; };
 		49EF164516C568EA00460BD7 /* Profile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Profile.h; sourceTree = "<group>"; };
 		49EF164616C568EA00460BD7 /* Profile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Profile.m; sourceTree = "<group>"; };
+		5102616D1BBE8324002AB8BB /* ARAuctionWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ARAuctionWebViewController.h; path = Auction_Results/ARAuctionWebViewController.h; sourceTree = "<group>"; };
+		5102616E1BBE8324002AB8BB /* ARAuctionWebViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ARAuctionWebViewController.m; path = Auction_Results/ARAuctionWebViewController.m; sourceTree = "<group>"; };
+		510261701BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAuctionWebViewControllerTests.m; sourceTree = "<group>"; };
 		5108A7BB1BA1AB2C0011CD72 /* ARAppActivityContinuationDelegateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ARAppActivityContinuationDelegateTests.m; sourceTree = "<group>"; };
 		512AB35A1BD7C7A100F92B9A /* CoreSpotlight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreSpotlight.framework; path = System/Library/Frameworks/CoreSpotlight.framework; sourceTree = SDKROOT; };
 		514E56471BA0BABA008A0DF6 /* ARAppActivityContinuationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARAppActivityContinuationDelegate.h; sourceTree = "<group>"; };
@@ -1620,6 +1625,7 @@
 				3C6AEE26188F228600DD98FC /* ARInternalMobileWebViewControllerTests.m */,
 				60A309A91AC99B47000783C1 /* ARInternalShareValidatorTests.m */,
 				D3ACE5381AEEF47C0053E0CE /* ARExternalWebBrowserViewControllerTests.m */,
+				510261701BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m */,
 			);
 			name = "Web Browsing";
 			path = Web_Browsing;
@@ -1822,6 +1828,8 @@
 		5E47F34B1C3EC98200EC0751 /* Auction */ = {
 			isa = PBXGroup;
 			children = (
+				5102616D1BBE8324002AB8BB /* ARAuctionWebViewController.h */,
+				5102616E1BBE8324002AB8BB /* ARAuctionWebViewController.m */,
 				5EA7BC2A1C60024D009C52C9 /* Networking */,
 				60C1C3111C5F9C6500EC98EE /* Auction Presentation */,
 				51DCC6C71C60E26800455309 /* AuctionInformationViewController.swift */,
@@ -3520,6 +3528,7 @@
 				60FBAA511CC688F7005ED890 /* LiveAuctionViewController.swift in Sources */,
 				6019A9061C7E64B700E292FA /* LiveAuctionLotSetViewController.swift in Sources */,
 				3CEE0B5F18A16EA200FEA6E6 /* ArtsyAPI+Profiles.m in Sources */,
+				5102616F1BBE8324002AB8BB /* ARAuctionWebViewController.m in Sources */,
 				5EBD44E01D07325300C60F9F /* UITableViewController+Animations.swift in Sources */,
 				5E1DDF1D1CE24FBF00DFEE2A /* LiveAuctionBiddingViewModel.swift in Sources */,
 				5EA250661C4EE95B001E4950 /* NSArray+Additions.m in Sources */,
@@ -3636,6 +3645,7 @@
 				FC9DDAF6274D64B1005DEE85 /* Fixtures.swift in Sources */,
 				60F242FC1CB3F32F00387AA1 /* LiveAuctionBidViewControllerTests.swift in Sources */,
 				5E6A16931C98A914004DB29B /* LiveAuctionStateManagerSpec.swift in Sources */,
+				510261711BBE96BE002AB8BB /* ARAuctionWebViewControllerTests.m in Sources */,
 				3C6BDCBD18E0AEF60028EF5D /* ArtsyAPI+PrivateTests.m in Sources */,
 				3CB37D991922483100089A1D /* ArtsyAPI+ErrorHandlers.m in Sources */,
 				60CE3CAB1B46F3EE00CA2B75 /* ArtsyOHHTTPAPI.m in Sources */,

--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -232,7 +232,7 @@ RCT_EXPORT_METHOD(popToRootAndScrollToTop:(nonnull NSString *)stackID
 
 + (UIViewController *)loadWebViewAuctionRegistrationWithID:(NSString *)auctionID
 {
-    NSString *path = [NSString stringWithFormat:@"/auction-registration/%@", auctionID];
+    NSString *path = [NSString stringWithFormat:@"/auction/%@/register", auctionID];
     NSURL *URL = [ARRouter resolveRelativeUrl:path];
     return [[ARAuctionWebViewController alloc] initWithURL:URL auctionID:auctionID artworkID:nil];
 }

--- a/Artsy/App/ARScreenPresenterModule.m
+++ b/Artsy/App/ARScreenPresenterModule.m
@@ -7,6 +7,7 @@
 #import "ARInternalMobileWebViewController.h"
 #import "Artsy-Swift.h"
 #import "AREigenMapContainerViewController.h"
+#import "ARAuctionWebViewController.h"
 #import "ArtsyEcho.h"
 #import "ARAppDelegate+Echo.h"
 #import "ARRouter.h"
@@ -227,6 +228,13 @@ RCT_EXPORT_METHOD(popToRootAndScrollToTop:(nonnull NSString *)stackID
     [stack popToRootViewControllerAnimated:YES];
     [stack.viewControllers[0].view ar_scrollToTopAnimated:YES];
     resolve(nil);
+}
+
++ (UIViewController *)loadWebViewAuctionRegistrationWithID:(NSString *)auctionID
+{
+    NSString *path = [NSString stringWithFormat:@"/auction-registration/%@", auctionID];
+    NSURL *URL = [ARRouter resolveRelativeUrl:path];
+    return [[ARAuctionWebViewController alloc] initWithURL:URL auctionID:auctionID artworkID:nil];
 }
 
 /// To be kept in lock-step with the corresponding echo value, and updated when there is a breaking causality change.

--- a/Artsy/Constants/ARAppConstants.h
+++ b/Artsy/Constants/ARAppConstants.h
@@ -16,8 +16,11 @@ extern NSString *const ARAPNSDeviceTokenKey;
 extern NSString *const ARNetworkAvailableNotification;
 extern NSString *const ARNetworkUnavailableNotification;
 
+extern NSString *const ARAuctionArtworkBidUpdatedNotification;
 extern NSString *const ARAuctionArtworkRegistrationUpdatedNotification;
 extern NSString *const ARAuctionSaleOnHoldBannerTappedNotification;
+extern NSString *const ARAuctionIDKey;
+extern NSString *const ARAuctionArtworkIDKey;
 
 typedef NS_OPTIONS(NSUInteger, ARAuctionState) {
     ARAuctionStateDefault = 0,

--- a/Artsy/Constants/ARAppConstants.m
+++ b/Artsy/Constants/ARAppConstants.m
@@ -16,8 +16,11 @@ NSString *const AROAuthTokenKey = @"access_token";
 NSString *const ARNetworkAvailableNotification = @"network_available_notification";
 NSString *const ARNetworkUnavailableNotification = @"network_unavailable_notification";
 
+NSString *const ARAuctionArtworkBidUpdatedNotification = @"ARAuctionArtworkBidUpdated";
 NSString *const ARAuctionArtworkRegistrationUpdatedNotification = @"ARAuctionArtworkRegistrationUpdated";
 NSString *const ARAuctionSaleOnHoldBannerTappedNotification = @"ARAuctionSaleOnHoldBannerTappedNotification";
+NSString *const ARAuctionIDKey = @"ARAuctionID";
+NSString *const ARAuctionArtworkIDKey = @"ARAuctionArtworkID";
 
 NSString *const ARAPNSDeviceTokenKey = @"apns_device_token";
 

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.h
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.h
@@ -1,0 +1,16 @@
+#import "ARInternalMobileWebViewController.h"
+
+#import "ARMacros.h"
+
+@interface ARAuctionWebViewController : ARInternalMobileWebViewController
+
+@property (nonatomic, strong, readonly) NSString *auctionID;
+@property (nonatomic, strong, readonly) NSString *artworkID;
+
+- (instancetype)initWithURL:(NSURL *)URL;
+
+- (instancetype)initWithURL:(NSURL *)URL
+                  auctionID:(NSString *)auctionID
+                  artworkID:(NSString *)artworkID AR_VC_DESIGNATED_INITIALIZER;
+
+@end

--- a/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
+++ b/Artsy/View_Controllers/Auction_Results/ARAuctionWebViewController.m
@@ -1,0 +1,130 @@
+#import "ARLogger.h"
+#import "ARAuctionWebViewController.h"
+#import "ARAppConstants.h"
+#import <Emission/AREmission.h>
+#import <React/RCTRootView.h>
+#import "User.h"
+#import "Artwork.h"
+
+#import "UIDevice-Hardware.h"
+
+
+@implementation ARAuctionWebViewController
+
+- (void)dealloc;
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (instancetype)initWithURL:(NSURL *)URL;
+{
+    NSString *auctionID = nil;
+    NSString *artworkID = nil;
+    NSArray *components = [URL.path componentsSeparatedByString:@"/"];
+    switch (components.count) {
+        case 5:
+            artworkID = components[4];
+        case 3:
+            auctionID = components[2];
+            break;
+        default:
+            NSAssert(NO, @"Unexpected amount of auction URL components.");
+    }
+    return [self initWithURL:URL auctionID:auctionID artworkID:artworkID];
+}
+
+- (instancetype)initWithURL:(NSURL *)URL
+                  auctionID:(NSString *)auctionID
+                  artworkID:(NSString *)artworkID;
+{
+    if ((self = [super initWithURL:URL])) {
+        _auctionID = auctionID;
+        _artworkID = artworkID;
+
+        NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+        [nc addObserver:self
+               selector:@selector(artworkBidUpdated:)
+                   name:ARAuctionArtworkBidUpdatedNotification
+                 object:nil];
+        if (artworkID) {
+            [nc addObserver:self
+                   selector:@selector(registrationUpdated:)
+                       name:ARAuctionArtworkRegistrationUpdatedNotification
+                     object:nil];
+        }
+    }
+    return self;
+}
+
+- (WKNavigationActionPolicy)shouldLoadNavigationAction:(WKNavigationAction *)navigationAction;
+{
+    if (navigationAction.navigationType == WKNavigationTypeOther) {
+        NSURL *URL = navigationAction.request.URL;
+        // martsy uses the fragment, force uses a path component
+        if ([URL.fragment isEqualToString:@"confirm-bid"] || [URL.lastPathComponent isEqualToString:@"confirm-bid"]) {
+            [self bidHasBeenConfirmed];
+            return WKNavigationActionPolicyCancel;
+        }
+        if ([URL.lastPathComponent isEqualToString:@"confirm-registration"]) {
+            [self registrationHasBeenConfirmed];
+            return WKNavigationActionPolicyCancel;
+        }
+    }
+    return [super shouldLoadNavigationAction:navigationAction];
+}
+
+- (void)bidHasBeenConfirmed;
+{
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+
+    // Ensure we don’t send a notification to ourselves.
+    // The observer can be removed, because this VC will be removed from the stack anyways.
+    [nc removeObserver:self];
+
+    [nc postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                      object:self
+                    userInfo:@{ARAuctionIDKey : self.auctionID, ARAuctionArtworkIDKey : self.artworkID}];
+
+    [self.navigationController popViewControllerAnimated:ARPerformWorkAsynchronously];
+    [[AREmission sharedInstance] navigate:[NSString stringWithFormat:@"/artwork/%@", self.artworkID]];
+}
+
+- (void)artworkBidUpdated:(NSNotification *)notification;
+{
+    NSDictionary *info = notification.userInfo;
+    if ([info[ARAuctionIDKey] isEqualToString:self.auctionID] && (self.artworkID == nil || [info[ARAuctionArtworkIDKey] isEqualToString:self.artworkID])) {
+        ARActionLog(@"Will reload due to auction artwork bid updated: %@ - auction:%@ - artwork:%@",
+                    self, self.auctionID, self.artworkID);
+        [self reload];
+    }
+}
+
+- (void)registrationHasBeenConfirmed;
+{
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+
+    // Ensure we don’t send a notification to ourselves.
+    // The observer can be removed, because this VC will be removed from the stack anyways.
+    [nc removeObserver:self];
+
+    [nc postNotificationName:ARAuctionArtworkRegistrationUpdatedNotification
+                      object:self
+                    userInfo:@{ARAuctionIDKey : self.auctionID}];
+
+    if (self.presentingViewController) {
+        [self.presentingViewController dismissViewControllerAnimated:ARPerformWorkAsynchronously completion:nil];
+    } else {
+        [self.navigationController popViewControllerAnimated:ARPerformWorkAsynchronously];
+    }
+}
+
+- (void)registrationUpdated:(NSNotification *)notification;
+{
+    NSDictionary *info = notification.userInfo;
+    if ([info[ARAuctionIDKey] isEqualToString:self.auctionID]) {
+        ARActionLog(@"Will reload due to auction registration updated: %@ - auction:%@", self, self.auctionID);
+        [self reload];
+    }
+}
+
+@end

--- a/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARAuctionWebViewControllerTests.m
+++ b/Artsy_Tests/View_Controller_Tests/Web_Browsing/ARAuctionWebViewControllerTests.m
@@ -1,0 +1,168 @@
+#import "ARAuctionWebViewController.h"
+#import "ARRouter.h"
+
+#import <OCMock/OCObserverMockObject.h>
+
+
+@interface ARAuctionWebViewController (Private)
+- (void)bidHasBeenConfirmed;
+@end
+
+
+static NSURL *
+URLWithPath(NSString *path)
+{
+    // For some reason the URL produced by this method does not equal a NSURL initialized with -URLWithString:
+    NSURL *URL = [ARRouter resolveRelativeUrl:path];
+    return [NSURL URLWithString:URL.absoluteString];
+}
+
+static NSURL *
+AuctionURL(NSString *auctionID)
+{
+    return URLWithPath([NSString stringWithFormat:@"/auctions/%@", auctionID]);
+}
+
+static NSURL *
+AuctionArtworkURL(NSString *auctionID, NSString *artworkID)
+{
+    return URLWithPath([NSString stringWithFormat:@"/auction/%@/bid/%@", auctionID, artworkID]);
+}
+
+SpecBegin(ARAuctionWebViewController);
+
+__block ARAuctionWebViewController *controller = nil;
+
+afterEach(^{
+    controller = nil;
+});
+
+it(@"parses the aution/lot IDs from the URL", ^{
+    NSURL *auctionURL = AuctionURL(@"the-auction");
+    controller = [[ARAuctionWebViewController alloc] initWithURL:auctionURL];
+    expect(controller.currentURL).to.equal(auctionURL);
+    expect(controller.auctionID).to.equal(@"the-auction");
+    expect(controller.artworkID).to.beNil();
+
+    NSURL *artworkURL = AuctionArtworkURL(@"the-auction", @"the-artwork");
+    controller = [[ARAuctionWebViewController alloc] initWithURL:artworkURL];
+    expect(controller.currentURL).to.equal(artworkURL);
+    expect(controller.auctionID).to.equal(@"the-auction");
+    expect(controller.artworkID).to.equal(@"the-artwork");
+});
+
+describe(@"with an artwork", ^{
+    beforeEach(^{
+        controller = [[ARAuctionWebViewController alloc] initWithURL:AuctionArtworkURL(@"the-auction", @"the-artwork")];
+    });
+
+    it(@"listens for a bid to be confirmed", ^{
+        id navigationActionMock = [OCMockObject mockForClass:WKNavigationAction.class];
+        [[[navigationActionMock stub] andReturnValue:@(WKNavigationTypeOther)] navigationType];
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://artsy.net/artwork/the-artwork#confirm-bid"]];
+        [[[navigationActionMock stub] andReturn:request] request];
+
+        id mock = [OCMockObject partialMockForObject:controller];
+        [[mock expect] bidHasBeenConfirmed];
+
+        expect([controller shouldLoadNavigationAction:navigationActionMock]).to.equal(WKNavigationActionPolicyCancel);
+        [mock verify];
+    });
+
+    describe(@"once a bid has been confirmed", ^{
+        it(@"posts a ‘updated’ notification", ^{
+            id mock = [OCMockObject observerMock];
+            [[NSNotificationCenter defaultCenter] addMockObserver:mock
+                                                             name:ARAuctionArtworkBidUpdatedNotification
+                                                           object:nil];
+
+            [[mock expect] notificationWithName:ARAuctionArtworkBidUpdatedNotification
+                                         object:controller
+                                       userInfo:@{ ARAuctionIDKey: @"the-auction", ARAuctionArtworkIDKey: @"the-artwork" }];
+            [controller bidHasBeenConfirmed];
+
+            [mock verify];
+            [[NSNotificationCenter defaultCenter] removeObserver:mock];
+        });
+
+        // TODO MAXIM : fix tests
+//        it(@"pops the VC from the stack once a bid has been confirmed", ^{
+//            ARArtworkSetViewController *artworkViewController = [[ARArtworkSetViewController alloc] initWithArtworkID:@"the-artwork"];
+//            (void)artworkViewController.view; // Ensure there’s a currentArtworkViewController
+//
+//            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:artworkViewController];
+//            [navigationController pushViewController:controller animated:NO];
+//
+//            [controller bidHasBeenConfirmed];
+//            expect(navigationController.viewControllers.count).to.equal(1);
+//        });
+//
+//        it(@"inserts an artwork view controller underneath the webview if there is none", ^{
+//            UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:[UIViewController new]];
+//            [navigationController pushViewController:controller animated:NO];
+//
+//            [controller bidHasBeenConfirmed];
+//            expect(navigationController.viewControllers.count).to.equal(2);
+//
+//            ARArtworkSetViewController *artworkViewController = navigationController.viewControllers[1];
+//            (void)artworkViewController.view; // Ensure there’s a currentArtworkViewController
+//            expect(artworkViewController.currentArtworkViewController.artwork.artworkID).to.equal(@"the-artwork");
+//        });
+    });
+
+    it(@"reloads only if the ‘updated’ notification is about the artwork in question", ^{
+        id mock = nil;
+        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+
+        mock = [OCMockObject partialMockForObject:controller];
+        [(ARAuctionWebViewController *)[mock reject] reload];
+        [notificationCenter postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                                          object:nil
+                                        userInfo:@{ ARAuctionIDKey: @"another-auction", ARAuctionArtworkIDKey: @"the-artwork" }];
+        [mock verifyWithDelay:1];
+        [mock stopMocking];
+
+        mock = [OCMockObject partialMockForObject:controller];
+        [(ARAuctionWebViewController *)[mock reject] reload];
+        [notificationCenter postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                                          object:nil
+                                        userInfo:@{ ARAuctionIDKey: @"the-auction", ARAuctionArtworkIDKey: @"another-artwork" }];
+        [mock verifyWithDelay:1];
+        [mock stopMocking];
+
+        mock = [OCMockObject partialMockForObject:controller];
+        [(ARAuctionWebViewController *)[mock expect] reload];
+        [notificationCenter postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                                          object:nil
+                                        userInfo:@{ ARAuctionIDKey: @"the-auction", ARAuctionArtworkIDKey: @"the-artwork" }];
+        [mock verifyWithDelay:1];
+        [mock stopMocking];
+    });
+});
+
+describe(@"with an auction", ^{
+    it(@"reloads if the artwork, that the ‘updated’ notification is about, is part of the auction", ^{
+        controller = [[ARAuctionWebViewController alloc] initWithURL:AuctionURL(@"the-auction")];
+
+        id mock = nil;
+        NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
+
+        mock = [OCMockObject partialMockForObject:controller];
+        [(ARAuctionWebViewController *)[mock reject] reload];
+        [notificationCenter postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                                          object:nil
+                                        userInfo:@{ ARAuctionIDKey: @"another-auction", ARAuctionArtworkIDKey: @"any-artwork" }];
+        [mock verifyWithDelay:1];
+        [mock stopMocking];
+
+        mock = [OCMockObject partialMockForObject:controller];
+        [(ARAuctionWebViewController *)[mock expect] reload];
+        [notificationCenter postNotificationName:ARAuctionArtworkBidUpdatedNotification
+                                          object:nil
+                                        userInfo:@{ ARAuctionIDKey: @"the-auction", ARAuctionArtworkIDKey: @"any-artwork" }];
+        [mock verifyWithDelay:1];
+        [mock stopMocking];
+    });
+});
+
+SpecEnd;

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -675,8 +675,6 @@ PODS:
     - Sentry (= 7.9.0)
   - RNShare (7.3.6):
     - React-Core
-  - RNSplit (0.0.1):
-    - React
   - RNSVG (9.13.3):
     - React
   - SDWebImage (5.8.3):
@@ -846,7 +844,6 @@ DEPENDENCIES:
   - RNScreens (from `node_modules/react-native-screens`)
   - "RNSentry (from `node_modules/@sentry/react-native`)"
   - RNShare (from `node_modules/react-native-share`)
-  - "RNSplit (from `node_modules/@splitsoftware/splitio-react-native`)"
   - RNSVG (from `node_modules/react-native-svg`)
   - SDWebImage (= 5.8.3)
   - Segment-Adjust (= 3.1.4)
@@ -862,7 +859,14 @@ DEPENDENCIES:
   - Yoga (from `./node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://cdn.cocoapods.org/:
+  https://github.com/artsy/Specs.git:
+    - Aerodramus
+    - "Artsy+UIColors"
+    - "Artsy+UIFonts"
+    - "Artsy+UILabels"
+    - Artsy-UIButtons
+    - Extraction
+  trunk:
     - Adjust
     - AFNetworkActivityLogger
     - AFNetworking
@@ -937,13 +941,6 @@ SPEC REPOS:
     - "UIView+BooleanAnimations"
     - "XCTest+OHHTTPStubSuiteCleanUp"
     - YogaKit
-  https://github.com/artsy/Specs.git:
-    - Aerodramus
-    - "Artsy+UIColors"
-    - "Artsy+UIFonts"
-    - "Artsy+UILabels"
-    - Artsy-UIButtons
-    - Extraction
 
 EXTERNAL SOURCES:
   AFOAuth1Client:
@@ -1144,7 +1141,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   DHCShakeNotifier: 64048427ecaa763f2472d0032f58bf7a10074eee
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   EDColor: 91d127cd67d7c1d3862846fb11ef4b3851151bfa
   Emission: ce472ad11d5dcd1e332938722aef6e97945e4efb
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
@@ -1173,7 +1170,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
   GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->
This PR resolves [MOPLAT-213]
This PR resolves [MOPLAT-214]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds back native auction web view we use for live auction registration we removed a bit too hastily. 

### PR Checklist (tick all before merging)

<!-- 💡 MOPLAT warmly welcomes any feedback about the list or how it impacts your workflow. -->

- [x] Tested on **iOS** and **Android**
- [x] Screenshots and videos 
- [x] Added Tests and Stories
- [x] App state migration
- [x] Feature flag

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Add back auction web view for live auction registration - Brian

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>


[MOPLAT-213]: https://artsyproduct.atlassian.net/browse/MOPLAT-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MOPLAT-214]: https://artsyproduct.atlassian.net/browse/MOPLAT-214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ