### PR TITLE
fix: counter offer flow broken for artsy shipping orders

### DIFF
--- a/src/app/utils/getOrderStatus.tests.ts
+++ b/src/app/utils/getOrderStatus.tests.ts
@@ -15,6 +15,8 @@ describe(getOrderStatus, () => {
 
   describe("with shipment status", () => {
     it("returns correct statuses", () => {
+      mockLineItem = { shipment: { status: "draft" } }
+      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("pending")
       mockLineItem = { shipment: { status: "pending" } }
       expect(getOrderStatus("APPROVED", mockLineItem)).toBe("processing")
       mockLineItem = { shipment: { status: "confirmed" } }

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -13,6 +13,7 @@ export type OrderState = Exclude<
   "ABANDONED" | "PENDING" | "%future added value"
 >
 export type ShipmentStatus =
+  | "DRAFT"
   | "PENDING"
   | "CONFIRMED"
   | "COLLECTED"
@@ -44,6 +45,7 @@ const orderStatusesMap = {
   REFUNDED: ORDER_STATUSES.Refunded,
   PENDING: SHIPMENT_STATUSES.Processing,
   CONFIRMED: SHIPMENT_STATUSES.Processing,
+  DRAFT: ORDER_STATUSES.Pending,
   PROCESSING_APPROVAL: ORDER_STATUSES.PaymentProcessing,
   COLLECTED: SHIPMENT_STATUSES.InTransit,
   IN_TRANSIT: SHIPMENT_STATUSES.InTransit,


### PR DESCRIPTION
This PR resolves [PX-5333](https://artsyproduct.atlassian.net/browse/PX-5333)

### Description
Discovered that the counter offer modal was not popping up for orders that were being shipped with artsy shipping. Instead, collectors were redirected to the user/purchases/<id> receipt screen with no way to view/submit counter offers, getting stuck forever.

It is because of this mapping that is going on to determine where to direct the user on [this](https://github.com/artsy/eigen/blob/main/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx#L84-L98) button press. Since we were not accounting for `draft` shipments, this was always returning `undefined` and incorrectly directing the user to the `user/purchases/<id>`receipts page. We started building "draft" shipments as part of artsy shipping to collect metadata earlier in the checkout flow



## Experience before the fix:

https://user-images.githubusercontent.com/12748344/199347181-e517d13a-89ea-436e-995e-92c78e49fa2a.mov



## Experience after the fix:

https://user-images.githubusercontent.com/12748344/199347228-4797206f-30e2-4bdf-bb45-23f7cf25451e.mov




### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
