### PR TITLE
fix(CX-2543): Fix performance with my collection search

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -330,3 +330,14 @@ When the fix is in a release in the library or when we stop using this library.
 #### Explanation/Context
 
 With updated react native version (66) this library causes an error calling the now non-existent getNode() function, it is fixed on the main branch in the library but has not yet been released on npm.
+
+## [Android ContentOffset Bug]: Using marginTop: -headerHeight to initially hide HeaderComponent in MyCollectionArtworksList.tsx and InfiniteScrollArtworkGrid.tsx
+
+#### When we can remove this:
+
+When we upgrade to a react native version that contentOffset works for android
+
+#### Explanation/Context
+
+contentOffset for vertical scrollviews appear to be broken on v0.66.4 (current version). We need the contentOffset to initially hide the HeaderComponent. The workaround currently is to use contentContainerStyle and set the marginTop to -HeightOfHeaderComponent and then remove this when a user scrolls to the top.
+Caveat/Introduced bug: User has to scroll to an offset of any number > 0 to revert the marginTop to 0.

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -420,6 +420,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
             if (autoFetch) {
               this.handleFetchNextPageOnScroll(ev)
             }
+            // [Android ContentOffset Bug]: See Hacks.MD
             if (Platform.OS === "android" && ev.nativeEvent.contentOffset.y - 0 === 0) {
               LayoutAnimation.configureNext({
                 ...LayoutAnimation.Presets.linear,
@@ -428,9 +429,11 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
               this.setState({ marginTop: 0 })
             }
           }}
+          // [Android ContentOffset Bug]: See Hacks.MD for why we are using marginTop here to hide header
           contentContainerStyle={
             Platform.OS === "android" && hideHeaderInitially ? { marginTop: -marginTop } : undefined
           }
+          // [Android ContentOffset Bug]: contentOffset not working on android. This will only apply to iOS. See Hacks.MD
           contentOffset={hideHeaderInitially ? { x: 0, y: headerHeight } : undefined}
           scrollEventThrottle={50}
           onLayout={this.onLayout}

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -18,6 +18,7 @@ import React from "react"
 import {
   ActivityIndicator,
   Dimensions,
+  LayoutAnimation,
   LayoutChangeEvent,
   Platform,
   ScrollView,
@@ -114,6 +115,9 @@ export interface Props {
   updateRecentSearchesOnTap?: boolean
 
   localSortAndFilterArtworks?: (artworks: any[]) => any[]
+
+  /** Hide the header initially when rendered. Default is false */
+  hideHeaderInitially?: boolean
 }
 
 interface PrivateProps {
@@ -160,6 +164,8 @@ const InfiniteScrollArtworksGridMapper: React.FC<MapperProps & Omit<Props, "isMy
 interface State {
   sectionDimension: number
   isLoading: boolean
+  headerHeight: number
+  marginTop: number
 }
 
 export const DEFAULT_SECTION_MARGIN = 20
@@ -178,11 +184,14 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
     useParentAwareScrollView: Platform.OS === "android",
     showLoadingSpinner: false,
     updateRecentSearchesOnTap: false,
+    hideHeaderInitially: false,
   }
 
   state = {
     sectionDimension: this.getSectionDimension(this.props.width),
     isLoading: false,
+    headerHeight: 0,
+    marginTop: 0,
   }
 
   fetchNextPage = () => {
@@ -243,6 +252,13 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
   onLayout = (event: LayoutChangeEvent) => {
     this.setState({
       sectionDimension: this.getSectionDimension(event.nativeEvent.layout.width),
+    })
+  }
+
+  onHeaderLayout = (event: LayoutChangeEvent) => {
+    this.setState({
+      headerHeight: event.nativeEvent.layout.height,
+      marginTop: event.nativeEvent.layout.height,
     })
   }
 
@@ -363,7 +379,13 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
       return null
     }
 
-    return React.isValidElement(HeaderComponent) ? HeaderComponent : <HeaderComponent />
+    return React.isValidElement(HeaderComponent) ? (
+      <View onLayout={this.onHeaderLayout}>{HeaderComponent}</View>
+    ) : (
+      <View onLayout={this.onHeaderLayout}>
+        <HeaderComponent />
+      </View>
+    )
   }
 
   renderFooter() {
@@ -377,7 +399,16 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
 
   render() {
     const artworks = this.state.sectionDimension ? this.renderSections() : null
-    const { shouldAddPadding, hasMore, stickyHeaderIndices, useParentAwareScrollView } = this.props
+    const {
+      shouldAddPadding,
+      hasMore,
+      stickyHeaderIndices,
+      useParentAwareScrollView,
+      autoFetch,
+      hideHeaderInitially,
+      showLoadingSpinner,
+    } = this.props
+    const { isLoading, headerHeight, marginTop } = this.state
     const boxPadding = shouldAddPadding ? 2 : 0
 
     const ScrollViewWrapper = !!useParentAwareScrollView ? ParentAwareScrollView : ScrollView
@@ -386,10 +417,21 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
       <>
         <ScrollViewWrapper
           onScroll={(ev) => {
-            if (this.props.autoFetch) {
+            if (autoFetch) {
               this.handleFetchNextPageOnScroll(ev)
             }
+            if (Platform.OS === "android" && ev.nativeEvent.contentOffset.y - 0 === 0) {
+              LayoutAnimation.configureNext({
+                ...LayoutAnimation.Presets.linear,
+                duration: 200,
+              })
+              this.setState({ marginTop: 0 })
+            }
           }}
+          contentContainerStyle={
+            Platform.OS === "android" && hideHeaderInitially ? { marginTop: -marginTop } : undefined
+          }
+          contentOffset={hideHeaderInitially ? { x: 0, y: headerHeight } : undefined}
           scrollEventThrottle={50}
           onLayout={this.onLayout}
           scrollsToTop={false}
@@ -405,7 +447,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
             </View>
           </Box>
 
-          {!this.props.autoFetch && !!hasMore() && (
+          {!autoFetch && !!hasMore() && (
             <Button
               mt={5}
               mb={3}
@@ -418,14 +460,14 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
               Show more
             </Button>
           )}
-          {!!this.props.showLoadingSpinner && !!this.state.isLoading && (
+          {!!showLoadingSpinner && !!isLoading && (
             <Flex mt={2} mb={4} flexDirection="row" justifyContent="center">
               <Spinner />
             </Flex>
           )}
         </ScrollViewWrapper>
 
-        {this.state.isLoading && hasMore() && (
+        {isLoading && hasMore() && (
           <Flex
             alignItems="center"
             justifyContent="center"
@@ -433,7 +475,7 @@ class InfiniteScrollArtworksGrid extends React.Component<Props & PrivateProps, S
             pb="9"
             style={{ opacity: this.state.isLoading && hasMore() ? 1 : 0 }}
           >
-            {!!this.props.autoFetch && (
+            {!!autoFetch && (
               <ActivityIndicator color={Platform.OS === "android" ? "black" : undefined} />
             )}
           </Flex>

--- a/src/app/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPage.tsx
@@ -5,7 +5,7 @@ import { useGlobalState } from "app/utils/useGlobalState"
 import { useScreenDimensions } from "app/utils/useScreenDimensions"
 import { Box } from "palette"
 import React, { EffectCallback, useEffect, useMemo, useRef, useState } from "react"
-import { LayoutAnimation, View } from "react-native"
+import { View } from "react-native"
 import Animated from "react-native-reanimated"
 import { useTracking } from "react-tracking"
 import { useAnimatedValue } from "./reanimatedHelpers"
@@ -61,11 +61,9 @@ export const StickyTabPage: React.FC<StickyTabPageProps> = ({
   const [tabSpecificStickyHeaderContent, setTabSpecificStickyHeaderContent] = useState<
     Array<JSX.Element | null>
   >([])
-  const [isStaticHeaderVisible, setIsStaticHeaderVisible] = useState(true)
 
-  const { jsx: staticHeader, nativeHeight: staticHeaderHeight } = useAutoCollapsingMeasuredView(
-    isStaticHeaderVisible ? staticHeaderContent : null
-  )
+  const { jsx: staticHeader, nativeHeight: staticHeaderHeight } =
+    useAutoCollapsingMeasuredView(staticHeaderContent)
 
   const stickyRailRef = useRef<SnappyHorizontalRail>(null)
 
@@ -84,11 +82,6 @@ export const StickyTabPage: React.FC<StickyTabPageProps> = ({
   const tracking = useTracking()
 
   const headerOffsetY = useAnimatedValue(0)
-
-  // We need to set the header offset to 0 after hiding or showing the static header.
-  useEffect(() => {
-    requestAnimationFrame(() => headerOffsetY.setValue(0))
-  }, [isStaticHeaderVisible])
 
   const railRef = useRef<SnappyHorizontalRail>(null)
 
@@ -118,14 +111,6 @@ export const StickyTabPage: React.FC<StickyTabPageProps> = ({
         headerOffsetY,
         tabLabels: tabs.map((tab) => tab.title),
         tabSuperscripts: tabs.map((tab) => tab.superscript),
-        hideStaticHeader() {
-          LayoutAnimation.spring()
-          setIsStaticHeaderVisible(false)
-        },
-        showStaticHeader() {
-          LayoutAnimation.spring()
-          setIsStaticHeaderVisible(true)
-        },
         setActiveTabIndex(index) {
           setActiveTabIndex(index)
           activeTabIndexNative.setValue(index)

--- a/src/app/Components/StickyTabPage/StickyTabPageContext.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageContext.tsx
@@ -9,8 +9,6 @@ export const StickyTabPageContext = React.createContext<{
   tabLabels: string[]
   tabSuperscripts: Array<string | undefined>
   activeTabIndex: GlobalState<number>
-  showStaticHeader: () => void
-  hideStaticHeader: () => void
   setActiveTabIndex(index: number): void
 }>(null as any)
 

--- a/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
@@ -84,9 +84,11 @@ export const MyCollectionArtworkList: React.FC<{
 
   return (
     <ScrollView
+      // [Android ContentOffset Bug]: See Hacks.MD for why we are using marginTop here to hide header
       contentContainerStyle={
         Platform.OS === "android" && hideHeaderInitially ? { marginTop: -marginTop } : undefined
       }
+      // [Android ContentOffset Bug]: contentOffset not working on android. This will only apply to iOS. See Hacks.MD
       contentOffset={hideHeaderInitially ? { x: 0, y: headerHeight } : undefined}
     >
       {/*
@@ -98,6 +100,7 @@ export const MyCollectionArtworkList: React.FC<{
       {renderHeader()}
       <PrefetchFlatList
         onScroll={
+          // [Android ContentOffset Bug]: See Hacks.MD
           Platform.OS === "android"
             ? ({ nativeEvent }) => {
                 if (nativeEvent.contentOffset.y - 0 === 0) {

--- a/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
@@ -11,7 +11,7 @@ import { RelayPaginationProp, useFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 import { MyCollectionArtworkListItem } from "./MyCollectionArtworkListItem"
 
-export const MyCollectionArtworkList: React.FC<{
+export interface MyCollectionArtworkListProps {
   myCollectionConnection: MyCollectionArtworkList_myCollectionConnection$key | null
   localSortAndFilterArtworks?: (artworks: any[]) => any[]
   loadMore: RelayPaginationProp["loadMore"]
@@ -21,15 +21,18 @@ export const MyCollectionArtworkList: React.FC<{
 
   /** Hide the header initially when rendered. Default is false */
   hideHeaderInitially?: boolean
-}> = ({
+}
+
+export const MyCollectionArtworkList: React.FC<MyCollectionArtworkListProps> = ({
   localSortAndFilterArtworks,
   isLoading,
   loadMore,
   hasMore,
   HeaderComponent,
-  hideHeaderInitially,
+  hideHeaderInitially = false,
   ...restProps
 }) => {
+  console.log("myCollectionConnection", restProps.myCollectionConnection)
   const { height: screenHeight } = useScreenDimensions()
 
   const [headerHeight, setHeaderHeight] = useState(0)
@@ -84,6 +87,7 @@ export const MyCollectionArtworkList: React.FC<{
 
   return (
     <ScrollView
+      testID="MyCollectionArtworkListScrollView"
       // [Android ContentOffset Bug]: See Hacks.MD for why we are using marginTop here to hide header
       contentContainerStyle={
         Platform.OS === "android" && hideHeaderInitially ? { marginTop: -marginTop } : undefined
@@ -137,7 +141,7 @@ export const MyCollectionArtworkList: React.FC<{
   )
 }
 
-const artworkConnectionFragment = graphql`
+export const artworkConnectionFragment = graphql`
   fragment MyCollectionArtworkList_myCollectionConnection on MyCollectionConnection {
     pageInfo {
       hasNextPage

--- a/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionArtworkList.tsx
@@ -32,7 +32,6 @@ export const MyCollectionArtworkList: React.FC<MyCollectionArtworkListProps> = (
   hideHeaderInitially = false,
   ...restProps
 }) => {
-  console.log("myCollectionConnection", restProps.myCollectionConnection)
   const { height: screenHeight } = useScreenDimensions()
 
   const [headerHeight, setHeaderHeight] = useState(0)

--- a/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tests.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tests.tsx
@@ -1,0 +1,62 @@
+import { fireEvent } from "@testing-library/react-native"
+import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import React from "react"
+import { MyCollectionSearchBar, MyCollectionSearchBarProps } from "./MyCollectionSearchBar"
+
+describe("MyCollectionSearchBar", () => {
+  const defaultProps: MyCollectionSearchBarProps = {
+    onChangeText: jest.fn(),
+    searchString: "",
+    setHasUsedSearchBar: jest.fn(),
+    setSearchBarStillFocused: jest.fn(),
+  }
+  const wrapper = (props: MyCollectionSearchBarProps) =>
+    renderWithWrappersTL(
+      <StickyTabPage
+        tabs={[
+          {
+            title: "My Collection",
+            content: <MyCollectionSearchBar {...props} />,
+          },
+        ]}
+      />
+    )
+
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableMyCollectionSearchBar: true })
+  })
+
+  describe("renders properly", () => {
+    it("When isFocused is true", () => {
+      const { queryByTestId } = wrapper({ ...defaultProps, startAsFocused: true })
+      expect(queryByTestId("MyCollectionSearchBarInput")).toBeDefined()
+      expect(queryByTestId("MyCollectionSearchBarInputCancelButton")).toBeDefined()
+
+      expect(queryByTestId("MyCollectionSearchBarNoInputTouchable")).toBe(null)
+      expect(queryByTestId("MyCollectionSearchListIconTouchable")).toBe(null)
+      expect(queryByTestId("MyCollectionSearchGridIconTouchable")).toBe(null)
+    })
+
+    it("When isFocused is false", () => {
+      const { queryByTestId } = wrapper({ ...defaultProps, startAsFocused: false })
+      expect(queryByTestId("MyCollectionSearchBarNoInputTouchable")).toBeDefined()
+      expect(queryByTestId("MyCollectionSearchListIconTouchable")).toBeDefined()
+      expect(queryByTestId("MyCollectionSearchGridIconTouchable")).toBeDefined()
+      expect(queryByTestId("MyCollectionSearchBarInput")).toBe(null)
+      expect(queryByTestId("MyCollectionSearchBarInputCancelButton")).toBe(null)
+    })
+  })
+
+  it("can switch from Grid to List and vice-versa", () => {
+    const { queryByTestId } = wrapper({ ...defaultProps, startAsFocused: false })
+    expect(__globalStoreTestUtils__?.getCurrentState().userPrefs.artworkViewOption).toEqual("grid")
+    const listIcon = queryByTestId("MyCollectionSearchListIconTouchable")
+    const gridIcon = queryByTestId("MyCollectionSearchGridIconTouchable")
+    fireEvent(listIcon!, "onPress")
+    expect(__globalStoreTestUtils__?.getCurrentState().userPrefs.artworkViewOption).toEqual("list")
+    fireEvent(gridIcon!, "onPress")
+    expect(__globalStoreTestUtils__?.getCurrentState().userPrefs.artworkViewOption).toEqual("grid")
+  })
+})

--- a/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tsx
@@ -18,7 +18,7 @@ import {
 } from "react-native"
 import Animated from "react-native-reanimated"
 
-interface MyCollectionSearchBarProps {
+export interface MyCollectionSearchBarProps {
   onChangeText: ((text: string) => void) | undefined
   onFocus?: (e: NativeSyntheticEvent<TextInputFocusEventData>) => void
   innerFlatListRef?: React.MutableRefObject<{ getNode(): FlatList<any> } | null>
@@ -112,6 +112,7 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
       {isFocused ? (
         <Flex flexDirection="row" alignItems="center">
           <Input
+            testID="MyCollectionSearchBarInput"
             placeholder="Search by Artist, Artwork or Keyword"
             onChangeText={setValue}
             onFocus={onFocus}
@@ -127,6 +128,7 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
           />
 
           <TouchableWithoutFeedback
+            testID="MyCollectionSearchBarInputCancelButton"
             onPress={() => {
               setValue("")
               hasRunFocusedAnimation.setValue(new Animated.Value(0))
@@ -144,6 +146,7 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
           <Flex flexDirection="row" my={1} py={0.5} justifyContent="space-between">
             <Flex>
               <TouchableWithoutFeedback
+                testID="MyCollectionSearchBarNoInputTouchable"
                 onPress={() => {
                   hasRunFocusedAnimation.setValue(new Animated.Value(0))
                   setIsFocused(true)
@@ -160,7 +163,10 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
             </Flex>
             <Flex flexDirection="row">
               <Flex mr={1}>
-                <TouchableWithoutFeedback onPress={() => onViewOptionChange("list")}>
+                <TouchableWithoutFeedback
+                  testID="MyCollectionSearchListIconTouchable"
+                  onPress={() => onViewOptionChange("list")}
+                >
                   <Flex width={30} height={30} alignItems="center" justifyContent="center">
                     <ListViewIcon
                       fill={viewOption === "list" ? "black" : "gray"}
@@ -170,7 +176,10 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
                   </Flex>
                 </TouchableWithoutFeedback>
               </Flex>
-              <TouchableWithoutFeedback onPress={() => onViewOptionChange("grid")}>
+              <TouchableWithoutFeedback
+                testID="MyCollectionSearchGridIconTouchable"
+                onPress={() => onViewOptionChange("grid")}
+              >
                 <Flex width={30} height={30} alignItems="center" justifyContent="center">
                   <GridViewIcon
                     fill={viewOption === "grid" ? "black" : "gray"}

--- a/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionSearchBar.tsx
@@ -98,6 +98,8 @@ export const MyCollectionSearchBar: React.FC<MyCollectionSearchBarProps> = ({
     if (isFocused) {
       setHasUsedSearchBar(true)
       setSearchBarStillFocused(true)
+    } else {
+      setSearchBarStillFocused(false)
     }
   }, [isFocused])
 

--- a/src/app/Scenes/MyCollection/MyCollection.tests.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tests.tsx
@@ -5,8 +5,7 @@ import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/Artwor
 import { InfiniteScrollMyCollectionArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
-import { GridViewIcon } from "app/Icons/GridViewIcon"
-import { ListViewIcon } from "app/Icons/ListViewIcon"
+
 import { navigate } from "app/navigation/navigate"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { extractText } from "app/tests/extractText"
@@ -17,8 +16,6 @@ import React from "react"
 import { graphql, QueryRenderer } from "react-relay"
 import { act, ReactTestRenderer } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { MyCollectionArtworkList } from "./Components/MyCollectionArtworkList"
-import { MyCollectionSearchBar } from "./Components/MyCollectionSearchBar"
 import { MyCollectionContainer } from "./MyCollection"
 
 jest.unmock("react-relay")
@@ -125,35 +122,6 @@ describe("MyCollection", () => {
     it("renders without throwing an error", () => {
       expect(tree.root.findByType(StickyTabPageScrollView)).toBeDefined()
       expect(tree.root.findByType(InfiniteScrollMyCollectionArtworksGridContainer)).toBeDefined()
-    })
-  })
-
-  describe("search bar", () => {
-    let tree: ReactTestRenderer
-
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableMyCollectionSearchBar: true })
-
-      tree = getWrapper()
-    })
-
-    it("user can switch between grid and list view when search the bar is visible", async () => {
-      const scrollView = tree.root.findByType(StickyTabPageScrollView)
-
-      // Scrolling up should make the search bar visible
-      scrollView.props.onScrollBeginDrag({ nativeEvent: { contentOffset: { y: -10 } } })
-
-      await flushPromiseQueue()
-
-      expect(tree.root.findByType(MyCollectionSearchBar)).toBeDefined()
-
-      act(() => fireEvent.press(tree.root.findByType(GridViewIcon)))
-
-      expect(MyCollectionArtworkList).toBeDefined()
-
-      act(() => fireEvent.press(tree.root.findByType(ListViewIcon)))
-
-      expect(MyCollectionArtworkList).toBeDefined()
     })
   })
 


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [CX-2543]

### Description
#### Previous Issues this PR fixes:
- MyCollection screen hangs because we try to store yScrollOffset
- Header animation into view is a bit janky
- When moving from FilteredStateZero to another state, SearchBar jumps across the screen from the top to the bottom
- Switching from Grid to List view, search bar jumps from top to bottom
- SearchBar is added to StickyHeader thereby reducing available scrollable area

#### What was done in this PR:
- Remove need for scrolloffset, instead using staticHeader height to scroll
- Remove hideStaticHeader and showStaticHeader. Instead get a handle on the inner flatlist and perform scroll on it. This removes the jumping from bottom to top.
- Pass the search bar as a header component instead, thereby not reducing the scrollable area.
- contentOffset to initially hide the header.
- When switching from Grid to List or to ZerofilteredArtworks state: SearchBar should remain at its previous position and not jump across screens, SearchBar should remain focused if was previously focused on the previous View, and do not hide the searchbar if it has been interacted with on a previous View

#### Possible Remaining issues:
- iOS: None
- Android: User will have to have scrolled atleast an offset of greater than zero to reveal hidden search bar. 



https://user-images.githubusercontent.com/18648835/165947777-543d108d-2f98-456a-adfc-493501ff5baf.mp4




https://user-images.githubusercontent.com/18648835/165947614-a15daf58-798f-482a-ba99-3dd440553e20.mp4



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix performance issues associated with MyCollectionSearch - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[CX-2543]: https://artsyproduct.atlassian.net/browse/CX-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ