### PR TITLE
fix: (SWA-357): Display multiple photos when uploaded in Submission flow

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -88,7 +88,7 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
     })
 
     // store photos in asynstorage to be retrieved later when the user goes to My Collection
-    storeLocalPhotos(submission.submissionId, photos)
+    storeLocalPhotos(submission.submissionId, allPhotos)
 
     setFieldValue("photos", allPhotos)
   }

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -1,7 +1,10 @@
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { captureMessage } from "@sentry/react-native"
 import { storeLocalPhotos } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionImageUtil"
-import { Photo, PhotosFormModel } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
+import {
+  Photo,
+  PhotosFormModel,
+} from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { GlobalStore } from "app/store/GlobalStore"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
 import { useFormikContext } from "formik"
@@ -87,7 +90,7 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
     // store photos in asynstorage to be retrieved later when the user goes to My Collection
     storeLocalPhotos(submission.submissionId, photos)
 
-    setFieldValue("photos", photos)
+    setFieldValue("photos", allPhotos)
   }
 
   // show Native action sheet and get photos from user's phone


### PR DESCRIPTION
This PR resolves [SWA-357]

### Description

This PR fixes the problem that when a user uploads multiple photos back to back, only 1 photo is shown as uploaded in the UI, although all uploaded photos are sent to the API. With the fix, all uploaded photos are displayed in the UI as expected. 

### Video
https://user-images.githubusercontent.com/42584148/167811906-e6646fbb-ed20-4ee6-ad3e-20b1580de5ba.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes
This bug fix is effective for all users using the submission flow in all platforms. 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md


[SWA-357]: https://artsyproduct.atlassian.net/browse/SWA-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ