### PR TITLE
fix: change copy of timers to closes in

### DIFF
--- a/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
+++ b/src/app/Components/ArtworkGrids/LotCloseInfo.tests.tsx
@@ -109,7 +109,7 @@ describe("LotCloseInfo", () => {
       </Theme>
     )
 
-    const lotCloseText = getByText("Closes, 18h 28m")
+    const lotCloseText = getByText("Closes in 18h 28m")
 
     expect(lotCloseText).toBeTruthy()
     expect(lotCloseText.props.color).toEqual("black100")
@@ -140,7 +140,7 @@ describe("LotCloseInfo", () => {
       </Theme>
     )
 
-    const lotCloseText = getByText("Closes, 18h 28m")
+    const lotCloseText = getByText("Closes in 18h 28m")
 
     expect(lotCloseText).toBeTruthy()
     expect(lotCloseText.props.color).toEqual("black100")
@@ -171,7 +171,7 @@ describe("LotCloseInfo", () => {
       </Theme>
     )
 
-    const lotCloseText = getByText("Closes, 0m 18s")
+    const lotCloseText = getByText("Closes in 0m 18s")
 
     expect(lotCloseText).toBeTruthy()
     expect(lotCloseText.props.color).toEqual("red100")

--- a/src/app/Components/ArtworkGrids/LotCloseInfo.tsx
+++ b/src/app/Components/ArtworkGrids/LotCloseInfo.tsx
@@ -59,7 +59,7 @@ export const LotCloseInfo: React.FC<LotCloseInfoProps> = ({
   } else if (saleHasStarted) {
     // Sale has started and lots are <24 hours from closing or are actively closing
     if (duration.asDays() < 1 || lotsAreClosing) {
-      lotCloseCopy = `Closes, ${timerCopy.copy}`
+      lotCloseCopy = `Closes in ${timerCopy.copy}`
       if (duration.hours() < 1 && duration.minutes() < sale.cascadingEndTimeIntervalMinutes!) {
         labelColor = "red100"
       } else {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-4069]

### Description

This pr updates the copy of the popcorn bidding timers that we show on lots for the close time.

Note that when the lots close in > 24hrs we get the whole string value from metaphysics from [here](https://github.com/artsy/metaphysics/blob/main/src/lib/date.ts#L305)

Metaphysics PR for > 24hrs https://github.com/artsy/metaphysics/pull/4220

When the lots close in < 24hrs we format the date on the clients.

#### Screenshots
|<24hrs|>24hrs|
|---|---|
|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 10 59 50](https://user-images.githubusercontent.com/21178754/177958018-de77f31d-ba19-4c6d-89f8-177bef74c2ba.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-07-08 at 10 59 02](https://user-images.githubusercontent.com/21178754/177958270-16f0ad7d-659c-4fba-b57d-69fa1ce70b52.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### QA Test Case(s)

<!-- Does this PR need QA testing? (hint: it probably does). If so add details here. See example below. These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->



| Test Case | Feature | Environment | Acceptance Criteria | Setup Instructions/Link |
| --------- | :-----: | ----------: | ------------------: | ----------------------: |
|           |         |      staging / iOS / Android       |                     |Use [jenkins job](https://joe.artsy.net/job/gravity-staging-create-auction-on-demand/build?delay=0sec) to create a mock auction change number of lots to 30 to speed up the process. Visit https://auctions-staging.artsy.net/sales/your-auction-name/edit and change the cascading end time interval to some minutes and press save changes, the timers become visible in the clients.|
|           |Copy change closes, on lot timers reads closes on|      staging / iOS / Android       |the copy should read Closes on {date}| Change the end at time above to be > 24hrs.|
|           |Copy change closes, on lot timers reads closes in|      staging / iOS / Android       |the copy should read Closes in {hrs mins}| Change the end at time above to be < 24hrs.|


<!--
| Save a search | Search | Staging    | The user should be able to .. | Start from ..  |
-->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- change copy of popcorn bidding closing lot time -gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4069]: https://artsyproduct.atlassian.net/browse/FX-4069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ