### PR TITLE
fix: Use standard separator height for braze content cards GRO-1365

### DIFF
--- a/src/app/Scenes/Home/Components/ContentCards.tsx
+++ b/src/app/Scenes/Home/Components/ContentCards.tsx
@@ -49,7 +49,7 @@ const ContentCard: React.FC<CardProps> = ({ item }) => {
   )
 }
 
-export const ContentCards: React.FC = () => {
+export const ContentCards: React.FC<{ mb?: number }> = ({ mb }) => {
   const [cards, setCards] = useState<ReactAppboy.CaptionedContentCard[]>([])
   const eventName = ReactAppboy.Events?.CONTENT_CARDS_UPDATED
 
@@ -79,14 +79,15 @@ export const ContentCards: React.FC = () => {
     return null
   }
 
-  return <CardList cards={cards} />
+  return <CardList cards={cards} mb={mb} />
 }
 
 interface CardListProps {
   cards: ReactAppboy.CaptionedContentCard[]
+  mb?: number
 }
 
-export const CardList: React.FC<CardListProps> = ({ cards }) => {
+export const CardList: React.FC<CardListProps> = ({ cards, mb }) => {
   const [currentCardIndex, setCurrentCardIndex] = useState(0)
   const [viewedCards, setViewedCards] = useState([] as ReactAppboy.CaptionedContentCard[])
 
@@ -126,7 +127,7 @@ export const CardList: React.FC<CardListProps> = ({ cards }) => {
       />
       <Spacer mb={2} />
       <PaginationDots currentIndex={currentCardIndex} length={cards.length} />
-      <Spacer mb={2} />
+      <Spacer mb={mb} />
     </>
   )
 }

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -217,7 +217,7 @@ const Home = (props: Props) => {
 
             switch (item.type) {
               case "contentCards":
-                return <ContentCards />
+                return <ContentCards mb={MODULE_SEPARATOR_HEIGHT} />
               case "articles":
                 return (
                   <ArticlesRailFragmentContainer


### PR DESCRIPTION
I def missed that items on the homefeed have a standard margin so this PR uses that value to make the content cards look more consistent!

<img width="466" alt="Screen Shot 2022-10-27 at 4 51 05 PM" src="https://user-images.githubusercontent.com/79799/198405060-55d1426c-2386-497d-9984-96d867a60163.png">


https://artsyproduct.atlassian.net/browse/GRO-1365

/cc @artsy/grow-devs