### PR TITLE
chore(FX-3989): copy update

### DIFF
--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tsx
@@ -95,7 +95,7 @@ const CreateArtworkAlertButtonsSection: FC<CreateArtworkAlertButtonsSectionProps
       <Box accessible accessibilityLabel="Create artwork alert buttons section">
         <Text variant="lg">{isInClosedAuction ? "Bidding closed" : "Sold"}</Text>
         <Text variant="xs" color="black60">
-          Be notified when a similar piece is available
+          Be notified when a similar work is available
         </Text>
 
         <Spacer mt={2} />

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tsx
@@ -90,7 +90,7 @@ export const CreateArtworkAlertSection: FC<CreateArtworkAlertSectionProps> = ({ 
       >
         <Flex flex={1}>
           <Text variant="xs" numberOfLines={2}>
-            Be notified when a similar piece is available
+            Be notified when a similar work is available
           </Text>
         </Flex>
 


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-3989]

### Description

Changing copy from `piece` -> `work`, the reasoning for this can be found in the jira ticket.

Force also has the same `work` copy 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- copy update on create alert section - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3898]: https://artsyproduct.atlassian.net/browse/FX-3898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-3989]: https://artsyproduct.atlassian.net/browse/FX-3989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ