### PR TITLE
fix(NX-3251): attachment open inside conversation android

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Message.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Message.tsx
@@ -5,7 +5,7 @@ import { Schema, Track, track as _track } from "app/utils/track"
 import { compact } from "lodash"
 import { BoxProps, ClassTheme, Flex, Spacer, Text } from "palette"
 import React from "react"
-import { View } from "react-native"
+import { Linking, Platform, View } from "react-native"
 import Hyperlink from "react-native-hyperlink"
 import { createFragmentContainer } from "react-relay"
 import { graphql } from "relay-runtime"
@@ -35,12 +35,15 @@ export class Message extends React.Component<Props> {
     // download progress bar on.
     const previewAttachment = (reactNodeHandle: number, attachmentID: string) => {
       const attachment = compact(attachments).find(({ internalID }) => internalID === attachmentID)!
-      LegacyNativeModules.ARTNativeScreenPresenterModule.presentMediaPreviewController(
-        reactNodeHandle,
-        attachment.downloadURL,
-        attachment.contentType,
-        attachment.internalID
-      )
+      if (Platform.OS === "ios") {
+        return LegacyNativeModules.ARTNativeScreenPresenterModule.presentMediaPreviewController(
+          reactNodeHandle,
+          attachment.downloadURL,
+          attachment.contentType,
+          attachment.internalID
+        )
+      }
+      return Linking.openURL(attachment.downloadURL)
     }
 
     return compact(attachments).map((attachment, index) => {


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

This PR partially resolves [NX-3251]

We only have attachments preview on iOS, Android has no module for that, in order to keep the attachments being opened from a conversation we are reproducing the same behavior from the conversation details attachments.

https://user-images.githubusercontent.com/15792853/184088945-5eea9e32-70ee-43bb-8539-e732743a2456.mov

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- conversation attachments opening - araujobarret

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3251]: https://artsyproduct.atlassian.net/browse/NX-3251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ