### PR TITLE
fix: Improve support for dynamic text in content cards GRO-1403

### DIFF
--- a/src/app/Scenes/Home/Components/ContentCards.tsx
+++ b/src/app/Scenes/Home/Components/ContentCards.tsx
@@ -2,7 +2,7 @@ import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "app/navigation/navigate"
 import { Box, Button, Flex, Spacer, Text, Touchable } from "palette"
 import React, { useEffect, useRef, useState } from "react"
-import { FlatList, ViewabilityConfig } from "react-native"
+import { FlatList, PixelRatio, ViewabilityConfig } from "react-native"
 import ReactAppboy from "react-native-appboy-sdk"
 import { useScreenDimensions } from "shared/hooks"
 import { PaginationDots } from "./PaginationDots"
@@ -11,8 +11,11 @@ interface CardProps {
   item: ReactAppboy.CaptionedContentCard
 }
 
-const CARD_HEIGHT = 250
+const fontScale = PixelRatio.getFontScale()
+
+const CARD_HEIGHT = 250 * fontScale
 const CARD_IMAGE_WIDTH = 125
+const DESCRIPTION_LINES = fontScale > 1 ? 4 : 3
 
 const ContentCard: React.FC<CardProps> = ({ item }) => {
   const { width: screenWidth } = useScreenDimensions()
@@ -37,7 +40,7 @@ const ContentCard: React.FC<CardProps> = ({ item }) => {
           <Text color="white100" mb={1} numberOfLines={2} variant="lg-display">
             {item.title}
           </Text>
-          <Text color="white100" mb={2} numberOfLines={3}>
+          <Text color="white100" mb={2} numberOfLines={DESCRIPTION_LINES}>
             {item.cardDescription}
           </Text>
           <Button size="small" variant="outlineLight" onPress={handlePress}>


### PR DESCRIPTION
Turns out it's pretty easy to get at the font scale for users that have increased it! Docs here:

https://reactnative.dev/docs/pixelratio#getfontscale

And so @pvinis had the idea to just use this scale to grow the content card height and that does in fact ensure that the button shows up.

<details>
<summary>screenshots</summary>

<img width="410" alt="Screen Shot 2022-11-02 at 9 16 51 AM" src="https://user-images.githubusercontent.com/79799/199514464-81489ffa-001b-42fe-90a1-9777b3b55b2a.png">
<img width="414" alt="Screen Shot 2022-11-02 at 9 17 12 AM" src="https://user-images.githubusercontent.com/79799/199514472-d83088ab-1f5c-4742-8ded-1a55987fd86e.png">


</details>

https://artsyproduct.atlassian.net/browse/GRO-1403

/cc @artsy/grow-devs