### PR TITLE
fix: Add loading skeleton to Select Artist screen

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
@@ -2,7 +2,10 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { StackScreenProps } from "@react-navigation/stack"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { AutosuggestResult } from "app/Scenes/Search/AutosuggestResults"
+import { AutosuggestResultsPlaceholder } from "app/Scenes/Search/components/placeholders/AutosuggestResultsPlaceholder"
 import { GlobalStore } from "app/store/GlobalStore"
+import { ProvidePlaceholderContext } from "app/utils/placeholders"
+import { Suspense } from "react"
 import { useTracking } from "react-tracking"
 import { ScreenMargin } from "../../../Components/ScreenMargin"
 import { ArtistAutosuggest } from "../Components/ArtistAutosuggest"
@@ -44,7 +47,9 @@ export const MyCollectionArtworkFormArtist: React.FC<
         Select an Artist
       </FancyModalHeader>
       <ScreenMargin>
-        <ArtistAutosuggest onResultPress={handleResultPress} onSkipPress={handleSkipPress} />
+        <Suspense fallback={() => <Placeholder />}>
+          <ArtistAutosuggest onResultPress={handleResultPress} onSkipPress={handleSkipPress} />
+        </Suspense>{" "}
       </ScreenMargin>
     </>
   )
@@ -58,3 +63,9 @@ const tracks = {
     context_screen_owner_slug: artistSlug,
   }),
 }
+
+const Placeholder: React.FC = () => (
+  <ProvidePlaceholderContext>
+    <AutosuggestResultsPlaceholder />
+  </ProvidePlaceholderContext>
+)


### PR DESCRIPTION
This PR resolves [CX-3103] <!-- eg [PROJECT-XXXX] -->

### Description
Add loading skeleton to Select Artist screen.



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3103]: https://artsyproduct.atlassian.net/browse/CX-3103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ