### PR TITLE
chore: render children as button content instead of a specific prop

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx
@@ -44,7 +44,9 @@ const TestRenderer = () => {
               artwork={props!.artwork!}
               editionSetID={null}
               conversationID="1234"
-            />
+            >
+              Make an Offer
+            </InquiryMakeOfferButtonFragmentContainer>
           )
         } else if (Boolean(error)) {
           console.error(error)

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
@@ -139,7 +139,7 @@ export class InquiryMakeOfferButton extends React.Component<InquiryMakeOfferButt
         variant={variant}
         haptic
       >
-        {children || "Make an Offer"}
+        {children}
       </Button>
     )
   }

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
@@ -3,20 +3,16 @@ import { InquiryMakeOfferButtonOrderMutation } from "__generated__/InquiryMakeOf
 import { navigate } from "app/navigation/navigate"
 import { Button, ButtonProps } from "palette"
 import React from "react"
-import { Alert, GestureResponderEvent } from "react-native"
+import { Alert } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 
-export interface InquiryMakeOfferButtonProps {
+export interface InquiryMakeOfferButtonProps extends ButtonProps {
   artwork: InquiryMakeOfferButton_artwork
   relay: RelayProp
   // EditionSetID is passed down from the edition selected by the user
   editionSetID: string | null
-  variant?: ButtonProps["variant"]
-  buttonText?: string
-  disabled?: boolean
   conversationID: string
   replaceModalView?: boolean
-  onPress?: (event?: GestureResponderEvent) => void
 }
 
 export interface State {
@@ -127,7 +123,7 @@ export class InquiryMakeOfferButton extends React.Component<InquiryMakeOfferButt
 
   render() {
     const { isCommittingCreateOfferOrderMutation } = this.state
-    const { onPress, disabled, variant, buttonText } = this.props
+    const { onPress, disabled, variant, children } = this.props
 
     return (
       <Button
@@ -143,7 +139,7 @@ export class InquiryMakeOfferButton extends React.Component<InquiryMakeOfferButt
         variant={variant}
         haptic
       >
-        {buttonText ? buttonText : "Make an Offer"}
+        {children || "Make an Offer"}
       </Button>
     )
   }

--- a/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -63,12 +63,13 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
           )}
           <InquiryMakeOfferButton
             variant="fillDark"
-            buttonText="Confirm"
             artwork={artwork}
             disabled={!!artwork.isEdition && !selectedEdition}
             editionSetID={selectedEdition ? selectedEdition : null}
             conversationID={conversationID}
-          />
+          >
+            Confirm
+          </InquiryMakeOfferButton>
           <Button
             mt={1}
             size="large"

--- a/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tsx
@@ -67,7 +67,9 @@ export const OpenInquiryModalButton: React.FC<OpenInquiryModalButtonProps> = ({
             conversationID={conversationID}
             onPress={() => trackEvent(tracks.trackTappedMakeOffer(conversationID))}
             replaceModalView={false}
-          />
+          >
+            Make an Offer
+          </InquiryMakeOfferButtonFragmentContainer>
         )}
       </Flex>
     </>


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Replace property `buttonText` with `children` on InquiryMakeOfferButton.
Keep the default value of `Make an Offer`
See [implementation on Force](https://github.com/artsy/force/blob/main/src/v2/Apps/Conversation/Components/ConfirmArtworkButton.tsx#L87).

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Replace property `buttonText` with `children` on InquiryMakeOfferButton - LeandroL

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
