### PR TITLE
chore: simplify error name for relay errors

### DIFF
--- a/src/app/relay/createEnvironment.ts
+++ b/src/app/relay/createEnvironment.ts
@@ -22,7 +22,7 @@ import { uploadMiddleware } from "./middlewares/uploadMiddleware"
 export function createEnvironment(
   networkConfig: ConstructorParameters<typeof RelayNetworkLayer> = [
     [
-      // The top middlewares run first, i.e. they are the furtherst from the fetch
+      // The top middlewares run first, i.e. they are the furthest from the fetch
       // @ts-ignore
       cacheMiddleware(),
       persistedQueryMiddleware(),

--- a/src/app/relay/middlewares/errorMiddleware.tests.ts
+++ b/src/app/relay/middlewares/errorMiddleware.tests.ts
@@ -9,11 +9,6 @@ jest.mock("@sentry/react-native", () => ({
   captureException: jest.fn(),
 }))
 
-// jest.mock("app/store/GlobalStore", () => ({
-//   GlobalStoreProvider: jest.requireActual("app/store/GlobalStore").GlobalStoreProvider,
-//   GlobalStore: jest.requireActual("app/store/GlobalStore").GlobalStore,
-//   useSelectedTab: jest.fn(() => "home"),
-// }))
 
 describe(errorMiddleware, () => {
   const middleware = errorMiddleware()

--- a/src/app/relay/middlewares/errorMiddleware.tests.ts
+++ b/src/app/relay/middlewares/errorMiddleware.tests.ts
@@ -1,6 +1,19 @@
+import * as Sentry from "@sentry/react-native"
 import { MiddlewareNextFn, RelayNetworkLayerResponse } from "react-relay-network-modern/node8"
 import { errorMiddleware } from "./errorMiddleware"
 import { GraphQLRequest } from "./types"
+
+jest.mock("@sentry/react-native", () => ({
+  init: jest.requireActual("@sentry/react-native").init,
+  withScope: jest.requireActual("@sentry/react-native").withScope,
+  captureException: jest.fn(),
+}))
+
+// jest.mock("app/store/GlobalStore", () => ({
+//   GlobalStoreProvider: jest.requireActual("app/store/GlobalStore").GlobalStoreProvider,
+//   GlobalStore: jest.requireActual("app/store/GlobalStore").GlobalStore,
+//   useSelectedTab: jest.fn(() => "home"),
+// }))
 
 describe(errorMiddleware, () => {
   const middleware = errorMiddleware()
@@ -175,6 +188,127 @@ describe(errorMiddleware, () => {
           expect(err.message).toContain("Relay request for `xxx` failed")
         }
       })
+    })
+  })
+
+  describe("error reporting", () => {
+    const request: GraphQLRequest = {
+      // @ts-ignore
+      operation: {
+        operationKind: "query",
+        name: "ArtworkQuery",
+      },
+      getID: () => "xxx",
+    }
+
+    it("reports an error title with graphql name and error if it can be parsed", async () => {
+      // @ts-ignore
+      const relayResponse: RelayNetworkLayerResponse = {
+        json: {
+          errors: [
+            {
+              message:
+                'https://stagingapi.artsy.net/api/v1/artwork/asdf? - {"error":"Artwork Not Found"}',
+              locations: [
+                {
+                  line: 2,
+                  column: 2,
+                },
+              ],
+              path: ["artwork"],
+              extensions: {
+                httpStatusCodes: [404],
+              },
+            },
+          ],
+        },
+        errors: [
+          {
+            message:
+              'https://stagingapi.artsy.net/api/v1/artwork/asdf? - {"error":"Artwork Not Found"}',
+            locations: [
+              {
+                line: 2,
+                column: 2,
+              },
+            ],
+            // @ts-ignore
+            path: ["artwork"],
+            extensions: {
+              httpStatusCodes: [404],
+            },
+          },
+        ],
+      }
+
+      const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
+
+      expect.assertions(1)
+      try {
+        await middleware(next)(request)
+      } catch (err: any) {
+        // do nothing
+      }
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ArtworkQuery - Artwork Not Found",
+        })
+      )
+    })
+
+    it("reports an error title with graphql name and generic error if it CANNOT be parsed", async () => {
+      // @ts-ignore
+      const relayResponse: RelayNetworkLayerResponse = {
+        json: {
+          errors: [
+            {
+              message:
+                'https://stagingapi.artsy.net/api/v1/artwork/asdf? - {"baderror":"Artwork Not Found"}',
+              locations: [
+                {
+                  line: 2,
+                  column: 2,
+                },
+              ],
+              path: ["artwork"],
+              extensions: {
+                httpStatusCodes: [404],
+              },
+            },
+          ],
+        },
+        errors: [
+          {
+            message:
+              'https://stagingapi.artsy.net/api/v1/artwork/asdf? - {"baderror":"Artwork Not Found"}',
+            locations: [
+              {
+                line: 2,
+                column: 2,
+              },
+            ],
+            // @ts-ignore
+            path: ["artwork"],
+            extensions: {
+              httpStatusCodes: [404],
+            },
+          },
+        ],
+      }
+
+      const next: MiddlewareNextFn = () => Promise.resolve(relayResponse)
+
+      expect.assertions(1)
+      try {
+        await middleware(next)(request)
+      } catch (err: any) {
+        // do nothing
+      }
+      expect(Sentry.captureException).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "ArtworkQuery - Generic Error - see metadata",
+        })
+      )
     })
   })
 })


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [MOPLAT-294]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Relay errors in eigen were reporting with their title as the formatted GraphQL errors from relay. The problem with this is this includes url params and error message, so for almost every request it is distinct leading us to have 1000s of 1 time errors reported in Eigen. This changes the title to a shorter version with just the GraphQL request name and the error if we can parse it out. The full formatted error is still in the metadata of the error.

Old Style:
https://sentry.io/organizations/artsynet/issues/3388128437/?project=5867225&query=is%3Aunresolved&statsPeriod=14d

New Style:
https://sentry.io/organizations/artsynet/issues/3385708903/?project=5867225&query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A%5Bme%2C+none%5D&sort=inbox&statsPeriod=14d

Follow-up:
- After this is merged I will go through sentry and resolve or ignore any errors of the old style, if they are still occurring they should show up in the next released build with the new style error.

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Clean up sentry network error reporting - Brian

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-294]: https://artsyproduct.atlassian.net/browse/MOPLAT-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ