### PR TITLE
chore: small improvements for activity item images

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -17,6 +17,7 @@ interface ActivityItemProps {
 }
 
 const UNREAD_INDICATOR_SIZE = 8
+const ARTWORK_IMAGE_SIZE = 55
 
 export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const tracking = useTracking()
@@ -78,7 +79,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
 
           <Spacer mb={1} />
 
-          <Flex flexDirection="row" alignItems="center" flexWrap="wrap">
+          <Flex flexDirection="row" alignItems="center">
             {artworks.map((artwork) => {
               return (
                 <Flex
@@ -86,7 +87,11 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
                   mr={1}
                   accessibilityLabel="Activity Artwork Image"
                 >
-                  <OpaqueImageView imageURL={artwork.image?.preview?.src} width={58} height={58} />
+                  <OpaqueImageView
+                    imageURL={artwork.image?.preview?.src}
+                    width={ARTWORK_IMAGE_SIZE}
+                    height={ARTWORK_IMAGE_SIZE}
+                  />
                 </Flex>
               )
             })}
@@ -98,7 +103,6 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
             width={UNREAD_INDICATOR_SIZE}
             height={UNREAD_INDICATOR_SIZE}
             borderRadius={UNREAD_INDICATOR_SIZE / 2}
-            ml={1}
             bg="blue100"
             accessibilityLabel="Unread notification indicator"
           />


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Demo
| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3513494/199778177-9aef7d04-c4cf-4798-8f3b-4cef22b3cbc8.png) | ![after](https://user-images.githubusercontent.com/3513494/199778254-bcfdcd05-cd04-453d-8903-68ea172ef76d.png) |

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- small improvements for activity item images - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
