### PR TITLE
chore: CI uses detect secrets v1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ commands:
 jobs:
   detect-secrets:
     docker:
-      - image: artsy/detect-secrets:1.2.0
+      - image: artsy/detect-secrets:1.3.0
     working_directory: /usr/src/app
     steps:
       - checkout

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -73,6 +73,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -114,18 +118,15 @@
         "__generated__",
         "ios\\/.*\\.xcscheme$"
       ]
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_secret",
+      "pattern": [
+        "[a-fA-F0-9]{24}"
+      ]
     }
   ],
   "results": {
-    "android/app/build.gradle": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "android/app/build.gradle",
-        "hashed_secret": "91f71e355c66ef5ff819b35c867d4d28b9a8c469",
-        "is_verified": false,
-        "line_number": 153
-      }
-    ],
     "ios/Artsy/Constants/ARAppConstants.m": [
       {
         "type": "Secret Keyword",
@@ -133,176 +134,6 @@
         "hashed_secret": "ffec45c8cc883aa1a0c0d3acd75cc97a3aa509ae",
         "is_verified": false,
         "line_number": 6
-      }
-    ],
-    "ios/Artsy/View_Controllers/live_auctions_socket.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "8c33911cc724f80a2448f86385843e8e5fbc2deb",
-        "is_verified": false,
-        "line_number": 4
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "1197074fe5b1688d89854feea51cdb81a82b0163",
-        "is_verified": false,
-        "line_number": 24
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "546a28e2fb097ecf73f202e4d76d23fae06664e6",
-        "is_verified": false,
-        "line_number": 44
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "cf2c190b800ef74fc211f29f5bde9d11b04513e9",
-        "is_verified": false,
-        "line_number": 64
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "5fa1aaa871c4398160078e9a69bc182fe8459d20",
-        "is_verified": false,
-        "line_number": 84
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "f56be5ff1f0fcb442ab5552de01ed4a0f33a6197",
-        "is_verified": false,
-        "line_number": 104
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "70202e4a31db4efda93ac5da4467aee15955e757",
-        "is_verified": false,
-        "line_number": 124
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "441a1efbb2f5fb389482a6e9714bbb1156940fb5",
-        "is_verified": false,
-        "line_number": 144
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "2bb9e6a9d15129a5fa4906884daab855b574d14e",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "2fb6535d257d8b802e76567e0b2d1e70a6c992d5",
-        "is_verified": false,
-        "line_number": 184
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "2bbe2040d1b3cc7e668020597d24cca4ff1c9c94",
-        "is_verified": false,
-        "line_number": 218
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "5413f91d254d6035fdd778aefe3ed908dfdc3f51",
-        "is_verified": false,
-        "line_number": 387
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "84494ababe4e8e8616748bb5e63d94b8cabfb02e",
-        "is_verified": false,
-        "line_number": 407
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "33b79b577ef868edd8c22430c399b8952baaf1ef",
-        "is_verified": false,
-        "line_number": 427
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "8e1dd297b57bbd9d31c0248274fca83ca7a37c20",
-        "is_verified": false,
-        "line_number": 447
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "6db41c8b237d299690cc2e0a4f7e8262a5db86d7",
-        "is_verified": false,
-        "line_number": 467
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "6c3d2a4ac9e1d85285af7bc1dd78c006296f17a4",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "081249a9ea03533a59b18bdc677c9c5916d5c751",
-        "is_verified": false,
-        "line_number": 507
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "65ce5f5dd82e1879cfaf2f9b7c77574ed8cbb811",
-        "is_verified": false,
-        "line_number": 527
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "cfc760c8009779fd188ee5858206ea49552a9878",
-        "is_verified": false,
-        "line_number": 547
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "b695bb92e86201d04c75ef5c71337934a7c9a63e",
-        "is_verified": false,
-        "line_number": 567
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "05743cb98cadf74cce41f74650b7a32e655b6212",
-        "is_verified": false,
-        "line_number": 587
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "a675752cd43399fa57679f18e0f96df6e19dfd47",
-        "is_verified": false,
-        "line_number": 607
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/Artsy/View_Controllers/live_auctions_socket.json",
-        "hashed_secret": "2ad401dfee2508f7293eda83bd7ca9fe993ad7aa",
-        "is_verified": false,
-        "line_number": 627
       }
     ],
     "ios/ArtsyTests/View_Controller_Tests/Live_Auction/FakeSalesPerson.swift": [
@@ -328,36 +159,6 @@
         "line_number": 86
       }
     ],
-    "ios/ArtsyWidget/Fixtures.swift": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/ArtsyWidget/Fixtures.swift",
-        "hashed_secret": "82c71809ac7630dec40d356c729955b7f4f0a23c",
-        "is_verified": false,
-        "line_number": 5
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/ArtsyWidget/Fixtures.swift",
-        "hashed_secret": "2e529c680f8ffeed9cba698fe2539a42e6a1e7fa",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/ArtsyWidget/Fixtures.swift",
-        "hashed_secret": "79c7825718a30565467f7ddd1075ba61c86e3374",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "ios/ArtsyWidget/Fixtures.swift",
-        "hashed_secret": "98d980009dbf0506036553c0a3957171c321f33a",
-        "is_verified": false,
-        "line_number": 26
-      }
-    ],
     "package.json": [
       {
         "type": "Secret Keyword",
@@ -367,29 +168,1237 @@
         "line_number": 40
       }
     ],
-    "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx": [
+    "patches/react-native-credit-card-input+0.4.1.patch": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
-        "hashed_secret": "b5b44d59e3036fde34acae6a4ac3a669e27496ab",
+        "type": "AWS Access Key",
+        "filename": "patches/react-native-credit-card-input+0.4.1.patch",
+        "hashed_secret": "0f208f85b7560b054566822b7063d4b20610dfed",
         "is_verified": false,
-        "line_number": 668
+        "line_number": 51
       }
     ],
-    "src/app/Scenes/MyCollection/utils/randomMyCollectionArtwork.ts": [
+    "src/app/Components/Artist/ArtistConsignButton.tests.tsx": [
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/app/Scenes/MyCollection/utils/randomMyCollectionArtwork.ts",
-        "hashed_secret": "3ab18e9e12e053d935e40699910af0f0ff95b41a",
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Components/Artist/ArtistConsignButton.tests.tsx",
+        "hashed_secret": "822223a23a97d9099e4d3f19e3cdd44f09324be3",
+        "is_verified": false,
+        "line_number": 75
+      }
+    ],
+    "src/app/Components/Home/ArtistRails/RecommendedArtistsRail.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Components/Home/ArtistRails/RecommendedArtistsRail.tests.tsx",
+        "hashed_secret": "add2ff75d3a3b549ae2de387c8cc2d5d81547117",
+        "is_verified": false,
+        "line_number": 53
+      }
+    ],
+    "src/app/Scenes/Artwork/Components/CommercialEditionSetInformation.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/CommercialEditionSetInformation.tests.tsx",
+        "hashed_secret": "ce1457b7dd97fa6c22518c6a5bf141e9d375fe8c",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
+        "hashed_secret": "ce1457b7dd97fa6c22518c6a5bf141e9d375fe8c",
+        "is_verified": false,
+        "line_number": 305
+      }
+    ],
+    "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx",
+        "hashed_secret": "a224c3873da21944d5b5a8fd3ad09aa3af09756a",
+        "is_verified": false,
+        "line_number": 173
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx",
+        "hashed_secret": "151bdaf691928862bc82780e4ba375debdf08208",
+        "is_verified": false,
+        "line_number": 178
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx",
+        "hashed_secret": "1cd5fcc63e1467ee96f046289486522ae9b2a0ad",
+        "is_verified": false,
+        "line_number": 189
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx",
+        "hashed_secret": "b527ed9047b53df8778477534f1721cb0da04be2",
+        "is_verified": false,
+        "line_number": 195
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx",
+        "hashed_secret": "85d92391931fc6e2badbb5dc56a83b1524479f3a",
+        "is_verified": false,
+        "line_number": 209
+      }
+    ],
+    "src/app/Scenes/City/Components/BMWEventSection/index.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/City/Components/BMWEventSection/index.tests.tsx",
+        "hashed_secret": "4d3f5429714b267f0714ed59737e6c2475826176",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "src/app/Scenes/City/Components/Event/index.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/City/Components/Event/index.tests.tsx",
+        "hashed_secret": "4d3f5429714b267f0714ed59737e6c2475826176",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "src/app/Scenes/City/Components/EventSection/index.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/City/Components/EventSection/index.tests.tsx",
+        "hashed_secret": "4d3f5429714b267f0714ed59737e6c2475826176",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "src/app/Scenes/City/Components/FairEventSection/index.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/City/Components/FairEventSection/index.tests.tsx",
+        "hashed_secret": "08c7350d5831b9943fbbe013862e213b0fe1366b",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "src/app/Scenes/City/Components/TabFairItemRow/index.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/City/Components/TabFairItemRow/index.tests.tsx",
+        "hashed_secret": "5d4d720117d9b923461eda104bdee573deb27d4e",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "src/app/Scenes/Collection/Components/__fixtures__/CollectionFixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/CollectionFixture.ts",
+        "hashed_secret": "0076bd5ec916a6ce0107857c40d6eb2da26df988",
+        "is_verified": false,
+        "line_number": 28
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/CollectionFixture.ts",
+        "hashed_secret": "8feb29f756cdc99520b5dbdf1bcd5d5e717c52f1",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "src/app/Scenes/Collection/Components/__fixtures__/index.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "8feb29f756cdc99520b5dbdf1bcd5d5e717c52f1",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "238dc4d52886d82d41515f8b7ed4ba48db8d760f",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "80f6a1219624361fc9b4fbc51cb9a86820af8bf3",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "0937b4f3656636d2ed6e26be7568bef769557373",
+        "is_verified": false,
+        "line_number": 102
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "04b5ac806ef12bbd19031b0b137436e6199be5cb",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "76c04ef2bcd07258bcd942e3b78f87a56b17796d",
+        "is_verified": false,
+        "line_number": 160
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "db152d9af5e8a7b0548b493a9ddc9810ea4a844e",
+        "is_verified": false,
+        "line_number": 189
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "ac339a135b07e82561a0bdf29cdb335c3955e844",
+        "is_verified": false,
+        "line_number": 218
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "23344ef4487ac933aa962f0111a2b0ffb204ae6c",
+        "is_verified": false,
+        "line_number": 276
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "4d66ddfa0e4b840a92d371132de728003e468d9f",
+        "is_verified": false,
+        "line_number": 305
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "b949b71d698240ea1a305f37b936125ba8b42c7a",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "53935f50d51e2f1ecdcfec89b7aa8a5aaea697a0",
+        "is_verified": false,
+        "line_number": 363
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "58f3b4f2ba26daeb72f0d49482403b7ac4eb2aaa",
+        "is_verified": false,
+        "line_number": 392
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "135f28d7e4e943c7296d59252909b5c3d1df9030",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "c58c48faf82b4313a5ea8d64ca296fa3c769a197",
+        "is_verified": false,
+        "line_number": 450
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "6efc04bf4a60b7a9c27c1df850a19b3109d1748e",
+        "is_verified": false,
+        "line_number": 479
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "cf6037e0bb5c43c1196ae8b82780112954fceebd",
+        "is_verified": false,
+        "line_number": 508
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Collection/Components/__fixtures__/index.ts",
+        "hashed_secret": "282561f113d62d9cd0f454d8ec2dfa1a4d660e09",
+        "is_verified": false,
+        "line_number": 538
+      }
+    ],
+    "src/app/Scenes/Home/Components/ShowsRail.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Home/Components/ShowsRail.tests.tsx",
+        "hashed_secret": "8cf54e3fea51ec0c6e138c7a1f07e7516c1b47d9",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "src/app/Scenes/MyCollection/MyCollection.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/MyCollection/MyCollection.tests.tsx",
+        "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
+        "is_verified": false,
+        "line_number": 170
+      }
+    ],
+    "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
+        "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
+        "is_verified": false,
+        "line_number": 586
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
+        "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
+        "is_verified": false,
+        "line_number": 653
+      }
+    ],
+    "src/app/Scenes/MyCollection/Screens/Insights/AverageSalePriceSelectArtist.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/MyCollection/Screens/Insights/AverageSalePriceSelectArtist.tests.tsx",
+        "hashed_secret": "4d32797fc3625cc2a1608f59fdbc5b378caed77b",
+        "is_verified": false,
+        "line_number": 153
+      }
+    ],
+    "src/app/Scenes/NewWorksForYou/NewWorksForYou.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/NewWorksForYou/NewWorksForYou.tests.tsx",
+        "hashed_secret": "a076563fc37456df2805b17d215d443848e003e8",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/NewWorksForYou/NewWorksForYou.tests.tsx",
+        "hashed_secret": "5fc95b23b49abd95f51677d81103e1e136cdc7d8",
+        "is_verified": false,
+        "line_number": 75
+      }
+    ],
+    "src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx",
+        "hashed_secret": "93b7de46c3a1b8545624f0e125cd7919da42d787",
+        "is_verified": false,
+        "line_number": 102
+      }
+    ],
+    "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx",
+        "hashed_secret": "f1027d2a399ad325b12780b0ed8c7557bfea41db",
+        "is_verified": false,
+        "line_number": 115
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx",
+        "hashed_secret": "71de11a26b02e42b44389dee26238733d3dfb4ea",
+        "is_verified": false,
+        "line_number": 131
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx",
+        "hashed_secret": "4ce6a7a9f0859a760b917614e5f3467acb280885",
+        "is_verified": false,
+        "line_number": 153
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx",
+        "hashed_secret": "62050713c51be285f18b693ff76fc17cc51cecdc",
+        "is_verified": false,
+        "line_number": 199
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx",
+        "hashed_secret": "d295dad571802542c7462317749556de47cff20e",
+        "is_verified": false,
+        "line_number": 215
+      }
+    ],
+    "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "2f71fe17eb1ef3eaea41bd4d984e12e1f5d66471",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "22d7848a14ab4a0dc0328c3fd6e30dd42dd598a7",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "4200c8ca3c4c8b418a32c3873a0e3ef54b275cea",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "df8ad3e93352d960ab4dd47040122fec213f26e8",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "c1c1adfcf66652ca0468bc612e8ed7d3cc0a5a4a",
+        "is_verified": false,
+        "line_number": 121
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "8181e8cb8841d33f8f31f9faa33e92c8447db692",
+        "is_verified": false,
+        "line_number": 148
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "2cdac3a61f1bc203b6ce508d0cb1740a44e597d8",
+        "is_verified": false,
+        "line_number": 175
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "7512a39b3983a1216d43c7086bef83b4b2f3b8e7",
+        "is_verified": false,
+        "line_number": 202
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "6f764119d6d895968f3c3eed42eefb26403d4eb4",
+        "is_verified": false,
+        "line_number": 229
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Components/__fixtures__/PartnerArtwork-fixture.ts",
+        "hashed_secret": "b0f1043728c8f5cadbc533aac9a5e5ed964fac23",
+        "is_verified": false,
+        "line_number": 256
+      }
+    ],
+    "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "b87320c33d3fb985799ea3aad6985ccf20314dc5",
+        "is_verified": false,
+        "line_number": 8
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "76cc1716f9d3781172a45b3e9c3d90b2328ca0e2",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "e6423fcf69167d8e393362f1b93ce5c367c925bc",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "9dac05840a6e8e0dc6b8ae5981a0c5e6f723c912",
+        "is_verified": false,
+        "line_number": 113
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "7220576713b157b7feb9b11af93b44de92c49e84",
+        "is_verified": false,
+        "line_number": 128
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts",
+        "hashed_secret": "0b59d36ed63eb10ac678b727583cc7cb61884469",
+        "is_verified": false,
+        "line_number": 143
+      }
+    ],
+    "src/app/__fixtures__/ArtworkFixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "85d92391931fc6e2badbb5dc56a83b1524479f3a",
+        "is_verified": false,
+        "line_number": 135
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "2ed85c16970f9e3ef3d87abba301ee5cf8841845",
+        "is_verified": false,
+        "line_number": 164
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "21fa50bc4578cf51cba0246c622c32106260c516",
+        "is_verified": false,
+        "line_number": 193
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "7d0d66f7127132b72ec8ea776da6bbc072e91a19",
+        "is_verified": false,
+        "line_number": 222
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "236ca1ac61285adec289677c60590852f9e93478",
+        "is_verified": false,
+        "line_number": 251
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "37e9a4f7e5fbfd70adbdf55155e84b4062114fd2",
+        "is_verified": false,
+        "line_number": 280
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "f55475d0e58bd3161695b6035ac0631cd4dedcf4",
+        "is_verified": false,
+        "line_number": 309
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "b6d5128e1a4d025e409dea02f4f3f7fd5437077a",
+        "is_verified": false,
+        "line_number": 338
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "60756577d40b07f95e07cd210e2b4547cd4c68d5",
+        "is_verified": false,
+        "line_number": 377
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "34e6e0c622e709134a4049ebcdf690dc5b4d1923",
+        "is_verified": false,
+        "line_number": 435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "300edd3061261c1261a608a6e44497296566c406",
+        "is_verified": false,
+        "line_number": 464
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "14313d7585df514ffade847556de12aad1baee0b",
+        "is_verified": false,
+        "line_number": 522
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/ArtworkFixture.ts",
+        "hashed_secret": "82e9537811ef6549577de84aabd60d501af762c1",
+        "is_verified": false,
+        "line_number": 551
+      }
+    ],
+    "src/app/__fixtures__/CityFixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "95ebf28eba7f7ff34ed44bb0f0ec97954d70aa40",
+        "is_verified": false,
+        "line_number": 38
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "d1b25cf6b74aa9fd266e9a68bb87cc10bfff2eaf",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "c0f4daeb6e057421fad4e0d2141dfa91aa475a81",
+        "is_verified": false,
+        "line_number": 124
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "b9c0e5dcb969ce933bfd562a3ae1e84879af162a",
+        "is_verified": false,
+        "line_number": 232
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "fbae29c9c9676e208813d5c7d2f0f901b5cd9e78",
+        "is_verified": false,
+        "line_number": 383
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "8b0281611d7e7edfcfd03f1de040834a295f1cda",
+        "is_verified": false,
+        "line_number": 391
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "0226ba4a802057880a25705098a5e5602a4ff3fc",
+        "is_verified": false,
+        "line_number": 421
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "b749677f30496b569f884cffeb6d590a6b06c19c",
+        "is_verified": false,
+        "line_number": 458
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "a56d01f02988b8fafdd25d3b46116351bb84b6fb",
+        "is_verified": false,
+        "line_number": 495
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "1df2ce829149416232a47bc82a962675f06fd551",
+        "is_verified": false,
+        "line_number": 532
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "47dfa0f5de3c617e678de99ca93f3b5e00b19c93",
+        "is_verified": false,
+        "line_number": 569
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "d4da8f302b6bfe0ad5a51433a2fe60e7d31d6019",
+        "is_verified": false,
+        "line_number": 607
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "edf1a70ec0a4bd6e44f41e0a2cc4145fb38ecd0d",
+        "is_verified": false,
+        "line_number": 644
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "6a3d96c7e5fc299404a28a014e773e57ec312da8",
+        "is_verified": false,
+        "line_number": 682
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "620816da29ab52d3bee7c4bc088e585ebbb752c2",
+        "is_verified": false,
+        "line_number": 719
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "a0d7a4c65195788a0b198b21744ee34493fd131d",
+        "is_verified": false,
+        "line_number": 727
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "25d34be4a3d5bbcce7f277322010110109a832b7",
+        "is_verified": false,
+        "line_number": 757
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "6899c527e47ced05c0cea1fcc40b65b4299173c6",
+        "is_verified": false,
+        "line_number": 794
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "d76377a10868e18c4d123943fb53bad9e47301a0",
+        "is_verified": false,
+        "line_number": 831
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "2fdcad3be6bc4322650ece2c0de9a663cad1b41d",
+        "is_verified": false,
+        "line_number": 868
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "7f430432a1247179b48f88f9242f6f4b5c2dc065",
+        "is_verified": false,
+        "line_number": 906
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "df856c1e37d7bb5302f7b0ca5ab42ec139b26342",
+        "is_verified": false,
+        "line_number": 914
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "a5b2c486bcaa5933f8ba3b4a3b91be915d668bf5",
+        "is_verified": false,
+        "line_number": 944
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "2ee0b7a62b937b07c970be027205c6bf9c356634",
+        "is_verified": false,
+        "line_number": 981
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "95b90a2c891f35f91c5d3b80d0c93ad9f938a746",
+        "is_verified": false,
+        "line_number": 1018
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "98752598077800b32da45958f10c4d9cae696faf",
+        "is_verified": false,
+        "line_number": 1055
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "f9f2e5fbe0de5bb7a321425dec1b86c5a5847217",
+        "is_verified": false,
+        "line_number": 1063
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "8168aaf4cabad9c1cd2d4b2dc138b7d8972c0ea6",
+        "is_verified": false,
+        "line_number": 1093
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "26e2a5b2a488d6e64403b30d680b3ead4d55c2ea",
+        "is_verified": false,
+        "line_number": 1105
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "34f002d4b727aa9620c61dc59d794f09e9a76291",
+        "is_verified": false,
+        "line_number": 1130
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "e3a3f03c8c6a8a7583fe6ee569543700f22ba6e1",
+        "is_verified": false,
+        "line_number": 1167
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "88c2213443fde7035f0fd0e3e32ff04645eb6d8d",
+        "is_verified": false,
+        "line_number": 1204
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "1fef2582f3c8d1d2d26773a1fc9de744deb0c982",
+        "is_verified": false,
+        "line_number": 1241
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "ae67972f715dab0b0bedcdc929d292ce147c8daa",
+        "is_verified": false,
+        "line_number": 1279
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "9d85a7647f6b3c434f54606806b043d63331c9f0",
+        "is_verified": false,
+        "line_number": 1324
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "bb5d8b677a1f914441cd36f97df35e8ad2702a0c",
+        "is_verified": false,
+        "line_number": 1353
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "156f23d71c0217d425b86baf532de97a3a9c860e",
+        "is_verified": false,
+        "line_number": 1390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "3ad331525f2d6a6d5b93b47f810edc6be7c35852",
+        "is_verified": false,
+        "line_number": 1427
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "d38b1f7b8db6b947bd1470ca5af8b5c554bb48e7",
+        "is_verified": false,
+        "line_number": 1464
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "ead6434d1888f05f3e02a2e038181279d63a0cb4",
+        "is_verified": false,
+        "line_number": 1472
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "e603854cc6b44cc846d0189a158bd3b0eb376ee2",
+        "is_verified": false,
+        "line_number": 1476
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "fbe4b923d51986ca5dba02d2f5f528ca9e4b2467",
+        "is_verified": false,
+        "line_number": 1501
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "fbbc0c6af7f71cf3b9819eec8a45df8531b53f41",
+        "is_verified": false,
+        "line_number": 1538
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "42d6f94a2743c2511f981ebfd6ab41024160602f",
+        "is_verified": false,
+        "line_number": 1546
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "2f0e50cd4f9ff4d169e178572e04897214a6c532",
+        "is_verified": false,
+        "line_number": 1575
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "6a5f32bf2be9e7715c9a290c41831555fe2a1e87",
+        "is_verified": false,
+        "line_number": 1583
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "f5afbaa0672278374b547d23765d9692f23fd4db",
+        "is_verified": false,
+        "line_number": 1612
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "3915aeb1916dd10990ff378929c1dc98e7bdc31c",
+        "is_verified": false,
+        "line_number": 1649
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "1a94f916554b6089dc6c0182a726c3713f9c9e3a",
+        "is_verified": false,
+        "line_number": 1657
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "4e7c3a1b7e2b24d753e9cc995e761ebc74c509fb",
+        "is_verified": false,
+        "line_number": 1686
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "ad42c3653bff47d2ca0f0fe50c31787dd9dce79d",
+        "is_verified": false,
+        "line_number": 1694
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "15b025b7a0d9b859038480f2558caf9eae605942",
+        "is_verified": false,
+        "line_number": 1723
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "5496ddc39e59d6ece46e1e2a33aec9c95ef06483",
+        "is_verified": false,
+        "line_number": 1761
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "8173654eb68f4c5c371141bda738d86fba9fcbd0",
+        "is_verified": false,
+        "line_number": 1798
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "8a41ce51343631d0daf9feb3f937f5cb0e8e790c",
+        "is_verified": false,
+        "line_number": 1835
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "bca9d7132d730b656d8b08bb62ea66a595c5f885",
+        "is_verified": false,
+        "line_number": 1872
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "3538514a1e4bae652581750a6462edc1a2b8c209",
+        "is_verified": false,
+        "line_number": 1880
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "f63321d24abfc869a5114cf3368b911cbdc08185",
+        "is_verified": false,
+        "line_number": 1910
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "86d9d5ae308dd3f8ce983239f99690bd8a53fec8",
+        "is_verified": false,
+        "line_number": 1947
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "4373ffb6e5caf8270d2e4419ff56246ab3f37582",
+        "is_verified": false,
+        "line_number": 1984
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "9145b71cc9aa7c3b41925bcea5852298bd9430a4",
+        "is_verified": false,
+        "line_number": 2021
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "9d209b3cbc376288553984ce85c34f7d82434678",
+        "is_verified": false,
+        "line_number": 2058
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "5113400787393d4ce80e730f3c8b66756c8b81fc",
+        "is_verified": false,
+        "line_number": 2095
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "ed7f0b859f0fc3f841a3a0e98e68902330201a5f",
+        "is_verified": false,
+        "line_number": 2132
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "50584b0576fa9bde11a314d6f817bbda184d0d4b",
+        "is_verified": false,
+        "line_number": 2169
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "14abf7fe9bfd639273c1907253cba80d2156cf58",
+        "is_verified": false,
+        "line_number": 2177
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "5ec075b06735b8b842dfb713a9c7c93bb40e7507",
+        "is_verified": false,
+        "line_number": 2206
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/CityFixture.ts",
+        "hashed_secret": "8572bdd8eb58e1daa8998c11b628f0d10418f442",
+        "is_verified": false,
+        "line_number": 2214
+      }
+    ],
+    "src/app/__fixtures__/FairBoothShowFixture.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "d35fe7c0eac8de39132a3d75d42fb72174abfdba",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "5de2201afc6e9972f628abf594e9d4c8aae2ebf2",
+        "is_verified": false,
+        "line_number": 15
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "b060e0c3d6edc5ff8fc6d3ea2f82b0d264f0e4b8",
         "is_verified": false,
         "line_number": 19
       },
       {
-        "type": "Hex High Entropy String",
-        "filename": "src/app/Scenes/MyCollection/utils/randomMyCollectionArtwork.ts",
-        "hashed_secret": "42079fa93fed2bbfcf020877932d355fd854f19f",
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "7c4e82dfe8d11486a909a8ee444538911a95661c",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 46
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "85b925d460a53dab7e4a64a9ca7b60e1375ccf65",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "a4e2f590674172bc31522cb5fa69ee2810a2f907",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "f273053332c194d272a510e3d654c83acecb0398",
+        "is_verified": false,
+        "line_number": 127
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "d67d3ae908a05b47b4666477561caf0054a69a72",
+        "is_verified": false,
+        "line_number": 154
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "cf140c132bee4c008d3552ae3cbfffa9448c5c9e",
+        "is_verified": false,
+        "line_number": 390
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "f8da79bc7aa880ae20a622bc757d3acde8fb2e97",
+        "is_verified": false,
+        "line_number": 400
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "bcec36fb5b52c027e0af3fb9092a47683d558df7",
+        "is_verified": false,
+        "line_number": 405
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "cd231204b4ffd91cf6d6f4fe7266b93e13dec660",
+        "is_verified": false,
+        "line_number": 425
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "eb0b90fe81f435abaa50080d9a73fa77f3a365fa",
+        "is_verified": false,
+        "line_number": 435
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "6ad48ae9ec95563ef843dd4d9a6ce4d0db7a5677",
+        "is_verified": false,
+        "line_number": 445
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "d6cb95a2075d297aeca1805b94a2259aa8336cb3",
+        "is_verified": false,
+        "line_number": 456
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "78265808fa4672c22d8c39ae4a7524b296e71b29",
+        "is_verified": false,
+        "line_number": 487
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "b46d66f21036376cc71f33ae4f892e6b07b1c5a2",
+        "is_verified": false,
+        "line_number": 518
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "daf90b1ec2e0fa2cc1be485ffa289b66ca05928e",
+        "is_verified": false,
+        "line_number": 549
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "651d35648f3d2977d510f982e0bd061d1b71a57e",
+        "is_verified": false,
+        "line_number": 580
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "1a14e183aff5d1eb1bc0d2794486a7ff19421407",
+        "is_verified": false,
+        "line_number": 611
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "8c9a1fb00687716d382d8f472467a0e42fc34720",
+        "is_verified": false,
+        "line_number": 642
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "99185763dd5e62a3edf59bea0fc86506b93aa8d5",
+        "is_verified": false,
+        "line_number": 673
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "a6592e819233d83decbb1ec49cb68f754c192910",
+        "is_verified": false,
+        "line_number": 704
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "src/app/__fixtures__/FairBoothShowFixture.ts",
+        "hashed_secret": "10403556643fa4591f0f0e1a25e10ff0c043ae3f",
+        "is_verified": false,
+        "line_number": 735
       }
     ],
     "src/app/store/AuthModel.tests.ts": [
@@ -425,5 +1434,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-06T15:26:30Z"
+  "generated_at": "2022-07-25T20:59:34Z"
 }

--- a/scripts/secrets-generate-baseline
+++ b/scripts/secrets-generate-baseline
@@ -11,4 +11,5 @@ detect-secrets scan \
   --exclude-files "\.jar$"    `# ignore jar files`   \
   --exclude-files "__generated__"      `# ignore relay generated files` \
   --exclude-files "ios\/.*\.xcscheme$" `# ignore Xcode scheme files`    \
+  --exclude-secrets '[a-fA-F0-9]{24}' `# ignore mongo ID like UUIDs` \
   > .secrets.baseline


### PR DESCRIPTION
### Change

* This updates CI to use `artsy/detect-secrets:1.3.0`
* Regenerate the `.secrets.baseline` under the new version

### Motivation

Last Friday a new version of detect-secrets was [released](https://github.com/Yelp/detect-secrets/releases/tag/v1.3.0) and it trickled down into various projects that use 3rd party image, not Eigen 👏 (Thank you @pvinis). This caused issues in some projects when running in CI as the new version seems to be detecting additional secrets, not detected by v1.2.0.

After rebuilding the `baseline` [in Force](https://github.com/artsy/force/pull/10597) under the new version, I was going to announce in #dev asking developers to upgrade their local version of the tool however, I then realized that Eigen is pinned to v1.2.0. This updates Eigen CI to use the latest version of the tool so that we can ask developers to upgrade and not run into version conflicts when working in Eigen and other projects.

The new image has been built and pushed to [docker-hub](https://hub.docker.com/layers/detect-secrets/artsy/detect-secrets/1.3.0/images/sha256-60eccdb9dd700881b40998015044ba583375881f3701db40609b3239f99cdbce?context=explore).

```
➜  docker run artsy/detect-secrets:1.3.0 detect-secrets-hook --version
1.3.0
```

