### PR TITLE
(BID-294): Add timers sale artwork grid

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -8,7 +8,8 @@ import { Touchable } from "palette"
 import React from "react"
 import "react-native"
 import { act } from "react-test-renderer"
-import Artwork, { LotCloseInfo } from "./ArtworkGridItem"
+import Artwork from "./ArtworkGridItem"
+import { LotCloseInfo } from "./LotCloseInfo"
 
 const ArtworkWithProviders = (props: any) => {
   return (

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -8,7 +8,7 @@ import { Touchable } from "palette"
 import React from "react"
 import "react-native"
 import { act } from "react-test-renderer"
-import Artwork from "./ArtworkGridItem"
+import Artwork, { LotCloseInfo } from "./ArtworkGridItem"
 
 const ArtworkWithProviders = (props: any) => {
   return (
@@ -186,11 +186,42 @@ describe("in a closed sale", () => {
   })
 })
 
+describe("cascading end times", () => {
+  it("shows the LotCloseInfo component when the sale has cascading end times", () => {
+    const saleArtwork = {
+      lotLabel: "Lot 1",
+      sale: {
+        isClosed: false,
+        cascadingEndTimeIntervalMinutes: 1,
+      },
+    }
+    const tree = renderWithWrappers(
+      <Artwork showLotLabel artwork={artworkProps(saleArtwork) as any} />
+    )
+
+    expect(tree.root.findAllByType(LotCloseInfo).length).toEqual(1)
+  })
+
+  it("does not show the LotCloseInfo component when the sale does not have cascading end times", () => {
+    const saleArtwork = {
+      lotLabel: "Lot 1",
+      sale: {
+        isClosed: true,
+      },
+    }
+    const tree = renderWithWrappers(
+      <Artwork showLotLabel artwork={artworkProps(saleArtwork) as any} />
+    )
+
+    expect(tree.root.findAllByType(LotCloseInfo).length).toEqual(0)
+  })
+})
+
 const artworkProps = (
   saleArtwork:
     | {
         currentBid?: { display: string }
-        sale?: { isClosed: boolean }
+        sale?: { isClosed: boolean; cascadingEndTimeIntervalMinutes?: number }
       }
     | null
     | undefined = null

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -188,6 +188,10 @@ describe("in a closed sale", () => {
 })
 
 describe("cascading end times", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerSalePageGrid: false })
+  })
+
   it("shows the LotCloseInfo component when the sale has cascading end times", () => {
     const saleArtwork = {
       lotLabel: "Lot 1",
@@ -215,6 +219,26 @@ describe("cascading end times", () => {
     )
 
     expect(tree.root.findAllByType(LotCloseInfo).length).toEqual(0)
+  })
+
+  describe("when the disable cascade end times flag is turned on", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerSalePageGrid: true })
+    })
+    it("does not show the LotCloseInfo even if other conditions are met", () => {
+      const saleArtwork = {
+        lotLabel: "Lot 1",
+        sale: {
+          isClosed: false,
+          cascadingEndTimeIntervalMinutes: 1,
+        },
+      }
+      const tree = renderWithWrappers(
+        <Artwork showLotLabel artwork={artworkProps(saleArtwork) as any} />
+      )
+
+      expect(tree.root.findAllByType(LotCloseInfo).length).toEqual(0)
+    })
   })
 })
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -189,7 +189,7 @@ describe("in a closed sale", () => {
 
 describe("cascading end times", () => {
   beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerSalePageGrid: false })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerSalePageGrid: true })
   })
 
   it("shows the LotCloseInfo component when the sale has cascading end times", () => {
@@ -221,9 +221,9 @@ describe("cascading end times", () => {
     expect(tree.root.findAllByType(LotCloseInfo).length).toEqual(0)
   })
 
-  describe("when the disable cascade end times flag is turned on", () => {
+  describe("when the enable cascade end times flag is turned off", () => {
     beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ ARDisableCascadingEndTimerSalePageGrid: true })
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerSalePageGrid: false })
     })
     it("does not show the LotCloseInfo even if other conditions are met", () => {
       const saleArtwork = {

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -236,6 +236,7 @@ const artworkProps = (
       isClosed: saleArtwork == null,
       displayTimelyAt: "ends in 6d",
       endAt: "2020-08-26T02:50:09+00:00",
+      cascadingEndTimeIntervalMinutes: saleArtwork?.sale?.cascadingEndTimeIntervalMinutes || null,
     },
     saleArtwork,
     image: {

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -174,17 +174,15 @@ export const Artwork: React.FC<ArtworkProps> = ({
               <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
                 Lot {artwork.saleArtwork.lotLabel}
               </Text>
-              {!!artwork.sale &&
-                !!artwork.sale.cascadingEndTimeIntervalMinutes &&
-                !!cascadingEndTimeFeatureEnabled && (
-                  <DurationProvider startAt={artwork.saleArtwork.endAt!}>
-                    <LotCloseInfo
-                      duration={null}
-                      saleArtwork={artwork.saleArtwork}
-                      sale={artwork.sale}
-                    />
-                  </DurationProvider>
-                )}
+              {!!artwork.sale?.cascadingEndTimeIntervalMinutes && !!cascadingEndTimeFeatureEnabled && (
+                <DurationProvider startAt={artwork.saleArtwork.endAt!}>
+                  <LotCloseInfo
+                    duration={null}
+                    saleArtwork={artwork.saleArtwork}
+                    sale={artwork.sale}
+                  />
+                </DurationProvider>
+              )}
             </>
           )}
           {!!artwork.artistNames && (

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -137,7 +137,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
   const urgencyTag = getUrgencyTag(artwork?.sale?.endAt)
 
-  const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerSalePageGrid")
+  const cascadingEndTimeFeatureEnabled = useFeatureFlag("AREnableCascadingEndTimerSalePageGrid")
 
   return (
     <Touchable onPress={handleTap} testID={`artworkGridItem-${artwork.title}`}>

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -4,7 +4,7 @@ import { filterArtworksParams } from "app/Components/ArtworkFilter/ArtworkFilter
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "app/navigation/navigate"
-import { GlobalStore } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import {
   PlaceholderBox,
@@ -137,6 +137,8 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
   const urgencyTag = getUrgencyTag(artwork?.sale?.endAt)
 
+  const cascadingEndTimeFeatureEnabled = !useFeatureFlag("ARDisableCascadingEndTimerSalePageGrid")
+
   return (
     <Touchable onPress={handleTap} testID={`artworkGridItem-${artwork.title}`}>
       <View ref={itemRef}>
@@ -172,15 +174,17 @@ export const Artwork: React.FC<ArtworkProps> = ({
               <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
                 Lot {artwork.saleArtwork.lotLabel}
               </Text>
-              {!!artwork.sale && !!artwork.sale.cascadingEndTimeIntervalMinutes && (
-                <DurationProvider startAt={artwork.saleArtwork.endAt!}>
-                  <LotCloseInfo
-                    duration={null}
-                    saleArtwork={artwork.saleArtwork}
-                    sale={artwork.sale}
-                  />
-                </DurationProvider>
-              )}
+              {!!artwork.sale &&
+                !!artwork.sale.cascadingEndTimeIntervalMinutes &&
+                !!cascadingEndTimeFeatureEnabled && (
+                  <DurationProvider startAt={artwork.saleArtwork.endAt!}>
+                    <LotCloseInfo
+                      duration={null}
+                      saleArtwork={artwork.saleArtwork}
+                      sale={artwork.sale}
+                    />
+                  </DurationProvider>
+                )}
             </>
           )}
           {!!artwork.artistNames && (

--- a/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
+++ b/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
@@ -73,7 +73,7 @@ describe("LotCloseInfo", () => {
     // Sale has started, lots have not started closing, sale artwork's end date is less than a day away
     const sale = {
       startAt: "2017-05-09T11:12:48-04:00",
-      endAt: "2018-05-10T20:20:48-04:00",
+      endAt: "2018-05-11T09:20:48-04:00",
       ...basicSale,
     }
     const saleArtwork = {
@@ -95,10 +95,10 @@ describe("LotCloseInfo", () => {
   })
 
   it("shows the countdown when lots are actively closing", () => {
-    // Sale has started and lots have started closing
+    // Sale has started and lots have started closing (sale end time has passed)
     const sale = {
       startAt: "2017-05-09T11:12:48-04:00",
-      endAt: "2018-05-10T05:20:48-04:00",
+      endAt: "2018-05-09T05:20:48-04:00",
       ...basicSale,
     }
     const saleArtwork = {
@@ -119,7 +119,7 @@ describe("LotCloseInfo", () => {
     expect(lotCloseText.props.color).toEqual("black100")
   })
 
-  it.only("shows the countdown in red when lot is less than the cascade interval amount from closing", () => {
+  it("shows the countdown in red when lot is less than the cascade interval amount from closing", () => {
     // Sale artwork is <1 min from closing
     const sale = {
       startAt: "2017-05-09T11:12:48-04:00",

--- a/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
+++ b/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
@@ -1,0 +1,170 @@
+import { render } from "@testing-library/react-native"
+import { Theme } from "palette"
+import React from "react"
+import { DurationProvider } from "../Countdown"
+import { LotCloseInfo } from "./LotCloseInfo"
+
+// Today is Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
+Date.now = () => 1525983752000
+
+const basicSale = {
+  isAuction: true,
+  isClosed: false,
+  displayTimelyAt: null,
+  cascadingEndTimeIntervalMinutes: 1,
+}
+
+const basicSaleArtwork = {
+  counts: null,
+  formattedEndDateTime: "Formatted end date time",
+  currentBid: null,
+  lotLabel: "Lot 1",
+}
+
+describe("LotCloseInfo", () => {
+  it("does not show any lot close info when the sale has not started", () => {
+    // Sale start date in the future
+    const sale = {
+      startAt: "2019-04-19T11:12:48-04:00",
+      endAt: "2019-04-25T11:12:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2019-04-25T11:12:48-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    expect(() => getByText(/(Closed|Closes)$/)).toThrow()
+  })
+
+  it("shows the sale artwork's formatted end time when the sale has started but lots have not started closing", () => {
+    // Sale has started but sale end date is in the future
+    const sale = {
+      startAt: "2018-05-09T11:12:48-04:00",
+      endAt: "2018-05-25T11:12:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2018-05-25T11:12:48-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    const lotCloseText = getByText("Formatted end date time")
+
+    expect(lotCloseText).toBeTruthy()
+    expect(lotCloseText.props.color).toEqual("black60")
+  })
+
+  it("shows the countdown when lots are less than a day from closing", () => {
+    // Sale has started, lots have not started closing, sale artwork's end date is less than a day away
+    const sale = {
+      startAt: "2017-05-09T11:12:48-04:00",
+      endAt: "2018-05-10T20:20:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2018-05-11T10:50:50-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    const lotCloseText = getByText("Closes, 18h 28m")
+
+    expect(lotCloseText).toBeTruthy()
+    expect(lotCloseText.props.color).toEqual("black100")
+  })
+
+  it("shows the countdown when lots are actively closing", () => {
+    // Sale has started and lots have started closing
+    const sale = {
+      startAt: "2017-05-09T11:12:48-04:00",
+      endAt: "2018-05-10T05:20:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2018-05-11T10:50:50-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    const lotCloseText = getByText("Closes, 18h 28m")
+
+    expect(lotCloseText).toBeTruthy()
+    expect(lotCloseText.props.color).toEqual("black100")
+  })
+
+  it.only("shows the countdown in red when lot is less than the cascade interval amount from closing", () => {
+    // Sale artwork is <1 min from closing
+    const sale = {
+      startAt: "2017-05-09T11:12:48-04:00",
+      endAt: "2018-05-10T05:20:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2018-05-10T16:22:50-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    const lotCloseText = getByText("Closes, 0m 18s")
+
+    expect(lotCloseText).toBeTruthy()
+    expect(lotCloseText.props.color).toEqual("red100")
+  })
+
+  it("shows Closed when the sale is over", () => {
+    const sale = {
+      startAt: "2017-04-19T11:12:48-04:00",
+      endAt: "2017-04-25T11:12:48-04:00",
+      ...basicSale,
+    }
+    const saleArtwork = {
+      endAt: "2017-04-25T11:12:48-04:00",
+      ...basicSaleArtwork,
+    }
+    const { getByText } = render(
+      <Theme>
+        <DurationProvider startAt={saleArtwork.endAt}>
+          <LotCloseInfo duration={null} saleArtwork={saleArtwork} sale={sale} />
+        </DurationProvider>
+      </Theme>
+    )
+
+    const lotCloseText = getByText("Closed")
+
+    expect(lotCloseText).toBeTruthy()
+    expect(lotCloseText.props.color).toEqual("black60")
+  })
+})

--- a/src/app/Components/ArtworkGrids/LotCloseInfo.tsx
+++ b/src/app/Components/ArtworkGrids/LotCloseInfo.tsx
@@ -1,0 +1,54 @@
+import { ArtworkGridItem_artwork } from "__generated__/ArtworkGridItem_artwork.graphql"
+import { useTimer } from "app/utils/useTimer"
+import { Duration } from "moment"
+import { Text } from "palette"
+import { getTimerInfo } from "../Countdown/Ticker"
+
+interface LotCloseInfoProps {
+  saleArtwork: NonNullable<ArtworkGridItem_artwork["saleArtwork"]>
+  sale: NonNullable<ArtworkGridItem_artwork["sale"]>
+  duration: Duration | null
+}
+
+export const LotCloseInfo: React.FC<LotCloseInfoProps> = ({ saleArtwork, sale, duration }) => {
+  const { hasEnded: lotHasClosed } = useTimer(saleArtwork.endAt!, sale.startAt!)
+
+  const { hasEnded: lotsAreClosing, hasStarted: saleHasStarted } = useTimer(
+    sale.endAt!,
+    sale.startAt!
+  )
+
+  if (!saleHasStarted || !duration) {
+    return null
+  }
+
+  const timerCopy = getTimerInfo(duration, saleHasStarted)
+
+  let lotCloseCopy
+  let labelColor = "black60"
+
+  // Lot has already closed
+  if (lotHasClosed) {
+    lotCloseCopy = "Closed"
+  } else if (saleHasStarted) {
+    // Sale has started and lots are <24 hours from closing or are actively closing
+    if (duration.asDays() < 1 || lotsAreClosing) {
+      lotCloseCopy = `Closes, ${timerCopy.copy}`
+      if (duration.hours() < 1 && duration.minutes() < sale.cascadingEndTimeIntervalMinutes!) {
+        labelColor = "red100"
+      } else {
+        labelColor = "black100"
+      }
+    }
+    // Sale has started but lots have not started closing
+    else {
+      lotCloseCopy = saleArtwork.formattedEndDateTime
+    }
+  }
+
+  return (
+    <Text variant="xs" color={labelColor}>
+      {lotCloseCopy}
+    </Text>
+  )
+}

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -1,3 +1,4 @@
+import { Time } from "app/utils/useTimer"
 import { Duration } from "moment"
 import { Flex, Sans, Text } from "palette"
 import React from "react"
@@ -91,7 +92,14 @@ interface ModernTickerProps {
 }
 
 export const ModernTicker: React.FC<ModernTickerProps> = ({ duration, hasStarted }) => {
-  const timerInfo = getTimerInfo(duration, hasStarted)
+  console.log(duration)
+  const time: Time = {
+    days: duration.asDays().toString(),
+    hours: duration.hours().toString(),
+    minutes: duration.minutes().toString(),
+    seconds: duration.seconds().toString(),
+  }
+  const timerInfo = getTimerInfo(time, hasStarted)
 
   return <Text color={timerInfo.color}>{timerInfo.copy}</Text>
 }
@@ -101,16 +109,13 @@ interface TimerInfo {
   color: string
 }
 
-export const getTimerInfo = (duration: Duration, hasStarted?: boolean): TimerInfo => {
-  const days = duration.asDays()
-  const hours = duration.hours()
-  const minutes = duration.minutes()
-  const seconds = duration.seconds()
+export const getTimerInfo = (time: Time, hasStarted?: boolean): TimerInfo => {
+  const { days, hours, minutes, seconds } = time
 
-  const parsedDays = parseInt(days.toString(), 10)
-  const parsedHours = parseInt(hours.toString(), 10)
-  const parsedMinutes = parseInt(minutes.toString(), 10)
-  const parsedSeconds = parseInt(seconds.toString(), 10)
+  const parsedDays = parseInt(days, 10)
+  const parsedHours = parseInt(hours, 10)
+  const parsedMinutes = parseInt(minutes, 10)
+  const parsedSeconds = parseInt(seconds, 10)
 
   let copy = ""
   let color = "blue100"

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -1,4 +1,3 @@
-import { Time } from "app/utils/useTimer"
 import { Duration } from "moment"
 import { Flex, Sans, Text } from "palette"
 import React from "react"
@@ -92,14 +91,7 @@ interface ModernTickerProps {
 }
 
 export const ModernTicker: React.FC<ModernTickerProps> = ({ duration, hasStarted }) => {
-  console.log(duration)
-  const time: Time = {
-    days: duration.asDays().toString(),
-    hours: duration.hours().toString(),
-    minutes: duration.minutes().toString(),
-    seconds: duration.seconds().toString(),
-  }
-  const timerInfo = getTimerInfo(time, hasStarted)
+  const timerInfo = getTimerInfo(duration, hasStarted)
 
   return <Text color={timerInfo.color}>{timerInfo.copy}</Text>
 }
@@ -109,13 +101,16 @@ interface TimerInfo {
   color: string
 }
 
-export const getTimerInfo = (time: Time, hasStarted?: boolean): TimerInfo => {
-  const { days, hours, minutes, seconds } = time
+export const getTimerInfo = (duration: Duration, hasStarted?: boolean): TimerInfo => {
+  const days = duration.asDays()
+  const hours = duration.hours()
+  const minutes = duration.minutes()
+  const seconds = duration.seconds()
 
-  const parsedDays = parseInt(days, 10)
-  const parsedHours = parseInt(hours, 10)
-  const parsedMinutes = parseInt(minutes, 10)
-  const parsedSeconds = parseInt(seconds, 10)
+  const parsedDays = parseInt(days.toString(), 10)
+  const parsedHours = parseInt(hours.toString(), 10)
+  const parsedMinutes = parseInt(minutes.toString(), 10)
+  const parsedSeconds = parseInt(seconds.toString(), 10)
 
   let copy = ""
   let color = "blue100"

--- a/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
+++ b/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
@@ -124,60 +124,9 @@ export const SaleArtworkTileRailCard: React.FC<SaleArtworkTileRailCardProps> = (
 
   const lotNumber = saleArtwork.lotLabel ? (
     <Text numberOfLines={1} lineHeight="20" variant="sm">
-      Lot {saleArtwork.lotLabel} HI
+      Lot {saleArtwork.lotLabel}
     </Text>
   ) : null
-
-  const lotCloseInfo = saleArtwork.sale?.cascadingEndTimeIntervalMinutes && <Text>"Closed"</Text>
-
-  // const LotCloseInfo: React.FC<LotCloseInfoProps> = ({
-  //   saleArtwork,
-  //   sale,
-  // }) => {
-  //   const { hasEnded: lotHasClosed, time } = useTimer(
-  //     saleArtwork.endAt!,
-  //     sale.startAt!
-  //   )
-
-  //   const { hasEnded: lotsAreClosing, hasStarted: saleHasStarted } = useTimer(
-  //     sale.endAt!,
-  //     sale.startAt!
-  //   )
-
-  //   if (!saleHasStarted) {
-  //     return null
-  //   }
-
-  //   const timerCopy = getTimerCopy(time, saleHasStarted)
-
-  //   let lotCloseCopy
-  //   let labelColor = "black60"
-
-  //   // Lot has already closed
-  //   if (lotHasClosed) {
-  //     lotCloseCopy = "Closed"
-  //   } else if (saleHasStarted) {
-  //     // Sale has started and lots are <24 hours from closing or are actively closing
-  //     if (parseInt(time.days) < 1 || lotsAreClosing) {
-  //       lotCloseCopy = `Closes, ${timerCopy.copy}`
-  //       if (timerCopy.color === "red100") {
-  //         labelColor = "red100"
-  //       } else {
-  //         labelColor = "black100"
-  //       }
-  //     }
-  //     // Sale has started but lots have not started closing
-  //     else {
-  //       lotCloseCopy = saleArtwork.formattedEndDateTime
-  //     }
-  //   }
-
-  //   return (
-  //     <Text variant="xs" color={labelColor}>
-  //       {lotCloseCopy}
-  //     </Text>
-  //   )
-  // }
 
   return (
     <SaleArtworkCard onPress={handleTap}>
@@ -185,7 +134,6 @@ export const SaleArtworkTileRailCard: React.FC<SaleArtworkTileRailCardProps> = (
         {imageDisplay}
         <Box mt={1} width={CONTAINER_HEIGHT}>
           {lotNumber}
-          {lotCloseInfo}
           {artistNamesDisplay}
           {titleAndDateDisplay}
           {customSaleMessage ? customSaleMessageDisplay : saleMessageDisplay}

--- a/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
+++ b/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
@@ -124,9 +124,60 @@ export const SaleArtworkTileRailCard: React.FC<SaleArtworkTileRailCardProps> = (
 
   const lotNumber = saleArtwork.lotLabel ? (
     <Text numberOfLines={1} lineHeight="20" variant="sm">
-      Lot {saleArtwork.lotLabel}
+      Lot {saleArtwork.lotLabel} HI
     </Text>
   ) : null
+
+  const lotCloseInfo = saleArtwork.sale?.cascadingEndTimeIntervalMinutes && <Text>"Closed"</Text>
+
+  // const LotCloseInfo: React.FC<LotCloseInfoProps> = ({
+  //   saleArtwork,
+  //   sale,
+  // }) => {
+  //   const { hasEnded: lotHasClosed, time } = useTimer(
+  //     saleArtwork.endAt!,
+  //     sale.startAt!
+  //   )
+
+  //   const { hasEnded: lotsAreClosing, hasStarted: saleHasStarted } = useTimer(
+  //     sale.endAt!,
+  //     sale.startAt!
+  //   )
+
+  //   if (!saleHasStarted) {
+  //     return null
+  //   }
+
+  //   const timerCopy = getTimerCopy(time, saleHasStarted)
+
+  //   let lotCloseCopy
+  //   let labelColor = "black60"
+
+  //   // Lot has already closed
+  //   if (lotHasClosed) {
+  //     lotCloseCopy = "Closed"
+  //   } else if (saleHasStarted) {
+  //     // Sale has started and lots are <24 hours from closing or are actively closing
+  //     if (parseInt(time.days) < 1 || lotsAreClosing) {
+  //       lotCloseCopy = `Closes, ${timerCopy.copy}`
+  //       if (timerCopy.color === "red100") {
+  //         labelColor = "red100"
+  //       } else {
+  //         labelColor = "black100"
+  //       }
+  //     }
+  //     // Sale has started but lots have not started closing
+  //     else {
+  //       lotCloseCopy = saleArtwork.formattedEndDateTime
+  //     }
+  //   }
+
+  //   return (
+  //     <Text variant="xs" color={labelColor}>
+  //       {lotCloseCopy}
+  //     </Text>
+  //   )
+  // }
 
   return (
     <SaleArtworkCard onPress={handleTap}>
@@ -134,6 +185,7 @@ export const SaleArtworkTileRailCard: React.FC<SaleArtworkTileRailCardProps> = (
         {imageDisplay}
         <Box mt={1} width={CONTAINER_HEIGHT}>
           {lotNumber}
+          {lotCloseInfo}
           {artistNamesDisplay}
           {titleAndDateDisplay}
           {customSaleMessage ? customSaleMessageDisplay : saleMessageDisplay}
@@ -171,6 +223,7 @@ export const SaleArtworkTileRailCardContainer = createFragmentContainer(SaleArtw
         isAuction
         isClosed
         displayTimelyAt
+        cascadingEndTimeIntervalMinutes
       }
     }
   `,

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -106,6 +106,12 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnableCascadingEndTimerLotPage",
   },
+  ARDisableCascadingEndTimerSalePageGrid: {
+    readyForRelease: false,
+    description: "Disable cascading end times on the sale page lot grid",
+    showInAdminMenu: true,
+    echoFlagKey: "ARDisableCascadingEndTimerLotPage",
+  },
   AREnableImageSearch: {
     readyForRelease: false,
     description: "Enable search with image",

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -106,11 +106,11 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnableCascadingEndTimerLotPage",
   },
-  ARDisableCascadingEndTimerSalePageGrid: {
-    readyForRelease: false,
-    description: "Disable cascading end times on the sale page lot grid",
+  AREnableCascadingEndTimerSalePageGrid: {
+    readyForRelease: true,
+    description: "Enable cascading end times on the sale page lot grid",
     showInAdminMenu: true,
-    echoFlagKey: "ARDisableCascadingEndTimerLotPage",
+    echoFlagKey: "AREnableCascadingEndTimerSalePageGrid",
   },
   AREnableImageSearch: {
     readyForRelease: false,

--- a/src/app/utils/useTimer.tsx
+++ b/src/app/utils/useTimer.tsx
@@ -1,0 +1,55 @@
+import { DateTime, Duration } from "luxon"
+
+export interface Time {
+  days: string
+  hours: string
+  minutes: string
+  seconds: string
+}
+
+interface Timer {
+  hasEnded: boolean
+  time: Time
+  hasStarted: boolean
+}
+
+const padWithZero = (num: number) => {
+  return num.toString().padStart(2, "0")
+}
+
+const extractTime = (time: number) => {
+  return padWithZero(Math.max(0, Math.floor(time)))
+}
+
+export const useTimer = (endDate: string, startAt: string = ""): Timer => {
+  const currentTime = DateTime.local().toString()
+
+  const timeBeforeEnd = Duration.fromISO(
+    DateTime.fromISO(endDate).diff(DateTime.fromISO(currentTime)).toString()
+  )
+  const hasEnded = Math.floor(timeBeforeEnd.seconds) <= 0
+
+  const timeBeforeStart = Duration.fromISO(
+    DateTime.fromISO(startAt).diff(DateTime.fromISO(currentTime)).toString()
+  )
+
+  const hasStarted = Math.floor(timeBeforeStart.seconds) <= 0
+
+  // If startAt is passed into this hook and it is in the future,
+  // show the time before start. Otherwise show the time before end.
+  const duration = hasStarted || startAt === "" ? timeBeforeEnd : timeBeforeStart
+
+  const days = extractTime(duration.as("days"))
+  const hours = extractTime(duration.as("hours") % 24)
+  const minutes = extractTime(duration.as("minutes") % 60)
+  const seconds = extractTime(duration.as("seconds") % 60)
+
+  const time = {
+    days,
+    hours,
+    minutes,
+    seconds,
+  }
+
+  return { hasEnded, time, hasStarted }
+}


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [BX-294](https://artsyproduct.atlassian.net/browse/BID-294)

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR adds the countdown timer to the lot grid on the sale page for sales with cascading end times turned on:

Lots are in the middle of closing:
<img width="418" alt="Screen Shot 2022-04-19 at 11 39 36 AM" src="https://user-images.githubusercontent.com/9466631/164044173-3c202dfe-f141-4bd0-abde-ac2d10b7cf78.png">

Lot is less than the cascade end interval (1 min) from closing:
<img width="408" alt="Screen Shot 2022-04-19 at 11 38 31 AM" src="https://user-images.githubusercontent.com/9466631/164044128-2accaaa6-16a1-4da5-ab69-7d9d5f2bc6a9.png">

Lots are minutes from closing:
<img width="396" alt="Screen Shot 2022-04-19 at 11 37 12 AM" src="https://user-images.githubusercontent.com/9466631/164044080-82df632c-3a8a-4b38-91aa-e7c3770f5abc.png">

Lots are hours from closing:
<img width="408" alt="Screen Shot 2022-04-19 at 11 26 51 AM" src="https://user-images.githubusercontent.com/9466631/164044039-55b4f341-f90c-4ce0-9a06-712a3fccaa00.png">

When the sale is open but lots are more than a day from closing (formatted lot end time):
<img width="407" alt="Screen Shot 2022-04-19 at 11 04 48 AM" src="https://user-images.githubusercontent.com/9466631/164043948-2fe70f51-75f5-479a-9aa0-8511af656763.png">

When the sale is not yet open (no label):
<img width="405" alt="Screen Shot 2022-04-19 at 10 39 32 AM" src="https://user-images.githubusercontent.com/9466631/164043901-152289f4-1bf7-4025-926d-d49d0b89a134.png">


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
