### PR TITLE
fix(FX-3904): `CVC` text in Card Information is poorly wrapped and truncated

### DIFF
--- a/patches/react-native-credit-card-input+0.4.1.patch
+++ b/patches/react-native-credit-card-input+0.4.1.patch
@@ -35,7 +35,7 @@ index dde3aec..aec1f45 100644
                s.baseInputStyle,
                inputStyle,
 diff --git a/node_modules/react-native-credit-card-input/src/LiteCreditCardInput.js b/node_modules/react-native-credit-card-input/src/LiteCreditCardInput.js
-index a5f166b..20ede42 100644
+index a5f166b..35e81c4 100644
 --- a/node_modules/react-native-credit-card-input/src/LiteCreditCardInput.js
 +++ b/node_modules/react-native-credit-card-input/src/LiteCreditCardInput.js
 @@ -5,11 +5,14 @@ import {
@@ -71,16 +71,18 @@ index a5f166b..20ede42 100644
      resizeMode: "contain",
    },
    expanded: {
-@@ -50,18 +54,20 @@ const s = StyleSheet.create({
+@@ -50,18 +54,22 @@ const s = StyleSheet.create({
      width: INFINITE_WIDTH,
    },
    expiryInput: {
 -    width: 80,
-+    width: 70,
++    width: "100%",
++    marginRight: 5,
    },
    cvcInput: {
 -    width: 80,
-+    width: 40,
++    width: "100%",
++    marginRight: 3, // fix truncated text for custom font
    },
    last4Input: {
      width: 60,
@@ -96,7 +98,7 @@ index a5f166b..20ede42 100644
    },
  });
  
-@@ -83,13 +89,13 @@ export default class LiteCreditCardInput extends Component {
+@@ -83,13 +91,13 @@ export default class LiteCreditCardInput extends Component {
  
    static defaultProps = {
      placeholders: {
@@ -112,7 +114,7 @@ index a5f166b..20ede42 100644
      additionalInputsProps: {},
    };
  
-@@ -105,7 +111,7 @@ export default class LiteCreditCardInput extends Component {
+@@ -105,7 +113,7 @@ export default class LiteCreditCardInput extends Component {
    _focus = field => {
      if (!field) return;
      this.refs[field].focus();
@@ -121,7 +123,7 @@ index a5f166b..20ede42 100644
    }
  
    _inputProps = field => {
-@@ -113,6 +119,7 @@ export default class LiteCreditCardInput extends Component {
+@@ -113,6 +121,7 @@ export default class LiteCreditCardInput extends Component {
        inputStyle, validColor, invalidColor, placeholderColor,
        placeholders, values, status,
        onFocus, onChange, onBecomeEmpty, onBecomeValid,
@@ -129,7 +131,7 @@ index a5f166b..20ede42 100644
        additionalInputsProps,
      } = this.props;
  
-@@ -126,6 +133,7 @@ export default class LiteCreditCardInput extends Component {
+@@ -126,6 +135,7 @@ export default class LiteCreditCardInput extends Component {
        status: status[field],
  
        onFocus, onChange, onBecomeEmpty, onBecomeValid,
@@ -137,7 +139,7 @@ index a5f166b..20ede42 100644
        additionalInputProps: additionalInputsProps[field],
      };
    };
-@@ -139,11 +147,22 @@ export default class LiteCreditCardInput extends Component {
+@@ -139,11 +149,22 @@ export default class LiteCreditCardInput extends Component {
    }
  
    render() {
@@ -162,7 +164,7 @@ index a5f166b..20ede42 100644
          <View style={[
            s.leftPart,
            showRightPart ? s.hidden : s.expanded,
-@@ -152,16 +171,23 @@ export default class LiteCreditCardInput extends Component {
+@@ -152,16 +173,23 @@ export default class LiteCreditCardInput extends Component {
              keyboardType="numeric"
              containerStyle={s.numberInput} />
          </View>
@@ -190,7 +192,7 @@ index a5f166b..20ede42 100644
                <CCInput field="last4"
                  keyboardType="numeric"
                  value={ numberStatus === "valid" ? number.substr(number.length - 4, 4) : "" }
-@@ -180,3 +206,14 @@ export default class LiteCreditCardInput extends Component {
+@@ -180,3 +208,14 @@ export default class LiteCreditCardInput extends Component {
      );
    }
  }


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [FX-3904]

### Steps to reproduce
1. Open the app
2. From the Home screen locate the "Auction Lots Ending Soon" section (in this case 'Shared Online - Only Mocktion')
3. Tap the first tile 'LOT 1 Emma Camden Self-Portrait'
4. Tap 'Bid' button > Next
5. Tap 'Add' for Credit card
6. Enter Card number `4242 4242 4242 4242`
7. _or_ just navigate to Profile -> Settings -> Payment -> Add new card

### Demo
#### Android
Displaying a component with different [system font size
](https://support.google.com/accessibility/android/answer/11183305?hl=en#fontsize)

| Small | Medium | Large | Largest |
| ------------- | ------------- | ------------- | ------------- |
| ![small](https://user-images.githubusercontent.com/3513494/163828846-eb6738de-313b-4793-a144-f5fce55fa3eb.png) | ![default](https://user-images.githubusercontent.com/3513494/163828834-17ab48d5-736f-4dfd-a030-fa1f2823fc05.png) | ![large](https://user-images.githubusercontent.com/3513494/163828840-3beb24f7-3c35-4bfa-8170-39c05d0270e3.png) | ![largest](https://user-images.githubusercontent.com/3513494/163828844-583c8d51-9e53-413f-b7ca-597a0ffedb3b.png) |

#### iOS
Displaying a component with different [system font size](https://support.apple.com/en-us/HT202828#:~:text=Go%20to%20Settings%20%3E%20Accessibility%2C%20then,the%20font%20size%20you%20want.)

| Smallest | Small  | Medium | Large | Largest |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| ![Smallest](https://user-images.githubusercontent.com/3513494/163827584-53a58a1f-d478-4748-a172-e7d9cfeb5466.png) | ![Small](https://user-images.githubusercontent.com/3513494/163827578-24685229-2f5c-4215-9781-a915ca3d62b0.png) | ![Default](https://user-images.githubusercontent.com/3513494/163827567-38ce00f7-c149-4c90-b8c8-8a5136b8df42.png) | ![Large](https://user-images.githubusercontent.com/3513494/163827571-bebf173d-f62c-4258-97f0-ea0e504e508c.png) | ![Largest](https://user-images.githubusercontent.com/3513494/163827574-e58955df-6b9b-4487-8613-796d70b31922.png) |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix `CVC` text in Card Information is poorly wrapped and truncated - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[FX-3904]: https://artsyproduct.atlassian.net/browse/FX-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ