### PR TITLE
chore: dismiss modal after interactions are done

### DIFF
--- a/src/app/navigation/navigate.ts
+++ b/src/app/navigation/navigate.ts
@@ -8,7 +8,7 @@ import { propsStore } from "app/store/PropsStore"
 import { postEventToProviders } from "app/utils/track/providers"
 import { visualize } from "app/utils/visualizer"
 import { EventEmitter } from "events"
-import { Linking, Platform } from "react-native"
+import { InteractionManager, Linking, Platform } from "react-native"
 import { matchRoute } from "./routes"
 import { saveDevNavigationStateSelectedTab } from "./useReloadedDevNavigationState"
 
@@ -170,10 +170,14 @@ const tracks = {
 }
 
 export function dismissModal() {
-  LegacyNativeModules.ARScreenPresenterModule.dismissModal()
-  if (Platform.OS === "android") {
-    navigationEvents.emit("modalDismissed")
-  }
+  // We wait for interaction to finish before dismissing the modal, otherwise,
+  // we might get a race condition that causes the UI to freeze
+  InteractionManager.runAfterInteractions(() => {
+    LegacyNativeModules.ARScreenPresenterModule.dismissModal()
+    if (Platform.OS === "android") {
+      navigationEvents.emit("modalDismissed")
+    }
+  })
 }
 
 export function goBack(backProps?: GoBackProps) {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [CX-2157]

### Description
This PR comes up as a follow-up from @brainbicycle comment here https://github.com/artsy/eigen/pull/6963#issuecomment-1164911781


https://user-images.githubusercontent.com/11945712/175520525-3ace5f9a-65e5-4d9b-8c79-f285515d4e88.mov


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- dismiss modal after interactions are done - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
