### PR TITLE
fix(ux): dont ask notif permissions  right after signin

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tests.tsx
@@ -1,12 +1,9 @@
 import { OnboardingPersonalization_highlights$data } from "__generated__/OnboardingPersonalization_highlights.graphql"
 import { OnboardingPersonalizationTestsQuery } from "__generated__/OnboardingPersonalizationTestsQuery.graphql"
-import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { mockFetchNotificationPermissions } from "app/tests/mockFetchNotificationPermissions"
 import { mockNavigate } from "app/tests/navigationMocks"
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
-import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
 import { OnboardingPersonalizationList } from "./OnboardingPersonalization"
@@ -63,12 +60,8 @@ describe("OnboardingPersonalizationList", () => {
   })
 
   describe("Button", () => {
-    it("Sets the onboarding state to complete and requests for push notifications permission when it's not yet determined", async () => {
+    it("Sets the onboarding state to complete", async () => {
       jest.useFakeTimers()
-
-      mockFetchNotificationPermissions(false).mockImplementationOnce((cb) =>
-        cb(null, PushAuthorizationStatus.NotDetermined)
-      )
 
       const tree = renderWithWrappersLEGACY(<TestRenderer />)
       resolveMostRecentRelayOperation(mockEnvironment)
@@ -79,9 +72,6 @@ describe("OnboardingPersonalizationList", () => {
       jest.runAllTimers()
 
       expect(__globalStoreTestUtils__?.getCurrentState().auth.onboardingState).toEqual("complete")
-      expect(
-        LegacyNativeModules.ARTemporaryAPIModule.requestPrepromptNotificationPermissions
-      ).toBeCalled()
     })
   })
 })

--- a/src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingPersonalization/OnboardingPersonalization.tsx
@@ -8,7 +8,6 @@ import {
 } from "app/Components/ArtistListItem"
 import SearchIcon from "app/Icons/SearchIcon"
 import { GlobalStore } from "app/store/GlobalStore"
-import { requestPushNotificationsPermission } from "app/utils/PushNotification"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { compact, times } from "lodash"
 import { Box, Button, Flex, Join, Spacer, Text, Touchable, useColor, useSpace } from "palette"
@@ -159,7 +158,6 @@ export const OnboardingPersonalizationList: React.FC<OnboardingPersonalizationLi
 
 const handleFinishOnboardingPersonalization = async () => {
   GlobalStore.actions.auth.setState({ onboardingState: "complete" })
-  requestPushNotificationsPermission()
 }
 
 export const OnboardingPersonalizationListRefetchContainer = createFragmentContainer(

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -19,7 +19,6 @@ import {
 } from "react-native-fbsdk-next"
 import Keychain from "react-native-keychain"
 import { LegacyNativeModules } from "../NativeModules/LegacyNativeModules"
-import { requestPushNotificationsPermission } from "../utils/PushNotification"
 import { AuthError } from "./AuthError"
 import { getCurrentEmissionState, GlobalStore } from "./GlobalStore"
 import type { GlobalStoreModel } from "./GlobalStoreModel"
@@ -367,10 +366,6 @@ export const getAuthModel = (): AuthModel => ({
       }
 
       postEventToProviders(tracks.loggedIn(oauthProvider))
-
-      if (!onboardingState || onboardingState === "complete" || onboardingState === "none") {
-        requestPushNotificationsPermission()
-      }
 
       onSignIn?.()
 


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

Right after signing, we ask for push notif permissions. this ux feels bad. I checked if we ask for permission before doing anything that needs it, and we do. So we don't need to ask up front so early. We will ask when the users needs it anyway.

We ask here:
- https://github.com/artsy/eigen/blob/3ddbd6746cc233c1733b635c67c09319247b62f0/src/app/Scenes/SavedSearchAlert/helpers.ts#L22
- https://github.com/artsy/eigen/blob/e09d9f37f46264bf08bf9a85519362e413007bf4/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx#L85


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [MOPLAT-175]

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-175]: https://artsyproduct.atlassian.net/browse/MOPLAT-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ