### PR TITLE
WIP: Add Video support to Artwork Carousel 

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "react-native-share": "7.3.6",
     "react-native-svg": "9.13.3",
     "react-native-view-shot": "3.4.0",
+    "react-native-vimeo-iframe": "1.2.0",
     "react-native-vision-camera": "2.14.1",
     "react-native-webview": "11.3.1",
     "react-relay": "14.0.0",

--- a/src/app/Scenes/Artwork/Components/ArtworkHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkHeader.tsx
@@ -127,6 +127,7 @@ export const ArtworkHeader: React.FC<ArtworkHeaderProps> = (props) => {
         )}
         <Spacer mb={2} />
         <ImageCarouselFragmentContainer
+          artwork={artwork}
           images={artwork.images as any /* STRICTNESS_MIGRATION */}
           cardHeight={screenDimensions.width >= 375 ? 340 : 290}
           onImageIndexChange={(imageIndex) => setCurrentImageIndex(imageIndex)}
@@ -204,6 +205,7 @@ export const ArtworkHeaderFragmentContainer = createFragmentContainer(ArtworkHea
     fragment ArtworkHeader_artwork on Artwork {
       ...ArtworkActions_artwork
       ...ArtworkTombstone_artwork
+      ...ImageCarousel_artwork
       images {
         ...ImageCarousel_images
         url: imageURL

--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel.tests.tsx
@@ -103,7 +103,9 @@ describe("ImageCarouselFragmentContainer", () => {
           query ImageCarouselTestsQuery @raw_response_type {
             artwork(id: "unused") {
               images {
-                ...ImageCarousel_images
+                internalID
+                # FIXME
+                # ...ImageCarousel_images
               }
             }
           }

--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselContext.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselContext.tsx
@@ -4,10 +4,16 @@ import React, { useMemo, useRef } from "react"
 import { Animated, FlatList, View } from "react-native"
 import { useTracking } from "react-tracking"
 import { GlobalState, useGlobalState } from "../../../../utils/useGlobalState"
+import { ImageCarousel_artwork$data } from "__generated__/ImageCarousel_artwork.graphql"
 
 export type ImageDescriptor = Pick<
   ImageCarousel_images$data[number],
   "deepZoom" | "height" | "width" | "url"
+>
+
+export type ImageDescriptor2 = Extract<
+  ImageCarousel_artwork$data["figures"][number],
+  "height" | "width" | "url"
 >
 
 export type ImageCarouselAction =
@@ -48,6 +54,9 @@ export interface ImageCarouselContext {
   fullScreenState: GlobalState<FullScreenState>
   isZoomedCompletelyOut: GlobalState<boolean>
   images: ImageDescriptor[]
+  videos: any
+  media: any
+  setVideoAsCover: boolean
   embeddedImageRefs: View[]
   embeddedFlatListRef: React.RefObject<FlatList<any>>
   xScrollOffsetAnimatedValue: React.RefObject<Animated.Value>
@@ -56,9 +65,13 @@ export interface ImageCarouselContext {
 
 export function useNewImageCarouselContext({
   images,
+  videos,
+  setVideoAsCover,
   onImageIndexChange,
 }: {
   images: ImageDescriptor[]
+  videos: any
+  setVideoAsCover: boolean
   onImageIndexChange?: (imageIndex: number) => void
 }): ImageCarouselContext {
   const embeddedImageRefs = useMemo(() => [], [])
@@ -70,6 +83,8 @@ export function useNewImageCarouselContext({
   const [isZoomedCompletelyOut, setIsZoomedCompletelyOut] = useGlobalState(true)
   const tracking = useTracking()
 
+  const media = setVideoAsCover ? [...videos, ...images] : [...images, ...videos]
+
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   return useMemo(
     () => ({
@@ -78,6 +93,9 @@ export function useNewImageCarouselContext({
       fullScreenState,
       isZoomedCompletelyOut,
       images,
+      videos,
+      setVideoAsCover,
+      media,
       embeddedImageRefs,
       embeddedFlatListRef,
       xScrollOffsetAnimatedValue,

--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselPaginationIndicator.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselPaginationIndicator.tsx
@@ -17,12 +17,12 @@ export const PaginationIndicator: React.FC<{ indicatorType: IndicatorType }> = (
 }
 
 const PaginationDots: React.FC = () => {
-  const { images } = useContext(ImageCarouselContext)
+  const { media } = useContext(ImageCarouselContext)
   return (
     <>
       <Spacer mb={2} />
       <Flex flexDirection="row" justifyContent="center">
-        {images.map((_, index) => (
+        {media.map((_, index) => (
           <PaginationDot key={index} diameter={5} index={index} />
         ))}
       </Flex>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12661,6 +12661,11 @@ react-native-view-shot@3.4.0:
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.4.0.tgz#787b31b2d0525a197864e12aaea214e905e97f9a"
   integrity sha512-b0CcWJGO0xLCXRsstIYRUEg/UStrR7uujQV9jFHRIVyPfBH0gRplT7Vlgimr+PX+Xg+9/rCyIKPjqK1Knv8hxg==
 
+react-native-vimeo-iframe@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-vimeo-iframe/-/react-native-vimeo-iframe-1.2.0.tgz#c85d0a96dff6b29d6c9bcd71b08a5e834cf02549"
+  integrity sha512-BCEPg0rMqW5RRRW3xO08jvuEr7upaf1uu1vrO9GR6IeFhb/cl0tNCayHt6n2jp6vyY+CR9Xzr3LZ2H3mvdRlYw==
+
 react-native-vision-camera@2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/react-native-vision-camera/-/react-native-vision-camera-2.14.1.tgz#6b9fecd5c5976167b8e8752455be24cd12c3d84f"


### PR DESCRIPTION
Super WIP around types, but works! 

Couple things. 
- Tried to refactor this to "do things correctly" in a separate PR -- that is, replace `images` field on Artwork with `figures`, and then narrow the type. This led to a cascade of failures, in addition to the need to refactor the implementation as the ImageCarousel is used in a few different ways around eigen. Aborted that mission.
- The approach in this PR keeps the existing code, and adds a new fragment on the carousel to include `figures` which exclusively extracts video code. Then we shuttle that data along and pass it into the carousel and merge the two together. 
- Works well enough, but ideally everything is refactored to use one consistent form -- `figures`. Ran into type errors doing this, even though the change _should_ have been straight forward and 1:1  