### PR TITLE
feat(FX-4311): Loading states for Activity Panel

### DIFF
--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -3,10 +3,11 @@ import { ActivityQuery } from "__generated__/ActivityQuery.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage, TabProps } from "app/Components/StickyTabPage/StickyTabPage"
 import { goBack } from "app/navigation/navigate"
-import { Flex, Text } from "palette"
+import { Flex } from "palette"
 import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { ActivityList } from "./ActivityList"
+import { ActivityTabPlaceholder } from "./ActivityTabPlaceholder"
 import { NotificationType } from "./types"
 
 interface ActivityProps {
@@ -25,7 +26,7 @@ export const ActivityContent: React.FC<ActivityProps> = ({ type }) => {
 
 export const ActivityContainer: React.FC<ActivityProps> = (props) => {
   return (
-    <Suspense fallback={<Placeholder />}>
+    <Suspense fallback={<ActivityTabPlaceholder />}>
       <ActivityContent {...props} />
     </Suspense>
   )
@@ -58,12 +59,6 @@ export const Activity = () => {
     </Flex>
   )
 }
-
-const Placeholder = () => (
-  <Flex flex={1} justifyContent="center" alignItems="center">
-    <Text>Loading</Text>
-  </Flex>
-)
 
 const ActivityScreenQuery = graphql`
   query ActivityQuery($count: Int, $after: String, $types: [NotificationTypesEnum]) {

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -5,7 +5,7 @@ import {
   StickyTabSection,
 } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { extractNodes } from "app/utils/extractNodes"
-import { Separator } from "palette"
+import { Flex, Separator, Spinner } from "palette"
 import { useState } from "react"
 import { graphql, usePaginationFragment } from "react-relay"
 import { ActivityItem } from "./ActivityItem"
@@ -74,6 +74,13 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type }) => {
       }}
       onEndReached={handleLoadMore}
       onRefresh={handleRefresh}
+      ListFooterComponent={
+        isLoadingNext ? (
+          <Flex my={2} alignItems="center" justifyContent="center">
+            <Spinner />
+          </Flex>
+        ) : null
+      }
     />
   )
 }

--- a/src/app/Scenes/Activity/ActivityTabPlaceholder.tsx
+++ b/src/app/Scenes/Activity/ActivityTabPlaceholder.tsx
@@ -1,7 +1,7 @@
 import { useStickyTabPageContext } from "app/Components/StickyTabPage/StickyTabPageContext"
-import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
+import { PlaceholderBox } from "app/utils/placeholders"
 import { times } from "lodash"
-import { Box, Flex, Separator, Spacer, Text } from "palette"
+import { Box, Flex, Separator, Spacer } from "palette"
 import { Fragment } from "react"
 import Animated from "react-native-reanimated"
 

--- a/src/app/Scenes/Activity/ActivityTabPlaceholder.tsx
+++ b/src/app/Scenes/Activity/ActivityTabPlaceholder.tsx
@@ -1,0 +1,52 @@
+import { useStickyTabPageContext } from "app/Components/StickyTabPage/StickyTabPageContext"
+import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
+import { times } from "lodash"
+import { Box, Flex, Separator, Spacer, Text } from "palette"
+import { Fragment } from "react"
+import Animated from "react-native-reanimated"
+
+const ActivityItemPlaceholder = () => {
+  return (
+    <Box my={2}>
+      <PlaceholderBox width={30} height={15} />
+      <Spacer mt={0.5} />
+      <PlaceholderBox width={130} height={15} />
+      <Spacer mt={0.5} />
+      <PlaceholderBox width={100} height={15} />
+      <Spacer mt={1} />
+      <Flex flexDirection="row">
+        <PlaceholderBox width={58} height={60} marginRight={10} />
+        <PlaceholderBox width={58} height={60} marginRight={10} />
+        <PlaceholderBox width={58} height={60} />
+      </Flex>
+    </Box>
+  )
+}
+
+export const ActivityTabPlaceholder = () => {
+  const { staticHeaderHeight, stickyHeaderHeight } = useStickyTabPageContext()
+  const headerHeight = Animated.add(staticHeaderHeight ?? 0, stickyHeaderHeight ?? 0)
+
+  return (
+    <Flex flex={1}>
+      <Animated.View
+        style={{
+          height: headerHeight ?? 0,
+        }}
+      />
+      <Flex flex={1} px={2}>
+        {/* Subheader */}
+        <Flex my={2}>
+          <PlaceholderBox width={120} height={30} />
+        </Flex>
+
+        {times(3).map((index) => (
+          <Fragment key={`placeholder-item-${index}`}>
+            <ActivityItemPlaceholder />
+            <Separator />
+          </Fragment>
+        ))}
+      </Flex>
+    </Flex>
+  )
+}


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Demo
#### Loading activity item placeholder
https://user-images.githubusercontent.com/3513494/193255621-e002be35-3edb-47a1-b5ee-2919d1dc9f8f.mp4

#### Fetching more indicator
https://user-images.githubusercontent.com/3513494/193255646-c7b2d3c1-43f2-4db1-866a-16bf94028d28.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [FX-4311]

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Loading states for Activity Panel - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4311]: https://artsyproduct.atlassian.net/browse/FX-4311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ