### PR TITLE
chore(colors): drop support for old color filtering options

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
@@ -40,9 +40,9 @@ describe("Colors options screen", () => {
           value: "yellow",
         },
         {
-          name: "Violet",
+          name: "Purple",
           count: 145,
-          value: "violet",
+          value: "purple",
         },
       ],
     },

--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -14,28 +14,6 @@ import React from "react"
 import { ColorsSwatch } from "./ColorsSwatch"
 import { useMultiSelect } from "./useMultiSelect"
 
-// TODO: delete after all artworks are reindexed to use new colors only
-const OLD_COLORS = [
-  {
-    value: "black-and-white",
-    name: "Black and White",
-    backgroundColor: "#000",
-    foregroundColor: "#fff",
-  },
-  { value: "red", name: "Red", backgroundColor: "#FF0000", foregroundColor: "#fff" },
-  { value: "yellow", name: "Yellow", backgroundColor: "#FBE854", foregroundColor: "#000" },
-  { value: "pink", name: "Pink", backgroundColor: "#FB81CD", foregroundColor: "#000" },
-  { value: "violet", name: "Violet", backgroundColor: "#B82C83", foregroundColor: "#fff" },
-  { value: "gold", name: "Gold", backgroundColor: "#DAA520", foregroundColor: "#000" },
-  { value: "orange", name: "Orange", backgroundColor: "#F7923A", foregroundColor: "#000" },
-  { value: "darkviolet", name: "Dark Violet", backgroundColor: "#642B7F", foregroundColor: "#fff" },
-  { value: "lightgreen", name: "Light Green", backgroundColor: "#BCCC46", foregroundColor: "#000" },
-  { value: "lightblue", name: "Light Blue", backgroundColor: "#C2D5F1", foregroundColor: "#000" },
-  { value: "darkblue", name: "Dark Blue", backgroundColor: "#0A1AB4", foregroundColor: "#fff" },
-  { value: "darkorange", name: "Dark Orange", backgroundColor: "#612A00", foregroundColor: "#fff" },
-  { value: "darkgreen", name: "Dark Green", backgroundColor: "#004600", foregroundColor: "#fff" },
-] as const
-
 export const COLORS = [
   { value: "red", name: "Red", backgroundColor: "#BB392D", foregroundColor: "#fff" },
   { value: "orange", name: "Orange", backgroundColor: "#EA6B1F", foregroundColor: "#000" },
@@ -53,9 +31,9 @@ export const COLORS = [
   { value: "pink", name: "Pink", backgroundColor: "#E1ADCD", foregroundColor: "#000" },
 ] as const
 
-type Color = typeof COLORS[number] | typeof OLD_COLORS[number]
+type Color = typeof COLORS[number]
 
-export const COLORS_INDEXED_BY_VALUE = [...COLORS, ...OLD_COLORS].reduce(
+export const COLORS_INDEXED_BY_VALUE = COLORS.reduce(
   (acc: Record<string, Color>, color) => ({ ...acc, [color.value]: color }),
   {}
 )
@@ -89,7 +67,7 @@ export const ColorsOptionsScreen: React.FC<ColorsOptionsScreenProps> = ({ naviga
 
   // Sort according to order of COLORS constant
   const sortedOptions = sortBy(options, (option) => {
-    return [...COLORS, ...OLD_COLORS].findIndex(({ value }) => value === option.paramValue)
+    return COLORS.findIndex(({ value }) => value === option.paramValue)
   })
 
   const { handleSelect, isSelected, handleClear, isActive } = useMultiSelect({

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
@@ -219,7 +219,7 @@ describe("extractPillsFromCriteria", () => {
 
   it("should correctly extract color pills", () => {
     const attributes: SearchCriteriaAttributes = {
-      colors: ["pink", "orange", "darkorange"],
+      colors: ["pink", "orange"],
     }
     const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
 
@@ -233,11 +233,6 @@ describe("extractPillsFromCriteria", () => {
         label: "Orange",
         paramName: SearchCriteria.colors,
         value: "orange",
-      },
-      {
-        label: "Dark Orange",
-        paramName: SearchCriteria.colors,
-        value: "darkorange",
       },
     ])
   })


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-4011]

### Description

Now that [old and new colors are indexed](https://github.com/artsy/gravity/pull/15407) in production, it is safe to drop support for the old colors in future versions of the app

(The ability to support new colors has been out since https://github.com/artsy/eigen/pull/6317, so should have near-universal adoption by now.)

### Screenshot

Old and new colors are _both_ indexed to Elasticsearch, as of this writing. But after this change is merged we'll only show the new ones, as on the right hand side of the images below.

#### iOS

|Before|After|
|---|---|
|<img width="646" alt="Screen Shot 2022-06-06 at 11 09 43 AM" src="https://user-images.githubusercontent.com/140521/172190384-8556205a-ced2-4760-a346-36b89626febe.png">|<img width="646" alt="Screen Shot 2022-06-06 at 11 09 10 AM" src="https://user-images.githubusercontent.com/140521/172190385-65f8a8cb-9e8d-4aaf-873a-12c757b5d630.png">|

#### Android

|Before|After|
|---|---|
|<img width="521" alt="Screen Shot 2022-06-06 at 12 23 23 PM" src="https://user-images.githubusercontent.com/140521/172202936-544a2b66-d9c5-4e9b-b9dd-f39b58169d51.png">|<img width="521" alt="Screen Shot 2022-06-06 at 12 22 26 PM" src="https://user-images.githubusercontent.com/140521/172202934-f3eefb6a-adba-44b1-8c7f-18e1f2fb2554.png">|

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- ~I added an [app state migration]~
- ~I hid my changes behind a [feature flag]~

### To the reviewers 👀

- ~I would like **at least one** of the reviewers to run this PR on the simulator or device.~

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4011]: https://artsyproduct.atlassian.net/browse/FX-4011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ