### PR TITLE
fix: hide filter menu item when aggregation counts are empty

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -83,6 +83,10 @@ export const ArtworkFilterOptionsScreen: React.FC<
 
   const aggregateFilterOptions: FilterDisplayConfig[] = _.compact(
     concreteAggregations.map((aggregation) => {
+      if (aggregation?.counts?.length === 0) {
+        return null
+      }
+
       const filterOption = filterKeyFromAggregation[aggregation.slice]
       return filterOption ? filterOptionToDisplayConfigMap[filterOption] : null
     })

--- a/src/app/Components/ArtworkFilter/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/FilterModal.tests.tsx
@@ -183,6 +183,90 @@ const MockFilterModalNavigator = ({
   </GlobalStoreProvider>
 )
 
+describe("Filter modal", () => {
+  it("should display filter when aggregation counts are NOT empty", () => {
+    const injectedState: ArtworkFiltersState = {
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [
+        {
+          slice: "MEDIUM",
+          counts: [
+            {
+              name: "Sculpture",
+              count: 277,
+              value: "sculpture",
+            },
+          ],
+        },
+        {
+          slice: "MAJOR_PERIOD",
+          counts: [
+            {
+              name: "Late 19th Century",
+              count: 6,
+              value: "Late 19th Century",
+            },
+          ],
+        },
+      ],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+      sizeMetric: "cm",
+    }
+
+    const { getByText } = renderWithWrappersTL(
+      <MockFilterModalNavigator initialData={injectedState} />
+    )
+
+    expect(getByText("Medium")).toBeTruthy()
+    expect(getByText("Time Period")).toBeTruthy()
+  })
+
+  it("should hide filter when aggregation counts are empty", () => {
+    const injectedState: ArtworkFiltersState = {
+      selectedFilters: [],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: [
+        {
+          slice: "MEDIUM",
+          counts: [],
+        },
+        {
+          slice: "MAJOR_PERIOD",
+          counts: [
+            {
+              name: "Late 19th Century",
+              count: 6,
+              value: "Late 19th Century",
+            },
+          ],
+        },
+      ],
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+      sizeMetric: "cm",
+    }
+
+    const { getByText, queryByText } = renderWithWrappersTL(
+      <MockFilterModalNavigator initialData={injectedState} />
+    )
+
+    expect(queryByText("Medium")).toBeFalsy()
+    expect(getByText("Time Period")).toBeTruthy()
+  })
+})
+
 describe("Filter modal navigation flow", () => {
   it("allows users to navigate forward to sort screen from filter screen", () => {
     const { getByText } = renderWithWrappersTL(


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

### Description

- Hides filters when aggregation counts are empty

### Useful links
* [Notion card](https://www.notion.so/artsy/Auctions-Sort-Filter-medium-is-empty-b528af1c5c244d0383ab5b1d93ad49e6)

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/164752745-6e3d6641-f2e0-4620-92dd-72a35bd7398a.mp4

#### After
https://user-images.githubusercontent.com/3513494/164752666-2ef4290a-19a7-42f9-b6c5-13f28ed9bb8f.mp4


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Hide filters when aggregation counts are empty 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
