### PR TITLE
feat(FX-4418): "Recently Added" sort option should be preselected when the user clicks on an notification

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,7 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtistArtworks_artist$data } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
-import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { Aggregations, FilterArray } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import {
   ArtworkFiltersStoreProvider,
   ArtworksFiltersStore,
@@ -32,6 +32,7 @@ interface ArtworksGridProps extends InfiniteScrollGridProps {
   artist: ArtistArtworks_artist$data
   searchCriteria: SearchCriteriaAttributes | null
   relay: RelayPaginationProp
+  predefinedFilters?: FilterArray
 }
 
 type FilterModalOpenedFrom = "sortAndFilter" | "createAlert"
@@ -104,6 +105,7 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   artist,
   relay,
   searchCriteria,
+  predefinedFilters,
   openFilterModal,
   ...props
 }) => {
@@ -125,6 +127,12 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
   })
 
   useEffect(() => {
+    let filters: FilterArray = []
+
+    if (Array.isArray(predefinedFilters)) {
+      filters = predefinedFilters
+    }
+
     if (searchCriteria && artist.aggregations?.aggregations) {
       const params = convertSavedSearchCriteriaToFilterParams(
         searchCriteria,
@@ -132,10 +140,12 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
       )
       const sortFilterItem = ORDERED_ARTWORK_SORTS.find(
         (sortEntity) => sortEntity.paramValue === "-published_at"
-      )
+      )!
 
-      setInitialFilterStateAction([...params, sortFilterItem!])
+      filters = [...params, sortFilterItem]
     }
+
+    setInitialFilterStateAction(filters)
   }, [])
 
   // TODO: Convert to use cohesion

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -5,7 +5,9 @@ import { FilterArray } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ORDERED_ARTWORK_SORTS } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { last } from "lodash"
 import { Flex, OpaqueImageView, Spacer, Text } from "palette"
+import { parse as parseQueryString } from "query-string"
 import { TouchableOpacity } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -32,6 +34,10 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const notificationTypeLabel = getNotificationType()
 
   const handlePress = () => {
+    const splittedQueryParams = item.targetHref.split("?")
+    const queryParams = last(splittedQueryParams) ?? ""
+    const parsed = parseQueryString(queryParams)
+
     const sortFilterItem = ORDERED_ARTWORK_SORTS.find(
       (sortEntity) => sortEntity.paramValue === "-published_at"
     )!
@@ -40,6 +46,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
     navigate(item.targetHref, {
       passProps: {
         predefinedFilters: [sortFilterItem] as FilterArray,
+        searchCriteriaID: parsed.search_criteria_id,
       },
     })
   }

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -1,6 +1,8 @@
 import { ActionType } from "@artsy/cohesion"
 import { ClickedActivityPanelNotificationItem } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
 import { ActivityItem_item$key } from "__generated__/ActivityItem_item.graphql"
+import { FilterArray } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { ORDERED_ARTWORK_SORTS } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, OpaqueImageView, Spacer, Text } from "palette"
@@ -30,8 +32,16 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const notificationTypeLabel = getNotificationType()
 
   const handlePress = () => {
-    navigate(item.targetHref)
+    const sortFilterItem = ORDERED_ARTWORK_SORTS.find(
+      (sortEntity) => sortEntity.paramValue === "-published_at"
+    )!
+
     tracking.trackEvent(tracks.tappedNotification(item.notificationType))
+    navigate(item.targetHref, {
+      passProps: {
+        predefinedFilters: [sortFilterItem] as FilterArray,
+      },
+    })
   }
 
   return (


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- "Recently Added" sort option should be preselected when the user clicks on an notification and navigates to the artist artworks screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
