### PR TITLE
fix: links should open a webview when not assigned to a native screen

### DIFF
--- a/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
@@ -1,8 +1,9 @@
+import { ArtsyWebView } from "app/Components/ArtsyWebView"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { Fair, FairFragmentContainer, FairPlaceholder } from "app/Scenes/Fair/Fair"
 import { PartnerContainer } from "app/Scenes/Partner"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { renderWithWrappers, renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import { __renderWithPlaceholderTestUtils__ } from "app/utils/renderWithPlaceholder"
 import { Spinner } from "palette"
 import React from "react"
@@ -13,19 +14,17 @@ import { VanityURLPossibleRedirect } from "./VanityURLPossibleRedirect"
 
 jest.unmock("react-relay")
 
-jest.mock("./VanityURLPossibleRedirect", () => {
-  return {
-    VanityURLPossibleRedirect: () => null,
-  }
-})
+jest.mock("./VanityURLPossibleRedirect", () => ({
+  VanityURLPossibleRedirect: () => null,
+}))
 
 const TestRenderer: React.FC<{
   entity: "fair" | "partner" | "unknown"
   slugType?: "profileID" | "fairID"
   slug: string
-}> = ({ entity, slugType, slug }) => {
-  return <VanityURLEntityRenderer entity={entity} slugType={slugType} slug={slug} />
-}
+}> = ({ entity, slugType, slug }) => (
+  <VanityURLEntityRenderer entity={entity} slugType={slugType} slug={slug} />
+)
 
 describe("VanityURLEntity", () => {
   let env: ReturnType<typeof createMockEnvironment>
@@ -35,14 +34,14 @@ describe("VanityURLEntity", () => {
     env = require("app/relay/createEnvironment").defaultEnvironment
   })
 
-  it("renders a VanityURLPossibleRedirect when 404", () => {
+  it("renders an ArtsyWebViewPage when 404", () => {
     if (__renderWithPlaceholderTestUtils__) {
       __renderWithPlaceholderTestUtils__.allowFallbacksAtTestTime = true
     }
-    const tree = renderWithWrappers(<TestRenderer entity="unknown" slug="some-fair" />)
-    expect(tree.root.findAllByType(VanityURLPossibleRedirect)).toHaveLength(0)
-    env.mock.resolveMostRecentOperation({ data: undefined, errors: [{ message: "404" }] })
-    expect(tree.root.findAllByType(VanityURLPossibleRedirect)).toHaveLength(1)
+    const { UNSAFE_getAllByType } = renderWithWrappersTL(
+      <TestRenderer entity="unknown" slug="a-cool-new-url" />
+    )
+    expect(UNSAFE_getAllByType(ArtsyWebView)).toHaveLength(1)
   })
 
   it("renders a fairQueryRenderer when given a fair id", () => {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
@@ -1,4 +1,3 @@
-import { ArtsyWebView } from "app/Components/ArtsyWebView"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { Fair, FairFragmentContainer, FairPlaceholder } from "app/Scenes/Fair/Fair"
 import { PartnerContainer } from "app/Scenes/Partner"
@@ -34,14 +33,15 @@ describe("VanityURLEntity", () => {
     env = require("app/relay/createEnvironment").defaultEnvironment
   })
 
-  it("renders an ArtsyWebViewPage when 404", () => {
+  it("renders an VanityURLPossibleRedirect when 404", () => {
     if (__renderWithPlaceholderTestUtils__) {
       __renderWithPlaceholderTestUtils__.allowFallbacksAtTestTime = true
     }
     const { UNSAFE_getAllByType } = renderWithWrappersTL(
       <TestRenderer entity="unknown" slug="a-cool-new-url" />
     )
-    expect(UNSAFE_getAllByType(ArtsyWebView)).toHaveLength(1)
+    env.mock.resolveMostRecentOperation({ data: undefined, errors: [{ message: "404" }] })
+    expect(UNSAFE_getAllByType(VanityURLPossibleRedirect)).toHaveLength(1)
   })
 
   it("renders a fairQueryRenderer when given a fair id", () => {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tsx
@@ -1,6 +1,5 @@
 import { VanityURLEntity_fairOrPartner$data } from "__generated__/VanityURLEntity_fairOrPartner.graphql"
 import { VanityURLEntityQuery } from "__generated__/VanityURLEntityQuery.graphql"
-import { ArtsyWebView } from "app/Components/ArtsyWebView"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -61,10 +60,6 @@ interface RendererProps {
 }
 
 export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugType, slug }) => {
-  if (slugType === undefined) {
-    return <ArtsyWebView url={`/${slug}`} />
-  }
-
   if (slugType === "fairID") {
     return <FairQueryRenderer fairID={slug} />
   } else {
@@ -81,6 +76,7 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
         `}
         variables={{ id: slug }}
         render={renderWithPlaceholder({
+          showNotFoundView: false,
           renderFallback: () => <VanityURLPossibleRedirect slug={slug} />,
           renderPlaceholder: () => {
             switch (entity) {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tsx
@@ -1,5 +1,6 @@
 import { VanityURLEntity_fairOrPartner$data } from "__generated__/VanityURLEntity_fairOrPartner.graphql"
 import { VanityURLEntityQuery } from "__generated__/VanityURLEntityQuery.graphql"
+import { ArtsyWebView } from "app/Components/ArtsyWebView"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -60,6 +61,10 @@ interface RendererProps {
 }
 
 export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugType, slug }) => {
+  if (slugType === undefined) {
+    return <ArtsyWebView url={`/${slug}`} />
+  }
+
   if (slugType === "fairID") {
     return <FairQueryRenderer fairID={slug} />
   } else {

--- a/src/app/utils/renderWithPlaceholder.tsx
+++ b/src/app/utils/renderWithPlaceholder.tsx
@@ -26,7 +26,7 @@ export function renderWithPlaceholder<Props>({
   renderFallback?: FallbackRenderer
   initialProps?: object
   placeholderProps?: object
-  showNotFoundView: boolean
+  showNotFoundView?: boolean
 }): (readyState: ReadyState) => React.ReactElement | null {
   if (!Container && !render) {
     throw new Error("Please supply one of `render` or `Component` to renderWithPlaceholder")

--- a/src/app/utils/renderWithPlaceholder.tsx
+++ b/src/app/utils/renderWithPlaceholder.tsx
@@ -18,6 +18,7 @@ export function renderWithPlaceholder<Props>({
   renderFallback,
   initialProps = {},
   placeholderProps = {},
+  showNotFoundView = true,
 }: {
   Container?: React.ComponentType<Props>
   render?: (props: Props) => React.ReactChild
@@ -25,6 +26,7 @@ export function renderWithPlaceholder<Props>({
   renderFallback?: FallbackRenderer
   initialProps?: object
   placeholderProps?: object
+  showNotFoundView: boolean
 }): (readyState: ReadyState) => React.ReactElement | null {
   if (!Container && !render) {
     throw new Error("Please supply one of `render` or `Component` to renderWithPlaceholder")
@@ -59,7 +61,7 @@ export function renderWithPlaceholder<Props>({
 
       const isNotFoundError = getErrorHttpStatusCodes(error).includes(404)
 
-      if (isNotFoundError && enableNotFoundFailureView) {
+      if (isNotFoundError && enableNotFoundFailureView && showNotFoundView) {
         return <NotFoundFailureView error={error} />
       }
 


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves []

### Description


trying to open https://www.artsy.net/art-appraisals was going to a 404 in the app. after this, it will open a webview.

we also need to put that link to the blocklist so it doesn't open the app, but its a good default to not go to 404 when we have forgotten to block the next one.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
