### PR TITLE
refactor: EditionSelectBox conversion to Relay Fragment component

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tests.tsx
@@ -1,0 +1,130 @@
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__, GlobalStoreProvider } from "app/store/GlobalStore"
+import { setupTestWrapperTL } from "app/tests/setupTestWrapper"
+import { Theme } from "palette"
+import React from "react"
+import { graphql } from "relay-runtime"
+import { EditionSelectBoxFragmentContainer } from "./EditionSelectBox"
+
+jest.unmock("react-relay")
+
+describe("EditionSelectBox", () => {
+  let selected: boolean
+  const onPress = jest.fn()
+
+  const { renderWithRelay } = setupTestWrapperTL({
+    Component: ({ artwork }: any) => (
+      <Theme>
+        <GlobalStoreProvider>
+          <EditionSelectBoxFragmentContainer
+            editionSet={artwork.editionSets[0]}
+            selected={selected}
+            onPress={onPress}
+          />
+        </GlobalStoreProvider>
+      </Theme>
+    ),
+    query: graphql`
+      query EditionSelectBoxTestQuery {
+        artwork(id: "test-id") {
+          internalID
+          editionSets {
+            ...EditionSelectBox_editionSet
+          }
+        }
+      }
+    `,
+  })
+
+  beforeEach(() => {
+    selected = false
+    onPress.mockReset()
+  })
+
+  it("renders edition set with isOfferableFromInquiry", () => {
+    const { getByText } = renderWithRelay({
+      Artwork: () => ({
+        slug: "test-artwork",
+        editionSets: [
+          {
+            internalID: "test-id",
+            isOfferableFromInquiry: true,
+            dimensions: {
+              in: "in x in x in",
+              cm: "cm x cm x cm",
+            },
+            listPrice: {
+              __typename: "Money",
+              display: "$100.00",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getByText("in x in x in")).toBeTruthy()
+    expect(getByText("cm x cm x cm")).toBeTruthy()
+    expect(getByText("$100.00")).toBeTruthy()
+
+    fireEvent.press(getByText("in x in x in"))
+    expect(onPress).toHaveBeenCalledWith("test-id", true)
+  })
+
+  it("renders edition set with isAcquireable and the feature flag", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
+    const { getByText } = renderWithRelay({
+      Artwork: () => ({
+        slug: "test-artwork",
+        editionSets: [
+          {
+            internalID: "test-id",
+            isAcquireable: true,
+            dimensions: {
+              in: "in x in x in",
+              cm: "cm x cm x cm",
+            },
+            listPrice: {
+              __typename: "Money",
+              display: "$100.00",
+            },
+          },
+        ],
+      }),
+    })
+    expect(getByText("$100.00")).toBeTruthy()
+
+    fireEvent.press(getByText("in x in x in"))
+    expect(onPress).toHaveBeenCalledWith("test-id", true)
+  })
+
+  it("renders unavailable edition set", () => {
+    const { getByText } = renderWithRelay({
+      Artwork: () => ({
+        slug: "test-artwork",
+        editionSets: [
+          {
+            internalID: "test-id",
+            isOfferableFromInquiry: false,
+            isAcquireable: true,
+            dimensions: {
+              in: "in x in x in",
+              cm: "cm x cm x cm",
+            },
+            listPrice: {
+              __typename: "Money",
+              display: "$100.00",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(getByText("in x in x in")).toBeTruthy()
+    expect(getByText("cm x cm x cm")).toBeTruthy()
+    expect(getByText("Unavailable")).toBeTruthy()
+    expect(() => getByText("$100.00")).toThrow()
+
+    fireEvent.press(getByText("in x in x in"))
+    expect(onPress).toHaveBeenCalledWith("test-id", false)
+  })
+})

--- a/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/EditionSelectBox.tsx
@@ -1,12 +1,12 @@
 import { themeGet } from "@styled-system/theme-get"
+import { EditionSelectBox_editionSet } from "__generated__/EditionSelectBox_editionSet.graphql"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { BorderBox, Flex, Text, Touchable } from "palette"
 import { RadioButton } from "palette/elements/Radio"
 import React from "react"
 import { View } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components/native"
-
-import { MakeOfferModal_artwork } from "__generated__/MakeOfferModal_artwork.graphql"
 
 const UnavailableIndicator = styled(View)`
   height: 8px;
@@ -17,29 +17,33 @@ const UnavailableIndicator = styled(View)`
 `
 
 interface Props {
-  edition: NonNullable<NonNullable<MakeOfferModal_artwork["editionSets"]>[number]>
+  editionSet: EditionSelectBox_editionSet
   selected: boolean
   onPress: (editionSetId: string, isAvailable: boolean) => void
 }
 
-export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }) => {
+export const EditionSelectBox: React.FC<Props> = ({ editionSet, selected, onPress }) => {
   const enableConversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
   const available =
-    !!edition.isOfferableFromInquiry || (enableConversationalBuyNow && !!edition.isAcquireable)
+    !!editionSet.isOfferableFromInquiry ||
+    (enableConversationalBuyNow && !!editionSet.isAcquireable)
 
   return (
-    <Touchable onPress={() => onPress(edition.internalID, available)}>
+    <Touchable onPress={() => onPress(editionSet.internalID, available)}>
       <BorderBox p={2} my={0.5} flexDirection="row">
-        <RadioButton selected={selected} onPress={() => onPress(edition.internalID, available)} />
+        <RadioButton
+          selected={selected}
+          onPress={() => onPress(editionSet.internalID, available)}
+        />
         <Flex mx={1} flexGrow={1}>
-          <Text color={available ? "black100" : "black30"}>{edition.dimensions?.in}</Text>
+          <Text color={available ? "black100" : "black30"}>{editionSet.dimensions?.in}</Text>
           <Text color={available ? "black60" : "black30"} variant="xs">
-            {edition.dimensions?.cm}
+            {editionSet.dimensions?.cm}
           </Text>
-          <Text color={available ? "black60" : "black30"}>{edition.editionOf}</Text>
+          <Text color={available ? "black60" : "black30"}>{editionSet.editionOf}</Text>
         </Flex>
         {available ? (
-          <Text>{edition.listPrice?.display || "Price on request"}</Text>
+          <Text>{editionSet.listPrice?.display || "Price on request"}</Text>
         ) : (
           <Flex flexDirection="row" alignItems="baseline">
             <UnavailableIndicator />
@@ -50,3 +54,26 @@ export const EditionSelectBox: React.FC<Props> = ({ edition, selected, onPress }
     </Touchable>
   )
 }
+
+export const EditionSelectBoxFragmentContainer = createFragmentContainer(EditionSelectBox, {
+  editionSet: graphql`
+    fragment EditionSelectBox_editionSet on EditionSet {
+      internalID
+      editionOf
+      isAcquireable
+      isOfferableFromInquiry
+      listPrice {
+        ... on Money {
+          display
+        }
+        ... on PriceRange {
+          display
+        }
+      }
+      dimensions {
+        cm
+        in
+      }
+    }
+  `,
+})

--- a/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tests.tsx
@@ -148,8 +148,8 @@ describe("<MakeOfferModal />", () => {
   describe("when artwork is edition set", () => {
     const tapOn = (edition: ReactTestInstance) => {
       edition.props.onPress(
-        edition.props.edition.internalID,
-        edition.props.edition.isOfferableFromInquiry
+        edition.props.editionSet.internalID,
+        edition.props.editionSet.isOfferableFromInquiry
       )
     }
     it("shows edition selection when it's an edition", () => {
@@ -173,7 +173,7 @@ describe("<MakeOfferModal />", () => {
       const wrapper = getWrapper(mockEditionsResolver)
       const selection = wrapper.root
         .findAllByType(EditionSelectBox)
-        .find((edtn) => edtn.props.edition.internalID === "edition-2")!
+        .find((edtn) => edtn.props.editionSet.internalID === "edition-2")!
       const text = extractText(selection)
       expect(text).toContain("Unavailable")
       expect(text).not.toContain("€200")
@@ -186,8 +186,10 @@ describe("<MakeOfferModal />", () => {
     it("allows the user to toggle between available editions and confirm", async () => {
       const wrapper = getWrapper(mockEditionsResolver)
       const editions = wrapper.root.findAllByType(EditionSelectBox)
-      const selection = editions.find((edtn) => edtn.props.edition.internalID === "edition-1")!
-      const selectionAlt = editions.find((edtn) => edtn.props.edition.internalID === "edition-3")!
+      const selection = editions.find((edtn) => edtn.props.editionSet.internalID === "edition-1")!
+      const selectionAlt = editions.find(
+        (edtn) => edtn.props.editionSet.internalID === "edition-3"
+      )!
       tapOn(selection)
       const confirmBtn = wrapper.root.findByType(InquiryMakeOfferButton)
       await flushPromiseQueue()

--- a/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -16,7 +16,7 @@ import { ScrollView, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { InquiryMakeOfferButtonFragmentContainer as InquiryMakeOfferButton } from "./InquiryMakeOfferButton"
 
-import { EditionSelectBox } from "./EditionSelectBox"
+import { EditionSelectBoxFragmentContainer } from "./EditionSelectBox"
 
 interface MakeOfferModalProps {
   artwork: MakeOfferModal_artwork
@@ -52,8 +52,8 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
           {!!artwork.isEdition && artwork.editionSets!.length > 1 && (
             <Flex mb={2}>
               {artwork.editionSets?.map((edition) => (
-                <EditionSelectBox
-                  edition={edition!}
+                <EditionSelectBoxFragmentContainer
+                  editionSet={edition!}
                   selected={edition!.internalID === selectedEdition}
                   onPress={selectEdition}
                   key={`edition-set-${edition?.internalID}`}
@@ -96,22 +96,8 @@ export const MakeOfferModalFragmentContainer = createFragmentContainer(MakeOffer
       internalID
       isEdition
       editionSets {
+        ...EditionSelectBox_editionSet
         internalID
-        editionOf
-        isAcquireable
-        isOfferableFromInquiry
-        listPrice {
-          ... on Money {
-            display
-          }
-          ... on PriceRange {
-            display
-          }
-        }
-        dimensions {
-          cm
-          in
-        }
       }
     }
   `,

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
@@ -15,7 +15,7 @@ import React, { useState } from "react"
 import { ScrollView, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
-import { EditionSelectBox } from "./EditionSelectBox"
+import { EditionSelectBoxFragmentContainer } from "./EditionSelectBox"
 import { InquiryPurchaseButtonFragmentContainer } from "./InquiryPurchaseButton"
 
 interface PurchaseModalProps {
@@ -52,8 +52,8 @@ export const PurchaseModal: React.FC<PurchaseModalProps> = ({ ...props }) => {
           {!!artwork.isEdition && artwork.editionSets!.length > 1 && (
             <Flex mb={2}>
               {artwork.editionSets?.map((edition) => (
-                <EditionSelectBox
-                  edition={edition!}
+                <EditionSelectBoxFragmentContainer
+                  editionSet={edition!}
                   selected={edition!.internalID === selectedEdition}
                   onPress={selectEdition}
                   key={`edition-set-${edition?.internalID}`}
@@ -95,22 +95,8 @@ export const PurchaseModalFragmentContainer = createFragmentContainer(PurchaseMo
       internalID
       isEdition
       editionSets {
+        ...EditionSelectBox_editionSet
         internalID
-        editionOf
-        isAcquireable
-        isOfferableFromInquiry
-        listPrice {
-          ... on Money {
-            display
-          }
-          ... on PriceRange {
-            display
-          }
-        }
-        dimensions {
-          cm
-          in
-        }
       }
     }
   `,


### PR DESCRIPTION
<!-- 

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adjusts the Select Edition Set component used in Inbox to act like a real relay fragment component instead of prop drilling manually from parent components.

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look on our [docs], or get in touch with us.

[app state migration]: /docs/adding_state_migrations.md
[feature flag]: /docs/developing_a_feature.md
[docs]: /docs/README.md
