### PR TITLE
feat(colors): add brown color filter option

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tests.tsx
@@ -44,6 +44,11 @@ describe("Colors options screen", () => {
           count: 145,
           value: "purple",
         },
+        {
+          name: "Brown",
+          count: 133,
+          value: "brown",
+        },
       ],
     },
   ]

--- a/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ColorsOptions.tsx
@@ -27,6 +27,7 @@ export const COLORS = [
     backgroundColor: "#000",
     foregroundColor: "#f00",
   },
+  { value: "brown", name: "Brown", backgroundColor: "#7B5927", foregroundColor: "#fff" },
   { value: "gray", name: "Gray", backgroundColor: "#C2C2C2", foregroundColor: "#000" },
   { value: "pink", name: "Pink", backgroundColor: "#E1ADCD", foregroundColor: "#000" },
 ] as const


### PR DESCRIPTION
This PR resolves [FX-3779]

### Description

Simply adds a new color filtering option for **brown**.

Should be safe to merge, since we display this swatch _only if_ it's in the current artwork results' aggregation. 

(Thus we won't risk showing it prematurely, i.e. before we've reindexed artworks to detect brown. See: https://github.com/artsy/gravity/pull/15433)

<img width="200" alt="brown app" src="https://user-images.githubusercontent.com/140521/172864250-bd515836-12e6-4b85-bf05-30b33c147ffa.png">

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [x] ~I added an [app state migration].~
- [x] ~I hid my changes behind a [feature flag].~

### To the reviewers 👀

- [x] ~I would like **at least one** of the reviewers to run this PR on the simulator or device.~

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Adds support for filtering artwork results by the color brown

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-3779]: https://artsyproduct.atlassian.net/browse/FX-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ