### PR TITLE
fix: find follows banner should appear after the user has followed gene

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/GeneHeader.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/GeneHeader.tsx
@@ -2,6 +2,7 @@ import { useNavigation } from "@react-navigation/native"
 import { GeneHeaderFragment_Gene$key } from "__generated__/GeneHeaderFragment_Gene.graphql"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/OnboardingV2/Hooks/useOnboardingTracking"
 import { Flex, FollowButton, Spacer, Text } from "palette"
+import { useCallback, useEffect, useState } from "react"
 import { ImageBackground, ImageSourcePropType } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
 import { OnboardingGeneId } from "../OnboardingGene"
@@ -20,6 +21,7 @@ export const images: Record<OnboardingGeneId, ImageSourcePropType> = {
 }
 
 export const GeneHeader: React.FC<GeneHeaderProps> = ({ geneID, gene, description }) => {
+  const [shouldDisplayTooltip, setShouldDisplayTooltip] = useState(false)
   const [commit, isInFlight] = useMutation(FollowGeneMutation)
 
   const { name, isFollowed } = useFragment(GeneHeaderFragment, gene)
@@ -38,6 +40,16 @@ export const GeneHeader: React.FC<GeneHeaderProps> = ({ geneID, gene, descriptio
       },
     })
   }
+
+  const showTooltip = useCallback(() => {
+    setShouldDisplayTooltip(true)
+  }, [])
+
+  useEffect(() => {
+    if (isFollowed) {
+      showTooltip()
+    }
+  }, [showTooltip, isFollowed])
 
   return (
     <Flex pb={2}>
@@ -59,7 +71,7 @@ export const GeneHeader: React.FC<GeneHeaderProps> = ({ geneID, gene, descriptio
           />
         </Flex>
       </ImageBackground>
-      <AnimatedTooltip />
+      {!!shouldDisplayTooltip && <AnimatedTooltip />}
     </Flex>
   )
 }

--- a/src/palette/atoms/BackButton/BackButton.tsx
+++ b/src/palette/atoms/BackButton/BackButton.tsx
@@ -1,20 +1,24 @@
 import { Color, Flex } from "palette"
 import { ChevronIcon, CloseIcon } from "palette/svgs"
-import { TouchableOpacity } from "react-native"
+import { TouchableOpacity, TouchableOpacityProps } from "react-native"
 
 interface BackButtonProps {
   onPress?: () => void
   showX?: boolean
   color?: Color
+  containerStyle?: TouchableOpacityProps["style"]
+  hitSlop?: TouchableOpacityProps["hitSlop"]
 }
 
 export const BackButton: React.FC<BackButtonProps> = ({
   onPress,
   showX = false,
   color = "black100",
+  containerStyle,
+  hitSlop,
 }) => {
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity hitSlop={hitSlop} style={containerStyle} onPress={onPress}>
       {showX ? (
         <CloseIcon fill={color} width={26} height={26} />
       ) : (

--- a/src/palette/organisms/screenStructure/Screen.tsx
+++ b/src/palette/organisms/screenStructure/Screen.tsx
@@ -94,15 +94,18 @@ export const Header: React.FC<HeaderProps> = ({ onBack, onSkip }) => {
       flexDirection="row"
       alignItems="center"
       justifyContent="space-between"
+      px={SCREEN_HORIZONTAL_PADDING}
     >
-      <Touchable haptic="impactLight" onPress={onBack}>
-        <Flex height="100%" justifyContent="center" px={SCREEN_HORIZONTAL_PADDING}>
-          <BackButton />
-        </Flex>
-      </Touchable>
+      <Flex>
+        <BackButton
+          onPress={onBack}
+          containerStyle={{ flex: 1, justifyContent: "center" }}
+          hitSlop={{ left: 20, right: 20 }}
+        />
+      </Flex>
       {!!onSkip && (
         <Touchable haptic="impactLight" onPress={onSkip}>
-          <Flex height="100%" justifyContent="center" px={SCREEN_HORIZONTAL_PADDING}>
+          <Flex height="100%" justifyContent="center">
             <Text textAlign="right" variant="xs">
               Skip
             </Text>


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

- [x] follows gene banner appears after the user has followed the gene
- [x] also squeezed in a back button improvement

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [GRO-1225]

#### Demo Video

https://user-images.githubusercontent.com/21178754/185610151-4014745c-1316-4fbb-8463-96286f49e105.mp4

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- onboarding follows banner appearing after user has followed a gene - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[GRO-1225]: https://artsyproduct.atlassian.net/browse/GRO-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ