### PR TITLE
fix(FX-3895): handle special characters on pricerangeoptions screen

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
@@ -183,4 +183,22 @@ describe("PriceRangeOptions", () => {
 
     expect(minInput.props.value).toBe("")
   })
+
+  it("should not update input with a special character (included in android num-pad)", () => {
+    const { getByTestId, queryByDisplayValue } = getTree()
+    const minInput = getByTestId("price-min-input")
+
+    fireEvent.changeText(minInput, ".")
+
+    expect(minInput).toHaveProp("value", "")
+    fireEvent.changeText(minInput, " ")
+    expect(minInput).toHaveProp("value", "")
+    fireEvent.changeText(minInput, "-")
+    expect(minInput).toHaveProp("value", "")
+    fireEvent.changeText(minInput, ",")
+    expect(minInput).toHaveProp("value", "")
+
+    fireEvent.changeText(minInput, "1242135")
+    queryByDisplayValue("1242135")
+  })
 })

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -43,6 +43,7 @@ export const getBarsFromAggregations = (aggregations?: Aggregations) => {
   return sortedBars
 }
 
+const NUMBERS_REGEX = /^(|\d)+$/
 const DEBOUNCE_DELAY = 500
 const DEFAULT_PRICE_RANGE = DEFAULT_PRICE_OPTION.paramValue
 const DEFAULT_RANGE = [0, 50000]
@@ -121,8 +122,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
     // Early exit the input update if the value is not a number
     // This was added for the android number-pad keyboard that
     // includes some special characters
-    const numbersRegex = /^(|\d)+$/
-    if (!numbersRegex.test(value)) {
+    if (!NUMBERS_REGEX.test(value)) {
       return
     }
 

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -118,6 +118,14 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
   const isActive = selectedFilterOption.paramValue !== DEFAULT_PRICE_OPTION.paramValue
 
   const handleTextChange = (changedIndex: number) => (value: string) => {
+    // Early exit the input update if the value is not a number
+    // This was added for the android number-pad keyboard that
+    // includes some special characters
+    const numbersRegex = /^(|\d)+$/
+    if (!numbersRegex.test(value)) {
+      return
+    }
+
     const updatedRange = range.map((rangeValue, index) => {
       if (index === changedIndex) {
         if (value === "" || value === "0") {


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [FX-3895]

### Description

Android keybordType number-pad includes some special characters that iOS does not ( `.` `,` `-` ).

When a user navigated to the price filter screen in an Android device and pressed any of the `.` `,` `-`, the app displayed an error screen 👇  Demo behavior below

https://user-images.githubusercontent.com/21178754/163377922-d9e112f2-fedc-4f72-a2dd-ee532086d769.mp4

This pr fixes this issue by adding an early exit clause in the onChangeText event of the PriceRangeOptions screen to prevent that.

Also added some test cases.

Video demo of behavior after the fix:

https://user-images.githubusercontent.com/21178754/163378613-855d28c6-f634-49ab-9399-d8db65c5bb4e.mp4


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- handle gracefully errors from special characters entered in the price filter input - gkartalis

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[FX-3895]: https://artsyproduct.atlassian.net/browse/FX-3895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ