### PR TITLE
fix(CX-3096): Go back to artwork not MyCollection after sending request price estimate

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tests.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent } from "@testing-library/react-native"
-import { popToRoot } from "app/navigation/navigate"
+import { goBack } from "app/navigation/navigate"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { RequestForPriceEstimateConfirmationScreen } from "./RequestForPriceEstimateConfirmationScreen"
 
@@ -20,6 +20,6 @@ describe("RequestForPriceEstimateConfirmationScreen", () => {
   it("navigates correctly", () => {
     const { getByTestId } = getWrapper()
     act(() => fireEvent.press(getByTestId("back-to-my-collection-button")))
-    expect(popToRoot).toHaveBeenCalled()
+    expect(goBack).toHaveBeenCalled()
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateConfirmationScreen.tsx
@@ -1,4 +1,4 @@
-import { popToRoot } from "app/navigation/navigate"
+import { goBack } from "app/navigation/navigate"
 import { ArtsyLogoIcon, Box, Button, Flex, Text } from "palette"
 
 export const RequestForPriceEstimateConfirmationScreen: React.FC<{}> = () => {
@@ -14,7 +14,7 @@ export const RequestForPriceEstimateConfirmationScreen: React.FC<{}> = () => {
         An Artsy Specialist will evaluate your artwork and contact you with a free price estimate.
       </Text>
       <Button
-        onPress={popToRoot}
+        onPress={() => goBack()}
         block
         variant="fillDark"
         size="large"


### PR DESCRIPTION

This PR resolves [CX-3096] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
- After sending request price estimate, when user taps on Back to My Collection they should return to artwork screen and not My Collection screen


https://user-images.githubusercontent.com/18648835/198990740-f5aae550-04e8-4fce-8a63-b56eee9a197c.mov



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Go back to artwork not MyCollection after sending request price estimate - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3096]: https://artsyproduct.atlassian.net/browse/CX-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ