### PR TITLE
feat(BX-211): Update labels for sale details when a sale has cascading end times turned on

### DIFF
--- a/src/app/Scenes/Sale/SaleHeader.tests.tsx
+++ b/src/app/Scenes/Sale/SaleHeader.tests.tsx
@@ -1,8 +1,9 @@
 import { SaleHeaderTestsQuery } from "__generated__/SaleHeaderTestsQuery.graphql"
 import { CaretButton } from "app/Components/Buttons/CaretButton"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { extractText } from "app/tests/extractText"
-import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { renderWithWrappers, renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import moment from "moment"
 import React from "react"
 import { Animated } from "react-native"
@@ -85,6 +86,37 @@ describe("SaleHeader", () => {
     )
   })
 
+  describe("when the cascading end time feature flag is on", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableCascadingEndTimerSalePageDetails: true,
+      })
+    })
+
+    it("does not render auction is closed when cascading end time is enabled", () => {
+      const { queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+      mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation, {
+          Sale: () => ({
+            endAt: moment().subtract(1, "day").toISOString(),
+            startAt: "2020-09-01T15:00:00",
+            timeZone: "Europe/Berlin",
+            coverImage: {
+              url: "cover image url",
+            },
+            name: "sale name",
+            liveStartAt: "2020-09-01T15:00:00",
+            internalID: "the-sale-internal",
+            cascadingEndTimeIntervalMinutes: 1,
+          }),
+        })
+      )
+
+      expect(queryByText("Auction closed")).toBeFalsy()
+    })
+  })
+
   it("does not render auction is closed when an auction is still active", () => {
     const tree = renderWithWrappers(<TestRenderer />)
 
@@ -105,5 +137,75 @@ describe("SaleHeader", () => {
     )
 
     expect(extractText(tree.root.findAllByType(OpaqueImageView)[0])).not.toContain("Auction closed")
+  })
+
+  describe("cascading end times", () => {
+    const baseSale = {
+      timeZone: "Europe/Berlin",
+      coverImage: {
+        url: "cover image url",
+      },
+      name: "sale name",
+      liveStartAt: "2020-09-01T15:00:00",
+      internalID: "the-sale-internal",
+    }
+
+    beforeEach(() => {
+      Date.now = () => 1525983752000 // Thursday, May 10, 2018 8:22:32.000 PM UTC in milliseconds
+    })
+
+    describe("when the cascade end time flag is turned on", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableCascadingEndTimerSalePageDetails: true,
+        })
+      })
+
+      it("shows the cascading end time label", () => {
+        const { getByText } = renderWithWrappersTL(<TestRenderer />)
+
+        mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+          MockPayloadGenerator.generate(operation, {
+            Sale: () => ({
+              endAt: "2018-05-16T15:00:00",
+              startAt: "2018-05-13T15:00:00",
+              endedAt: null,
+              cascadingEndTimeIntervalMinutes: 1,
+              ...baseSale,
+            }),
+          })
+        )
+
+        const cascadeEndTimeLabel = getByText("Lots close at 1-minute intervals")
+        expect(cascadeEndTimeLabel).toBeTruthy()
+      })
+    })
+
+    describe("when the cascade end time flag is turned off", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableCascadingEndTimerSalePageDetails: false,
+        })
+      })
+
+      it("does not show the cascading end time label", () => {
+        const { queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+        mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+          MockPayloadGenerator.generate(operation, {
+            Sale: () => ({
+              endAt: "2018-05-10T18:00:00",
+              startAt: "2018-05-13T15:00:00",
+              endedAt: null,
+              cascadingEndTimeIntervalMinutes: 1,
+              ...baseSale,
+            }),
+          })
+        )
+
+        const cascadeEndTimeLabel = queryByText("Lots close at 1-minute intervals")
+        expect(cascadeEndTimeLabel).toBeFalsy()
+      })
+    })
   })
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -106,6 +106,12 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnableCascadingEndTimerLotPage",
   },
+  AREnableCascadingEndTimerSalePageDetails: {
+    readyForRelease: true,
+    description: "Enable cascading end times on the sale page details",
+    showInAdminMenu: true,
+    echoFlagKey: "AREnableCascadingEndTimerSalePageDetails",
+  },
   AREnableCascadingEndTimerSalePageGrid: {
     readyForRelease: true,
     description: "Enable cascading end times on the sale page lot grid",

--- a/src/app/utils/saleTime.ts
+++ b/src/app/utils/saleTime.ts
@@ -134,3 +134,58 @@ const ends = (now: moment.Moment, endDate: moment.Moment): string | null => {
     return null
   }
 }
+
+const getAbsoluteTime = (
+  saleStartMoment: moment.Moment | null,
+  saleEndMoment: moment.Moment | null,
+  saleEndedMoment: moment.Moment | null,
+  userTimeZone: string
+): string | null => {
+  const thisMoment = moment.tz(moment(), userTimeZone)
+  if (saleStartMoment && thisMoment.isBefore(saleStartMoment)) {
+    return `${saleStartMoment.format("MMM D, YYYY")} • ${saleStartMoment.format("h:mma z")}`
+  } else if (saleEndedMoment && thisMoment.isAfter(saleEndedMoment)) {
+    return `Closed ${saleEndedMoment.format("MMM D, YYYY")} • ${saleEndedMoment.format("h:mma z")}`
+  } else if (saleEndMoment) {
+    return `${saleEndMoment.format("MMM D, YYYY")} • ${saleEndMoment.format("h:mma z")}`
+  } else {
+    return null
+  }
+}
+
+export const getCascadingEndTimeFeatureSaleDetails = (
+  sale: {
+    startAt: string | null
+    endAt: string | null
+    endedAt: string | null
+    timeZone: string | null
+  } | null
+): { absolute: string | null; relative: { copy: string; color: string } | null } => {
+  if (!sale?.timeZone || !sale.endAt || !sale.startAt) {
+    return { absolute: null, relative: null }
+  }
+
+  // TODO: Implement function to return relative time for cascade end time feature
+  const relativeTime = null
+  const userTimeZone = moment.tz.guess()
+  const startDateMoment =
+    sale.startAt !== null
+      ? moment.tz(sale.startAt, moment.ISO_8601, sale.timeZone).tz(userTimeZone)
+      : null
+  const endDateMoment =
+    sale.endAt !== null
+      ? moment.tz(sale.endAt, moment.ISO_8601, sale.timeZone).tz(userTimeZone)
+      : null
+  const endedDateMoment =
+    sale.endedAt !== null
+      ? moment.tz(sale.endedAt, moment.ISO_8601, sale.timeZone).tz(userTimeZone)
+      : null
+
+  const absoluteTime = getAbsoluteTime(
+    startDateMoment,
+    endDateMoment,
+    endedDateMoment,
+    userTimeZone
+  )
+  return { absolute: absoluteTime, relative: relativeTime }
+}


### PR DESCRIPTION

<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [BX-211](https://artsyproduct.atlassian.net/browse/BID-211)

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This work just updates the label that shows the absolute time for the sale and when it's closed and removes the auction closed label so it doesn't appear before the lots finish closing. 

Before the sale opens (shows the sale open time):
<img width="217" alt="Screen Shot 2022-04-21 at 5 16 31 PM" src="https://user-images.githubusercontent.com/9466631/164553666-7caa1c74-f0d8-49ee-816d-83edcfd44ef8.png">

After the sale opens (shows the sale end time) and as the lots are closing:
(This currently says the auction is closed, so even though this label isn't ideal, it's much less confusing than the current experience)
<img width="243" alt="Screen Shot 2022-04-21 at 5 18 37 PM" src="https://user-images.githubusercontent.com/9466631/164553983-849d970c-7a38-445c-aa21-8e5a3a567cc7.png">

After the sale ends (shows that the sale is closed):
<img width="267" alt="Screen Shot 2022-04-21 at 5 32 13 PM" src="https://user-images.githubusercontent.com/9466631/164555698-620c4061-8aca-48d3-9053-dc405d2313c4.png">


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
