### PR TITLE
chore(CX-2520): clean up feature flag AREnableMyCollectionComparableWorks

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -3,7 +3,7 @@ import { MyCollectionArtworkQuery } from "__generated__/MyCollectionArtworkQuery
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { goBack, navigate, popToRoot } from "app/navigation/navigate"
-import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore } from "app/store/GlobalStore"
 import { PlaceholderBox, ProvidePlaceholderContext } from "app/utils/placeholders"
 import { compact } from "lodash"
 import { Flex, Text } from "palette/elements"
@@ -64,8 +64,6 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
     medium,
   })
 
-  const enableMyCollectionComparableWorks = useFeatureFlag("AREnableMyCollectionComparableWorks")
-
   const comparableWorksCount = data?.artwork?.comparableAuctionResults?.totalCount
   const auctionResultsCount = data?.artwork?.artist?.auctionResultsConnection?.totalCount
 
@@ -93,7 +91,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const shouldShowInsightsTab =
     !!data?._marketPriceInsights ||
-    (!!enableMyCollectionComparableWorks && (comparableWorksCount ?? 0) > 0) ||
+    (comparableWorksCount ?? 0) > 0 ||
     (auctionResultsCount ?? 0) > 0
 
   const tabs = compact([

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tests.tsx
@@ -56,7 +56,6 @@ describe("MyCollectionArtworkInsights", () => {
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableMyCollectionComparableWorks: true })
   })
 
   it("renders without throwing an error", async () => {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -35,8 +35,6 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
 
   const me = useFragment<MyCollectionArtworkInsights_me$key>(meFragment, restProps.me)
 
-  const enableMyCollectionComparableWorks = useFeatureFlag("AREnableMyCollectionComparableWorks")
-
   const isP1Artist = artwork.artist?.targetSupply?.isP1
 
   const showPriceEstimateBanner =
@@ -75,9 +73,7 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
           />
         )}
 
-        {!!enableMyCollectionComparableWorks && (
-          <MyCollectionArtworkComparableWorks artwork={artwork} />
-        )}
+        <MyCollectionArtworkComparableWorks artwork={artwork} />
 
         <MyCollectionArtworkArtistAuctionResults artwork={artwork} />
 

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -162,12 +162,6 @@ export const features = defineFeatures({
     description: "Enable My Collection Price Estimate Range",
     showInAdminMenu: false,
   },
-  AREnableMyCollectionComparableWorks: {
-    readyForRelease: true,
-    description: "Enable My Collection Comparable Works",
-    showInAdminMenu: true,
-    echoFlagKey: "AREnableMyCollectionComparableWorks",
-  },
   AREnableHomeScreenArtworkRecommendations: {
     readyForRelease: true,
     description: "Enable Home Screen Artwork Recommendations",


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [CX-2520]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
clean up feature flag AREnableMyCollectionComparableWorks
### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [x] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- clean up feature flag AREnableMyCollectionComparableWorks -daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[CX-2520]: https://artsyproduct.atlassian.net/browse/CX-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ