### PR TITLE
fix(BID-402): Show the correct start time on lot page for different days

### DIFF
--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -166,7 +166,12 @@ export const Countdown: React.FC<CountdownProps> = ({
   return (
     <Flex alignItems="center">
       {cascadingEndTimeFeatureEnabled && cascadingEndTimeIntervalMinutes ? (
-        <ModernTicker duration={duration} hasStarted={hasStarted} isExtended={hasBeenExtended} />
+        <ModernTicker
+          duration={duration}
+          hasStarted={hasStarted}
+          isExtended={hasBeenExtended}
+          startAt={startAt}
+        />
       ) : (
         <SimpleTicker duration={duration} separator="  " size="4t" weight="medium" />
       )}

--- a/src/app/Components/Countdown/Ticker.tests.tsx
+++ b/src/app/Components/Countdown/Ticker.tests.tsx
@@ -87,6 +87,22 @@ describe("ModernTicker", () => {
       expect(timerText.props.color).toEqual("blue100")
     })
 
+    it("shows Bidding Starts In 7 Hours if Bidding is starting in 7 hours BUT NOT THE SAME DAY", () => {
+      const sevenHrs = 1000 * 60 * 60 * 7
+      const startAt = new Date(Date.now() + sevenHrs).toISOString()
+      const todayDuration = moment.duration(sevenHrs)
+      const { getByText } = render(
+        <Theme>
+          <ModernTicker duration={todayDuration} startAt={startAt} />
+        </Theme>
+      )
+
+      const timerText = getByText("Bidding Starts In 7 Hours")
+
+      expect(timerText).toBeTruthy()
+      expect(timerText.props.color).toEqual("blue100")
+    })
+
     it("renders 1 Day Until Bidding Starts in blue when start time is >24 hours but less than 2 days away", () => {
       // 28 hours
       const dayDuration = moment.duration(100800000)

--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -92,9 +92,15 @@ interface ModernTickerProps {
   duration: CountdownTimerProps["duration"]
   hasStarted?: boolean
   isExtended?: boolean
+  startAt?: string | null
 }
 
-export const ModernTicker: React.FC<ModernTickerProps> = ({ duration, hasStarted, isExtended }) => {
+export const ModernTicker: React.FC<ModernTickerProps> = ({
+  duration,
+  hasStarted,
+  isExtended,
+  startAt,
+}) => {
   if (!duration) {
     return null
   }
@@ -103,7 +109,7 @@ export const ModernTicker: React.FC<ModernTickerProps> = ({ duration, hasStarted
     hours: duration.hours().toString(),
     minutes: duration.minutes().toString(),
     seconds: duration.seconds().toString(),
-    startAt: "",
+    startAt: startAt ?? "",
     endDate: "",
   }
   const timerInfo = getTimerInfo(time, { hasStarted, isExtended })


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [BID-402]

### Description
- While the Sale page accounts for when Sale starts within less than 24 hours but not on the same day, the Lot detail page doesn't. This PR fixes that for the lot page.
<p><img src="https://user-images.githubusercontent.com/18648835/171709979-8e43135b-e55e-453e-bcae-ff917534d231.png" width="45%" /></p>
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Show the correct end time on lot page for different days - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[BID-402]: https://artsyproduct.atlassian.net/browse/BID-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ