### PR TITLE
fix(CX-2751): dismiss career highlights modal after adding a new artwork

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsPromotionalCard.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsPromotionalCard.tsx
@@ -1,4 +1,4 @@
-import { navigate, popToRoot } from "app/navigation/navigate"
+import { dismissModal, navigate } from "app/navigation/navigate"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { Button, Flex, Text } from "palette"
 import { Image } from "react-native"
@@ -24,7 +24,11 @@ export const CareerHighlightsPromotionalCard: React.FC = () => {
               passProps: {
                 mode: "add",
                 source: Tab.insights,
-                onSuccess: popToRoot,
+                onSuccess: () => {
+                  // Since the career highlights screen is a modal, we need to dismiss it after
+                  // saving the artwork.
+                  dismissModal()
+                },
               },
             })
           }}


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [CX-2751]

- Dismiss career highlights modal after adding a new artwork


### QA Testing

https://user-images.githubusercontent.com/11945712/184327290-71a987be-27db-4397-b464-d56f7ef642a5.mov


<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

#nochangelog

[CX-2751]: https://artsyproduct.atlassian.net/browse/CX-2751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ