### PR TITLE
feat: Double new for you recs GRO-1386

### DIFF
--- a/src/app/Scenes/Home/Components/NewWorksForYouRail.tsx
+++ b/src/app/Scenes/Home/Components/NewWorksForYouRail.tsx
@@ -74,7 +74,7 @@ export const NewWorksForYouRail: React.FC<NewWorksForYouRailProps & RailScrollPr
 
 const artworksFragment = graphql`
   fragment NewWorksForYouRail_artworkConnection on Viewer {
-    artworksForUser(maxWorksPerArtist: 3, includeBackfill: true, first: 20) {
+    artworksForUser(maxWorksPerArtist: 3, includeBackfill: true, first: 40) {
       edges {
         node {
           title


### PR DESCRIPTION
After some surprising results and some scratching of heads, we have decided to double the number of artwork recs on the new for you page.

Investigation here:

https://www.notion.so/artsy/Investigate-artwork-rec-differences-eb461849f7d149518497a0ba98c491c5

Chatter here:

https://artsy.slack.com/archives/C033E79AQG4/p1667232723970619

https://artsyproduct.atlassian.net/browse/GRO-1386

/cc @artsy/grow-devs @isakelaris 