### PR TITLE
feat(FX-4089): replace `saleArtworksConnection` with `viewer.artworksConnection` for Auction screen

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -71,6 +71,8 @@ export const getSortDefaultValueByFilterType = (filterType: FilterType) => {
   return {
     artwork: "-decayed_merch",
     saleArtwork: "position",
+    // TODO: Replace newSaleArtwork with saleArtwork when AREnableArtworksConnectionForAuction is released
+    newSaleArtwork: "sale_position",
     showArtwork: "partner_show_position",
     auctionResult: "DATE_DESC",
     geneArtwork: "-partner_updated_at",
@@ -187,6 +189,8 @@ export type FilterArray = ReadonlyArray<FilterData>
 export type FilterType =
   | "artwork"
   | "saleArtwork"
+  // TODO: Replace newSaleArtwork with saleArtwork when AREnableArtworksConnectionForAuction is released
+  | "newSaleArtwork"
   | "showArtwork"
   | "auctionResult"
   | "geneArtwork"
@@ -240,6 +244,12 @@ const DEFAULT_SALE_ARTWORKS_PARAMS = {
   estimateRange: "",
 } as FilterParams
 
+// TODO: Replace DEFAULT_NEW_SALE_ARTWORKS_PARAMS with DEFAULT_SALE_ARTWORKS_PARAMS when AREnableArtworksConnectionForAuction is released
+const DEFAULT_NEW_SALE_ARTWORKS_PARAMS = {
+  sort: "sale_position",
+  estimateRange: "",
+} as FilterParams
+
 const DEFAULT_SHOW_ARTWORKS_PARAMS = {
   ...DEFAULT_ARTWORKS_PARAMS,
   sort: "partner_show_position",
@@ -278,6 +288,8 @@ const getDefaultParamsByType = (filterType: FilterType) => {
   return {
     artwork: DEFAULT_ARTWORKS_PARAMS,
     saleArtwork: DEFAULT_SALE_ARTWORKS_PARAMS,
+    // TODO: Replace newSaleArtwork with saleArtwork when AREnableArtworksConnectionForAuction is released
+    newSaleArtwork: DEFAULT_NEW_SALE_ARTWORKS_PARAMS,
     showArtwork: DEFAULT_SHOW_ARTWORKS_PARAMS,
     auctionResult: DEFAULT_AUCTION_RESULT_PARAMS,
     geneArtwork: DEFAULT_GENE_ARTWORK_PARAMS,

--- a/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -229,6 +229,12 @@ export const selectedOptionsUnion = ({
       paramValue: "position",
       displayText: "Lot Number Ascending",
     },
+    // TODO: Replace newSaleArtwork with saleArtwork when AREnableArtworksConnectionForAuction is released
+    newSaleArtwork: {
+      paramName: FilterParamName.sort,
+      paramValue: "sale_position",
+      displayText: "Lot Number Ascending",
+    },
     showArtwork: {
       paramName: FilterParamName.sort,
       paramValue: "partner_show_position",

--- a/src/app/Components/ArtworkFilter/Filters/ArtistIDsOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ArtistIDsOptionsScreen.tsx
@@ -9,7 +9,8 @@ export const ArtistIDsOptionsScreen = (
 ) => {
   const filterType = ArtworksFiltersStore.useStoreState((state) => state.filterType)
 
-  if (filterType === "saleArtwork") {
+  // TODO: Replace newSaleArtwork when AREnableArtworksConnectionForAuction is released
+  if (filterType === "saleArtwork" || filterType === "newSaleArtwork") {
     return <ArtistIDsSaleArtworksOptionsScreen {...props} />
   }
   return <ArtistIDsArtworksOptionsScreen {...props} />

--- a/src/app/Components/ArtworkFilter/Filters/EstimateRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/EstimateRangeOptions.tsx
@@ -5,6 +5,7 @@ import {
   ArtworksFiltersStore,
   useSelectedOptionsDisplay,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import { Separator, Text } from "palette"
 import { SingleSelectOptionScreen } from "./SingleSelectOption"
 
@@ -20,16 +21,28 @@ const EstimateRanges = [
   { paramValue: "5000000-*", paramDisplay: "$50,000+" },
 ]
 
+// TODO: Replace NewEstimateRanges with EstimateRanges when AREnableArtworksConnectionForAuction is released
+const NewEstimateRanges = [
+  { paramValue: "", paramDisplay: "All" },
+  { paramValue: "*-1000", paramDisplay: "$0-1,000" },
+  { paramValue: "1000-5000", paramDisplay: "$1000-5,000" },
+  { paramValue: "5000-10000", paramDisplay: "$5,000-10,000" },
+  { paramValue: "10000-50000", paramDisplay: "$10,000-50,000" },
+  { paramValue: "50000-*", paramDisplay: "$50,000+" },
+]
+
 export const EstimateRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = ({
   navigation,
 }) => {
+  const enableArtworksConnection = useFeatureFlag("AREnableArtworksConnectionForAuction")
   const paramName = FilterParamName.estimateRange
+  const ranges = enableArtworksConnection ? NewEstimateRanges : EstimateRanges
 
   const selectFiltersAction = ArtworksFiltersStore.useStoreActions(
     (state) => state.selectFiltersAction
   )
 
-  const options = EstimateRanges.map((estimateRange) => {
+  const options = ranges.map((estimateRange) => {
     return {
       displayText: estimateRange.paramDisplay,
       paramName,

--- a/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
@@ -118,6 +118,40 @@ export const ORDERED_SALE_ARTWORK_SORTS: FilterData[] = [
   },
 ]
 
+// TODO: Replace DEFAULT_NEW_SALE_ARTWORKS_PARAMS with DEFAULT_SALE_ARTWORKS_PARAMS when AREnableArtworksConnectionForAuction is released
+export const ORDERED_NEW_SALE_ARTWORK_SORTS: FilterData[] = [
+  {
+    displayText: "Lot Number Ascending",
+    paramName: FilterParamName.sort,
+    paramValue: "sale_position",
+  },
+  {
+    displayText: "Lot Number Descending",
+    paramName: FilterParamName.sort,
+    paramValue: "-sale_position",
+  },
+  {
+    displayText: "Most Bids",
+    paramName: FilterParamName.sort,
+    paramValue: "-bidder_positions_count",
+  },
+  {
+    displayText: "Least Bids",
+    paramName: FilterParamName.sort,
+    paramValue: "bidder_positions_count",
+  },
+  {
+    displayText: "Price Ascending",
+    paramName: FilterParamName.sort,
+    paramValue: "prices",
+  },
+  {
+    displayText: "Price Descending",
+    paramName: FilterParamName.sort,
+    paramValue: "-prices",
+  },
+]
+
 export const ORDERED_AUCTION_RESULTS_SORTS: FilterData[] = [
   {
     displayText: "Most Recent Sale Date",
@@ -151,6 +185,8 @@ export const SortOptionsScreen: React.FC<SortOptionsScreenProps> = ({ navigation
   const filterOptions = {
     artwork: [DEFAULT_ARTWORK_SORT, ...ORDERED_ARTWORK_SORTS],
     saleArtwork: ORDERED_SALE_ARTWORK_SORTS,
+    // TODO: Replace newSaleArtwork with saleArtwork when AREnableArtworksConnectionForAuction is released
+    newSaleArtwork: ORDERED_NEW_SALE_ARTWORK_SORTS,
     showArtwork: [GALLERY_CURATED_ARTWORK_SORT, DEFAULT_ARTWORK_SORT, ...ORDERED_ARTWORK_SORTS],
     auctionResult: ORDERED_AUCTION_RESULTS_SORTS,
     geneArtwork: [DEFAULT_GENE_SORT, ...ORDERED_ARTWORK_SORTS],

--- a/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
@@ -52,6 +52,12 @@ const DEFAULT_TAG_SORT = {
   paramValue: "-partner_updated_at",
 }
 
+export const DEFAULT_NEW_SALE_ARTWORK_SORT = {
+  displayText: "Lot Number Ascending",
+  paramName: FilterParamName.sort,
+  paramValue: "sale_position",
+}
+
 export const ORDERED_ARTWORK_SORTS: FilterData[] = [
   {
     displayText: "Price (High to Low)",
@@ -120,11 +126,7 @@ export const ORDERED_SALE_ARTWORK_SORTS: FilterData[] = [
 
 // TODO: Replace DEFAULT_NEW_SALE_ARTWORKS_PARAMS with DEFAULT_SALE_ARTWORKS_PARAMS when AREnableArtworksConnectionForAuction is released
 export const ORDERED_NEW_SALE_ARTWORK_SORTS: FilterData[] = [
-  {
-    displayText: "Lot Number Ascending",
-    paramName: FilterParamName.sort,
-    paramValue: "sale_position",
-  },
+  DEFAULT_NEW_SALE_ARTWORK_SORT,
   {
     displayText: "Lot Number Descending",
     paramName: FilterParamName.sort,

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tests.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tests.tsx
@@ -1,0 +1,108 @@
+import { NewSaleLotsListTestsQuery } from "__generated__/NewSaleLotsListTestsQuery.graphql"
+import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { NewSaleLotsListContainer } from "./NewSaleLotsList"
+
+jest.unmock("react-relay")
+
+describe("NewSaleLotsList", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  const TestRenderer = () => {
+    return (
+      <QueryRenderer<NewSaleLotsListTestsQuery>
+        environment={mockEnvironment}
+        query={graphql`
+          query NewSaleLotsListTestsQuery($saleID: ID) @relay_test_operation {
+            viewer {
+              unfilteredArtworks: artworksConnection(
+                saleID: $saleID
+                aggregations: [FOLLOWED_ARTISTS, ARTIST, MEDIUM, TOTAL]
+                first: 0
+              ) {
+                ...NewSaleLotsList_unfilteredArtworks
+              }
+              ...NewSaleLotsList_viewer @arguments(saleID: $saleID)
+            }
+          }
+        `}
+        variables={{ saleID: "saleID" }}
+        render={({ props }) => {
+          if (props?.viewer) {
+            return (
+              <ArtworkFiltersStoreProvider>
+                <NewSaleLotsListContainer
+                  viewer={props.viewer}
+                  unfilteredArtworks={props.viewer.unfilteredArtworks}
+                  saleID="saleID"
+                  saleSlug="saleSlug"
+                  scrollToTop={jest.fn()}
+                />
+              </ArtworkFiltersStoreProvider>
+            )
+          }
+
+          return null
+        }}
+      />
+    )
+  }
+
+  it("renders nothing if not sale artworks are available", () => {
+    const { toJSON } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      FilterArtworksConnection: () => ({
+        counts: {
+          followedArtists: 0,
+          total: 0,
+        },
+        edges: [],
+      }),
+    })
+
+    expect(toJSON()).toBeNull()
+  })
+
+  it("renders content", () => {
+    const { getByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      FilterArtworksConnection: () => mockedFilterArtworksConnection,
+    })
+
+    expect(getByText("Artwork Title")).toBeDefined()
+  })
+
+  it("renders header", () => {
+    const { getByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      FilterArtworksConnection: () => mockedFilterArtworksConnection,
+    })
+
+    expect(getByText("Sorted by Lot Number Ascending")).toBeDefined()
+    expect(getByText("Showing 1 of 1")).toBeDefined()
+  })
+})
+
+const mockedFilterArtworksConnection = {
+  counts: {
+    followedArtists: 0,
+    total: 1,
+  },
+  edges: [
+    {
+      node: {
+        title: "Artwork Title",
+      },
+    },
+  ],
+}

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -88,7 +88,7 @@ export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
   useArtworkFilters({
     relay,
     aggregations: unfilteredArtworks?.aggregations,
-    componentPath: "Sale/SaleLotsList",
+    componentPath: "Sale/NewSaleLotsList",
     refetchVariables,
     refetchRef: artworksRefetchRef,
     onApply: () => scrollToTop(),

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -4,6 +4,7 @@ import { NewSaleLotsList_viewer$data } from "__generated__/NewSaleLotsList_viewe
 import {
   filterArtworksParams,
   FilterParamName,
+  prepareFilterArtworksParamsForInput,
   ViewAsValues,
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
@@ -76,11 +77,11 @@ export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
     }
   }, [])
 
-  const { estimateRange, ...rest } = filterParams
+  const input = prepareFilterArtworksParamsForInput(filterParams)
   const refetchVariables = {
     input: {
-      ...rest,
-      priceRange: estimateRange,
+      priceRange: filterParams.estimateRange,
+      ...input,
     },
   }
 

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -66,7 +66,7 @@ export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
   }
 
   useEffect(() => {
-    setFilterTypeAction("saleArtwork")
+    setFilterTypeAction("newSaleArtwork")
 
     if (unfilteredArtworks?.counts) {
       setFiltersCountAction(unfilteredArtworks.counts)

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -7,16 +7,16 @@ import {
   ViewAsValues,
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { ORDERED_NEW_SALE_ARTWORK_SORTS } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { Schema } from "app/utils/track"
-import { Box, Flex } from "palette"
+import { Box, Flex, Text } from "palette"
 import { MutableRefObject, useEffect } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 import { SaleArtworkListContainer } from "./SaleArtworkList"
-import { SaleLotsListSortMode } from "./SaleLotsList"
 
 interface NewSaleLotsListProps {
   unfilteredArtworks: NewSaleLotsList_unfilteredArtworks$data | null
@@ -53,6 +53,9 @@ export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
   )
   const counts = viewer?.artworksConnection?.counts?.total
   const totalCount = unfilteredArtworks?.counts?.total
+  const sortMode = ORDERED_NEW_SALE_ARTWORK_SORTS.find(
+    (sort) => sort.paramValue === filterParams?.sort
+  )
 
   const trackClear = (id: string, slug: string) => {
     tracking.trackEvent({
@@ -104,11 +107,15 @@ export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
 
   return (
     <Flex flex={0} my={4}>
-      <SaleLotsListSortMode
-        filterParams={filterParams}
-        filteredTotal={counts}
-        totalCount={totalCount}
-      />
+      <Flex px={2} mb={2}>
+        <Text variant="md" ellipsizeMode="tail">
+          Sorted by {sortMode?.displayText}
+        </Text>
+
+        <Text color="black60" variant="sm">
+          Showing {counts} of {totalCount}
+        </Text>
+      </Flex>
 
       {viewAsFilter?.paramValue === ViewAsValues.List ? (
         <SaleArtworkListContainer

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -1,0 +1,217 @@
+import { OwnerType } from "@artsy/cohesion"
+import { NewSaleLotsList_unfilteredArtworks$data } from "__generated__/NewSaleLotsList_unfilteredArtworks.graphql"
+import { NewSaleLotsList_viewer$data } from "__generated__/NewSaleLotsList_viewer.graphql"
+import {
+  filterArtworksParams,
+  FilterParamName,
+  ViewAsValues,
+} from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
+import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
+import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { Schema } from "app/utils/track"
+import { Box, Flex } from "palette"
+import { MutableRefObject, useEffect } from "react"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { useTracking } from "react-tracking"
+import { SaleArtworkListContainer } from "./SaleArtworkList"
+import { SaleLotsListSortMode } from "./SaleLotsList"
+
+interface NewSaleLotsListProps {
+  unfilteredArtworks: NewSaleLotsList_unfilteredArtworks$data | null
+  viewer: NewSaleLotsList_viewer$data | null
+  saleID: string
+  saleSlug: string
+  relay: RelayPaginationProp
+  artworksRefetchRef?: MutableRefObject<() => void>
+  scrollToTop: () => void
+}
+
+export const NewSaleLotsList: React.FC<NewSaleLotsListProps> = ({
+  unfilteredArtworks,
+  viewer,
+  saleID,
+  saleSlug,
+  relay,
+  artworksRefetchRef,
+  scrollToTop,
+}) => {
+  const tracking = useTracking()
+  const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
+  const filterTypeState = ArtworksFiltersStore.useStoreState((state) => state.filterType)
+  const setFiltersCountAction = ArtworksFiltersStore.useStoreActions(
+    (action) => action.setFiltersCountAction
+  )
+  const setFilterTypeAction = ArtworksFiltersStore.useStoreActions(
+    (action) => action.setFilterTypeAction
+  )
+
+  const filterParams = filterArtworksParams(appliedFiltersState, filterTypeState)
+  const viewAsFilter = appliedFiltersState.find(
+    (filter) => filter.paramName === FilterParamName.viewAs
+  )
+  const counts = viewer?.artworksConnection?.counts?.total
+  const totalCount = unfilteredArtworks?.counts?.total
+
+  const trackClear = (id: string, slug: string) => {
+    tracking.trackEvent({
+      action_name: "clearFilters",
+      context_screen: Schema.ContextModules.Auction,
+      context_screen_owner_type: Schema.OwnerEntityTypes.Auction,
+      context_screen_owner_id: id,
+      context_screen_owner_slug: slug,
+      action_type: Schema.ActionTypes.Tap,
+    })
+  }
+
+  useEffect(() => {
+    setFilterTypeAction("saleArtwork")
+
+    if (unfilteredArtworks?.counts) {
+      setFiltersCountAction(unfilteredArtworks.counts)
+    }
+  }, [])
+
+  const { estimateRange, ...rest } = filterParams
+  const refetchVariables = {
+    input: {
+      ...rest,
+      priceRange: estimateRange,
+    },
+  }
+
+  useArtworkFilters({
+    relay,
+    aggregations: unfilteredArtworks?.aggregations,
+    componentPath: "Sale/SaleLotsList",
+    refetchVariables,
+    refetchRef: artworksRefetchRef,
+    onApply: () => scrollToTop(),
+  })
+
+  if (totalCount === 0) {
+    return null
+  }
+
+  if (!viewer?.artworksConnection?.edges?.length) {
+    return (
+      <Box my="80px">
+        <FilteredArtworkGridZeroState id={saleID} slug={saleSlug} trackClear={trackClear} />
+      </Box>
+    )
+  }
+
+  return (
+    <Flex flex={0} my={4}>
+      <SaleLotsListSortMode
+        filterParams={filterParams}
+        filteredTotal={counts}
+        totalCount={totalCount}
+      />
+
+      {viewAsFilter?.paramValue === ViewAsValues.List ? (
+        <SaleArtworkListContainer
+          connection={viewer.artworksConnection}
+          hasMore={relay.hasMore}
+          loadMore={relay.loadMore}
+          isLoading={relay.isLoading}
+          contextScreenOwnerType={OwnerType.sale}
+          contextScreenOwnerId={saleID}
+          contextScreenOwnerSlug={saleSlug}
+        />
+      ) : (
+        <Flex px={2}>
+          <InfiniteScrollArtworksGridContainer
+            connection={viewer.artworksConnection}
+            contextScreenOwnerType={OwnerType.sale}
+            contextScreenOwnerId={saleID}
+            contextScreenOwnerSlug={saleSlug}
+            hasMore={relay.hasMore}
+            loadMore={relay.loadMore}
+            isLoading={relay.isLoading}
+            showLotLabel
+            hidePartner
+            hideUrgencyTags
+          />
+        </Flex>
+      )}
+    </Flex>
+  )
+}
+
+export const NewSaleLotsListContainer = createPaginationContainer(
+  NewSaleLotsList,
+  {
+    unfilteredArtworks: graphql`
+      fragment NewSaleLotsList_unfilteredArtworks on FilterArtworksConnection {
+        counts {
+          followedArtists
+          total
+        }
+
+        aggregations {
+          slice
+          counts {
+            count
+            name
+            value
+          }
+        }
+      }
+    `,
+    viewer: graphql`
+      fragment NewSaleLotsList_viewer on Viewer
+      @argumentDefinitions(
+        saleID: { type: "ID" }
+        count: { type: "Int", defaultValue: 10 }
+        cursor: { type: "String" }
+        input: { type: "FilterArtworksInput" }
+      ) {
+        artworksConnection(
+          saleID: $saleID
+          first: $count
+          after: $cursor
+          input: $input
+          aggregations: [TOTAL]
+        ) @connection(key: "NewSaleLotsList__artworksConnection") {
+          counts {
+            total
+          }
+          edges {
+            node {
+              id
+            }
+          }
+          ...SaleArtworkList_connection
+          ...InfiniteScrollArtworksGrid_connection
+        }
+      }
+    `,
+  },
+  {
+    getConnectionFromProps(props) {
+      return props.viewer?.artworksConnection
+    },
+    getVariables(_props, { count, cursor }, fragmentVariables) {
+      return {
+        ...fragmentVariables,
+        cursor,
+        count,
+      }
+    },
+    query: graphql`
+      query NewSaleLotsListQuery(
+        $saleID: ID!
+        $count: Int
+        $cursor: String
+        $input: FilterArtworksInput
+      ) {
+        viewer {
+          ...NewSaleLotsList_viewer
+            @arguments(saleID: $saleID, count: $count, cursor: $cursor, input: $input)
+        }
+      }
+    `,
+  }
+)

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -252,6 +252,11 @@ export const features = defineFeatures({
     description: "Enable new Onboarding flow",
     showInAdminMenu: true,
   },
+  AREnableArtworksConnectionForAuction: {
+    readyForRelease: false,
+    description: "Use artworksConnection for Auction screen",
+    showInAdminMenu: true,
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [FX-4089]

### Changes
* using `viewer.artworksConnection` instead of `saleArtworksConnection` to get artworks like [on Force](https://github.com/artsy/force/blob/15693e3b173c8daa510d72014eb0bf378a6eacd7/src/v2/Apps/Auction/AuctionApp.tsx#L206)
* displaying the same sort options as [on Force](https://github.com/artsy/force/blob/15693e3b173c8daa510d72014eb0bf378a6eacd7/src/v2/Apps/Auction/Components/AuctionArtworkFilter.tsx#L42-L47)
* changes behind `AREnableArtworksConnectionForAuction` flag

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/179784061-6666d468-a06b-4dcc-a13c-3c69b65bcde6.mp4

#### Android
https://user-images.githubusercontent.com/3513494/179795018-24a35253-f702-4a90-8417-fd552e80cdfa.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### QA Test Case(s)

<!-- Does this PR need QA testing? (hint: it probably does). If so add details here. See example below. These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

| Test Case | Feature | Environment | Acceptance Criteria | Setup Instructions/Link |
| --------- | :-----: | ----------: | ------------------: | ----------------------: |
|           |         |             |                     |                         |

<!--
| Save a search | Search | Staging    | The user should be able to .. | Start from ..  |
-->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Replace `saleArtworksConnection` with `viewer.artworksConnection` for Sale screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4089]: https://artsyproduct.atlassian.net/browse/FX-4089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ