### PR TITLE
feat(FX-3978): Separate Faq Section from Auction Faq and add it to artwork screen

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -246,10 +246,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    if (enableCreateArtworkAlert) {
+    if (
+      !!(artworkAboveTheFold?.isAcquireable || artworkAboveTheFold?.isOfferable) &&
+      enableCreateArtworkAlert
+    ) {
       sections.push({
         key: "faqSection",
-        element: <FaqAndSpecialistSection artwork={artworkAboveTheFold!} />,
+        element: <FaqAndSpecialistSection artwork={artworkAboveTheFold} />,
         verticalMargin: 2,
       })
     }

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -26,6 +26,7 @@ import { AboutArtistFragmentContainer as AboutArtist } from "./Components/AboutA
 import { AboutWorkFragmentContainer as AboutWork } from "./Components/AboutWork"
 import { AboveTheFoldPlaceholder } from "./Components/AboveTheFoldArtworkPlaceholder"
 import { ArtworkDetailsFragmentContainer as ArtworkDetails } from "./Components/ArtworkDetails"
+import { FaqAndSpecialistSectionFragmentContainer as FaqAndSpecialistSection } from "./Components/ArtworkExtraLinks/FaqAndSpecialistSection"
 import { ArtworkHeaderFragmentContainer as ArtworkHeader } from "./Components/ArtworkHeader"
 import { ArtworkHistoryFragmentContainer as ArtworkHistory } from "./Components/ArtworkHistory"
 import { ArtworksInSeriesRail } from "./Components/ArtworksInSeriesRail"
@@ -245,13 +246,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    // add FAQ section but maybe here we want to check some things, and also the code is 🤯 might need to address that in another ticket?
-    // if (enableCreateArtworkAlert) {
-    //   sections.push({
-    //     key: "faqSection",
-    //     element: <FaqAndSpecialistSection artwork={artworkAboveTheFold} />
-    //   })
-    // }
+    if (enableCreateArtworkAlert) {
+      sections.push({
+        key: "faqSection",
+        element: <FaqAndSpecialistSection artwork={artworkAboveTheFold!} />,
+        verticalMargin: 2,
+      })
+    }
 
     if (!artworkBelowTheFold) {
       sections.push({
@@ -414,6 +415,7 @@ export const ArtworkContainer = createRefetchContainer(
       fragment Artwork_artworkAboveTheFold on Artwork {
         ...ArtworkHeader_artwork
         ...CommercialInformation_artwork
+        ...FaqAndSpecialistSection_artwork
         slug
         internalID
         id

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/AuctionFaqSection.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/AuctionFaqSection.tsx
@@ -1,0 +1,93 @@
+import { ArtworkExtraLinks_artwork } from "__generated__/ArtworkExtraLinks_artwork.graphql"
+import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
+import { navigate } from "app/navigation/navigate"
+import { sendEmail } from "app/utils/sendEmail"
+import { Schema } from "app/utils/track"
+import { Sans, Spacer } from "palette"
+import React from "react"
+import { Text } from "react-native"
+import { useTracking } from "react-tracking"
+import { partnerName } from "./partnerName"
+
+interface AuctionFaqSectionProps {
+  artwork: ArtworkExtraLinks_artwork
+  auctionState: AuctionTimerState
+}
+
+export const AuctionFaqSection: React.FC<AuctionFaqSectionProps> = ({ artwork, auctionState }) => {
+  const { isInAuction, sale, isForSale } = artwork
+  const { trackEvent } = useTracking()
+
+  const handleReadOurAuctionFAQsTap = () => {
+    trackEvent(tracks.tappedAuctionFAQs())
+    navigate(`/auction-faq`)
+  }
+  const handleConditionsOfSaleTap = () => {
+    trackEvent(tracks.tappedConditionsOfSale())
+    navigate(`/conditions-of-sale`)
+  }
+
+  const handleAskASpecialistTap = (emailAddress: string) => {
+    trackEvent(tracks.tappedAskASpecialist())
+
+    const mailtoSubject = `Inquiry on ${artwork.title}`.concat(
+      artwork.artist && artwork.artist.name ? ` by ${artwork.artist.name}` : ""
+    )
+    sendEmail(emailAddress, { subject: mailtoSubject })
+  }
+
+  if (isInAuction && sale && isForSale && auctionState !== AuctionTimerState.CLOSED) {
+    return (
+      <>
+        <Sans size="2" color="black60">
+          By placing a bid you agree to {partnerName(sale)}{" "}
+          <Text
+            style={{ textDecorationLine: "underline" }}
+            onPress={() => handleConditionsOfSaleTap()}
+          >
+            Conditions of Sale
+          </Text>
+          .
+        </Sans>
+        <Spacer mb={1} />
+        <Sans size="2" color="black60">
+          Have a question?{" "}
+          <Text
+            style={{ textDecorationLine: "underline" }}
+            onPress={() => handleReadOurAuctionFAQsTap()}
+          >
+            Read our auction FAQs
+          </Text>{" "}
+          or{" "}
+          <Text
+            style={{ textDecorationLine: "underline" }}
+            onPress={() => handleAskASpecialistTap("specialist@artsy.net")}
+          >
+            ask a specialist
+          </Text>
+          .
+        </Sans>
+      </>
+    )
+  }
+  return null
+}
+
+// TODO: move track events to cohesion
+const tracks = {
+  tappedAskASpecialist: () => ({
+    action_name: Schema.ActionNames.AskASpecialist,
+    action_type: Schema.ActionTypes.Tap,
+    context_module: Schema.ContextModules.ArtworkExtraLinks,
+  }),
+  tappedAuctionFAQs: () => ({
+    action_name: Schema.ActionNames.AuctionsFAQ,
+    action_type: Schema.ActionTypes.Tap,
+    context_module: Schema.ContextModules.ArtworkExtraLinks,
+  }),
+  tappedConditionsOfSale: () => ({
+    action_name: Schema.ActionNames.ConditionsOfSale,
+    action_type: Schema.ActionTypes.Tap,
+    context_module: Schema.ContextModules.ArtworkExtraLinks,
+  }),
+}

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tsx
@@ -1,35 +1,19 @@
 import { ArtworkExtraLinks_artwork } from "__generated__/ArtworkExtraLinks_artwork.graphql"
-import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { navigate } from "app/navigation/navigate"
-import { partnerName } from "app/Scenes/Artwork/Components/ArtworkExtraLinks/partnerName"
 import { sendEmail } from "app/utils/sendEmail"
 import { Schema } from "app/utils/track"
-import { Sans, Spacer } from "palette"
+import { Sans } from "palette"
 import React from "react"
 import { Text } from "react-native"
 import { useTracking } from "react-tracking"
 
 interface FaqAndSpecialistSectionProps {
   artwork: ArtworkExtraLinks_artwork
-  auctionState: AuctionTimerState
 }
 
-export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = ({
-  artwork,
-  auctionState,
-}) => {
-  const { isAcquireable, isOfferable, isInAuction, sale, isForSale } = artwork
+export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = ({ artwork }) => {
+  const { isAcquireable, isOfferable } = artwork
   const { trackEvent } = useTracking()
-
-  const handleConditionsOfSaleTap = () => {
-    trackEvent(tracks.tappedConditionsOfSale())
-    navigate(`/conditions-of-sale`)
-  }
-
-  const handleReadOurAuctionFAQsTap = () => {
-    trackEvent(tracks.tappedAuctionFAQs())
-    navigate(`/auction-faq`)
-  }
 
   const handleAskASpecialistTap = (emailAddress: string) => {
     trackEvent(tracks.tappedAskASpecialist())
@@ -45,40 +29,7 @@ export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = (
     navigate(`/buy-now-feature-faq`)
   }
 
-  if (isInAuction && sale && isForSale && auctionState !== AuctionTimerState.CLOSED) {
-    return (
-      <>
-        <Sans size="2" color="black60">
-          By placing a bid you agree to {partnerName(sale)}{" "}
-          <Text
-            style={{ textDecorationLine: "underline" }}
-            onPress={() => handleConditionsOfSaleTap()}
-          >
-            Conditions of Sale
-          </Text>
-          .
-        </Sans>
-        <Spacer mb={1} />
-        <Sans size="2" color="black60">
-          Have a question?{" "}
-          <Text
-            style={{ textDecorationLine: "underline" }}
-            onPress={() => handleReadOurAuctionFAQsTap()}
-          >
-            Read our auction FAQs
-          </Text>{" "}
-          or{" "}
-          <Text
-            style={{ textDecorationLine: "underline" }}
-            onPress={() => handleAskASpecialistTap("specialist@artsy.net")}
-          >
-            ask a specialist
-          </Text>
-          .
-        </Sans>
-      </>
-    )
-  } else if (isAcquireable || isOfferable) {
+  if (isAcquireable || isOfferable) {
     return (
       <Sans size="2" color="black60">
         Have a question?{" "}
@@ -104,16 +55,6 @@ export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = (
 const tracks = {
   tappedAskASpecialist: () => ({
     action_name: Schema.ActionNames.AskASpecialist,
-    action_type: Schema.ActionTypes.Tap,
-    context_module: Schema.ContextModules.ArtworkExtraLinks,
-  }),
-  tappedAuctionFAQs: () => ({
-    action_name: Schema.ActionNames.AuctionsFAQ,
-    action_type: Schema.ActionTypes.Tap,
-    context_module: Schema.ContextModules.ArtworkExtraLinks,
-  }),
-  tappedConditionsOfSale: () => ({
-    action_name: Schema.ActionNames.ConditionsOfSale,
     action_type: Schema.ActionTypes.Tap,
     context_module: Schema.ContextModules.ArtworkExtraLinks,
   }),

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tsx
@@ -1,17 +1,18 @@
-import { ArtworkExtraLinks_artwork } from "__generated__/ArtworkExtraLinks_artwork.graphql"
+import { FaqAndSpecialistSection_artwork } from "__generated__/FaqAndSpecialistSection_artwork.graphql"
 import { navigate } from "app/navigation/navigate"
 import { sendEmail } from "app/utils/sendEmail"
 import { Schema } from "app/utils/track"
 import { Sans } from "palette"
 import React from "react"
 import { Text } from "react-native"
+import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface FaqAndSpecialistSectionProps {
-  artwork: ArtworkExtraLinks_artwork
+  artwork: FaqAndSpecialistSection_artwork
 }
 
-export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = ({ artwork }) => {
+const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = ({ artwork }) => {
   const { isAcquireable, isOfferable } = artwork
   const { trackEvent } = useTracking()
 
@@ -50,6 +51,22 @@ export const FaqAndSpecialistSection: React.FC<FaqAndSpecialistSectionProps> = (
     return null
   }
 }
+
+export const FaqAndSpecialistSectionFragmentContainer = createFragmentContainer(
+  FaqAndSpecialistSection,
+  {
+    artwork: graphql`
+      fragment FaqAndSpecialistSection_artwork on Artwork {
+        isAcquireable
+        isOfferable
+        title
+        artist {
+          name
+        }
+      }
+    `,
+  }
+)
 
 // TODO: move track events to cohesion
 const tracks = {

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tests.tsx
@@ -377,12 +377,13 @@ describe("ArtworkExtraLinks", () => {
 
         // Makes sure that no parts of the text references of the FaqAndSpecialistSection
         // appear in the rendered component when ff - AREnableCreateArtworkAlert is true
-
-        expect(queryByText("By placing a bid you agree to")).toBeNull()
-        expect(queryByText("Conditions of Sale")).toBeNull()
-        expect(queryByText("Have a question?")).toBeNull()
-        expect(queryByText("Read our auction FAQs")).toBeNull()
-        expect(queryByText("ask a specialist")).toBeNull()
+        expect(
+          queryByText("By placing a bid you agree to Artsy's and Christie's", { exact: false })
+        ).toBeTruthy()
+        expect(queryByText("Conditions of Sale")).toBeTruthy()
+        expect(queryByText("Have a question?", { exact: false })).toBeTruthy()
+        expect(queryByText("Read our auction FAQs")).toBeTruthy()
+        expect(queryByText("ask a specialist")).toBeTruthy()
         expect(queryByText("Read our FAQ")).toBeNull()
       })
     })

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
@@ -8,6 +8,7 @@ import React from "react"
 import { Text, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
+import { AuctionFaqSection } from "./AuctionFaqSection"
 import { FaqAndSpecialistSection } from "./FaqAndSpecialistSection"
 
 export interface ArtworkExtraLinksProps {
@@ -24,9 +25,8 @@ export const ArtworkExtraLinks: React.FC<ArtworkExtraLinksProps> = ({ artwork, a
 
   return (
     <>
-      {!enableCreateArtworkAlert && (
-        <FaqAndSpecialistSection artwork={artwork} auctionState={auctionState} />
-      )}
+      <AuctionFaqSection artwork={artwork} auctionState={auctionState} />
+      {!enableCreateArtworkAlert && <FaqAndSpecialistSection artwork={artwork} />}
       {!!consignableArtistsCount && (
         <ConsignmentsLink
           artistName={consignableArtistsCount > 1 ? "these artists" : artistName ?? "this artist"}

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
@@ -9,7 +9,7 @@ import { Text, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { AuctionFaqSection } from "./AuctionFaqSection"
-import { FaqAndSpecialistSection } from "./FaqAndSpecialistSection"
+import { FaqAndSpecialistSectionFragmentContainer as FaqAndSpecialistSection } from "./FaqAndSpecialistSection"
 
 export interface ArtworkExtraLinksProps {
   artwork: ArtworkExtraLinks_artwork
@@ -66,6 +66,7 @@ const ConsignmentsLink: React.FC<{ artistName: string }> = ({ artistName }) => {
 export const ArtworkExtraLinksFragmentContainer = createFragmentContainer(ArtworkExtraLinks, {
   artwork: graphql`
     fragment ArtworkExtraLinks_artwork on Artwork {
+      ...FaqAndSpecialistSection_artwork
       isAcquireable
       isInAuction
       isOfferable


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-3978]

### Description

- remove AuctionFaqSection out of FAqAndSpecialistSection component
- use feature flag to conditionally render FaqAndSpecialistSection when ff is on to its own section
- Changes behind `AREnableCreateArtworkAlert` feature flag

#### Screenshots

|AREnableCreateArtworkAlert = false|||||
|---|---|---|---|---|
|![b4_1](https://user-images.githubusercontent.com/21178754/169055442-a4fac592-cccb-4ef6-b2b7-e87570a5daaa.png)|![b4_2](https://user-images.githubusercontent.com/21178754/169055465-dc76a2fa-a018-4449-bdeb-880c1c19dab1.png)|![b4_3](https://user-images.githubusercontent.com/21178754/169055460-05e82ef1-ce77-482c-9d41-9995c338af07.png)|![b4+4](https://user-images.githubusercontent.com/21178754/169055448-5003fd54-e59b-4b27-ae68-a6c6ed6dcd6a.png)|![b4](https://user-images.githubusercontent.com/21178754/169055468-11cb33df-fc83-40b5-82c4-e5bbe57fe975.png)|
|AREnableCreateArtworkAlert = true|||||
|![after1](https://user-images.githubusercontent.com/21178754/169055418-3eec30fe-52d6-4386-bd8b-4fde4441ab92.png)|![after2](https://user-images.githubusercontent.com/21178754/169055475-e4b77371-76a3-4eca-8b2a-a77a1704ce70.png)|![after3](https://user-images.githubusercontent.com/21178754/169055478-9247cf97-47e7-40ec-83a0-05b7eb1bb6f8.png)|![after4](https://user-images.githubusercontent.com/21178754/169055450-157a63fd-f21a-4b65-9672-8566da25398a.png)|![after](https://user-images.githubusercontent.com/21178754/169055456-60dd1271-81c5-41f6-9bc0-90d254d76b22.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- move faq section on artwork screen - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3978]: https://artsyproduct.atlassian.net/browse/FX-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ