### PR TITLE
chore(CX-2640): add tests to visual clues

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -67,6 +67,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -430,7 +434,7 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "b5b44d59e3036fde34acae6a4ac3a669e27496ab",
         "is_verified": false,
-        "line_number": 669
+        "line_number": 701
       }
     ],
     "src/app/Scenes/MyCollection/utils/randomMyCollectionArtwork.ts": [
@@ -482,5 +486,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-03T15:04:55Z"
+  "generated_at": "2022-06-23T12:42:30Z"
 }

--- a/docs/add_a_visual_clue.md
+++ b/docs/add_a_visual_clue.md
@@ -78,3 +78,24 @@ Session clues are visual cues that can be shown when an event happened. They are
   setVisualClueAsSeen("MyNewVisualClue")
 
 ```
+
+# Testing Clues
+
+When testing visual clues, instead of using `addClue`/`setVisualClueAsSeen`/.. methods, please, use GlobalStore directly.
+Othervise the tests will fail due to the way JS works
+
+Method to test:
+
+```jsx
+GlobalStore.actions.visualClue.addClue("MyNewVisualClue")
+```
+
+The test:
+
+```jsx
+it("tests that MyNewVisualClue was added to the array of clues", () => {
+  expect(__globalStoreTestUtils__?.getCurrentState().visualClue.sessionState.clues).toEqual([
+    "MyNewVisualClue",
+  ])
+})
+```

--- a/docs/add_a_visual_clue.md
+++ b/docs/add_a_visual_clue.md
@@ -55,14 +55,14 @@ return(
 ```diff
   // The component that renders the new feature
 + useEffect(() => {
-+    setVisualClueAsSeen("NewVisualClue")
++    GlobalStore.actions.visualClue.setVisualClueAsSeen("NewVisualClue")
 + }, [])
 )
 ```
 
 # Session Clues
 
-Session clues are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a session clue you can add them with `addClue("SessionClue")` anywhere in the code and mark them as seen with `setVisualClueAsSeen("SessionClue")`.
+Session clues are visual cues that can be shown when an event happened. They are not supposed to be added to `visualClues.ts` and can show up multiple times. To show a session clue you can add them with `GlobalStore.actions.visualClue.addClue("SessionClue")` anywhere in the code and mark them as seen with `GlobalStore.actions.visualClue.setVisualClueAsSeen("SessionClue")`.
 
 ```jsx
   const { showVisualClue } = useVisualClue()
@@ -71,17 +71,17 @@ Session clues are visual cues that can be shown when an event happened. They are
 
   // show visual cue
   ...
-  addClue("MyNewVisualClue")
+  GlobalStore.actions.visualClue.addClue("MyNewVisualClue")
   ...
 
   // mark visual cue as seen
-  setVisualClueAsSeen("MyNewVisualClue")
+  GlobalStore.actions.visualClue.setVisualClueAsSeen("MyNewVisualClue")
 
 ```
 
 # Testing Clues
 
-When testing visual clues, instead of using `addClue`/`setVisualClueAsSeen`/.. methods, please, use GlobalStore directly.
+When testing GlobalStore state, please, use GlobalStore directly.
 Othervise the tests will fail due to the way JS works
 
 Method to test:

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -14,13 +14,7 @@ import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabP
 import { useToast } from "app/Components/Toast/toastHook"
 import { navigate, popToRoot } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
-import {
-  GlobalStore,
-  setVisualClueAsSeen,
-  useDevToggle,
-  useFeatureFlag,
-  useVisualClue,
-} from "app/store/GlobalStore"
+import { GlobalStore, useDevToggle, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   PlaceholderBox,
@@ -157,7 +151,9 @@ const MyCollection: React.FC<{
         )}
         {!!showSubmissionMessage && (
           <SubmittedArtworkAddedMessage
-            onClose={() => setVisualClueAsSeen("ArtworkSubmissionMessage")}
+            onClose={() =>
+              GlobalStore.actions.visualClue.setVisualClueAsSeen("ArtworkSubmissionMessage")
+            }
           />
         )}
         {!!enableMyCollectionInsights && (

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -19,6 +19,7 @@ import { createMockEnvironment } from "relay-test-utils"
 import * as artworkMutations from "../../mutations/myCollectionCreateArtwork"
 import { ArtworkFormValues } from "../../State/MyCollectionArtworkModel"
 import {
+  addArtworkMessages,
   MyCollectionArtworkForm,
   MyCollectionArtworkFormProps,
   updateArtwork,
@@ -573,6 +574,37 @@ describe("MyCollectionArtworkForm", () => {
 
         expect(getByTestId("loading-modal").props.visible).toBe(true)
       })
+    })
+  })
+
+  describe("adds correct visual clues", () => {
+    it("hasMarketPriceInsights: true, sourceTab: Tab.collection", () => {
+      addArtworkMessages({ hasMarketPriceInsights: true, sourceTab: Tab.collection })
+      expect(__globalStoreTestUtils__?.getCurrentState().visualClue.sessionState.clues).toEqual([
+        "AddedArtworkWithInsightsMessage_MyCTab",
+        "AddedArtworkWithInsightsVisualClueDot",
+      ])
+    })
+
+    it("hasMarketPriceInsights: false, sourceTab: Tab.collection", () => {
+      addArtworkMessages({ hasMarketPriceInsights: true, sourceTab: Tab.insights })
+      expect(__globalStoreTestUtils__?.getCurrentState().visualClue.sessionState.clues).toEqual([
+        "AddedArtworkWithInsightsMessage_InsightsTab",
+      ])
+    })
+
+    it("hasMarketPriceInsights: false, sourceTab: Tab.collection", () => {
+      addArtworkMessages({ hasMarketPriceInsights: false, sourceTab: Tab.collection })
+      expect(__globalStoreTestUtils__?.getCurrentState().visualClue.sessionState.clues).toEqual([
+        "AddedArtworkWithoutInsightsMessage_MyCTab",
+      ])
+    })
+
+    it("hasMarketPriceInsights: false, sourceTab: Tab.insights", () => {
+      addArtworkMessages({ hasMarketPriceInsights: false, sourceTab: Tab.insights })
+      expect(__globalStoreTestUtils__?.getCurrentState().visualClue.sessionState.clues).toEqual([
+        "AddedArtworkWithoutInsightsMessage_InsightsTab",
+      ])
     })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -13,7 +13,7 @@ import {
   explicitlyClearedFields,
 } from "app/Scenes/MyCollection/utils/cleanArtworkPayload"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
-import { addClue, GlobalStore, setVisualClueAsSeen, useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore, setVisualClueAsSeen, useFeatureFlag } from "app/store/GlobalStore"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
 import { isEqual } from "lodash"
@@ -362,18 +362,19 @@ export const addArtworkMessages = ({
 
   if (hasMarketPriceInsights) {
     if (sourceTab === Tab.collection) {
-      addClue("AddedArtworkWithInsightsMessage_MyCTab")
-      addClue("AddedArtworkWithInsightsVisualClueDot")
+      // We need to call GlobalStore.actions here directly for tests to work correctly
+      GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsMessage_MyCTab")
+      GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsVisualClueDot")
     } else {
       setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
-      addClue("AddedArtworkWithInsightsMessage_InsightsTab")
+      GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsMessage_InsightsTab")
     }
   } else {
     if (sourceTab === Tab.collection) {
-      addClue("AddedArtworkWithoutInsightsMessage_MyCTab")
+      GlobalStore.actions.visualClue.addClue("AddedArtworkWithoutInsightsMessage_MyCTab")
     } else {
       setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
-      addClue("AddedArtworkWithoutInsightsMessage_InsightsTab")
+      GlobalStore.actions.visualClue.addClue("AddedArtworkWithoutInsightsMessage_InsightsTab")
     }
   }
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -13,7 +13,7 @@ import {
   explicitlyClearedFields,
 } from "app/Scenes/MyCollection/utils/cleanArtworkPayload"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
-import { GlobalStore, setVisualClueAsSeen, useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
 import { isEqual } from "lodash"
@@ -355,10 +355,12 @@ export const addArtworkMessages = ({
   hasMarketPriceInsights: boolean | null | undefined
   sourceTab: Tab
 }) => {
-  setVisualClueAsSeen("AddedArtworkWithInsightsMessage_InsightsTab")
-  setVisualClueAsSeen("AddedArtworkWithInsightsMessage_MyCTab")
-  setVisualClueAsSeen("AddedArtworkWithoutInsightsMessage_InsightsTab")
-  setVisualClueAsSeen("AddedArtworkWithoutInsightsMessage_MyCTab")
+  GlobalStore.actions.visualClue.setVisualClueAsSeen("AddedArtworkWithInsightsMessage_InsightsTab")
+  GlobalStore.actions.visualClue.setVisualClueAsSeen("AddedArtworkWithInsightsMessage_MyCTab")
+  GlobalStore.actions.visualClue.setVisualClueAsSeen(
+    "AddedArtworkWithoutInsightsMessage_InsightsTab"
+  )
+  GlobalStore.actions.visualClue.setVisualClueAsSeen("AddedArtworkWithoutInsightsMessage_MyCTab")
 
   if (hasMarketPriceInsights) {
     if (sourceTab === Tab.collection) {
@@ -366,14 +368,14 @@ export const addArtworkMessages = ({
       GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsMessage_MyCTab")
       GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsVisualClueDot")
     } else {
-      setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
+      GlobalStore.actions.visualClue.setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
       GlobalStore.actions.visualClue.addClue("AddedArtworkWithInsightsMessage_InsightsTab")
     }
   } else {
     if (sourceTab === Tab.collection) {
       GlobalStore.actions.visualClue.addClue("AddedArtworkWithoutInsightsMessage_MyCTab")
     } else {
-      setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
+      GlobalStore.actions.visualClue.setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")
       GlobalStore.actions.visualClue.addClue("AddedArtworkWithoutInsightsMessage_InsightsTab")
     }
   }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -348,7 +348,7 @@ const tracks = {
   },
 }
 
-const addArtworkMessages = async ({
+export const addArtworkMessages = ({
   hasMarketPriceInsights,
   sourceTab,
 }: {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkUploadMessages.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkUploadMessages.tsx
@@ -1,5 +1,5 @@
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
-import { setVisualClueAsSeen, useVisualClue } from "app/store/GlobalStore"
+import { GlobalStore, useVisualClue } from "app/store/GlobalStore"
 import { Flex } from "palette"
 import React from "react"
 import {
@@ -31,17 +31,29 @@ export const MyCollectionArtworkUploadMessages: React.FC<
     <Flex>
       {!!showAddedArtworkWithInsightsMessage && (
         <AddedArtworkWithInsightsMessage
-          onClose={() => setVisualClueAsSeen(`AddedArtworkWithInsightsMessage_${tabPrefix}`)}
+          onClose={() =>
+            GlobalStore.actions.visualClue.setVisualClueAsSeen(
+              `AddedArtworkWithInsightsMessage_${tabPrefix}`
+            )
+          }
         />
       )}
       {!!showAddedArtworkWithoutInsightsMessage &&
         (hasMarketSignals ? (
           <AddedArtworkWithoutInsightsMessage
-            onClose={() => setVisualClueAsSeen(`AddedArtworkWithoutInsightsMessage_${tabPrefix}`)}
+            onClose={() =>
+              GlobalStore.actions.visualClue.setVisualClueAsSeen(
+                `AddedArtworkWithoutInsightsMessage_${tabPrefix}`
+              )
+            }
           />
         ) : (
           <AddedArtworkWithoutAnyCollectionInsightsMessage
-            onClose={() => setVisualClueAsSeen(`AddedArtworkWithoutInsightsMessage_${tabPrefix}`)}
+            onClose={() =>
+              GlobalStore.actions.visualClue.setVisualClueAsSeen(
+                `AddedArtworkWithoutInsightsMessage_${tabPrefix}`
+              )
+            }
           />
         ))}
     </Flex>

--- a/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
@@ -3,7 +3,7 @@ import { StickyTabPageFlatListContext } from "app/Components/StickyTabPage/Stick
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
-import { setVisualClueAsSeen, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   MY_COLLECTION_INSIGHTS_REFRESH_KEY,
@@ -81,7 +81,11 @@ export const MyCollectionInsights: React.FC<{}> = ({}) => {
       <>
         {!!showMyCollectionInsightsIncompleteMessage && (
           <MyCollectionInsightsIncompleteMessage
-            onClose={() => setVisualClueAsSeen("MyCollectionInsightsIncompleteMessage")}
+            onClose={() =>
+              GlobalStore.actions.visualClue.setVisualClueAsSeen(
+                "MyCollectionInsightsIncompleteMessage"
+              )
+            }
           />
         )}
         <MyCollectionArtworkUploadMessages

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -2,7 +2,7 @@ import { useNavigation } from "@react-navigation/native"
 import { MyProfileHeader_me$key } from "__generated__/MyProfileHeader_me.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { navigate } from "app/navigation/navigate"
-import { setVisualClueAsSeen, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag, useVisualClue } from "app/store/GlobalStore"
 import {
   Avatar,
   Box,
@@ -44,7 +44,7 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeader_me$key }> = (props)
   )
 
   useEffect(() => {
-    setVisualClueAsSeen("CompleteCollectorProfileMessage")
+    GlobalStore.actions.visualClue.setVisualClueAsSeen("CompleteCollectorProfileMessage")
   }, [])
 
   const isCollectorProfileCompleted = !!(

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
@@ -4,7 +4,7 @@ import { ContactInformationQueryRendererQuery } from "__generated__/ContactInfor
 import { ErrorView } from "app/Components/ErrorView/ErrorView"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { consignmentSubmittedEvent } from "app/Scenes/SellWithArtsy/utils/TrackingEvent"
-import { addClue, GlobalStore } from "app/store/GlobalStore"
+import { GlobalStore } from "app/store/GlobalStore"
 import { Formik } from "formik"
 import { CTAButton, Flex, Input, Spacer, Text } from "palette"
 import { PhoneInput } from "palette/elements/Input/PhoneInput/PhoneInput"
@@ -42,7 +42,7 @@ export const ContactInformation: React.FC<{
         trackEvent(consignmentSubmittedEvent(updatedSubmissionId, formValues.userEmail, userID))
 
         GlobalStore.actions.artworkSubmission.submission.resetSessionState()
-        addClue("ArtworkSubmissionMessage")
+        GlobalStore.actions.visualClue.addClue("ArtworkSubmissionMessage")
         handlePress(submissionId)
       }
     } catch (error) {

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -197,6 +197,8 @@ export const useVisualClue = () => {
   return { seenVisualClues, showVisualClue }
 }
 
+// when using visualClue and there is a need to test the visualClue model state, do not use this export
+// instead use GlobalStore directly
 export const addClue = GlobalStore.actions.visualClue.addClue
 
 export const setVisualClueAsSeen = GlobalStore.actions.visualClue.setVisualClueAsSeen

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -90,11 +90,11 @@ export const __globalStoreTestUtils__ = __TEST__
     }
   : undefined
 
-if (__TEST__) {
+/* if (__TEST__) {
   beforeEach(() => {
     __globalStoreTestUtils__?.reset()
   })
-}
+} */
 
 const hooks = createTypedHooks<GlobalStoreModel>()
 

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -90,11 +90,11 @@ export const __globalStoreTestUtils__ = __TEST__
     }
   : undefined
 
-/* if (__TEST__) {
+if (__TEST__) {
   beforeEach(() => {
     __globalStoreTestUtils__?.reset()
   })
-} */
+}
 
 const hooks = createTypedHooks<GlobalStoreModel>()
 
@@ -196,8 +196,6 @@ export const useVisualClue = () => {
 
   return { seenVisualClues, showVisualClue }
 }
-
-export const addClue = GlobalStore.actions.visualClue.addClue
 
 export const setVisualClueAsSeen = GlobalStore.actions.visualClue.setVisualClueAsSeen
 

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -197,6 +197,8 @@ export const useVisualClue = () => {
   return { seenVisualClues, showVisualClue }
 }
 
+export const addClue = GlobalStore.actions.visualClue.addClue
+
 export const setVisualClueAsSeen = GlobalStore.actions.visualClue.setVisualClueAsSeen
 
 export function unsafe_getUserAccessToken() {

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -197,12 +197,6 @@ export const useVisualClue = () => {
   return { seenVisualClues, showVisualClue }
 }
 
-// when using visualClue and there is a need to test the visualClue model state, do not use this export
-// instead use GlobalStore directly
-export const addClue = GlobalStore.actions.visualClue.addClue
-
-export const setVisualClueAsSeen = GlobalStore.actions.visualClue.setVisualClueAsSeen
-
 export function unsafe_getUserAccessToken() {
   const state = globalStoreInstance().getState() ?? null
   if (state) {

--- a/src/palette/elements/Tabs/NavigationalTabs.tsx
+++ b/src/palette/elements/Tabs/NavigationalTabs.tsx
@@ -1,5 +1,5 @@
 import { VisualClueName } from "app/store/config/visualClues"
-import { setVisualClueAsSeen, useVisualClue } from "app/store/GlobalStore"
+import { GlobalStore, useVisualClue } from "app/store/GlobalStore"
 import { Box } from "palette"
 import { Tab, TabsProps } from "palette/elements/Tabs"
 import React, { useState } from "react"
@@ -35,7 +35,7 @@ export const NavigationalTabs: React.FC<TabsProps> = ({ onTabPress, activeTab, t
               onPress={() => {
                 if (visualClues) {
                   visualClues.forEach(({ visualClueName: name }) => {
-                    setVisualClueAsSeen(name)
+                    GlobalStore.actions.visualClue.setVisualClueAsSeen(name)
                   })
                 }
 


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [CX-2640]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Test the visual clues after adding a new artwork from MyCollection or MyCollection Insights tab

Thanks all for helping with that! 💔 
The problem was with the way we call the GlobalStore action. we need to call it directly to make the tests work and keep the state up to date.
### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Test the visual clues after adding a new artwork from MyCollection or MyCollection Insights tab -daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2640]: https://artsyproduct.atlassian.net/browse/CX-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ