### PR TITLE
fix(CX-2754): MyC / Insights / Saved empty states are not aligned [Android]

### DIFF
--- a/src/app/Scenes/Favorites/FavoriteArtworks.tsx
+++ b/src/app/Scenes/Favorites/FavoriteArtworks.tsx
@@ -87,7 +87,7 @@ export class SavedWorks extends Component<Props, State> {
               onRefresh={this.handleRefresh}
             />
           }
-          contentContainerStyle={{ flexGrow: 1, justifyContent: "center" }}
+          contentContainerStyle={{ flexGrow: 1, justifyContent: "center", height: "100%" }}
         >
           <ZeroState
             title="You haven’t saved any works yet"

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -202,6 +202,7 @@ const MyCollection: React.FC<{
           // Extend the container flex when there are no artworks for accurate vertical centering
           flexGrow: artworks.length ? undefined : 1,
           justifyContent: artworks.length ? "flex-start" : "center",
+          height: artworks.length ? "auto" : "100%",
         }}
         refreshControl={
           <StickTabPageRefreshControl onRefresh={refetch} refreshing={isRefreshing} />

--- a/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
@@ -126,6 +126,7 @@ export const MyCollectionInsights: React.FC<{}> = ({}) => {
         // Extend the container flex when there are no artworks for accurate vertical centering
         flexGrow: myCollectionArtworksCount > 0 ? undefined : 1,
         justifyContent: myCollectionArtworksCount > 0 ? "flex-start" : "center",
+        height: myCollectionArtworksCount > 0 ? "auto" : "100%",
       }}
       paddingHorizontal={0}
     >


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
<img width="413" alt="image" src="https://user-images.githubusercontent.com/36167539/184359539-3dbde5fd-0065-41f9-838f-8cd80c4049ad.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/36167539/184359570-ec75401a-104b-4914-a8a5-b229d9966768.png">
<img width="405" alt="image" src="https://user-images.githubusercontent.com/36167539/184359679-9e18dea2-bfef-45bf-996d-9242dcab1cf0.png">

This PR resolves [CX-2754]

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

- the alignment of empty states is fixed, the content is on the centre of the screen

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fix alignment of MyC/Insights/Saved empty states -daria 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2754]: https://artsyproduct.atlassian.net/browse/CX-2754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ