### PR TITLE
feat[FX-4251]: replace genes with collections in onboarding

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/GeneHeader.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/GeneHeader.tsx
@@ -54,7 +54,7 @@ export const GeneHeader: React.FC<GeneHeaderProps> = ({ geneID, gene, descriptio
   }, [showTooltip, isFollowed])
 
   return (
-    <Flex pb={2}>
+    <Flex>
       <ImageBackground style={{ height: 300 }} resizeMode="cover" source={images[geneID]}>
         <Flex pt={6} px={2}>
           <Text variant="xl" color="white100">

--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/MarketingCollectionHeader.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/MarketingCollectionHeader.tsx
@@ -26,23 +26,21 @@ export const MarketingCollectionHeader: React.FC<MarketingCollectionHeaderProps>
   const collection = useFragment(marketingCollectionHeaderFragment, marketingCollection)
 
   return (
-    <Flex>
-      <ImageBackground style={{ height: 230 }} resizeMode="cover" source={images[collectionSlug]}>
-        <Flex pt={6} px={2}>
-          <Text variant="xl" color="white100">
-            {collection.title}
-          </Text>
-          <Spacer mt={2} />
-          <Text variant="sm" color="white100">
-            {description}
-          </Text>
-          <Spacer mt={2} />
-          <Text variant="sm" color="white100">
-            {SAVE_INSTRUCTIONS}
-          </Text>
-        </Flex>
-      </ImageBackground>
-    </Flex>
+    <ImageBackground style={{ height: 230 }} resizeMode="cover" source={images[collectionSlug]}>
+      <Flex pt={6} px={2}>
+        <Text variant="xl" color="white100">
+          {collection.title}
+        </Text>
+        <Spacer mt={2} />
+        <Text variant="sm" color="white100">
+          {description}
+        </Text>
+        <Spacer mt={2} />
+        <Text variant="sm" color="white100">
+          {SAVE_INSTRUCTIONS}
+        </Text>
+      </Flex>
+    </ImageBackground>
   )
 }
 

--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/MarketingCollectionHeader.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/MarketingCollectionHeader.tsx
@@ -1,0 +1,53 @@
+import { MarketingCollectionHeaderFragment_marketingCollection$key } from "__generated__/MarketingCollectionHeaderFragment_marketingCollection.graphql"
+import { Flex, Spacer, Text } from "palette"
+import { ImageBackground, ImageSourcePropType } from "react-native"
+import { graphql, useFragment } from "react-relay"
+import { OnboardingMarketingCollectionSlug } from "../OnboardingMarketingCollection"
+
+interface MarketingCollectionHeaderProps {
+  collectionSlug: OnboardingMarketingCollectionSlug
+  description: string
+  marketingCollection: MarketingCollectionHeaderFragment_marketingCollection$key
+}
+
+export const images: Record<OnboardingMarketingCollectionSlug, ImageSourcePropType> = {
+  "artists-on-the-rise": require("images/CohnMakeAMountain.webp"),
+  "trove-editors-picks": require("images/HirstTheWonder.webp"),
+  "top-auction-lots": require("images/HirstTheWonder.webp"),
+}
+
+const SAVE_INSTRUCTIONS = "Love an artwork? Tap twice to save it."
+
+export const MarketingCollectionHeader: React.FC<MarketingCollectionHeaderProps> = ({
+  collectionSlug,
+  marketingCollection,
+  description,
+}) => {
+  const collection = useFragment(marketingCollectionHeaderFragment, marketingCollection)
+
+  return (
+    <Flex>
+      <ImageBackground style={{ height: 230 }} resizeMode="cover" source={images[collectionSlug]}>
+        <Flex pt={6} px={2}>
+          <Text variant="xl" color="white100">
+            {collection.title}
+          </Text>
+          <Spacer mt={2} />
+          <Text variant="sm" color="white100">
+            {description}
+          </Text>
+          <Spacer mt={2} />
+          <Text variant="sm" color="white100">
+            {SAVE_INSTRUCTIONS}
+          </Text>
+        </Flex>
+      </ImageBackground>
+    </Flex>
+  )
+}
+
+const marketingCollectionHeaderFragment = graphql`
+  fragment MarketingCollectionHeaderFragment_marketingCollection on MarketingCollection {
+    title
+  }
+`

--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/OnboardingResultsGrid.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/OnboardingResultsGrid.tsx
@@ -6,7 +6,7 @@ import { calculateLayoutValues, getSectionedItems } from "app/Components/Artwork
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { useDoublePressCallback } from "app/Scenes/Artwork/Components/ImageCarousel/FullScreen/useDoublePressCallback"
 import { extractNodes } from "app/utils/extractNodes"
-import { Box, Flex, HeartFillIcon, HeartIcon, Text, TextProps, Touchable } from "palette"
+import { Box, Flex, HeartFillIcon, HeartIcon, Text, TextProps, Touchable, useTheme } from "palette"
 import { FC } from "react"
 import { Dimensions, ScrollView } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
@@ -24,6 +24,8 @@ interface OnboardingResultsGridProps {
 }
 
 export const OnboardingResultsGrid: FC<OnboardingResultsGridProps> = ({ connection }) => {
+  const { space } = useTheme()
+
   const [commit] = useMutation(SaveArtworkMutation)
   if (!connection) {
     return null
@@ -82,17 +84,21 @@ export const OnboardingResultsGrid: FC<OnboardingResultsGridProps> = ({ connecti
   }
 
   return (
-    <ScrollView
-      keyboardDismissMode="on-drag"
-      keyboardShouldPersistTaps="handled"
-      scrollsToTop={false}
-      accessibilityLabel="Artworks ScrollView"
-    >
-      <Flex flexDirection="row" pr={1} mt={2}>
-        {renderSections()}
-      </Flex>
-      <Flex height={400} />
-    </ScrollView>
+    <Flex flex={1}>
+      <ScrollView
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        scrollsToTop={false}
+        accessibilityLabel="Artworks ScrollView"
+        contentContainerStyle={{
+          paddingHorizontal: space(2),
+        }}
+      >
+        <Flex flexDirection="row" pr={1} mt={2}>
+          {renderSections()}
+        </Flex>
+      </ScrollView>
+    </Flex>
   )
 }
 
@@ -145,18 +151,18 @@ const GridItem: FC<GridItemProps> = ({ artwork, itemWidth }) => {
   const height = itemWidth / aspectRatio
 
   return (
-    <Box>
+    <Box width={itemWidth}>
       <OpaqueImageView aspectRatio={aspectRatio} imageURL={url} width={itemWidth} height={height} />
-      <Flex flex={1} flexDirection="row" pt={0.5} width={itemWidth}>
-        <Flex justifySelf="flex-start" width={itemWidth - 16}>
-          <GridItemText>{artwork.artistNames}</GridItemText>
-          <GridItemText color="black60">{artwork.title}</GridItemText>
-          <GridItemText>{artwork.date}</GridItemText>
-          <GridItemText>{artwork.partner?.name}</GridItemText>
+      <Flex flex={1} pt={0.5}>
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Flex flex={1} mr={0.5}>
+            <GridItemText>{artwork.artistNames}</GridItemText>
+          </Flex>
+          <Box>{!!artwork.isSaved ? <HeartFillIcon /> : <HeartIcon />}</Box>
         </Flex>
-        <Flex position="absolute" right={0} pt={0.5}>
-          {!!artwork.isSaved ? <HeartFillIcon /> : <HeartIcon />}
-        </Flex>
+        <GridItemText color="black60">{artwork.title}</GridItemText>
+        <GridItemText>{artwork.date}</GridItemText>
+        <GridItemText>{artwork.partner?.name}</GridItemText>
       </Flex>
     </Box>
   )

--- a/src/app/Scenes/Onboarding/OnboardingV2/Components/OnboardingResultsGrid.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Components/OnboardingResultsGrid.tsx
@@ -38,8 +38,6 @@ export const OnboardingResultsGrid: FC<OnboardingResultsGridProps> = ({ connecti
   const sectionedGridItems = getSectionedItems(gridItems, sectionCount)
 
   const handleSaveArtwork = useDoublePressCallback((artwork: GridItem) => {
-    console.log("saving artwork", artwork)
-
     const { internalID, isSaved } = artwork!
 
     commit({
@@ -90,7 +88,7 @@ export const OnboardingResultsGrid: FC<OnboardingResultsGridProps> = ({ connecti
       scrollsToTop={false}
       accessibilityLabel="Artworks ScrollView"
     >
-      <Flex flexDirection="row" pr={1}>
+      <Flex flexDirection="row" pr={1} mt={2}>
         {renderSections()}
       </Flex>
       <Flex height={400} />
@@ -150,7 +148,7 @@ const GridItem: FC<GridItemProps> = ({ artwork, itemWidth }) => {
     <Box>
       <OpaqueImageView aspectRatio={aspectRatio} imageURL={url} width={itemWidth} height={height} />
       <Flex flex={1} flexDirection="row" pt={0.5} width={itemWidth}>
-        <Flex justifySelf="flex-start">
+        <Flex justifySelf="flex-start" width={itemWidth - 16}>
           <GridItemText>{artwork.artistNames}</GridItemText>
           <GridItemText color="black60">{artwork.title}</GridItemText>
           <GridItemText>{artwork.date}</GridItemText>

--- a/src/app/Scenes/Onboarding/OnboardingV2/Hooks/useNextOnboardingScreen.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/Hooks/useNextOnboardingScreen.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from "app/store/GlobalStore"
 import {
   OPTION_A_CURATED_SELECTION_OF_ARTWORKS,
   OPTION_ARTISTS_ON_THE_RISE,
@@ -11,21 +12,32 @@ const screenNames = {
   OnboardingArtistsOnTheRise: "OnboardingArtistsOnTheRise",
   OnboardingCuratedArtworks: "OnboardingCuratedArtworks",
   OnboardingTopAuctionLots: "OnboardingTopAuctionLots",
+  OnboardingArtistsOnTheRiseCollection: "OnboardingArtistsOnTheRiseCollection",
+  OnboardingCuratedArtworksCollection: "OnboardingCuratedArtworksCollection",
+  OnboardingTopAuctionLotsCollection: "OnboardingTopAuctionLotsCollection",
   OnboardingFollowArtists: "OnboardingFollowArtists",
   OnboardingFollowGalleries: "OnboardingFollowGalleries",
 }
 
 export const useNextOnboardingScreen = () => {
+  const replaceGenesWithCollections = useFeatureFlag("AREnableCollectionsInOnboarding")
+
   const { state } = useOnboardingContext()
   switch (state.questionThree) {
     case OPTION_TOP_AUCTION_LOTS:
-      return screenNames.OnboardingTopAuctionLots
+      return replaceGenesWithCollections
+        ? screenNames.OnboardingTopAuctionLotsCollection
+        : screenNames.OnboardingTopAuctionLots
 
     case OPTION_A_CURATED_SELECTION_OF_ARTWORKS:
-      return screenNames.OnboardingCuratedArtworks
+      return replaceGenesWithCollections
+        ? screenNames.OnboardingCuratedArtworksCollection
+        : screenNames.OnboardingCuratedArtworks
 
     case OPTION_ARTISTS_ON_THE_RISE:
-      return screenNames.OnboardingArtistsOnTheRise
+      return replaceGenesWithCollections
+        ? screenNames.OnboardingArtistsOnTheRiseCollection
+        : screenNames.OnboardingArtistsOnTheRise
 
     case OPTION_FOLLOW_ARTISTS_I_WANT_TO_COLLECT:
       return screenNames.OnboardingFollowArtists

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingArtistsOnTheRiseCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingArtistsOnTheRiseCollection.tsx
@@ -1,0 +1,10 @@
+import { OnboardingMarketingCollectionScreen } from "./OnboardingMarketingCollection"
+
+export const OnboardingArtistsOnTheRiseCollection: React.FC = () => {
+  return (
+    <OnboardingMarketingCollectionScreen
+      slug="artists-on-the-rise"
+      description="Fresh works from the studios of up-and-coming artists in your home feed."
+    />
+  )
+}

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingCuratedArtworksCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingCuratedArtworksCollection.tsx
@@ -1,0 +1,10 @@
+import { OnboardingMarketingCollectionScreen } from "./OnboardingMarketingCollection"
+
+export const OnboardingCuratedArtworksCollection: React.FC = () => {
+  return (
+    <OnboardingMarketingCollectionScreen
+      slug="trove-editors-picks"
+      description="The best works on Artsy each week, all available now."
+    />
+  )
+}

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingGene.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingGene.tsx
@@ -33,10 +33,8 @@ const OnboardingGene: React.FC<OnboardingGeneProps> = ({ id, description }) => {
     <Screen>
       <Screen.Background>
         <GeneHeader geneID={id} description={description} gene={gene!} />
-        <Flex px={2}>
-          <OnboardingResultsGrid connection={gene?.artworks} />
-        </Flex>
-        <Flex p={2} background="white" position="absolute" bottom={0}>
+        <OnboardingResultsGrid connection={gene?.artworks} />
+        <Flex p={2} background="white">
           <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>
             Explore More on Artsy
           </Button>

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingMarketingCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingMarketingCollection.tsx
@@ -46,10 +46,8 @@ const OnboardingMarketingCollection: React.FC<OnboardingMarketingCollectionProps
           description={description}
           marketingCollection={marketingCollection!}
         />
-        <Flex px={2}>
-          <OnboardingResultsGrid connection={marketingCollection?.artworks} />
-        </Flex>
-        <Flex p={2} background="white" position="absolute" bottom={0}>
+        <OnboardingResultsGrid connection={marketingCollection?.artworks} />
+        <Flex p={2} background="white">
           <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>
             Explore More on Artsy
           </Button>

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingMarketingCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingMarketingCollection.tsx
@@ -1,0 +1,88 @@
+import { NavigationProp, useNavigation } from "@react-navigation/native"
+import { OnboardingMarketingCollectionQuery } from "__generated__/OnboardingMarketingCollectionQuery.graphql"
+import { FullScreenLoadingImage } from "app/Components/FullScreenLoadingImage"
+import { OnboardingResultsGrid } from "app/Scenes/Onboarding/OnboardingV2/Components/OnboardingResultsGrid"
+import { OnboardingNavigationStack } from "app/Scenes/Onboarding/OnboardingV2/OnboardingV2"
+import { Button, Flex, Screen } from "palette"
+import { Suspense } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { useBackHandler } from "shared/hooks/useBackHandler"
+import { images, MarketingCollectionHeader } from "./Components/MarketingCollectionHeader"
+
+export type OnboardingMarketingCollectionSlug =
+  | "artists-on-the-rise"
+  | "trove-editors-picks"
+  | "top-auction-lots"
+
+interface OnboardingMarketingCollectionProps {
+  slug: OnboardingMarketingCollectionSlug
+  description: string
+}
+
+const OnboardingMarketingCollection: React.FC<OnboardingMarketingCollectionProps> = ({
+  slug,
+  description,
+}) => {
+  // prevents Android users from going back with hardware button
+  useBackHandler(() => true)
+  const { navigate } = useNavigation<NavigationProp<OnboardingNavigationStack>>()
+
+  const { marketingCollection } = useLazyLoadQuery<OnboardingMarketingCollectionQuery>(
+    OnboardingMarketingCollectionScreenQuery,
+    {
+      slug,
+    }
+  )
+
+  if (!marketingCollection?.artworks) {
+    return null
+  }
+
+  return (
+    <Screen>
+      <Screen.Background>
+        <MarketingCollectionHeader
+          collectionSlug={slug}
+          description={description}
+          marketingCollection={marketingCollection!}
+        />
+        <Flex px={2}>
+          <OnboardingResultsGrid connection={marketingCollection?.artworks} />
+        </Flex>
+        <Flex p={2} background="white" position="absolute" bottom={0}>
+          <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>
+            Explore More on Artsy
+          </Button>
+        </Flex>
+      </Screen.Background>
+    </Screen>
+  )
+}
+
+export const OnboardingMarketingCollectionScreen: React.FC<OnboardingMarketingCollectionProps> = (
+  props
+) => (
+  <Suspense
+    fallback={
+      <FullScreenLoadingImage
+        imgSource={images[props.slug]}
+        spacerHeight="80px"
+        loadingText={"Great choice" + "\n" + "We’re finding a collection for you"}
+      />
+    }
+  >
+    <OnboardingMarketingCollection {...props} />
+  </Suspense>
+)
+
+const OnboardingMarketingCollectionScreenQuery = graphql`
+  query OnboardingMarketingCollectionQuery($slug: String!) {
+    marketingCollection(slug: $slug) {
+      ...MarketingCollectionHeaderFragment_marketingCollection
+      internalID
+      artworks: artworksConnection(first: 100, page: 1, sort: "-decayed_merch") {
+        ...OnboardingResultsGrid_connection
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingTopAuctionLotsCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingTopAuctionLotsCollection.tsx
@@ -1,0 +1,10 @@
+import { OnboardingMarketingCollectionScreen } from "./OnboardingMarketingCollection"
+
+export const OnboardingTopAuctionLotsCollection: React.FC = () => {
+  return (
+    <OnboardingMarketingCollectionScreen
+      slug="top-auction-lots"
+      description="Works by emerging and established market stars—now open for bidding."
+    />
+  )
+}

--- a/src/app/Scenes/Onboarding/OnboardingV2/OnboardingV2.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/OnboardingV2.tsx
@@ -5,7 +5,9 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { OnboardingProvider } from "./Hooks/useOnboardingContext"
 import { useUpdateUserProfile } from "./Hooks/useUpdateUserProfile"
 import { OnboardingArtistsOnTheRise } from "./OnboardingArtistsOnTheRise"
+import { OnboardingArtistsOnTheRiseCollection } from "./OnboardingArtistsOnTheRiseCollection"
 import { OnboardingCuratedArtworks } from "./OnboardingCuratedArtworks"
+import { OnboardingCuratedArtworksCollection } from "./OnboardingCuratedArtworksCollection"
 import { OnboardingFollowArtists } from "./OnboardingFollowArtists"
 import { OnboardingFollowGalleries } from "./OnboardingFollowGalleries"
 import { OnboardingPostFollowLoadingScreen } from "./OnboardingPostFollowLoadingScreen"
@@ -13,6 +15,7 @@ import { OnboardingQuestionOne } from "./OnboardingQuestionOne"
 import { OnboardingQuestionThree } from "./OnboardingQuestionThree"
 import { OnboardingQuestionTwo } from "./OnboardingQuestionTwo"
 import { OnboardingTopAuctionLots } from "./OnboardingTopAuctionLots"
+import { OnboardingTopAuctionLotsCollection } from "./OnboardingTopAuctionLotsCollection"
 import { OnboardingWelcomeScreen } from "./OnboardingWelcome"
 
 // tslint:disable-next-line:interface-over-type-literal
@@ -27,6 +30,9 @@ export type OnboardingNavigationStack = {
   OnboardingFollowArtists: undefined
   OnboardingFollowGalleries: undefined
   OnboardingPostFollowLoadingScreen: undefined
+  OnboardingTopAuctionLotsCollection: undefined
+  OnboardingArtistsOnTheRiseCollection: undefined
+  OnboardingCuratedArtworksCollection: undefined
 }
 
 const StackNavigator = createStackNavigator<OnboardingNavigationStack>()
@@ -68,6 +74,7 @@ export const OnboardingV2 = () => {
             name="OnboardingQuestionThree"
             component={OnboardingQuestionThree}
           />
+
           <StackNavigator.Screen
             name="OnboardingTopAuctionLots"
             component={OnboardingTopAuctionLots}
@@ -80,6 +87,20 @@ export const OnboardingV2 = () => {
             name="OnboardingCuratedArtworks"
             component={OnboardingCuratedArtworks}
           />
+
+          <StackNavigator.Screen
+            name="OnboardingTopAuctionLotsCollection"
+            component={OnboardingTopAuctionLotsCollection}
+          />
+          <StackNavigator.Screen
+            name="OnboardingArtistsOnTheRiseCollection"
+            component={OnboardingArtistsOnTheRiseCollection}
+          />
+          <StackNavigator.Screen
+            name="OnboardingCuratedArtworksCollection"
+            component={OnboardingCuratedArtworksCollection}
+          />
+
           <StackNavigator.Screen
             name="OnboardingFollowArtists"
             component={OnboardingFollowArtists}

--- a/src/app/Scenes/Onboarding/OnboardingV2/__tests__/OnboardingMarketingCollection.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingV2/__tests__/OnboardingMarketingCollection.tests.tsx
@@ -1,0 +1,55 @@
+import { screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { renderWithHookWrappersTL } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { createMockEnvironment } from "relay-test-utils"
+import { OnboardingMarketingCollectionScreen } from "../OnboardingMarketingCollection"
+
+jest.unmock("react-relay")
+
+const mockedNavigate = jest.fn()
+
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native")
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      getId: () => "onboarding-marketing-collection-id",
+      navigate: mockedNavigate,
+    }),
+  }
+})
+
+describe("OnboardingMarketingCollection", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
+
+  const description = "This is the description."
+  const placeholderText = "Great choice\nWe’re finding a collection for you"
+
+  it("renders properly", async () => {
+    renderWithHookWrappersTL(
+      <OnboardingMarketingCollectionScreen slug="trove-editors-picks" description={description} />,
+      env
+    )
+
+    expect(screen.queryByText(placeholderText)).toBeTruthy()
+
+    resolveMostRecentRelayOperation(env, {
+      MarketingCollection: () => ({
+        title: "Example Collection",
+      }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.getByText(placeholderText))
+
+    expect(screen.queryByText(placeholderText)).toBeNull()
+
+    expect(screen.queryByText("Example Collection")).toBeTruthy()
+    expect(screen.queryByText(description)).toBeTruthy()
+
+    expect(screen.queryByText("Explore More on Artsy")).toBeTruthy()
+  })
+})

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -290,6 +290,12 @@ export const features = defineFeatures({
     description: "Enable Activity",
     showInAdminMenu: true,
   },
+  AREnableCollectionsInOnboarding: {
+    description: "Replace genes with collections in onboarding",
+    showInAdminMenu: true,
+    readyForRelease: false,
+    // echoFlagKey: "AREnableCollectionsInOnboarding",
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
~~Will come back and finish the PR checklist on Monday (still gotta set up Android etc.). Opening for review though since I think it's ready for 👀 !~~ OK I think I got it! Phew!

### Description

This PR introduces a change (behind a feature flag) to source artworks from collections instead of genes during onboarding. It also removes the "follow" button from those screens since we don't support following collections

This PR resolves [FX-4251]

<img width="300" alt="Screen Shot 2022-09-26 at 16 08 20" src="https://user-images.githubusercontent.com/5361806/192298274-c9e3521e-89a4-470a-a0da-cb68fb4d133a.png"> | <img width="300" alt="Screen Shot 2022-09-26 at 11 04 14" src="https://user-images.githubusercontent.com/5361806/192298487-69bc52d8-5b11-4c9b-a684-03fe4ec78a71.png">

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

1. Log in as an admin
2. Flip the feature flag in the admin menu
3. Log out
4. Sign up for a new account
5. Select the following answers: "No, I have not collected before", "Developing my taste in art"
6. Select any of the resulting options to see a collection of artworks, now sourced from a collection instead of a gene

#### Acceptance Criteria

- Both with and without feature flag enabled, these gene/collection-backed screens do not crash

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] ~~I added an [app state migration].~~
- [x] I hid my changes behind a [feature flag].
- [x] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4251]: https://artsyproduct.atlassian.net/browse/FX-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ