### PR TITLE
fix: Adjust Submission My Collection artwork image logic

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -12,6 +12,7 @@ export interface MyCollectionImageViewProps {
   imageHeight?: number
   aspectRatio?: number
   artworkSlug: string
+  artworkSubmissionId?: string | null
 }
 
 export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
@@ -20,6 +21,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   imageHeight,
   aspectRatio,
   artworkSlug,
+  artworkSubmissionId,
 }) => {
   const color = useColor()
   const [localImage, setLocalImage] = useState<LocalImage | null>(null)
@@ -32,11 +34,19 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
       }
     })
   }, [])
-  const { photos } = GlobalStore.useAppState(
-    (state) => state.artworkSubmission.submission.photosForMyCollection
-  )
+
+  const {
+    photosForMyCollection: { photos },
+    submissionIdForMyCollection,
+  } = GlobalStore.useAppState((state) => state.artworkSubmission.submission)
+
   useEffect(() => {
-    if (photos !== null && photos.length > 0) {
+    if (
+      photos !== null &&
+      photos.length > 0 &&
+      artworkSubmissionId &&
+      submissionIdForMyCollection === artworkSubmissionId
+    ) {
       setLocalImageConsignments(photos[0])
     }
   }, [])
@@ -54,18 +64,6 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           source={{ uri: localImage.path }}
         />
       )
-    } else if (imageURL) {
-      const targetURL = imageURL.replace(":version", "square")
-      return (
-        <OpaqueImageView
-          testID="Image-Remote"
-          imageURL={targetURL}
-          retryFailedURLs
-          height={imageHeight}
-          width={imageWidth}
-          aspectRatio={aspectRatio}
-        />
-      )
     } else if (localImageConsignments) {
       return (
         <RNImage
@@ -80,6 +78,18 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           source={{
             uri: localImageConsignments.path,
           }}
+        />
+      )
+    } else if (imageURL) {
+      const targetURL = imageURL.replace(":version", "square")
+      return (
+        <OpaqueImageView
+          testID="Image-Remote"
+          imageURL={targetURL}
+          retryFailedURLs
+          height={imageHeight}
+          width={imageWidth}
+          aspectRatio={aspectRatio}
         />
       )
     } else {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tsx
@@ -25,7 +25,18 @@ const MyCollectionArtworkGridItem: React.FC<MyCollectionArtworkGridItemProps> = 
     (artwork.images && artwork.images[0]?.url)
   const { width } = useScreenDimensions()
 
-  const { artist, artistNames, internalID, medium, mediumType, slug, title, image, date } = artwork
+  const {
+    artist,
+    artistNames,
+    internalID,
+    medium,
+    mediumType,
+    slug,
+    title,
+    image,
+    date,
+    submissionId,
+  } = artwork
 
   // consistent with how sections are derived in InfiniteScrollArtworksGrid
   const screen = useScreenDimensions()
@@ -62,6 +73,7 @@ const MyCollectionArtworkGridItem: React.FC<MyCollectionArtworkGridItemProps> = 
           imageURL={imageURL ?? undefined}
           aspectRatio={image?.aspectRatio}
           artworkSlug={slug}
+          artworkSubmissionId={submissionId}
         />
         <Box maxWidth={width} mt={1} style={{ flex: 1 }}>
           <Text lineHeight="18" weight="regular" variant="xs" numberOfLines={2}>
@@ -111,6 +123,7 @@ export const MyCollectionArtworkGridItemFragmentContainer = createFragmentContai
         artistNames
         medium
         slug
+        submissionId
         title
         date
         marketPriceInsights {

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -40,6 +40,7 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({ recentlySo
     GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
       photos: [],
     })
+    GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection("")
     const route = "/collections/my-collection/artworks/new/submissions/new"
     navigate(route)
   }
@@ -50,6 +51,7 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({ recentlySo
       GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
         photos: [],
       })
+      GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection("")
     }
   }, [])
 

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -83,6 +83,9 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
     GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
       photos: allPhotos,
     })
+    GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(
+      submission.submissionId
+    )
     GlobalStore.actions.artworkSubmission.submission.setPhotos({
       photos: allPhotos,
     })
@@ -119,6 +122,9 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
       GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
         photos: filteredPhotos,
       })
+      GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(
+        submission.submissionId
+      )
       GlobalStore.actions.artworkSubmission.submission.setPhotos({
         photos: filteredPhotos,
       })

--- a/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
+++ b/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
@@ -17,6 +17,7 @@ interface ConsignmentsSubmissionUtmParams {
 
 export interface ArtworkSubmissionModel {
   submissionId: string
+  submissionIdForMyCollection: string
   setSubmissionId: Action<ArtworkSubmissionModel, string>
   artworkDetails: ArtworkDetailsFormModel
   dirtyArtworkDetailsValues: ArtworkDetailsFormModel
@@ -28,6 +29,7 @@ export interface ArtworkSubmissionModel {
   photosForMyCollection: PhotosFormModel
   setPhotos: Action<ArtworkSubmissionModel, PhotosFormModel>
   setPhotosForMyCollection: Action<ArtworkSubmissionModel, PhotosFormModel>
+  setSubmissionIdForMyCollection: Action<ArtworkSubmissionModel, string>
   setUtmParams: Action<ArtworkSubmissionModel, ConsignmentsSubmissionUtmParams>
   resetSessionState: Action<ArtworkSubmissionModel>
 }
@@ -39,12 +41,16 @@ export interface SubmissionModel {
 export const getSubmissionModel = (): SubmissionModel => ({
   submission: {
     submissionId: "",
+    submissionIdForMyCollection: "",
     artworkDetails: artworkDetailsEmptyInitialValues,
     dirtyArtworkDetailsValues: artworkDetailsEmptyInitialValues,
     photos: photosEmptyInitialValues,
     photosForMyCollection: photosEmptyInitialValues,
     setPhotosForMyCollection: action((state, photos) => {
       state.photosForMyCollection = photos
+    }),
+    setSubmissionIdForMyCollection: action((state, submissionId) => {
+      state.submissionIdForMyCollection = submissionId
     }),
     setPhotos: action((state, photos) => {
       state.photos = photos

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -712,3 +712,21 @@ describe("App version Versions.RemoveDeviceId", () => {
     expect(migratedState.native.deviceId).toBe(undefined)
   })
 })
+
+describe("App version Versions.AddSubmissionIdForMyCollection", () => {
+  const migrationToTest = Versions.AddSubmissionIdForMyCollection
+
+  it("removes deviceId", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    }) as any
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect(migratedState.artworkSubmission.submission.submissionIdForMyCollection).toEqual("")
+  })
+})

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -39,9 +39,10 @@ export const Versions = {
   AddZipCodeAndCountryCodeInSubmissionArtworkDetails: 27,
   AddDirtyFormValuesToSubmissionState: 28,
   RemoveDeviceId: 29,
+  AddSubmissionIdForMyCollection: 30,
 }
 
-export const CURRENT_APP_VERSION = Versions.RemoveDeviceId
+export const CURRENT_APP_VERSION = Versions.AddSubmissionIdForMyCollection
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -235,6 +236,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.RemoveDeviceId]: (state) => {
     delete state.native.deviceId
+  },
+  [Versions.AddSubmissionIdForMyCollection]: (state) => {
+    state.artworkSubmission.submission.submissionIdForMyCollection = ""
   },
 }
 


### PR DESCRIPTION
This PR resolves [CX-3127] <!-- eg [PROJECT-XXXX] -->

### Description

This PR stores the ID of the last submission to ensure that only the artwork in My Collection with this ID displays the image of the submission. Without this correction, any artwork in My Collection without an image set would display the image of the last submission.

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Adjust image logic for My Collection after submitting an artwork - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3127]: https://artsyproduct.atlassian.net/browse/CX-3127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ