### PR TITLE
feat: mark onboarding collections ready for release

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -293,8 +293,8 @@ export const features = defineFeatures({
   AREnableCollectionsInOnboarding: {
     description: "Replace genes with collections in onboarding",
     showInAdminMenu: true,
-    readyForRelease: false,
-    // echoFlagKey: "AREnableCollectionsInOnboarding",
+    readyForRelease: true,
+    echoFlagKey: "AREnableCollectionsInOnboarding",
   },
 })
 


### PR DESCRIPTION
### Description

Marks the change from gene-backed works in onboarding to collection-backed works as ready for release in preparation for [the launch](https://www.notion.so/artsy/Curated-collections-launch-plan-8181a3ef06884b66a6b71664e65e5598).

Paired Echo PR: https://github.com/artsy/echo/pull/324

I did one more check on my device (flipping flag on -> going through onboarding) and it looked good to me.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

<!-- end_changelog_updates -->

</details>
