### PR TITLE
feat(NX-3131): add contact gallery small cta for buy now artworks

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -31,6 +31,7 @@ import { CommercialPartnerInformation } from "./Components/CommercialPartnerInfo
 import { ContextCard } from "./Components/ContextCard"
 import { ImageCarousel } from "./Components/ImageCarousel/ImageCarousel"
 import { OtherWorksFragmentContainer } from "./Components/OtherWorks/OtherWorks"
+import { QuestionsFragmentContainer } from "./Components/Questions"
 
 type ArtworkQueries =
   | "ArtworkAboveTheFoldQuery"
@@ -382,6 +383,24 @@ describe("Artwork", () => {
     await flushPromiseQueue()
 
     expect(tree.root.findAllByType(ContextCard)).toHaveLength(1)
+  })
+
+  it("renders buy now contact gallery when feature flag is enabled", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+    const tree = renderWithWrappers(<TestRenderer />)
+
+    mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
+      Artwork: () => ({
+        slug: "test-artwork",
+        isAcquireable: true,
+      }),
+    })
+    mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
+    mockMostRecentOperation("ArtworkBelowTheFoldQuery")
+
+    await flushPromiseQueue()
+
+    expect(tree.root.findAllByType(QuestionsFragmentContainer)).toHaveLength(1)
   })
 
   describe("Live Auction States", () => {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -65,7 +65,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
 }) => {
   const [refreshing, setRefreshing] = useState(false)
   const [fetchingData, setFetchingData] = useState(false)
-  const conversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
+  const enableConversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
 
   const { internalID, slug } = artworkAboveTheFold || {}
   const {
@@ -240,7 +240,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       return sections
     }
 
-    if (conversationalBuyNow && artworkAboveTheFold?.isAcquireable) {
+    if (enableConversationalBuyNow && artworkAboveTheFold?.isAcquireable) {
       sections.push({
         key: "contactGallery",
         element: <QuestionsFragmentContainer artwork={artworkBelowTheFold} />,

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -44,6 +44,7 @@ import {
   populatedGrids,
 } from "./Components/OtherWorks/OtherWorks"
 import { PartnerCardFragmentContainer as PartnerCard } from "./Components/PartnerCard"
+import { QuestionsFragmentContainer } from "./Components/Questions"
 
 interface ArtworkProps {
   artworkAboveTheFold: Artwork_artworkAboveTheFold | null
@@ -237,6 +238,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
         element: <BelowTheFoldPlaceholder />,
       })
       return sections
+    }
+
+    if (conversationalBuyNow && artworkAboveTheFold?.isAcquireable) {
+      sections.push({
+        key: "contactGallery",
+        element: <QuestionsFragmentContainer artwork={artworkBelowTheFold} />,
+      })
     }
 
     if (artworkBelowTheFold.description || artworkBelowTheFold.additionalInformation) {
@@ -467,6 +475,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ContextCard_artwork
         ...ArtworkHistory_artwork
         ...ArtworksInSeriesRail_artwork
+        ...Questions_artwork
       }
     `,
     me: graphql`

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -9,6 +9,7 @@ import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import { navigationEvents } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { isPad } from "app/utils/hardware"
 import {
@@ -63,6 +64,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
 }) => {
   const [refreshing, setRefreshing] = useState(false)
   const [fetchingData, setFetchingData] = useState(false)
+  const conversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
 
   const { internalID, slug } = artworkAboveTheFold || {}
   const {

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CommercialButtons.tsx
@@ -79,11 +79,7 @@ export const CommercialButtons: React.FC<CommercialButtonProps> = ({
         {isInquireable && (
           <>
             <Spacer my={0.5} />
-            <InquiryButtonsFragmentContainer
-              artwork={artwork}
-              editionSetID={editionSetID}
-              variant="outline"
-            />
+            <InquiryButtonsFragmentContainer artwork={artwork} variant="outline" block />
           </>
         )}
       </>
@@ -91,7 +87,7 @@ export const CommercialButtons: React.FC<CommercialButtonProps> = ({
   }
 
   if (isInquireable) {
-    return <InquiryButtonsFragmentContainer artwork={artwork} editionSetID={editionSetID} />
+    return <InquiryButtonsFragmentContainer artwork={artwork} block />
   }
 
   return null

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -12,18 +12,15 @@ import React, { useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { InquiryModalFragmentContainer } from "./InquiryModal"
-export interface InquiryButtonsProps {
+export type InquiryButtonsProps = Omit<ButtonProps, "children"> & {
   artwork: InquiryButtons_artwork
-  // EditionSetID is passed down from the edition selected by the user
-  editionSetID?: string
-  variant?: ButtonProps["variant"]
 }
 
 export interface InquiryButtonsState {
   modalIsVisible: boolean
 }
 
-const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, variant }) => {
+const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...rest }) => {
   const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
   const [notificationVisibility, setNotificationVisibility] = useState(false)
@@ -48,11 +45,8 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, variant }) => 
           trackEvent(tracks.trackTappedContactGallery(artwork.slug, artwork.internalID))
           dispatchAction(InquiryOptions.ContactGallery)
         }}
-        variant={variant}
-        size="large"
-        block
-        width={100}
         haptic
+        {...rest}
       >
         {InquiryOptions.ContactGallery}
       </Button>

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -1,0 +1,33 @@
+import { setupTestWrapperTL } from "app/tests/setupTestWrapper"
+import { Theme } from "palette"
+import React from "react"
+import { graphql } from "relay-runtime"
+import { QuestionsFragmentContainer } from "./Questions"
+
+jest.unmock("react-relay")
+
+describe("Questions", () => {
+  const { renderWithRelay } = setupTestWrapperTL({
+    Component: ({ artwork }: any) => (
+      <Theme>
+        <QuestionsFragmentContainer artwork={artwork} />
+      </Theme>
+    ),
+    query: graphql`
+      query Questions_Test_Query {
+        artwork(id: "test-id") {
+          ...Questions_artwork
+        }
+      }
+    `,
+  })
+
+  it("renders", () => {
+    const { getByText, getAllByText } = renderWithRelay({
+      Artwork: () => ({}),
+    })
+
+    expect(getByText("Questions about this piece?")).toBeDefined()
+    expect(getAllByText("Contact Gallery")).toHaveLength(2)
+  })
+})

--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -1,0 +1,31 @@
+import { Questions_artwork } from "__generated__/Questions_artwork.graphql"
+import { Box, Text } from "palette"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { InquiryButtonsFragmentContainer } from "./CommercialButtons/InquiryButtons"
+
+export interface QuestionsProps {
+  artwork: Questions_artwork
+}
+
+export const Questions: React.FC<QuestionsProps> = ({ artwork }) => {
+  return (
+    <Box>
+      <Text>Questions about this piece?</Text>
+      <InquiryButtonsFragmentContainer
+        artwork={artwork}
+        variant="outlineGray"
+        size="small"
+        mt={1}
+      />
+    </Box>
+  )
+}
+
+export const QuestionsFragmentContainer = createFragmentContainer(Questions, {
+  artwork: graphql`
+    fragment Questions_artwork on Artwork {
+      ...InquiryButtons_artwork
+    }
+  `,
+})


### PR DESCRIPTION
<!-- Use a PR title in the form of
  `type(PROJECT-XXXX): what changed`
-->

<!-- If this is a work in progress, please make sure it's a draft or prefix it with [WIP] -->

<!-- Jira ticket in square brackets like [PROJECT-XXXX] -->

This PR resolves [NX-3131]

### Description

Adds a small contact block in the artwork screen (hidden under the feature flag AREnableConversationalBuyNow)

cc @artsy/negotiate-devs 

before:
<img width="360" alt="Screenshot 2022-04-27 at 11 11 02" src="https://user-images.githubusercontent.com/15792853/165720420-97c9b703-f547-4914-8fa6-904301d345fe.png">

after
<img width="360" alt="Screenshot 2022-04-27 at 11 10 33" src="https://user-images.githubusercontent.com/15792853/165720484-277ff047-9987-44f6-a939-5c4b8f320f5e.png">


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[NX-3131]: https://artsyproduct.atlassian.net/browse/NX-3131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ