### PR TITLE
fix: Show initials for artists without images in the MyC

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -132,6 +132,7 @@ export const MyCollectionArtworkScreenQuery = graphql`
       }
       artist {
         internalID
+        initials
         formattedNationalityAndBirthday
         auctionResultsConnection(first: 3, sort: DATE_DESC) {
           totalCount

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult.tsx
@@ -6,7 +6,11 @@ export const ArtistSearchResult: React.FC<{
 }> = ({ result }) => {
   return (
     <Flex flexDirection="row" alignItems="center">
-      <Avatar src={result.imageUrl || undefined} size="xs" />
+      <Avatar
+        src={result.imageUrl || undefined}
+        initials={result.initials || undefined}
+        size="xs"
+      />
       <Spacer ml="1" />
       <Flex flex={1} flexDirection="column" justifyContent="center">
         <Text variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>

--- a/src/app/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/app/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -88,7 +88,7 @@ export interface MyCollectionArtworkModel {
     Partial<MyCollectionArtwork_sharedProps$data> & {
       internalID: string
       id: string
-      artist: { internalID: string }
+      artist: { internalID: string; initials: string }
       artistNames: string
       images: Image[]
     },
@@ -186,6 +186,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
         displayLabel: artwork?.artistNames,
         imageUrl: artwork?.images?.[0]?.imageURL?.replace(":version", "square"),
         formattedNationalityAndBirthday: artwork?.artist?.formattedNationalityAndBirthday,
+        initials: artwork?.artist?.initials,
       },
       attributionClass,
       category: artwork.category,


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description
Show initials for artists without images in the My Collection artwork form.



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
