### PR TITLE
fix: Bypass cache for Artwork and Sales/Auctions screens

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -544,7 +544,7 @@ export const ArtworkQueryRenderer: React.FC<{
 }> = ({ artworkID, environment, ...others }) => {
   return (
     <RetryErrorBoundaryLegacy
-      render={({ isRetry }) => {
+      render={() => {
         return (
           <AboveTheFoldQueryRenderer<ArtworkAboveTheFoldQuery, ArtworkBelowTheFoldQuery>
             environment={environment || defaultEnvironment}
@@ -575,10 +575,8 @@ export const ArtworkQueryRenderer: React.FC<{
                 )
               },
             }}
-            cacheConfig={{
-              // Bypass Relay cache on retries.
-              ...(isRetry && { force: true }),
-            }}
+            fetchPolicy="store-and-network"
+            cacheConfig={{ force: true }}
           />
         )
       }}

--- a/src/app/Scenes/Sales/index.tsx
+++ b/src/app/Scenes/Sales/index.tsx
@@ -89,7 +89,14 @@ export const Sales: React.FC<{ data: SalesQueryResponse }> = ({ data }) => {
 }
 
 export const SalesQueryRenderer = () => {
-  const data = useLazyLoadQuery<SalesQuery>(SalesScreenQuery, {})
+  const data = useLazyLoadQuery<SalesQuery>(
+    SalesScreenQuery,
+    {},
+    {
+      fetchPolicy: "store-and-network",
+      networkCacheConfig: { force: true },
+    }
+  )
   return (
     <ProvideScreenTrackingWithCohesionSchema
       info={screen({ context_screen_owner_type: OwnerType.auctions })}

--- a/src/app/utils/AboveTheFoldQueryRenderer.tsx
+++ b/src/app/utils/AboveTheFoldQueryRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react"
 import { QueryRenderer } from "react-relay"
-import { CacheConfig, GraphQLTaggedNode, OperationType } from "relay-runtime"
+import { CacheConfig, FetchPolicy, GraphQLTaggedNode, OperationType } from "relay-runtime"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { renderWithPlaceholder } from "./renderWithPlaceholder"
 
@@ -30,6 +30,7 @@ interface AboveTheFoldQueryRendererProps<
         renderPlaceholder: () => React.ReactChild
       }
   cacheConfig?: CacheConfig | null
+  fetchPolicy?: FetchPolicy
   /** Fire below-the-fold query after the given timeout or when the above-the-fold query returns. */
   /** If 'belowTheFoldTimeout' is not set, the below-the-fold query will be fired when the above-the-fold query returns */
   belowTheFoldTimeout?: number
@@ -122,6 +123,7 @@ export function AboveTheFoldQueryRenderer<
               })
             : null
         }}
+        fetchPolicy={props.fetchPolicy}
         cacheConfig={props.cacheConfig || null}
       />
       {(renderBelowTheFold || aboveArgs?.props) && (
@@ -139,6 +141,7 @@ export function AboveTheFoldQueryRenderer<
             }
             return null
           }}
+          fetchPolicy={props.fetchPolicy}
           cacheConfig={props.cacheConfig || null}
         />
       )}


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->



### Description

Use Relays `network-and-store` fetch policy for the screens Artwork and Sales/Auctions in order to not see stale data.

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Use network-and-store fetch policy for Artwork and Sales/Auctions screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
