### PR TITLE
fix: Remove ArtworkSubmissionMessage session clue from clue list

### DIFF
--- a/docs/add_a_visual_clue.md
+++ b/docs/add_a_visual_clue.md
@@ -60,9 +60,9 @@ return(
 )
 ```
 
-# Session visual cues
+# Session Visual Clues
 
-"Session visual cues" are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a "session visual clue" you can add them with `addClue("SessionClue")` anywhere in the code and mark them as seen with `setVisualClueAsSeen("SessionClue")`.
+"Session visual clues" are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a "session visual clue" you can add them with `addClue("SessionClue")` anywhere in the code and mark them as seen with `setVisualClueAsSeen("SessionClue")`.
 
 ```jsx
   const { showVisualClue } = useVisualClue()

--- a/docs/add_a_visual_clue.md
+++ b/docs/add_a_visual_clue.md
@@ -60,9 +60,9 @@ return(
 )
 ```
 
-# Session Visual Clues
+# Session Clues
 
-"Session visual clues" are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a "session visual clue" you can add them with `addClue("SessionClue")` anywhere in the code and mark them as seen with `setVisualClueAsSeen("SessionClue")`.
+Session clues are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a session clue you can add them with `addClue("SessionClue")` anywhere in the code and mark them as seen with `setVisualClueAsSeen("SessionClue")`.
 
 ```jsx
   const { showVisualClue } = useVisualClue()

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -119,7 +119,7 @@ const MyCollection: React.FC<{
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX
 
   const showMessages = async () => {
-    const showConsignmentsMessage = showVisualClue("ArtworkSubmissionMessage")
+    const showSubmissionMessage = showVisualClue("ArtworkSubmissionMessage")
     const showNewWorksMessage =
       me.myCollectionInfo?.includesPurchasedArtworks &&
       !(await AsyncStorage.getItem(HAS_SEEN_MY_COLLECTION_NEW_WORKS_BANNER))
@@ -154,7 +154,7 @@ const MyCollection: React.FC<{
             onClose={() => AsyncStorage.setItem(HAS_SEEN_MY_COLLECTION_NEW_WORKS_BANNER, "true")}
           />
         )}
-        {!!showConsignmentsMessage && (
+        {!!showSubmissionMessage && (
           <SubmittedArtworkAddedMessage
             onClose={() => setVisualClueAsSeen("ArtworkSubmissionMessage")}
           />

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -97,23 +97,23 @@ const MyCollection: React.FC<{
   }
 
   const notifyMyCollectionInsightsTab = () => {
-    const artworksWithoutInsight = artworks.find((artwork) => !artwork._marketPriceInsights)
+    // Waiting until all artworks have been loaded to check whether all of them have insights or not,
+    // in order to show the message
+    // TODO: wait exactly until all artworks have been loaded
+    setTimeout(() => {
+      const artworksWithoutInsight = artworks.find((artwork) => !artwork._marketPriceInsights)
 
-    refreshMyCollectionInsights({
-      collectionHasArtworksWithoutInsights: !!(artworks.length && artworksWithoutInsight),
-    })
+      refreshMyCollectionInsights({
+        collectionHasArtworksWithoutInsights: !!(artworks.length && artworksWithoutInsight),
+      })
+    }, 3000)
   }
 
-  // Load all artworks and then check whether all of them have insights
   useEffect(() => {
-    if (!relay.hasMore()) {
-      notifyMyCollectionInsightsTab()
-    }
-
-    console.log("MyCollection.tsx: useEffect: relay.hasMore()", artworks.length)
-
     relay.loadMore(100)
-  }, [me?.myCollectionConnection])
+
+    notifyMyCollectionInsightsTab()
+  }, [])
 
   // hack for tests. we should fix that.
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -97,23 +97,23 @@ const MyCollection: React.FC<{
   }
 
   const notifyMyCollectionInsightsTab = () => {
-    // Waiting until all artworks have been loaded to check whether all of them have insights or not,
-    // in order to show the message
-    // TODO: wait exactly until all artworks have been loaded
-    setTimeout(() => {
-      const artworksWithoutInsight = artworks.find((artwork) => !artwork._marketPriceInsights)
+    const artworksWithoutInsight = artworks.find((artwork) => !artwork._marketPriceInsights)
 
-      refreshMyCollectionInsights({
-        collectionHasArtworksWithoutInsights: !!(artworks.length && artworksWithoutInsight),
-      })
-    }, 3000)
+    refreshMyCollectionInsights({
+      collectionHasArtworksWithoutInsights: !!(artworks.length && artworksWithoutInsight),
+    })
   }
 
+  // Load all artworks and then check whether all of them have insights
   useEffect(() => {
-    relay.loadMore(100)
+    if (!relay.hasMore()) {
+      notifyMyCollectionInsightsTab()
+    }
 
-    notifyMyCollectionInsightsTab()
-  }, [])
+    console.log("MyCollection.tsx: useEffect: relay.hasMore()", artworks.length)
+
+    relay.loadMore(100)
+  }, [me?.myCollectionConnection])
 
   // hack for tests. we should fix that.
   const setJSX = useContext(StickyTabPageFlatListContext).setJSX

--- a/src/app/store/config/visualClues.ts
+++ b/src/app/store/config/visualClues.ts
@@ -15,9 +15,6 @@ function defineVisualClues<T extends string>(visualClueMap: {
 }
 
 export const visualClues = defineVisualClues({
-  ArtworkSubmissionMessage: {
-    description: "The message shown after artwork submission with SWA flow",
-  },
   CompleteCollectorProfileMessage: {
     description: "The message shown if the collector profile is incomplete",
   },


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->



### Description

This PR removes the `ArtworkSubmissionMessage` session clue from the clue list to prevent the message from being shown when the app starts (see [docs about session clues](https://github.com/artsy/eigen/blob/main/docs/add_a_visual_clue.md#L63)). 

I really think we shouldn't use the logic and data structure of visual clues for these messages. It gets super confusing. 

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
