### PR TITLE
fix: cache problems for sale screen

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -245,7 +245,7 @@ const DEFAULT_SALE_ARTWORKS_PARAMS = {
 } as FilterParams
 
 // TODO: Replace DEFAULT_NEW_SALE_ARTWORKS_PARAMS with DEFAULT_SALE_ARTWORKS_PARAMS when AREnableArtworksConnectionForAuction is released
-const DEFAULT_NEW_SALE_ARTWORKS_PARAMS = {
+export const DEFAULT_NEW_SALE_ARTWORKS_PARAMS = {
   sort: "sale_position",
   estimateRange: "",
 } as FilterParams

--- a/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -245,7 +245,7 @@ const DEFAULT_SALE_ARTWORKS_PARAMS = {
 } as FilterParams
 
 // TODO: Replace DEFAULT_NEW_SALE_ARTWORKS_PARAMS with DEFAULT_SALE_ARTWORKS_PARAMS when AREnableArtworksConnectionForAuction is released
-export const DEFAULT_NEW_SALE_ARTWORKS_PARAMS = {
+const DEFAULT_NEW_SALE_ARTWORKS_PARAMS = {
   sort: "sale_position",
   estimateRange: "",
 } as FilterParams

--- a/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/NewSaleLotsList.tsx
@@ -181,7 +181,7 @@ export const NewSaleLotsListContainer = createPaginationContainer(
           first: $count
           after: $cursor
           input: $input
-          aggregations: [TOTAL]
+          aggregations: [TOTAL, FOLLOWED_ARTISTS]
         ) @connection(key: "NewSaleLotsList__artworksConnection") {
           counts {
             total
@@ -209,7 +209,7 @@ export const NewSaleLotsListContainer = createPaginationContainer(
       }
     },
     query: graphql`
-      query NewSaleLotsListQuery(
+      query NewSaleLotsListRefetchQuery(
         $saleID: ID!
         $count: Int
         $cursor: String

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -9,7 +9,6 @@ import {
   ArtworkFilterNavigator,
   FilterModalMode,
 } from "app/Components/ArtworkFilter"
-import { DEFAULT_NEW_SALE_ARTWORKS_PARAMS } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { DEFAULT_NEW_SALE_ARTWORK_SORT } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { LoadFailureView } from "app/Components/LoadFailureView"
@@ -484,7 +483,7 @@ export const SaleQueryRenderer: React.FC<{
                       // @ts-ignore
                       input: {
                         sort: DEFAULT_NEW_SALE_ARTWORK_SORT.paramValue,
-                        priceRange: DEFAULT_NEW_SALE_ARTWORKS_PARAMS.priceRange,
+                        priceRange: "",
                       },
                     },
                   }

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -9,6 +9,7 @@ import {
   ArtworkFilterNavigator,
   FilterModalMode,
 } from "app/Components/ArtworkFilter"
+import { DEFAULT_NEW_SALE_ARTWORKS_PARAMS } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { DEFAULT_NEW_SALE_ARTWORK_SORT } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { LoadFailureView } from "app/Components/LoadFailureView"
@@ -483,6 +484,7 @@ export const SaleQueryRenderer: React.FC<{
                       // @ts-ignore
                       input: {
                         sort: DEFAULT_NEW_SALE_ARTWORK_SORT.paramValue,
+                        priceRange: DEFAULT_NEW_SALE_ARTWORKS_PARAMS.priceRange,
                       },
                     },
                   }

--- a/src/app/relay/middlewares/cacheMiddleware.ts
+++ b/src/app/relay/middlewares/cacheMiddleware.ts
@@ -7,6 +7,8 @@ const IGNORE_CACHE_CLEAR_MUTATION_ALLOWLIST = ["ArtworkMarkAsRecentlyViewedQuery
  * TODO:
  * Replace NewSaleLotsListRefetchQuery with SaleLotsListQuery when AREnableArtworksConnectionForAuction is released
  * or remove it when relay hooks will be used for Sale screen and cache problem for loadMore will be fixed
+ *
+ * Jira ticket: https://artsyproduct.atlassian.net/browse/FX-4133
  */
 const IGNORE_CACHE_QUERY_ALLOWLIST = ["NewSaleLotsListRefetchQuery"]
 

--- a/src/app/relay/middlewares/cacheMiddleware.ts
+++ b/src/app/relay/middlewares/cacheMiddleware.ts
@@ -3,15 +3,22 @@ import { MiddlewareNextFn } from "react-relay-network-modern/node8"
 import { GraphQLRequest } from "./types"
 
 const IGNORE_CACHE_CLEAR_MUTATION_ALLOWLIST = ["ArtworkMarkAsRecentlyViewedQuery"]
+/**
+ * TODO:
+ * Replace NewSaleLotsListRefetchQuery with SaleLotsListQuery when AREnableArtworksConnectionForAuction is released
+ * or remove it when relay hooks will be used for Sale screen and cache problem for loadMore will be fixed
+ */
+const IGNORE_CACHE_QUERY_ALLOWLIST = ["NewSaleLotsListRefetchQuery"]
 
 export const cacheMiddleware = () => {
   return (next: MiddlewareNextFn) => async (req: GraphQLRequest) => {
     const { cacheConfig, operation, variables } = req
     const isQuery = operation.operationKind === "query"
+    const isCacheIgnoredQuery = IGNORE_CACHE_QUERY_ALLOWLIST.includes(operation.name)
     const queryID = operation.id
 
     // If we have valid data in cache return
-    if (isQuery && !cacheConfig.force) {
+    if (isQuery && !cacheConfig.force && !isCacheIgnoredQuery) {
       const dataFromCache = await cache.get(queryID!, variables)
       if (dataFromCache) {
         return JSON.parse(dataFromCache)


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves []

Slack thread to get more context: https://artsy.slack.com/archives/C9SATFLUU/p1659353897000399?thread_ts=1659342586.520909&cid=C9SATFLUU

### Description
If the lot has moved to the “bidding closed” state and the info about this lot is in the cache (for example, the user previously opened this sale screen), then this lot will not be displayed at the end of the list

I think it’s related to [this problem](https://github.com/artsy/eigen/pull/6612#issue-1204382195) with `loadMore` (when only data from the cache is used and the fresh data received by the request is ignored) and some problem with cursor paginations/cache.

For example, in the first attached video, you can observe that **lot 7** and **lot 8** are not displayed at the end of the list until we manually update the data (but even after manually updating the data, go back from the screen and navigate to the screen again, **lot 7** and **lot 8** will not be displayed)

https://user-images.githubusercontent.com/3513494/182160164-7d736eeb-6f1f-4790-a15c-309152816eae.mp4

In the second video you can observe that **lot 10**-**lot 13** is not displayed


https://user-images.githubusercontent.com/3513494/182160287-cb9a769b-49f7-41e3-bf95-4bf3814d022e.mp4

### Ways to solve the problem:
* refactor the sales screen so that relay hooks are used instead of `createFragmentContainer`, `createPaginationContainer`, `QueryRenderer`
* add some sale queries to the allowed list so that the cache is always ignored for these queries 👈 Current PR

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### QA Test Case(s)

<!-- Does this PR need QA testing? (hint: it probably does). If so add details here. See example below. These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

| Test Case | Feature | Environment | Acceptance Criteria | Setup Instructions/Link |
| --------- | :-----: | ----------: | ------------------: | ----------------------: |
|           |         |             |                     |                         |

<!--
| Save a search | Search | Staging    | The user should be able to .. | Start from ..  |
-->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- cache problems for sale screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
