### PR TITLE
feat(cx-2438): sort and filter for high demand index

### DIFF
--- a/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
+++ b/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
@@ -155,5 +155,8 @@ export const MyCollectionFilterPropsFragment = graphql`
     width
     height
     date
+    marketPriceInsights {
+      demandRank
+    }
   }
 `

--- a/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
+++ b/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
@@ -95,7 +95,7 @@ export const useLocalArtworkFilter = (artworksList?: any[] | null) => {
       },
       {
         paramName: FilterParamName.sort,
-        displayText: "Demand Index (High to low)",
+        displayText: "Demand Index (High to Low)",
         paramValue: "demand-index-high-to-low",
         // tslint:disable-next-line: no-shadowed-variable
         localSortAndFilter: (artworks) =>
@@ -106,10 +106,8 @@ export const useLocalArtworkFilter = (artworksList?: any[] | null) => {
         displayText: "Demand Index (Low to High)",
         paramValue: "demand-index-low-to-high",
         // tslint:disable-next-line: no-shadowed-variable
-        localSortAndFilter: (artworks) => {
-          console.log("artworks", artworks)
-          return orderBy(artworks, (a) => a.marketPriceInsights?.demandRank ?? 0, "asc")
-        },
+        localSortAndFilter: (artworks) =>
+          orderBy(artworks, (a) => a.marketPriceInsights?.demandRank ?? 0, "asc"),
       },
     ])
     setFilterOptions(

--- a/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
+++ b/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
@@ -93,6 +93,24 @@ export const useLocalArtworkFilter = (artworksList?: any[] | null) => {
         // tslint:disable-next-line: no-shadowed-variable
         localSortAndFilter: (artworks) => orderBy(artworks, (a) => a.artistNames, "desc"),
       },
+      {
+        paramName: FilterParamName.sort,
+        displayText: "Demand Index (High to low)",
+        paramValue: "demand-index-high-to-low",
+        // tslint:disable-next-line: no-shadowed-variable
+        localSortAndFilter: (artworks) =>
+          orderBy(artworks, (a) => a.marketPriceInsights?.demandRank ?? 0, "desc"),
+      },
+      {
+        paramName: FilterParamName.sort,
+        displayText: "Demand Index (Low to High)",
+        paramValue: "demand-index-low-to-high",
+        // tslint:disable-next-line: no-shadowed-variable
+        localSortAndFilter: (artworks) => {
+          console.log("artworks", artworks)
+          return orderBy(artworks, (a) => a.marketPriceInsights?.demandRank ?? 0, "asc")
+        },
+      },
     ])
     setFilterOptions(
       compact([


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [CX-2438]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


https://user-images.githubusercontent.com/18648835/165268042-fbe4d8a6-b3b4-40f4-86ee-2f58782972cd.mp4



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- sort and filter for high demand index - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[CX-2438]: https://artsyproduct.atlassian.net/browse/CX-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ