### PR TITLE
fix: disable new image comp on new-works-for-you grid

### DIFF
--- a/src/app/Components/ArticleCard.tsx
+++ b/src/app/Components/ArticleCard.tsx
@@ -31,7 +31,7 @@ export const ArticleCard: React.FC<ArticleCardProps> = ({ article, onPress, isFl
 
   const { space } = useTheme()
   const { width } = useWindowDimensions()
-  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImage")
 
   return (
     <Flex width={isFluid ? "100%" : WIDTH}>

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -64,6 +64,7 @@ export interface ArtworkProps {
   partnerNameTextStyle?: TextProps
   /** allows for artwork to be added to recent searches */
   updateRecentSearchesOnTap?: boolean
+  disableNewOpaqueImageView?: boolean
 }
 
 export const Artwork: React.FC<ArtworkProps> = ({
@@ -89,10 +90,12 @@ export const Artwork: React.FC<ArtworkProps> = ({
   saleInfoTextStyle,
   partnerNameTextStyle,
   updateRecentSearchesOnTap = false,
+  disableNewOpaqueImageView = false,
 }) => {
   const itemRef = useRef<any>()
   const tracking = useTracking()
   const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const shouldShowNewOpaqueImageView = enableNewOpaqueImageView && !disableNewOpaqueImageView
 
   let filterParams: any
 
@@ -180,7 +183,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       <View ref={itemRef}>
         {!!artwork.image && (
           <View>
-            {enableNewOpaqueImageView ? (
+            {shouldShowNewOpaqueImageView ? (
               <NewOpaqueImageView
                 aspectRatio={artwork.image?.aspectRatio ?? 1}
                 imageURL={artwork.image?.url}

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -94,7 +94,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
 }) => {
   const itemRef = useRef<any>()
   const tracking = useTracking()
-  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImage")
   const shouldShowNewOpaqueImageView = enableNewOpaqueImageView && !disableNewOpaqueImageView
 
   let filterParams: any

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -118,6 +118,9 @@ export interface Props {
   updateRecentSearchesOnTap?: boolean
 
   localSortAndFilterArtworks?: (artworks: any[]) => any[]
+
+  // override the new opaque image view, this is only for the newWorksForYou grid
+  disableNewOpaqueImageView?: boolean
 }
 
 interface PrivateProps {
@@ -195,6 +198,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   contextScreenOwnerSlug,
   contextScreenOwnerId,
   contextScreenOwnerType,
+  disableNewOpaqueImageView,
 }) => {
   const getSectionDimension = (gridWidth: number | null | undefined) => {
     // Setting the dimension to 1 for tests to avoid adjusting the screen width
@@ -321,6 +325,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
             {...itemComponentProps}
             height={imgHeight}
             width={imgWidth}
+            disableNewOpaqueImageView={disableNewOpaqueImageView}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/app/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/app/Components/Home/ArtistRails/ArtistCard.tsx
@@ -35,7 +35,7 @@ export const ArtistCard: React.FC<ArtistCardProps> = ({ artist, onDismiss, onFol
     }
   }
 
-  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImage")
 
   return (
     <ArtistCardWrapper onPress={handlePress}>

--- a/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
+++ b/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
@@ -37,6 +37,7 @@ const NewWorksForYou: React.FC<NewWorksForYouProps> = ({ viewer }) => {
               shouldAddPadding
               showLoadingSpinner
               useParentAwareScrollView={false}
+              disableNewOpaqueImageView
             />
           ) : (
             <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>

--- a/src/app/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/app/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -33,7 +33,7 @@ export const ViewingRoomArtworks: React.FC<ViewingRoomArtworksProps> = (props) =
   const tracking = useTracking()
   const artworks = extractNodes(viewingRoom.artworksConnection)
   const { width } = useWindowDimensions()
-  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImage")
 
   const sections: ArtworkSection[] = useMemo(() => {
     return artworks.map((artwork, index) => {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -190,11 +190,11 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnableAuctionShareButton",
   },
-  AREnableNewImageComponent: {
+  AREnableNewImage: {
     readyForRelease: true,
     description: "Enable New Image Component",
     showInAdminMenu: true,
-    echoFlagKey: "AREnableNewImageComponent",
+    echoFlagKey: "AREnableNewImage",
   },
   AREnableConversationalBuyNow: {
     readyForRelease: true,

--- a/src/palette/elements/Cards/MediumCard.tsx
+++ b/src/palette/elements/Cards/MediumCard.tsx
@@ -25,7 +25,7 @@ const MEDIUM_CARD_WIDTH = 280
  */
 export const MediumCard: React.FC<MediumCardProps> = ({ image, title, subtitle, tag, ...rest }) => {
   const { color, space } = useTheme()
-  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImageComponent")
+  const enableNewOpaqueImageView = useFeatureFlag("AREnableNewImage")
 
   return (
     <Box


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

We want to release the new opaqueImageView component in all the grids except the new works for  you grid.

The reason for that is that when a user gets redirected to the new works for you grid from a notification or from an email, the grid with the new image is breaking.

This pr solves that.

Also renews the feature flag to make sure that we don't release it in older versions that have the bug

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves []

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- disable new opaque image view on new-works-for-you grid - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
