### PR TITLE
fix: Always show message when a price estimate has been sent

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tests.tsx
@@ -64,6 +64,16 @@ describe("RequestForPriceEstimateBanner", () => {
   it("renders without throwing an error", () => {
     const { getByTestId } = renderWithWrappers(<TestRenderer />)
     resolveData({
+      Artwork: () => ({
+        internalID: "some-internal-id",
+        submissionId: null,
+        hasPriceEstimateRequest: false,
+        artist: {
+          targetSupply: {
+            isP1: true,
+          },
+        },
+      }),
       MarketPriceInsights: () => ({
         demandRank: 7.5,
       }),
@@ -119,6 +129,13 @@ describe("RequestForPriceEstimateBanner", () => {
       Artwork: () => ({
         internalID: "artwork-id",
         slug: "artwork-slug",
+        submissionId: null,
+        hasPriceEstimateRequest: false,
+        artist: {
+          targetSupply: {
+            isP1: true,
+          },
+        },
       }),
       MarketPriceInsights: () => ({
         demandRank: 7.5,

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateBanner.tsx
@@ -38,6 +38,9 @@ export const RequestForPriceEstimateBanner: React.FC<RequestForPriceEstimateProp
     (enableRemotePriceEstimateRequestedLogic && artwork.hasPriceEstimateRequest) ||
     !!localRequestedPriceEstimates[artwork.internalID]
 
+  const isP1Artist = artwork.artist?.targetSupply?.isP1
+  const isAlreadySubmitted = artwork.submissionId
+
   if (priceEstimateRequested) {
     return (
       <Box>
@@ -51,6 +54,10 @@ export const RequestForPriceEstimateBanner: React.FC<RequestForPriceEstimateProp
         <Separator mt={2} mb={3} borderColor="black10" />
       </Box>
     )
+  }
+
+  if (!isP1Artist || isAlreadySubmitted) {
+    return null
   }
 
   return (
@@ -104,8 +111,14 @@ export const RequestForPriceEstimateBanner: React.FC<RequestForPriceEstimateProp
 
 const artworkFragment = graphql`
   fragment RequestForPriceEstimateBanner_artwork on Artwork {
+    artist {
+      targetSupply {
+        isP1
+      }
+    }
     internalID
     slug
+    submissionId
     hasPriceEstimateRequest
   }
 `

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -32,10 +32,6 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
   const me = useFragment(meFragment, restProps.me)
 
   const isP1Artist = artwork.artist?.targetSupply?.isP1
-  const isAlreadySubmitted = artwork.consignmentSubmission?.displayText
-
-  const showPriceEstimateBanner =
-    useFeatureFlag("ARShowRequestPriceEstimateBanner") && isP1Artist && !isAlreadySubmitted
 
   return (
     <StickyTabPageScrollView>
@@ -49,7 +45,7 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
           </>
         )}
 
-        {!!showPriceEstimateBanner && (
+        {!!useFeatureFlag("ARShowRequestPriceEstimateBanner") && (
           <RequestForPriceEstimateBanner
             me={me}
             artwork={artwork}
@@ -83,9 +79,6 @@ const artworkFragment = graphql`
       targetSupply {
         isP1
       }
-    }
-    consignmentSubmission {
-      displayText
     }
     ...RequestForPriceEstimateBanner_artwork
     ...MyCollectionArtworkDemandIndex_artwork


### PR DESCRIPTION
This PR resolves [CX-3100] <!-- eg [PROJECT-XXXX] -->


### Description

This PR adjusts the display logic for the price estimate section on the artist screen to always show a message when a price estimate has been sent for the artwork.

[PR implementing the same in Force](https://github.com/artsy/force/pull/11279)


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Always show a message when a price estimate has been sent - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3100]: https://artsyproduct.atlassian.net/browse/CX-3100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ