### PR TITLE
refactor: move ArtworkMaker to different component

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tests.tsx
@@ -1,0 +1,172 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { navigate } from "app/navigation/navigate"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { setupTestWrapperTL } from "app/tests/setupTestWrapper"
+import { Theme } from "palette"
+import { graphql } from "react-relay"
+import { ArtworkMakerTitleFragmentContainer } from "./ArtworkMakerTitle"
+
+jest.unmock("react-relay")
+
+describe("ArtworkMakerTitle", () => {
+  const { renderWithRelay } = setupTestWrapperTL({
+    Component: (props) => (
+      <Theme>
+        <ArtworkMakerTitleFragmentContainer {...props} />
+      </Theme>
+    ),
+    query: graphql`
+      query ArtworkMakerTitle_Test_Query {
+        artwork(id: "test-artwork") {
+          ...ArtworkMakerTitle_artwork
+        }
+      }
+    `,
+  })
+
+  it("renders fields correctly", async () => {
+    renderWithRelay({
+      Artwork: () => ({
+        artists: [
+          { name: "Andy Warhol", href: "https://testhref" },
+          { name: "Jeff Koons", href: "https://testhref" },
+          { name: "Damien Hirst", href: "https://testhref" },
+          { name: "Another Artist", href: "https://testhref" },
+          { name: "Bruce Kurtman", href: "https://testhref" },
+          { name: "Wes Borland", href: "https://testhref" },
+        ],
+        culturalMaker: null,
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Andy Warhol,")).toBeTruthy()
+    expect(screen.queryByText("Jeff Koons,")).toBeTruthy()
+    expect(screen.queryByText("Damien Hirst,")).toBeTruthy()
+    expect(screen.queryByText("3 more")).toBeTruthy()
+  })
+
+  it("redirects to artist page when artist name is clicked", async () => {
+    renderWithRelay({
+      Artwork: () => ({
+        artists: [{ name: "Andy Warhol", href: "/artist/andy-warhol" }],
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText(/Andy Warhol/)).toBeTruthy()
+    fireEvent.press(screen.getByText(/Andy Warhol/))
+
+    expect(navigate).toHaveBeenCalledWith("/artist/andy-warhol")
+  })
+
+  describe("for an artwork with more than 3 artists", () => {
+    it("truncates artist names", async () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [
+            { name: "Andy Warhol", href: "https://testhref" },
+            { name: "Jeff Koons", href: "https://testhref" },
+            { name: "Damien Hirst", href: "https://testhref" },
+            { name: "Another Artist", href: "https://testhref" },
+            { name: "Bruce Kurtman", href: "https://testhref" },
+            { name: "Wes Borland", href: "https://testhref" },
+          ],
+          culturalMaker: null,
+        }),
+      })
+
+      await flushPromiseQueue()
+      expect(screen.queryByText("Andy Warhol,")).toBeTruthy()
+      expect(screen.queryByText("Jeff Koons,")).toBeTruthy()
+      expect(screen.queryByText("Damien Hirst,")).toBeTruthy()
+      expect(screen.queryByText("3 more")).toBeTruthy()
+      expect(screen.queryByText("Another Artist")).toBeNull()
+      expect(screen.queryByText("Bruce Kurtman")).toBeNull()
+      expect(screen.queryByText("Wes Borland")).toBeNull()
+    })
+
+    it("shows truncated artist names when 'x more' is clicked", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [
+            { name: "Andy Warhol", href: "https://testhref" },
+            { name: "Jeff Koons", href: "https://testhref" },
+            { name: "Damien Hirst", href: "https://testhref" },
+            { name: "Another Artist", href: "https://testhref" },
+            { name: "Bruce Kurtman", href: "https://testhref" },
+            { name: "Wes Borland", href: "https://testhref" },
+          ],
+          culturalMaker: null,
+        }),
+      })
+
+      fireEvent.press(screen.getByText("3 more"))
+
+      expect(screen.queryByText("3 more")).toBeNull()
+      expect(screen.queryByText(/Another Artist/)).toBeTruthy()
+      expect(screen.queryByText(/Bruce Kurtman/)).toBeTruthy()
+      expect(screen.queryByText(/Wes Borland/)).toBeTruthy()
+    })
+  })
+
+  describe("for an artwork with less than 4 artists but more than 1", () => {
+    it("doesn't truncate artist names", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [
+            { name: "Andy Warhol", href: "https://testhref" },
+            { name: "Jeff Koons", href: "https://testhref" },
+            { name: "Damien Hirst", href: "https://testhref" },
+          ],
+          culturalMaker: null,
+        }),
+      })
+
+      expect(screen.queryByText("Andy Warhol,")).toBeTruthy()
+      expect(screen.queryByText("Jeff Koons,")).toBeTruthy()
+      expect(screen.queryByText("Damien Hirst")).toBeTruthy()
+      expect(screen.queryByText(/more/)).toBeNull()
+    })
+  })
+
+  describe("for an artwork with one artist", () => {
+    it("renders artist name", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [{ name: "Andy Warhol", href: "https://testhref" }],
+          culturalMaker: null,
+        }),
+      })
+
+      expect(screen.queryByText(/Andy Warhol/)).toBeTruthy()
+    })
+
+    it("Artist name is not clickable if no href provided", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [{ name: "Andy Warhol", href: null }],
+          culturalMaker: null,
+        }),
+      })
+
+      expect(screen.queryByText(/Andy Warhol/)).toBeTruthy()
+      expect(screen.getByA11yHint("Go to artist page")).toBeDisabled()
+    })
+  })
+
+  describe("for an artwork with no artists but a cultural maker", () => {
+    it("renders artist name", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artists: [],
+          culturalMaker: "18th century American",
+        }),
+      })
+
+      expect(screen.queryByText("18th century American")).toBeTruthy()
+    })
+  })
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
@@ -17,10 +17,6 @@ const ArtworkMaker: React.FC<ArtworkMakerProps> = ({ artistName, href }) => {
   const { trackEvent } = useTracking()
 
   const handleArtistTap = (artistHref: string) => {
-    if (!artistHref) {
-      return
-    }
-
     trackEvent({
       action_name: Schema.ActionNames.ArtistName,
       action_type: Schema.ActionTypes.Tap,

--- a/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
@@ -79,11 +79,11 @@ const ArtworkMultipleMakers: React.FC<ArtworkMultipleMakersProps> = ({ artists }
   )
 }
 
-interface ComponentProps {
+interface ArtworkMakerTitleProps {
   artwork: ArtworkMakerTitle_artwork$data
 }
 
-export const ArtworkMakerTitle: React.FC<ComponentProps> = ({ artwork }) => {
+const ArtworkMakerTitle: React.FC<ArtworkMakerTitleProps> = ({ artwork }) => {
   const { artists, culturalMaker } = artwork
 
   if (artists?.length === 0 && !!culturalMaker) {
@@ -101,16 +101,14 @@ export const ArtworkMakerTitle: React.FC<ComponentProps> = ({ artwork }) => {
   return null
 }
 
-const artworkMakerTitleFragment = graphql`
-  fragment ArtworkMakerTitle_artwork on Artwork {
-    culturalMaker
-    artists {
-      name
-      href
-    }
-  }
-`
-
 export const ArtworkMakerTitleFragmentContainer = createFragmentContainer(ArtworkMakerTitle, {
-  artwork: artworkMakerTitleFragment,
+  artwork: graphql`
+    fragment ArtworkMakerTitle_artwork on Artwork {
+      culturalMaker
+      artists {
+        name
+        href
+      }
+    }
+  `,
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkMakerTitle.tsx
@@ -1,0 +1,103 @@
+import { ArtworkTombstone_artwork$data } from "__generated__/ArtworkTombstone_artwork.graphql"
+import { navigate } from "app/navigation/navigate"
+import { Schema } from "app/utils/track"
+import { Flex, Text } from "palette"
+import { useState } from "react"
+import React from "react"
+import { TouchableWithoutFeedback } from "react-native"
+import { useTracking } from "react-tracking"
+
+interface ArtworkMakerProps {
+  artistName: string
+  href?: string | null
+}
+
+const ArtworkMaker: React.FC<ArtworkMakerProps> = ({ artistName, href }) => {
+  const { trackEvent } = useTracking()
+
+  const handleArtistTap = (artistHref: string) => {
+    if (!artistHref) {
+      return
+    }
+
+    trackEvent({
+      action_name: Schema.ActionNames.ArtistName,
+      action_type: Schema.ActionTypes.Tap,
+      context_module: Schema.ContextModules.ArtworkTombstone,
+    })
+
+    navigate(artistHref)
+  }
+
+  if (!href) {
+    return <Text variant="lg-display">{artistName}</Text>
+  }
+
+  return (
+    <TouchableWithoutFeedback
+      accessibilityRole="link"
+      accessibilityHint="Go to artist page"
+      onPress={() => handleArtistTap(href)}
+    >
+      <Text variant="lg-display">{artistName}</Text>
+    </TouchableWithoutFeedback>
+  )
+}
+
+interface ArtworkMultipleMakersProps {
+  artists: ArtworkTombstone_artwork$data["artists"]
+}
+
+const ArtworkMultipleMakers: React.FC<ArtworkMultipleMakersProps> = ({ artists }) => {
+  const [showMoreArtists, setShowMoreArtists] = useState(false)
+
+  const toggleShowMoreArtists = () => {
+    setShowMoreArtists((current) => !current)
+  }
+
+  const truncatedArtists = !showMoreArtists ? artists?.slice(0, 3) : artists
+
+  const artistNames = truncatedArtists?.map((artist, index) => {
+    const artistNameWithComma = index !== artists!.length - 1 ? artist!.name + ", " : artist!.name!
+
+    return <ArtworkMaker key={artist!.href} artistName={artistNameWithComma} href={artist!.href} />
+  })
+
+  return (
+    <Flex flexDirection="row" flexWrap="wrap">
+      <Text variant="lg-display">
+        {artistNames}
+        {!showMoreArtists && artists!.length > 3 && (
+          <TouchableWithoutFeedback
+            accessibilityRole="togglebutton"
+            accessibilityHint={!showMoreArtists ? "Show more artists" : "Show less artists"}
+            onPress={toggleShowMoreArtists}
+          >
+            <Text variant="lg-display">{artists!.length - 3} more</Text>
+          </TouchableWithoutFeedback>
+        )}
+      </Text>
+    </Flex>
+  )
+}
+
+interface ComponentProps {
+  artists: ArtworkTombstone_artwork$data["artists"]
+  culturalMaker: ArtworkTombstone_artwork$data["culturalMaker"]
+}
+
+export const ArtworkMakerTitle: React.FC<ComponentProps> = ({ artists, culturalMaker }) => {
+  if (artists?.length === 1) {
+    return <ArtworkMaker artistName={artists[0]!.name!} href={artists[0]!.href!} />
+  }
+
+  if (!!artists && artists?.length > 1) {
+    return <ArtworkMultipleMakers artists={artists} />
+  }
+
+  if (artists?.length === 0 && !!culturalMaker) {
+    return <ArtworkMaker artistName={culturalMaker} />
+  }
+
+  return null
+}

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -1,14 +1,9 @@
 import { ArtworkTombstone_artwork$data } from "__generated__/ArtworkTombstone_artwork.graphql"
-import { navigate } from "app/navigation/navigate"
-import { Schema } from "app/utils/track"
 import { Box, comma, Flex, Spacer, Text } from "palette"
-import React, { useState } from "react"
-import { TouchableWithoutFeedback } from "react-native"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useTracking } from "react-tracking"
+import { ArtworkMakerTitle } from "./ArtworkMakerTitle"
 import { CascadingEndTimesBanner } from "./CascadingEndTimesBanner"
-
-type Artist = NonNullable<NonNullable<ArtworkTombstone_artwork$data["artists"]>[0]>
 
 export interface ArtworkTombstoneProps {
   artwork: ArtworkTombstone_artwork$data
@@ -20,62 +15,6 @@ export interface ArtworkTombstoneState {
 }
 
 export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) => {
-  const { trackEvent } = useTracking()
-  const [showingMoreArtists, setShowingMoreArtists] = useState(false)
-
-  const handleArtistTap = (href: string) => {
-    trackEvent({
-      action_name: Schema.ActionNames.ArtistName,
-      action_type: Schema.ActionTypes.Tap,
-      context_module: Schema.ContextModules.ArtworkTombstone,
-    })
-    navigate(href)
-  }
-
-  const showMoreArtists = () => {
-    setShowingMoreArtists((current) => !current)
-  }
-
-  const renderSingleArtist = (artist: Artist) => {
-    return <Text variant="lg-display">{renderArtistName(artist.name!, artist.href)}</Text>
-  }
-
-  const renderArtistName = (artistName: string, href: string | null) => {
-    return href ? (
-      <TouchableWithoutFeedback onPress={() => handleArtistTap(href)}>
-        <Text variant="lg-display">{artistName}</Text>
-      </TouchableWithoutFeedback>
-    ) : (
-      <Text variant="lg-display">{artistName}</Text>
-    )
-  }
-
-  const renderMultipleArtists = () => {
-    const artists = artwork.artists ?? []
-    const truncatedArtists = !showingMoreArtists ? artists.slice(0, 3) : artists
-    const artistNames = truncatedArtists.map((artist, index) => {
-      const artistNameWithComma = index !== artists.length - 1 ? artist!.name + ", " : artist!.name!
-      return (
-        <React.Fragment key={artist!.href}>
-          {renderArtistName(artistNameWithComma, artist!.href)}
-        </React.Fragment>
-      )
-    })
-
-    return (
-      <Flex flexDirection="row" flexWrap="wrap">
-        <Text variant="lg-display">
-          {artistNames}
-          {!showingMoreArtists && artists!.length > 3 && (
-            <TouchableWithoutFeedback onPress={showMoreArtists}>
-              <Text variant="lg-display">{artists!.length - 3} more</Text>
-            </TouchableWithoutFeedback>
-          )}
-        </Text>
-      </Flex>
-    )
-  }
-
   const getArtworkTitleAndMaybeDate = () => {
     if (artwork.date) {
       return `${artwork.title!}${comma} ${artwork.date}`
@@ -102,11 +41,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) =
         </>
       )}
       <Flex flexDirection="row" flexWrap="wrap">
-        {artwork.artists?.length === 1
-          ? renderSingleArtist(artwork!.artists![0]!)
-          : renderMultipleArtists()}
-        {!!(artwork.artists?.length === 0 && artwork.culturalMaker) &&
-          renderArtistName(artwork.culturalMaker, null)}
+        <ArtworkMakerTitle artists={artwork.artists} culturalMaker={artwork.culturalMaker} />
       </Flex>
       <Flex flexDirection="row" flexWrap="wrap">
         <Text variant="lg-display" color="black60">

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -1,7 +1,7 @@
 import { ArtworkTombstone_artwork$data } from "__generated__/ArtworkTombstone_artwork.graphql"
 import { Box, comma, Flex, Spacer, Text } from "palette"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ArtworkMakerTitle } from "./ArtworkMakerTitle"
+import { ArtworkMakerTitleFragmentContainer } from "./ArtworkMakerTitle"
 import { CascadingEndTimesBanner } from "./CascadingEndTimesBanner"
 
 export interface ArtworkTombstoneProps {
@@ -40,7 +40,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) =
         </>
       )}
       <Flex flexDirection="row" flexWrap="wrap">
-        <ArtworkMakerTitle artwork={artwork} />
+        <ArtworkMakerTitleFragmentContainer artwork={artwork} />
       </Flex>
       <Flex flexDirection="row" flexWrap="wrap">
         <Text variant="lg-display" color="black60">

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -1,6 +1,5 @@
 import { ArtworkTombstone_artwork$data } from "__generated__/ArtworkTombstone_artwork.graphql"
 import { Box, comma, Flex, Spacer, Text } from "palette"
-import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkMakerTitle } from "./ArtworkMakerTitle"
 import { CascadingEndTimesBanner } from "./CascadingEndTimesBanner"
@@ -41,7 +40,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) =
         </>
       )}
       <Flex flexDirection="row" flexWrap="wrap">
-        <ArtworkMakerTitle artists={artwork.artists} culturalMaker={artwork.culturalMaker} />
+        <ArtworkMakerTitle artwork={artwork} />
       </Flex>
       <Flex flexDirection="row" flexWrap="wrap">
         <Text variant="lg-display" color="black60">
@@ -82,7 +81,6 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
       isInAuction
       medium
       date
-      culturalMaker
       saleArtwork {
         lotLabel
         estimate
@@ -95,11 +93,7 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
         cascadingEndTimeIntervalMinutes
         extendedBiddingIntervalMinutes
       }
-      artists {
-        name
-        href
-        ...FollowArtistLink_artist
-      }
+      ...ArtworkMakerTitle_artwork
     }
   `,
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -39,9 +39,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) =
           </Text>
         </>
       )}
-      <Flex flexDirection="row" flexWrap="wrap">
-        <ArtworkMakerTitleFragmentContainer artwork={artwork} />
-      </Flex>
+      <ArtworkMakerTitleFragmentContainer artwork={artwork} />
       <Flex flexDirection="row" flexWrap="wrap">
         <Text variant="lg-display" color="black60">
           {getArtworkTitleAndMaybeDate()}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Small refactor that removes the artist name component logic from ArtworkTombstone

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#nochangelog

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
