### PR TITLE
refactor: remove `AREnableCreateArtworkAlert` feature flag since it was released

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -200,7 +204,7 @@
         "filename": "src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx",
         "hashed_secret": "ce1457b7dd97fa6c22518c6a5bf141e9d375fe8c",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 277
       }
     ],
     "src/app/Scenes/Artwork/Components/ContextCard.tests.tsx": [
@@ -1424,5 +1428,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-06T10:03:32Z"
+  "generated_at": "2022-10-18T13:50:25Z"
 }

--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -43,6 +43,7 @@ type ArtworkQueries =
 
 jest.unmock("react-relay")
 
+// TODO: remove the use of renderWithWrappersLEGACY
 jest.mock("app/Components/Bidding/Context/TimeOffsetProvider", () => {
   class TimeOffsetProvider extends require("react").Component {
     static childContextTypes = {
@@ -98,8 +99,6 @@ describe("Artwork", () => {
   beforeEach(() => {
     require("app/relay/createEnvironment").reset()
     environment = require("app/relay/createEnvironment").defaultEnvironment
-    // TODO: Remove it when AREnableCreateArtworkAlert flag is true in Echo
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: false })
   })
 
   afterEach(() => {
@@ -136,10 +135,16 @@ describe("Artwork", () => {
         Artwork() {
           return {
             artist: {
+              biographyBlurb: null,
               artistSeriesConnection: {
                 totalCount: 5,
               },
             },
+            // Hide some other sections
+            // otherwise arties series components will not be found
+            sale: null,
+            partner: null,
+            context: null,
           }
         },
       })
@@ -163,6 +168,11 @@ describe("Artwork", () => {
             artistSeriesConnection: {
               edges: [],
             },
+            // Hide some other sections
+            // otherwise arties series components will not be found
+            sale: null,
+            partner: null,
+            context: null,
           }
         },
       })
@@ -205,6 +215,11 @@ describe("Artwork", () => {
                 ],
               },
             },
+            // Hide some other sections
+            // otherwise arties series components will not be found
+            sale: null,
+            partner: null,
+            context: null,
           }
         },
       })
@@ -419,7 +434,9 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {},
+              {
+                isSold: false,
+              },
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationClosed,
               RegisteredBidder
@@ -439,7 +456,9 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {},
+              {
+                isSold: false,
+              },
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationClosed,
               NotRegisteredToBid
@@ -460,7 +479,9 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {},
+              {
+                isSold: false,
+              },
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationOpen,
               NotRegisteredToBid
@@ -478,10 +499,6 @@ describe("Artwork", () => {
   })
 
   describe("Partner Section", () => {
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: true })
-    })
-
     it("should not display partner link if CBN flag is on", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
 
@@ -516,10 +533,6 @@ describe("Artwork", () => {
   })
 
   describe("Create Alert button", () => {
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: true })
-    })
-
     it("should display create artwork alert section by default", () => {
       const { queryByLabelText } = renderWithWrappers(<TestRenderer />)
 

--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -434,9 +434,7 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {
-                isSold: false,
-              },
+              {},
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationClosed,
               RegisteredBidder
@@ -456,9 +454,7 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {
-                isSold: false,
-              },
+              {},
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationClosed,
               NotRegisteredToBid
@@ -479,9 +475,7 @@ describe("Artwork", () => {
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
           Artwork() {
             return merge(
-              {
-                isSold: false,
-              },
+              {},
               ArtworkFixture,
               ArtworkFromLiveAuctionRegistrationOpen,
               NotRegisteredToBid

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -66,7 +66,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const [refreshing, setRefreshing] = useState(false)
   const [fetchingData, setFetchingData] = useState(false)
   const enableConversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
-  const enableCreateArtworkAlert = useFeatureFlag("AREnableCreateArtworkAlert")
 
   const { internalID, slug, isInAuction, partner: partnerAbove } = artworkAboveTheFold || {}
   const { isPreview, isClosed, liveStartAt } = artworkAboveTheFold?.sale ?? {}
@@ -257,12 +256,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    if (
-      enableCreateArtworkAlert &&
-      !enableConversationalBuyNow &&
-      !!partnerAbove?.name &&
-      artworkAboveTheFold
-    ) {
+    if (!enableConversationalBuyNow && !!partnerAbove?.name && artworkAboveTheFold) {
       sections.push({
         key: "partnerSection",
         element: <PartnerLink artwork={artworkAboveTheFold} />,
@@ -283,7 +277,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
     }
 
     if (
-      enableCreateArtworkAlert &&
       !isEmpty(artworkAboveTheFold?.artists) &&
       !artworkAboveTheFold?.isSold &&
       !isInClosedAuction
@@ -295,10 +288,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    if (
-      !!(artworkAboveTheFold?.isAcquireable || artworkAboveTheFold?.isOfferable) &&
-      enableCreateArtworkAlert
-    ) {
+    if (!!(artworkAboveTheFold?.isAcquireable || artworkAboveTheFold?.isOfferable)) {
       sections.push({
         key: "faqSection",
         element: <FaqAndSpecialistSection artwork={artworkAboveTheFold} />,

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/FaqAndSpecialistSection.tests.tsx
@@ -1,0 +1,105 @@
+import { FaqAndSpecialistSectionTestsQuery } from "__generated__/FaqAndSpecialistSectionTestsQuery.graphql"
+import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { FaqAndSpecialistSectionFragmentContainer as FaqAndSpecialistSection } from "./FaqAndSpecialistSection"
+
+jest.unmock("react-relay")
+
+describe("FAQ and specialist BNMO links", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  const TestRenderer = () => (
+    <QueryRenderer<FaqAndSpecialistSectionTestsQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query FaqAndSpecialistSectionTestsQuery @relay_test_operation {
+          artwork(id: "artworkID") {
+            ...FaqAndSpecialistSection_artwork
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props }) => {
+        if (props?.artwork) {
+          return <FaqAndSpecialistSection artwork={props.artwork} />
+        }
+
+        return null
+      }}
+    />
+  )
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  it("does not render FAQ or ask a specialist links when isInquireable", () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isAcquireable: false,
+      isInquireable: true,
+      isForSale: true,
+      artists: [
+        {
+          name: "Santa",
+          isConsignable: true,
+        },
+      ],
+    }
+
+    const { queryByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => artwork,
+    })
+
+    expect(queryByText("Read our FAQ")).toBeNull()
+    expect(queryByText("ask a specialist")).toBeNull()
+  })
+
+  it("renders ask a specialist link when isAcquireable", () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isAcquireable: true,
+      isForSale: true,
+      isInquireable: true,
+      artists: [
+        {
+          name: "Santa",
+          isConsignable: true,
+        },
+      ],
+    }
+
+    const { queryByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => artwork,
+    })
+
+    expect(queryByText("Read our FAQ")).toBeTruthy()
+    expect(queryByText("ask a specialist")).toBeTruthy()
+  })
+
+  it("renders ask a specialist link when isOfferable", () => {
+    const artwork = {
+      ...ArtworkFixture,
+      isOfferable: true,
+      isForSale: true,
+      isInquireable: true,
+      artists: [{ name: "Santa", isConsignable: true }],
+    }
+
+    const { queryByText } = renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => artwork,
+    })
+
+    expect(queryByText("Read our FAQ")).toBeTruthy()
+    expect(queryByText("ask a specialist")).toBeTruthy()
+  })
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tests.tsx
@@ -4,14 +4,13 @@ import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ModalStack } from "app/navigation/ModalStack"
 import { navigate } from "app/navigation/navigate"
-import { __globalStoreTestUtils__, useSelectedTab } from "app/store/GlobalStore"
+import { useSelectedTab } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { CleanRelayFragment } from "app/utils/relayHelpers"
 import { ArtworkExtraLinks } from "./index"
 
 jest.mock("app/store/GlobalStore", () => ({
-  __globalStoreTestUtils__: jest.requireActual("app/store/GlobalStore").__globalStoreTestUtils__,
   GlobalStoreProvider: jest.requireActual("app/store/GlobalStore").GlobalStoreProvider,
   useSelectedTab: jest.fn(() => "home"),
   useFeatureFlag: jest.requireActual("app/store/GlobalStore").useFeatureFlag,
@@ -32,10 +31,6 @@ const getWrapper = ({
   )
 
 describe("ArtworkExtraLinks", () => {
-  beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: false })
-  })
-
   it("redirects to /sales when consignments link is clicked from outside of sell tab", () => {
     const artwork = {
       ...ArtworkFixture,
@@ -144,60 +139,6 @@ describe("ArtworkExtraLinks", () => {
       const { queryByText } = getWrapper({ artwork })
       expect(queryByText(/Want to sell a work by Santa?/)).toBeTruthy()
       expect(queryByText(/Consign with Artsy/)).toBeTruthy()
-    })
-  })
-
-  describe("FAQ and specialist BNMO links", () => {
-    it("does not render FAQ or ask a specialist links when isInquireable", () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: false,
-        isInquireable: true,
-        isForSale: true,
-        artists: [
-          {
-            name: "Santa",
-            isConsignable: true,
-          },
-        ],
-      }
-
-      const { queryByText } = getWrapper({ artwork })
-      expect(queryByText("Read our FAQ")).toBeNull()
-      expect(queryByText("ask a specialist")).toBeNull()
-    })
-
-    it("renders ask a specialist link when isAcquireable", () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: true,
-        isForSale: true,
-        isInquireable: true,
-        artists: [
-          {
-            name: "Santa",
-            isConsignable: true,
-          },
-        ],
-      }
-
-      const { queryByText } = getWrapper({ artwork })
-      expect(queryByText("Read our FAQ")).toBeTruthy()
-      expect(queryByText("ask a specialist")).toBeTruthy()
-    })
-
-    it("renders ask a specialist link when isOfferable", () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isOfferable: true,
-        isForSale: true,
-        isInquireable: true,
-        artists: [{ name: "Santa", isConsignable: true }],
-      }
-
-      const { queryByText } = getWrapper({ artwork })
-      expect(queryByText("Read our FAQ")).toBeTruthy()
-      expect(queryByText("ask a specialist")).toBeTruthy()
     })
   })
 
@@ -360,34 +301,6 @@ describe("ArtworkExtraLinks", () => {
             },
           ]
         `)
-      })
-    })
-
-    describe("AREnableCreateArtworkAlert is switched to true", () => {
-      beforeEach(() => {
-        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: true })
-      })
-
-      const TestRenderer = () =>
-        renderWithWrappers(
-          <ModalStack>
-            <ArtworkExtraLinks artwork={artwork as any} auctionState={AuctionTimerState.CLOSING} />
-          </ModalStack>
-        )
-
-      it("should not show the FaqAndSpecialistSection component", () => {
-        const { queryByText } = TestRenderer()
-
-        // Makes sure that no parts of the text references of the FaqAndSpecialistSection
-        // appear in the rendered component when ff - AREnableCreateArtworkAlert is true
-        expect(
-          queryByText("By placing a bid you agree to Artsy's and Christie's", { exact: false })
-        ).toBeTruthy()
-        expect(queryByText("Conditions of Sale")).toBeTruthy()
-        expect(queryByText("Have a question?", { exact: false })).toBeTruthy()
-        expect(queryByText("Read our auction FAQs")).toBeTruthy()
-        expect(queryByText("ask a specialist")).toBeTruthy()
-        expect(queryByText("Read our FAQ")).toBeNull()
       })
     })
   })

--- a/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkExtraLinks/index.tsx
@@ -1,14 +1,13 @@
 import { ArtworkExtraLinks_artwork$data } from "__generated__/ArtworkExtraLinks_artwork.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { navigate } from "app/navigation/navigate"
-import { useFeatureFlag, useSelectedTab } from "app/store/GlobalStore"
+import { useSelectedTab } from "app/store/GlobalStore"
 import { Schema } from "app/utils/track"
 import { Text } from "palette"
 import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { AuctionFaqSection } from "./AuctionFaqSection"
-import { FaqAndSpecialistSectionFragmentContainer as FaqAndSpecialistSection } from "./FaqAndSpecialistSection"
 
 export interface ArtworkExtraLinksProps {
   artwork: ArtworkExtraLinks_artwork$data
@@ -20,12 +19,9 @@ export const ArtworkExtraLinks: React.FC<ArtworkExtraLinksProps> = ({ artwork, a
   const consignableArtistsCount = artists.filter((artist) => artist?.isConsignable).length ?? 0
   const artistName = artists.length === 1 ? artists[0]!.name : null
 
-  const enableCreateArtworkAlert = useFeatureFlag("AREnableCreateArtworkAlert")
-
   return (
     <>
       <AuctionFaqSection artwork={artwork} auctionState={auctionState} />
-      {!enableCreateArtworkAlert && <FaqAndSpecialistSection artwork={artwork} />}
       {!!consignableArtistsCount && (
         <ConsignmentsLink
           artistName={consignableArtistsCount > 1 ? "these artists" : artistName ?? "this artist"}

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tests.tsx
@@ -13,11 +13,6 @@ import { CommercialButtons } from "./CommercialButtons/CommercialButtons"
 import { CommercialInformationTimerWrapper } from "./CommercialInformation"
 
 describe("CommercialInformation", () => {
-  beforeEach(() => {
-    // TODO: Remove it when AREnableCreateArtworkAlert flag is true in Echo
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: false })
-  })
-
   it("renders all information when the data is present", () => {
     const ForSaleArtwork = {
       ...CommercialInformationArtwork,
@@ -36,12 +31,10 @@ describe("CommercialInformation", () => {
     )
 
     expect(queryByText("For sale")).toBeTruthy()
-    expect(queryByText("From I'm a Gallery")).toBeTruthy()
     expect(queryByText("Consign with Artsy")).toBeTruthy()
   })
 
-  it("returns correct information with ff true and artworks is sold", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: true })
+  it("returns correct information when artworks is sold", () => {
     const ForSaleArtwork = {
       ...CommercialInformationArtwork,
       isSold: true,
@@ -61,8 +54,7 @@ describe("CommercialInformation", () => {
     expect(queryByText("Sold")).toBeTruthy()
   })
 
-  it("returns correct information for auction works when the auction has ended and ff true", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: true })
+  it("returns correct information for auction works when the auction has ended", () => {
     const Artwork = {
       ...CommercialInformationArtwork,
       isInAuction: true,
@@ -258,26 +250,6 @@ describe("CommercialInformation", () => {
     expect(queryByText("For sale")).toBeNull()
     expect(queryByText("I'm a Gallery")).toBeNull()
     expect(queryByText("Consign with Artsy.")).toBeNull()
-  })
-
-  it("renders seller info correctly for non-commercial works", () => {
-    const CommercialInformationArtworkNonCommercial = {
-      ...CommercialInformationArtwork,
-      availability: null,
-      isForSale: false,
-    }
-
-    const { queryByText } = renderWithWrappers(
-      <ModalStack>
-        <CommercialInformationTimerWrapper
-          artwork={CommercialInformationArtworkNonCommercial as any}
-          me={{ identityVerified: false } as any}
-          refetchArtwork={jest.fn()}
-        />
-      </ModalStack>
-    )
-
-    expect(queryByText("At I'm a Gallery")).toBeTruthy()
   })
 
   it("renders consign with Artsy text", () => {

--- a/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialInformation.tsx
@@ -156,7 +156,6 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
   setAuctionTimerState,
 }) => {
   const { trackEvent } = useTracking()
-  const enableCreateArtworkAlert = useFeatureFlag("AREnableCreateArtworkAlert")
   const [editionSetID, setEditionSetID] = useState<string | null>(null)
   const { isAcquireable, isOfferable, isInquireable, isInAuction, sale, isForSale, isSold } =
     artwork
@@ -169,8 +168,7 @@ export const CommercialInformation: React.FC<CommercialInformationProps> = ({
     isInAuction && sale && timerState !== AuctionTimerState.CLOSED && isForSale
   const canTakeCommercialAction =
     isAcquireable || isOfferable || isInquireable || isBiddableInAuction
-  const shouldShowCreateArtworkAlertButton =
-    enableCreateArtworkAlert && (isSold || isInClosedAuction)
+  const shouldShowCreateArtworkAlertButton = isSold || isInClosedAuction
 
   useEffect(() => {
     const artworkIsInActiveAuction = artwork.isInAuction && timerState !== AuctionTimerState.CLOSED

--- a/src/app/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialPartnerInformation.tests.tsx
@@ -35,7 +35,6 @@ describe("CommercialPartnerInformation", () => {
   }
 
   beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCreateArtworkAlert: false })
     mockEnvironment = createMockEnvironment()
   })
 
@@ -46,7 +45,6 @@ describe("CommercialPartnerInformation", () => {
       Artwork: () => CommercialPartnerInformationArtwork,
     })
 
-    expect(getByText("From Bob's Gallery")).toBeTruthy()
     expect(getByText("Ships from Brooklyn")).toBeTruthy()
     expect(getByText("Ships within the continental USA")).toBeTruthy()
     expect(getByText("VAT included in price")).toBeTruthy()
@@ -64,46 +62,6 @@ describe("CommercialPartnerInformation", () => {
     expect(queryByText("VAT included in price")).toBeFalsy()
   })
 
-  it("hides shipping info for works from closed auctions", () => {
-    const CommercialPartnerInformationArtworkClosedAuction = {
-      ...CommercialPartnerInformationArtwork,
-      availability: "not for sale",
-      isForSale: false,
-      isOfferable: false,
-      isAcquireable: false,
-    }
-    const { queryByText } = renderWithWrappers(<TestWrapper />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => CommercialPartnerInformationArtworkClosedAuction,
-    })
-
-    expect(queryByText("At Bob's Gallery")).toBeTruthy()
-    expect(queryByText("Ships from Brooklyn")).toBeFalsy()
-    expect(queryByText("Ships within the continental USA")).toBeFalsy()
-    expect(queryByText("VAT included in price")).toBeFalsy()
-  })
-
-  it("hides shipping information for sold works", () => {
-    const CommercialPartnerInformationSoldArtwork = {
-      ...CommercialPartnerInformationArtwork,
-      availability: "sold",
-      isForSale: false,
-      isOfferable: false,
-      isAcquireable: false,
-    }
-    const { queryByText } = renderWithWrappers(<TestWrapper />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => CommercialPartnerInformationSoldArtwork,
-    })
-
-    expect(queryByText("From Bob's Gallery")).toBeTruthy()
-    expect(queryByText("Ships from Brooklyn")).toBeFalsy()
-    expect(queryByText("Ships within the continental USA")).toBeFalsy()
-    expect(queryByText("VAT included in price")).toBeFalsy()
-  })
-
   it("Hides shipping/tax information if the work is not enabled for buy now or make offer", () => {
     const CommercialPartnerInformationNoEcommerce = {
       ...CommercialPartnerInformationArtwork,
@@ -116,27 +74,6 @@ describe("CommercialPartnerInformation", () => {
       Artwork: () => CommercialPartnerInformationNoEcommerce,
     })
 
-    expect(queryByText("From Bob's Gallery")).toBeTruthy()
-    expect(queryByText("Ships from Brooklyn")).toBeFalsy()
-    expect(queryByText("Ships within the continental USA")).toBeFalsy()
-    expect(queryByText("VAT included in price")).toBeFalsy()
-  })
-
-  it("Says 'At Gallery Name' instead of 'From Gallery Name' and hides shipping info for non-commercial works", () => {
-    const Artwork = {
-      ...CommercialPartnerInformationArtwork,
-      availability: null,
-      isForSale: false,
-      isOfferable: false,
-      isAcquireable: false,
-    }
-    const { queryByText } = renderWithWrappers(<TestWrapper />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => Artwork,
-    })
-
-    expect(queryByText("At Bob's Gallery")).toBeTruthy()
     expect(queryByText("Ships from Brooklyn")).toBeFalsy()
     expect(queryByText("Ships within the continental USA")).toBeFalsy()
     expect(queryByText("VAT included in price")).toBeFalsy()
@@ -144,9 +81,7 @@ describe("CommercialPartnerInformation", () => {
 })
 
 const CommercialPartnerInformationArtwork = {
-  availability: "for sale",
   isAcquireable: true,
-  isForSale: true,
   isOfferable: false,
   shippingOrigin: "Brooklyn",
   shippingInfo: "Ships within the continental USA",

--- a/src/app/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialPartnerInformation.tsx
@@ -9,40 +9,26 @@ interface Props {
 }
 
 export const CommercialPartnerInformation: React.FC<Props> = ({ artwork }) => {
-  const artworkIsSold = artwork.availability && artwork.availability === "sold"
   const artworkEcommerceAvailable = artwork.isAcquireable || artwork.isOfferable
   const showsSellerInfo = artwork.partner && artwork.partner.name
-  const availabilityDisplayText = artwork.isForSale || artworkIsSold ? "From" : "At"
   const avalaraPhase2 = useFeatureFlag("AREnableAvalaraPhase2")
-  const enableCreateArtworkAlert = useFeatureFlag("AREnableCreateArtworkAlert")
   const shouldRenderShipsFromLabel = artworkEcommerceAvailable && !!artwork.shippingOrigin
   const shouldRenderShippingInfoLabel = artworkEcommerceAvailable && !!artwork.shippingInfo
   const shouldRenderPriceTaxLabel =
     artworkEcommerceAvailable && !!artwork.priceIncludesTaxDisplay && !avalaraPhase2
-
-  if (!showsSellerInfo) {
-    return null
-  }
-
   const shouldRenderLabels =
     avalaraPhase2 ||
-    !enableCreateArtworkAlert ||
     shouldRenderShipsFromLabel ||
     shouldRenderShippingInfoLabel ||
     shouldRenderPriceTaxLabel
 
-  if (!shouldRenderLabels) {
+  if (!showsSellerInfo || !shouldRenderLabels) {
     return null
   }
 
   return (
     <>
       <Spacer mb={1} />
-      {!enableCreateArtworkAlert && (
-        <Text variant="xs" color="black60">
-          {availabilityDisplayText} {artwork.partner!.name}
-        </Text>
-      )}
       {avalaraPhase2 && (
         <Text variant="xs" color="black60">
           Taxes may apply at checkout.{" "}
@@ -81,9 +67,7 @@ export const CommercialPartnerInformationFragmentContainer = createFragmentConta
   {
     artwork: graphql`
       fragment CommercialPartnerInformation_artwork on Artwork {
-        availability
         isAcquireable
-        isForSale
         isOfferable
         shippingOrigin
         shippingInfo

--- a/src/app/__fixtures__/ArtworkBidAction.ts
+++ b/src/app/__fixtures__/ArtworkBidAction.ts
@@ -80,6 +80,7 @@ export const ArtworkFromTimedAuctionRegistrationClosed = {
 export const ArtworkFromLiveAuctionRegistrationOpen = {
   ...InAuctionForSale,
   internalID: "artwork_from_open_live_auction_open_registration",
+  isSold: false,
   sale: {
     isAuction: true,
     registrationStatus: null,
@@ -108,6 +109,7 @@ export const ArtworkFromLiveAuctionRegistrationOpen = {
 export const ArtworkFromLiveAuctionRegistrationClosed = {
   ...InAuctionForSale,
   internalID: "artwork_from_open_live_auction_closed_registration",
+  isSold: false,
   sale: {
     isAuction: true,
     registrationStatus: null,

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -249,12 +249,6 @@ export const features = defineFeatures({
     description: "Enable My Collection artworks from non-Artsy artists",
     showInAdminMenu: true,
   },
-  AREnableCreateArtworkAlert: {
-    readyForRelease: true,
-    description: "Enable Create Alert on Artwork pages",
-    showInAdminMenu: true,
-    echoFlagKey: "AREnableCreateArtworkAlert",
-  },
   AREnableNewOnboarding: {
     readyForRelease: true,
     description: "Enable new Onboarding flow 2022",


### PR DESCRIPTION
<!--
➡️ Use a PR title in the form of  `type(PROJECT-XXXX): what changed`
➡️ Provide the Jira ticket in square brackets like [PROJECT-XXXX]

❗️ If this is a work in progress, remember to prefix it with [WIP] and/or open a draft PR instead of normal PR
-->

This PR resolves []

### Description
remove `AREnableCreateArtworkAlert` feature flag since it was released. Also these changes will be useful for [Reorganize Mobile Artwork Screen](https://artsyproduct.atlassian.net/browse/FX-4272) epic

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### QA Testing

<!-- Please provide information on how to test this PR.
These tests will be run in recent changes QA, they do not have to be extensive, just a high level feature sanity check, you should do your own extensive QA with your team. -->

#### Acceptance Criteria

-

#### Setup Instructions

-

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- remove `AREnableCreateArtworkAlert` feature flag since it was released - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
