### PR TITLE
feat(FX-4209): setup analytics for reverse image

### DIFF
--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tests.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tests.tsx
@@ -1,0 +1,70 @@
+import { OwnerType } from "@artsy/cohesion"
+import { fireEvent } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockTrackEvent } from "app/tests/globallyMockedStuff"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import {
+  SearchImageHeaderButton,
+  SearchImageHeaderButtonOwner,
+  SearchImageHeaderButtonProps,
+} from "./SearchImageHeaderButton"
+
+describe("SearchImageHeaderButton", () => {
+  const TestRenderer = (props: Partial<SearchImageHeaderButtonProps>) => (
+    <SearchImageHeaderButton {...defaultProps} {...props} />
+  )
+
+  describe("with AREnableImageSearch feature flag disabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImageSearch: false })
+    })
+
+    it("should not be rendered", () => {
+      const { queryByLabelText } = renderWithWrappers(<TestRenderer />)
+      expect(queryByLabelText("Search by image")).toBeNull()
+    })
+  })
+
+  describe("with AREnableImageSearch feature flag enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableImageSearch: true })
+    })
+
+    it("should not be rendered when isImageSearchButtonVisible is false", () => {
+      const { queryByLabelText } = renderWithWrappers(
+        <TestRenderer isImageSearchButtonVisible={false} />
+      )
+
+      expect(queryByLabelText("Search by image")).toBeNull()
+    })
+
+    it("should correctly track analytics when button is tapped", () => {
+      const { getByLabelText } = renderWithWrappers(<TestRenderer />)
+
+      fireEvent.press(getByLabelText("Search by image"))
+
+      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action": "tappedReverseImageSearch",
+            "context_screen_owner_type": "reverseImageSearch",
+            "owner_id": "owner-id",
+            "owner_slug": "owner-slug",
+            "owner_type": "fair",
+          },
+        ]
+      `)
+    })
+  })
+})
+
+const defaultOwner: SearchImageHeaderButtonOwner = {
+  type: OwnerType.fair,
+  id: "owner-id",
+  slug: "owner-slug",
+}
+
+const defaultProps: SearchImageHeaderButtonProps = {
+  isImageSearchButtonVisible: true,
+  owner: defaultOwner,
+}

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tests.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tests.tsx
@@ -1,13 +1,10 @@
 import { OwnerType } from "@artsy/cohesion"
 import { fireEvent } from "@testing-library/react-native"
+import { ReverseImageOwner } from "app/Scenes/ReverseImage/types"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
-import {
-  SearchImageHeaderButton,
-  SearchImageHeaderButtonOwner,
-  SearchImageHeaderButtonProps,
-} from "./SearchImageHeaderButton"
+import { SearchImageHeaderButton, SearchImageHeaderButtonProps } from "./SearchImageHeaderButton"
 
 describe("SearchImageHeaderButton", () => {
   const TestRenderer = (props: Partial<SearchImageHeaderButtonProps>) => (
@@ -58,7 +55,7 @@ describe("SearchImageHeaderButton", () => {
   })
 })
 
-const defaultOwner: SearchImageHeaderButtonOwner = {
+const defaultOwner: ReverseImageOwner = {
   type: OwnerType.fair,
   id: "owner-id",
   slug: "owner-slug",

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -1,19 +1,30 @@
+import { ActionType, OwnerType, TappedReverseImageSearch } from "@artsy/cohesion"
 import { navigate } from "app/navigation/navigate"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { AddIcon, Box } from "palette"
 import { TouchableOpacity } from "react-native"
+import { useTracking } from "react-tracking"
 import { useScreenDimensions } from "shared/hooks"
 
 const CAMERA_ICON_CONTAINER_SIZE = 40
 const CAMERA_ICON_SIZE = 20
 
-interface SearchImageHeaderButtonProps {
+export interface SearchImageHeaderButtonOwner {
+  id: string
+  slug: string
+  type: OwnerType
+}
+
+export interface SearchImageHeaderButtonProps {
   isImageSearchButtonVisible: boolean
+  owner: SearchImageHeaderButtonOwner
 }
 
 export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = ({
   isImageSearchButtonVisible,
+  owner,
 }) => {
+  const tracking = useTracking()
   const isImageSearchEnabled = useFeatureFlag("AREnableImageSearch")
 
   if (!isImageSearchButtonVisible || !isImageSearchEnabled) {
@@ -21,7 +32,20 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
   }
 
   const handleSearchPress = () => {
-    return navigate("/reverse-image")
+    const event: TappedReverseImageSearch = {
+      action: ActionType.tappedReverseImageSearch,
+      context_screen_owner_type: OwnerType.reverseImageSearch,
+      owner_type: owner.type,
+      owner_id: owner.id,
+      owner_slug: owner.slug,
+    }
+
+    tracking.trackEvent(event)
+    navigate("/reverse-image", {
+      passProps: {
+        owner,
+      },
+    })
   }
 
   return (

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -1,5 +1,6 @@
 import { ActionType, OwnerType, TappedReverseImageSearch } from "@artsy/cohesion"
 import { navigate } from "app/navigation/navigate"
+import { ReverseImageOwner } from "app/Scenes/ReverseImage/types"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { AddIcon, Box } from "palette"
 import { TouchableOpacity } from "react-native"
@@ -9,15 +10,9 @@ import { useScreenDimensions } from "shared/hooks"
 const CAMERA_ICON_CONTAINER_SIZE = 40
 const CAMERA_ICON_SIZE = 20
 
-export interface SearchImageHeaderButtonOwner {
-  id: string
-  slug: string
-  type: OwnerType
-}
-
 export interface SearchImageHeaderButtonProps {
   isImageSearchButtonVisible: boolean
-  owner: SearchImageHeaderButtonOwner
+  owner: ReverseImageOwner
 }
 
 export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = ({

--- a/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
+++ b/src/app/Components/SearchImageHeaderButton/SearchImageHeaderButton.tsx
@@ -27,15 +27,7 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
   }
 
   const handleSearchPress = () => {
-    const event: TappedReverseImageSearch = {
-      action: ActionType.tappedReverseImageSearch,
-      context_screen_owner_type: OwnerType.reverseImageSearch,
-      owner_type: owner.type,
-      owner_id: owner.id,
-      owner_slug: owner.slug,
-    }
-
-    tracking.trackEvent(event)
+    tracking.trackEvent(tracks.tappedReverseImageSearch(owner))
     navigate("/reverse-image", {
       passProps: {
         owner,
@@ -67,4 +59,14 @@ export const SearchImageHeaderButton: React.FC<SearchImageHeaderButtonProps> = (
       </Box>
     </TouchableOpacity>
   )
+}
+
+const tracks = {
+  tappedReverseImageSearch: (owner: ReverseImageOwner): TappedReverseImageSearch => ({
+    action: ActionType.tappedReverseImageSearch,
+    context_screen_owner_type: OwnerType.reverseImageSearch,
+    owner_type: owner.type,
+    owner_id: owner.id,
+    owner_slug: owner.slug,
+  }),
 }

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -261,7 +261,14 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
         />
       </ArtworkFiltersStoreProvider>
 
-      <SearchImageHeaderButton isImageSearchButtonVisible={shouldShowImageSearchButton} />
+      <SearchImageHeaderButton
+        isImageSearchButtonVisible={shouldShowImageSearchButton}
+        owner={{
+          type: OwnerType.fair,
+          id: fair.internalID,
+          slug: fair.slug,
+        }}
+      />
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/ReverseImage/ReverseImage.tsx
+++ b/src/app/Scenes/ReverseImage/ReverseImage.tsx
@@ -5,16 +5,15 @@ import {
   DEFAULT_NAVIGATION_BAR_COLOR,
 } from "app/NativeModules/ArtsyNativeModule"
 import { useCallback, useEffect } from "react"
-import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
 import { Platform, StatusBar } from "react-native"
 import { ReverseImageArtworkNotFoundScreen } from "./Screens/ArtworkNotFound/ReverseImageArtworkNotFoundScreen"
 import { ReverseImageCameraScreen } from "./Screens/Camera/ReverseImageCamera"
 import { ReverseImageMultipleResultsScreen } from "./Screens/MultipleResults/ReverseImageMultipleResults"
 import { ReverseImagePreviewScreen } from "./Screens/Preview/ReverseImagePreview"
-import { ReverseImageNavigationStack } from "./types"
+import { ReverseImageNavigationStack, ReverseImageOwner } from "./types"
 
 interface ReverseImageProps {
-  owner: SearchImageHeaderButtonOwner
+  owner: ReverseImageOwner
 }
 
 const Stack = createStackNavigator<ReverseImageNavigationStack>()

--- a/src/app/Scenes/ReverseImage/ReverseImage.tsx
+++ b/src/app/Scenes/ReverseImage/ReverseImage.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_NAVIGATION_BAR_COLOR,
 } from "app/NativeModules/ArtsyNativeModule"
 import { useCallback, useEffect } from "react"
+import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
 import { Platform, StatusBar } from "react-native"
 import { ReverseImageArtworkNotFoundScreen } from "./Screens/ArtworkNotFound/ReverseImageArtworkNotFoundScreen"
 import { ReverseImageCameraScreen } from "./Screens/Camera/ReverseImageCamera"
@@ -12,9 +13,13 @@ import { ReverseImageMultipleResultsScreen } from "./Screens/MultipleResults/Rev
 import { ReverseImagePreviewScreen } from "./Screens/Preview/ReverseImagePreview"
 import { ReverseImageNavigationStack } from "./types"
 
+interface ReverseImageProps {
+  owner: SearchImageHeaderButtonOwner
+}
+
 const Stack = createStackNavigator<ReverseImageNavigationStack>()
 
-export const ReverseImage = () => {
+export const ReverseImage: React.FC<ReverseImageProps> = ({ owner }) => {
   const updateStatusBar = useCallback(() => {
     StatusBar.setBarStyle("light-content")
 
@@ -58,7 +63,11 @@ export const ReverseImage = () => {
           animationTypeForReplace: "push",
         }}
       >
-        <Stack.Screen name="Camera" component={ReverseImageCameraScreen} />
+        <Stack.Screen
+          name="Camera"
+          component={ReverseImageCameraScreen}
+          initialParams={{ owner }}
+        />
         <Stack.Screen name="MultipleResults" component={ReverseImageMultipleResultsScreen} />
         <Stack.Screen name="ArtworkNotFound" component={ReverseImageArtworkNotFoundScreen} />
         <Stack.Screen

--- a/src/app/Scenes/ReverseImage/Screens/Camera/ReverseImageCamera.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/Camera/ReverseImageCamera.tsx
@@ -1,8 +1,8 @@
 import {
   ActionType,
   OwnerType,
-  TappedToggleCameraFlash,
   TappedPickImageFromLibrary,
+  TappedToggleCameraFlash,
 } from "@artsy/cohesion"
 import { useIsFocused } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
@@ -25,7 +25,7 @@ import { Background, BACKGROUND_COLOR } from "../../Components/Background"
 import { CameraFramesContainer } from "../../Components/CameraFramesContainer"
 import { HeaderContainer } from "../../Components/HeaderContainer"
 import { HeaderTitle } from "../../Components/HeaderTitle"
-import { FocusCoords, ReverseImageNavigationStack } from "../../types"
+import { FocusCoords, ReverseImageNavigationStack, ReverseImageOwner } from "../../types"
 import { CAMERA_BUTTONS_HEIGHT, CameraButtons } from "./Components/CameraButtons"
 import { CameraErrorState } from "./Components/CameraErrorState"
 import { CameraGrantPermissions } from "./Components/CameraGrantPermissions"
@@ -98,15 +98,7 @@ export const ReverseImageCameraScreen: React.FC<Props> = (props) => {
   }
 
   const toggleFlash = () => {
-    const event: TappedToggleCameraFlash = {
-      action: ActionType.tappedToggleCameraFlash,
-      context_screen_owner_type: OwnerType.reverseImageSearch,
-      owner_type: owner.type,
-      owner_id: owner.id,
-      owner_slug: owner.slug,
-    }
-
-    tracking.trackEvent(event)
+    tracking.trackEvent(tracks.tappedToggleCameraFlash(owner))
     setEnableFlash(!enableFlash)
   }
 
@@ -159,15 +151,7 @@ export const ReverseImageCameraScreen: React.FC<Props> = (props) => {
 
   const selectPhotosFromLibrary = async () => {
     try {
-      const event: TappedPickImageFromLibrary = {
-        action: ActionType.tappedPickImageFromLibrary,
-        context_screen_owner_type: OwnerType.reverseImageSearch,
-        owner_type: owner.type,
-        owner_id: owner.id,
-        owner_slug: owner.slug,
-      }
-
-      tracking.trackEvent(event)
+      tracking.trackEvent(tracks.tappedPickImageFromLibrary(owner))
       const images = await requestPhotos(false)
 
       /**
@@ -181,6 +165,7 @@ export const ReverseImageCameraScreen: React.FC<Props> = (props) => {
       const image = images[0]
 
       navigation.navigate("Preview", {
+        owner,
         photo: {
           path: image.path,
           width: image.width,
@@ -292,4 +277,21 @@ export const ReverseImageCameraScreen: React.FC<Props> = (props) => {
       </Flex>
     </Flex>
   )
+}
+
+const tracks = {
+  tappedToggleCameraFlash: (owner: ReverseImageOwner): TappedToggleCameraFlash => ({
+    action: ActionType.tappedToggleCameraFlash,
+    context_screen_owner_type: OwnerType.reverseImageSearch,
+    owner_type: owner.type,
+    owner_id: owner.id,
+    owner_slug: owner.slug,
+  }),
+  tappedPickImageFromLibrary: (owner: ReverseImageOwner): TappedPickImageFromLibrary => ({
+    action: ActionType.tappedPickImageFromLibrary,
+    context_screen_owner_type: OwnerType.reverseImageSearch,
+    owner_type: owner.type,
+    owner_id: owner.id,
+    owner_slug: owner.slug,
+  }),
 }

--- a/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
@@ -1,24 +1,25 @@
+import { ActionType, OwnerType, SelectedArtworkFromReverseImageSearch } from "@artsy/cohesion"
 import { ReverseImageArtworksRail$key } from "__generated__/ReverseImageArtworksRail.graphql"
 import { SmallArtworkRail } from "app/Components/ArtworkRail/SmallArtworkRail"
+import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Text } from "palette"
 import { graphql, useFragment } from "react-relay"
-import { RouteProp, useRoute } from "@react-navigation/native"
 import { useTracking } from "react-tracking"
-import { ActionType, OwnerType, SelectedArtworkFromReverseImageSearch } from "@artsy/cohesion"
-import { ReverseImageNavigationStack } from "../../types"
 
 interface ReverseImageArtworksRailProps {
   artworks: ReverseImageArtworksRail$key
+  owner: SearchImageHeaderButtonOwner
 }
 
-export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> = (props) => {
-  const route = useRoute<RouteProp<ReverseImageNavigationStack, "MultipleResults">>()
-  const { owner } = route.params
+export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> = ({
+  artworks,
+  owner,
+}) => {
   const tracking = useTracking()
-  const data = useFragment(reverseImageArtworksRailFragment, props.artworks)
-  const artworks = extractNodes(data)
+  const data = useFragment(reverseImageArtworksRailFragment, artworks)
+  const nodes = extractNodes(data)
 
   return (
     <Flex>
@@ -27,7 +28,7 @@ export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> =
       </Text>
 
       <SmallArtworkRail
-        artworks={artworks}
+        artworks={nodes}
         onPress={(artwork, index) => {
           const event: SelectedArtworkFromReverseImageSearch = {
             action: ActionType.selectedArtworkFromReverseImageSearch,
@@ -38,7 +39,7 @@ export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> =
             owner_type: owner.type,
             owner_id: owner.id,
             owner_slug: owner.slug,
-            total_matches_count: artworks.length,
+            total_matches_count: nodes.length,
             position: index,
           }
 

--- a/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
@@ -4,12 +4,19 @@ import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Text } from "palette"
 import { graphql, useFragment } from "react-relay"
+import { RouteProp, useRoute } from "@react-navigation/native"
+import { useTracking } from "react-tracking"
+import { ActionType, OwnerType, SelectedArtworkFromReverseImageSearch } from "@artsy/cohesion"
+import { ReverseImageNavigationStack } from "../../types"
 
 interface ReverseImageArtworksRailProps {
   artworks: ReverseImageArtworksRail$key
 }
 
 export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> = (props) => {
+  const route = useRoute<RouteProp<ReverseImageNavigationStack, "MultipleResults">>()
+  const { owner } = route.params
+  const tracking = useTracking()
   const data = useFragment(reverseImageArtworksRailFragment, props.artworks)
   const artworks = extractNodes(data)
 
@@ -21,7 +28,21 @@ export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> =
 
       <SmallArtworkRail
         artworks={artworks}
-        onPress={(artwork) => {
+        onPress={(artwork, index) => {
+          const event: SelectedArtworkFromReverseImageSearch = {
+            action: ActionType.selectedArtworkFromReverseImageSearch,
+            context_screen_owner_type: OwnerType.reverseImageSearch,
+            destination_owner_type: OwnerType.artwork,
+            destination_owner_id: artwork.internalID,
+            destination_owner_slug: artwork.slug,
+            owner_type: owner.type,
+            owner_id: owner.id,
+            owner_slug: owner.slug,
+            total_matches_count: artworks.length,
+            position: index,
+          }
+
+          tracking.trackEvent(event)
           navigate(`/artwork/${artwork.internalID}`)
         }}
       />

--- a/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
@@ -1,16 +1,16 @@
 import { ActionType, OwnerType, SelectedArtworkFromReverseImageSearch } from "@artsy/cohesion"
 import { ReverseImageArtworksRail$key } from "__generated__/ReverseImageArtworksRail.graphql"
 import { SmallArtworkRail } from "app/Components/ArtworkRail/SmallArtworkRail"
-import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Text } from "palette"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
+import { ReverseImageOwner } from "../../types"
 
 interface ReverseImageArtworksRailProps {
   artworks: ReverseImageArtworksRail$key
-  owner: SearchImageHeaderButtonOwner
+  owner: ReverseImageOwner
 }
 
 export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> = ({

--- a/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageArtworksRail.tsx
@@ -30,20 +30,15 @@ export const ReverseImageArtworksRail: React.FC<ReverseImageArtworksRailProps> =
       <SmallArtworkRail
         artworks={nodes}
         onPress={(artwork, index) => {
-          const event: SelectedArtworkFromReverseImageSearch = {
-            action: ActionType.selectedArtworkFromReverseImageSearch,
-            context_screen_owner_type: OwnerType.reverseImageSearch,
-            destination_owner_type: OwnerType.artwork,
-            destination_owner_id: artwork.internalID,
-            destination_owner_slug: artwork.slug,
-            owner_type: owner.type,
-            owner_id: owner.id,
-            owner_slug: owner.slug,
-            total_matches_count: nodes.length,
-            position: index,
-          }
-
-          tracking.trackEvent(event)
+          tracking.trackEvent(
+            tracks.selectedArtworkFromReverseImageSearch({
+              owner,
+              position: index,
+              artworkId: artwork.internalID,
+              artworkSlug: artwork.slug,
+              totalMatchesCount: nodes.length,
+            })
+          )
           navigate(`/artwork/${artwork.internalID}`)
         }}
       />
@@ -60,3 +55,32 @@ const reverseImageArtworksRailFragment = graphql`
     }
   }
 `
+
+interface SelectedArtworkEventData {
+  owner: ReverseImageOwner
+  artworkId: string
+  artworkSlug: string
+  position: number
+  totalMatchesCount: number
+}
+
+const tracks = {
+  selectedArtworkFromReverseImageSearch: ({
+    owner,
+    artworkId,
+    artworkSlug,
+    position,
+    totalMatchesCount,
+  }: SelectedArtworkEventData): SelectedArtworkFromReverseImageSearch => ({
+    action: ActionType.selectedArtworkFromReverseImageSearch,
+    context_screen_owner_type: OwnerType.reverseImageSearch,
+    destination_owner_type: OwnerType.artwork,
+    destination_owner_id: artworkId,
+    destination_owner_slug: artworkSlug,
+    owner_type: owner.type,
+    owner_id: owner.id,
+    owner_slug: owner.slug,
+    total_matches_count: totalMatchesCount,
+    position,
+  }),
+}

--- a/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageMultipleResults.tsx
+++ b/src/app/Scenes/ReverseImage/Screens/MultipleResults/ReverseImageMultipleResults.tsx
@@ -13,7 +13,7 @@ type Props = StackScreenProps<ReverseImageNavigationStack, "MultipleResults">
 
 export const ReverseImageMultipleResults: React.FC<Props> = (props) => {
   const { route, navigation } = props
-  const { artworkIDs, photoPath } = route.params
+  const { artworkIDs, photoPath, owner } = route.params
   const data = useLazyLoadQuery<ReverseImageMultipleResultsQuery>(
     reverseImageMultipleResultsQuery,
     {
@@ -47,7 +47,7 @@ export const ReverseImageMultipleResults: React.FC<Props> = (props) => {
           />
         </Flex>
 
-        <ReverseImageArtworksRail artworks={data.artworks!} />
+        <ReverseImageArtworksRail artworks={data.artworks!} owner={owner} />
       </Flex>
     </Flex>
   )

--- a/src/app/Scenes/ReverseImage/types.ts
+++ b/src/app/Scenes/ReverseImage/types.ts
@@ -1,3 +1,5 @@
+import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
+
 export interface PhotoEntity {
   path: string
   width: number
@@ -12,15 +14,19 @@ export interface FocusCoords {
 
 // tslint:disable-next-line:interface-over-type-literal
 export type ReverseImageNavigationStack = {
-  Camera: undefined
+  Camera: {
+    owner: SearchImageHeaderButtonOwner
+  }
   MultipleResults: {
     photoPath: string
     artworkIDs: string[]
+    owner: SearchImageHeaderButtonOwner
   }
   ArtworkNotFound: {
     photoPath: string
   }
   Preview: {
     photo: PhotoEntity
+    owner: SearchImageHeaderButtonOwner
   }
 }

--- a/src/app/Scenes/ReverseImage/types.ts
+++ b/src/app/Scenes/ReverseImage/types.ts
@@ -1,4 +1,4 @@
-import { OwnerType } from "@artsy/cohesion"
+import { ScreenOwnerType } from "@artsy/cohesion"
 
 export interface PhotoEntity {
   path: string
@@ -15,7 +15,7 @@ export interface FocusCoords {
 export interface ReverseImageOwner {
   id: string
   slug: string
-  type: OwnerType
+  type: ScreenOwnerType
 }
 
 // tslint:disable-next-line:interface-over-type-literal

--- a/src/app/Scenes/ReverseImage/types.ts
+++ b/src/app/Scenes/ReverseImage/types.ts
@@ -1,4 +1,4 @@
-import { SearchImageHeaderButtonOwner } from "app/Components/SearchImageHeaderButton"
+import { OwnerType } from "@artsy/cohesion"
 
 export interface PhotoEntity {
   path: string
@@ -12,21 +12,27 @@ export interface FocusCoords {
   y: number
 }
 
+export interface ReverseImageOwner {
+  id: string
+  slug: string
+  type: OwnerType
+}
+
 // tslint:disable-next-line:interface-over-type-literal
 export type ReverseImageNavigationStack = {
   Camera: {
-    owner: SearchImageHeaderButtonOwner
+    owner: ReverseImageOwner
   }
   MultipleResults: {
     photoPath: string
     artworkIDs: string[]
-    owner: SearchImageHeaderButtonOwner
+    owner: ReverseImageOwner
   }
   ArtworkNotFound: {
     photoPath: string
   }
   Preview: {
     photo: PhotoEntity
-    owner: SearchImageHeaderButtonOwner
+    owner: ReverseImageOwner
   }
 }

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Show_show$data } from "__generated__/Show_show.graphql"
 import { ShowQuery } from "__generated__/ShowQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
@@ -140,7 +141,10 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
         />
       </ArtworkFiltersStoreProvider>
 
-      <SearchImageHeaderButton isImageSearchButtonVisible={shouldShowImageSearchButton} />
+      <SearchImageHeaderButton
+        isImageSearchButtonVisible={shouldShowImageSearchButton}
+        owner={{ type: OwnerType.show, id: show.internalID, slug: show.slug }}
+      />
     </ProvideScreenTracking>
   )
 }


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

Cohesion PR: artsy/cohesion#348

This PR resolves [FX-4209]

Reverse Image Search Analytics: https://www.notion.so/artsy/reverse-image-search-analytics-d8fcb365752f4cfe9ad326f2280e8b39

### Acceptance Criteria
* A user taps the reverse image search button on a fair or show screen - `tappedReverseImageSearch`
* A user taps the flash button on the reverse image search camera screen - `tappedToggleCameraFlash`
* A user taps the library button on the reverse image search camera screen - `tappedPickImageFromLibrary`
* A user searches with a reverse image query with results (for single and multiple results) - `searchedReverseImageWithResults`
* A user searches with a reverse image query with no results - `searchedReverseImageWithNoResults`
* A user selects an artwork from reverse image search results - `selectedArtworkFromReverseImageSearch`

### Demos
#### `tappedReverseImageSearch`
https://user-images.githubusercontent.com/3513494/189173757-b492910d-d2ba-434f-8eb0-fd1013964b44.MP4

#### `tappedPickImageFromLibrary`
https://user-images.githubusercontent.com/3513494/189173970-53608a5d-7b97-4702-9302-fd4066b7d438.MP4

#### `tappedToggleCameraFlash`
https://user-images.githubusercontent.com/3513494/189174900-22756c48-b21c-45fb-aa30-dc1a4fa27cf0.MP4

#### `searchedReverseImageWithResults`
https://user-images.githubusercontent.com/3513494/189175671-7051b543-bff0-40d3-b85e-cfa9b1ff7acf.MP4

#### `searchedReverseImageWithNoResults`
https://user-images.githubusercontent.com/3513494/189175932-1487db72-4e55-4c1c-923c-4f31d3ec00ee.MP4

#### `selectedArtworkFromReverseImageSearch`
https://user-images.githubusercontent.com/3513494/189176270-f0849eec-f707-4f7b-abb9-5b5cab5fa1f0.MP4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- setup analytics for reverse image - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4209]: https://artsyproduct.atlassian.net/browse/FX-4209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ