### PR TITLE
feat: add ability to refetch notifications for empty state

### DIFF
--- a/src/app/Scenes/Activity/ActivityEmptyView.tsx
+++ b/src/app/Scenes/Activity/ActivityEmptyView.tsx
@@ -1,8 +1,4 @@
-import { useStickyTabPageContext } from "app/Components/StickyTabPage/StickyTabPageContext"
-import { StickyTabPageFlatListContext } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { apostrophe, Flex, quoteLeft, quoteRight, Spacer, Text } from "palette"
-import { useContext } from "react"
-import Animated from "react-native-reanimated"
 import { NotificationType } from "./types"
 
 interface ActivityEmptyViewProps {
@@ -22,25 +18,15 @@ const entityByType: Record<NotificationType, { title: string; message: string }>
 }
 
 export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) => {
-  const { staticHeaderHeight } = useStickyTabPageContext()
-  const { tabSpecificContentHeight } = useContext(StickyTabPageFlatListContext)
-  const headerHeight = Animated.add(staticHeaderHeight ?? 0, tabSpecificContentHeight ?? 0)
   const entity = entityByType[type]
 
   return (
-    <Flex flex={1} accessibilityLabel="Activities are empty">
-      <Animated.View
-        style={{
-          height: headerHeight ?? 0,
-        }}
-      />
-      <Flex flex={1} justifyContent="center" mx={2}>
-        <Text textAlign="center">{entity.title}</Text>
-        <Spacer mt={2} />
-        <Text variant="xs" color="black60" textAlign="center">
-          {entity.message}
-        </Text>
-      </Flex>
+    <Flex mx={2} accessibilityLabel="Activities are empty">
+      <Text textAlign="center">{entity.title}</Text>
+      <Spacer mt={2} />
+      <Text variant="xs" color="black60" textAlign="center">
+        {entity.message}
+      </Text>
     </Flex>
   )
 }

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -7,6 +7,7 @@ import {
   StickyTabPageFlatListContext,
   StickyTabSection,
 } from "app/Components/StickyTabPage/StickyTabPageFlatList"
+import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Separator, Spinner } from "palette"
 import { useContext, useEffect, useState } from "react"
@@ -78,7 +79,21 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
   }, [hasUnreadNotifications])
 
   if (notifications.length === 0) {
-    return <ActivityEmptyView type={type} />
+    return (
+      <StickyTabPageScrollView
+        contentContainerStyle={{
+          // Extend the container flex when there are no artworks for accurate vertical centering
+          flexGrow: 1,
+          justifyContent: "center",
+          height: "100%",
+        }}
+        refreshControl={
+          <StickTabPageRefreshControl onRefresh={handleRefresh} refreshing={refreshing} />
+        }
+      >
+        <ActivityEmptyView type={type} />
+      </StickyTabPageScrollView>
+    )
   }
 
   return (


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/199784079-e9034abb-2986-443b-92ea-7e53d986f442.mp4

#### Android
https://user-images.githubusercontent.com/3513494/199786402-fe116b89-31fb-49a7-8f4a-570f5f62ac35.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add ability to refetch notifications for empty state - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
