### PR TITLE
fix: Correct Sticky Tab Page offset when rotating the device

### DIFF
--- a/src/app/Components/StickyTabPage/StickyTabPage.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPage.tsx
@@ -127,6 +127,10 @@ export const StickyTabPage: React.FC<StickyTabPageProps> = ({
             action_type: Schema.ActionTypes.Tap,
           })
         },
+        adjustCurrentOffset() {
+          railRef.current?.setOffset(activeTabIndex.current * width)
+          stickyRailRef.current?.setOffset(activeTabIndex.current * width)
+        },
       }}
     >
       <View style={{ flex: 1, position: "relative", overflow: "hidden" }}>

--- a/src/app/Components/StickyTabPage/StickyTabPageContext.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageContext.tsx
@@ -11,6 +11,7 @@ export const StickyTabPageContext = React.createContext<{
   tabVisualClues: Array<TabVisualClues | undefined>
   activeTabIndex: GlobalState<number>
   setActiveTabIndex(index: number): void
+  adjustCurrentOffset(): void
 }>(null as any)
 
 export function useStickyTabPageContext() {

--- a/src/app/Components/StickyTabPage/StickyTabPageTabBar.tsx
+++ b/src/app/Components/StickyTabPage/StickyTabPageTabBar.tsx
@@ -18,7 +18,8 @@ export const StickyTabPageTabBar: React.FC<{
   onTabPress?(tab: { label: string; index: number }): void
 }> = ({ onTabPress }) => {
   const screen = useScreenDimensions()
-  const { tabLabels, activeTabIndex, setActiveTabIndex, tabVisualClues } = useStickyTabPageContext()
+  const { activeTabIndex, adjustCurrentOffset, setActiveTabIndex, tabLabels, tabVisualClues } =
+    useStickyTabPageContext()
   activeTabIndex.useUpdates()
 
   const [tabLayouts] = useState<Array<LayoutRectangle | null>>(tabLabels.map(() => null))
@@ -49,6 +50,10 @@ export const StickyTabPageTabBar: React.FC<{
     label,
     visualClues: tabVisualClues[index],
   }))
+
+  useEffect(() => {
+    adjustCurrentOffset()
+  }, [screen.width])
 
   return (
     <NavigationalTabs

--- a/src/app/Scenes/MyProfile/__tests__/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
@@ -18,7 +18,7 @@ import {
   MyProfileHeaderMyCollectionAndSavedWorksFragmentContainer,
 } from "../MyProfileHeaderMyCollectionAndSavedWorks"
 
-jest.mock("./LoggedInUserInfo")
+jest.mock("../LoggedInUserInfo")
 jest.unmock("react-relay")
 jest.mock("@react-navigation/native", () => {
   const actualNav = jest.requireActual("@react-navigation/native")

--- a/src/app/Scenes/MyProfile/__tests__/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfileHeaderMyCollectionAndSavedWorks.tests.tsx
@@ -2,6 +2,8 @@ import { MyProfileHeaderMyCollectionAndSavedWorksTestsQuery } from "__generated_
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { navigate } from "app/navigation/navigate"
+import { FavoriteArtworksQueryRenderer } from "app/Scenes/Favorites/FavoriteArtworks"
+import { MyCollectionQueryRenderer } from "app/Scenes/MyCollection/MyCollection"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
@@ -11,12 +13,10 @@ import { Avatar } from "palette"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment } from "relay-test-utils"
-import { FavoriteArtworksQueryRenderer } from "../Favorites/FavoriteArtworks"
-import { MyCollectionQueryRenderer } from "../MyCollection/MyCollection"
 import {
   LOCAL_PROFILE_ICON_PATH_KEY,
   MyProfileHeaderMyCollectionAndSavedWorksFragmentContainer,
-} from "./MyProfileHeaderMyCollectionAndSavedWorks"
+} from "../MyProfileHeaderMyCollectionAndSavedWorks"
 
 jest.mock("./LoggedInUserInfo")
 jest.unmock("react-relay")


### PR DESCRIPTION
<!--

➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR

-->

This PR resolves [CX-2631]

### Description

On screens using the `StickyTabPage` when rotating the device, the content offset doesn't adjust automatically. This can lead to situations where the offset is wrong and the content of two tabs is shown (see screenshot).

This PR adds an effect that adjusts the offset when the screen width changes.

![simulator_screenshot_8E609EDD-AC00-4F70-A820-5901AD647F06](https://user-images.githubusercontent.com/4691889/182556291-9091cd65-4ba2-4e83-90aa-6ce81b8cc646.png)

### QA Test Case(s)

<!-- Does this PR need QA testing? (hint: it probably does). If so add details here. See example below. These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

| Test Case | Feature | Environment | Acceptance Criteria | Setup Instructions/Link |
| --------- | :-----: | ----------: | ------------------: | ----------------------: |
|           |         |             |                     |                         |

<!--
| Save a search | Search | Staging    | The user should be able to .. | Start from ..  |
-->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Correct Sticky Tab Page offset when rotating the device - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2631]: https://artsyproduct.atlassian.net/browse/CX-2631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ