### PR TITLE
fix: Update bottom bar visual clue logic

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -1,4 +1,4 @@
-import { GlobalStore, useIsStaging } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag, useIsStaging } from "app/store/GlobalStore"
 import { Flex, Separator, useTheme } from "palette"
 import React, { useEffect } from "react"
 import useInterval from "react-use/lib/useInterval"
@@ -22,6 +22,7 @@ export const BottomTabs: React.FC = () => {
   }, 1000 * 60)
 
   const isStaging = useIsStaging()
+  const enableMyCollectionInsights = useFeatureFlag("AREnableMyCollectionInsights")
 
   return (
     <Flex>
@@ -35,7 +36,10 @@ export const BottomTabs: React.FC = () => {
         <BottomTabsButton tab="search" />
         <BottomTabsButton tab="inbox" badgeCount={unreadConversationCount} />
         <BottomTabsButton tab="sell" />
-        <BottomTabsButton tab="profile" visualClue="MyCollectionInsights" />
+        <BottomTabsButton
+          tab="profile"
+          visualClue={enableMyCollectionInsights ? "MyCollectionInsights" : undefined}
+        />
       </Flex>
     </Flex>
   )


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

### Description
This PR updates showing the visual clue on the bottom bar to only show it when the `AREnableMyCollectionInsights` is feature flag enabled

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update My Profile bottom bar visual clue logic - mrsltun

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
