### PR TITLE
fix(setup): Invoke prettier via npx to avoid error during repo setup

### DIFF
--- a/scripts/update-echo
+++ b/scripts/update-echo
@@ -3,4 +3,4 @@ set -euxo pipefail
 
 
 curl https://echo.artsy.net/Echo.json > ios/Artsy/App/EchoNew.json
-yarn prettier -w ios/Artsy/App/EchoNew.json
+npx prettier -w ios/Artsy/App/EchoNew.json


### PR DESCRIPTION
### Description

Following the install docs, after running `yarn setup:artsy` the process crashed due to prettier not being installed globally on my system: 

<img width="356" alt="Screenshot 2022-11-09 at 9 14 35 AM" src="https://user-images.githubusercontent.com/236943/200896990-ddf419a7-d080-4ad1-bae5-df7621bf546a.png">

This PR swaps the `yarn` invocation with `npx`, which is designed for these kinds of cases where packages are used outside of the normal package.json flow. 


