### PR TITLE
fix(NX-3269): conversations list all shown on the list

### DIFF
--- a/src/app/Containers/Inbox.tsx
+++ b/src/app/Containers/Inbox.tsx
@@ -136,7 +136,7 @@ export class Inbox extends React.Component<Props, State> {
         <TabWrapper
           tabLabel="Inquiries"
           key="inquiries"
-          style={{ flexGrow: 1, justifyContent: "flex-start" }}
+          style={{ flex: 1, justifyContent: "flex-start" }}
         >
           <ConversationsContainer
             me={this.props.me}

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -113,6 +113,17 @@ export const Conversations: React.FC<Props> = (props) => {
         }
         keyExtractor={(item) => item.internalID!}
         ItemSeparatorComponent={() => <Separator mx={2} width="auto" />}
+        ListFooterComponent={() => {
+          if (!!(relay.hasMore() && isLoading)) {
+            return (
+              <Flex mb={ICON_HEIGHT} mt={2} alignItems="center">
+                <ActivityIndicator />
+              </Flex>
+            )
+          }
+
+          return null
+        }}
         renderItem={({ item }) => {
           return (
             <ConversationSnippet
@@ -126,15 +137,9 @@ export const Conversations: React.FC<Props> = (props) => {
         contentContainerStyle={{
           flexGrow: 1,
           justifyContent: !conversations.length ? "center" : "flex-start",
-          paddingBottom: ICON_HEIGHT,
         }}
         ListEmptyComponent={<NoMessages />}
       />
-      {!!(relay.hasMore() && isLoading) && (
-        <Flex p={3} alignItems="center">
-          <ActivityIndicator />
-        </Flex>
-      )}
     </ProvideScreenTrackingWithCohesionSchema>
   )
 }

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -2,6 +2,7 @@ import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Conversations_me$data } from "__generated__/Conversations_me.graphql"
 import { PAGE_SIZE } from "app/Components/constants"
 import { navigate } from "app/navigation/navigate"
+import { ICON_HEIGHT } from "app/Scenes/BottomTabs/BottomTabsIcon"
 import { extractNodes } from "app/utils/extractNodes"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
@@ -96,12 +97,7 @@ export const Conversations: React.FC<Props> = (props) => {
       info={screen({ context_screen_owner_type: OwnerType.inboxInquiries })}
     >
       <Flex py={1} style={{ borderBottomWidth: 1, borderBottomColor: color("black10") }}>
-        <Text
-          variant="lg"
-          mx={2}
-          mt={1}
-          style={{ borderBottomWidth: 1, borderBottomColor: color("black10") }}
-        >
+        <Text variant="lg" mx={2} mt={1}>
           Inbox {unreadCounter}
         </Text>
       </Flex>
@@ -130,6 +126,7 @@ export const Conversations: React.FC<Props> = (props) => {
         contentContainerStyle={{
           flexGrow: 1,
           justifyContent: !conversations.length ? "center" : "flex-start",
+          paddingBottom: ICON_HEIGHT,
         }}
         ListEmptyComponent={<NoMessages />}
       />


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

The last element of Inbox conversations wasn't fully shown on iOS and Android as well, this PR addresses this issue plus removes a border only shown on Android from the `Inbox` text element.

This PR resolves [NX-3269]

*Android*

https://user-images.githubusercontent.com/15792853/184616869-ad3b3a8e-22eb-4052-b376-dc855ccb8aaf.mov

*iOS*

https://user-images.githubusercontent.com/15792853/184616995-02aeb1d2-7f20-4ee0-8ba8-0c5c4d7befa5.mov

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- conversations items respect the bottom tab height - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3269]: https://artsyproduct.atlassian.net/browse/NX-3269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ