### PR TITLE
feat(NX-3133): Add Purchase button to conversations

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -87,6 +87,7 @@
                 <data android:pathPrefix="/inquiry" />
                 <data android:pathPrefix="/map" />
                 <data android:pathPrefix="/make-offer" />
+                <data android:pathPrefix="/purchase" />
                 <data android:pathPrefix="/my-account" />
                 <data android:pathPrefix="/my-profile" />
                 <data android:pathPrefix="/my-profile/saved-addresses" />

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -54,6 +54,7 @@ import { ForceUpdate } from "./Scenes/ForceUpdate/ForceUpdate"
 import { GeneQueryRenderer } from "./Scenes/Gene/Gene"
 import { HomeQueryRenderer } from "./Scenes/Home/Home"
 import { MakeOfferModalQueryRenderer } from "./Scenes/Inbox/Components/Conversations/MakeOfferModal"
+import { PurchaseModalQueryRenderer } from "./Scenes/Inbox/Components/Conversations/PurchaseModal"
 import { ConversationNavigator } from "./Scenes/Inbox/ConversationNavigator"
 import { ConversationDetailsQueryRenderer } from "./Scenes/Inbox/Screens/ConversationDetails"
 import {
@@ -383,6 +384,9 @@ export const modules = defineModules({
     hidesBackButton: true,
   }),
   MakeOfferModal: reactModule(MakeOfferModalQueryRenderer, {
+    hasOwnModalCloseButton: true,
+  }),
+  PurchaseModal: reactModule(PurchaseModalQueryRenderer, {
     hasOwnModalCloseButton: true,
   }),
   Map: reactModule(MapContainer, { fullBleed: true }),

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -240,7 +240,11 @@ export const Artwork: React.FC<ArtworkProps> = ({
       return sections
     }
 
-    if (enableConversationalBuyNow && artworkAboveTheFold?.isAcquireable) {
+    if (
+      enableConversationalBuyNow &&
+      (artworkAboveTheFold?.isAcquireable ||
+        (!artworkAboveTheFold?.isInquireable && artworkAboveTheFold?.isOfferable))
+    ) {
       sections.push({
         key: "contactGallery",
         element: <Questions artwork={artworkBelowTheFold} />,

--- a/src/app/Scenes/Inbox/Components/Conversations/CTAPopUp.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/CTAPopUp.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Animated, Easing } from "react-native"
 
-export const CTAPopUp = ({ show, children }: { show: boolean; children: JSX.Element }) => {
+export const CTAPopUp = ({ show, children }: { show: boolean; children: React.ReactNode }) => {
   const [CTAHeight, setCTAHeight] = useState<number>(0)
   const [hidden, setHidden] = useState<boolean>(!show)
   const animationProgress = useRef(new Animated.Value(show ? 0 : 1)).current

--- a/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -1,4 +1,5 @@
 import { themeGet } from "@styled-system/theme-get"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import { BorderBox, Flex, Text, Touchable } from "palette"
 import { RadioButton } from "palette/elements/Radio"
 import React from "react"
@@ -22,16 +23,14 @@ interface Props {
 }
 
 export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }) => {
-  const available = !!edition.isOfferableFromInquiry
+  const enableConversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
+  const available =
+    !!edition.isOfferableFromInquiry || (enableConversationalBuyNow && !!edition.isAcquireable)
 
   return (
-    <Touchable
-      onPress={() => {
-        onPress(edition.internalID, available)
-      }}
-    >
+    <Touchable onPress={() => onPress(edition.internalID, available)}>
       <BorderBox p={2} my={0.5} flexDirection="row">
-        <RadioButton selected={selected} />
+        <RadioButton selected={selected} onPress={() => onPress(edition.internalID, available)} />
         <Flex mx={1} flexGrow={1}>
           <Text color={available ? "black100" : "black30"}>{edition.dimensions?.in}</Text>
           <Text color={available ? "black60" : "black30"} variant="xs">

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
@@ -1,0 +1,118 @@
+import { fireEvent } from "@testing-library/react-native"
+import { InquiryPurchaseButtonTestsQuery } from "__generated__/InquiryPurchaseButtonTestsQuery.graphql"
+import { navigate } from "app/navigation/navigate"
+import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import React from "react"
+import { Alert } from "react-native"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { InquiryPurchaseButtonFragmentContainer } from "./InquiryPurchaseButton"
+
+jest.unmock("react-relay")
+jest.spyOn(Alert, "alert")
+
+let environment: ReturnType<typeof createMockEnvironment>
+
+const TestRenderer = () => {
+  return (
+    <QueryRenderer<InquiryPurchaseButtonTestsQuery>
+      environment={environment}
+      query={graphql`
+        query InquiryPurchaseButtonTestsQuery($id: String!) @relay_test_operation {
+          artwork(id: $id) {
+            ...InquiryPurchaseButton_artwork
+          }
+        }
+      `}
+      variables={{ id: "test-id" }}
+      render={({ props, error }) => {
+        if (props?.artwork) {
+          return (
+            <InquiryPurchaseButtonFragmentContainer
+              artwork={props!.artwork!}
+              editionSetID={null}
+              conversationID="1234"
+            >
+              Purchase
+            </InquiryPurchaseButtonFragmentContainer>
+          )
+        } else if (error) {
+          console.error(error)
+        }
+      }}
+    />
+  )
+}
+
+const getWrapper = (mockResolvers = {}) => {
+  const tree = renderWithWrappersTL(<TestRenderer />)
+  act(() => {
+    environment.mock.resolveMostRecentOperation((operation) =>
+      MockPayloadGenerator.generate(operation, mockResolvers)
+    )
+  })
+  return tree
+}
+
+describe("InquiryPurchaseButton", () => {
+  beforeEach(() => {
+    require("app/relay/createEnvironment").reset()
+    environment = require("app/relay/createEnvironment").defaultEnvironment
+  })
+
+  it("navigates to the order webview when button is tapped", () => {
+    const { getAllByText } = getWrapper({
+      Artwork: () => ({
+        internalID: "test-id",
+      }),
+    })
+
+    fireEvent.press(getAllByText("Purchase")[1])
+    environment.mock.resolveMostRecentOperation((operation) => {
+      return MockPayloadGenerator.generate(operation, {
+        Mutation: () => {
+          return {
+            createInquiryOrder: {
+              orderOrError: {
+                __typename: "CommerceOrderWithMutationSuccess",
+                order: { internalID: "4567" },
+              },
+            },
+          }
+        },
+      })
+    })
+
+    expect(navigate).toHaveBeenCalledWith("/orders/4567", {
+      modal: true,
+      replace: true,
+      passProps: { orderID: "4567", title: "Purchase" },
+    })
+  })
+
+  it("presents an error dialogue if mutation returns an error response", () => {
+    const { getAllByText } = getWrapper({
+      Artwork: () => ({
+        internalID: "test-id",
+      }),
+    })
+
+    fireEvent.press(getAllByText("Purchase")[1])
+    environment.mock.resolveMostRecentOperation((operation) => {
+      return MockPayloadGenerator.generate(operation, {
+        Mutation: () => {
+          return {
+            createInquiryOrder: {
+              orderOrError: {
+                __typename: "CommerceOrderWithMutationFailure",
+                error: "Error",
+              },
+            },
+          }
+        },
+      })
+    })
+    expect(Alert.alert).toHaveBeenCalled()
+  })
+})

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
@@ -1,0 +1,146 @@
+import { InquiryPurchaseButton_artwork } from "__generated__/InquiryPurchaseButton_artwork.graphql"
+import { InquiryPurchaseButtonOrderMutation } from "__generated__/InquiryPurchaseButtonOrderMutation.graphql"
+import { navigate } from "app/navigation/navigate"
+import { defaultEnvironment } from "app/relay/createEnvironment"
+import { Button, ButtonProps } from "palette"
+import React, { useState } from "react"
+import { Alert } from "react-native"
+import { commitMutation, createFragmentContainer, graphql } from "react-relay"
+
+export interface InquiryPurchaseButtonProps {
+  artwork: InquiryPurchaseButton_artwork
+  editionSetID: string | null
+  conversationID: string
+  replaceModalView?: boolean
+  onPress?: ButtonProps["onPress"]
+  disabled?: ButtonProps["disabled"]
+}
+
+export const InquiryPurchaseButton: React.FC<InquiryPurchaseButtonProps> = ({
+  artwork,
+  editionSetID,
+  conversationID,
+  children,
+  replaceModalView = true,
+  onPress,
+  disabled = false,
+}) => {
+  const [isCommittingMutation, setIsCommittingMutation] = useState(false)
+
+  const onMutationError = (error: any) => {
+    Alert.alert(
+      "Sorry, we couldn't process the request.",
+      "Please try again or contact orders@artsy.net for help.",
+      [
+        {
+          text: "Cancel",
+          style: "cancel",
+        },
+        {
+          text: "Retry",
+          onPress: () => {
+            handleCreateInquiryOrder()
+          },
+        },
+      ]
+    )
+    console.log(
+      "src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx",
+      JSON.stringify(error, null, 2)
+    )
+  }
+
+  const handleCreateInquiryOrder = () => {
+    const { internalID } = artwork
+
+    if (isCommittingMutation) {
+      return
+    }
+
+    setIsCommittingMutation(true)
+    commitMutation<InquiryPurchaseButtonOrderMutation>(defaultEnvironment, {
+      mutation: graphql`
+        mutation InquiryPurchaseButtonOrderMutation(
+          $input: CommerceCreateInquiryOrderWithArtworkInput!
+        ) {
+          createInquiryOrder(input: $input) {
+            orderOrError {
+              __typename
+              ... on CommerceOrderWithMutationSuccess {
+                order {
+                  internalID
+                  mode
+                }
+              }
+              ... on CommerceOrderWithMutationFailure {
+                error {
+                  type
+                  code
+                  data
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {
+        input: {
+          artworkId: internalID,
+          editionSetId: editionSetID,
+          impulseConversationId: conversationID,
+        },
+      },
+      onCompleted: (data) => {
+        setIsCommittingMutation(false)
+
+        const orderOrError = data.createInquiryOrder?.orderOrError!
+        if (orderOrError.__typename === "CommerceOrderWithMutationFailure") {
+          onMutationError(orderOrError.error)
+          return
+        }
+
+        if (orderOrError.__typename === "CommerceOrderWithMutationSuccess") {
+          navigate(`/orders/${orderOrError.order.internalID}`, {
+            modal: true,
+            replace: !!replaceModalView,
+            passProps: {
+              orderID: orderOrError.order.internalID,
+              title: "Purchase",
+            },
+          })
+        }
+      },
+      onError: (error) => {
+        setIsCommittingMutation(false)
+        onMutationError(error)
+      },
+    })
+  }
+
+  return (
+    <Button
+      onPress={(event) => {
+        onPress?.(event)
+        handleCreateInquiryOrder()
+      }}
+      disabled={disabled}
+      loading={isCommittingMutation}
+      size="large"
+      block
+      haptic
+    >
+      {children}
+    </Button>
+  )
+}
+
+export const InquiryPurchaseButtonFragmentContainer = createFragmentContainer(
+  InquiryPurchaseButton,
+  {
+    artwork: graphql`
+      fragment InquiryPurchaseButton_artwork on Artwork {
+        internalID
+      }
+    `,
+  }
+)

--- a/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react-native"
 import { OpenInquiryModalButtonTestQuery } from "__generated__/OpenInquiryModalButtonTestQuery.graphql"
 import { navigate } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockEnvironmentPayload } from "app/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import React from "react"
@@ -17,6 +18,14 @@ jest.unmock("react-relay")
 
 const tappedMakeOfferEvent = {
   action: "tappedMakeOffer",
+  context_owner_type: "conversation",
+  impulse_conversation_id: "123",
+}
+
+const tappedPurchaseEvent = {
+  action: "tappedBuyNow",
+  context_owner_id: "fancy-art",
+  context_owner_slug: "slug-1",
   context_owner_type: "conversation",
   impulse_conversation_id: "123",
 }
@@ -51,66 +60,148 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
     return renderer
   }
 
-  it("clicking the button on unique artworks creates an offer", () => {
-    relay.commitMutation = jest.fn()
-
-    const { getAllByText } = getWrapper({
-      Artwork: () => ({ internalID: "fancy-art" }),
-    })
-
-    fireEvent(getAllByText("Make an Offer")[0], "press")
-    expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
-    expect(relay.commitMutation).toHaveBeenCalledTimes(1)
-  })
-
-  it("clicking the button on artworks with one edition set creates an offer", () => {
-    relay.commitMutation = jest.fn()
-
+  it("renders Purchase and Make Offer CTAs", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
     const { getAllByText } = getWrapper({
       Artwork: () => ({
         internalID: "fancy-art",
-        isEdition: true,
-        editionSets: [
-          {
-            internalID: "an-edition-set",
-          },
-        ],
+        slug: "slug-1",
+        isAcquireable: true,
+        isOfferableFromInquiry: true,
       }),
     })
 
-    fireEvent(getAllByText("Make an Offer")[0], "press")
-    expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
-    expect(relay.commitMutation).toHaveBeenCalledTimes(1)
+    expect(getAllByText("Make an Offer")[0]).toBeTruthy()
+    expect(getAllByText("Purchase")[0]).toBeTruthy()
   })
 
-  it("clicking the button on non-unique artworks opens the confirmation modal", () => {
-    const { getAllByText } = getWrapper({
-      Artwork: () => ({
-        internalID: "fancy-art",
-        isEdition: true,
-        editionSets: [
-          {
-            internalID: "an-edition-set",
-          },
-          {
-            internalID: "another-edition-set",
-          },
-        ],
-      }),
+  describe("make offer", () => {
+    it("clicking the button on unique artworks creates an offer", () => {
+      relay.commitMutation = jest.fn()
+
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({ internalID: "fancy-art", isOfferableFromInquiry: true }),
+      })
+
+      fireEvent(getAllByText("Make an Offer")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
+      expect(relay.commitMutation).toHaveBeenCalledTimes(1)
     })
 
-    fireEvent(getAllByText("Make an Offer")[0], "press")
-    expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
-    expect(navigate).toHaveBeenCalledWith("make-offer/fancy-art", {
-      modal: true,
-      passProps: { conversationID: "123" },
+    it("clicking the button on artworks with one edition set creates an offer", () => {
+      relay.commitMutation = jest.fn()
+
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({
+          internalID: "fancy-art",
+          isEdition: true,
+          editionSets: [
+            {
+              internalID: "an-edition-set",
+            },
+          ],
+          isOfferableFromInquiry: true,
+        }),
+      })
+
+      fireEvent(getAllByText("Make an Offer")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
+      expect(relay.commitMutation).toHaveBeenCalledTimes(1)
+    })
+
+    it("clicking the button on non-unique artworks opens the confirmation modal", () => {
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({
+          internalID: "fancy-art",
+          isEdition: true,
+          isOfferableFromInquiry: true,
+          editionSets: [
+            {
+              internalID: "an-edition-set",
+            },
+            {
+              internalID: "another-edition-set",
+            },
+          ],
+        }),
+      })
+
+      fireEvent(getAllByText("Make an Offer")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
+      expect(navigate).toHaveBeenCalledWith("make-offer/fancy-art", {
+        modal: true,
+        passProps: { conversationID: "123" },
+      })
+    })
+  })
+
+  describe("purchase", () => {
+    it("clicking the button on unique artworks creates an order", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+      relay.commitMutation = jest.fn()
+
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({ internalID: "fancy-art", isAcquireable: true }),
+      })
+
+      fireEvent(getAllByText("Purchase")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
+      expect(relay.commitMutation).toHaveBeenCalledTimes(1)
+    })
+
+    it("clicking the button on artworks with one edition set creates an order", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+      relay.commitMutation = jest.fn()
+
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({
+          internalID: "fancy-art",
+          isEdition: true,
+          editionSets: [
+            {
+              internalID: "an-edition-set",
+            },
+          ],
+          isAcquireable: true,
+        }),
+      })
+
+      fireEvent(getAllByText("Purchase")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
+      expect(relay.commitMutation).toHaveBeenCalledTimes(1)
+    })
+
+    it("clicking the button on non-unique artworks opens the confirmation modal", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+      const { getAllByText } = getWrapper({
+        Artwork: () => ({
+          internalID: "fancy-art",
+          isEdition: true,
+          isAcquireable: true,
+          editionSets: [
+            {
+              internalID: "an-edition-set",
+            },
+            {
+              internalID: "another-edition-set",
+            },
+          ],
+        }),
+      })
+
+      fireEvent(getAllByText("Purchase")[0], "press")
+      expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
+      expect(navigate).toHaveBeenCalledWith("purchase/fancy-art", {
+        modal: true,
+        passProps: { conversationID: "123" },
+      })
     })
   })
 
   describe("Artsy guarantee message ad link", () => {
     it("display the correct message and button", () => {
       const { getByText, getAllByText } = getWrapper({
-        Artwork: () => ({ internalID: "fancy-art" }),
+        Artwork: () => ({ internalID: "fancy-art", isOfferableFromInquiry: true }),
       })
 
       expect(getByText("The Artsy Guarantee")).toBeDefined()

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tests.tsx
@@ -1,0 +1,122 @@
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__, GlobalStoreProvider } from "app/store/GlobalStore"
+import { setupTestWrapperTL } from "app/tests/setupTestWrapper"
+import { Theme } from "palette"
+import React from "react"
+import { graphql } from "react-relay"
+import { PurchaseModalFragmentContainer } from "./PurchaseModal"
+
+jest.unmock("react-relay")
+
+describe("PurchaseModal", () => {
+  const { renderWithRelay } = setupTestWrapperTL({
+    Component: (props) => (
+      <Theme>
+        <GlobalStoreProvider>
+          <PurchaseModalFragmentContainer artwork={props.artwork} conversationID="1234" />
+        </GlobalStoreProvider>
+      </Theme>
+    ),
+    query: graphql`
+      query PurchaseModalTestQuery @relay_test_operation {
+        artwork(id: "artwork-id") {
+          ...PurchaseModal_artwork
+        }
+      }
+    `,
+  })
+
+  it("renders edition sets radio buttons", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+
+    const { getAllByText } = renderWithRelay({
+      Artwork: () => ({
+        internalID: "test-id",
+        isEdition: true,
+        editionSets: [
+          {
+            internalID: "first-edition-set",
+            dimensions: {
+              cm: "cm1 x cm1 x cm1",
+              in: "in1 x in1 x in1",
+            },
+          },
+          {
+            internalID: "second-edition-set",
+            dimensions: {
+              cm: "cm2 x cm2 x cm2",
+              in: "in2 x in2 x in2",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    expect(getAllByText("Cancel")[0]).toBeEnabled()
+  })
+
+  it("doesn't allow edition set selection when it's not isAcquireable", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+
+    const { getAllByText, getByText } = renderWithRelay({
+      Artwork: () => ({
+        internalID: "test-id",
+        isEdition: true,
+        editionSets: [
+          {
+            internalID: "first-edition-set",
+            dimensions: {
+              cm: "cm1 x cm1 x cm1",
+              in: "in1 x in1 x in1",
+            },
+          },
+          {
+            internalID: "second-edition-set",
+            dimensions: {
+              cm: "cm2 x cm2 x cm2",
+              in: "in2 x in2 x in2",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    fireEvent.press(getByText("in1 x in1 x in1"))
+    expect(getAllByText("Confirm")[0]).toBeDisabled()
+  })
+
+  it("enables confirm button when an edition set is selected", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+
+    const { getAllByText, getByText } = renderWithRelay({
+      Artwork: () => ({
+        internalID: "test-id",
+        isEdition: true,
+        editionSets: [
+          {
+            isAcquireable: true,
+            internalID: "first-edition-set",
+            dimensions: {
+              cm: "cm1 x cm1 x cm1",
+              in: "in1 x in1 x in1",
+            },
+          },
+          {
+            isAcquireable: true,
+            internalID: "second-edition-set",
+            dimensions: {
+              cm: "cm2 x cm2 x cm2",
+              in: "in2 x in2 x in2",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    fireEvent.press(getByText("in1 x in1 x in1"))
+    expect(getAllByText("Confirm")[0]).toBeEnabled()
+  })
+})

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
@@ -1,9 +1,9 @@
 import { ActionType, OwnerType } from "@artsy/cohesion"
-import { MakeOfferModal_artwork } from "__generated__/MakeOfferModal_artwork.graphql"
+import { PurchaseModal_artwork } from "__generated__/PurchaseModal_artwork.graphql"
 import {
-  MakeOfferModalQuery,
-  MakeOfferModalQueryResponse,
-} from "__generated__/MakeOfferModalQuery.graphql"
+  PurchaseModalQuery,
+  PurchaseModalQueryResponse,
+} from "__generated__/PurchaseModalQuery.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { dismissModal } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
@@ -14,16 +14,16 @@ import { BorderBox, Button, Flex, Text } from "palette"
 import React, { useState } from "react"
 import { ScrollView, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { InquiryMakeOfferButtonFragmentContainer as InquiryMakeOfferButton } from "./InquiryMakeOfferButton"
 
 import { EditionSelectBox } from "./EditionSelectBox"
+import { InquiryPurchaseButtonFragmentContainer } from "./InquiryPurchaseButton"
 
-interface MakeOfferModalProps {
-  artwork: MakeOfferModal_artwork
+interface PurchaseModalProps {
+  artwork: PurchaseModal_artwork
   conversationID: string
 }
 
-export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
+export const PurchaseModal: React.FC<PurchaseModalProps> = ({ ...props }) => {
   const { artwork, conversationID } = props
   const { editionSets } = artwork
 
@@ -41,7 +41,7 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   return (
     <View>
       <FancyModalHeader rightButtonDisabled hideBottomDivider>
-        Make Offer
+        Purchase
       </FancyModalHeader>
       <ScrollView showsVerticalScrollIndicator={false}>
         <Flex p={1.5}>
@@ -61,15 +61,14 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
               ))}
             </Flex>
           )}
-          <InquiryMakeOfferButton
-            variant="fillDark"
+          <InquiryPurchaseButtonFragmentContainer
             artwork={artwork}
             disabled={!!artwork.isEdition && !selectedEdition}
             editionSetID={selectedEdition ? selectedEdition : null}
             conversationID={conversationID}
           >
             Confirm
-          </InquiryMakeOfferButton>
+          </InquiryPurchaseButtonFragmentContainer>
           <Button
             mt={1}
             size="large"
@@ -88,11 +87,11 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
   )
 }
 
-export const MakeOfferModalFragmentContainer = createFragmentContainer(MakeOfferModal, {
+export const PurchaseModalFragmentContainer = createFragmentContainer(PurchaseModal, {
   artwork: graphql`
-    fragment MakeOfferModal_artwork on Artwork {
+    fragment PurchaseModal_artwork on Artwork {
       ...CollapsibleArtworkDetails_artwork
-      ...InquiryMakeOfferButton_artwork
+      ...InquiryPurchaseButton_artwork
       internalID
       isEdition
       editionSets {
@@ -117,7 +116,7 @@ export const MakeOfferModalFragmentContainer = createFragmentContainer(MakeOffer
   `,
 })
 
-export const MakeOfferModalQueryRenderer: React.FC<{
+export const PurchaseModalQueryRenderer: React.FC<{
   artworkID: string
   conversationID: string
 }> = ({ artworkID, conversationID }) => {
@@ -125,24 +124,24 @@ export const MakeOfferModalQueryRenderer: React.FC<{
     <ProvideScreenTrackingWithCohesionSchema
       info={{
         action: ActionType.screen,
-        context_screen_owner_type: OwnerType.conversationMakeOfferConfirmArtwork,
+        context_screen_owner_type: OwnerType.conversation,
         context_screen_referrer_type: OwnerType.conversation,
       }}
     >
-      <QueryRenderer<MakeOfferModalQuery>
+      <QueryRenderer<PurchaseModalQuery>
         environment={defaultEnvironment}
         query={graphql`
-          query MakeOfferModalQuery($artworkID: String!) {
+          query PurchaseModalQuery($artworkID: String!) {
             artwork(id: $artworkID) {
-              ...MakeOfferModal_artwork
+              ...PurchaseModal_artwork
             }
           }
         `}
         variables={{
           artworkID,
         }}
-        render={renderWithLoadProgress<MakeOfferModalQueryResponse>(({ artwork }) => (
-          <MakeOfferModalFragmentContainer artwork={artwork!} conversationID={conversationID} />
+        render={renderWithLoadProgress<PurchaseModalQueryResponse>(({ artwork }) => (
+          <PurchaseModalFragmentContainer artwork={artwork!} conversationID={conversationID} />
         ))}
       />
     </ProvideScreenTrackingWithCohesionSchema>

--- a/src/app/navigation/routes.tsx
+++ b/src/app/navigation/routes.tsx
@@ -235,6 +235,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
 
     addRoute("/city-bmw-list/:citySlug", "CityBMWList"),
     addRoute("/make-offer/:artworkID", "MakeOfferModal"),
+    addRoute("/purchase/:artworkID", "PurchaseModal"),
     addRoute("/user/purchases/:orderID", "OrderDetails"),
     addRoute("/my-profile/saved-search-alerts", "SavedSearchAlertsList"),
     addRoute("/my-profile/saved-search-alerts/:savedSearchAlertId", "EditSavedSearchAlert"),


### PR DESCRIPTION
<!-- 

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [NX-3133]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds Purchase button (hidden under feature flag) to conversations when it's `isAcquireable`. Covers unique and edition sets, since we re-used some boilerplate code from MOI it's already covering Edition Sets. Foreword in regards to some code duplication, the way we define the routes in Eigen is kinda funky, so abstracting to reuse the same modal component for example would be tricky and require some not type-safe prop drilling from the AppRegistry, so that's one of the main reasons.


<img width="412" alt="Screenshot 2022-05-10 at 19 13 00" src="https://user-images.githubusercontent.com/15792853/167689056-8c4b8bff-ab98-4ca9-af19-ec566e13c648.png">

<img width="414" alt="Screenshot 2022-05-10 at 18 45 23" src="https://user-images.githubusercontent.com/15792853/167689218-ecb9b6b8-c135-44a3-87d3-63767aa55071.png">

cc @artsy/negotiate-devs 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add purchase button to conversations - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[NX-3133]: https://artsyproduct.atlassian.net/browse/NX-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ