### PR TITLE
fix: Use first artwork image in widget GRO-1135

### DIFF
--- a/ios/ArtsyWidget/Fixtures.swift
+++ b/ios/ArtsyWidget/Fixtures.swift
@@ -90,7 +90,7 @@ extension Fixtures {
     
     static var primaryArtwork: Artwork {
         let artist = Artist(name: "Alex Katz")
-        let artworkImage = ArtworkImage(geminiToken: "pd7rW3I1mXhW0vbAJDVm3Q")
+        let artworkImage = ArtworkImage(geminiToken: "pd7rW3I1mXhW0vbAJDVm3Q", position: 1)
         let image = UIImage(named: "PrimaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -105,7 +105,7 @@ extension Fixtures {
     
     static var secondaryArtwork: Artwork {
         let artist = Artist(name: "René Magritte")
-        let artworkImage = ArtworkImage(geminiToken: "qX0FwYdx5eGxF7cx8V6fkw")
+        let artworkImage = ArtworkImage(geminiToken: "qX0FwYdx5eGxF7cx8V6fkw", position: 1)
         let image = UIImage(named: "SecondaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -120,7 +120,7 @@ extension Fixtures {
     
     static var tertiaryArtwork: Artwork {
         let artist = Artist(name: "Judy Chicago")
-        let artworkImage = ArtworkImage(geminiToken: "wh7YA3qtmGFEwC611OklJQ")
+        let artworkImage = ArtworkImage(geminiToken: "wh7YA3qtmGFEwC611OklJQ", position: 1)
         let image = UIImage(named: "TertiaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -135,7 +135,7 @@ extension Fixtures {
     
     static var quaternaryArtwork: Artwork {
         let artist = Artist(name: "Francis Picabia")
-        let artworkImage = ArtworkImage(geminiToken: "ZjpYFZIoBhhLCzQow6V7DA")
+        let artworkImage = ArtworkImage(geminiToken: "ZjpYFZIoBhhLCzQow6V7DA", position: 1)
         let image = UIImage(named: "QuaternaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,

--- a/ios/ArtsyWidget/Models/Artwork.swift
+++ b/ios/ArtsyWidget/Models/Artwork.swift
@@ -14,7 +14,8 @@ struct Artwork: Codable {
     var image: UIImage?
     
     var firstImageToken: String {
-        let firstImage = artworkImages.first ?? ArtworkImage.fallback()
+        let sortedImages = artworkImages.sorted { $0.position < $1.position }
+        let firstImage = sortedImages.first ?? ArtworkImage.fallback()
         
         return firstImage.geminiToken
     }

--- a/ios/ArtsyWidget/Models/ArtworkImage.swift
+++ b/ios/ArtsyWidget/Models/ArtworkImage.swift
@@ -4,9 +4,10 @@ struct ArtworkImage: Codable {
     static func fallback() -> ArtworkImage {
         let artwork = Fixtures.primaryArtwork
         let token = artwork.artworkImages.first!.geminiToken
-        let artworkImage = ArtworkImage(geminiToken: token)
+        let artworkImage = ArtworkImage(geminiToken: token, position: 1)
         return artworkImage
     }
     
     let geminiToken: String
+    let position: Int
 }


### PR DESCRIPTION
Turns out that using the first image in an array is insufficient! 😝 In the case of this artwork:

https://www.artsy.net/artwork/lynne-drexler-untitled-46

The first image in the array is the signature by the artist, not the shot of the work! Instead, you're better off using the `position` property on the `images` array. This PR does that. Pretty pictures:

### before

![Simulator Screen Shot - iPhone 13 - 2022-07-14 at 14 42 13](https://user-images.githubusercontent.com/79799/179070826-58e633a9-ed50-45ee-a469-c9661bb44cb0.png)


### after


![Simulator Screen Shot - iPhone 13 - 2022-07-14 at 14 43 02](https://user-images.githubusercontent.com/79799/179070867-513095fa-4bc1-4dac-878b-070e5a5c856f.png)

https://artsyproduct.atlassian.net/browse/GRO-1135

/cc @artsy/grow-devs