### PR TITLE
feat(FX-3916): prevent users from entering special chars in size filter input

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
@@ -49,12 +49,12 @@ describe("CustomSizeInputs", () => {
     expect(onChangeMock).toBeCalledWith({ min: "*", max: 10 })
   })
 
-  it("should return default value if a non-numeric value is entered in the input", () => {
+  it("should NOT call `onChange` handler if a non-decimal value is entered in the input", () => {
     const onChangeMock = jest.fn()
     const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer onChange={onChangeMock} />)
 
     fireEvent.changeText(getByA11yLabel("Maximum Label Input"), "hello")
 
-    expect(onChangeMock).toBeCalledWith({ min: "*", max: "*" })
+    expect(onChangeMock).toBeCalledTimes(0)
   })
 })

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
@@ -77,6 +77,23 @@ describe("CustomSizeInputs", () => {
     })
   })
 
+  it("should allow to enter only 2 digits after floating point", () => {
+    const mockOnChange = jest.fn()
+    const { getByDisplayValue, getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer onChange={mockOnChange} range={{ min: 1, max: 2 }} />
+    )
+
+    // Min input
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5.5555")
+    expect(getByDisplayValue("1")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    // Max input
+    fireEvent.changeText(getByA11yLabel("Maximum Label Input"), "10.5555")
+    expect(getByDisplayValue("2")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+  })
+
   it("should NOT allow to enter values with special chars", () => {
     const mockOnChange = jest.fn()
     const { getByDisplayValue, getByA11yLabel } = renderWithWrappersTL(

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tests.tsx
@@ -31,6 +31,93 @@ describe("CustomSizeInputs", () => {
     expect(getByDisplayValue("10")).toBeTruthy()
   })
 
+  it("should allow to enter integer values", () => {
+    const mockOnChange = jest.fn()
+    const { getByDisplayValue, getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer onChange={mockOnChange} />
+    )
+
+    // Min input
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5")
+    expect(getByDisplayValue("5")).toBeTruthy()
+    expect(mockOnChange).toBeCalledWith({
+      min: 5,
+      max: "*",
+    })
+
+    // Max input
+    fireEvent.changeText(getByA11yLabel("Maximum Label Input"), "10")
+    expect(getByDisplayValue("10")).toBeTruthy()
+    expect(mockOnChange).toBeCalledWith({
+      min: "*",
+      max: 10,
+    })
+  })
+
+  it("should allow to enter floating point values", () => {
+    const mockOnChange = jest.fn()
+    const { getByDisplayValue, getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer onChange={mockOnChange} />
+    )
+
+    // Min input
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5.55")
+    expect(getByDisplayValue("5.55")).toBeTruthy()
+    expect(mockOnChange).toBeCalledWith({
+      min: 5.55,
+      max: "*",
+    })
+
+    // Max input
+    fireEvent.changeText(getByA11yLabel("Maximum Label Input"), "10.55")
+    expect(getByDisplayValue("10.55")).toBeTruthy()
+    expect(mockOnChange).toBeCalledWith({
+      min: "*",
+      max: 10.55,
+    })
+  })
+
+  it("should NOT allow to enter values with special chars", () => {
+    const mockOnChange = jest.fn()
+    const { getByDisplayValue, getByA11yLabel } = renderWithWrappersTL(
+      <TestRenderer onChange={mockOnChange} range={{ min: 1, max: 2 }} />
+    )
+
+    // Min input
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "#5.55")
+    expect(getByDisplayValue("1")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5,55")
+    expect(getByDisplayValue("1")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5#55")
+    expect(getByDisplayValue("1")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5.55%")
+    expect(getByDisplayValue("1")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    // Max input
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "#5.55")
+    expect(getByDisplayValue("2")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5,55")
+    expect(getByDisplayValue("2")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5#55")
+    expect(getByDisplayValue("2")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+
+    fireEvent.changeText(getByA11yLabel("Minimum Label Input"), "5.55%")
+    expect(getByDisplayValue("2")).toBeTruthy()
+    expect(mockOnChange).toBeCalledTimes(0)
+  })
+
   it("should call handler when the minimum value is changed", () => {
     const onChangeMock = jest.fn()
     const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer onChange={onChangeMock} />)
@@ -49,7 +136,7 @@ describe("CustomSizeInputs", () => {
     expect(onChangeMock).toBeCalledWith({ min: "*", max: 10 })
   })
 
-  it("should NOT call `onChange` handler if a non-decimal value is entered in the input", () => {
+  it("should NOT call `onChange` handler if a non-floating point or non-integer value is entered in the input", () => {
     const onChangeMock = jest.fn()
     const { getByA11yLabel } = renderWithWrappersTL(<TestRenderer onChange={onChangeMock} />)
 

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -1,6 +1,6 @@
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import { Box, Flex, Input, Join, Spacer, Text, useColor } from "palette"
-import React from "react"
+import React, { useState } from "react"
 import { TextStyle } from "react-native"
 import { Numeric, Range } from "./helpers"
 
@@ -12,8 +12,13 @@ export interface CustomSizeInputsProps {
   selectedMetric: Metric
 }
 
-// Constants
-const NUMBERS_REGEX = /^(|\d)+$/
+/**
+ * Acceptable values
+ * 123
+ * 123.
+ * 123.456
+ */
+const DECIMAL_REGEX = /^(\d+\.?(\d+)?)?$/
 
 // Helpers
 const getValue = (value: Numeric) => {
@@ -32,16 +37,20 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
   selectedMetric,
 }) => {
   const color = useColor()
+  const [localRange, setLocalRange] = useState(range)
+
   const handleInputChange = (field: keyof Range) => (text: string) => {
-    if (!NUMBERS_REGEX.test(text)) {
+    if (!DECIMAL_REGEX.test(text)) {
       return
     }
 
     const parsed = parseFloat(text)
     const value = isNaN(parsed) ? "*" : parsed
 
+    setLocalRange({ ...localRange, [field]: text })
     onChange({ ...range, [field]: value })
   }
+
   const inputTextStyle: TextStyle = {
     color: active ? color("black100") : color("black60"),
   }
@@ -61,7 +70,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
               onChangeText={handleInputChange("min")}
               fixedRightPlaceholder={selectedMetric}
               accessibilityLabel={`Minimum ${label} Input`}
-              value={getValue(range.min)}
+              value={getValue(localRange.min)}
               inputTextStyle={inputTextStyle}
             />
           </Flex>
@@ -73,7 +82,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
               onChangeText={handleInputChange("max")}
               fixedRightPlaceholder={selectedMetric}
               accessibilityLabel={`Maximum ${label} Input`}
-              value={getValue(range.max)}
+              value={getValue(localRange.max)}
               inputTextStyle={inputTextStyle}
             />
           </Flex>

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -12,6 +12,9 @@ export interface CustomSizeInputsProps {
   selectedMetric: Metric
 }
 
+// Constants
+const NUMBERS_REGEX = /^(|\d)+$/
+
 // Helpers
 const getValue = (value: Numeric) => {
   if (value === "*" || value === 0) {
@@ -30,6 +33,10 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
 }) => {
   const color = useColor()
   const handleInputChange = (field: keyof Range) => (text: string) => {
+    if (!NUMBERS_REGEX.test(text)) {
+      return
+    }
+
     const parsed = parseFloat(text)
     const value = isNaN(parsed) ? "*" : parsed
 
@@ -54,7 +61,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
               onChangeText={handleInputChange("min")}
               fixedRightPlaceholder={selectedMetric}
               accessibilityLabel={`Minimum ${label} Input`}
-              defaultValue={getValue(range.min)}
+              value={getValue(range.min)}
               inputTextStyle={inputTextStyle}
             />
           </Flex>
@@ -66,7 +73,7 @@ export const CustomSizeInputs: React.FC<CustomSizeInputsProps> = ({
               onChangeText={handleInputChange("max")}
               fixedRightPlaceholder={selectedMetric}
               accessibilityLabel={`Maximum ${label} Input`}
-              defaultValue={getValue(range.max)}
+              value={getValue(range.max)}
               inputTextStyle={inputTextStyle}
             />
           </Flex>

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -16,9 +16,9 @@ export interface CustomSizeInputsProps {
  * Acceptable values
  * 123
  * 123.
- * 123.456
+ * 123.45
  */
-const DECIMAL_REGEX = /^(\d+\.?(\d+)?)?$/
+const DECIMAL_REGEX = /^(\d+\.?\d*)?$/
 
 // Helpers
 const getValue = (value: Numeric) => {

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -18,7 +18,7 @@ export interface CustomSizeInputsProps {
  * 123.
  * 123.45
  */
-const DECIMAL_REGEX = /^(\d+\.?\d*)?$/
+const DECIMAL_REGEX = /^(\d+\.?\d{0,2})?$/
 
 // Helpers
 const getValue = (value: Numeric) => {

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -18,7 +18,7 @@ const NUMBERS_REGEX = /^(|\d)+$/
 // Helpers
 const getValue = (value: Numeric) => {
   if (value === "*" || value === 0) {
-    return
+    return ""
   }
 
   return value.toString()


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-3916]

### Description
Right now the behavior in size input is not consistent between android and iOS. 
Users in iOS are not able to insert decimal numbers while in Android they can (this comes by design from `keyboardType=”number-pad` prop.

### Acceptance Criteria
* Prevent the users from entering invalid inputs (like commas, dashes, dots) in the beginning of the input
* Allow to enter floating point values (e.g `123`, `123.45`)
* Allow to enter only 2 digits after floating point

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/171634592-89e88a8e-d56e-4eb6-9804-f8db5fc1e2f1.mp4

#### Android
https://user-images.githubusercontent.com/3513494/171636212-74260835-c234-4508-a7cf-11bbb742b14e.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Prevent users from entering special chars in size filter input - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3916]: https://artsyproduct.atlassian.net/browse/FX-3916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ