### PR TITLE
Fix (BX-357): Fix negative confirm bid timers

### DIFF
--- a/src/app/Components/Bidding/Screens/BidResult.tests.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tests.tsx
@@ -213,7 +213,7 @@ describe("BidResult component", () => {
 
       it("shows the sale's end time if the sale does not have cascading end times", () => {
         const { getByText } = renderWithWrappersTL(<BidResult {...propsForNonCascadingSale} />)
-        // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+        // Today is May 10. Sale artwork's end time null. Sale's end day is May 10.
         const timerText = getByText("00d 00h 00m 10s")
         expect(timerText).toBeTruthy()
       })

--- a/src/app/Components/Bidding/Screens/BidResult.tests.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tests.tsx
@@ -1,7 +1,7 @@
 import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.graphql"
 import { dismissModal, navigate } from "app/navigation/navigate"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { renderWithWrappers, renderWithWrappersTL } from "app/tests/renderWithWrappers"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { shallow } from "enzyme"
 import { Button } from "palette"
@@ -195,6 +195,42 @@ describe("BidResult component", () => {
       })
     })
   })
+
+  describe("cascading end times", () => {
+    describe("with cascading end times turned on", () => {
+      beforeEach(() => {
+        Date.now = () => 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerLotPage: true })
+      })
+
+      it("shows the sale artwork's end time if the sale has cascading end times", () => {
+        const { getByText } = renderWithWrappersTL(<BidResult {...propsForCascadingSale} />)
+        // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+
+        const timerText = getByText("03d 00h 00m 10s")
+        expect(timerText).toBeTruthy()
+      })
+
+      it("shows the sale's end time if the sale does not have cascading end times", () => {
+        const { getByText } = renderWithWrappersTL(<BidResult {...propsForNonCascadingSale} />)
+        // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+        const timerText = getByText("00d 00h 00m 10s")
+        expect(timerText).toBeTruthy()
+      })
+    })
+
+    describe("with cacsading end time feature disabled", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerLotPage: false })
+      })
+      it("shows the sale's end time", () => {
+        const { getByText } = renderWithWrappersTL(<BidResult {...propsForCascadingSale} />)
+        // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+        const timerText = getByText("00d 00h 00m 10s")
+        expect(timerText).toBeTruthy()
+      })
+    })
+  })
 })
 
 const Statuses = {
@@ -224,4 +260,44 @@ const Statuses = {
     `,
     position: null,
   } as BidderPositionResult,
+}
+
+const cascadingSaleArtwork: BidResult_sale_artwork = {
+  endAt: "2018-05-13T20:22:42+00:00",
+  sale: {
+    liveStartAt: null,
+    endAt: "2018-05-10T20:22:42+00:00",
+    slug: "sale-id",
+    cascadingEndTimeIntervalMinutes: 1,
+  },
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $refType": null, // needs this to keep TS happy
+}
+
+const nonCascadingSaleArtwork: BidResult_sale_artwork = {
+  endAt: null,
+  sale: {
+    liveStartAt: null,
+    endAt: "2018-05-10T20:22:42+00:00",
+    slug: "sale-id",
+    cascadingEndTimeIntervalMinutes: null,
+  },
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $refType": null, // needs this to keep TS happy
+}
+
+const propsForCascadingSale = {
+  refreshBidderInfo: refreshBidderInfoMock,
+  refreshSaleArtwork: refreshSaleArtworkInfoMock,
+  bidderPositionResult: Statuses.outbid,
+  sale_artwork: cascadingSaleArtwork,
+  navigator: jest.fn() as any,
+}
+
+const propsForNonCascadingSale = {
+  refreshBidderInfo: refreshBidderInfoMock,
+  refreshSaleArtwork: refreshSaleArtworkInfoMock,
+  bidderPositionResult: Statuses.outbid,
+  sale_artwork: nonCascadingSaleArtwork,
+  navigator: jest.fn() as any,
 }

--- a/src/app/Components/Bidding/Screens/BidResult.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tsx
@@ -17,7 +17,7 @@ import { BidderPositionResult } from "../types"
 
 import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
-import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
+import { unsafe__getEnvironment, unsafe_getFeatureFlag } from "app/store/GlobalStore"
 
 const SHOW_TIMER_STATUSES = ["WINNING", "OUTBID", "RESERVE_NOT_MET"]
 

--- a/src/app/Components/Bidding/Screens/BidResult.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tsx
@@ -17,7 +17,7 @@ import { BidderPositionResult } from "../types"
 
 import { BidResult_sale_artwork } from "__generated__/BidResult_sale_artwork.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
-import { unsafe__getEnvironment } from "app/store/GlobalStore"
+import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 
 const SHOW_TIMER_STATUSES = ["WINNING", "OUTBID", "RESERVE_NOT_MET"]
 
@@ -96,8 +96,11 @@ export class BidResult extends React.Component<BidResultProps> {
   render() {
     const { sale_artwork, bidderPositionResult } = this.props
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-    const { liveStartAt, endAt } = sale_artwork.sale
+    const { liveStartAt, endAt: saleEndAt, cascadingEndTimeIntervalMinutes } = sale_artwork.sale
     const { status, message_header, message_description_md } = bidderPositionResult
+
+    const casacadingEndTimeFeatureEnabled =
+      unsafe_getFeatureFlag("AREnableCascadingEndTimerLotPage") && cascadingEndTimeIntervalMinutes
 
     return (
       <View style={{ flex: 1 }}>
@@ -126,7 +129,10 @@ export class BidResult extends React.Component<BidResultProps> {
                 </Markdown>
               )}
               {!!this.shouldDisplayTimer(status) && (
-                <Timer liveStartsAt={liveStartAt} endsAt={endAt} />
+                <Timer
+                  liveStartsAt={liveStartAt}
+                  endsAt={casacadingEndTimeFeatureEnabled ? sale_artwork.endAt : saleEndAt}
+                />
               )}
             </Flex>
           </View>
@@ -156,10 +162,12 @@ export class BidResult extends React.Component<BidResultProps> {
 export const BidResultScreen = createFragmentContainer(BidResult, {
   sale_artwork: graphql`
     fragment BidResult_sale_artwork on SaleArtwork {
+      endAt
       sale {
         liveStartAt
         endAt
         slug
+        cascadingEndTimeIntervalMinutes
       }
     }
   `,

--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -10,7 +10,7 @@ import Spinner from "app/Components/Spinner"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { renderWithWrappers, renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import { waitUntil } from "app/tests/waitUntil"
 import { merge } from "lodash"
 import { Button, LinkText, Sans, Serif, Text } from "palette"
@@ -28,6 +28,8 @@ import { BillingAddress } from "./BillingAddress"
 import { ConfirmBid, ConfirmBidProps } from "./ConfirmBid"
 import { CreditCardForm } from "./CreditCardForm"
 import { SelectMaxBid } from "./SelectMaxBid"
+
+Date.now = () => 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
 
 jest.mock("app/Components/Bidding/Screens/ConfirmBid/BidderPositionQuery", () => ({
   bidderPositionQuery: jest.fn(),
@@ -581,6 +583,7 @@ describe("polling to verify bid position", () => {
           refreshBidderInfo: expect.anything(),
           refreshSaleArtwork: expect.anything(),
           sale_artwork: {
+            endAt: null,
             id: "node-id",
             internalID: "internal-id",
             " $fragmentRefs": null,
@@ -596,6 +599,8 @@ describe("polling to verify bid position", () => {
             },
             lot_label: "538",
             sale: {
+              start_at: "2018-05-08T20:22:42+00:00",
+              cascadingEndTimeIntervalMinutes: null,
               end_at: "2018-05-10T20:22:42+00:00",
               isBenefit: false,
               live_start_at: "2018-05-09T20:22:42+00:00",
@@ -905,6 +910,46 @@ describe("ConfirmBid for unqualified user", () => {
   })
 })
 
+describe("cascading end times", () => {
+  beforeEach(() => {
+    Date.now = () => 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
+  })
+
+  describe("with cacsading end time feature enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerLotPage: true })
+    })
+
+    it("shows the sale artwork's end time if the sale has cascading end times", () => {
+      const { getByText } = renderWithWrappersTL(<ConfirmBid {...initialPropsForCascadingSale} />)
+      // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+      const timerText = getByText("03d 00h 00m 10s")
+      expect(timerText).toBeTruthy()
+    })
+
+    it("shows the sale's end time if the sale does not have cascading end times", () => {
+      const { getByText } = renderWithWrappersTL(
+        <ConfirmBid {...initialPropsForNonCascadingSale} />
+      )
+      // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+      const timerText = getByText("00d 00h 00m 10s")
+      expect(timerText).toBeTruthy()
+    })
+  })
+
+  describe("with cacsading end time feature disabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCascadingEndTimerLotPage: false })
+    })
+    it("shows the sale's end time", () => {
+      const { getByText } = renderWithWrappersTL(<ConfirmBid {...initialPropsForCascadingSale} />)
+      // Today is May 10. Sale artwork's end time is May 13. Sale's end day is May 10.
+      const timerText = getByText("00d 00h 00m 10s")
+      expect(timerText).toBeTruthy()
+    })
+  })
+})
+
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 const serifChildren = (comp) =>
   comp.root
@@ -913,7 +958,7 @@ const serifChildren = (comp) =>
     .map((c) => (c.props.children.join ? c.props.children.join("") : c.props.children))
     .join(" ")
 
-const saleArtwork: ConfirmBid_sale_artwork = {
+const baseSaleArtwork = {
   id: "node-id",
   internalID: "internal-id",
   artwork: {
@@ -927,7 +972,7 @@ const saleArtwork: ConfirmBid_sale_artwork = {
   },
   sale: {
     slug: "best-art-sale-in-town",
-    live_start_at: "2018-05-09T20:22:42+00:00",
+    start_at: "2018-05-08T20:22:42+00:00",
     end_at: "2018-05-10T20:22:42+00:00",
     isBenefit: false,
     partner: {
@@ -935,6 +980,47 @@ const saleArtwork: ConfirmBid_sale_artwork = {
     },
   },
   lot_label: "538",
+}
+
+const saleArtwork: ConfirmBid_sale_artwork = {
+  ...baseSaleArtwork,
+  endAt: null,
+  sale: {
+    ...baseSaleArtwork.sale,
+    live_start_at: "2018-05-09T20:22:42+00:00",
+    cascadingEndTimeIntervalMinutes: null,
+  },
+
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $fragmentRefs": null, // needs this to keep TS happy
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $refType": null, // needs this to keep TS happy
+}
+
+const nonCascadeSaleArtwork: ConfirmBid_sale_artwork = {
+  ...baseSaleArtwork,
+  endAt: null,
+  sale: {
+    ...baseSaleArtwork.sale,
+    live_start_at: null,
+    cascadingEndTimeIntervalMinutes: null,
+  },
+
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $fragmentRefs": null, // needs this to keep TS happy
+  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+  " $refType": null, // needs this to keep TS happy
+}
+
+const cascadingEndTimeSaleArtwork: ConfirmBid_sale_artwork = {
+  ...saleArtwork,
+  endAt: "2018-05-13T20:22:42+00:00",
+  sale: {
+    ...baseSaleArtwork.sale,
+    live_start_at: null,
+    cascadingEndTimeIntervalMinutes: 1,
+  },
+
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   " $fragmentRefs": null, // needs this to keep TS happy
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -1114,3 +1200,13 @@ const initialPropsForRegisteredUser = {
     bidders: [{ qualified_for_bidding: true }],
   },
 } as any
+
+const initialPropsForCascadingSale = {
+  ...initialProps,
+  sale_artwork: cascadingEndTimeSaleArtwork,
+}
+
+const initialPropsForNonCascadingSale = {
+  ...initialProps,
+  sale_artwork: nonCascadeSaleArtwork,
+}

--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -452,13 +452,18 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   render() {
-    const { id, artwork, lot_label, sale } = this.props.sale_artwork
+    const { sale_artwork } = this.props
+    const { id, artwork, lot_label, sale } = sale_artwork
     const { requiresPaymentInformation, requiresCheckbox, isLoading } = this.state
     // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
     const artworkImage = artwork.image
 
     // GOTCHA: Don't copy this kind of feature flag code if you're working in a functional component. use `useFeatureFlag` instead
     const enablePriceTransparency = unsafe_getFeatureFlag("AROptionsPriceTransparency")
+
+    const casacadingEndTimeFeatureEnabled =
+      unsafe_getFeatureFlag("AREnableCascadingEndTimerLotPage") &&
+      sale?.cascadingEndTimeIntervalMinutes
 
     return (
       <Flex m={0} flex={1} flexDirection="column">
@@ -473,7 +478,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
               // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
               liveStartsAt={sale.live_start_at}
               // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-              endsAt={sale.end_at}
+              endsAt={casacadingEndTimeFeatureEnabled ? sale_artwork.endAt : sale.end_at}
             />
           </Flex>
 
@@ -636,6 +641,7 @@ export const ConfirmBidScreen = createRefetchContainer(
           live_start_at: liveStartAt
           end_at: endAt
           isBenefit
+          cascadingEndTimeIntervalMinutes
           partner {
             name
           }
@@ -650,6 +656,7 @@ export const ConfirmBidScreen = createRefetchContainer(
           }
         }
         lot_label: lotLabel
+        endAt
         ...BidResult_sale_artwork
       }
     `,


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [BX-357](https://artsyproduct.atlassian.net/browse/BID-357)

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

During QA, we discovered that the app has additional surfaces that use a timer component (on the confirm id modal). That timer component was always receiving the sale's `endAt` date even if the sale had cascading end times turned on. The result was that the the timer countdown showed a negative number when a user placed bids as lots were closing because the sale level end date had passed, but the lots were still open. The fix is to pass in the sale artwork's `endAt` date to the timer if the sale has cascading end times so the countdown will show time left on the lot, not on the sale.

The results: 

<img width="387" alt="Screen Shot 2022-04-20 at 3 27 29 PM" src="https://user-images.githubusercontent.com/9466631/164463927-e172834e-2357-4582-98d0-a450ca3934b7.png">

<img width="399" alt="Screen Shot 2022-04-20 at 3 27 43 PM" src="https://user-images.githubusercontent.com/9466631/164463914-077622ab-6dc6-41db-8412-d6d2b64502e6.png">

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
