### PR TITLE
fix(FX-3921): use displayName over name in gene page

### DIFF
--- a/src/app/Components/Gene/Header.tsx
+++ b/src/app/Components/Gene/Header.tsx
@@ -23,11 +23,13 @@ class Header extends React.Component<Props, State> {
 
   render() {
     const { gene } = this.props
+    const title = gene.displayName || gene.name || ""
+
     return (
       <>
         <Box marginTop={60} justifyContent="center">
           <Sans size="8" numberOfLines={2}>
-            {gene.name || ""}
+            {title}
           </Sans>
         </Box>
         {this.renderFollowButton()}
@@ -155,6 +157,7 @@ export default createFragmentContainer(Header, {
       id
       isFollowed
       name
+      displayName
     }
   `,
 })


### PR DESCRIPTION
<!-- 

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-3921]

### Description

- use `displayName` over `name` when it exists in Gene Screen
- Didn't change the test file yet, might create also a ticket to refactor this screen and write some better tests

> 🙏 Suggestion: Let's merge like this to manage to get it out in this release 


#### Screenshots
|Before `name` | After `displayName` |
|---|---|
|![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-05-06 at 09 36 01](https://user-images.githubusercontent.com/21178754/167088212-0e41691f-6c9e-414a-84e6-9dc4f0c62f50.png)|![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-05-06 at 09 35 25](https://user-images.githubusercontent.com/21178754/167088224-2bc3c5d4-d62a-48e5-923f-0c0fe32c754a.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- use displayName over name in genes screen title - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
