### PR TITLE
feat(NX-3129): Add authenticity modal and icons to Artwork screen

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkHeader.tsx
@@ -133,7 +133,7 @@ export const ArtworkHeader: React.FC<ArtworkHeaderProps> = (props) => {
             }}
           />
         </Flex>
-        <Spacer mb={2} />
+        <Spacer mb={4} />
         <Box px={2}>
           <ArtworkTombstone artwork={artwork} />
         </Box>

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -2,27 +2,29 @@ import { ArtworkTombstone_artwork } from "__generated__/ArtworkTombstone_artwork
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { navigate } from "app/navigation/navigate"
-import { GlobalStoreProvider } from "app/store/GlobalStore"
 // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
 import { mount } from "enzyme"
 import { Theme } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
+import { SafeAreaProvider } from "react-native-safe-area-context"
 import { ArtworkTombstone } from "./ArtworkTombstone"
+import { CertificateAuthenticityModal } from "./CertificateAuthenticityModal"
 
 describe("ArtworkTombstone", () => {
   it("renders fields correctly", () => {
     const component = mount(
-      <GlobalStoreProvider>
+      <SafeAreaProvider>
         <Theme>
           <ArtworkTombstone artwork={artworkTombstoneArtwork} />
         </Theme>
-      </GlobalStoreProvider>
+      </SafeAreaProvider>
     )
     expect(component.text()).toContain("Hello im a title, 1992")
     expect(component.text()).toContain("Painting")
     expect(component.text()).toContain("Edition 100/200")
-    expect(component.text()).toContain("This is an edition of something")
+    expect(component.text()).toContain("This work is part of a limited edition set.")
+    expect(component.text()).toContain("This work includes a Certificate of Authenticity.")
     expect(component.text()).not.toContain("Lot 8")
     expect(component.text()).not.toContain("Cool Auction")
     expect(component.text()).not.toContain("Estimated value: CHF 160,000–CHF 230,000")
@@ -30,11 +32,11 @@ describe("ArtworkTombstone", () => {
 
   it("renders auction fields correctly", () => {
     const component = mount(
-      <GlobalStoreProvider>
+      <SafeAreaProvider>
         <Theme>
           <ArtworkTombstone artwork={artworkTombstoneAuctionArtwork} />
         </Theme>
-      </GlobalStoreProvider>
+      </SafeAreaProvider>
     )
     expect(component.text()).toContain("Lot 8")
     expect(component.text()).toContain("Cool Auction")
@@ -43,11 +45,11 @@ describe("ArtworkTombstone", () => {
 
   it("redirects to artist page when artist name is clicked", () => {
     const component = mount(
-      <GlobalStoreProvider>
+      <SafeAreaProvider>
         <Theme>
           <ArtworkTombstone artwork={artworkTombstoneArtwork} />
         </Theme>
-      </GlobalStoreProvider>
+      </SafeAreaProvider>
     )
     const artistName = component.find(TouchableWithoutFeedback).at(0)
     expect(artistName.text()).toContain("Andy Warhol")
@@ -57,27 +59,62 @@ describe("ArtworkTombstone", () => {
 
   it("redirects to attribution class faq page when attribution class is clicked", () => {
     const component = mount(
-      <GlobalStoreProvider>
+      <SafeAreaProvider>
         <Theme>
           <ArtworkTombstone artwork={artworkTombstoneArtwork} />
         </Theme>
-      </GlobalStoreProvider>
+      </SafeAreaProvider>
     )
     const attributionClass = component.find(TouchableWithoutFeedback).at(4)
-    expect(attributionClass.text()).toContain("This is an edition of something")
+    expect(attributionClass.text()).toContain("a limited edition set")
     attributionClass.props().onPress()
     expect(navigate).toHaveBeenCalledWith("/artwork-classifications")
+  })
+
+  it("shows the authenticity modal when Certificate of Authenticity is tapped", () => {
+    const component = mount(
+      <SafeAreaProvider>
+        <Theme>
+          <ArtworkTombstone artwork={artworkTombstoneArtwork} />
+        </Theme>
+      </SafeAreaProvider>
+    )
+    const attributionClass = component.find(TouchableWithoutFeedback).at(5)
+    expect(attributionClass.text()).toContain("Certificate of Authenticity")
+
+    expect(component.find(CertificateAuthenticityModal).props().visible).toBeFalse()
+    attributionClass.props().onPress()
+    component.update()
+    expect(component.find(CertificateAuthenticityModal).props().visible).toBeTrue()
+  })
+
+  it("closes the authenticity modal when Certificate of Authenticity", () => {
+    const component = mount(
+      <SafeAreaProvider>
+        <Theme>
+          <ArtworkTombstone artwork={artworkTombstoneArtwork} />
+        </Theme>
+      </SafeAreaProvider>
+    )
+    const attributionClass = component.find(TouchableWithoutFeedback).at(5)
+    attributionClass.props().onPress()
+    component.update()
+    expect(component.find(CertificateAuthenticityModal).props().visible).toBeTrue()
+
+    component.find(CertificateAuthenticityModal).props().onClose()
+    component.update()
+    expect(component.find(CertificateAuthenticityModal).props().visible).toBeFalse()
   })
 
   describe("for a user not in the US", () => {
     it("renders dimensions in centimeters", () => {
       LegacyNativeModules.ARCocoaConstantsModule.CurrentLocale = "fr_FR"
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("38.1 × 50.8 cm")
     })
@@ -87,11 +124,11 @@ describe("ArtworkTombstone", () => {
     it("renders dimensions in inches", () => {
       LegacyNativeModules.ARCocoaConstantsModule.CurrentLocale = "en_US"
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("15 × 20 in")
     })
@@ -100,11 +137,11 @@ describe("ArtworkTombstone", () => {
   describe("for an artwork with more than 3 artists", () => {
     it("truncates artist names", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("Andy Warhol")
       expect(component.text()).toContain("Alex Katz")
@@ -116,22 +153,22 @@ describe("ArtworkTombstone", () => {
 
     it("doesn't show follow button", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).not.toContain("Follow")
     })
 
     it("shows truncated artist names when 'x more' is clicked", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       const showMore = component.find(TouchableWithoutFeedback).at(3)
       expect(showMore.text()).toContain("2 more")
@@ -147,11 +184,11 @@ describe("ArtworkTombstone", () => {
     const popcornMessage = "Closing times may be extended due to last minute competitive bidding. "
     it("renders the notification banner with cascading message", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneCascadingEndTimesAuctionArtwork()} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
 
       expect(component.text()).toContain(cascadingMessage)
@@ -160,11 +197,11 @@ describe("ArtworkTombstone", () => {
 
     it("renders the notification banner with popcorn message", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneCascadingEndTimesAuctionArtwork(true)} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
 
       expect(component.text()).not.toContain(cascadingMessage)
@@ -175,11 +212,11 @@ describe("ArtworkTombstone", () => {
   describe("for an artwork in a sale without cascading end times", () => {
     it("renders the notification banner", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneAuctionArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
 
       expect(component.text()).not.toContain("Lots will close at 1-minute intervals.")
@@ -195,22 +232,22 @@ describe("ArtworkTombstone", () => {
 
     it("doesn't show follow button", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).not.toContain("Follow")
     })
 
     it("doesn't truncate artist names", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("Andy Warhol")
       expect(component.text()).toContain("Alex Katz")
@@ -229,22 +266,22 @@ describe("ArtworkTombstone", () => {
 
     it("renders artist name", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("Andy Warhol")
     })
 
     it("shows follow button", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("Follow")
     })
@@ -260,22 +297,22 @@ describe("ArtworkTombstone", () => {
 
     it("renders artist name", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).toContain("18th century American")
     })
 
     it("shows follow button", () => {
       const component = mount(
-        <GlobalStoreProvider>
+        <SafeAreaProvider>
           <Theme>
             <ArtworkTombstone artwork={artworkTombstoneArtwork} />
           </Theme>
-        </GlobalStoreProvider>
+        </SafeAreaProvider>
       )
       expect(component.text()).not.toContain("Follow")
     })
@@ -320,8 +357,11 @@ const artworkTombstoneArtwork: ArtworkTombstone_artwork = {
     cm: "38.1 × 50.8 cm",
   },
   edition_of: "Edition 100/200",
-  attribution_class: {
-    shortDescription: "This is an edition of something",
+  attributionClass: {
+    shortArrayDescription: ["This work is part of", "a limited edition set"],
+  },
+  certificateOfAuthenticity: {
+    __typename: "Certificate",
   },
   " $refType": null as any,
 }

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -2,11 +2,12 @@ import { ArtworkTombstone_artwork } from "__generated__/ArtworkTombstone_artwork
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { navigate } from "app/navigation/navigate"
 import { Schema, track } from "app/utils/track"
-import { Box, Flex, Sans, Spacer, Text } from "palette"
+import { ArtworkIcon, Box, CertificateIcon, Flex, Sans, Spacer, Text } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CascadingEndTimesBanner } from "./CascadingEndTimesBanner"
+import { CertificateAuthenticityModal } from "./CertificateAuthenticityModal"
 import { FollowArtistLinkFragmentContainer as FollowArtistLink } from "./FollowArtistLink"
 
 type Artist = NonNullable<NonNullable<ArtworkTombstone_artwork["artists"]>[0]>
@@ -17,6 +18,7 @@ export interface ArtworkTombstoneProps {
 
 export interface ArtworkTombstoneState {
   showingMoreArtists: boolean
+  showAuthenticityCertificateModal: boolean
 }
 
 @track()
@@ -26,6 +28,7 @@ export class ArtworkTombstone extends React.Component<
 > {
   state = {
     showingMoreArtists: false,
+    showAuthenticityCertificateModal: false,
   }
 
   @track(() => ({
@@ -52,6 +55,7 @@ export class ArtworkTombstone extends React.Component<
 
   showMoreArtists = () => {
     this.setState({
+      ...this.state,
       showingMoreArtists: !this.state.showingMoreArtists,
     })
   }
@@ -131,6 +135,7 @@ export class ArtworkTombstone extends React.Component<
       artwork.saleArtwork.lotLabel &&
       artwork.sale &&
       !artwork.sale.isClosed
+    const attributionClass = artwork.attributionClass
 
     return (
       <Box textAlign="left">
@@ -181,19 +186,49 @@ export class ArtworkTombstone extends React.Component<
             {artwork.edition_of}
           </Sans>
         )}
-        {!!artwork.attribution_class && (
-          <Sans color="black60" size="3" mt={1}>
-            <TouchableWithoutFeedback
-              onPress={() => this.handleClassificationTap("/artwork-classifications")}
-            >
-              <Text style={{ textDecorationLine: "underline" }}>
-                {artwork.attribution_class.shortDescription}
+        <Spacer my={1} />
+        {!!attributionClass?.shortArrayDescription &&
+          !!Array.isArray(attributionClass.shortArrayDescription) &&
+          attributionClass.shortArrayDescription.length > 0 && (
+            <Box mt={0.5} flexDirection="row">
+              <ArtworkIcon fill="black60" />
+              <Text color="black60" variant="xs" ml={1}>
+                {attributionClass.shortArrayDescription
+                  .slice(0, attributionClass.shortArrayDescription.length - 1)
+                  .join(" ") + " "}
+                <TouchableWithoutFeedback
+                  onPress={() => this.handleClassificationTap("/artwork-classifications")}
+                >
+                  <Text variant="xs" style={{ textDecorationLine: "underline" }}>
+                    {
+                      attributionClass.shortArrayDescription[
+                        attributionClass.shortArrayDescription.length - 1
+                      ]
+                    }
+                  </Text>
+                </TouchableWithoutFeedback>
+                .
               </Text>
-            </TouchableWithoutFeedback>
-            .
-          </Sans>
+            </Box>
+          )}
+        {!!artwork.certificateOfAuthenticity && (
+          <Box mt={0.5} flexDirection="row">
+            <CertificateIcon fill="black60" />
+            <Text color="black60" variant="xs" ml={1}>
+              This work includes a{" "}
+              <TouchableWithoutFeedback
+                onPress={() =>
+                  this.setState({ ...this.setState, showAuthenticityCertificateModal: true })
+                }
+              >
+                <Text variant="xs" style={{ textDecorationLine: "underline" }}>
+                  {"Certificate of Authenticity"}
+                </Text>
+              </TouchableWithoutFeedback>
+              .
+            </Text>
+          </Box>
         )}
-
         {!!artwork.isInAuction && !artwork.sale?.isClosed && (
           <>
             {!!artwork.sale?.cascadingEndTimeIntervalMinutes && (
@@ -215,6 +250,10 @@ export class ArtworkTombstone extends React.Component<
             )}
           </>
         )}
+        <CertificateAuthenticityModal
+          visible={this.state.showAuthenticityCertificateModal}
+          onClose={() => this.setState({ ...this.state, showAuthenticityCertificateModal: false })}
+        />
       </Box>
     )
   }
@@ -235,6 +274,9 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
       partner {
         name
       }
+      certificateOfAuthenticity {
+        __typename
+      }
       sale {
         isClosed
         cascadingEndTimeIntervalMinutes
@@ -250,8 +292,8 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
         cm
       }
       edition_of: editionOf
-      attribution_class: attributionClass {
-        shortDescription
+      attributionClass {
+        shortArrayDescription
       }
     }
   `,

--- a/src/app/Scenes/Artwork/Components/CertificateAuthenticityModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CertificateAuthenticityModal.tests.tsx
@@ -1,0 +1,38 @@
+import { fireEvent } from "@testing-library/react-native"
+import { navigate } from "app/navigation/navigate"
+import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
+import { CertificateAuthenticityModal } from "./CertificateAuthenticityModal"
+
+jest.mock("app/navigation/navigate", () => ({
+  navigate: jest.fn(),
+}))
+
+describe("CertificateAuthenticityModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders", () => {
+    const { getByText } = renderWithWrappersTL(
+      <CertificateAuthenticityModal visible onClose={() => null} />
+    )
+
+    expect(getByText("A certificate of authenticity (COA)", { exact: false })).toBeDefined()
+    expect(
+      getByText("COAs typically include the name of the artist,", { exact: false })
+    ).toBeDefined()
+    expect(getByText("Read more about artwork authenticity in our", { exact: false })).toBeDefined()
+    expect(getByText("Help Center")).toBeDefined()
+  })
+
+  it("navigates to support page", () => {
+    const { getByText } = renderWithWrappersTL(
+      <CertificateAuthenticityModal visible onClose={() => null} />
+    )
+
+    fireEvent.press(getByText("Help Center"))
+    expect(navigate).toHaveBeenCalledWith(
+      "https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+    )
+  })
+})

--- a/src/app/Scenes/Artwork/Components/CertificateAuthenticityModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CertificateAuthenticityModal.tsx
@@ -1,0 +1,55 @@
+import { NavigationContainer } from "@react-navigation/native"
+import { FancyModal } from "app/Components/FancyModal/FancyModal"
+import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { navigate } from "app/navigation/navigate"
+import { Box, Join, Spacer, Text } from "palette"
+import React from "react"
+
+interface CertificateAuthenticityModalProps {
+  visible: boolean
+  onClose: () => void
+}
+
+export const CertificateAuthenticityModal: React.FC<CertificateAuthenticityModalProps> = ({
+  visible,
+  onClose,
+}) => {
+  return (
+    <NavigationContainer independent>
+      <FancyModal visible={visible} onBackgroundPressed={onClose}>
+        <FancyModalHeader rightCloseButton onRightButtonPress={onClose}>
+          <Text variant="lg">Certificate of Authenticity</Text>
+        </FancyModalHeader>
+        <Box flex={1} px={2} py={2}>
+          <Join separator={<Spacer my={0.5} />}>
+            <Text>
+              A certificate of authenticity (COA) is a document from an authoritative source that
+              verifies the artwork’s authenticity. While many COAs are signed by the artist, others
+              will be signed by the representing gallery or the printmaker who collaborated with the
+              artist on the work. For secondary market works, authorized estates or foundations are
+              often the issuing party.
+            </Text>
+            <Text>
+              COAs typically include the name of the artist, the details (title, date, medium,
+              dimensions) of the work in question, and whenever possible an image of the work.
+            </Text>
+            <Text>
+              Read more about artwork authenticity in our{" "}
+              <Text
+                underline
+                onPress={() =>
+                  navigate(
+                    "https://support.artsy.net/hc/en-us/articles/360058123933-What-Counts-as-an-Artwork-s-Proof-of-Authenticity-"
+                  )
+                }
+              >
+                Help Center
+              </Text>
+              .
+            </Text>
+          </Join>
+        </Box>
+      </FancyModal>
+    </NavigationContainer>
+  )
+}

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -39,7 +39,7 @@ describe("Questions", () => {
     mockEnvironmentPayloadAndEnsureUpdated(mockEnvironment, { Artwork: () => ({}) })
     await waitFor(() => expect(getByText("SusLoading")).toBeDefined())
 
-    expect(getByText("Questions about this piece?")).toBeDefined()
+    await waitFor(() => expect(getByText("Questions about this piece?")).toBeDefined())
     expect(getAllByText("Contact Gallery")).toHaveLength(2)
   })
 })

--- a/src/app/__fixtures__/ArtworkFixture.ts
+++ b/src/app/__fixtures__/ArtworkFixture.ts
@@ -34,6 +34,7 @@ export const ArtworkFixture = {
   medium: "photograph",
   attributionClass: {
     name: "Unique",
+    shortArrayDescription: ["This is", "a unique work"],
   },
   editionOf: "",
   image: {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [NX-3129]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Add Certificate of Authenticity modal and atrributionClass of the Artwork to the Screen

https://user-images.githubusercontent.com/15792853/172653057-781b0334-04e4-45fc-bcf3-1fd20c8a33cd.mov

cc @artsy/negotiate-devs 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add attribution class and authenticity data to artwork screen - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3129]: https://artsyproduct.atlassian.net/browse/NX-3129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ