### PR TITLE
chore: show submission banner inside edit artwork flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -463,14 +463,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 585
+        "line_number": 588
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 652
+        "line_number": 655
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1434,5 +1434,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-26T13:15:12Z"
+  "generated_at": "2022-08-29T09:09:02Z"
 }

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -203,6 +203,11 @@ export const ArtworkMetaProps = graphql`
     }
     artistNames
     category
+    # needed to show the banner inside the edit artwork view
+    # TODO: move logic to the edit artwork view https://artsyproduct.atlassian.net/browse/CX-2846
+    consignmentSubmission {
+      displayText
+    }
     pricePaid {
       display
       minor

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -389,6 +389,9 @@ describe("MyCollectionArtworkForm", () => {
                       isP1: false,
                     },
                   },
+                  consignmentSubmission: {
+                    displayText: "In progress",
+                  },
                   dimensions: {
                     in: "23",
                     cm: "26",

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -58,6 +58,7 @@ export type ArtworkFormScreen = {
   }
   ArtworkFormMain: {
     mode: ArtworkFormMode
+    isSubmission?: boolean
     clearForm(): void
     onDelete(): void
     onHeaderBackButtonPress(): void
@@ -257,7 +258,18 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           <Stack.Screen
             name="ArtworkFormMain"
             component={MyCollectionArtworkFormMain}
-            initialParams={{ onDelete, clearForm, mode: props.mode, onHeaderBackButtonPress }}
+            initialParams={{
+              onDelete,
+              clearForm,
+              mode: props.mode,
+              onHeaderBackButtonPress,
+              isSubmission: (() => {
+                if (props.mode === "edit") {
+                  return !!props.artwork.consignmentSubmission?.displayText
+                }
+                return false
+              })(),
+            }}
           />
           <Stack.Screen name="AddPhotos" component={MyCollectionAddPhotos} />
         </Stack.Navigator>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -5,10 +5,22 @@ import { Currency } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "app/store/GlobalStore"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
 import { isEmpty } from "lodash"
-import { Box, Button, Flex, Input, Join, Separator, Spacer, Text } from "palette"
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Join,
+  Message,
+  Separator,
+  Spacer,
+  Text,
+  useColor,
+  useSpace,
+} from "palette"
 import { Select } from "palette/elements/Select"
 import React, { useEffect } from "react"
-import { Alert, ScrollView, TouchableOpacity } from "react-native"
+import { Alert, Image, ScrollView, TouchableOpacity } from "react-native"
 import { ArtsyKeyboardAvoidingView } from "shared/utils"
 import { ScreenMargin } from "../../../Components/ScreenMargin"
 import { ArrowDetails } from "../Components/ArrowDetails"
@@ -27,6 +39,9 @@ export const MyCollectionArtworkFormMain: React.FC<
   const artworkActions = GlobalStore.actions.myCollection.artwork
   const artworkState = GlobalStore.useAppState((state) => state.myCollection.artwork)
   const { formik } = useArtworkForm()
+  const color = useColor()
+  const space = useSpace()
+
   const { showActionSheetWithOptions } = useActionSheet()
   const modalType = route.params.mode
   const addOrEditLabel = modalType === "edit" ? "Edit" : "Add"
@@ -87,6 +102,19 @@ export const MyCollectionArtworkFormMain: React.FC<
           {addOrEditLabel} Details
         </FancyModalHeader>
         <ScrollView keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
+          {!!route.params.isSubmission && (
+            <Message
+              containerStyle={{ marginX: space(2) }}
+              title="Changes will only appear in My Collection. They will not be applied to your sale submission."
+              IconComponent={() => (
+                <Image
+                  source={require("images/info.webp")}
+                  style={{ tintColor: color("black100") }}
+                />
+              )}
+            />
+          )}
+
           <Flex p={2}>
             <Join separator={<Spacer my={1} />}>
               {formik.values.artistSearchResult ? (

--- a/src/palette/elements/Message/Message.tsx
+++ b/src/palette/elements/Message/Message.tsx
@@ -7,27 +7,29 @@ import { Animated, Easing, TouchableOpacity } from "react-native"
 type MessageVariant = "default" | "info" | "success" | "warning" | "error"
 
 export interface MessageProps {
-  title: string
-  text: string
+  bodyTextStyle?: TextProps
+  containerStyle?: FlexProps
+  IconComponent?: React.FC<any>
   onClose?: () => void
   showCloseButton?: boolean
-  containerStyle?: FlexProps
-  titleStyle?: TextProps
-  bodyTextStyle?: TextProps
-  variant: MessageVariant
   testID?: string
+  text?: string
+  title: string
+  titleStyle?: TextProps
+  variant?: MessageVariant
 }
 
 export const Message: React.FC<MessageProps> = ({
-  title,
-  text,
+  bodyTextStyle,
+  containerStyle,
+  IconComponent,
   onClose,
   showCloseButton = false,
-  containerStyle,
-  titleStyle,
-  bodyTextStyle,
-  variant,
   testID,
+  text,
+  title,
+  titleStyle,
+  variant = "default",
 }) => {
   const color = useColor()
 
@@ -96,12 +98,21 @@ export const Message: React.FC<MessageProps> = ({
       <Flex backgroundColor={color(colors[variant].backgroundColor)} {...containerStyle}>
         <Flex px={2} py={1} flexDirection="row" justifyContent="space-between">
           <Flex flex={1}>
-            <Text variant="xs" color={color(colors[variant].titleColor)} {...titleStyle}>
-              {title}
-            </Text>
-            <Text variant="xs" color={color(colors[variant].textColor)} {...bodyTextStyle}>
-              {text}
-            </Text>
+            <Flex flexDirection="row">
+              {!!IconComponent && (
+                <Flex mr={1}>
+                  <IconComponent />
+                </Flex>
+              )}
+              <Text pr={2} variant="xs" color={color(colors[variant].titleColor)} {...titleStyle}>
+                {title}
+              </Text>
+            </Flex>
+            {!!text && (
+              <Text variant="xs" color={color(colors[variant].textColor)} {...bodyTextStyle}>
+                {text}
+              </Text>
+            )}
           </Flex>
 
           {!!showCloseButton && (


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

Show submission banner inside edit artwork flow 

https://user-images.githubusercontent.com/11945712/187166667-56e9d0f4-f327-41af-a6d0-270d620e2993.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves []

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- show artwork is a submission banner while editing it - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
