### PR TITLE
feat: Initialize artist name input field in MyC upload flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -427,14 +427,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 637
+        "line_number": 646
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 725
+        "line_number": 734
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-01T16:56:34Z"
+  "generated_at": "2022-11-03T14:28:11Z"
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
@@ -13,7 +13,7 @@ import { useArtworkForm } from "../Form/useArtworkForm"
 
 interface ArtistAutosuggestProps {
   onResultPress: (result: AutosuggestResult) => void
-  onSkipPress?: () => void
+  onSkipPress?: (artistDisplayName: string) => void
 }
 
 export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
@@ -69,7 +69,7 @@ export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
                       Or skip ahead to{" "}
                     </Text>
                     <Touchable
-                      onPress={onSkipPress}
+                      onPress={() => onSkipPress?.(trimmedQuery)}
                       testID="my-collection-artwork-form-artist-skip-button"
                       hitSlop={{ top: 10, left: 10, right: 10, bottom: 10 }}
                     >
@@ -85,7 +85,12 @@ export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
                   <Flex width="100%" my={2}>
                     <Text>We didn't find "{trimmedQuery}" on Artsy.</Text>
                     <Text>You can add their name in the artwork details.</Text>
-                    <Button variant="outline" onPress={onSkipPress} mt={4} block>
+                    <Button
+                      variant="outline"
+                      onPress={() => onSkipPress?.(trimmedQuery)}
+                      mt={4}
+                      block
+                    >
                       Add Artist
                     </Button>
                   </Flex>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -255,8 +255,8 @@ describe("MyCollectionArtworkForm", () => {
         })
       })
 
-      it("displays the artist display name input", async () => {
-        const { getByText, getByTestId } = renderWithHookWrappersTL(
+      it("initializes the artist name input field", async () => {
+        const { getByText, getByTestId, getByPlaceholderText } = renderWithHookWrappersTL(
           <MyCollectionArtworkForm mode="add" onSuccess={jest.fn()} source={Tab.collection} />,
           mockEnvironment
         )
@@ -274,6 +274,15 @@ describe("MyCollectionArtworkForm", () => {
 
         expect(getByText("Select an Artist")).toBeTruthy()
 
+        act(() =>
+          fireEvent.changeText(getByPlaceholderText("Search for artists on Artsy"), "foo bar")
+        )
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({
+            errors: [],
+            data: mockArtistSearchResult,
+          })
+        )
         act(() => fireEvent.press(getByTestId("my-collection-artwork-form-artist-skip-button")))
 
         await flushPromiseQueue()
@@ -282,7 +291,7 @@ describe("MyCollectionArtworkForm", () => {
 
         expect(getByText("Add Details")).toBeTruthy()
 
-        expect(getByTestId("ArtistDisplayNameInput").props.value).toBe(undefined)
+        expect(getByTestId("ArtistDisplayNameInput").props.value).toBe("foo bar")
         expect(getByTestId("TitleInput").props.value).toBe("")
         expect(getByTestId("DateInput").props.value).toBe("")
         expect(getByTestId("MaterialsInput").props.value).toBe("")

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
@@ -19,6 +19,10 @@ export const MyCollectionArtworkFormArtist: React.FC<
   const handleResultPress = async (result: AutosuggestResult) => {
     tracking.trackEvent(tracks.tappedArtist({ artistSlug: result.slug, artistId: result.slug }))
 
+    GlobalStore.actions.myCollection.artwork.updateFormValues({
+      metric: preferredMetric,
+      pricePaidCurrency: preferredCurrency,
+    })
     await GlobalStore.actions.myCollection.artwork.setArtistSearchResult(result)
 
     if (result.isPersonalArtist) {
@@ -28,9 +32,10 @@ export const MyCollectionArtworkFormArtist: React.FC<
     }
   }
 
-  const handleSkipPress = async () => {
+  const handleSkipPress = async (artistDisplayName: string) => {
     requestAnimationFrame(() => {
       GlobalStore.actions.myCollection.artwork.updateFormValues({
+        artistDisplayName,
         metric: preferredMetric,
         pricePaidCurrency: preferredCurrency,
       })


### PR DESCRIPTION
This PR resolves [CX-2727] <!-- eg [PROJECT-XXXX] -->

### Description
Initialize artist name input field in MyC upload flow.



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2727]: https://artsyproduct.atlassian.net/browse/CX-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ