### PR TITLE
feat(FX-4385): Hide activity panel notifications without artworks

### DIFF
--- a/src/app/Scenes/Activity/utils/isArtworksBasedNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/isArtworksBasedNotification.tests.ts
@@ -1,0 +1,16 @@
+import { isArtworksBasedNotification } from "./isArtworksBasedNotification"
+
+describe("isArtworksBasedNotification", () => {
+  it("returns true when notification is artworks based", () => {
+    const result = isArtworksBasedNotification("ARTWORK_ALERT")
+    expect(result).toEqual(true)
+
+    const result2 = isArtworksBasedNotification("ARTWORK_PUBLISHED")
+    expect(result2).toEqual(true)
+  })
+
+  it("returns false for all other notification types", () => {
+    const result = isArtworksBasedNotification("VIEWING_ROOM_PUBLISHED")
+    expect(result).toEqual(false)
+  })
+})

--- a/src/app/Scenes/Activity/utils/isArtworksBasedNotification.ts
+++ b/src/app/Scenes/Activity/utils/isArtworksBasedNotification.ts
@@ -1,0 +1,3 @@
+export const isArtworksBasedNotification = (notificationType: string) => {
+  return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)
+}


### PR DESCRIPTION
This PR resolves [FX-4385] <!-- eg [PROJECT-XXXX] -->

Related Force PR: artsy/force#11164

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Hide activity panel notifications without artworks - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4385]: https://artsyproduct.atlassian.net/browse/FX-4385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ