### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/beta-android.yml
+++ b/.github/workflows/beta-android.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [beta-android]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger release

--- a/.github/workflows/beta-ios-manual.yml
+++ b/.github/workflows/beta-ios-manual.yml
@@ -7,6 +7,8 @@ permissions:
 
 jobs:
   build:
+      permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/beta-ios-manual.yml
+++ b/.github/workflows/beta-ios-manual.yml
@@ -2,6 +2,9 @@ name: Trigger beta iOS release
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/beta-ios.yml
+++ b/.github/workflows/beta-ios.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [beta-ios]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger release

--- a/.github/workflows/promote-android.yml
+++ b/.github/workflows/promote-android.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [play_store_submission]
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger promotion

--- a/.github/workflows/promote-ios.yml
+++ b/.github/workflows/promote-ios.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [app_store_submission]
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger promotion

--- a/.github/workflows/release-ios-app.yml
+++ b/.github/workflows/release-ios-app.yml
@@ -6,8 +6,13 @@ on:
   push:
     branches: [release-ios-app]
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: 🚨 Trigger release ios app to users

--- a/.github/workflows/trigger-ci-after-ready-to-review.yml
+++ b/.github/workflows/trigger-ci-after-ready-to-review.yml
@@ -6,8 +6,13 @@ on:
   pull_request:
     types: [ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - name: Trigger release


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
