### PR TITLE
feat(FX-4305): add ability to hide bottom tabs

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -11,7 +11,7 @@ import { BackButton } from "app/navigation/BackButton"
 import { navigationEvents } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
-import { useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { QAInfoPanel } from "app/utils/QAInfo"
@@ -148,6 +148,14 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
     return () => {
       navigationEvents.removeListener("modalDismissed", handleModalDismissed)
+    }
+  }, [])
+
+  useEffect(() => {
+    GlobalStore.actions.bottomTabs.toggleBottomTabForCurrentTab({ isVisible: false })
+
+    return () => {
+      GlobalStore.actions.bottomTabs.toggleBottomTabForCurrentTab({ isVisible: true })
     }
   }, [])
 

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -151,7 +151,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
     }
   }, [])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     GlobalStore.actions.bottomTabs.toggleBottomTabForCurrentTab({ isVisible: false })
 
     return () => {

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -9,9 +9,12 @@ import { ICON_HEIGHT } from "./BottomTabsIcon"
 export const BottomTabs: React.FC = () => {
   const { color } = useTheme()
 
+  const sessionState = GlobalStore.useAppState((state) => state.bottomTabs.sessionState)
   const unreadConversationCount = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.unreadConversationCount
   )
+  const selectedTabProps = sessionState.tabProps[sessionState.selectedTab]
+  const isVisibleTab = (selectedTabProps as { isVisibleTab?: boolean })?.isVisibleTab ?? true
 
   useEffect(() => {
     GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
@@ -26,6 +29,11 @@ export const BottomTabs: React.FC = () => {
   const enableMyCollectionInsights = useFeatureFlag("AREnableMyCollectionInsights")
 
   const { bottom } = useScreenDimensions().safeAreaInsets
+
+  if (!isVisibleTab) {
+    return null
+  }
+
   return (
     <Flex style={{ paddingBottom: bottom }}>
       <Separator

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -73,7 +73,10 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   toggleBottomTabForCurrentTab: action((state, { isVisible }) => {
     const selectedTab = state.sessionState.selectedTab
+    const prevTabState = state.sessionState.tabProps[selectedTab]
+
     state.sessionState.tabProps[selectedTab] = {
+      ...prevTabState,
       isVisibleTab: isVisible,
     }
   }),

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -20,6 +20,7 @@ export interface BottomTabsModel {
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
+  toggleBottomTabForCurrentTab: Action<BottomTabsModel, { isVisible: boolean }>
 }
 
 export const getBottomTabsModel = (): BottomTabsModel => ({
@@ -69,5 +70,11 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
+  }),
+  toggleBottomTabForCurrentTab: action((state, { isVisible }) => {
+    const selectedTab = state.sessionState.selectedTab
+    state.sessionState.tabProps[selectedTab] = {
+      isVisibleTab: isVisible,
+    }
   }),
 })


### PR DESCRIPTION
This PR resolves [FX-4305] <!-- eg [PROJECT-XXXX] -->

### Problems
#### Problem 1
Strange behavior on iOS if you open a previously visited page again

https://user-images.githubusercontent.com/3513494/200888373-252b1c99-622a-405a-b357-0ca7f85e67c4.mp4

#### Problem 2
There is a possibility that the display state of bottom tabs may be overwritten if [setTabProps](https://github.com/artsy/eigen/blob/6b1089496781aea00fe7aecd84381c63b13e07cf/src/app/Scenes/BottomTabs/BottomTabsModel.ts#L71-L73) is used somewhere in the code (for example, like [this](https://github.com/artsy/eigen/blob/72f27636505077dc4a20b95d07ed2d534863b1a5/src/app/navigation/navigate.ts#L138) or [this](https://github.com/artsy/eigen/blob/72f27636505077dc4a20b95d07ed2d534863b1a5/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/index.tsx#L95)). To solve this potential problem, we can store the display state of bottoms tabs for the current tab not in `tabProps` (see example below)

```javascript
export interface BottomTabsModel {
  sessionState: {
    ...
    tabProps: Partial<{ [k in BottomTabType]: object }>
    visibleStateByTab: Partial<{ [k in BottomTabType]: boolean }>
  }
  ...
}

export const getBottomTabsModel = (): BottomTabsModel => ({
  ...
  toggleBottomTabForCurrentTab: action((state, { isVisible }) => {
    const selectedTab = state.sessionState.selectedTab
    state.sessionState.visibleStateByTab[selectedTab] = isVisible
  }),
})
```

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4305]: https://artsyproduct.atlassian.net/browse/FX-4305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ