### PR TITLE
feat(NX-3183): adjust order and components of Artwork screen

### DIFF
--- a/src/app/Scenes/Artwork/Components/PartnerLink.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerLink.tests.tsx
@@ -1,0 +1,60 @@
+import { fireEvent } from "@testing-library/react-native"
+import { PartnerLink_Test_Query } from "__generated__/PartnerLink_Test_Query.graphql"
+import * as navigate from "app/navigation/navigate"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { renderWithHookWrappersTL } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { PartnerLink } from "./PartnerLink"
+
+jest.unmock("react-relay")
+
+describe("PartnerLink", () => {
+  const TestRenderer = () => {
+    const data = useLazyLoadQuery<PartnerLink_Test_Query>(
+      graphql`
+        query PartnerLink_Test_Query {
+          artwork(id: "test-id") {
+            ...PartnerLink_artwork
+          }
+        }
+      `,
+      {}
+    )
+    return <PartnerLink artwork={data.artwork!} />
+  }
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const navigateToPartnerSpy = jest.spyOn(navigate, "navigateToPartner")
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+    jest.clearAllMocks()
+  })
+
+  it("renders and calls navigation", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+    resolveMostRecentRelayOperation(mockEnvironment, {})
+    await flushPromiseQueue()
+
+    expect(getByText("name-1")).toBeDefined()
+    fireEvent.press(getByText("name-1"))
+    expect(navigateToPartnerSpy).toHaveBeenLastCalledWith("href-1")
+  })
+
+  it("does not call navigation given a non linkable partner", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => ({
+        partner: {
+          name: "non-linkable",
+          isLinkable: false,
+        },
+      }),
+    })
+    await flushPromiseQueue()
+
+    fireEvent.press(getByText("non-linkable"))
+    expect(navigateToPartnerSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/Scenes/Artwork/Components/PartnerLink.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerLink.tsx
@@ -16,7 +16,7 @@ export const PartnerLink: React.FC<PartnerLinkProps> = ({ artwork }) => {
 
   const { name, href, isLinkable } = artworkData.partner
 
-  if (isLinkable && href) {
+  if (isLinkable && !!href) {
     return (
       <LinkText
         accessibilityRole="link"

--- a/src/app/Scenes/Artwork/Components/PartnerLink.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerLink.tsx
@@ -1,0 +1,43 @@
+import { PartnerLink_artwork$key } from "__generated__/PartnerLink_artwork.graphql"
+import { navigateToPartner } from "app/navigation/navigate"
+import { LinkText, Text } from "palette"
+import { graphql, useFragment } from "react-relay"
+
+interface PartnerLinkProps {
+  artwork: PartnerLink_artwork$key
+}
+
+export const PartnerLink: React.FC<PartnerLinkProps> = ({ artwork }) => {
+  const artworkData = useFragment(artworkFragment, artwork)
+
+  if (!artworkData?.partner) {
+    return null
+  }
+
+  const { name, href, isLinkable } = artworkData.partner
+
+  if (isLinkable && href) {
+    return (
+      <LinkText
+        accessibilityRole="link"
+        accessibilityLabel={name ?? ""}
+        accessibilityHint={`Visit ${name} page`}
+        onPress={() => navigateToPartner(href)}
+      >
+        {name}
+      </LinkText>
+    )
+  }
+
+  return <Text testID="non linkable partner">{name}</Text>
+}
+
+const artworkFragment = graphql`
+  fragment PartnerLink_artwork on Artwork {
+    partner @required(action: NONE) {
+      name
+      href
+      isLinkable
+    }
+  }
+`

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -1,4 +1,5 @@
 import { Questions_Test_Query } from "__generated__/Questions_Test_Query.graphql"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
 import { Suspense } from "react"
@@ -28,7 +29,7 @@ describe("Questions", () => {
   beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("renders", async () => {
-    const { queryByText } = renderWithWrappers(
+    const { getByText } = renderWithWrappers(
       <RelayEnvironmentProvider environment={mockEnvironment}>
         <Suspense fallback={<Text>SusLoading</Text>}>
           <TestRenderer />
@@ -36,9 +37,12 @@ describe("Questions", () => {
       </RelayEnvironmentProvider>
     )
     resolveMostRecentRelayOperation(mockEnvironment, { Artwork: () => ({}) })
-    expect(queryByText("SusLoading")).toBeDefined()
+    expect(getByText("SusLoading")).toBeDefined()
 
-    expect(queryByText("Questions about this piece?")).toBeDefined()
-    expect(queryByText("Contact Gallery")).toBeDefined()
+    await flushPromiseQueue()
+
+    expect(getByText("Questions about this piece?")).toBeDefined()
+    expect(getByText("partner.name-1")).toBeDefined()
+    expect(getByText("Contact Gallery")).toBeDefined()
   })
 })

--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -20,7 +20,7 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
 
       <InquiryButtonsFragmentContainer
         artwork={artworkData}
-        variant="outlineGray"
+        variant="outline"
         size="small"
         icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
       />

--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -1,7 +1,8 @@
 import { Questions_artwork$key } from "__generated__/Questions_artwork.graphql"
-import { Box, Text } from "palette"
+import { EnvelopeIcon, Flex, Text } from "palette"
 import { graphql, useFragment } from "react-relay"
 import { InquiryButtonsFragmentContainer } from "./CommercialButtons/InquiryButtons"
+import { PartnerLink } from "./PartnerLink"
 
 interface QuestionsProps {
   artwork: Questions_artwork$key
@@ -11,20 +12,25 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
 
   return (
-    <Box>
-      <Text>Questions about this piece?</Text>
+    <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+      <Flex>
+        <Text variant="xs">Questions about this piece?</Text>
+        <PartnerLink artwork={artworkData} />
+      </Flex>
+
       <InquiryButtonsFragmentContainer
         artwork={artworkData}
         variant="outlineGray"
         size="small"
-        mt={1}
+        icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
       />
-    </Box>
+    </Flex>
   )
 }
 
 const artworkFragment = graphql`
   fragment Questions_artwork on Artwork {
     ...InquiryButtons_artwork
+    ...PartnerLink_artwork
   }
 `


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [NX-3183]

### Description

Changes the new Contact Gallery component in the Artwork, also incorporating the Partner link to it.

Before

https://user-images.githubusercontent.com/15792853/180398604-05d76d8e-a15b-4193-8b05-99d2de93a457.mov

After

https://user-images.githubusercontent.com/15792853/180398658-4248375b-6167-4649-8b91-ab5ae19aaa5d.mov

cc @artsy/negotiate-devs 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- changes contact gallery component order and design - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3183]: https://artsyproduct.atlassian.net/browse/NX-3183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ