### PR TITLE
fix: display single "Create Alert" button on artwork page for bidding closed state

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -97,7 +97,9 @@ export const Artwork: React.FC<ArtworkProps> = ({
     }
   }
 
-  const [auctionTimerState, setAuctionTimerState] = useState(getInitialAuctionTimerState())
+  const [auctionTimerState, setAuctionTimerState] = useState<string | undefined>(
+    getInitialAuctionTimerState()
+  )
   const isInClosedAuction = isInAuction && auctionTimerState === AuctionTimerState.CLOSED
 
   const shouldRenderDetails = () => {

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -35,7 +35,7 @@ interface CommercialInformationProps extends CountdownTimerProps {
   biddingEndAt?: string
   hasBeenExtended?: boolean
   refetchArtwork: () => void
-  setAuctionTimerState?: (auctionTimerState: AuctionTimerState) => void
+  setAuctionTimerState?: (auctionTimerState: string) => void
 }
 
 // On Android, the useArtworkBidding fails to receive data, bringing the
@@ -72,8 +72,6 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
 
     const initialBiddingEndAt = extendedBiddingEndAt ?? lotEndAt ?? saleEndAt
 
-    const { setAuctionTimerState } = props
-
     const { currentBiddingEndAt, lotSaleExtended } = useArtworkBidding({
       lotID,
       lotEndAt,
@@ -100,8 +98,6 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
               biddingEndAt: currentBiddingEndAt,
             })
 
-            setAuctionTimerState?.(state)
-
             return {
               label,
               date,
@@ -122,8 +118,6 @@ export const CommercialInformationTimerWrapper: React.FC<CommercialInformationPr
               lotEndAt,
               biddingEndAt: currentBiddingEndAt,
             })
-
-            setAuctionTimerState?.(nextState)
 
             return {
               state: nextState,
@@ -177,6 +171,7 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
   hasStarted,
   biddingEndAt,
   hasBeenExtended,
+  setAuctionTimerState,
 }) => {
   const { trackEvent } = useTracking()
   const enableCreateArtworkAlert = useFeatureFlag("AREnableCreateArtworkAlert")
@@ -208,6 +203,12 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
       })
     }
   }, [])
+
+  useEffect(() => {
+    if (timerState) {
+      setAuctionTimerState?.(timerState)
+    }
+  }, [timerState])
 
   const renderSingleEditionArtwork = () => {
     const artworkIsInClosedAuction = artwork.isInAuction && timerState === AuctionTimerState.CLOSED


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves []

### Screenshots
| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3513494/170553324-514df006-bce8-40d6-a20a-f54d5d7331bc.png) | ![after](https://user-images.githubusercontent.com/3513494/170553416-98462a09-4af2-41f7-8f13-95917ab76be4.png) |

### Video
#### Before
https://user-images.githubusercontent.com/3513494/170553524-97d64ecd-b986-4bf5-9a4f-b07c81e5ff42.mp4

#### After
https://user-images.githubusercontent.com/3513494/170553574-d212d4d0-e6af-475b-9bae-ac560873aec6.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- display single "Create Alert" button on artwork page for bidding closed state - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
