### PR TITLE
feat(NX-3141): add new orderUpdateState to coenversation orders queries

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Composer.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Composer.tests.tsx
@@ -163,6 +163,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "SUBMITTED",
                   lastOffer: {
                     fromParticipant: "BUYER",
@@ -197,6 +198,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "SUBMITTED",
                   lastOffer: {
                     fromParticipant: "SELLER",
@@ -237,6 +239,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "APPROVED",
                   lastOffer: {
                     fromParticipant: "BUYER",
@@ -278,6 +281,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "CANCELED",
                   stateReason: "seller_rejected",
                   lastOffer: {
@@ -315,6 +319,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "SUBMITTED",
                   lastTransactionFailed: true,
                   lastOffer: {
@@ -356,6 +361,7 @@ describe("inquiry offer", () => {
             edges: [
               {
                 node: {
+                  mode: "OFFER",
                   state: "CANCELED",
                   stateReason: "buyer_lapsed",
                   lastOffer: {

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
@@ -8,6 +8,7 @@ import { graphql, QueryRenderer } from "react-relay"
 import { act, ReactTestRenderer } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { ConversationCTA, ConversationCTAFragmentContainer } from "./ConversationCTA"
+import { CTAPopUp } from "./CTAPopUp"
 import { OpenInquiryModalButton } from "./OpenInquiryModalButton"
 import { ReviewOfferButton } from "./ReviewOfferButton"
 jest.unmock("react-relay")
@@ -117,7 +118,7 @@ describe("ConversationCTA", () => {
     })
 
     it("renders the payment failed message if the payment failed", () => {
-      const wrapper = getWrapperWithOrders({ lastTransactionFailed: true })
+      const wrapper = getWrapperWithOrders({ lastTransactionFailed: true, mode: "OFFER" })
 
       expectReviewOfferButton(wrapper, {
         bg: "red100",
@@ -131,6 +132,7 @@ describe("ConversationCTA", () => {
 
     it("doesn't render when the last offer is from a buyer and it has not been accepted or rejected by the seller", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "SUBMITTED",
         lastOffer: {
           fromParticipant: "BUYER",
@@ -141,6 +143,7 @@ describe("ConversationCTA", () => {
 
     it("renders the pending offer when the last offer is from the seller", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "SUBMITTED",
         lastOffer: {
           fromParticipant: "SELLER",
@@ -156,6 +159,7 @@ describe("ConversationCTA", () => {
 
     it("shows correct message for an offer accepted by the buyer", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "APPROVED",
         lastOffer: { fromParticipant: "BUYER" },
       })
@@ -169,6 +173,7 @@ describe("ConversationCTA", () => {
 
     it("shows correct message for an offer accepted by the seller that does not define total (change amount)", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "APPROVED",
         lastOffer: { fromParticipant: "SELLER", definesTotal: false },
       })
@@ -182,6 +187,7 @@ describe("ConversationCTA", () => {
 
     it("shows counter received - confirm total when offer defines total and amount changes", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "SUBMITTED",
         lastOffer: { fromParticipant: "SELLER", offerAmountChanged: true, definesTotal: true },
       })
@@ -195,6 +201,7 @@ describe("ConversationCTA", () => {
 
     it("shows the 'approved' banner for fulfilled offers", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "FULFILLED",
         lastOffer: { fromParticipant: "BUYER" },
       })
@@ -208,6 +215,7 @@ describe("ConversationCTA", () => {
 
     it("shows accepted  - confirm total when offer defines total and amount stays the same", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "SUBMITTED",
         lastOffer: { fromParticipant: "SELLER", offerAmountChanged: false, definesTotal: true },
       })
@@ -221,6 +229,7 @@ describe("ConversationCTA", () => {
 
     it("shows offer accepted when buyer also approves the provisional offer", () => {
       const wrapper = getWrapperWithOrders({
+        mode: "OFFER",
         state: "APPROVED",
         lastOffer: { fromParticipant: "SELLER", definesTotal: true },
       })
@@ -229,6 +238,16 @@ describe("ConversationCTA", () => {
         bg: "green100",
         strings: ["Offer Accepted"],
         Icon: MoneyFillIcon,
+      })
+    })
+
+    describe("given BUY mode", () => {
+      it("doesn't render anything", () => {
+        const wrapper = getWrapperWithOrders({
+          mode: "BUY",
+        })
+
+        expect(wrapper.root.findAllByType(CTAPopUp)).toHaveLength(0)
       })
     })
   })

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -43,10 +43,12 @@ export const ConversationCTA: React.FC<Props> = ({ conversation, show }) => {
     return null
   }
 
-  const { lastTransactionFailed, state, lastOffer } = activeOrder
+  const { lastTransactionFailed, state, lastOffer, mode } = activeOrder
   let kind: ReviewOfferCTAKind | null = null
 
-  if (lastTransactionFailed) {
+  if (mode === "BUY") {
+    kind = null
+  } else if (lastTransactionFailed) {
     kind = "PAYMENT_FAILED"
   } else if (state === "SUBMITTED" && lastOffer?.fromParticipant === "SELLER") {
     if (lastOffer.definesTotal) {
@@ -109,6 +111,7 @@ export const ConversationCTAFragmentContainer = createFragmentContainer(Conversa
         edges {
           node {
             internalID
+            mode
             state
             stateReason
             stateExpiresAt

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
@@ -234,13 +234,12 @@ describe("messages with order updates", () => {
   it("does not remove 'Offer accepted' events when payment succeeds", () => {
     const day1Time1 = "2020-03-18T02:58:37.699Z"
     const day1Time2 = "2020-03-18T02:59:37.699Z"
-    const day2Time1 = "2020-03-19T02:59:37.699Z"
 
     const tree = withConversationItems(getWrapper, {
       events: [
         {
           __typename: "CommerceOrderStateChangedEvent",
-          state: "SUBMITTED",
+          orderUpdateState: "offer_approved",
           createdAt: day1Time1,
         },
         {
@@ -249,12 +248,6 @@ describe("messages with order updates", () => {
             respondsTo: null,
           },
           createdAt: day1Time2,
-        },
-        // this event should be omitted from the output because it is irrelevant
-        {
-          __typename: "CommerceOrderStateChangedEvent",
-          state: "APPROVED",
-          createdAt: day2Time1,
         },
       ],
     })

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -95,7 +95,10 @@ it("renders without throwing an error", () => {
 
 describe("OrderUpdate with order updates", () => {
   it("displays the offer approved event", () => {
-    const tree = getWrapper({ __typename: "CommerceOrderStateChangedEvent", state: "APPROVED" })
+    const tree = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "offer_approved",
+    })
 
     expect(extractText(tree.root)).toMatch("Offer Accepted")
     expect(extractText(tree.root)).not.toMatch("See details")
@@ -105,8 +108,7 @@ describe("OrderUpdate with order updates", () => {
   it("displays the seller declined event", () => {
     const tree = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
-      state: "CANCELED",
-      stateReason: "seller_rejected_offer_too_low",
+      orderUpdateState: "offer_rejected",
     })
 
     expect(extractText(tree.root)).toMatch("Offer Declined")
@@ -117,8 +119,7 @@ describe("OrderUpdate with order updates", () => {
   it("displays the buyer declined event", () => {
     const tree = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
-      state: "CANCELED",
-      stateReason: "buyer_rejected",
+      orderUpdateState: "offer_rejected",
     })
 
     expect(extractText(tree.root)).toMatch("Offer Declined")
@@ -129,8 +130,7 @@ describe("OrderUpdate with order updates", () => {
   it("displays the offer expired event", () => {
     const tree = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
-      state: "CANCELED",
-      stateReason: "someone_lapsed",
+      orderUpdateState: "offer_lapsed",
     })
 
     expect(extractText(tree.root)).toMatch("Offer Expired")
@@ -177,6 +177,7 @@ describe("OrderUpdate with order updates", () => {
     expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(AlertCircleFillIcon)
   })
+
   it("shows an accepted offer from the partner with pending action", () => {
     const tree = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
@@ -190,5 +191,16 @@ describe("OrderUpdate with order updates", () => {
     expect(extractText(tree.root)).toMatch("Offer Accepted - Pending Action")
     expect(extractText(tree.root)).not.toMatch("See details")
     tree.root.findByType(AlertCircleFillIcon)
+  })
+
+  it("shows an approved buy order", () => {
+    const tree = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "buy_submitted",
+    })
+
+    expect(extractText(tree.root)).toMatch("You purchased this artwork")
+    expect(extractText(tree.root)).toMatch("See details")
+    tree.root.findByType(MoneyFillIcon)
   })
 })

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -26,6 +26,10 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
   let Icon: React.FC<IconProps> = MoneyFillIcon
   let action: { label?: string; onPress?: () => void } = {}
 
+  if (event.__typename === "%other") {
+    return null
+  }
+
   if (event.__typename === "CommerceOfferSubmittedEvent") {
     const { offer } = event
     const isCounter = offer.respondsTo !== null
@@ -53,22 +57,30 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
       return null
     }
   } else if (event.__typename === "CommerceOrderStateChangedEvent") {
-    const { state, stateReason } = event
-    if (state === "APPROVED") {
+    const { orderUpdateState } = event
+    if (orderUpdateState === "offer_approved") {
       color = "green100"
       message = `Offer Accepted`
-    } else if (state === "CANCELED" && stateReason?.includes("_rejected")) {
+    } else if (orderUpdateState === "offer_rejected") {
       color = "red100"
       message = `Offer Declined`
-    } else if (state === "CANCELED" && stateReason?.includes("_lapsed")) {
+    } else if (orderUpdateState === "offer_lapsed") {
       color = "black60"
       message = `Offer Expired`
+    } else if (orderUpdateState === "buy_submitted") {
+      color = "black100"
+      message = `You purchased this artwork`
+      action = {
+        label: "See details",
+        onPress: () => navigate(`/conversation/${conversationId}/details`),
+      }
     } else {
       return null
     }
   } else {
     return null
   }
+
   return (
     <Flex>
       <TimeSince style={{ alignSelf: "center" }} time={event.createdAt} exact mb={1} />
@@ -99,8 +111,7 @@ export const OrderUpdateFragmentContainer = createFragmentContainer(OrderUpdate,
       __typename
       ... on CommerceOrderStateChangedEvent {
         createdAt
-        stateReason
-        state
+        orderUpdateState
       }
       ... on CommerceOfferSubmittedEvent {
         createdAt


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [NX-3141]

### Description

<img width="444" alt="image" src="https://user-images.githubusercontent.com/15792853/174260015-fa2110fa-5432-4c35-aabf-73f72341f3af.png">

Relies on orderUpdateState when rendering order events from `CommerceOrderStateChangedEvent` type inside conversations.

cc @artsy/negotiate-devs 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3141]: https://artsyproduct.atlassian.net/browse/NX-3141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ