### PR TITLE
fix(Request Price Estimate): fix back gesture and back button handling

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tests.tsx
@@ -1,14 +1,11 @@
 import { act, fireEvent } from "@testing-library/react-native"
-import { navigate } from "app/navigation/navigate"
+import { popToRoot } from "app/navigation/navigate"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { RequestForPriceEstimateConfirmationScreen } from "./RequestForPriceEstimateConfirmationScreen"
 
 describe("RequestForPriceEstimateConfirmationScreen", () => {
-  const props = {
-    artworkID: "artworkId",
-  }
   const getWrapper = () => {
-    return renderWithWrappers(<RequestForPriceEstimateConfirmationScreen {...props} />)
+    return renderWithWrappers(<RequestForPriceEstimateConfirmationScreen />)
   }
   it("renders without errors", () => {
     const { getByText } = getWrapper()
@@ -23,6 +20,6 @@ describe("RequestForPriceEstimateConfirmationScreen", () => {
   it("navigates correctly", () => {
     const { getByTestId } = getWrapper()
     act(() => fireEvent.press(getByTestId("back-to-my-collection-button")))
-    expect(navigate).toHaveBeenCalledWith("/my-collection/artwork/artworkId")
+    expect(popToRoot).toHaveBeenCalled()
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tsx
@@ -1,12 +1,7 @@
-import { navigate } from "app/navigation/navigate"
+import { popToRoot } from "app/navigation/navigate"
 import { ArtsyLogoIcon, Box, Button, Flex, Text } from "palette"
 
-export const RequestForPriceEstimateConfirmationScreen: React.FC<{ artworkID: string }> = ({
-  artworkID,
-}) => {
-  const onPress = () => {
-    navigate(`/my-collection/artwork/${artworkID}`)
-  }
+export const RequestForPriceEstimateConfirmationScreen: React.FC<{}> = () => {
   return (
     <Box mt={2} px={2}>
       <Flex justifyContent="center" alignItems="center" mb={4}>
@@ -19,7 +14,7 @@ export const RequestForPriceEstimateConfirmationScreen: React.FC<{ artworkID: st
         An Artsy Specialist will evaluate your artwork and contact you with a free price estimate.
       </Text>
       <Button
-        onPress={onPress}
+        onPress={popToRoot}
         block
         variant="fillDark"
         size="large"

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateScreen.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateScreen.tsx
@@ -1,7 +1,8 @@
 import { ActionType, ContextModule, OwnerType, SentRequestPriceEstimate } from "@artsy/cohesion"
+import { CommonActions, useNavigation } from "@react-navigation/native"
 import { RequestForPriceEstimateScreenMutation } from "__generated__/RequestForPriceEstimateScreenMutation.graphql"
 import { Toast } from "app/Components/Toast/Toast"
-import { goBack, navigate } from "app/navigation/navigate"
+import { navigate } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { GlobalStore } from "app/store/GlobalStore"
 import { FormikProvider, useFormik } from "formik"
@@ -74,6 +75,7 @@ export const RequestForPriceEstimateScreen: React.FC<RequestForPriceEstimateScre
   phone,
 }) => {
   const { trackEvent } = useTracking()
+  const navigation = useNavigation()
 
   const formik = useFormik<RequestForPriceEstimateFormikSchema>({
     validateOnChange: true,
@@ -100,7 +102,16 @@ export const RequestForPriceEstimateScreen: React.FC<RequestForPriceEstimateScre
               demandRank ?? undefined
             )
           )
-          goBack()
+          // Remove this screen from the nav stack. This way when we go back we won't land on this screen again
+          navigation.dispatch((state) => {
+            const routes = state.routes.slice(0, state.routes.length - 1)
+            return CommonActions.reset({
+              ...state,
+              routes,
+              index: 0,
+            })
+          })
+          navigate(`/my-collection/artwork/${artworkID}/price-estimate/success`)
         }
       }
       const onError = () => {
@@ -109,9 +120,6 @@ export const RequestForPriceEstimateScreen: React.FC<RequestForPriceEstimateScre
         })
       }
       requestForPriceEstimateMutation(defaultEnvironment, onCompleted, onError, input)
-      navigate(`/my-collection/artwork/${artworkID}/price-estimate/success`, {
-        passProps: { artworkID },
-      })
     },
     validationSchema: ValidationSchema,
   })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR fixes the back logic for when a user lands on the Request Price Estimate success screen by:
- Removing the Request Estimate form screen from the nav stack, that way when a user goes back they won't land on that screen again
- Moving the navigation to success screen only when a success response is gotten after requesting price estimate
- Pop user to the root MyCollection screen when they press `Back To My Collection` button

#### A back gesture on iOS: Note it has always been common for me that the back gesture animation on my simulator to not be well defined. Feel free to run on a physical device if you can 🙏 
https://user-images.githubusercontent.com/18648835/197474541-2eb824d1-182a-4724-a045-7b3cfc656c12.mov


#### Tapping Back to My Collection on iOS. Same behaviour on android
https://user-images.githubusercontent.com/18648835/197474635-3672687d-6bae-402f-9928-ef05006bde0b.mov


#### Tapping on the Physical Back Button on android
https://user-images.githubusercontent.com/18648835/197474772-af11f1bc-e0a7-418c-a6fd-948ca04c72f6.mp4



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
