### PR TITLE
docs(troubleshooting): Add link to troubleshooting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 ## Getting Started
 
 - [Getting Started](getting_started.md)
+- [Troubleshooting](troubleshooting.md)
 
 ## Meandering Around
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -63,6 +63,10 @@ yarn install:all
 
 **Note**: `yarn pod-install` (which is included in `yarn install:all`) may fail the first time you run it (due to a [bug](https://github.com/orta/cocoapods-keys/issues/127) in a dependency of ours). Re-running the command should work.
 
+## Troubleshooting
+
+If there are issues setting up the app, see the [troubleshooting doc](docs/troubleshooting.md).
+
 ## Contribute
 
 We welcome independent contributions! Feel free to open an issue and open a PR and assign one of [Brian Beckerle](https://github.com/brainbicycle), [Pavlos Vinieratos](https://github.com/pvinis), [Mounir Dhahri](https://github.com/MounirDhahri) as a reviewer or anyone else listed [here](https://github.com/artsy/eigen#meta).


### PR DESCRIPTION
### Description

Adds links to the troubleshooting doc in `docs/README.md` and on the setup page. 