### PR TITLE
refactor: replacing isStaging with devtoggle

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -337,6 +337,9 @@ export const devToggles = defineDevToggles({
   DTShowErrorInLoadFailureView: {
     description: "Show error in load failure view",
   },
+  DTEnableNewImageLabel: {
+    description: "Show a label on new OpaqueImageView",
+  },
 })
 
 export const isDevToggle = (name: FeatureName | DevToggleName): name is DevToggleName => {

--- a/src/palette/elements/OpaqueImageView/OpaqueImageView2.tsx
+++ b/src/palette/elements/OpaqueImageView/OpaqueImageView2.tsx
@@ -1,5 +1,5 @@
 import { createGeminiUrl } from "app/Components/OpaqueImageView/createGeminiUrl"
-import { useIsStaging } from "app/store/GlobalStore"
+import { useDevToggle } from "app/store/GlobalStore"
 import _ from "lodash"
 import { Text, useColor } from "palette"
 import React, { useCallback, useRef, useState } from "react"
@@ -175,14 +175,16 @@ export const OpaqueImageView: React.FC<Props> = ({
     }
   }
 
-  const isStaging = useIsStaging()
+  const isDebugModeEnabled = useDevToggle("DTEnableNewImageLabel")
 
   const fastImageStyle = [{ height: fIHeight, width: fIWidth }, props.style]
-  const debugBorderStyles = isStaging ? { borderTopWidth: 2, borderColor: color("devpurple") } : {}
+  const debugBorderStyles = isDebugModeEnabled
+    ? { borderTopWidth: 2, borderColor: color("devpurple") }
+    : {}
 
   return (
     <View onLayout={onLayout} style={[fastImageStyle, debugBorderStyles]}>
-      {!!isStaging && (
+      {!!isDebugModeEnabled && (
         <View style={{ position: "absolute", zIndex: 1000, top: "50%" }}>
           <Text weight="medium" italic variant="xl" color="devpurple">
             NewImg


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Replacing the `isStaging` hook with a dev toggle to be able to render the label on top of the new image component

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add dev toggle for adding label on new opaqueImageView - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
