### PR TITLE
fix: prevent markdown lists from breaking the readmore component

### DIFF
--- a/src/app/Components/ReadMore.tests.tsx
+++ b/src/app/Components/ReadMore.tests.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, getDefaultNormalizer, within } from "@testing-library/react-native"
+import { act, fireEvent, getDefaultNormalizer, screen, within } from "@testing-library/react-native"
 import { navigate } from "app/navigation/navigate"
 import { extractText } from "app/tests/extractText"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
@@ -119,5 +119,22 @@ describe("ReadMore", () => {
     act(() => fireEvent.press(UNSAFE_getAllByType(LinkText)[0]))
 
     expect(navigate).toHaveBeenCalledWith("/artist/andy-warhol")
+  })
+
+  it("doesn't break when it gets a text with dashes and special characters", () => {
+    const text = "- first \n- second \n- third \n * star \n & another one \n ' whatarethose"
+
+    renderWithWrappers(<ReadMore maxChars={7} content={text} />)
+
+    // should display - first... Read more in the beginning
+    expect(screen.queryByText(text)).toBeFalsy()
+    expect(screen.queryByText("- first...")).toBeTruthy()
+    expect(screen.queryByText("Read more")).toBeTruthy()
+
+    fireEvent.press(screen.getByText("Read more"))
+
+    // after pressing read more, read more goes away and the full text is displayed
+    expect(screen.queryByText(text)).toBeTruthy()
+    expect(screen.queryByText("Read more")).toBeFalsy()
   })
 })

--- a/src/app/Components/ReadMore.tsx
+++ b/src/app/Components/ReadMore.tsx
@@ -27,7 +27,6 @@ interface Props {
   color?: ResponsiveValue<Color>
   textStyle?: "sans" | "new"
   testID?: string
-  type?: "show"
   textVariant?: PaletteTextProps["variant"]
   linkTextVariant?: PaletteTextProps["variant"]
 }
@@ -42,7 +41,6 @@ export const ReadMore = React.memo(
     contextModule,
     textStyle = "sans",
     testID,
-    type,
     textVariant = "xs",
     linkTextVariant = "xs",
   }: Props) => {
@@ -51,27 +49,24 @@ export const ReadMore = React.memo(
     const useNewTextStyles = textStyle === "new"
     const basicRules = defaultRules({ modal: presentLinksModally, useNewTextStyles })
     const TextComponent: React.ComponentType<PaletteTextProps> = PaletteText
-
     const textProps: PaletteTextProps = { variant: textVariant }
     const rules = {
       ...basicRules,
-      ...(type === "show" && {
-        list: {
-          ...basicRules.paragraph,
-          react: (
-            node: SimpleMarkdown.SingleASTNode,
-            output: SimpleMarkdown.Output<React.ReactNode>,
-            state: SimpleMarkdown.State
-          ) => {
-            return (
-              <TextComponent {...textProps} color={color || "black100"} key={state.key}>
-                {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}
-                {output(node.content, state)}
-              </TextComponent>
-            )
-          },
+      list: {
+        ...basicRules.paragraph,
+        react: (
+          node: SimpleMarkdown.SingleASTNode,
+          output: SimpleMarkdown.Output<React.ReactNode>,
+          state: SimpleMarkdown.State
+        ) => {
+          return (
+            <TextComponent {...textProps} color={color || "black100"} key={state.key}>
+              {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}
+              {output(node.content, state)}
+            </TextComponent>
+          )
         },
-      }),
+      },
       link: {
         ...basicRules.link,
         react: (

--- a/src/app/Scenes/Show/Screens/ShowMoreInfo.tsx
+++ b/src/app/Scenes/Show/Screens/ShowMoreInfo.tsx
@@ -93,7 +93,7 @@ export const ShowMoreInfo: React.FC<ShowMoreInfoProps> = ({ show }) => {
                 <Text variant="sm" mb={0.5}>
                   Press Release
                 </Text>
-                <ReadMore type="show" content={show.pressRelease} textStyle="sans" maxChars={500} />
+                <ReadMore content={show.pressRelease} textStyle="sans" maxChars={500} />
               </Box>
             ),
           },


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

[Slack thread](https://artsy.slack.com/archives/C02BAQ5K7/p1667866746452839) for more context.

The ReadMore component broke the app when it was trying to render lists due to a problem with the markdown dependency that we are using (opened an [issue](https://github.com/ariabuckles/simple-markdown/issues/112) a while ago but no one has replied..)

The solution is to prevent the component from rendering the markdown "list" (when it sees dashes it tries to render a markdown list but fails) and default to rendering it as a paragraph which is okay for now (see screenshot below)

![simulator_screenshot_4131C009-2056-478E-A025-BFC45923DFD0](https://user-images.githubusercontent.com/21178754/200525762-caae9e5e-cee6-4258-81a1-dd06d908e132.png)


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- fixed markdown lists from breaking readmore component - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
