### PR TITLE
feat(FX-3954): Create Alert button opens up modal pre-filled with relevant filters on artwork screen

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -1,10 +1,9 @@
 import { OwnerType } from "@artsy/cohesion"
 import { fireEvent } from "@testing-library/react-native"
 import {
-  ArtworkFiltersState,
-  ArtworkFiltersStoreProvider,
-} from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { SavedSearchEntity } from "app/Components/ArtworkFilter/SavedSearch/types"
+  SavedSearchEntity,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
 import { navigate } from "app/navigation/navigate"
 import { CreateSavedSearchAlert } from "app/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
 import { SavedSearchAlertMutationResult } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
@@ -31,24 +30,16 @@ const savedSearchEntity: SavedSearchEntity = {
   },
 }
 
+const attributes: SearchCriteriaAttributes = {
+  artistIDs: ["artistId"],
+}
+
 const defaultProps: CreateSavedSearchModalProps = {
   visible: true,
   entity: savedSearchEntity,
-  closeModal: jest.fn,
-}
-
-const initialData: ArtworkFiltersState = {
-  selectedFilters: [],
-  appliedFilters: [],
-  previouslyAppliedFilters: [],
-  applyFilters: false,
+  attributes,
   aggregations: [],
-  filterType: "artwork",
-  counts: {
-    total: null,
-    followedArtists: null,
-  },
-  sizeMetric: "cm",
+  closeModal: jest.fn,
 }
 
 const mockedMutationResult: SavedSearchAlertMutationResult = {
@@ -57,11 +48,7 @@ const mockedMutationResult: SavedSearchAlertMutationResult = {
 
 describe("CreateSavedSearchModal", () => {
   const TestRenderer = (props?: Partial<CreateSavedSearchModalProps>) => {
-    return (
-      <ArtworkFiltersStoreProvider initialData={initialData}>
-        <CreateSavedSearchModal {...defaultProps} {...props} />
-      </ArtworkFiltersStoreProvider>
-    )
+    return <CreateSavedSearchModal {...defaultProps} {...props} />
   }
 
   it("renders without throwing an error", () => {

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -1,8 +1,9 @@
 import { ActionType, ScreenOwnerType, ToggledSavedSearch } from "@artsy/cohesion"
-import { getUnitedSelectedAndAppliedFilters } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
-import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { getSearchCriteriaFromFilters } from "app/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
-import { SavedSearchEntity } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import {
+  SavedSearchEntity,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { navigate, NavigateOptions } from "app/navigation/navigate"
 import { CreateSavedSearchAlert } from "app/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
@@ -16,17 +17,16 @@ import { useTracking } from "react-tracking"
 export interface CreateSavedSearchModalProps {
   visible: boolean
   entity: SavedSearchEntity
+  attributes: SearchCriteriaAttributes
+  aggregations: Aggregations
   closeModal: () => void
   onComplete?: () => void
 }
 
 export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (props) => {
-  const { visible, entity, closeModal, onComplete } = props
+  const { visible, entity, attributes, aggregations, closeModal, onComplete } = props
   const tracking = useTracking()
   const popover = usePopoverMessage()
-  const filterState = ArtworksFiltersStore.useStoreState((state) => state)
-  const unitedFilters = getUnitedSelectedAndAppliedFilters(filterState)
-  const attributes = getSearchCriteriaFromFilters(entity, unitedFilters)
 
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
     const { owner } = entity
@@ -53,7 +53,7 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
   }
 
   const params: CreateSavedSearchAlertParams = {
-    aggregations: filterState.aggregations,
+    aggregations,
     attributes,
     entity,
     onClosePress: closeModal,

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -6,6 +6,7 @@ import {
   FilterArray,
   filterArtworksParams,
   FilterParams,
+  getUnitedSelectedAndAppliedFilters,
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { AdditionalGeneIDsOptionsScreen } from "app/Components/ArtworkFilter/Filters/AdditionalGeneIDsOptions"
@@ -40,6 +41,7 @@ import {
 import { ArtworkFilterApplyButton } from "./components/ArtworkFilterApplyButton"
 import { AuctionHouseOptionsScreen } from "./Filters/AuctionHouseOptions"
 import { LocationCitiesOptionsScreen } from "./Filters/LocationCitiesOptions"
+import { getSearchCriteriaFromFilters } from "./SavedSearch/searchCriteriaHelpers"
 import { SavedSearchEntity } from "./SavedSearch/types"
 
 interface ArtworkFilterProps extends ViewProps {
@@ -101,6 +103,16 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const { id, mode, slug, name, query, shouldShowCreateAlertButton, closeModal, exitModal } = props
   const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
+  const savedSearchEntity: SavedSearchEntity = {
+    placeholder: name!,
+    artists: [{ id: id!, name: name! }],
+    owner: {
+      type: OwnerType.artist,
+      id: id!,
+      slug: slug!,
+    },
+  }
+
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
   const previouslyAppliedFiltersState = ArtworksFiltersStore.useStoreState(
@@ -114,6 +126,10 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const resetFiltersAction = ArtworksFiltersStore.useStoreActions(
     (action) => action.resetFiltersAction
   )
+
+  const filterState = ArtworksFiltersStore.useStoreState((state) => state)
+  const unitedFilters = getUnitedSelectedAndAppliedFilters(filterState)
+  const attributes = getSearchCriteriaFromFilters(savedSearchEntity, unitedFilters)
 
   const handleClosingModal = () => {
     resetFiltersAction()
@@ -272,16 +288,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
     setSelectedMetric(localizedUnit)
   }, [])
 
-  const savedSearchEntity: SavedSearchEntity = {
-    placeholder: name!,
-    artists: [{ id: id!, name: name! }],
-    owner: {
-      type: OwnerType.artist,
-      id: id!,
-      slug: slug!,
-    },
-  }
-
   return (
     <NavigationContainer independent>
       <FancyModal
@@ -374,6 +380,8 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             entity={savedSearchEntity}
             closeModal={() => setIsCreateAlertModalVisible(false)}
             onComplete={exitModal}
+            attributes={attributes}
+            aggregations={filterState.aggregations}
           />
         </View>
       </FancyModal>

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -33,7 +33,7 @@ import { ArtworksInSeriesRail } from "./Components/ArtworksInSeriesRail"
 import { BelowTheFoldPlaceholder } from "./Components/BelowTheFoldPlaceholder"
 import { CommercialInformationFragmentContainer as CommercialInformation } from "./Components/CommercialInformation"
 import { ContextCardFragmentContainer as ContextCard } from "./Components/ContextCard"
-import { CreateArtworkAlertSection } from "./Components/CreateArtworkAlertSection"
+import { CreateArtworkAlertSectionFragmentContainer as CreateArtworkAlertSection } from "./Components/CreateArtworkAlertSection"
 import {
   OtherWorksFragmentContainer as OtherWorks,
   populatedGrids,
@@ -241,7 +241,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
     if (enableCreateArtworkAlert) {
       sections.push({
         key: "createAlertSection",
-        element: <CreateArtworkAlertSection />,
+        element: <CreateArtworkAlertSection artwork={artworkBelowTheFold} />,
         verticalMargin: 2,
       })
     }
@@ -512,6 +512,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkHistory_artwork
         ...ArtworksInSeriesRail_artwork
         ...Questions_artwork
+        ...CreateArtworkAlertSection_artwork
       }
     `,
     me: graphql`

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -241,7 +241,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
     if (enableCreateArtworkAlert) {
       sections.push({
         key: "createAlertSection",
-        element: <CreateArtworkAlertSection artwork={artworkBelowTheFold} />,
+        element: <CreateArtworkAlertSection artwork={artworkAboveTheFold} />,
         verticalMargin: 2,
       })
     }
@@ -419,6 +419,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkHeader_artwork
         ...CommercialInformation_artwork
         ...FaqAndSpecialistSection_artwork
+        ...CreateArtworkAlertSection_artwork
         slug
         internalID
         id
@@ -512,7 +513,6 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkHistory_artwork
         ...ArtworksInSeriesRail_artwork
         ...Questions_artwork
-        ...CreateArtworkAlertSection_artwork
       }
     `,
     me: graphql`

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
@@ -1,0 +1,122 @@
+import { fireEvent } from "@testing-library/react-native"
+import { CreateArtworkAlertSectionTestsQuery } from "__generated__/CreateArtworkAlertSectionTestsQuery.graphql"
+import { mockEnvironmentPayload } from "app/tests/mockEnvironmentPayload"
+import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { CreateArtworkAlertSectionFragmentContainer } from "./CreateArtworkAlertSection"
+
+jest.unmock("react-relay")
+
+describe("CreateArtworkAlertSection", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const TestRenderer = () => {
+    return (
+      <QueryRenderer<CreateArtworkAlertSectionTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query CreateArtworkAlertSectionTestsQuery @relay_test_operation {
+            artwork(id: "artwork-id") {
+              ...CreateArtworkAlertSection_artwork
+            }
+          }
+        `}
+        variables={{}}
+        render={({ props }) => {
+          if (props?.artwork) {
+            return <CreateArtworkAlertSectionFragmentContainer artwork={props.artwork} />
+          }
+          return null
+        }}
+      />
+    )
+  }
+
+  it("should correctly render placeholder", () => {
+    const placeholder = "Artworks like: Some artwork title"
+    const { getAllByText, getAllByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artwork: () => Artwork,
+    })
+
+    fireEvent.press(getAllByText("Create Alert")[0])
+
+    expect(getAllByPlaceholderText(placeholder)).toBeTruthy()
+  })
+
+  it("should correctly render pills", () => {
+    const { getAllByText, getByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artwork: () => Artwork,
+    })
+
+    fireEvent.press(getAllByText("Create Alert")[0])
+
+    expect(getByText("Banksy")).toBeTruthy()
+    expect(getByText("Limited Edition")).toBeTruthy()
+    expect(getByText("Prints")).toBeTruthy()
+  })
+
+  it("should not render `Rarity` pill if needed data is missing", () => {
+    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artwork: () => ({
+        ...Artwork,
+        attributionClass: null,
+      }),
+    })
+
+    fireEvent.press(getAllByText("Create Alert")[0])
+
+    expect(queryByText("Limited Edition")).toBeFalsy()
+  })
+
+  it("should not render `Medium` pill if needed data is missing", () => {
+    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artwork: () => ({
+        ...Artwork,
+        mediumType: null,
+      }),
+    })
+
+    fireEvent.press(getAllByText("Create Alert")[0])
+
+    expect(queryByText("Prints")).toBeFalsy()
+  })
+})
+
+const Artwork = {
+  title: "Some artwork title",
+  slug: "artwork-slug",
+  internalID: "artwork-id",
+  artists: [
+    {
+      internalID: "4dd1584de0091e000100207c",
+      name: "Banksy",
+      slug: "banksy",
+    },
+  ],
+  attributionClass: {
+    internalID: "limited edition",
+  },
+  mediumType: {
+    filterGene: {
+      slug: "prints",
+      name: "Prints",
+    },
+  },
+}

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
@@ -1,5 +1,6 @@
 import { fireEvent } from "@testing-library/react-native"
 import { CreateArtworkAlertSectionTestsQuery } from "__generated__/CreateArtworkAlertSectionTestsQuery.graphql"
+import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { mockEnvironmentPayload } from "app/tests/mockEnvironmentPayload"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import { graphql, QueryRenderer } from "react-relay"
@@ -96,6 +97,28 @@ describe("CreateArtworkAlertSection", () => {
     fireEvent.press(getAllByText("Create Alert")[0])
 
     expect(queryByText("Prints")).toBeFalsy()
+  })
+
+  it("should correctly track event when `Create Alert` button is pressed", () => {
+    const { getAllByText } = renderWithWrappersTL(<TestRenderer />)
+
+    mockEnvironmentPayload(mockEnvironment, {
+      Artwork: () => Artwork,
+    })
+
+    fireEvent.press(getAllByText("Create Alert")[0])
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "tappedCreateAlert",
+          "context_module": "artworkMetadata",
+          "context_screen_owner_id": "artwork-id",
+          "context_screen_owner_slug": "artwork-slug",
+          "context_screen_owner_type": "artwork",
+        },
+      ]
+    `)
   })
 })
 

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
@@ -130,7 +130,6 @@ const Artwork = {
     {
       internalID: "4dd1584de0091e000100207c",
       name: "Banksy",
-      slug: "banksy",
     },
   ],
   attributionClass: {

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
@@ -112,7 +112,7 @@ describe("CreateArtworkAlertSection", () => {
       Array [
         Object {
           "action": "tappedCreateAlert",
-          "context_module": "artworkMetadata",
+          "context_module": "ArtworkTombstone",
           "context_screen_owner_id": "artwork-id",
           "context_screen_owner_slug": "artwork-slug",
           "context_screen_owner_type": "artwork",

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
@@ -34,7 +34,6 @@ export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ 
   const formattedArtists: SavedSearchEntityArtist[] = artists.map((artist) => ({
     id: artist.internalID,
     name: artist.name!,
-    slug: artist.slug!,
   }))
 
   const entity: SavedSearchEntity = {
@@ -44,7 +43,6 @@ export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ 
       type: OwnerType.artwork,
       id: artwork?.internalID ?? "",
       slug: artwork?.slug ?? "",
-      name: artwork?.title ?? "",
     },
   }
 
@@ -137,7 +135,6 @@ export const CreateArtworkAlertSectionFragmentContainer = createFragmentContaine
         artists {
           internalID
           name
-          slug
         }
       }
     `,

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
@@ -1,26 +1,125 @@
+import { OwnerType } from "@artsy/cohesion"
+import { CreateArtworkAlertSection_artwork } from "__generated__/CreateArtworkAlertSection_artwork.graphql"
+import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
+import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import {
+  SavedSearchEntity,
+  SavedSearchEntityArtist,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
+import { compact } from "lodash"
 import { BellIcon, Button, Flex, Text } from "palette"
+import { FC, useState } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 
-export const CreateArtworkAlertSection = () => {
+interface CreateArtworkAlertSectionProps {
+  artwork: CreateArtworkAlertSection_artwork
+}
+
+export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ artwork }) => {
+  const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
+
+  let aggregations: Aggregations = []
+  let additionalGeneIDs: string[] = []
+  const artists = compact(artwork?.artists)
+  const attributionClass = compact([artwork?.attributionClass?.internalID])
+  const formattedArtists: SavedSearchEntityArtist[] = artists.map((artist) => ({
+    id: artist.internalID,
+    name: artist.name!,
+    slug: artist.slug!,
+  }))
+
+  const savedSearchEntity: SavedSearchEntity = {
+    placeholder: `Artworks like: ${artwork?.title!}`,
+    artists: formattedArtists,
+    owner: {
+      type: OwnerType.artwork,
+      id: artwork?.internalID,
+      slug: artwork?.slug,
+      name: artwork?.title!,
+    },
+  }
+
+  if (artwork?.mediumType?.filterGene?.name && artwork?.mediumType?.filterGene.slug) {
+    additionalGeneIDs = [artwork.mediumType.filterGene.slug]
+    aggregations = [
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            name: artwork.mediumType.filterGene.name,
+            value: artwork.mediumType.filterGene.slug,
+            count: 0,
+          },
+        ],
+      },
+    ]
+  }
+
+  const attributes: SearchCriteriaAttributes = {
+    artistIDs: formattedArtists.map((artist) => artist.id),
+    attributionClass,
+    additionalGeneIDs,
+  }
+
   return (
-    <Flex flexDirection="row" justifyContent="space-between">
-      <Flex flex={1}>
-        <Text variant="xs" numberOfLines={2}>
-          Be notified when a similar piece is available
-        </Text>
-      </Flex>
-
-      <Flex flex={1} alignItems="flex-end" justifyContent="center">
-        <Button
-          size="small"
-          variant="outline"
-          icon={<BellIcon fill="black100" width="16px" height="16px" />}
-          haptic
-        >
-          <Text variant="xs" ml={0.5} numberOfLines={1} lineHeight={16}>
-            Create Alert
+    <>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Flex flex={1}>
+          <Text variant="xs" numberOfLines={2}>
+            Be notified when a similar piece is available
           </Text>
-        </Button>
+        </Flex>
+
+        <Flex flex={1} alignItems="flex-end" justifyContent="center">
+          <Button
+            size="small"
+            variant="outline"
+            icon={<BellIcon fill="black100" width="16px" height="16px" />}
+            haptic
+            onPress={() => setIsCreateAlertModalVisible(true)}
+            disabled={!artwork}
+          >
+            <Text variant="xs" ml={0.5} numberOfLines={1} lineHeight={16}>
+              Create Alert
+            </Text>
+          </Button>
+        </Flex>
       </Flex>
-    </Flex>
+      <CreateSavedSearchModal
+        visible={isCreateAlertModalVisible}
+        entity={savedSearchEntity}
+        attributes={attributes}
+        aggregations={aggregations}
+        closeModal={() => setIsCreateAlertModalVisible(false)}
+      />
+    </>
   )
 }
+
+export const CreateArtworkAlertSectionFragmentContainer = createFragmentContainer(
+  CreateArtworkAlertSection,
+  {
+    artwork: graphql`
+      fragment CreateArtworkAlertSection_artwork on Artwork {
+        internalID
+        slug
+        title
+        attributionClass {
+          internalID
+        }
+        mediumType {
+          filterGene {
+            slug
+            name
+          }
+        }
+        artists {
+          internalID
+          name
+          slug
+        }
+      }
+    `,
+  }
+)

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
@@ -20,7 +20,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface CreateArtworkAlertSectionProps {
-  artwork: CreateArtworkAlertSection_artwork
+  artwork: CreateArtworkAlertSection_artwork | null
 }
 
 export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ artwork }) => {
@@ -42,9 +42,9 @@ export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ 
     artists: formattedArtists,
     owner: {
       type: OwnerType.artwork,
-      id: artwork?.internalID,
-      slug: artwork?.slug,
-      name: artwork?.title!,
+      id: artwork?.internalID ?? "",
+      slug: artwork?.slug ?? "",
+      name: artwork?.title ?? "",
     },
   }
 

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
@@ -157,7 +157,6 @@ const tracks = {
     context_screen_owner_type: ownerType,
     context_screen_owner_id: ownerId,
     context_screen_owner_slug: ownerSlug,
-    // TODO: Clarify this moment
-    context_module: ContextModule.artworkMetadata,
+    context_module: "ArtworkTombstone" as ContextModule,
   }),
 }


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-3954]

### Given I am on the artwork page
* And I can see the Create Alert button
* When I click the Create Alert button
* Then I am presented with the Create Alert modal
* And the name placeholder is specific to the artwork
* And supported filters are preconfigured

### Acceptance Criteria
* Can not remove the artists in this iteration
* Alert name: “Artworks like: [Title of work]” (do not include year)
* Display the create alert modal window when the “Create Alert“ button on artwork page was pressed
* Should be displayed pre-filled relevant filters in create alert modal

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/169017970-966ec49c-0f46-4eb0-a7f5-fb40823a1763.mp4

#### Android
https://user-images.githubusercontent.com/3513494/169019390-14064287-0d91-4589-86b1-7303fb72cf93.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Create Alert button opens up modal pre-filled with relevant filters on artwork screen - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3954]: https://artsyproduct.atlassian.net/browse/FX-3954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ