### PR TITLE
chore: hide shipping and taxes section if artwork is in auction

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -596,6 +596,24 @@ describe("Artwork", () => {
 
       expect(queryByText("Shipping and taxes")).toBeNull()
     })
+
+    it("should NOT be rendered if the work is in auction", () => {
+      const { queryByText } = renderWithWrappers(<TestRenderer />)
+
+      mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
+        Artwork: () => ({
+          isInAuction: true,
+        }),
+      })
+      mockMostRecentOperation("ArtworkMarkAsRecentlyViewedQuery")
+      mockMostRecentOperation("ArtworkBelowTheFoldQuery", {
+        Artwork: () => ({
+          isForSale: false,
+        }),
+      })
+
+      expect(queryByText("Shipping and taxes")).toBeNull()
+    })
   })
 
   describe("Artsy Guarantee section", () => {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -309,7 +309,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
       })
     }
 
-    if (!!artworkBelowTheFold.isForSale) {
+    if (!!(artworkBelowTheFold.isForSale && !isInAuction)) {
       sections.push({
         key: "shippingAndTaxes",
         element: <ShippingAndTaxesFragmentContainer artwork={artworkBelowTheFold!} />,


### PR DESCRIPTION
This PR resolves [FX-4280] <!-- eg [PROJECT-XXXX] -->

Initial PR: artsy/eigen#7495

### Description
> Show the Shipping & Taxes section unless the work is not for sale or the work is at auction (in which case we'd have that other copy above).

Based on [this comment](https://artsy.slack.com/archives/C9SATFLUU/p1667389698306379?thread_ts=1667388418.130119&cid=C9SATFLUU), we should hide the "Shipping and taxes" section if artwork is in auction

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/199955447-3a8d2c9d-fdce-414a-b34d-9a4574a7c0f5.mp4

#### After
https://user-images.githubusercontent.com/3513494/199955500-b38bd3b7-7338-47c2-94e5-e5431f84a573.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
