### PR TITLE
fix: Back button on MyC artwork screen

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -51,6 +51,11 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
     )
   }
 
+  const handleGoBack = () => {
+    // Navigating back to the MyCollection tab on the profile screen
+    navigate("/my-profile")
+  }
+
   const handleEdit = useCallback(() => {
     trackEvent(tracks.editCollectedArtwork(data.artwork!.internalID, data.artwork!.slug))
     GlobalStore.actions.myCollection.artwork.startEditingArtwork(data.artwork as any)
@@ -96,7 +101,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
   return (
     <>
       <FancyModalHeader
-        onLeftButtonPress={goBack}
+        onLeftButtonPress={handleGoBack}
         rightButtonText="Edit"
         onRightButtonPress={handleEdit}
         hideBottomDivider


### PR DESCRIPTION
This PR resolves [CX-3079] <!-- eg [PROJECT-XXXX] -->

### Description

To prevent landing on the Request Price Estimate confirmation screen when pressing the back button on the MyC artwork screen, this PR changes the logic of the back button to always navigate the user to the My Collection overview.


💁 Not sure if there is a better fix for this bug. Please let me know if you have any ideas! 



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3079]: https://artsyproduct.atlassian.net/browse/CX-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ