### PR TITLE
refactor(tests): prevent button text rendered twice in testing environment

### DIFF
--- a/src/app/Components/Modal.tests.tsx
+++ b/src/app/Components/Modal.tests.tsx
@@ -21,11 +21,11 @@ describe("Modal", () => {
 
   it("should call `closeModal` when `Ok` button is pressed", () => {
     const closeModalMock = jest.fn()
-    const { getAllByText } = renderWithWrappersTL(
+    const { getByText } = renderWithWrappersTL(
       <Modal visible headerText="Header" detailText="Detail" closeModal={closeModalMock} />
     )
 
-    fireEvent.press(getAllByText("Ok")[1])
+    fireEvent.press(getByText("Ok"))
 
     expect(closeModalMock).toBeCalled()
   })

--- a/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tests.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tests.tsx
@@ -73,7 +73,7 @@ describe("Artist Series Artworks", () => {
     expect(tree.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
     expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
     expect(extractText(tree.root)).toContain(
-      "No results found\nPlease try another search.Clear filtersClear filters"
+      "No results found\nPlease try another search.Clear filters"
     )
   })
 })

--- a/src/app/Scenes/Artwork/Components/ContextCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ContextCard.tests.tsx
@@ -88,9 +88,7 @@ describe("ContextCard", () => {
       )
       expect(component.find(Button)).toHaveLength(1)
 
-      expect(component.find(Button).at(0).render().text()).toMatchInlineSnapshot(
-        `"FollowingFollow"`
-      )
+      expect(component.find(Button).at(0).render().text()).toMatchInlineSnapshot(`"Follow"`)
     })
   })
 

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertButtonsSection.tests.tsx
@@ -48,17 +48,17 @@ describe("CreateArtworkAlertButtonsSection", () => {
   }
 
   it("should correctly 'Create Alert' modal", () => {
-    const { getAllByText, getByText } = renderWithWrappersTL(<TestRenderer />)
+    const { queryByText, getByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => Artwork,
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
-    expect(getByText("Banksy")).toBeTruthy()
-    expect(getByText("Limited Edition")).toBeTruthy()
-    expect(getByText("Prints")).toBeTruthy()
+    expect(queryByText("Banksy")).toBeTruthy()
+    expect(queryByText("Limited Edition")).toBeTruthy()
+    expect(queryByText("Prints")).toBeTruthy()
   })
 
   it("should not render create alert button and description text if artwork doesn't have any associated artists", () => {
@@ -76,7 +76,7 @@ describe("CreateArtworkAlertButtonsSection", () => {
   })
 
   it("should not render `Rarity` pill if needed data is missing", () => {
-    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => ({
@@ -85,13 +85,13 @@ describe("CreateArtworkAlertButtonsSection", () => {
       }),
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(queryByText("Limited Edition")).toBeFalsy()
   })
 
   it("should not render `Medium` pill if needed data is missing", () => {
-    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => ({
@@ -100,7 +100,7 @@ describe("CreateArtworkAlertButtonsSection", () => {
       }),
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(queryByText("Prints")).toBeFalsy()
   })

--- a/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CreateArtworkAlertSection.tests.tsx
@@ -44,33 +44,33 @@ describe("CreateArtworkAlertSection", () => {
 
   it("should correctly render placeholder", () => {
     const placeholder = "Artworks like: Some artwork title"
-    const { getAllByText, getAllByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, getAllByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => Artwork,
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(getAllByPlaceholderText(placeholder)).toBeTruthy()
   })
 
   it("should correctly render pills", () => {
-    const { getAllByText, getByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => Artwork,
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
-    expect(getByText("Banksy")).toBeTruthy()
-    expect(getByText("Limited Edition")).toBeTruthy()
-    expect(getByText("Prints")).toBeTruthy()
+    expect(queryByText("Banksy")).toBeTruthy()
+    expect(queryByText("Limited Edition")).toBeTruthy()
+    expect(queryByText("Prints")).toBeTruthy()
   })
 
   it("should not render `Rarity` pill if needed data is missing", () => {
-    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => ({
@@ -79,13 +79,13 @@ describe("CreateArtworkAlertSection", () => {
       }),
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(queryByText("Limited Edition")).toBeFalsy()
   })
 
   it("should not render `Medium` pill if needed data is missing", () => {
-    const { getAllByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, queryByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => ({
@@ -94,19 +94,19 @@ describe("CreateArtworkAlertSection", () => {
       }),
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(queryByText("Prints")).toBeFalsy()
   })
 
   it("should correctly track event when `Create Alert` button is pressed", () => {
-    const { getAllByText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText } = renderWithWrappersTL(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artwork: () => Artwork,
     })
 
-    fireEvent.press(getAllByText("Create Alert")[0])
+    fireEvent.press(getByText("Create Alert"))
 
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       Array [

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
@@ -141,7 +141,7 @@ describe("PartnerCard", () => {
     )
     expect(component.find(Button)).toHaveLength(1)
 
-    expect(component.find(Button).at(0).render().text()).toMatchInlineSnapshot(`"FollowingFollow"`)
+    expect(component.find(Button).at(0).render().text()).toMatchInlineSnapshot(`"Follow"`)
   })
 
   it("does not render when the partner is an auction house", () => {
@@ -255,7 +255,7 @@ describe("PartnerCard", () => {
       })
 
       const followButton = partnerCard.find(Button)
-      expect(followButton.text()).toMatchInlineSnapshot(`"FollowingFollowing"`)
+      expect(followButton.text()).toMatchInlineSnapshot(`"Following"`)
 
       await partnerCard.find(Button).at(0).props().onPress()
 
@@ -263,7 +263,7 @@ describe("PartnerCard", () => {
       partnerCard.update()
 
       const updatedFollowButton = partnerCard.find(Button).at(0)
-      expect(updatedFollowButton.text()).toMatchInlineSnapshot(`"FollowingFollow"`)
+      expect(updatedFollowButton.text()).toMatchInlineSnapshot(`"Follow"`)
     })
 
     it("correctly displays when the work is not followed, and allows following", async () => {
@@ -280,7 +280,7 @@ describe("PartnerCard", () => {
       })
 
       const followButton = partnerCard.find(Button).at(0)
-      expect(followButton.text()).toMatchInlineSnapshot(`"FollowingFollow"`)
+      expect(followButton.text()).toMatchInlineSnapshot(`"Follow"`)
 
       await partnerCard.find(Button).at(0).props().onPress()
 
@@ -288,7 +288,7 @@ describe("PartnerCard", () => {
       partnerCard.update()
 
       const updatedFollowButton = partnerCard.find(Button).at(0)
-      expect(updatedFollowButton.text()).toMatchInlineSnapshot(`"FollowingFollowing"`)
+      expect(updatedFollowButton.text()).toMatchInlineSnapshot(`"Following"`)
     })
 
     // TODO Update once we can use relay's new facilities for testing

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -1,4 +1,3 @@
-import { waitFor } from "@testing-library/react-native"
 import { Questions_Test_Query } from "__generated__/Questions_Test_Query.graphql"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
@@ -29,7 +28,7 @@ describe("Questions", () => {
   beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("renders", async () => {
-    const { getByText, getAllByText } = renderWithWrappersTL(
+    const { queryByText } = renderWithWrappersTL(
       <RelayEnvironmentProvider environment={mockEnvironment}>
         <Suspense fallback={<Text>SusLoading</Text>}>
           <TestRenderer />
@@ -37,9 +36,9 @@ describe("Questions", () => {
       </RelayEnvironmentProvider>
     )
     resolveMostRecentRelayOperation(mockEnvironment, { Artwork: () => ({}) })
-    await waitFor(() => expect(getByText("SusLoading")).toBeDefined())
+    expect(queryByText("SusLoading")).toBeDefined()
 
-    await waitFor(() => expect(getByText("Questions about this piece?")).toBeDefined())
-    expect(getAllByText("Contact Gallery")).toHaveLength(2)
+    expect(queryByText("Questions about this piece?")).toBeDefined()
+    expect(queryByText("Contact Gallery")).toBeDefined()
   })
 })

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tests.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tests.tsx
@@ -71,7 +71,7 @@ describe("CollectionArtworks", () => {
 
     expect(tree.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
     expect(extractText(tree.root)).toContain(
-      "No results found\nPlease try another search.Clear filtersClear filters"
+      "No results found\nPlease try another search.Clear filters"
     )
   })
 

--- a/src/app/Scenes/Fair/FairArtworks.tests.tsx
+++ b/src/app/Scenes/Fair/FairArtworks.tests.tsx
@@ -79,7 +79,7 @@ describe("FairArtworks", () => {
     expect(wrapper.root.findAllByType(InfiniteScrollArtworksGridContainer)).toHaveLength(0)
     expect(wrapper.root.findAllByType(FilteredArtworkGridZeroState)).toHaveLength(1)
     expect(extractText(wrapper.root)).toContain(
-      "No results found\nPlease try another search.Clear filtersClear filters"
+      "No results found\nPlease try another search.Clear filters"
     )
   })
 })

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
@@ -62,13 +62,13 @@ describe("InquiryPurchaseButton", () => {
   })
 
   it("navigates to the order webview when button is tapped", () => {
-    const { getAllByText } = getWrapper({
+    const { getByText } = getWrapper({
       Artwork: () => ({
         internalID: "test-id",
       }),
     })
 
-    fireEvent.press(getAllByText("Purchase")[1])
+    fireEvent.press(getByText("Purchase"))
     environment.mock.resolveMostRecentOperation((operation) => {
       return MockPayloadGenerator.generate(operation, {
         Mutation: () => {
@@ -92,13 +92,13 @@ describe("InquiryPurchaseButton", () => {
   })
 
   it("presents an error dialogue if mutation returns an error response", () => {
-    const { getAllByText } = getWrapper({
+    const { getByText } = getWrapper({
       Artwork: () => ({
         internalID: "test-id",
       }),
     })
 
-    fireEvent.press(getAllByText("Purchase")[1])
+    fireEvent.press(getByText("Purchase"))
     environment.mock.resolveMostRecentOperation((operation) => {
       return MockPayloadGenerator.generate(operation, {
         Mutation: () => {

--- a/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
@@ -5,7 +5,6 @@ import { defaultEnvironment } from "app/relay/createEnvironment"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
-import React from "react"
 import relay, { QueryRenderer } from "react-relay"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -62,7 +61,7 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
 
   it("renders Purchase and Make Offer CTAs", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
-    const { getAllByText } = getWrapper({
+    const { getByText } = getWrapper({
       Artwork: () => ({
         internalID: "fancy-art",
         slug: "slug-1",
@@ -71,19 +70,19 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
       }),
     })
 
-    expect(getAllByText("Make an Offer")[0]).toBeTruthy()
-    expect(getAllByText("Purchase")[0]).toBeTruthy()
+    expect(getByText("Make an Offer")).toBeTruthy()
+    expect(getByText("Purchase")).toBeTruthy()
   })
 
   describe("make offer", () => {
     it("clicking the button on unique artworks creates an offer", () => {
       relay.commitMutation = jest.fn()
 
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({ internalID: "fancy-art", isOfferableFromInquiry: true }),
       })
 
-      fireEvent(getAllByText("Make an Offer")[0], "press")
+      fireEvent(getByText("Make an Offer"), "press")
       expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
       expect(relay.commitMutation).toHaveBeenCalledTimes(1)
     })
@@ -91,7 +90,7 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
     it("clicking the button on artworks with one edition set creates an offer", () => {
       relay.commitMutation = jest.fn()
 
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({
           internalID: "fancy-art",
           isEdition: true,
@@ -104,13 +103,13 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
         }),
       })
 
-      fireEvent(getAllByText("Make an Offer")[0], "press")
+      fireEvent.press(getByText("Make an Offer"))
       expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
       expect(relay.commitMutation).toHaveBeenCalledTimes(1)
     })
 
     it("clicking the button on non-unique artworks opens the confirmation modal", () => {
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({
           internalID: "fancy-art",
           isEdition: true,
@@ -126,7 +125,7 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
         }),
       })
 
-      fireEvent(getAllByText("Make an Offer")[0], "press")
+      fireEvent.press(getByText("Make an Offer"))
       expect(trackEvent).toHaveBeenCalledWith(tappedMakeOfferEvent)
       expect(navigate).toHaveBeenCalledWith("make-offer/fancy-art", {
         modal: true,
@@ -140,11 +139,11 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
       relay.commitMutation = jest.fn()
 
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({ internalID: "fancy-art", isAcquireable: true }),
       })
 
-      fireEvent(getAllByText("Purchase")[0], "press")
+      fireEvent(getByText("Purchase"), "press")
       expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
       expect(relay.commitMutation).toHaveBeenCalledTimes(1)
     })
@@ -153,7 +152,7 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
       relay.commitMutation = jest.fn()
 
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({
           internalID: "fancy-art",
           isEdition: true,
@@ -166,14 +165,14 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
         }),
       })
 
-      fireEvent(getAllByText("Purchase")[0], "press")
+      fireEvent(getByText("Purchase"), "press")
       expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
       expect(relay.commitMutation).toHaveBeenCalledTimes(1)
     })
 
     it("clicking the button on non-unique artworks opens the confirmation modal", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
-      const { getAllByText } = getWrapper({
+      const { getByText } = getWrapper({
         Artwork: () => ({
           internalID: "fancy-art",
           isEdition: true,
@@ -189,7 +188,7 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
         }),
       })
 
-      fireEvent(getAllByText("Purchase")[0], "press")
+      fireEvent.press(getByText("Purchase"))
       expect(trackEvent).toHaveBeenCalledWith(tappedPurchaseEvent)
       expect(navigate).toHaveBeenCalledWith("purchase/fancy-art", {
         modal: true,
@@ -200,12 +199,12 @@ describe("OpenInquiryModalButtonTestQueryRenderer", () => {
 
   describe("Artsy guarantee message ad link", () => {
     it("display the correct message and button", () => {
-      const { getByText, getAllByText } = getWrapper({
+      const { queryByText } = getWrapper({
         Artwork: () => ({ internalID: "fancy-art", isOfferableFromInquiry: true }),
       })
 
-      expect(getByText("The Artsy Guarantee")).toBeDefined()
-      expect(getAllByText("Make an Offer")).toBeDefined()
+      expect(queryByText("The Artsy Guarantee")).toBeDefined()
+      expect(queryByText("Make an Offer")).toBeDefined()
     })
 
     it("navigates to the buyer guarantee page when tapped", () => {

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tests.tsx
@@ -2,7 +2,6 @@ import { fireEvent } from "@testing-library/react-native"
 import { __globalStoreTestUtils__, GlobalStoreProvider } from "app/store/GlobalStore"
 import { setupTestWrapperTL } from "app/tests/setupTestWrapper"
 import { Theme } from "palette"
-import React from "react"
 import { graphql } from "react-relay"
 import { PurchaseModalFragmentContainer } from "./PurchaseModal"
 
@@ -29,7 +28,7 @@ describe("PurchaseModal", () => {
   it("renders edition sets radio buttons", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
 
-    const { getAllByText } = renderWithRelay({
+    const { getByText } = renderWithRelay({
       Artwork: () => ({
         internalID: "test-id",
         isEdition: true,
@@ -52,14 +51,14 @@ describe("PurchaseModal", () => {
       }),
     })
 
-    expect(getAllByText("Confirm")[0]).toBeDisabled()
-    expect(getAllByText("Cancel")[0]).toBeEnabled()
+    expect(getByText("Confirm")).toBeDisabled()
+    expect(getByText("Cancel")).toBeEnabled()
   })
 
   it("doesn't allow edition set selection when it's not isAcquireable", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
 
-    const { getAllByText, getByText } = renderWithRelay({
+    const { getByText } = renderWithRelay({
       Artwork: () => ({
         internalID: "test-id",
         isEdition: true,
@@ -82,15 +81,15 @@ describe("PurchaseModal", () => {
       }),
     })
 
-    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    expect(getByText("Confirm")).toBeDisabled()
     fireEvent.press(getByText("in1 x in1 x in1"))
-    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    expect(getByText("Confirm")).toBeDisabled()
   })
 
   it("enables confirm button when an edition set is selected", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
 
-    const { getAllByText, getByText } = renderWithRelay({
+    const { getByText } = renderWithRelay({
       Artwork: () => ({
         internalID: "test-id",
         isEdition: true,
@@ -115,8 +114,8 @@ describe("PurchaseModal", () => {
       }),
     })
 
-    expect(getAllByText("Confirm")[0]).toBeDisabled()
+    expect(getByText("Confirm")).toBeDisabled()
     fireEvent.press(getByText("in1 x in1 x in1"))
-    expect(getAllByText("Confirm")[0]).toBeEnabled()
+    expect(getByText("Confirm")).toBeEnabled()
   })
 })

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -127,14 +127,14 @@ describe("CreateSavedSearchAlert", () => {
     const onCompleteMock = jest.fn()
 
     setStatusForPushNotifications(PushAuthorizationStatus.Authorized)
-    const { getByTestId, getAllByText } = renderWithWrappersTL(
+    const { getByTestId, getByText } = renderWithWrappersTL(
       <TestRenderer onComplete={onCompleteMock} />
     )
 
     resolveMostRecentRelayOperation(mockEnvironment)
 
     fireEvent.changeText(getByTestId("alert-input-name"), "something new")
-    fireEvent.press(getAllByText("Save Alert")[1])
+    fireEvent.press(getByText("Save Alert"))
 
     // Check alert duplicate
     await mockOperationByName("getSavedSearchIdByCriteriaQuery", {

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
@@ -4,8 +4,6 @@ import { defaultEnvironment } from "app/relay/createEnvironment"
 import { GlobalStore } from "app/store/GlobalStore"
 import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
 import { renderWithWrappersTL } from "app/tests/renderWithWrappers"
-import React from "react"
-import "react-native"
 import { useTracking } from "react-tracking"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils/"
 import { updateConsignSubmission } from "../../mutations"
@@ -39,7 +37,7 @@ describe("ContactInformationForm", () => {
   })
 
   it("Happy path: User can submit information", async () => {
-    const { getAllByText, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const { queryByText, getByText, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
     updateConsignSubmissionMock.mockResolvedValue("adsfasd")
     mockEnvironment.mock.resolveMostRecentOperation((operation) =>
       MockPayloadGenerator.generate(operation, {
@@ -66,9 +64,9 @@ describe("ContactInformationForm", () => {
     expect(inputs.phoneInput).toBeTruthy()
     expect(inputs.phoneInput).toHaveProp("value", "(202) 555-0174")
 
-    expect(getAllByText("Submit Artwork")).toBeTruthy()
+    expect(queryByText("Submit Artwork")).toBeTruthy()
 
-    fireEvent(getAllByText("Submit Artwork")[0], "press")
+    fireEvent.press(getByText("Submit Artwork"))
 
     await flushPromiseQueue()
 
@@ -81,7 +79,7 @@ describe("ContactInformationForm", () => {
   })
 
   it("Keeps Submit button deactivated when something is missing/not properly filled out. Gets enabled if everything is filled out.", async () => {
-    const { getAllByText, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
+    const { getByText, getByPlaceholderText } = renderWithWrappersTL(<TestRenderer />)
     updateConsignSubmissionMock.mockResolvedValue("adsfasd")
     mockEnvironment.mock.resolveMostRecentOperation((operation) =>
       MockPayloadGenerator.generate(operation, {
@@ -96,7 +94,7 @@ describe("ContactInformationForm", () => {
       phoneInput: getByPlaceholderText("(000) 000-0000"),
     }
 
-    const submitButton = getAllByText("Submit Artwork")[0]
+    const submitButton = getByText("Submit Artwork")
 
     await flushPromiseQueue()
 
@@ -206,7 +204,7 @@ describe("ContactInformationForm", () => {
     })
 
     it("tracks consignmentSubmitted event on save", async () => {
-      const { getAllByText } = renderWithWrappersTL(<TestRenderer />)
+      const { getByText } = renderWithWrappersTL(<TestRenderer />)
       updateConsignSubmissionMock.mockResolvedValue("54321")
       mockEnvironment.mock.resolveMostRecentOperation((operation) =>
         MockPayloadGenerator.generate(operation, {
@@ -218,7 +216,7 @@ describe("ContactInformationForm", () => {
 
       await flushPromiseQueue()
 
-      fireEvent(getAllByText("Submit Artwork")[0], "press")
+      fireEvent.press(getByText("Submit Artwork"))
 
       await flushPromiseQueue()
 

--- a/src/palette/elements/Button/Button.tsx
+++ b/src/palette/elements/Button/Button.tsx
@@ -182,11 +182,18 @@ export const Button: React.FC<ButtonProps> = ({
                       <Spacer mr={0.5} />
                     </>
                   ) : null}
-                  <MeasuredView setMeasuredState={setLongestTextMeasurements}>
-                    <Text color="red" style={textStyle}>
-                      {longestText ? longestText : children}
-                    </Text>
-                  </MeasuredView>
+                  {/* This makes sure that in testing environment the button text is
+                      not rendered twice, in normal environment this is not visible.
+                      This will result in us being able to use getByText over
+                      getAllByText()[0] to select the buttons in the test environment.
+                  */}
+                  {!__TEST__ && (
+                    <MeasuredView setMeasuredState={setLongestTextMeasurements}>
+                      <Text color="red" style={textStyle}>
+                        {longestText ? longestText : children}
+                      </Text>
+                    </MeasuredView>
+                  )}
                   <AnimatedText
                     style={[
                       {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves []

### Description

In the button component we use `MeasuredView` in order to prevent the button from changing size when the text changes (eg. save -> saved).

This results in the testing environment to have to select the button element with `getAllByText("btn text")[0]` due to button text being rendered twice in the testing tree snapshot even though in the real environment this is not displayed to the user.

This solution will prevent that.

TODO:
- [x] Also replaced all cases where we used `getAllByText("btn text")[0]` -> `getByText("btn text")`

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- prevent button text from rendering twice in testing environment - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
