### PR TITLE
feat(FX-4053): hide create artwork alert btn when artwork has no artists

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -541,11 +541,32 @@ describe("Artwork", () => {
           isSold: false,
           isInAuction: false,
           sale: null,
+          artists: [
+            {
+              name: "Test Artist",
+            },
+          ],
         }),
       })
 
       expect(queryByA11yLabel("Create artwork alert section")).toBeTruthy()
       expect(queryByA11yLabel("Create artwork alert buttons section")).toBeFalsy()
+    })
+
+    it("should not display create artwork alert button section when artwork doesn't have any artist", () => {
+      const { queryByA11yLabel } = renderWithWrappersTL(<TestRenderer />)
+
+      mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
+        Artwork: () => ({
+          isSold: false,
+          isInAuction: false,
+          sale: null,
+          artists: [],
+        }),
+      })
+
+      expect(queryByA11yLabel("Create artwork alert section")).toBeNull()
+      expect(queryByA11yLabel("Create artwork alert buttons section")).toBeNull()
     })
 
     it("should display create artwork alert buttons section when artwork is sold", () => {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -16,6 +16,7 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { QAInfoPanel } from "app/utils/QAInfo"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { AuctionWebsocketContextProvider } from "app/Websockets/auctions/AuctionSocketContext"
+import { isEmpty } from "lodash"
 import { Box, LinkText, Separator, Text } from "palette"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
@@ -276,7 +277,12 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    if (enableCreateArtworkAlert && !artworkAboveTheFold?.isSold && !isInClosedAuction) {
+    if (
+      enableCreateArtworkAlert &&
+      !isEmpty(artworkAboveTheFold?.artists) &&
+      !artworkAboveTheFold?.isSold &&
+      !isInClosedAuction
+    ) {
       sections.push({
         key: "createAlertSection",
         element: <CreateArtworkAlertSection artwork={artworkAboveTheFold} />,
@@ -479,6 +485,9 @@ export const ArtworkContainer = createRefetchContainer(
         isSold
         isInAuction
         availability
+        artists {
+          name
+        }
         sale {
           isClosed
           isPreview

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tests.tsx
@@ -61,6 +61,20 @@ describe("CreateArtworkAlertButtonsSection", () => {
     expect(getByText("Prints")).toBeTruthy()
   })
 
+  it("should not render create alert button and description text if artwork doesn't have any associated artists", () => {
+    const { queryByText } = renderWithWrappersTL(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => ({
+        ...Artwork,
+        artists: [],
+      }),
+    })
+
+    expect(queryByText("Be notified when a similar work is available")).toBeNull()
+    expect(queryByText("Create Alert")).toBeNull()
+  })
+
   it("should not render `Rarity` pill if needed data is missing", () => {
     const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tsx
@@ -14,7 +14,7 @@ import {
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
-import { compact } from "lodash"
+import { compact, isEmpty } from "lodash"
 import { Box, Button, Spacer, Text } from "palette"
 import { FC, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -94,15 +94,18 @@ const CreateArtworkAlertButtonsSection: FC<CreateArtworkAlertButtonsSectionProps
     <>
       <Box accessible accessibilityLabel="Create artwork alert buttons section">
         <Text variant="lg">{isInClosedAuction ? "Bidding closed" : "Sold"}</Text>
-        <Text variant="xs" color="black60">
-          Be notified when a similar work is available
-        </Text>
+        {!isEmpty(artists) && (
+          <>
+            <Text variant="xs" color="black60">
+              Be notified when a similar work is available
+            </Text>
+            <Spacer mt={2} />
 
-        <Spacer mt={2} />
-
-        <Button block onPress={handleCreateAlertPress}>
-          Create Alert
-        </Button>
+            <Button block onPress={handleCreateAlertPress}>
+              Create Alert
+            </Button>
+          </>
+        )}
 
         {!!isInquireable && !isInClosedAuction && (
           <InquiryButtonsFragmentContainer artwork={artwork} variant="outline" mt={1} block />


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-4053]

### Description

There are some cases of artworks that **don't have an associated artist**. When a user creates an Alert for those artworks we get a huge activity events (triggering notifications for any artworks that are published).

This pr solves that:

- changes should be for Artwork page **ONLY**
- Create Alert btn should be hidden, not disabled
- Create Alert btn should be hidden when artwork doesn't have any associated artists.

#### Screenshots

|no artists|with artists|
|---|---|
|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-24 at 11 11 03](https://user-images.githubusercontent.com/21178754/175493286-f627931a-0eb5-428f-ab51-e236681b7791.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-06-24 at 11 11 33](https://user-images.githubusercontent.com/21178754/175493269-62db3816-9dd7-4e8f-bbcf-fd230c611d91.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- hide create alert button for artworks that don't have an artist - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4053]: https://artsyproduct.atlassian.net/browse/FX-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ