### PR TITLE
fix: Always use local image if it exists in My Collection grid view

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -42,19 +42,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   }, [])
 
   const renderImage = () => {
-    if (!!imageURL) {
-      const targetURL = imageURL.replace(":version", "square")
-      return (
-        <OpaqueImageView
-          testID="Image-Remote"
-          imageURL={targetURL}
-          retryFailedURLs
-          height={imageHeight}
-          width={imageWidth}
-          aspectRatio={aspectRatio}
-        />
-      )
-    } else if (localImage) {
+    if (localImage) {
       return (
         <RNImage
           testID="Image-Local"
@@ -64,6 +52,18 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           }}
           resizeMode="contain"
           source={{ uri: localImage.path }}
+        />
+      )
+    } else if (imageURL) {
+      const targetURL = imageURL.replace(":version", "square")
+      return (
+        <OpaqueImageView
+          testID="Image-Remote"
+          imageURL={targetURL}
+          retryFailedURLs
+          height={imageHeight}
+          width={imageWidth}
+          aspectRatio={aspectRatio}
         />
       )
     } else if (localImageConsignments) {


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

This PR resolves [CX-2827]

### Description

After a My Collection artwork is created, we show the image in the wrong aspect ratio for some time until the correct version of the artwork is available (Gemini takes a while to process the image). This issue can be fixed by always using the locally stored version of the artwork image (which we store). Through this, we avoid using image versions with a wrong aspect ratio (e.g. squared) during the image processing.


### Test Instructions

- Upload a new artwork and choose "Scream II, 2022" by "Somaya Critchlos" or a local image with an aspect ratio that is not square and check if the aspect ratio is correct after the artwork got uploaded.

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2827]: https://artsyproduct.atlassian.net/browse/CX-2827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ