### PR TITLE
fix(FX-3814): problem when need to click "Show Results" button twice

### DIFF
--- a/src/app/Components/StickyHeaderPage.tsx
+++ b/src/app/Components/StickyHeaderPage.tsx
@@ -3,17 +3,22 @@ import { useUpdateShouldHideBackButton } from "app/utils/hideBackButtonOnScroll"
 import { useAutoCollapsingMeasuredView } from "app/utils/useAutoCollapsingMeasuredView"
 import { useScreenDimensions } from "app/utils/useScreenDimensions"
 import React from "react"
-import { View } from "react-native"
+import { ScrollViewProps, View } from "react-native"
 import Animated from "react-native-reanimated"
 
-interface StickyHeaderPageProps {
+type OmittedScrollViewProps = Omit<
+  ScrollViewProps,
+  "scrollEventThrottle" | "showsVerticalScrollIndicator" | "onScroll"
+>
+
+interface StickyHeaderPageProps extends OmittedScrollViewProps {
   headerContent: JSX.Element
   stickyHeaderContent: JSX.Element
   footerContent?: JSX.Element
 }
 
 export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
-  const { headerContent, stickyHeaderContent, footerContent, children } = props
+  const { headerContent, stickyHeaderContent, footerContent, children, ...rest } = props
 
   const { jsx: staticHeader, nativeHeight: headerHeight } =
     useAutoCollapsingMeasuredView(headerContent)
@@ -70,6 +75,7 @@ export const StickyHeaderPage: React.FC<StickyHeaderPageProps> = (props) => {
   return (
     <View style={{ flex: 1, position: "relative", overflow: "hidden" }}>
       <Animated.ScrollView
+        {...rest}
         scrollEventThrottle={0.0000000001}
         showsVerticalScrollIndicator={false}
         onScroll={Animated.event(

--- a/src/app/Components/Tag/TagArtworks.tsx
+++ b/src/app/Components/Tag/TagArtworks.tsx
@@ -106,7 +106,7 @@ const TagArtworksContainer: React.FC<TagArtworksContainerProps> = (props) => {
 
   return (
     <ArtworkFiltersStoreProvider>
-      <StickyTabPageScrollView>
+      <StickyTabPageScrollView keyboardShouldPersistTaps="handled">
         <TagArtworks {...props} openFilterModal={openFilterArtworksModal} />
         <ArtworkFilterNavigator
           {...props}

--- a/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -110,6 +110,7 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
             />
           </Flex>
         }
+        keyboardShouldPersistTaps="handled"
       >
         <Flex px={2} mt={2}>
           <Text variant="md" color="black60" mb={2}>

--- a/src/app/Scenes/Collection/Collection.tsx
+++ b/src/app/Scenes/Collection/Collection.tsx
@@ -63,6 +63,7 @@ export class Collection extends Component<CollectionProps> {
             ListHeaderComponent={<CollectionHeader collection={this.props.collection} />}
             ItemSeparatorComponent={() => <Spacer mb={2} />}
             stickyHeaderIndices={[3]}
+            keyboardShouldPersistTaps="handled"
             renderItem={({ item }): null | any => {
               switch (item) {
                 case "collectionFeaturedArtists":

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -186,6 +186,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
           scrollEventThrottle={100}
           // @ts-ignore
           CellRendererComponent={cellItemRenderer}
+          keyboardShouldPersistTaps="handled"
           renderItem={({ item }): null | any => {
             switch (item) {
               case "fairHeader": {

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -134,6 +134,7 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
               useNativeDriver: true,
             }
           )}
+          keyboardShouldPersistTaps="handled"
         />
       </ArtworkFiltersStoreProvider>
     </ProvideScreenTracking>


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [FX-3814]

### Steps for reproduce
1.  Open App
2. Tap on Search at bottom navigation bar
3. Type `Bedroom paintings`
4. Click on `Bedroom paintings`
5. Tap on `Sort & Filter`
6. Tap on Price
7. Tap on `Max Price`
8. Enter `500`
9. Tap on Show Results
10. Observe

#### Expected Result
Tapping on `Show Results` , Results should display.

#### Actual Result
First time tapping on `Show Results`, Closes num pad.

### Problem fixed for grids
* Tag artworks
* Artist series artworks
* Collection artworks
* Fair artworks
* Show artworks

### Demo
#### Before
_Artist series_

https://user-images.githubusercontent.com/3513494/163802435-4e9adf20-60b0-4eb5-ba3e-bcf448d5e471.mp4

_Tag_


https://user-images.githubusercontent.com/3513494/163802467-a95674bf-6172-4ca4-9d92-51b080aa0483.mp4

_Show_


https://user-images.githubusercontent.com/3513494/163802486-e86e9969-232e-4e05-aa8b-d977a73b7f29.mp4


#### After
_Artist series_

https://user-images.githubusercontent.com/3513494/163802704-0188722b-3a6d-43b3-b93e-f790dccacffa.mp4


_Tag_

https://user-images.githubusercontent.com/3513494/163802717-da8f42e9-462b-43ac-92c0-61e663461a84.mp4

_Show_

https://user-images.githubusercontent.com/3513494/163802735-ba96e81e-d463-4c60-803f-717f0c22c086.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[FX-3814]: https://artsyproduct.atlassian.net/browse/FX-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ