### PR TITLE
fix: broken tap areas in widget GRO-1348

### DIFF
--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -10,16 +10,19 @@ extension LatestArticles {
         var body: some SwiftUI.View {
             let artsyLogo = UIImage(named: "BlackArtsyLogo")!
             let articles = entry.articles
+            let artsyUrl = WidgetUrl.from(link: "https://www.artsy.net")!
             
             VStack() {
                 HStack(alignment: .center) {
-                    Text("LATEST ARTICLES")
-                        .foregroundColor(.black)
-                        .font(.system(size: 14, weight: .medium))
-                    Spacer()
-                    Image(uiImage: artsyLogo)
-                        .resizable()
-                        .frame(width: 20, height: 20)
+                    Link(destination: artsyUrl) {
+                        Text("LATEST ARTICLES")
+                            .foregroundColor(.black)
+                            .font(.system(size: 14, weight: .medium))
+                        Spacer()
+                        Image(uiImage: artsyLogo)
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                    }
                 }
                 Spacer()
                 VStack() {

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -10,16 +10,19 @@ extension LatestArticles {
         var body: some SwiftUI.View {
             let artsyLogo = UIImage(named: "BlackArtsyLogo")!
             let articles = entry.articles[0...1]
+            let artsyUrl = WidgetUrl.from(link: "https://www.artsy.net")!
             
             VStack() {
                 HStack(alignment: .center) {
-                    Text("LATEST ARTICLES")
-                        .foregroundColor(.black)
-                        .font(.system(size: 10, weight: .medium))
-                    Spacer()
-                    Image(uiImage: artsyLogo)
-                        .resizable()
-                        .frame(width: 20, height: 20)
+                    Link(destination: artsyUrl) {
+                        Text("LATEST ARTICLES")
+                            .foregroundColor(.black)
+                            .font(.system(size: 10, weight: .medium))
+                        Spacer()
+                        Image(uiImage: artsyLogo)
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                    }
                 }
                 Spacer()
                 VStack() {


### PR DESCRIPTION
Something I had not considered is what the widget does when you tap on areas that are not wrapped with a link. Turns out the app will crash if I don't tell it what to do!

So with this PR all I'm doing is wrapping the "Latest Articles" text and the artsy logo in links directing the user to the home feed.

https://artsyproduct.atlassian.net/browse/GRO-1348

/cc @artsy/grow-devs 