### PR TITLE
fix: use consistent 'eigen' service name for custom metric reporting

### DIFF
--- a/src/app/utils/volleyClient.tests.ts
+++ b/src/app/utils/volleyClient.tests.ts
@@ -33,7 +33,7 @@ describe("volleyClient", () => {
     expect(fetch.mock.calls[0][0]).toBe("https://volley-staging.artsy.net/report")
     expect(fetch.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
-        "body": "{\\"serviceName\\":\\"eigen-staging\\",\\"metrics\\":[{\\"type\\":\\"increment\\",\\"name\\":\\"counter\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]}]}",
+        "body": "{\\"serviceName\\":\\"eigen\\",\\"metrics\\":[{\\"type\\":\\"increment\\",\\"name\\":\\"counter\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]}]}",
         "headers": Object {
           "Content-Type": "application/json",
         },
@@ -50,7 +50,7 @@ describe("volleyClient", () => {
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(fetch.mock.calls[0][1]).toMatchInlineSnapshot(`
       Object {
-        "body": "{\\"serviceName\\":\\"eigen-staging\\",\\"metrics\\":[{\\"type\\":\\"increment\\",\\"name\\":\\"counter one\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]},{\\"type\\":\\"increment\\",\\"name\\":\\"counter two\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]},{\\"type\\":\\"decrement\\",\\"name\\":\\"counter one\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]}]}",
+        "body": "{\\"serviceName\\":\\"eigen\\",\\"metrics\\":[{\\"type\\":\\"increment\\",\\"name\\":\\"counter one\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]},{\\"type\\":\\"increment\\",\\"name\\":\\"counter two\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]},{\\"type\\":\\"decrement\\",\\"name\\":\\"counter one\\",\\"tags\\":[\\"device:ios testDevice\\",\\"network:cellular\\",\\"effective_network:3g\\"]}]}",
         "headers": Object {
           "Content-Type": "application/json",
         },

--- a/src/app/utils/volleyClient.ts
+++ b/src/app/utils/volleyClient.ts
@@ -68,9 +68,6 @@ export type VolleyMetric =
 
 class VolleyClient {
   queue: VolleyMetric[] = []
-  get serviceName() {
-    return unsafe__getEnvironment().env === "staging" ? "eigen-staging" : "eigen"
-  }
   private _dispatch = throttle(
     () => {
       const metrics = this.queue
@@ -90,7 +87,7 @@ class VolleyClient {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          serviceName: this.serviceName,
+          serviceName: "eigen",
           metrics,
         }),
       }).catch(() => {


### PR DESCRIPTION
Following up https://github.com/artsy/eigen/pull/7480, I noticed that Eigen metrics are namespaced as `eigen.*` or `eigen_staging.*`. However, this environment info is already captured in the automatic `env:[production|staging]` tag. This PR simplifies the client code to use a single, consistent service name, in line with our other services.

Post-release, [this dashboard](https://app.datadoghq.com/dashboard/8pd-u65-pb3/eigen-graphql-load-times) will need modifying to separate by the `env` tag instead of the namespace.