### PR TITLE
fix(NX-3253): add purchase expired and accepted states in conversation

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
@@ -233,12 +233,12 @@ describe("messages with order updates", () => {
   it("does not remove 'Offer accepted' events when payment succeeds", () => {
     const day1Time1 = "2020-03-18T02:58:37.699Z"
     const day1Time2 = "2020-03-18T02:59:37.699Z"
-
     const tree = withConversationItems(getWrapper, {
       events: [
         {
           __typename: "CommerceOrderStateChangedEvent",
           orderUpdateState: "offer_approved",
+          state: "APPROVED",
           createdAt: day1Time1,
         },
         {
@@ -255,7 +255,7 @@ describe("messages with order updates", () => {
       .findAllByType(Text)
       .filter((element) => element.props.color !== "black30")
       .map((element) => extractText(element))
-
+    console.log(messagesAndUpdates)
     expect(messagesAndUpdates).toContain("Offer Accepted")
   })
 

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tests.tsx
@@ -255,7 +255,6 @@ describe("messages with order updates", () => {
       .findAllByType(Text)
       .filter((element) => element.props.color !== "black30")
       .map((element) => extractText(element))
-    console.log(messagesAndUpdates)
     expect(messagesAndUpdates).toContain("Offer Accepted")
   })
 

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -1,8 +1,6 @@
 import { OrderUpdateTestsQuery } from "__generated__/OrderUpdateTestsQuery.graphql"
 import { navigate } from "app/navigation/navigate"
-import { extractText } from "app/tests/extractText"
-import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
-import { AlertCircleFillIcon, LinkText, MoneyFillIcon } from "palette"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import "react-native"
 import { QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
@@ -77,7 +75,7 @@ const getWrapper = (event = {}) => {
       ],
     },
   }
-  const tree = renderWithWrappersLEGACY(<TestRenderer />)
+  const tree = renderWithWrappers(<TestRenderer />)
   const finalResolvers = { Conversation: () => mockConversation }
   act(() => {
     env.mock.resolveMostRecentOperation((operation) =>
@@ -93,76 +91,59 @@ it("renders without throwing an error", () => {
 
 describe("OrderUpdate with order updates", () => {
   it("displays the offer approved event", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "offer_approved",
+      state: "APPROVED",
     })
-
-    expect(extractText(tree.root)).toMatch("Offer Accepted")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
+    expect(getByText("Offer Accepted")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("displays the seller declined event", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "offer_rejected",
     })
 
-    expect(extractText(tree.root)).toMatch("Offer Declined")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
-  })
-
-  it("displays the buyer declined event", () => {
-    const tree = getWrapper({
-      __typename: "CommerceOrderStateChangedEvent",
-      orderUpdateState: "offer_rejected",
-    })
-
-    expect(extractText(tree.root)).toMatch("Offer Declined")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
+    expect(getByText("Offer Declined")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("displays the offer expired event", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "offer_lapsed",
+      state: "CANCELED",
+      stateReason: ["_lapsed"],
     })
-
-    expect(extractText(tree.root)).toMatch("Offer Expired")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
+    expect(getByText("Offer Expired")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows an offer submitted event", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
       offer: { respondsTo: null },
     })
+    expect(getByText("You sent an offer")).toBeTruthy()
+    // expect(extractText(tree.root)).toMatch("See details")
 
-    expect(extractText(tree.root)).toMatch("You sent an offer")
-    expect(extractText(tree.root)).toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
-
-    tree.root.findByType(LinkText).props.onPress()
+    // tree.root.findByType(LinkText).props.onPress()
     expect(navigate).toHaveBeenCalledWith("/conversation/12345/details")
   })
 
   it("shows a counteroffer offer from the user", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
       offer: { respondsTo: {} },
     })
-
-    expect(extractText(tree.root)).toMatch("You sent a counteroffer")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
+    expect(getByText("You sent a counteroffer")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows a counteroffer from the partner", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
       offer: {
         respondsTo: {},
@@ -170,14 +151,12 @@ describe("OrderUpdate with order updates", () => {
         offerAmountChanged: true,
       },
     })
-
-    expect(extractText(tree.root)).toMatch("You received a counteroffer")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(AlertCircleFillIcon)
+    expect(getByText("You received a counteroffer")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows an accepted offer from the partner with pending action", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
       offer: {
         respondsTo: {},
@@ -185,40 +164,51 @@ describe("OrderUpdate with order updates", () => {
         offerAmountChanged: false,
       },
     })
-
-    expect(extractText(tree.root)).toMatch("Offer Accepted - Pending Action")
-    expect(extractText(tree.root)).not.toMatch("See details")
-    tree.root.findByType(AlertCircleFillIcon)
+    expect(getByText("Offer Accepted - Pending Action")).toBeTruthy()
+    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows buy order processing approval", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "buy_processing_approval",
     })
-
-    expect(extractText(tree.root)).toMatch("Order approved. Payment Processing")
-    tree.root.findByType(AlertCircleFillIcon)
+    expect(getByText("Order approved. Payment Processing")).toBeTruthy()
   })
 
   it("shows offer order processing approval", () => {
-    const tree = getWrapper({
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "offer_processing_approval",
     })
-
-    expect(extractText(tree.root)).toMatch("Offer accepted. Payment Processing")
-    tree.root.findByType(AlertCircleFillIcon)
+    expect(getByText("Offer accepted. Payment Processing")).toBeTruthy()
   })
 
-  it("shows an approved buy order", () => {
-    const tree = getWrapper({
+  it("shows a submitted buy order", () => {
+    const { getByText } = getWrapper({
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "buy_submitted",
     })
+    expect(getByText("You purchased this artwork")).toBeTruthy()
+    // expect(extractText(tree.root)).toMatch("See details")
+  })
 
-    expect(extractText(tree.root)).toMatch("You purchased this artwork")
-    expect(extractText(tree.root)).toMatch("See details")
-    tree.root.findByType(MoneyFillIcon)
+  it("shows an expired buy order", () => {
+    const { getByText } = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "buy_lapsed",
+      state: "CANCELED",
+      stateReason: ["_lapsed"],
+    })
+    expect(getByText("Purchase Expired")).toBeTruthy()
+    // expect(extractText(tree.root)).toMatch("See details")
+  })
+  it("shows an approved buy order", () => {
+    const { getByText } = getWrapper({
+      __typename: "CommerceOrderStateChangedEvent",
+      orderUpdateState: "buy_approved",
+      state: "APPROVED",
+    })
+    expect(getByText("Purchase Accepted")).toBeTruthy()
   })
 })

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tests.tsx
@@ -1,3 +1,4 @@
+import { fireEvent } from "@testing-library/react-native"
 import { OrderUpdateTestsQuery } from "__generated__/OrderUpdateTestsQuery.graphql"
 import { navigate } from "app/navigation/navigate"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
@@ -97,7 +98,6 @@ describe("OrderUpdate with order updates", () => {
       state: "APPROVED",
     })
     expect(getByText("Offer Accepted")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("displays the seller declined event", () => {
@@ -107,7 +107,6 @@ describe("OrderUpdate with order updates", () => {
     })
 
     expect(getByText("Offer Declined")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("displays the offer expired event", () => {
@@ -118,41 +117,37 @@ describe("OrderUpdate with order updates", () => {
       stateReason: ["_lapsed"],
     })
     expect(getByText("Offer Expired")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows an offer submitted event", () => {
     const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
-      offer: { respondsTo: null },
+      offer: { respondsTo: null, amount: "$100" },
     })
-    expect(getByText("You sent an offer")).toBeTruthy()
-    // expect(extractText(tree.root)).toMatch("See details")
-
-    // tree.root.findByType(LinkText).props.onPress()
+    expect(getByText("You sent an offer for $100.")).toBeTruthy()
+    fireEvent.press(getByText("See details."))
     expect(navigate).toHaveBeenCalledWith("/conversation/12345/details")
   })
 
   it("shows a counteroffer offer from the user", () => {
     const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
-      offer: { respondsTo: {} },
+      offer: { respondsTo: {}, amount: "$150" },
     })
-    expect(getByText("You sent a counteroffer")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
+    expect(getByText("You sent a counteroffer for $150")).toBeTruthy()
   })
 
   it("shows a counteroffer from the partner", () => {
     const { getByText } = getWrapper({
       __typename: "CommerceOfferSubmittedEvent",
       offer: {
+        amount: "$200",
         respondsTo: {},
         fromParticipant: "SELLER",
         offerAmountChanged: true,
       },
     })
-    expect(getByText("You received a counteroffer")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
+    expect(getByText("You received a counteroffer for $200")).toBeTruthy()
   })
 
   it("shows an accepted offer from the partner with pending action", () => {
@@ -165,7 +160,6 @@ describe("OrderUpdate with order updates", () => {
       },
     })
     expect(getByText("Offer Accepted - Pending Action")).toBeTruthy()
-    // expect(extractText(tree.root)).not.toMatch("See details")
   })
 
   it("shows buy order processing approval", () => {
@@ -189,8 +183,7 @@ describe("OrderUpdate with order updates", () => {
       __typename: "CommerceOrderStateChangedEvent",
       orderUpdateState: "buy_submitted",
     })
-    expect(getByText("You purchased this artwork")).toBeTruthy()
-    // expect(extractText(tree.root)).toMatch("See details")
+    expect(getByText("You purchased this artwork.")).toBeTruthy()
   })
 
   it("shows an expired buy order", () => {
@@ -201,7 +194,6 @@ describe("OrderUpdate with order updates", () => {
       stateReason: ["_lapsed"],
     })
     expect(getByText("Purchase Expired")).toBeTruthy()
-    // expect(extractText(tree.root)).toMatch("See details")
   })
   it("shows an approved buy order", () => {
     const { getByText } = getWrapper({

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -57,10 +57,11 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
       return null
     }
   } else if (event.__typename === "CommerceOrderStateChangedEvent") {
-    const { orderUpdateState } = event
-    if (orderUpdateState === "offer_approved") {
+    const { orderUpdateState, state, stateReason } = event
+    const reasonLapsed = stateReason?.includes("_lapsed")
+    if (state === "APPROVED") {
       color = "green100"
-      message = `Offer Accepted`
+      message = `${orderUpdateState === "offer_approved" ? "Offer" : "Purchase"} Accepted`
     } else if (orderUpdateState === "offer_processing_approval") {
       Icon = AlertCircleFillIcon
       color = "yellow100"
@@ -74,9 +75,9 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
     } else if (orderUpdateState === "offer_rejected") {
       color = "red100"
       message = `Offer Declined`
-    } else if (orderUpdateState === "offer_lapsed") {
+    } else if (state === "CANCELED" && reasonLapsed) {
       color = "black60"
-      message = `Offer Expired`
+      message = `${orderUpdateState === "offer_lapsed" ? "Offer" : "Purchase"} Expired`
     } else if (orderUpdateState === "buy_submitted") {
       color = "black100"
       message = `You purchased this artwork`
@@ -124,6 +125,8 @@ export const OrderUpdateFragmentContainer = createFragmentContainer(OrderUpdate,
       ... on CommerceOrderStateChangedEvent {
         createdAt
         orderUpdateState
+        state
+        stateReason
       }
       ... on CommerceOfferSubmittedEvent {
         createdAt


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

### Description

Added `Purchase Accepted` and `Purchase Expired` states in conversations.
Refactored tests because `renderWithWrappersLEGACY` is deprecated.
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR resolves [NX-3253](https://artsyproduct.atlassian.net/browse/NX-3253)

![Simulator Screen Shot - iPhone 13 - 2022-09-27 at 14 56 10](https://user-images.githubusercontent.com/17580625/194362555-aaab5fd7-f813-48d0-9e02-5b261371a887.png)


### QA Testing
Check if `Purchase Accepted` and `Purchase Expired` are showing up after a purchase is made in Conversations.

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
