### PR TITLE
feat(CX-2611): improve "Generating insights" while saving artwork modal logic

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -100,9 +100,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
   const showMyCollectionInsights = useFeatureFlag("AREnableMyCollectionInsights")
 
   const handleSubmit = async (values: ArtworkFormValues) => {
-    setLoading(true)
-
     try {
+      setLoading(true)
+
       await Promise.all([
         // This is to satisfy showing the insights modal for 2500 ms
         __TEST__ || !showMyCollectionInsights
@@ -119,9 +119,6 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
         // simulate requesting market data
         await new Promise((resolve) => setTimeout(resolve, 2000))
       }
-
-      refreshMyCollection()
-      props.onSuccess?.()
     } catch (e) {
       if (__DEV__) {
         console.error(e)
@@ -132,6 +129,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     } finally {
       setLoading(false)
       setIsArtworkSaved(false)
+      props.onSuccess?.()
     }
   }
 
@@ -333,6 +331,7 @@ export const updateArtwork = async (
       removeLocalPhotos(slug)
     }
   }
+  refreshMyCollection()
 }
 
 const tracks = {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -94,7 +94,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
 
   const [loading, setLoading] = useState<boolean>(false)
   const [isArtworkSaved, setIsArtworkSaved] = useState<boolean>(false)
-  const [displayText, setDisplayText] = useState<string>("")
+  const [savingArtworkModalDisplayText, setSavingArtworkModalDisplayText] = useState<string>("")
 
   const { showActionSheetWithOptions } = useActionSheet()
 
@@ -114,7 +114,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           lengthUnitPreference: preferredMetric.toUpperCase() as LengthUnitPreference,
         }),
         updateArtwork(values, dirtyFormCheckValues, props).then((hasMarketPriceInsights) => {
-          setDisplayText(hasMarketPriceInsights ? "Generating market data" : "Saving artwork")
+          setSavingArtworkModalDisplayText(
+            hasMarketPriceInsights ? "Generating market data" : "Saving artwork"
+          )
         }),
       ])
       if (showMyCollectionInsights) {
@@ -262,7 +264,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           <SavingArtworkModal
             testID="saving-artwork-modal"
             isVisible={loading}
-            loadingText={isArtworkSaved ? displayText : "Saving artwork"}
+            loadingText={isArtworkSaved ? savingArtworkModalDisplayText : "Saving artwork"}
           />
         ) : (
           <LoadingModal testID="loading-modal" isVisible={loading} />

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -95,14 +95,15 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
   const [loading, setLoading] = useState<boolean>(false)
   const [isArtworkSaved, setIsArtworkSaved] = useState<boolean>(false)
   const [displayText, setDisplayText] = useState<string>("")
+
   const { showActionSheetWithOptions } = useActionSheet()
 
   const showMyCollectionInsights = useFeatureFlag("AREnableMyCollectionInsights")
 
   const handleSubmit = async (values: ArtworkFormValues) => {
-    try {
-      setLoading(true)
+    setLoading(true)
 
+    try {
       await Promise.all([
         // This is to satisfy showing the insights modal for 2500 ms
         __TEST__ || !showMyCollectionInsights
@@ -122,6 +123,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
         await new Promise((resolve) => setTimeout(resolve, 2000))
       }
       refreshMyCollection()
+      props.onSuccess?.()
     } catch (e) {
       if (__DEV__) {
         console.error(e)
@@ -132,7 +134,6 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     } finally {
       setLoading(false)
       setIsArtworkSaved(false)
-      props.onSuccess?.()
     }
   }
 


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [CX-2611]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Added the logic to display "Generating market data" only when MarketPriceInsights are available. If not available - show inly "Saving artwork" text.

https://user-images.githubusercontent.com/36167539/174878171-5a1ef719-14ca-4929-8139-c5ace5c47812.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- improve saving artwork modal logic -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2611]: https://artsyproduct.atlassian.net/browse/CX-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ