### PR TITLE
fix: handle unrecognized color filter options without crashing

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
@@ -94,6 +94,36 @@ describe("Colors options screen", () => {
     expect(tree.root.findAllByType(ColorsSwatch)).toHaveLength(aggregation!.counts.length)
   })
 
+  describe("with unrecognized colors", () => {
+    const updatedMockAggregations: Aggregations = [
+      {
+        ...mockAggregations[0],
+        counts: [
+          ...mockAggregations[0].counts,
+          {
+            name: "Stanky Bean",
+            count: 197,
+            value: "stanky-bean",
+          },
+        ],
+      },
+    ]
+    const updatedAggregation = aggregationForFilter(FilterParamName.colors, updatedMockAggregations)
+
+    it("it does not try to render swatches for them", () => {
+      const tree = renderWithWrappers(
+        <MockColorScreen
+          aggregations={updatedMockAggregations}
+          {...getEssentialProps()}
+          initialData={initialState}
+        />
+      )
+
+      const expectedSwatchCount = updatedAggregation!.counts.length
+      expect(tree.root.findAllByType(ColorsSwatch)).toHaveLength(expectedSwatchCount - 1)
+    })
+  })
+
   describe("selecting a color filter", () => {
     it("displays a color filter option when selected", () => {
       const injectedState: ArtworkFiltersState = {

--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -8,7 +8,7 @@ import {
 import { ArtworkFilterBackHeader } from "app/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { useArtworkFiltersAggregation } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { useLayout } from "app/utils/useLayout"
-import { sortBy } from "lodash"
+import { compact, sortBy } from "lodash"
 import { Flex, useSpace } from "palette"
 import React from "react"
 import { ColorsSwatch } from "./ColorsSwatch"
@@ -74,14 +74,18 @@ export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ naviga
   })
 
   // Convert aggregations to filter options
-  const options: FilterData[] = (aggregation?.counts ?? []).map(({ value }) => {
-    return {
-      // names returned by Metaphysics are actually the slugs
-      displayText: COLORS_INDEXED_BY_VALUE[value].name,
-      paramValue: value,
-      paramName: FilterParamName.colors,
-    }
-  })
+  const options: FilterData[] = compact(
+    (aggregation?.counts ?? []).map(({ value }) => {
+      if (COLORS_INDEXED_BY_VALUE[value]?.name) {
+        return {
+          // names returned by Metaphysics are actually the slugs
+          displayText: COLORS_INDEXED_BY_VALUE[value].name,
+          paramValue: value,
+          paramName: FilterParamName.colors,
+        }
+      }
+    })
+  )
 
   // Sort according to order of COLORS constant
   const sortedOptions = sortBy(options, (option) => {


### PR DESCRIPTION
This PR resolves [FX-3996]

### Description

In the color filter screen within the artwork grid's filter modal, Eigen uses the list of aggregated colors coming from upstream  to render a color selection UI, one swatch for each color in the current aggregation.

It can only render colors that it actually knows about, because of various metadata that is hard-coded within [src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx](https://github.com/artsy/eigen/blob/main/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx)

If it encounters an unrecognized color, it crashes, which was the cause of a defect [back in March](https://artsy.slack.com/archives/C9SATFLUU/p1646667810727089).

We rolled back those changes, so it hasn't been a problem in the meantime. But we are ready to roll forward again, albeit more carefully this time. 

That's what this PR adds, just a little bit of defensiveness around unrecognized colors.

### Screenshot

_To produce this contrived example, I commented out the [lines that teach Eigen about dark blue, dark orange, dark green](https://github.com/artsy/eigen/blob/58717cb247190d047d468998571ed2ba8a3948a9/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx#L34-L36), so as far as Eigen was concerned these were unknown colors._

|Before|After|
|---|---|
|<img width="646" alt="Screen Shot 2022-06-01 at 4 58 32 PM" src="https://user-images.githubusercontent.com/140521/171508708-8c06b2ed-73cb-4c5f-815a-9c4d1847984a.png">|<img width="646" alt="Screen Shot 2022-06-01 at 4 57 54 PM" src="https://user-images.githubusercontent.com/140521/171508717-4c21d66d-cf33-4186-be20-de19a76b68e7.png">|





### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [x] ~I added an [app state migration].~
- [x] ~I hid my changes behind a [feature flag].~

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on an Android simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3996]: https://artsyproduct.atlassian.net/browse/FX-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ