### PR TITLE
feat: Show orders while processing approval

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderHistory.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistory.tsx
@@ -115,7 +115,7 @@ export const OrderHistoryContainer = createPaginationContainer(
         cursor: { type: "String" }
         states: {
           type: "[CommerceOrderStateEnum!]"
-          defaultValue: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED]
+          defaultValue: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL]
         }
       ) {
         orders(first: $count, after: $cursor, states: $states)

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -149,6 +149,17 @@ describe("Order history row", () => {
       expect(extractText(tree.findByProps({ testID: "order-status" }))).toBe("confirmed")
     })
 
+    it("PROCESSING_APPROVAL order", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        CommerceOrder: () => ({ ...mockOrder, state: "PROCESSING_APPROVAL" }),
+      })
+
+      expect(extractText(tree.findByProps({ testID: "order-status" }))).toContain(
+        "payment processing"
+      )
+    })
+
     it("FULFILLED order", () => {
       const tree = renderWithWrappersLEGACY(<TestRenderer />).root
       resolveMostRecentRelayOperation(mockEnvironment, {

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -26,6 +26,7 @@ enum ORDER_STATUSES {
   Delivered = "Delivered",
   Canceled = "Canceled",
   Refunded = "Refunded",
+  PaymentProcessing = "Payment processing",
 }
 
 enum SHIPMENT_STATUSES {
@@ -43,6 +44,7 @@ const orderStatusesMap = {
   REFUNDED: ORDER_STATUSES.Refunded,
   PENDING: SHIPMENT_STATUSES.Processing,
   CONFIRMED: SHIPMENT_STATUSES.Processing,
+  PROCESSING_APPROVAL: ORDER_STATUSES.PaymentProcessing,
   COLLECTED: SHIPMENT_STATUSES.InTransit,
   IN_TRANSIT: SHIPMENT_STATUSES.InTransit,
   COMPLETED: SHIPMENT_STATUSES.Delivered,


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [TX-575] by including orders with the 'processing approval' state in a user's order history.

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

- The order history view (in a user's settings) should show an order whose state is processing approval.

#### Setup Instructions

- The easiest way to check this is to create a wire transfer order, then accept it from the partner's side. This will trigger the `'processing_approval'` state until it is manually confirmed via the exchange admin interface.

### PR Checklist

- [x] I tested my changes on **iOS**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [x] N/A I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

<details><summary>Before and after:</summary>

  <img width="900" alt="image" src="https://user-images.githubusercontent.com/9088720/184150776-e4775791-a1c8-4175-ab1a-a91819610b7f.png">
 </details>

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Show data for new states in the user's order history view

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[TX-575]: https://artsyproduct.atlassian.net/browse/TX-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ