### PR TITLE
feat: Add Braze content cards to home feed GRO-1323

### DIFF
--- a/src/app/Scenes/Home/Components/ContentCards.tsx
+++ b/src/app/Scenes/Home/Components/ContentCards.tsx
@@ -1,0 +1,110 @@
+import { Box, Button, Flex, Spacer, Text, Touchable } from "palette"
+import ReactAppboy from "react-native-appboy-sdk"
+import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import { navigate } from "app/navigation/navigate"
+import { useScreenDimensions } from "shared/hooks"
+import { FlatList } from "react-native"
+import React, { useCallback, useEffect, useState } from "react"
+import { PaginationDots } from "./PaginationDots"
+
+interface CardProps {
+  item: ReactAppboy.CaptionedContentCard
+}
+
+const ContentCard: React.FC<CardProps> = ({ item }) => {
+  const { width: screenWidth } = useScreenDimensions()
+  const height = 250
+  const imageWidth = 125
+  const handlePress = () => {
+    ReactAppboy.logContentCardClicked(item.id)
+    item.url && navigate(item.url)
+  }
+
+  return (
+    <Touchable key={item.id} onPress={handlePress}>
+      <Flex bg="black100" flexDirection="row" height={height} width={screenWidth}>
+        <OpaqueImageView
+          height={height}
+          imageURL={item.image}
+          resizeMode="cover"
+          width={imageWidth}
+        />
+        <Box p={2} width={screenWidth - imageWidth}>
+          <Text color="white100" mb={1} numberOfLines={2} variant="lg-display">
+            {item.title}
+          </Text>
+          <Text color="white100" mb={2} numberOfLines={3}>
+            {item.cardDescription}
+          </Text>
+          <Button size="small" variant="outlineLight" onPress={handlePress}>
+            {item.domain}
+          </Button>
+        </Box>
+      </Flex>
+    </Touchable>
+  )
+}
+
+export const ContentCards: React.FC = () => {
+  const [cards, setCards] = useState([] as ReactAppboy.CaptionedContentCard[])
+  const [currentCardIndex, setCurrentCardIndex] = useState(0)
+  const [viewedCards, setViewedCards] = useState([] as ReactAppboy.CaptionedContentCard[])
+
+  useEffect(() => {
+    const eventName = ReactAppboy.Events.CONTENT_CARDS_UPDATED
+    const callback = async () => {
+      const updatedCards = await ReactAppboy.getContentCards()
+      const sortedCards = updatedCards.sort((lhs, rhs) =>
+        lhs.extras.position > rhs.extras.position ? 1 : -1
+      )
+      setCards(sortedCards as ReactAppboy.CaptionedContentCard[])
+    }
+
+    const listener = ReactAppboy.addListener(eventName, callback)
+    ReactAppboy.requestContentCardsRefresh()
+
+    return () => {
+      listener.remove()
+    }
+  }, [])
+
+  const handleViewableItemsChanged = useCallback(
+    (viewable) => {
+      const viewableCards = viewable.viewableItems.map(
+        (viewableItem: any) => viewableItem.item
+      ) as ReactAppboy.CaptionedContentCard[]
+      const lastShown = viewableCards[viewableCards.length - 1]
+      const newCardIndex = cards.findIndex((card) => card.id === lastShown.id)
+      setCurrentCardIndex(newCardIndex)
+      const filteredCards = viewableCards.filter((card) => !viewedCards.includes(card))
+      if (filteredCards.length === 0) return
+
+      filteredCards.forEach((card) => ReactAppboy.logContentCardImpression(card.id))
+      setViewedCards([...viewedCards, ...filteredCards])
+    },
+    [cards]
+  )
+
+  const { width } = useScreenDimensions()
+
+  if (cards.length < 1) return null
+
+  return (
+    <>
+      <FlatList
+        data={cards}
+        decelerationRate="fast"
+        horizontal
+        keyExtractor={(item) => item.id}
+        onViewableItemsChanged={handleViewableItemsChanged}
+        renderItem={({ item }) => <ContentCard item={item} />}
+        snapToAlignment="start"
+        snapToInterval={width}
+        viewabilityConfig={{ itemVisiblePercentThreshold: 25 }}
+      />
+      <Spacer mb={2} />
+      <PaginationDots currentIndex={currentCardIndex} length={cards.length} />
+      <Spacer mb={2} />
+    </>
+  )
+}

--- a/src/app/Scenes/Home/Components/PaginationDots.tsx
+++ b/src/app/Scenes/Home/Components/PaginationDots.tsx
@@ -1,0 +1,43 @@
+import { Flex } from "palette"
+import { Animated } from "react-native"
+
+interface PaginationDotProps {
+  active: boolean
+}
+
+const PaginationDot: React.FC<PaginationDotProps> = (props) => {
+  const { active } = props
+  const opacity = active ? 1 : 0.1
+  const diameter = 5
+
+  return (
+    <Animated.View
+      accessibilityLabel="Image Pagination Indicator"
+      style={{
+        backgroundColor: "black",
+        borderRadius: diameter / 2,
+        height: diameter,
+        marginHorizontal: diameter * 0.8,
+        opacity,
+        width: diameter,
+      }}
+    />
+  )
+}
+
+interface PaginationDotsProps {
+  currentIndex: number
+  length: number
+}
+
+export const PaginationDots: React.FC<PaginationDotsProps> = (props) => {
+  const { currentIndex, length } = props
+
+  return (
+    <Flex flexDirection="row" justifyContent="center">
+      {Array.from(Array(length)).map((_, index) => (
+        <PaginationDot active={currentIndex === index} key={index} />
+      ))}
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -46,7 +46,6 @@ import { ArtworkRecommendationsRail } from "./Components/ArtworkRecommendationsR
 import { HomeHeader } from "./Components/HomeHeader"
 import { NewWorksForYouRail } from "./Components/NewWorksForYouRail"
 import { ShowsRailFragmentContainer } from "./Components/ShowsRail"
-import { TroveFragmentContainer } from "./Components/Trove"
 import { RailScrollRef } from "./Components/types"
 
 const MODULE_SEPARATOR_HEIGHT = 6
@@ -148,7 +147,6 @@ const Home = (props: Props) => {
       type: "shows",
       data: showsByFollowedArtists,
     },
-    { title: "Trove", type: "trove", data: homePageBelow },
     {
       title: "Viewing Rooms",
       type: "viewing-rooms",
@@ -316,9 +314,6 @@ const Home = (props: Props) => {
                     mb={MODULE_SEPARATOR_HEIGHT}
                   />
                 )
-
-              case "trove":
-                return <TroveFragmentContainer trove={item.data} mb={MODULE_SEPARATOR_HEIGHT} />
               case "viewing-rooms":
                 return (
                   <ViewingRoomsHomeMainRail
@@ -387,8 +382,7 @@ export const HomeFragmentContainer = createRefetchContainer(
     `,
     // Make sure to exclude all modules that are part of "homePageAbove"
     homePageBelow: graphql`
-      fragment Home_homePageBelow on HomePage
-      @argumentDefinitions(heroImageVersion: { type: "HomePageHeroUnitImageVersion" }) {
+      fragment Home_homePageBelow on HomePage @argumentDefinitions {
         recentlyViewedWorksArtworkModule: artworkModule(key: RECENTLY_VIEWED_WORKS) {
           id
           ...ArtworkModuleRail_rail
@@ -407,7 +401,6 @@ export const HomeFragmentContainer = createRefetchContainer(
         marketingCollectionsModule {
           ...CollectionsRail_collectionsModule
         }
-        ...Trove_trove @arguments(heroImageVersion: $heroImageVersion)
       }
     `,
     meAbove: graphql`
@@ -446,12 +439,12 @@ export const HomeFragmentContainer = createRefetchContainer(
     `,
   },
   graphql`
-    query HomeRefetchQuery($heroImageVersion: HomePageHeroUnitImageVersion!) {
+    query HomeRefetchQuery {
       homePage @optionalField {
         ...Home_homePageAbove
       }
       homePageBelow: homePage @optionalField {
-        ...Home_homePageBelow @arguments(heroImageVersion: $heroImageVersion)
+        ...Home_homePageBelow
       }
       me @optionalField {
         ...Home_meAbove
@@ -639,12 +632,12 @@ export const HomeQueryRenderer: React.FC = () => {
       }}
       below={{
         query: graphql`
-          query HomeBelowTheFoldQuery($heroImageVersion: HomePageHeroUnitImageVersion) {
+          query HomeBelowTheFoldQuery {
             newWorksForYou: viewer @optionalField {
               ...Home_newWorksForYou
             }
             homePage @optionalField {
-              ...Home_homePageBelow @arguments(heroImageVersion: $heroImageVersion)
+              ...Home_homePageBelow
             }
             featured: viewingRooms(featured: true) @optionalField {
               ...Home_featured

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -47,6 +47,7 @@ import { HomeHeader } from "./Components/HomeHeader"
 import { NewWorksForYouRail } from "./Components/NewWorksForYouRail"
 import { ShowsRailFragmentContainer } from "./Components/ShowsRail"
 import { RailScrollRef } from "./Components/types"
+import { ContentCards } from "./Components/ContentCards"
 
 const MODULE_SEPARATOR_HEIGHT = 6
 
@@ -106,6 +107,12 @@ const Home = (props: Props) => {
       type: "newWorksForYou",
       data: newWorksForYou,
       prefetchUrl: "/new-works-for-you",
+    },
+    {
+      title: "",
+      type: "contentCards",
+      data: {},
+      prefetchUrl: "",
     },
     { title: "Your Active Bids", type: "artwork", data: homePageAbove?.activeBidsArtworkModule },
     {
@@ -209,6 +216,8 @@ const Home = (props: Props) => {
             }
 
             switch (item.type) {
+              case "contentCards":
+                return <ContentCards />
               case "articles":
                 return (
                   <ArticlesRailFragmentContainer


### PR DESCRIPTION
After some tinkering and getting feedback, I've landed here for getting Braze Content Cards in the app:

<img width="402" alt="Screen Shot 2022-10-18 at 2 44 26 PM" src="https://user-images.githubusercontent.com/79799/196528749-b4bd48d3-eb6d-45d4-9de1-60115f480abe.png">

They are coming in below the New Works For You rail and match this Figma file:

https://www.figma.com/file/k465puwy6YQOcEESEkppni/Smaller-Tasks-2022?node-id=317%3A2415

The first commit here removes the Trove item from the homefeed because that will morph into one of these content cards instead.

Next, my approach to adding the content cards was to mostly follow the ideas in this integration doc from them:

https://www.braze.com/docs/developer_guide/platform_integration_guides/react_native/content_cards/

And in terms of the Home component looks like this:

* add an item to the `modules` list for content cards
* add a `ContentCards` component to the switch statement on Home

This ContentCards component starts life as `null` and only pops in after an async call into the Braze sdk. In a `useEffect` hook I setup an event listener and then trigger it with a call to `ReactAppboy.requestContentCardsRefresh()`. Once this is resolved then I can update the state and cause a render with the cards array populated. If a user is not eligible for any cards, the homefeed will continue to NOT have this rail. This populating of the rail with content is done in the Braze dashboard and is outside the scope of this PR.

Ok so we have the cards array - next up we use a FlatList to horizontally render them and move onto a few more responsibilities:

* we have to register an impression as the user swipes through the cards
* we have to register a "click" when the user taps on a card

Those are just sdk function calls inside of handlers.

Last up was dealing with the indicator that there are more cards to look at. This is the bit underneath with the dots. I asked @pvinis and @brainbicycle about this and found that we have something in Palette for this:

https://palette.artsy.net/elements/progressdots/

But this is not in Eigen. Instead the closest we were able to find was the indicator in the artwork screen:

https://github.com/artsy/eigen/blob/main/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselPaginationIndicator.tsx

So I pondered adapting that code but in the end I just copy/pasted it over to this area and altered it to suite my needs. I'd love to improve this! Maybe I could extract a parent component so that we can use this elsewhere in Eigen? I'd also love to do the variant with the lines rather than the dots so that I could more closely match the Figma. But my feeling is that I can do all that type of work after landing this PR - what do you think?

https://artsyproduct.atlassian.net/browse/GRO-1323

/cc @artsy/grow-devs @kathytafel 