### PR TITLE
fix: remove request id from timing middleware tags, to avoid explosion in number of custom metrics

### DIFF
--- a/src/app/relay/middlewares/timingMiddleware.ts
+++ b/src/app/relay/middlewares/timingMiddleware.ts
@@ -12,7 +12,7 @@ export function timingMiddleware() {
         type: "timing",
         name: "graphql-request-duration",
         timing: duration,
-        tags: [`operation:${operation}`, `id:${req.id}`],
+        tags: [`operation:${operation}`],
       })
       return res
     })


### PR DESCRIPTION
Datadog pointed out that we were spending a lot on custom metrics over and above our contracted amount. We're generating ~22K/mo while our contract covers ~8K. Looking at [our recent usage](https://app.datadoghq.com/billing/usage?category=custom-metrics&data_source=billable&summary_month=2022-10&trends_start_date=2022-10-09&trends_time_frame=weekly), almost 70% of our custom metrics are labeled `eigen.graphql_request_duration.*` (or more than the total overage).

I think this is explained by the `id` tag which is unique to each request. Do we ever slice metrics by this tag? If not, I think we should drop it because each id value will be counted as a distinct metric, compounding our total volume.

Note that datadog also referred us to [this doc](https://docs.datadoghq.com/metrics/metrics-without-limits/#configuration-of-tags) about how to customize how metrics are ingested to include or exclude certain tags from indexing. We might be able to use that to mitigate the impact of already-installed apps, but either way I think it's easiest to clean this up at the source.