### PR TITLE
feat(BX-349): Add cascading end time banner to lot and sale page

### DIFF
--- a/src/app/Components/Bidding/Components/Timer.tests.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tests.tsx
@@ -263,7 +263,7 @@ describe("Countdown", () => {
             duration={duration}
             label="This is the label"
             hasStarted
-            cascadingEndTimeInterval={60}
+            cascadingEndTimeIntervalMinutes={1}
           />
         </Wrapper>
       )
@@ -298,7 +298,7 @@ describe("Countdown", () => {
             duration={duration}
             label="This is the label"
             hasStarted
-            cascadingEndTimeInterval={60}
+            cascadingEndTimeIntervalMinutes={1}
           />
         </Wrapper>
       )

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -110,20 +110,20 @@ export function currentTimerState({ isPreview, isClosed, liveStartsAt }: Props) 
 
 export interface CountdownProps extends CountdownTimerProps {
   hasStarted?: boolean
-  cascadingEndTimeInterval?: number | null
+  cascadingEndTimeIntervalMinutes?: number | null
 }
 
 export const Countdown: React.FC<CountdownProps> = ({
   duration,
   label,
   hasStarted,
-  cascadingEndTimeInterval,
+  cascadingEndTimeIntervalMinutes,
 }) => {
   const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerLotPage")
 
   return (
     <Flex alignItems="center">
-      {cascadingEndTimeFeatureEnabled && cascadingEndTimeInterval ? (
+      {cascadingEndTimeFeatureEnabled && cascadingEndTimeIntervalMinutes ? (
         <ModernTicker duration={duration} hasStarted={hasStarted} />
       ) : (
         <SimpleTicker duration={duration} separator="  " size="4t" weight="medium" />

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -142,6 +142,34 @@ describe("ArtworkTombstone", () => {
     })
   })
 
+  describe("for an artwork in a sale with cascading end times", () => {
+    it("renders the notification banner", () => {
+      const component = mount(
+        <GlobalStoreProvider>
+          <Theme>
+            <ArtworkTombstone artwork={artworkTombstoneCascadingEndTimesAuctionArtwork} />
+          </Theme>
+        </GlobalStoreProvider>
+      )
+
+      expect(component.text()).toContain("Lots will close at 1-minute intervals.")
+    })
+  })
+
+  describe("for an artwork in a sale without cascading end times", () => {
+    it("renders the notification banner", () => {
+      const component = mount(
+        <GlobalStoreProvider>
+          <Theme>
+            <ArtworkTombstone artwork={artworkTombstoneAuctionArtwork} />
+          </Theme>
+        </GlobalStoreProvider>
+      )
+
+      expect(component.text()).not.toContain("Lots will close at 1-minute intervals.")
+    })
+  })
+
   // TODO: THESE TESTS SHOULD NOT MUTATE THE FIXTURE!!!
   describe("for an artwork with less than 4 artists but more than 1", () => {
     beforeEach(() => {
@@ -294,5 +322,22 @@ const artworkTombstoneAuctionArtwork = {
   },
   sale: {
     isClosed: false,
+    cascadingEndTimeIntervalMinutes: null,
+  },
+}
+
+const artworkTombstoneCascadingEndTimesAuctionArtwork = {
+  ...artworkTombstoneArtwork,
+  isInAuction: true,
+  saleArtwork: {
+    lotLabel: "8",
+    estimate: "CHF 160,000–CHF 230,000",
+  },
+  partner: {
+    name: "Cool Auction",
+  },
+  sale: {
+    isClosed: false,
+    cascadingEndTimeIntervalMinutes: 1,
   },
 }

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -193,13 +193,14 @@ export class ArtworkTombstone extends React.Component<
             .
           </Sans>
         )}
-        {!!artwork.sale?.cascadingEndTimeIntervalMinutes && (
-          <CascadingEndTimesBanner
-            cascadingEndTimeInterval={artwork.sale.cascadingEndTimeIntervalMinutes}
-          />
-        )}
+
         {!!artwork.isInAuction && !!artwork.sale && !artwork.sale.isClosed && (
           <>
+            {!!artwork.sale?.cascadingEndTimeIntervalMinutes && (
+              <CascadingEndTimesBanner
+                cascadingEndTimeInterval={artwork.sale.cascadingEndTimeIntervalMinutes}
+              />
+            )}
             <Spacer mb={1} />
             {!!artwork.partner && (
               <Sans color="black100" size="3" weight="medium">

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -2,9 +2,10 @@ import { ArtworkTombstone_artwork } from "__generated__/ArtworkTombstone_artwork
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { navigate } from "app/navigation/navigate"
 import { Schema, track } from "app/utils/track"
-import { Box, Flex, Sans, Spacer } from "palette"
+import { Box, Flex, Sans, Spacer, Text } from "palette"
 import React from "react"
-import { Text, TouchableWithoutFeedback } from "react-native"
+import { TouchableWithoutFeedback } from "react-native"
+import Config from "react-native-config"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FollowArtistLinkFragmentContainer as FollowArtistLink } from "./FollowArtistLink"
 
@@ -131,6 +132,10 @@ export class ArtworkTombstone extends React.Component<
       artwork.sale &&
       !artwork.sale.isClosed
 
+    const helpArticleLink = Config.CASCADING_AUCTION_HELP_ARTICLE_LINK
+
+    const hasLink = !!helpArticleLink
+
     return (
       <Box textAlign="left">
         <Flex flexDirection="row" flexWrap="wrap">
@@ -192,6 +197,18 @@ export class ArtworkTombstone extends React.Component<
             .
           </Sans>
         )}
+        {!!artwork.sale?.cascadingEndTimeIntervalMinutes && (
+          <Flex backgroundColor="blue100" p={2} my={2}>
+            <Text color="white" style={{ textAlign: "center" }}>
+              {`Lots will close at ${artwork.sale.cascadingEndTimeIntervalMinutes}-minute intervals.`}
+              {!hasLink && (
+                <TouchableWithoutFeedback onPress={() => navigate(helpArticleLink)}>
+                  <Text style={{ textDecorationLine: "underline" }}>&nbsp;Learn more.</Text>
+                </TouchableWithoutFeedback>
+              )}
+            </Text>
+          </Flex>
+        )}
         {!!artwork.isInAuction && !!artwork.sale && !artwork.sale.isClosed && (
           <>
             <Spacer mb={1} />
@@ -229,6 +246,7 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
       }
       sale {
         isClosed
+        cascadingEndTimeIntervalMinutes
       }
       artists {
         name

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -5,8 +5,8 @@ import { Schema, track } from "app/utils/track"
 import { Box, Flex, Sans, Spacer, Text } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
-import Config from "react-native-config"
 import { createFragmentContainer, graphql } from "react-relay"
+import { CascadingEndTimesBanner } from "./CascadingEndTimesBanner"
 import { FollowArtistLinkFragmentContainer as FollowArtistLink } from "./FollowArtistLink"
 
 type Artist = NonNullable<NonNullable<ArtworkTombstone_artwork["artists"]>[0]>
@@ -132,10 +132,6 @@ export class ArtworkTombstone extends React.Component<
       artwork.sale &&
       !artwork.sale.isClosed
 
-    const helpArticleLink = Config.CASCADING_AUCTION_HELP_ARTICLE_LINK
-
-    const hasLink = !!helpArticleLink
-
     return (
       <Box textAlign="left">
         <Flex flexDirection="row" flexWrap="wrap">
@@ -198,16 +194,9 @@ export class ArtworkTombstone extends React.Component<
           </Sans>
         )}
         {!!artwork.sale?.cascadingEndTimeIntervalMinutes && (
-          <Flex backgroundColor="blue100" p={2} my={2}>
-            <Text color="white" style={{ textAlign: "center" }}>
-              {`Lots will close at ${artwork.sale.cascadingEndTimeIntervalMinutes}-minute intervals.`}
-              {!hasLink && (
-                <TouchableWithoutFeedback onPress={() => navigate(helpArticleLink)}>
-                  <Text style={{ textDecorationLine: "underline" }}>&nbsp;Learn more.</Text>
-                </TouchableWithoutFeedback>
-              )}
-            </Text>
-          </Flex>
+          <CascadingEndTimesBanner
+            cascadingEndTimeInterval={artwork.sale.cascadingEndTimeIntervalMinutes}
+          />
         )}
         {!!artwork.isInAuction && !!artwork.sale && !artwork.sale.isClosed && (
           <>

--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -1,0 +1,32 @@
+import { navigate } from "app/navigation/navigate"
+import { Flex, Text } from "palette"
+import React from "react"
+import Config from "react-native-config"
+
+interface CascadingEndTimesBannerProps {
+  cascadingEndTimeInterval: number
+}
+
+export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = ({
+  cascadingEndTimeInterval,
+}) => {
+  const helpArticleLink = Config.CASCADING_AUCTION_HELP_ARTICLE_LINK
+  const hasLink = !!helpArticleLink
+
+  return (
+    <Flex backgroundColor="blue100" p={2} my={2}>
+      <Text color="white" style={{ textAlign: "center" }}>
+        {`Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
+        {!hasLink && (
+          <Text
+            color="white"
+            onPress={() => navigate(helpArticleLink)}
+            style={{ textDecorationLine: "underline" }}
+          >
+            Learn more.
+          </Text>
+        )}
+      </Text>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -17,7 +17,7 @@ export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = (
     <Flex backgroundColor="blue100" p={2} my={2}>
       <Text color="white" style={{ textAlign: "center" }}>
         {`Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
-        {!hasLink && (
+        {!!hasLink && (
           <Text
             color="white"
             onPress={() => navigate(helpArticleLink)}

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
@@ -623,7 +623,7 @@ const CommercialInformationArtworkInCascadingEndTimeAuction = {
     endAt: "2019-08-16T20:20:00+00:00",
     liveStartAt: null,
     formattedStartDateTime: "Ends Aug 16 at 8:20pm UTC",
-    cascadingEndTimeInterval: 60,
+    cascadingEndTimeIntervalMinutes: 1,
   },
   saleArtwork: {
     endAt: "2019-08-18T20:20:00+00:00",

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -39,7 +39,7 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
     const {
       isPreview,
       isClosed,
-      cascadingEndTimeInterval,
+      cascadingEndTimeIntervalMinutes,
       liveStartAt: liveStartsAt,
       startAt: startsAt,
       endAt: saleEndAt,
@@ -50,7 +50,7 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
     const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerLotPage")
 
     const endsAt =
-      (cascadingEndTimeFeatureEnabled && cascadingEndTimeInterval ? lotEndAt : saleEndAt) ||
+      (cascadingEndTimeFeatureEnabled && cascadingEndTimeIntervalMinutes ? lotEndAt : saleEndAt) ||
       undefined
 
     return (
@@ -68,7 +68,7 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
               startsAt: startsAt || undefined,
               endsAt,
             })
-            return { label, date, state, hasStarted, cascadingEndTimeInterval }
+            return { label, date, state, hasStarted, cascadingEndTimeIntervalMinutes }
           }}
           onNextTickerState={({ state }) => {
             const nextState = nextTimerState(state as AuctionTimerState, {
@@ -248,7 +248,7 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
             <Countdown
               label={label}
               hasStarted={hasStarted}
-              cascadingEndTimeInterval={sale.cascadingEndTimeInterval}
+              cascadingEndTimeIntervalMinutes={sale.cascadingEndTimeIntervalMinutes}
               // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               duration={duration}
             />
@@ -297,7 +297,7 @@ export const CommercialInformationFragmentContainer = createFragmentContainer(
         }
 
         sale {
-          cascadingEndTimeInterval
+          cascadingEndTimeIntervalMinutes
           internalID
           isClosed
           isAuction

--- a/src/app/Scenes/Sale/Sale.tests.tsx
+++ b/src/app/Scenes/Sale/Sale.tests.tsx
@@ -5,6 +5,7 @@ import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { DateTime } from "luxon"
 import React, { Suspense } from "react"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { CascadingEndTimesBanner } from "../Artwork/Components/CascadingEndTimesBanner"
 import { RegisterToBidButtonContainer } from "./Components/RegisterToBidButton"
 import { SaleQueryRenderer } from "./Sale"
 
@@ -164,5 +165,43 @@ describe("Sale", () => {
     )
 
     expect(tree.findAllByType(RegisterToBidButtonContainer)).toHaveLength(0)
+  })
+
+  it("renders the banner when the sale has cascading end times", () => {
+    const tree = renderWithWrappers(<TestRenderer />).root
+
+    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Sale: () => ({
+          slug: "cascading-sale-slug",
+          startAt: DateTime.now().minus({ days: 3 }).toISO(),
+          liveStartAt: DateTime.now().minus({ days: 2 }).toISO(),
+          endAt: DateTime.now().plus({ day: 1 }).toISO(),
+          name: "Cascading Sale",
+          cascadingEndTimeIntervalMinutes: 1,
+        }),
+      })
+    )
+
+    expect(tree.findAllByType(CascadingEndTimesBanner)).toHaveLength(1)
+  })
+
+  it("doesn't render the banner when the sale has cascading end times", () => {
+    const tree = renderWithWrappers(<TestRenderer />).root
+
+    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Sale: () => ({
+          slug: "non-cascading-sale-slug",
+          startAt: DateTime.now().minus({ days: 3 }).toISO(),
+          liveStartAt: DateTime.now().minus({ days: 2 }).toISO(),
+          endAt: DateTime.now().plus({ day: 1 }).toISO(),
+          name: "Non Cascading Sale",
+          cascadingEndTimeIntervalMinutes: null,
+        }),
+      })
+    )
+
+    expect(tree.findAllByType(CascadingEndTimesBanner)).toHaveLength(0)
   })
 })

--- a/src/app/Scenes/Sale/Sale.tests.tsx
+++ b/src/app/Scenes/Sale/Sale.tests.tsx
@@ -186,7 +186,7 @@ describe("Sale", () => {
     expect(tree.findAllByType(CascadingEndTimesBanner)).toHaveLength(1)
   })
 
-  it("doesn't render the banner when the sale has cascading end times", () => {
+  it("doesn't render the banner when the sale does not have cascading end times", () => {
     const tree = renderWithWrappers(<TestRenderer />).root
 
     mockEnvironment.mock.resolveMostRecentOperation((operation) =>
@@ -198,6 +198,26 @@ describe("Sale", () => {
           endAt: DateTime.now().plus({ day: 1 }).toISO(),
           name: "Non Cascading Sale",
           cascadingEndTimeIntervalMinutes: null,
+        }),
+      })
+    )
+
+    expect(tree.findAllByType(CascadingEndTimesBanner)).toHaveLength(0)
+  })
+
+  it("doesn't render the banner when the sale has cascading end times but the sale is closed", () => {
+    const tree = renderWithWrappers(<TestRenderer />).root
+
+    mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, {
+        Sale: () => ({
+          slug: "closed-cascading-sale-slug",
+          startAt: DateTime.now().minus({ days: 3 }).toISO(),
+          liveStartAt: DateTime.now().minus({ days: 2 }).toISO(),
+          endAt: DateTime.now().minus({ day: 1 }).toISO(),
+          name: "Closed Cascading Sale",
+          cascadingEndTimeIntervalMinutes: 1,
+          isClosed: true,
         }),
       })
     )

--- a/src/app/Scenes/Sale/Sale.tests.tsx
+++ b/src/app/Scenes/Sale/Sale.tests.tsx
@@ -179,6 +179,7 @@ describe("Sale", () => {
           endAt: DateTime.now().plus({ day: 1 }).toISO(),
           name: "Cascading Sale",
           cascadingEndTimeIntervalMinutes: 1,
+          isClosed: false,
         }),
       })
     )
@@ -198,6 +199,7 @@ describe("Sale", () => {
           endAt: DateTime.now().plus({ day: 1 }).toISO(),
           name: "Non Cascading Sale",
           cascadingEndTimeIntervalMinutes: null,
+          isClosed: false,
         }),
       })
     )

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -30,6 +30,7 @@ import useInterval from "react-use/lib/useInterval"
 import usePrevious from "react-use/lib/usePrevious"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { SaleBelowTheFoldQueryResponse } from "../../../__generated__/SaleBelowTheFoldQuery.graphql"
+import { CascadingEndTimesBanner } from "../Artwork/Components/CascadingEndTimesBanner"
 import { BuyNowArtworksRailContainer } from "./Components/BuyNowArtworksRail"
 import { RegisterToBidButtonContainer } from "./Components/RegisterToBidButton"
 import { SaleActiveBidsContainer } from "./Components/SaleActiveBids"
@@ -52,6 +53,7 @@ interface SaleSection {
 
 const SALE_HEADER = "header"
 const SALE_REGISTER_TO_BID = "registerToBid"
+const SALE_CASCADING_END_TIMES_BANNER = "cascadingEndTimesBanner"
 const SALE_ACTIVE_BIDS = "saleActiveBids"
 const SALE_ARTWORKS_RAIL = "saleArtworksRail"
 const BUY_NOW_ARTWORKS_RAIL = "buyNowArtworksRail"
@@ -177,6 +179,12 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
             contextModule={ContextModule.auctionHome}
           />
         </Flex>
+      ),
+    },
+    sale.cascadingEndTimeIntervalMinutes && {
+      key: SALE_CASCADING_END_TIMES_BANNER,
+      content: (
+        <CascadingEndTimesBanner cascadingEndTimeInterval={sale.cascadingEndTimeIntervalMinutes} />
       ),
     },
     {
@@ -343,6 +351,7 @@ export const SaleContainer = createRefetchContainer(
         startAt
         registrationEndsAt
         slug
+        cascadingEndTimeIntervalMinutes
       }
     `,
   },

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -181,12 +181,15 @@ export const Sale: React.FC<Props> = ({ sale, me, below, relay }) => {
         </Flex>
       ),
     },
-    sale.cascadingEndTimeIntervalMinutes && {
-      key: SALE_CASCADING_END_TIMES_BANNER,
-      content: (
-        <CascadingEndTimesBanner cascadingEndTimeInterval={sale.cascadingEndTimeIntervalMinutes} />
-      ),
-    },
+    sale.cascadingEndTimeIntervalMinutes &&
+      !sale.isClosed && {
+        key: SALE_CASCADING_END_TIMES_BANNER,
+        content: (
+          <CascadingEndTimesBanner
+            cascadingEndTimeInterval={sale.cascadingEndTimeIntervalMinutes}
+          />
+        ),
+      },
     {
       key: SALE_ACTIVE_BIDS,
       content: <SaleActiveBidsContainer me={me} saleID={sale.internalID} />,
@@ -352,6 +355,7 @@ export const SaleContainer = createRefetchContainer(
         registrationEndsAt
         slug
         cascadingEndTimeIntervalMinutes
+        isClosed
       }
     `,
   },

--- a/src/app/__fixtures__/ArtworkBidAction.ts
+++ b/src/app/__fixtures__/ArtworkBidAction.ts
@@ -89,7 +89,7 @@ export const ArtworkFromLiveAuctionRegistrationOpen = {
     isClosed: false,
     isRegistrationClosed: false,
     requireIdentityVerification: false,
-    cascadingEndTimeInterval: null,
+    cascadingEndTimeIntervalMinutes: null,
     liveStartAt: DateTime.fromMillis(Date.now()).minus({ minutes: 1 }).toISO(),
     startAt: DateTime.fromMillis(Date.now()).minus({ minutes: 10 }).toISO(),
     endAt: null,


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [BX-349](https://artsyproduct.atlassian.net/browse/BID-349)

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adding cascading end time banner to the lot and sale page if the sale is open and if the sale has cascading end times. The banner shows the "Learn more" link if the env variable is configured to include the link.

Sale page:
<img width="407" alt="Screen Shot 2022-04-14 at 11 10 59 AM" src="https://user-images.githubusercontent.com/9466631/163419866-46ad7f75-4897-405e-88e9-b72f85f002e7.png">

Lot Page:
<img width="409" alt="Screen Shot 2022-04-14 at 5 14 37 PM" src="https://user-images.githubusercontent.com/9466631/163477271-3fcb7d21-3aa9-4f62-bf94-928200a47f44.png">


### Seeking feedback/help:
~~1. Because the banner is fit between two pieces of info as part of `ArtworkTombstone`, the margins on either side of the banner seem difficult to avoid but don't match the designs.
It's supposed to look like the following screenshot from figma w/ no margins:
<img width="381" alt="Screen Shot 2022-04-14 at 11 07 42 AM" src="https://user-images.githubusercontent.com/9466631/163419334-7d935e8e-8b3e-46fb-99b9-ffc81781f1a6.png">~~
I fixed this with @dzucconi and it looks great now!

2. I chose not to use a feature flag here because the changes seems relatively low risk and if the banner doesn't work properly, it's not a huge deal. But open to other opinions.

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
