### PR TITLE
feat(FX-4046): reverse image search control visible only enabled show entities

### DIFF
--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -1,0 +1,46 @@
+import { useFeatureFlag } from "app/store/GlobalStore"
+import { useImageSearch } from "app/utils/useImageSearch"
+import { AddIcon, Box, Spinner } from "palette"
+import React from "react"
+import { TouchableOpacity } from "react-native"
+
+const CAMERA_ICON_CONTAINER_SIZE = 38
+const CAMERA_ICON_SIZE = 20
+
+interface SearchImageHeaderButtonProps {
+  isReverseImageSearchEnabled: boolean
+}
+
+export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = ({
+  isReverseImageSearchEnabled,
+}) => {
+  const isImageSearchEnabled = isReverseImageSearchEnabled && useFeatureFlag("AREnableImageSearch")
+  const { searchingByImage, handleSeachByImage } = useImageSearch()
+
+  if (isImageSearchEnabled) {
+    return (
+      <TouchableOpacity
+        style={{ position: "absolute", top: 33, right: 12 }}
+        onPress={handleSeachByImage}
+        disabled={searchingByImage}
+      >
+        <Box
+          width={CAMERA_ICON_CONTAINER_SIZE}
+          height={CAMERA_ICON_CONTAINER_SIZE}
+          borderRadius={CAMERA_ICON_CONTAINER_SIZE / 2}
+          bg="white"
+          justifyContent="center"
+          alignItems="center"
+        >
+          {searchingByImage ? (
+            <Spinner size="small" />
+          ) : (
+            <AddIcon width={CAMERA_ICON_SIZE} height={CAMERA_ICON_SIZE} />
+          )}
+        </Box>
+      </TouchableOpacity>
+    )
+  }
+
+  return null
+}

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -3,8 +3,9 @@ import { useImageSearch } from "app/utils/useImageSearch"
 import { AddIcon, Box, Spinner } from "palette"
 import React from "react"
 import { TouchableOpacity } from "react-native"
+import { useScreenDimensions } from "shared/hooks"
 
-const CAMERA_ICON_CONTAINER_SIZE = 38
+const CAMERA_ICON_CONTAINER_SIZE = 40
 const CAMERA_ICON_SIZE = 20
 
 interface SearchImageHeaderButtonProps {
@@ -20,7 +21,11 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
   if (isImageSearchEnabled) {
     return (
       <TouchableOpacity
-        style={{ position: "absolute", top: 33, right: 12 }}
+        style={{
+          position: "absolute",
+          top: 13 + useScreenDimensions().safeAreaInsets.top,
+          right: 12,
+        }}
         onPress={handleSeachByImage}
         disabled={searchingByImage}
       >

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -8,13 +8,13 @@ const CAMERA_ICON_CONTAINER_SIZE = 38
 const CAMERA_ICON_SIZE = 20
 
 interface SearchImageHeaderButtonProps {
-  isReverseImageSearchEnabled: boolean
+  isImageSearchButtonVisible: boolean
 }
 
 export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = ({
-  isReverseImageSearchEnabled,
+  isImageSearchButtonVisible,
 }) => {
-  const isImageSearchEnabled = isReverseImageSearchEnabled && useFeatureFlag("AREnableImageSearch")
+  const isImageSearchEnabled = isImageSearchButtonVisible && useFeatureFlag("AREnableImageSearch")
   const { searchingByImage, handleSeachByImage } = useImageSearch()
 
   if (isImageSearchEnabled) {

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -21,6 +21,7 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
   if (isImageSearchEnabled) {
     return (
       <TouchableOpacity
+        accessibilityLabel="Search by image"
         style={{
           position: "absolute",
           top: 13 + useScreenDimensions().safeAreaInsets.top,

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -18,35 +18,37 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
   const isImageSearchEnabled = isImageSearchButtonVisible && useFeatureFlag("AREnableImageSearch")
   const { searchingByImage, handleSeachByImage } = useImageSearch()
 
-  if (isImageSearchEnabled) {
-    return (
-      <TouchableOpacity
-        accessibilityLabel="Search by image"
-        style={{
-          position: "absolute",
-          top: 13 + useScreenDimensions().safeAreaInsets.top,
-          right: 12,
-        }}
-        onPress={handleSeachByImage}
-        disabled={searchingByImage}
-      >
-        <Box
-          width={CAMERA_ICON_CONTAINER_SIZE}
-          height={CAMERA_ICON_CONTAINER_SIZE}
-          borderRadius={CAMERA_ICON_CONTAINER_SIZE / 2}
-          bg="white"
-          justifyContent="center"
-          alignItems="center"
-        >
-          {searchingByImage ? (
-            <Spinner size="small" />
-          ) : (
-            <AddIcon width={CAMERA_ICON_SIZE} height={CAMERA_ICON_SIZE} />
-          )}
-        </Box>
-      </TouchableOpacity>
-    )
+  if (!isImageSearchEnabled) {
+    return null
   }
 
-  return null
+  return (
+    <TouchableOpacity
+      accessibilityLabel="Search by image"
+      style={{
+        position: "absolute",
+        // the margin top here is the exact same as src/app/navigation/BackButton
+        // in order to align the back button with the search button
+        top: 13 + useScreenDimensions().safeAreaInsets.top,
+        right: 12,
+      }}
+      onPress={handleSeachByImage}
+      disabled={searchingByImage}
+    >
+      <Box
+        width={CAMERA_ICON_CONTAINER_SIZE}
+        height={CAMERA_ICON_CONTAINER_SIZE}
+        borderRadius={CAMERA_ICON_CONTAINER_SIZE / 2}
+        bg="white"
+        justifyContent="center"
+        alignItems="center"
+      >
+        {searchingByImage ? (
+          <Spinner size="small" />
+        ) : (
+          <AddIcon width={CAMERA_ICON_SIZE} height={CAMERA_ICON_SIZE} />
+        )}
+      </Box>
+    </TouchableOpacity>
+  )
 }

--- a/src/app/Components/SearchImageHeaderButton/index.ts
+++ b/src/app/Components/SearchImageHeaderButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./SearchImageHeaderButton"

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -4,18 +4,17 @@ import { FairQuery } from "__generated__/FairQuery.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { defaultEnvironment } from "app/relay/createEnvironment"
-import { useFeatureFlag } from "app/store/GlobalStore"
 import { useHideBackButtonOnScroll } from "app/utils/hideBackButtonOnScroll"
 
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
+import { SearchImageHeaderButton } from "app/Components/SearchImageHeaderButton"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
-import { useImageSearch } from "app/utils/useImageSearch"
-import { AddIcon, Box, Flex, Separator, Spacer, Spinner } from "palette"
+import { Box, Flex, Separator, Spacer } from "palette"
 import { NavigationalTabs, TabsType } from "palette/elements/Tabs"
 import React, { useCallback, useRef, useState } from "react"
-import { FlatList, TouchableOpacity, View } from "react-native"
+import { FlatList, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useScreenDimensions } from "shared/hooks"
@@ -44,9 +43,6 @@ const tabs: TabsType = [
   },
 ]
 
-const CAMERA_ICON_CONTAINER_SIZE = 38
-const CAMERA_ICON_SIZE = 20
-
 export const Fair: React.FC<FairProps> = ({ fair }) => {
   const { isActive, isReverseImageSearchEnabled } = fair
   const hasArticles = !!fair.articles?.edges?.length
@@ -56,12 +52,10 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
   const hasFollowedArtistArtworks = !!(fair.followedArtistArtworks?.edges?.length ?? 0 > 0)
 
   const tracking = useTracking()
-  const { searchingByImage, handleSeachByImage } = useImageSearch()
   const [activeTab, setActiveTab] = useState(0)
 
   const flatListRef = useRef<FlatList>(null)
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const isImageSearchEnabled = isReverseImageSearchEnabled && useFeatureFlag("AREnableImageSearch")
 
   const sections = isActive
     ? [
@@ -266,28 +260,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
         />
       </ArtworkFiltersStoreProvider>
 
-      {!!isImageSearchEnabled && (
-        <TouchableOpacity
-          style={{ position: "absolute", top: 33, right: 12 }}
-          onPress={handleSeachByImage}
-          disabled={searchingByImage}
-        >
-          <Box
-            width={CAMERA_ICON_CONTAINER_SIZE}
-            height={CAMERA_ICON_CONTAINER_SIZE}
-            borderRadius={CAMERA_ICON_CONTAINER_SIZE / 2}
-            bg="white"
-            justifyContent="center"
-            alignItems="center"
-          >
-            {searchingByImage ? (
-              <Spinner size="small" />
-            ) : (
-              <AddIcon width={CAMERA_ICON_SIZE} height={CAMERA_ICON_SIZE} />
-            )}
-          </Box>
-        </TouchableOpacity>
-      )}
+      <SearchImageHeaderButton isReverseImageSearchEnabled={isReverseImageSearchEnabled} />
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -260,7 +260,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
         />
       </ArtworkFiltersStoreProvider>
 
-      <SearchImageHeaderButton isReverseImageSearchEnabled={isReverseImageSearchEnabled} />
+      <SearchImageHeaderButton isImageSearchButtonVisible={isReverseImageSearchEnabled} />
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -1,8 +1,6 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import { useActionSheet } from "@expo/react-native-action-sheet"
 import { Fair_fair$data } from "__generated__/Fair_fair.graphql"
 import { FairQuery } from "__generated__/FairQuery.graphql"
-import { FairReverseImageSearchQuery } from "__generated__/FairReverseImageSearchQuery.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { defaultEnvironment } from "app/relay/createEnvironment"
@@ -10,21 +8,16 @@ import { useFeatureFlag } from "app/store/GlobalStore"
 import { useHideBackButtonOnScroll } from "app/utils/hideBackButtonOnScroll"
 
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
-import { navigate } from "app/navigation/navigate"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import { showPhotoActionSheet } from "app/utils/requestPhotos"
-import { resizeImage } from "app/utils/resizeImage"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
-import { ReactNativeFile } from "extract-files"
+import { useImageSearch } from "app/utils/useImageSearch"
 import { AddIcon, Box, Flex, Separator, Spacer, Spinner } from "palette"
 import { NavigationalTabs, TabsType } from "palette/elements/Tabs"
 import React, { useCallback, useRef, useState } from "react"
-import { Alert, FlatList, Platform, TouchableOpacity, View } from "react-native"
+import { FlatList, TouchableOpacity, View } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
-import { fetchQuery } from "relay-runtime"
-import RNFetchBlob from "rn-fetch-blob"
 import { useScreenDimensions } from "shared/hooks"
 import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
 import { FairCollectionsFragmentContainer } from "./Components/FairCollections"
@@ -55,7 +48,7 @@ const CAMERA_ICON_CONTAINER_SIZE = 38
 const CAMERA_ICON_SIZE = 20
 
 export const Fair: React.FC<FairProps> = ({ fair }) => {
-  const { isActive } = fair
+  const { isActive, isReverseImageSearchEnabled } = fair
   const hasArticles = !!fair.articles?.edges?.length
   const hasCollections = !!fair.marketingCollections.length
   const hasArtworks = !!(fair.counts?.artworks ?? 0 > 0)
@@ -63,13 +56,12 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
   const hasFollowedArtistArtworks = !!(fair.followedArtistArtworks?.edges?.length ?? 0 > 0)
 
   const tracking = useTracking()
+  const { searchingByImage, handleSeachByImage } = useImageSearch()
   const [activeTab, setActiveTab] = useState(0)
 
   const flatListRef = useRef<FlatList>(null)
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const [searchingByImage, setSearchingByImage] = useState(false)
-  const isImageSearchEnabled = useFeatureFlag("AREnableImageSearch")
-  const { showActionSheetWithOptions } = useActionSheet()
+  const isImageSearchEnabled = isReverseImageSearchEnabled && useFeatureFlag("AREnableImageSearch")
 
   const sections = isActive
     ? [
@@ -175,99 +167,6 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
       action_type: Schema.ActionTypes.Tap,
     })
     handleFilterArtworksModal()
-  }
-
-  const handleSeachByImage = async () => {
-    try {
-      const images = await showPhotoActionSheet(showActionSheetWithOptions, true, false)
-      const image = images[0]
-      let resizedWidth = image.width
-      let resizedHeight = image.height
-
-      /**
-       * For optimal performance of TinEye, image should be 600px in size in the smallest dimension
-       * For example, image with 1600x1200 size should be resized to 800x600
-       */
-      if (image.width > image.height) {
-        resizedHeight = 600
-      } else {
-        resizedWidth = 600
-      }
-
-      setSearchingByImage(true)
-
-      const resizedImage = await resizeImage({
-        uri: image.path,
-        width: resizedWidth,
-        height: resizedHeight,
-        quality: 85,
-        onlyScaleDown: true,
-      })
-
-      /**
-       * Images posted to server via fetch get their size inflated significantly for iOS.
-       * This is a small hack to solve this problem
-       *
-       * You can find more context here: https://github.com/facebook/react-native/issues/27099
-       */
-      if (Platform.OS === "ios") {
-        const updatedPath = replaceFilenameInValue(resizedImage.path, resizedImage.name)
-        const updatedURI = replaceFilenameInValue(resizedImage.uri, resizedImage.name)
-        const updatedFilename = replaceFilenameInValue(resizedImage.name, resizedImage.name)
-
-        await RNFetchBlob.fs.mv(resizedImage.path, updatedPath)
-
-        resizedImage.path = updatedPath
-        resizedImage.uri = updatedURI
-        resizedImage.name = updatedFilename
-      }
-
-      const fileImage = new ReactNativeFile({
-        uri: resizedImage.uri,
-        name: resizedImage.name,
-        type: "image/jpeg",
-      })
-
-      const execute = fetchQuery<FairReverseImageSearchQuery>(
-        defaultEnvironment,
-        graphql`
-          query FairReverseImageSearchQuery($file: Upload!) {
-            reverseImageSearch(image: $file) {
-              results {
-                matchPercent
-                artwork {
-                  href
-                }
-              }
-            }
-          }
-        `,
-        {
-          file: fileImage,
-        }
-      )
-      const response = await execute.toPromise()
-      const imageResults = response?.reverseImageSearch?.results ?? []
-
-      if (imageResults.length === 0) {
-        Alert.alert(
-          "Artwork Not Found",
-          "We couldn’t find an artwork based on your photo. Please try again"
-        )
-        return
-      }
-
-      const sortedImageResults = [...imageResults].sort(
-        (asc, desc) => desc!.matchPercent - asc!.matchPercent
-      )
-
-      navigate(sortedImageResults[0]!.artwork!.href!)
-    } catch (error) {
-      console.error(error)
-      Alert.alert("Something went wrong", (error as Error).message)
-    } finally {
-      setSearchingByImage(false)
-    }
   }
 
   const hideBackButtonOnScroll = useHideBackButtonOnScroll()
@@ -399,6 +298,7 @@ export const FairFragmentContainer = createFragmentContainer(Fair, {
       internalID
       slug
       isActive
+      isReverseImageSearchEnabled
       articles: articlesConnection(first: 5, sort: PUBLISHED_AT_DESC) {
         edges {
           __typename
@@ -470,7 +370,3 @@ export const FairPlaceholder: React.FC = () => (
     <PlaceholderGrid />
   </Flex>
 )
-
-const replaceFilenameInValue = (value: string, filename: string) => {
-  return value.replace(filename, `${filename}.toUpload`)
-}

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -45,6 +45,7 @@ const tabs: TabsType = [
 
 export const Fair: React.FC<FairProps> = ({ fair }) => {
   const { isActive, isReverseImageSearchEnabled } = fair
+  const shouldShowImageSearchButton = isReverseImageSearchEnabled && !!isActive
   const hasArticles = !!fair.articles?.edges?.length
   const hasCollections = !!fair.marketingCollections.length
   const hasArtworks = !!(fair.counts?.artworks ?? 0 > 0)
@@ -260,7 +261,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
         />
       </ArtworkFiltersStoreProvider>
 
-      <SearchImageHeaderButton isImageSearchButtonVisible={isReverseImageSearchEnabled} />
+      <SearchImageHeaderButton isImageSearchButtonVisible={shouldShowImageSearchButton} />
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -2,6 +2,7 @@ import { Show_show$data } from "__generated__/Show_show.graphql"
 import { ShowQuery } from "__generated__/ShowQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
+import { SearchImageHeaderButton } from "app/Components/SearchImageHeaderButton"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -47,6 +48,7 @@ interface ViewToken {
 
 export const Show: React.FC<ShowProps> = ({ show }) => {
   const [visible, setVisible] = useState(false)
+  const shouldShowImageSearchButton = show.isReverseImageSearchEnabled
 
   const filterComponentAnimationValue = new Animated.Value(0)
 
@@ -137,6 +139,8 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
           keyboardShouldPersistTaps="handled"
         />
       </ArtworkFiltersStoreProvider>
+
+      <SearchImageHeaderButton isImageSearchButtonVisible={shouldShowImageSearchButton} />
     </ProvideScreenTracking>
   )
 }
@@ -146,6 +150,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
     fragment Show_show on Show {
       internalID
       slug
+      isReverseImageSearchEnabled
       ...ShowHeader_show
       ...ShowInstallShots_show
       ...ShowInfo_show

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -48,7 +48,7 @@ interface ViewToken {
 
 export const Show: React.FC<ShowProps> = ({ show }) => {
   const [visible, setVisible] = useState(false)
-  const shouldShowImageSearchButton = show.isReverseImageSearchEnabled
+  const shouldShowImageSearchButton = show.isReverseImageSearchEnabled && !!show.isActive
 
   const filterComponentAnimationValue = new Animated.Value(0)
 
@@ -151,6 +151,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       internalID
       slug
       isReverseImageSearchEnabled
+      isActive
       ...ShowHeader_show
       ...ShowInstallShots_show
       ...ShowInfo_show

--- a/src/app/tests/mockEnvironmentPayload.ts
+++ b/src/app/tests/mockEnvironmentPayload.ts
@@ -1,4 +1,4 @@
-import { act } from "@testing-library/react-hooks"
+import { act } from "@testing-library/react-native"
 import { takeRight } from "lodash"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { MockResolverContext, MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"

--- a/src/app/utils/useImageSearch.ts
+++ b/src/app/utils/useImageSearch.ts
@@ -1,0 +1,119 @@
+import { useActionSheet } from "@expo/react-native-action-sheet"
+import { useImageSearchQuery } from "__generated__/useImageSearchQuery.graphql"
+import { navigate } from "app/navigation/navigate"
+import { defaultEnvironment } from "app/relay/createEnvironment"
+import { ReactNativeFile } from "extract-files"
+import { useState } from "react"
+import { Alert, Platform } from "react-native"
+import { fetchQuery, graphql } from "react-relay"
+import RNFetchBlob from "rn-fetch-blob"
+import { showPhotoActionSheet } from "./requestPhotos"
+import { resizeImage } from "./resizeImage"
+
+export const useImageSearch = () => {
+  const [searchingByImage, setSearchingByImage] = useState(false)
+  const { showActionSheetWithOptions } = useActionSheet()
+
+  const handleSeachByImage = async () => {
+    try {
+      const images = await showPhotoActionSheet(showActionSheetWithOptions, true, false)
+      const image = images[0]
+      console.warn({ image })
+      let resizedWidth = image.width
+      let resizedHeight = image.height
+
+      /**
+       * For optimal performance of TinEye, image should be 600px in size in the smallest dimension
+       * For example, image with 1600x1200 size should be resized to 800x600
+       */
+      if (image.width > image.height) {
+        resizedHeight = 600
+      } else {
+        resizedWidth = 600
+      }
+
+      setSearchingByImage(true)
+
+      const resizedImage = await resizeImage({
+        uri: image.path,
+        width: resizedWidth,
+        height: resizedHeight,
+        quality: 85,
+        onlyScaleDown: true,
+      })
+
+      /**
+       * Images posted to server via fetch get their size inflated significantly for iOS.
+       * This is a small hack to solve this problem
+       *
+       * You can find more context here: https://github.com/facebook/react-native/issues/27099
+       */
+      if (Platform.OS === "ios") {
+        const updatedPath = replaceFilenameInValue(resizedImage.path, resizedImage.name)
+        const updatedURI = replaceFilenameInValue(resizedImage.uri, resizedImage.name)
+        const updatedFilename = replaceFilenameInValue(resizedImage.name, resizedImage.name)
+
+        await RNFetchBlob.fs.mv(resizedImage.path, updatedPath)
+
+        resizedImage.path = updatedPath
+        resizedImage.uri = updatedURI
+        resizedImage.name = updatedFilename
+      }
+
+      const fileImage = new ReactNativeFile({
+        uri: resizedImage.uri,
+        name: resizedImage.name,
+        type: "image/jpeg",
+      })
+
+      const execute = fetchQuery<useImageSearchQuery>(
+        defaultEnvironment,
+        graphql`
+          query useImageSearchQuery($file: Upload!) {
+            reverseImageSearch(image: $file) {
+              results {
+                matchPercent
+                artwork {
+                  href
+                }
+              }
+            }
+          }
+        `,
+        {
+          file: fileImage,
+        }
+      )
+      const response = await execute.toPromise()
+      const imageResults = response?.reverseImageSearch?.results ?? []
+
+      if (imageResults.length === 0) {
+        Alert.alert(
+          "Artwork Not Found",
+          "We couldn’t find an artwork based on your photo. Please try again"
+        )
+        return
+      }
+
+      const sortedImageResults = [...imageResults].sort(
+        (asc, desc) => desc!.matchPercent - asc!.matchPercent
+      )
+
+      navigate(sortedImageResults[0]!.artwork!.href!)
+    } catch (error) {
+      console.error(error)
+      Alert.alert("Something went wrong", (error as Error).message)
+    } finally {
+      setSearchingByImage(false)
+    }
+  }
+
+  return {
+    searchingByImage,
+    handleSeachByImage,
+  }
+}
+
+const replaceFilenameInValue = (value: string, filename: string) => {
+  return value.replace(filename, `${filename}.toUpload`)
+}

--- a/src/app/utils/useImageSearch.ts
+++ b/src/app/utils/useImageSearch.ts
@@ -18,7 +18,6 @@ export const useImageSearch = () => {
     try {
       const images = await showPhotoActionSheet(showActionSheetWithOptions, true, false)
       const image = images[0]
-      console.warn({ image })
       let resizedWidth = image.width
       let resizedHeight = image.height
 

--- a/src/app/utils/useImageSearch.ts
+++ b/src/app/utils/useImageSearch.ts
@@ -65,7 +65,7 @@ export const useImageSearch = () => {
         type: "image/jpeg",
       })
 
-      const execute = fetchQuery<useImageSearchQuery>(
+      const response = await fetchQuery<useImageSearchQuery>(
         defaultEnvironment,
         graphql`
           query useImageSearchQuery($file: Upload!) {
@@ -82,8 +82,7 @@ export const useImageSearch = () => {
         {
           file: fileImage,
         }
-      )
-      const response = await execute.toPromise()
+      ).toPromise()
       const imageResults = response?.reverseImageSearch?.results ?? []
 
       if (imageResults.length === 0) {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-4046]

### Description

Right now for QA purposes I've added only one fair and one show in staging env vars in metaphysics using:
```bash
hokusai staging env set REVERSE_IMAGE_SEARCH_ENABLED_SHOW_SLUGS=debra-force-fine-art-abstractions-1930s-1980s
hokusai staging env set REVERSE_IMAGE_SEARCH_ENABLED_FAIR_SLUGS=liste-art-fair-basel-2022
```

for more context check the j[ira ticket](https://artsyproduct.atlassian.net/browse/FX-4046)

> ⚠️ ⚠️ This feature is behind `AREnableImageSearch` feature flag  ⚠️ ⚠️

**What changed**

- [x] Reverse image search control (button with + icon in the top right corner) is shown on all show and fair pages where isReverseImageSearchEnabled is true
- [x] Control is not shown on any other show/fair pages
- [x] Control is still behind feature flag
- [x] If the show or fair is closed, we should never show the control
- [x] refactor: pull image search logic into custom hook
- [x] refactor: pull out SearchImageHeaderButton to be a reusable component to be reused in shows
- [x] minor ui fix (copied over the back button position and reused it in search image button

#### Screenshots

|eligible show| random show| eligible fair | random fair| ui fix |
|---|---|---|---|---|
|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 18 21 53](https://user-images.githubusercontent.com/21178754/175071148-b545adf5-6e2d-4521-812b-1b7c52f57de9.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 18 22 01](https://user-images.githubusercontent.com/21178754/175071144-6a48446c-bb3d-4dc0-b60a-283d730d2e33.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 18 22 10](https://user-images.githubusercontent.com/21178754/175071121-7cd7d3b8-461e-4b6d-b48f-f3f914f1888b.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 18 22 06](https://user-images.githubusercontent.com/21178754/175071139-9578d03d-6007-4354-8b88-58b1fafc0dff.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 18 21 48](https://user-images.githubusercontent.com/21178754/175072149-5ac697a9-1830-4351-b700-fc0cec766429.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- enable reverse image search for selected shows and fairs - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4046]: https://artsyproduct.atlassian.net/browse/FX-4046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ