### PR TITLE
fix(NX-3277): change copy on fraud prevention banner

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
@@ -144,7 +144,7 @@ describe("messages with order updates", () => {
     })
 
     expect(extractText(tree.root)).toMatch(
-      "To protect your payment, always communicate and pay through the Artsy platform."
+      "To be covered by the Artsy Guarantee, always communicate and pay through the Artsy platform."
     )
     const toast = tree.root.findAllByType(Flex)[0]
     jest.advanceTimersByTime(150)

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -149,7 +149,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
       <ToastComponent
         id={1}
         positionIndex={-0.3}
-        message="To protect your payment, always communicate and pay through the Artsy platform."
+        message="To be covered by the Artsy Guarantee, always communicate and pay through the Artsy platform."
         placement="top"
         backgroundColor="blue100"
         duration="long"


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]
Ticket: [NX-3277](https://artsyproduct.atlassian.net/browse/NX-3277)
❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

Change copy on fraud prevention banner in conversations.

<img width="387" alt="Screenshot 2022-09-20 at 14 09 36" src="https://user-images.githubusercontent.com/17580625/191259748-b37cae21-602d-4ad6-af47-7036067f261e.png">


This PR resolves [NX-3277]

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

- Copy is changed to `To be covered by the Artsy Guarantee, always communicate and pay through the Artsy platform.`

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3277]: https://artsyproduct.atlassian.net/browse/NX-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ