### PR TITLE
fix: Hide visual clue when tapping bottom bar tab

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -2,7 +2,12 @@ import { tappedTabBar } from "@artsy/cohesion"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { switchTab } from "app/navigation/navigate"
 import { VisualClueName } from "app/store/config/visualClues"
-import { unsafe__getSelectedTab, useSelectedTab, useVisualClue } from "app/store/GlobalStore"
+import {
+  setVisualClueAsSeen,
+  unsafe__getSelectedTab,
+  useSelectedTab,
+  useVisualClue,
+} from "app/store/GlobalStore"
 import { PopIn, Sans, useColor } from "palette"
 import { VisualClueDot } from "palette/elements/VisualClue"
 import React, { useEffect, useRef, useState } from "react"
@@ -45,6 +50,9 @@ export const BottomTabsButton: React.FC<{
       LegacyNativeModules.ARScreenPresenterModule.popToRootOrScrollToTop(tab)
     } else {
       switchTab(tab)
+    }
+    if (visualClue) {
+      setVisualClueAsSeen(visualClue)
     }
     tracking.trackEvent(
       tappedTabBar({


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

### Description

Adds setVisualClueAsSeen logic to BottomTabsButton to hide the visual clue when the tab is pressed


https://user-images.githubusercontent.com/20655703/171457249-0490b663-5810-451e-a68c-425ffca392fa.mp4



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
