### PR TITLE
feat: Initialize artwork title input when skipping artwork selection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -427,14 +427,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 646
+        "line_number": 663
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 734
+        "line_number": 751
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-04T09:37:53Z"
+  "generated_at": "2022-11-07T14:11:59Z"
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
@@ -4,7 +4,7 @@ import { AutosuggestResult, AutosuggestResults } from "app/Scenes/Search/Autosug
 import { SearchContext, useSearchProviderValues } from "app/Scenes/Search/SearchContext"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
-import { sortBy, trim } from "lodash"
+import { sortBy } from "lodash"
 import { Box, Button, Flex, Input, Spacer, Text, Touchable } from "palette"
 import { useLazyLoadQuery } from "react-relay"
 import { graphql } from "relay-runtime"
@@ -23,7 +23,7 @@ export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
   const enableArtworksFromNonArtsyArtists = useFeatureFlag("AREnableArtworksFromNonArtsyArtists")
   const { formik } = useArtworkForm()
   const { artist: artistQuery } = formik.values
-  const trimmedQuery = trim(artistQuery)
+  const trimmedQuery = artistQuery.trimStart()
   const searchProviderValues = useSearchProviderValues(artistQuery)
 
   const queryData = useLazyLoadQuery<ArtistAutosuggestQuery>(

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
@@ -1,4 +1,5 @@
 import SearchIcon from "app/Icons/SearchIcon"
+import { trim } from "lodash"
 import { Flex, Input, Text, Touchable } from "palette"
 import React, { useState } from "react"
 import { useArtworkForm } from "../Form/useArtworkForm"
@@ -6,7 +7,7 @@ import { ArtworkAutosuggestResultsQueryRenderer } from "./ArtworkAutosuggestResu
 
 interface ArtworkAutosuggestProps {
   onResultPress: (artworkId: string) => void
-  onSkipPress: () => void
+  onSkipPress: (artworkTitle?: string) => void
 }
 
 export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
@@ -20,7 +21,7 @@ export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
   const artistSlug = artistSearchResult?.slug || ""
 
   const [artworkQuery, setArtworkQuery] = useState("")
-
+  const trimmedArtworkQuery = trim(artworkQuery)
   // In order to get results even before the user types anything, we need to add the artist slug to the query.
   const keyword = artworkQuery.length < 2 ? `${artistSlug} ${artworkQuery}` : artworkQuery
 
@@ -33,14 +34,14 @@ export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
           setArtworkQuery(value)
         }}
         onBlur={formik.handleBlur("artwork")}
-        value={artworkQuery}
+        value={trimmedArtworkQuery}
         enableClearButton
         autoFocus={typeof jest === "undefined"}
         autoCorrect={false}
       />
 
       {showSkipAheadToAddArtworkLink && (
-        <Touchable onPress={onSkipPress}>
+        <Touchable onPress={() => onSkipPress?.(trimmedArtworkQuery)}>
           <Flex flexDirection="row" my={1}>
             <Text variant="xs" color="black60">
               Or skip ahead to{" "}

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
@@ -1,5 +1,4 @@
 import SearchIcon from "app/Icons/SearchIcon"
-import { trim } from "lodash"
 import { Flex, Input, Text, Touchable } from "palette"
 import React, { useState } from "react"
 import { useArtworkForm } from "../Form/useArtworkForm"
@@ -21,7 +20,7 @@ export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
   const artistSlug = artistSearchResult?.slug || ""
 
   const [artworkQuery, setArtworkQuery] = useState("")
-  const trimmedArtworkQuery = trim(artworkQuery)
+  const trimmedArtworkQuery = artworkQuery.trimStart()
   // In order to get results even before the user types anything, we need to add the artist slug to the query.
   const keyword = artworkQuery.length < 2 ? `${artistSlug} ${artworkQuery}` : artworkQuery
 

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
@@ -60,7 +60,7 @@ export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
             keyword={keyword}
             artistSlug={artistSlug}
             onPress={onResultPress}
-            onSkipPress={onSkipPress}
+            onSkipPress={() => onSkipPress?.(trimmedArtworkQuery)}
             setShowSkipAheadToAddArtworkLink={setShowSkipAheadToAddArtworkLink}
           />
         </Flex>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest.tsx
@@ -40,8 +40,11 @@ export const ArtworkAutosuggest: React.FC<ArtworkAutosuggestProps> = ({
         autoCorrect={false}
       />
 
-      {showSkipAheadToAddArtworkLink && (
-        <Touchable onPress={() => onSkipPress?.(trimmedArtworkQuery)}>
+      {!!showSkipAheadToAddArtworkLink && (
+        <Touchable
+          onPress={() => onSkipPress?.(trimmedArtworkQuery)}
+          testID="my-collection-artwork-form-artwork-skip-button"
+        >
           <Flex flexDirection="row" my={1}>
             <Text variant="xs" color="black60">
               Or skip ahead to{" "}

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
@@ -6,6 +6,7 @@ import { FadeIn } from "app/Components/FadeIn"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
+import { trim } from "lodash"
 import { Button, Flex } from "palette"
 import React, { useEffect } from "react"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
@@ -16,7 +17,7 @@ export interface ArtworkAutosuggestResultsProps {
   relay: RelayPaginationProp
   keyword: string
   onPress?: (artworkID: string) => void
-  onSkipPress?: () => void
+  onSkipPress?: (artworkTitle?: string) => void
   setShowSkipAheadToAddArtworkLink: (showSkipAheadLink: boolean) => void
 }
 
@@ -50,7 +51,7 @@ const ArtworkAutosuggestResults: React.FC<ArtworkAutosuggestResultsProps> = ({
           <Flex alignItems="center">
             {/* Using `FadeIn` prevents the button from being displayed too early. */}
             <FadeIn delay={100} slide={false}>
-              <Button variant="outline" onPress={onSkipPress} mt={3}>
+              <Button variant="outline" onPress={() => onSkipPress?.(trim(keyword))} mt={3}>
                 Go to Add Artwork Details
               </Button>
             </FadeIn>
@@ -124,7 +125,7 @@ export const ArtworkAutosuggestResultsQueryRenderer: React.FC<{
   keyword: string
   artistSlug: string
   onPress?: (artworkId: string) => void
-  onSkipPress?: () => void
+  onSkipPress?: (artworkTitle?: string) => void
   setShowSkipAheadToAddArtworkLink: (showSkipAheadLink: boolean) => void
 }> = ({ keyword, artistSlug, onPress, onSkipPress, setShowSkipAheadToAddArtworkLink }) => {
   return (

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -235,11 +235,12 @@ describe("MyCollectionArtworkForm", () => {
         act(() => fireEvent.press(getByTestId("my-collection-artwork-form-artwork-skip-button")))
 
         await flushPromiseQueue()
+
         // Edit Details Screen
 
         expect(getByText("Add Details")).toBeTruthy()
 
-        expect(getByTestId("TitleInput").props.value).toBe("")
+        expect(getByTestId("TitleInput").props.value).toBe(undefined)
         expect(getByTestId("DateInput").props.value).toBe("")
         expect(getByTestId("MaterialsInput").props.value).toBe("")
         expect(getByTestId("WidthInput").props.value).toBe("")

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -224,6 +224,9 @@ describe("MyCollectionArtworkForm", () => {
             data: mockArtistSearchResult,
           })
         )
+
+        await flushPromiseQueue()
+
         act(() => fireEvent.press(getByTestId("autosuggest-search-result-Banksy")))
 
         await flushPromiseQueue()
@@ -231,6 +234,18 @@ describe("MyCollectionArtworkForm", () => {
         // Select Artwork Screen
 
         expect(getByText("Select an Artwork")).toBeTruthy()
+
+        act(() =>
+          fireEvent.changeText(getByPlaceholderText("Search artworks"), "Test Artwork Title")
+        )
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({
+            errors: [],
+            data: mockArtworkSearchResult,
+          })
+        )
+
+        await flushPromiseQueue()
 
         act(() => fireEvent.press(getByTestId("my-collection-artwork-form-artwork-skip-button")))
 
@@ -240,7 +255,7 @@ describe("MyCollectionArtworkForm", () => {
 
         expect(getByText("Add Details")).toBeTruthy()
 
-        expect(getByTestId("TitleInput").props.value).toBe(undefined)
+        expect(getByTestId("TitleInput").props.value).toBe("Test Artwork Title")
         expect(getByTestId("DateInput").props.value).toBe("")
         expect(getByTestId("MaterialsInput").props.value).toBe("")
         expect(getByTestId("WidthInput").props.value).toBe("")
@@ -532,6 +547,7 @@ describe("MyCollectionArtworkForm", () => {
         await flushPromiseQueue()
 
         // Select Artwork Screen
+
         act(() => fireEvent.changeText(getByPlaceholderText("Search artworks"), "banksy"))
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
@@ -103,7 +103,6 @@ export const MyCollectionArtworkFormArtwork: React.FC<
       <FancyModalHeader
         onLeftButtonPress={route.params.onHeaderBackButtonPress}
         rightButtonText="Skip"
-        rightButtonTestId="my-collection-artwork-form-artwork-skip-button"
         onRightButtonPress={onSkip}
         hideBottomDivider
       >

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
@@ -75,7 +75,10 @@ export const MyCollectionArtworkFormArtwork: React.FC<
     }
   }
 
-  const onSkip = () => {
+  const onSkip = (artworkTitle?: string) => {
+    GlobalStore.actions.myCollection.artwork.updateFormValues({
+      title: artworkTitle,
+    })
     trackEvent(
       tracks.tappedOnSkip(
         formik.values.artistSearchResult?.internalID!,


### PR DESCRIPTION
This PR resolves [CX-2728] <!-- eg [PROJECT-XXXX] -->

### Description

Initialize artwork title input when skipping the artwork selection in the My Collection artwork flow



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Initialize artwork title input when skipping artwork selection - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2728]: https://artsyproduct.atlassian.net/browse/CX-2728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ