### PR TITLE
chore(CX-3015): cleanup AREnableNotFoundFailureView

### DIFF
--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -1,5 +1,4 @@
 import { captureMessage } from "@sentry/react-native"
-import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import React, { Component } from "react"
 import { LoadFailureView } from "./LoadFailureView"
 import { NotFoundFailureView } from "./NotFoundFailureView"
@@ -77,8 +76,6 @@ export class RetryErrorBoundary extends Component<
       this.props
     const { error } = this.state
 
-    const enableNotFoundFailureView = unsafe_getFeatureFlag("AREnableNotFoundFailureView")
-
     if (error) {
       if (failureView) {
         return failureView({ error, retry: this._retry })
@@ -86,7 +83,7 @@ export class RetryErrorBoundary extends Component<
 
       const isNotFoundError = getErrorHttpStatusCodes(error).includes(404)
 
-      if (isNotFoundError && enableNotFoundFailureView) {
+      if (isNotFoundError) {
         return (
           <NotFoundFailureView
             title={notFoundTitle}

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -238,12 +238,6 @@ export const features = defineFeatures({
     showInAdminMenu: true,
     echoFlagKey: "AREnableMedianPriceChartCareerHighlights",
   },
-  AREnableNotFoundFailureView: {
-    readyForRelease: true,
-    description: "Enable Not Found Failure View",
-    showInAdminMenu: true,
-    echoFlagKey: "AREnableNotFoundFailureView",
-  },
   AREnableArtworksFromNonArtsyArtists: {
     readyForRelease: false,
     description: "Enable My Collection artworks from non-Artsy artists",

--- a/src/app/utils/renderWithPlaceholder.tsx
+++ b/src/app/utils/renderWithPlaceholder.tsx
@@ -3,7 +3,6 @@ import { QueryRenderer } from "react-relay"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { NotFoundFailureView } from "app/Components/NotFoundFailureView"
 import { getErrorHttpStatusCodes } from "app/Components/RetryErrorBoundary"
-import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import { ProvidePlaceholderContext } from "./placeholders"
 
 type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
@@ -56,11 +55,9 @@ export function renderWithPlaceholder<Props>({
         console.error("Error data", data)
       }
 
-      const enableNotFoundFailureView = unsafe_getFeatureFlag("AREnableNotFoundFailureView")
-
       const isNotFoundError = getErrorHttpStatusCodes(error).includes(404)
 
-      if (isNotFoundError && enableNotFoundFailureView && showNotFoundView) {
+      if (isNotFoundError && showNotFoundView) {
         return <NotFoundFailureView error={error} />
       }
 


### PR DESCRIPTION
This PR resolves [CX-3015] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- cleanup AREnableNotFoundFailureView -daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3015]: https://artsyproduct.atlassian.net/browse/CX-3015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ