### PR TITLE
style: minor visual glitches in Fair app

### DIFF
--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -11,17 +11,19 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
 
   return (
-    <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
-      <Flex>
+    <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" alignItems="center">
+      <Flex mr={0.5} flex={1}>
         <Text variant="xs">Questions about this piece?</Text>
       </Flex>
 
-      <InquiryButtonsFragmentContainer
-        artwork={artworkData}
-        variant="outline"
-        size="small"
-        icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
-      />
+      <Flex flex={1} alignItems="flex-end">
+        <InquiryButtonsFragmentContainer
+          artwork={artworkData}
+          variant="outline"
+          size="small"
+          icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
+        />
+      </Flex>
     </Flex>
   )
 }

--- a/src/app/Scenes/Fair/Components/FairHeader.tsx
+++ b/src/app/Scenes/Fair/Components/FairHeader.tsx
@@ -90,9 +90,9 @@ export const FairHeader: React.FC<FairHeaderProps> = ({ fair }) => {
         )}
         {!!canShowMoreInfoLink && (
           <TouchableOpacity onPress={() => navigate(`/fair/${slug}/info`)}>
-            <Flex pt={2} flexDirection="row" justifyContent="flex-start">
+            <Flex pt={2} flexDirection="row" justifyContent="flex-start" alignItems="center">
               <Text variant="sm">More info</Text>
-              <ChevronIcon mr="-5px" mt="2px" />
+              <ChevronIcon mr="-5px" mt="4px" />
             </Flex>
           </TouchableOpacity>
         )}


### PR DESCRIPTION
This PR resolves [FX-4420] 

### Description

Fixes some visual glitches observed while using the Fair app at IFPDA Print Fair

#### Misaligned Chevron

<img width="400" alt="chevron" src="https://user-images.githubusercontent.com/140521/199164430-b7bd4bbc-0604-4df6-9495-d80c1c843317.png">

#### Colliding text and Contact Partner button

<img width="400" alt="contact" src="https://user-images.githubusercontent.com/140521/199164453-2ac83e15-b572-4a3e-a2d0-598fd2a3241a.png">


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Minor style updates to fair screen

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4420]: https://artsyproduct.atlassian.net/browse/FX-4420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ