### PR TITLE
fix(NX-3299): Hyphenate 'last-minute'

### DIFF
--- a/src/app/Components/Bidding/Components/Timer.tests.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tests.tsx
@@ -213,7 +213,7 @@ describe("Countdown", () => {
         />
       )
 
-      const textBlock = getByText("*Closure times may be extended to accommodate last minute bids")
+      const textBlock = getByText("*Closure times may be extended to accommodate last-minute bids")
       expect(textBlock).toBeDefined()
     })
 

--- a/src/app/Components/Bidding/Components/Timer.tsx
+++ b/src/app/Components/Bidding/Components/Timer.tsx
@@ -188,7 +188,7 @@ export const Countdown: React.FC<CountdownProps> = ({
         <>
           <Spacer mt={1} />
           <Text variant="xs" color="black60" textAlign="center">
-            *Closure times may be extended to accommodate last minute bids
+            *Closure times may be extended to accommodate last-minute bids
           </Text>
         </>
       )}

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -145,7 +145,7 @@ describe("ArtworkTombstone", () => {
 
   describe("for an artwork in a sale with cascading end times or popcorn bidding", () => {
     const cascadingMessage = "Lots will close at 1-minute intervals."
-    const popcornMessage = "Closing times may be extended due to last minute competitive bidding. "
+    const popcornMessage = "Closing times may be extended due to last-minute competitive bidding. "
     it("renders the notification banner with cascading message", () => {
       const { queryByText } = renderWithWrappers(
         <ArtworkTombstone artwork={artworkTombstoneCascadingEndTimesAuctionArtwork()} />

--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -19,7 +19,7 @@ export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = (
     <Flex backgroundColor="blue100" p={2}>
       <Text color="white" style={{ textAlign: "center" }}>
         {canBeExtended
-          ? "Closing times may be extended due to last minute competitive bidding. "
+          ? "Closing times may be extended due to last-minute competitive bidding. "
           : `Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
 
         <Text


### PR DESCRIPTION
### Description

This PR resolves [NX-3299]

Just a simple copy change from "last minute", to "last-minute".

### QA Testing
N/A

#### Acceptance Criteria

- All instances of "last minute" should now be replaced with "last-minute".


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3299]: https://artsyproduct.atlassian.net/browse/NX-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ