### PR TITLE
feat(CX-3001): Ensure Previously requested price estimate flow does not break

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
@@ -47,6 +47,7 @@ describe("RequestForPriceEstimateBanner", () => {
 
   beforeEach(() => {
     mockEnvironment = createMockEnvironment()
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewRequestPriceEstimateLogic: true })
   })
 
   afterEach(() => {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
@@ -51,6 +51,7 @@ describe("RequestForPriceEstimateBanner", () => {
 
   afterEach(() => {
     jest.clearAllMocks()
+    __globalStoreTestUtils__?.reset()
   })
 
   const resolveData = (passedProps = {}) => {
@@ -71,12 +72,13 @@ describe("RequestForPriceEstimateBanner", () => {
     expect(getByTestId("request-price-estimate-banner-description")).toBeDefined()
   })
 
-  it("renders 'requested' state without throwing an error", () => {
+  it("renders 'requested' state if in global store without throwing an error", () => {
     const { getByText } = renderWithWrappers(<TestRenderer />)
     resolveData({
       Artwork: () => ({
         internalID: "artwork-id",
         slug: "artwork-id",
+        hasPriceEstimateRequest: null,
       }),
       MarketPriceInsights: () => ({
         demandRank: 7.5,
@@ -91,6 +93,21 @@ describe("RequestForPriceEstimateBanner", () => {
           },
         },
       },
+    })
+    expect(getByText("Price Estimate Request Sent")).toBeDefined()
+  })
+
+  it("renders 'requested' state if hasPriceEstimateRequest is true", () => {
+    const { getByText } = renderWithWrappers(<TestRenderer />)
+    resolveData({
+      Artwork: () => ({
+        internalID: "artwork-id",
+        slug: "artwork-id",
+        hasPriceEstimateRequest: true,
+      }),
+      MarketPriceInsights: () => ({
+        demandRank: 7.5,
+      }),
     })
     expect(getByText("Price Estimate Request Sent")).toBeDefined()
   })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
@@ -4,7 +4,7 @@ import { RequestForPriceEstimateBanner_marketPriceInsights$key } from "__generat
 import { RequestForPriceEstimateBanner_me$key } from "__generated__/RequestForPriceEstimateBanner_me.graphql"
 import { Toast } from "app/Components/Toast/Toast"
 import { navigate } from "app/navigation/navigate"
-import { GlobalStore } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { Box, Button, Flex, Separator, Text, WinningBidIcon } from "palette"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -26,12 +26,17 @@ export const RequestForPriceEstimateBanner: React.FC<RequestForPriceEstimateProp
 
   const me = useFragment(meFragment, otherProps.me)
 
+  const enableRemotePriceEstimateRequestedLogic = useFeatureFlag(
+    "AREnableNewRequestPriceEstimateLogic"
+  )
+
   const localRequestedPriceEstimates = GlobalStore.useAppState(
     (state) => state.requestedPriceEstimates.requestedPriceEstimates
   )
 
   const priceEstimateRequested =
-    artwork.hasPriceEstimateRequest || !!localRequestedPriceEstimates[artwork.internalID]
+    (enableRemotePriceEstimateRequestedLogic && artwork.hasPriceEstimateRequest) ||
+    !!localRequestedPriceEstimates[artwork.internalID]
 
   if (priceEstimateRequested) {
     return (

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
@@ -26,11 +26,12 @@ export const RequestForPriceEstimateBanner: React.FC<RequestForPriceEstimateProp
 
   const me = useFragment(meFragment, otherProps.me)
 
-  const requestedPriceEstimates = GlobalStore.useAppState(
+  const localRequestedPriceEstimates = GlobalStore.useAppState(
     (state) => state.requestedPriceEstimates.requestedPriceEstimates
   )
 
-  const priceEstimateRequested = !!requestedPriceEstimates[artwork.internalID]
+  const priceEstimateRequested =
+    artwork.hasPriceEstimateRequest || !!localRequestedPriceEstimates[artwork.internalID]
 
   if (priceEstimateRequested) {
     return (
@@ -100,6 +101,7 @@ const artworkFragment = graphql`
   fragment RequestForPriceEstimateBanner_artwork on Artwork {
     internalID
     slug
+    hasPriceEstimateRequest
   }
 `
 


### PR DESCRIPTION
This PR resolves [CX-3001] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
- Before we successfully migrate previously requested price estimate to the Gravity DB, there is need to ensure that on Eigen the logic that relies on locally stored records of requests works in parity with the remote db stored ones. This entails that if there is no record of request from the Gravity, then fall back on the local one.

<img src="https://user-images.githubusercontent.com/18648835/196937987-c76458f7-09ab-4812-a0c2-eaaa83917889.png" width="50%" />
### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Ensure Previously requested price estimate flow does not break - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3001]: https://artsyproduct.atlassian.net/browse/CX-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ