### PR TITLE
feat(FX-4309): Empty states for Activity Panel

### DIFF
--- a/src/app/Scenes/Activity/Activity.tests.tsx
+++ b/src/app/Scenes/Activity/Activity.tests.tsx
@@ -32,6 +32,20 @@ describe("Activity", () => {
     expect(getByText("All")).toBeTruthy()
     expect(getByText("Alerts")).toBeTruthy()
   })
+
+  it("renders empty states", async () => {
+    const { getByLabelText } = renderWithHookWrappersTL(<Activity />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      NotificationConnection: () => ({
+        edges: [],
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(getByLabelText("Activities are empty")).toBeTruthy()
+  })
 })
 
 const notifications = {

--- a/src/app/Scenes/Activity/ActivityEmptyView.tsx
+++ b/src/app/Scenes/Activity/ActivityEmptyView.tsx
@@ -1,0 +1,47 @@
+import { useStickyTabPageContext } from "app/Components/StickyTabPage/StickyTabPageContext"
+import { StickyTabPageFlatListContext } from "app/Components/StickyTabPage/StickyTabPageFlatList"
+import { Flex, Spacer, Text } from "palette"
+import { useContext } from "react"
+import Animated from "react-native-reanimated"
+import { NotificationType } from "./types"
+
+interface ActivityEmptyViewProps {
+  type: NotificationType
+}
+
+const entityByType: Record<NotificationType, { title: string; message: string }> = {
+  all: {
+    title: "You haven’t followed any artists, galleries or fairs yet.",
+    message:
+      "Follow artists to keep track of their latest work and career highlights. Following artists helps Artsy to recommend works you might like.",
+  },
+  alerts: {
+    title: "You haven’t created any Alerts yet.",
+    message:
+      "Filter for the artworks you love on an Artist Page and tap ‘Create Alert’ to be notified when new works are added to Artsy.",
+  },
+}
+
+export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) => {
+  const { staticHeaderHeight } = useStickyTabPageContext()
+  const { tabSpecificContentHeight } = useContext(StickyTabPageFlatListContext)
+  const headerHeight = Animated.add(staticHeaderHeight ?? 0, tabSpecificContentHeight ?? 0)
+  const entity = entityByType[type]
+
+  return (
+    <Flex flex={1} accessibilityLabel="Activities are empty">
+      <Animated.View
+        style={{
+          height: headerHeight ?? 0,
+        }}
+      />
+      <Flex flex={1} justifyContent="center" mx={2}>
+        <Text textAlign="center">{entity.title}</Text>
+        <Spacer mt={2} />
+        <Text variant="xs" color="black60" textAlign="center">
+          {entity.message}
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -8,6 +8,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Separator, Spinner } from "palette"
 import { useState } from "react"
 import { graphql, usePaginationFragment } from "react-relay"
+import { ActivityEmptyView } from "./ActivityEmptyView"
 import { ActivityItem } from "./ActivityItem"
 import { ActivityTabSubheader } from "./ActivityTabSubheader"
 import { NotificationType } from "./types"
@@ -56,6 +57,10 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type }) => {
         },
       }
     )
+  }
+
+  if (notifications.length === 0) {
+    return <ActivityEmptyView type={type} />
   }
 
   return (


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Demo
#### iOS
| All tab | Alerts tab |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-11 at 14 03 47](https://user-images.githubusercontent.com/3513494/195074044-46b82534-6a98-415e-8ed1-ef0f9485a3be.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-11 at 14 05 36](https://user-images.githubusercontent.com/3513494/195074262-10d25205-a863-433d-8945-707c0ab29681.png) | 

#### Android
| Before | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-11 at 14 03 47](https://user-images.githubusercontent.com/3513494/195077257-2cf2e1d9-0ff7-4d6c-b2c0-d01f6a8ae725.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-10-11 at 14 05 36](https://user-images.githubusercontent.com/3513494/195077288-d3dbd443-8989-41fd-8291-ec9dda39398d.png) | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [FX-4309]

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Empty states for Activity Panel - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4309]: https://artsyproduct.atlassian.net/browse/FX-4309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ