### PR TITLE
feat(TX-521): Erik/tx conversation support offers

### DIFF
--- a/src/app/Components/ConnectivityBanner.tsx
+++ b/src/app/Components/ConnectivityBanner.tsx
@@ -11,7 +11,7 @@ const Container = styled.View`
 `
 
 const ConnectivityMessage = styled.Text`
-  color: ${themeGet("colors.yellow100")};
+  color: ${themeGet("colors.copper100")};
   text-align: center;
   font-family: "Unica77LL-Regular";
   font-size: 16;

--- a/src/app/Containers/Inquiry.tsx
+++ b/src/app/Containers/Inquiry.tsx
@@ -63,7 +63,7 @@ const InquiryTextInput = styled.TextInput`
   font-family: "Unica77LL-Regular";
 `
 const ResponseRate = styled(SmallHeadline)`
-  color: ${themeGet("colors.yellow100")};
+  color: ${themeGet("colors.copper100")};
   margin-top: 5;
 `
 // TODO: Uncomment when use is uncommented in code below

--- a/src/app/Scenes/Inbox/Components/ActiveBids/ActiveBid.tsx
+++ b/src/app/Scenes/Inbox/Components/ActiveBids/ActiveBid.tsx
@@ -50,7 +50,7 @@ const StatusLabel = styled(MetadataText)`
       case "winning":
         return themeGet("colors.green100")
       case "reserve":
-        return themeGet("colors.yellow100")
+        return themeGet("colors.copper100")
       case "losing":
         return themeGet("colors.red100")
       case "live_auction":

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -106,7 +106,10 @@ export const ConversationCTAFragmentContainer = createFragmentContainer(Conversa
           }
         }
       }
-      activeOrders: orderConnection(first: 10, states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED]) {
+      activeOrders: orderConnection(
+        first: 10
+        states: [APPROVED, FULFILLED, SUBMITTED, REFUNDED, PROCESSING_APPROVAL]
+      ) {
         edges {
           node {
             internalID

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -191,6 +191,26 @@ describe("OrderUpdate with order updates", () => {
     tree.root.findByType(AlertCircleFillIcon)
   })
 
+  it("shows buy order processing approval", () => {
+    const tree = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "buy_processing_approval",
+    })
+
+    expect(extractText(tree.root)).toMatch("Order approved. Payment pending")
+    tree.root.findByType(AlertCircleFillIcon)
+  })
+
+  it("shows offer order processing approval", () => {
+    const tree = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "offer_processing_approval",
+    })
+
+    expect(extractText(tree.root)).toMatch("Offer accepted. Payment pending")
+    tree.root.findByType(AlertCircleFillIcon)
+  })
+
   it("shows an approved buy order", () => {
     const tree = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -21,6 +21,7 @@ export interface OrderUpdateProps {
 
 export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId }) => {
   let color: Color
+  let textColor: Color | null = null
   let message: string
   let Icon: React.FC<IconProps> = MoneyFillIcon
   let action: { label?: string; onPress?: () => void } = {}
@@ -60,6 +61,16 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
     if (orderUpdateState === "offer_approved") {
       color = "green100"
       message = `Offer Accepted`
+    } else if (orderUpdateState === "offer_processing_approval") {
+      Icon = AlertCircleFillIcon
+      color = "yellow100"
+      textColor = "black100"
+      message = "Offer accepted. Payment pending"
+    } else if (orderUpdateState === "buy_processing_approval") {
+      Icon = AlertCircleFillIcon
+      color = "yellow100"
+      textColor = "black100"
+      message = "Order approved. Payment pending"
     } else if (orderUpdateState === "offer_rejected") {
       color = "red100"
       message = `Offer Declined`
@@ -87,7 +98,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
         <Flex flexDirection="row">
           <Icon mt="1px" fill={color} />
           <Flex flexDirection="column" pl={1}>
-            <Text color={color} variant="xs">
+            <Text color={textColor || color} variant="xs">
               {message}
               {!!action.label && !!action.onPress && (
                 <>

--- a/src/app/Scenes/Inbox/Screens/ConversationDetails.tsx
+++ b/src/app/Scenes/Inbox/Screens/ConversationDetails.tsx
@@ -70,7 +70,10 @@ export const ConversationDetailsFragmentContainer = createFragmentContainer(Conv
             ...OrderInformation_artwork
           }
         }
-        orderConnection(first: 30, states: [APPROVED, PENDING, SUBMITTED, FULFILLED]) {
+        orderConnection(
+          first: 30
+          states: [APPROVED, PENDING, SUBMITTED, FULFILLED, PROCESSING_APPROVAL]
+        ) {
           edges {
             node {
               ...SellerReplyEstimate_order

--- a/src/app/Scenes/MyBids/Components/SaleInfo.tsx
+++ b/src/app/Scenes/MyBids/Components/SaleInfo.tsx
@@ -85,7 +85,7 @@ export const SaleInfo = ({
         </Text>
       </Flex>
       {!!line2 && (
-        <Text ml="25px" variant="xs" color="yellow100">
+        <Text ml="25px" variant="xs" color="copper100">
           {line2}
         </Text>
       )}

--- a/src/app/Scenes/MyBids/SaleInfo.tests.tsx
+++ b/src/app/Scenes/MyBids/SaleInfo.tests.tsx
@@ -77,7 +77,7 @@ describe(SaleInfo, () => {
 
         const lines = tree.root.findAllByType(Text)
         expect(lines.length).toEqual(2)
-        expect(lines[1].props.color).toEqual("yellow100")
+        expect(lines[1].props.color).toEqual("copper100")
 
         expect(text).toContain("Live bidding begins today at 2:00 a.m. (EDT)")
         expect(text).toContain("Opens in 38 minutes")
@@ -161,7 +161,7 @@ describe(SaleInfo, () => {
 
         const lines = tree.root.findAllByType(Text)
         expect(lines.length).toEqual(2)
-        expect(lines[1].props.color).toEqual("yellow100")
+        expect(lines[1].props.color).toEqual("copper100")
         expect(text).toContain("Closes today at 2:00 a.m.")
         expect(text).toContain("Ends in 38 minutes")
       })

--- a/src/palette/Theme.tsx
+++ b/src/palette/Theme.tsx
@@ -107,11 +107,13 @@ const fixColorV3 = (
   const ourColors = colors as any
   ourColors.devpurple = "#6E1EFF"
   ourColors.yellow150 = "#A47A0F"
-  ourColors.yellow100 = "#A85F00"
+  ourColors.yellow100 = "#E2B929"
   ourColors.yellow30 = "#FAE7BA"
   ourColors.yellow10 = "#F6EFE5"
   ourColors.orange10 = "#FCF7F3"
   ourColors.orange150 = "#A8501C"
+  // From our v2 colors
+  ourColors.copper100 = "#A85F00"
   return colors as any
 }
 


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [TX-521] and [TX-522]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR updates our conversation view to handle Orders with our new async/incomplete payment state `processing_approval`. In order to do this we need to 
- Add the state to the list of active order states in our queries 
- Show a little timestamped event for those states in the conversation view

Eigen currently uses our v2 theme's `yellow100` and this color is specified in several other components, including as a text color. In order to implement this new color I
- updated `yellow100` to its v3 version
- added `copper100` from our v2 theme [where the two values are aliases](https://github.com/artsy/palette/blob/main/packages/palette-tokens/src/themes/v2.tsx#L87-L106)
- changed previously-existing `yellow100` references to `copper100`.

### QA Test Case(s)

<!-- Does this PR need QA testing? (hint: it probably does). If so add details here. See example below. These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

Tests added for the timestamped order update.

#### Screenshots
<details><summary>**Rendered event with yellow alert icon and black text:**</summary>
<img width="358" alt="image" src="https://user-images.githubusercontent.com/9088720/181306403-d176aefb-45e2-476c-92c0-9493cdd8aad9.png">
</details>
<details><summary>**previously-existing v2 yellow100 text now using its v2 copper100 alias:**</summary>

<img width="358" alt="image" src="https://user-images.githubusercontent.com/9088720/181309345-a123d106-a6d4-4a00-8d24-525787b40cb2.png">

</details>



<!--
| Save a search | Search | Staging    | The user should be able to .. | Start from ..  |
-->

### PR Checklist

- [x] I tested my changes on **iOS**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add support for displaying orders with new payment methods in the Inbox view

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[TX-521]: https://artsyproduct.atlassian.net/browse/TX-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TX-522]: https://artsyproduct.atlassian.net/browse/TX-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ