### PR TITLE
fix: Only show size in selected metric on My Collection artwork screen

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tests.tsx
@@ -1,32 +1,4 @@
-import { getDimensionsText, getEstimatePrice } from "./MyCollectionArtworkAboutWork"
-
-describe("getDimensionsText", () => {
-  describe("returns the dimensions string", () => {
-    it("when CM and IN are available", () => {
-      expect(getDimensionsText({ in: "28 2/5 × 12 3/4 in", cm: "120 × 68 cm" })).toBe(
-        "28 2/5 × 12 3/4 in\n120 × 68 cm"
-      )
-    })
-
-    it("when only CM is available", () => {
-      expect(getDimensionsText({ in: null, cm: "120 × 68 cm" })).toBe("120 × 68 cm")
-    })
-
-    it("when only IN is available", () => {
-      expect(getDimensionsText({ in: "28 2/5 × 12 3/4 in", cm: null })).toBe("28 2/5 × 12 3/4 in")
-    })
-  })
-
-  describe("returns an empty string", () => {
-    it("when dimensions is null", () => {
-      expect(getDimensionsText(null)).toBe("")
-    })
-
-    it("when values are null", () => {
-      expect(getDimensionsText({ in: null, cm: null })).toBe("")
-    })
-  })
-})
+import { getEstimatePrice } from "./MyCollectionArtworkAboutWork"
 
 describe("getEstimatePrice", () => {
   describe("returns the estimate price string", () => {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
@@ -12,11 +12,6 @@ interface EstimatePriceType {
   highRangeCents: number | null
 }
 
-interface DimensionsType {
-  in: string | null
-  cm: string | null
-}
-
 interface MyCollectionArtworkAboutWorkProps {
   artwork: MyCollectionArtworkAboutWork_artwork$key
   marketPriceInsights: MyCollectionArtworkAboutWork_marketPriceInsights$key | null
@@ -30,9 +25,8 @@ export const MyCollectionArtworkAboutWork: React.FC<MyCollectionArtworkAboutWork
 
   const enablePriceEstimateRange = useFeatureFlag("AREnablePriceEstimateRange")
 
-  const { category, medium, dimensions, date, provenance } = artwork
+  const { category, medium, dimensions, date, provenance, metric } = artwork
 
-  const dimensionsText = getDimensionsText(dimensions)
   // FIXME: types of these values are unknown (coming from MP), so it needs to be casted to Number to work properly here
   const estimatePrice = getEstimatePrice({
     lowRangeCents: Number(marketPriceInsights?.lowRangeCents),
@@ -44,11 +38,10 @@ export const MyCollectionArtworkAboutWork: React.FC<MyCollectionArtworkAboutWork
       <Text variant="lg" my={1}>
         About the work
       </Text>
-
       {!!enablePriceEstimateRange && <Field label="Estimate Range" value={estimatePrice} />}
       <Field label="Medium" value={capitalize(category!)} />
       <Field label="Materials" value={capitalize(medium!)} />
-      <Field label="Dimensions" value={dimensionsText} />
+      <Field label="Dimensions" value={(metric === "in" ? dimensions?.in : dimensions?.cm) || ""} />
       <Field label="Year created" value={date} />
       <Field label="Provenance" value={provenance} />
     </Flex>
@@ -59,6 +52,7 @@ const artworkFragment = graphql`
   fragment MyCollectionArtworkAboutWork_artwork on Artwork {
     category
     medium
+    metric
     dimensions {
       in
       cm
@@ -74,14 +68,6 @@ const marketPriceInsightsFragment = graphql`
     highRangeCents
   }
 `
-
-export const getDimensionsText = (dimensions: DimensionsType | null) => {
-  if (dimensions === null) {
-    return ""
-  }
-
-  return [dimensions.in, dimensions.cm].filter((d) => d).join("\n")
-}
 
 export const getEstimatePrice = ({ lowRangeCents, highRangeCents }: EstimatePriceType) => {
   if (!lowRangeCents || !highRangeCents) {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
@@ -66,6 +66,7 @@ describe("MyCollectionArtworkAbout", () => {
           medium: "Painting",
           date: "2007",
           provenance: "Signed, Sealed, Delivered!",
+          metric: "in",
           dimensions: {
             in: "39 2/5 × 40 9/10 in",
             cm: "100 × 104 cm",
@@ -85,11 +86,41 @@ describe("MyCollectionArtworkAbout", () => {
     expect(getByText("Materials")).toBeTruthy()
     expect(getByText("Painting")).toBeTruthy()
     expect(getByText("Dimensions")).toBeTruthy()
-    expect(getByText("39 2/5 × 40 9/10 in 100 × 104 cm")).toBeTruthy()
+    expect(getByText("39 2/5 × 40 9/10 in")).toBeTruthy()
     expect(getByText("Year created")).toBeTruthy()
     expect(getByText("2007")).toBeTruthy()
     expect(getByText("Provenance")).toBeTruthy()
     expect(getByText("Signed, Sealed, Delivered!")).toBeTruthy()
+  })
+
+  it("renders size in cm", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnablePriceEstimateRange: true,
+    })
+
+    const { getByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Query: () => ({
+        artwork: {
+          category: "Oil on Canvas",
+          medium: "Painting",
+          date: "2007",
+          provenance: "Signed, Sealed, Delivered!",
+          metric: "cm",
+          dimensions: {
+            in: "39 2/5 × 40 9/10 in",
+            cm: "100 × 104 cm",
+          },
+        },
+        marketPriceInsights: {
+          lowRangeCents: 1780000,
+          highRangeCents: 4200000,
+        },
+      }),
+    })
+
+    expect(getByText("100 × 104 cm")).toBeTruthy()
   })
 
   it("renders no estimate range when feature flag is disabled", async () => {


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

Only show size in selected metric on My Collection artwork screen.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [CX-2893]

| cm | in |
| --- | --- |
|![Simulator Screen Shot - iPhone 13 Pro - 2022-09-19 at 15 28 25](https://user-images.githubusercontent.com/4691889/191029349-262e7f42-252d-4266-b5fd-66794b950d82.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-09-19 at 15 28 46](https://user-images.githubusercontent.com/4691889/191029378-4889d558-99f3-43f8-bad7-7dd1580bb80f.png)|

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Only show size in selected metric on My Collection artwork screen - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2893]: https://artsyproduct.atlassian.net/browse/CX-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ