### PR TITLE
feat(FX-4440): Pin Collector Profile-sourced price range as the last "recent" price range

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
@@ -258,6 +258,21 @@ describe("PriceRangeOptions", () => {
         expect(queryByText("Apply a recent Price Range")).toBeNull()
       })
 
+      it("should render the collector profile-sourced range", () => {
+        __globalStoreTestUtils__?.injectState({
+          userPrefs: {
+            priceRange: "0-5000",
+          },
+          recentPriceRanges: {
+            ranges: [],
+          },
+        })
+
+        const { queryByText } = getTree()
+
+        expect(queryByText("$0–5,000")).toBeTruthy()
+      })
+
       it("should correctly clear the recent price ranges when `Clear` button is pressed", () => {
         __globalStoreTestUtils__?.injectState({
           recentPriceRanges: {

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
@@ -258,42 +258,59 @@ describe("PriceRangeOptions", () => {
         expect(queryByText("Apply a recent Price Range")).toBeNull()
       })
 
-      it("should render the collector profile-sourced range", () => {
-        __globalStoreTestUtils__?.injectState({
-          userPrefs: {
-            priceRange: "0-5000",
-          },
-          recentPriceRanges: {
-            ranges: [],
-          },
+      describe("the collector profile-sourced price range", () => {
+        it("should NOT be rendered if it is NOT specified", () => {
+          __globalStoreTestUtils__?.injectState({
+            userPrefs: {
+              priceRange: "*-*",
+            },
+            recentPriceRanges: {
+              ranges: [],
+            },
+          })
+
+          const { queryAllByLabelText } = getTree()
+
+          expect(queryAllByLabelText("Price range pill")).toHaveLength(0)
         })
 
-        const { queryByText } = getTree()
+        it("should be rendered if it is specified", () => {
+          __globalStoreTestUtils__?.injectState({
+            userPrefs: {
+              priceRange: "0-5000",
+            },
+            recentPriceRanges: {
+              ranges: [],
+            },
+          })
 
-        expect(queryByText("$0–5,000")).toBeTruthy()
-      })
+          const { queryByText } = getTree()
 
-      it("should render 5 pills maximum (4 recently selected, 1 collector profile-sourced)", () => {
-        __globalStoreTestUtils__?.injectState({
-          userPrefs: {
-            priceRange: "0-5000",
-          },
-          recentPriceRanges: {
-            ranges: ["0-100", "100-200", "200-300", "300-400", "400-500"],
-          },
+          expect(queryByText("$0–5,000")).toBeTruthy()
         })
 
-        const { queryByText } = getTree()
+        it("should be rendered 5 pills maximum (4 recently selected, 1 collector profile-sourced)", () => {
+          __globalStoreTestUtils__?.injectState({
+            userPrefs: {
+              priceRange: "0-5000",
+            },
+            recentPriceRanges: {
+              ranges: ["0-100", "100-200", "200-300", "300-400", "400-500"],
+            },
+          })
 
-        expect(queryByText("$0–100")).toBeTruthy()
-        expect(queryByText("$100–200")).toBeTruthy()
-        expect(queryByText("$200–300")).toBeTruthy()
-        expect(queryByText("$300–400")).toBeTruthy()
+          const { queryByText } = getTree()
 
-        // collector profile-sourced
-        expect(queryByText("$0–5,000")).toBeTruthy()
+          expect(queryByText("$0–100")).toBeTruthy()
+          expect(queryByText("$100–200")).toBeTruthy()
+          expect(queryByText("$200–300")).toBeTruthy()
+          expect(queryByText("$300–400")).toBeTruthy()
 
-        expect(queryByText("$400–500")).toBeNull()
+          // collector profile-sourced
+          expect(queryByText("$0–5,000")).toBeTruthy()
+
+          expect(queryByText("$400–500")).toBeNull()
+        })
       })
 
       it("should correctly clear the recent price ranges when `Clear` button is pressed", () => {

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tests.tsx
@@ -273,6 +273,29 @@ describe("PriceRangeOptions", () => {
         expect(queryByText("$0–5,000")).toBeTruthy()
       })
 
+      it("should render 5 pills maximum (4 recently selected, 1 collector profile-sourced)", () => {
+        __globalStoreTestUtils__?.injectState({
+          userPrefs: {
+            priceRange: "0-5000",
+          },
+          recentPriceRanges: {
+            ranges: ["0-100", "100-200", "200-300", "300-400", "400-500"],
+          },
+        })
+
+        const { queryByText } = getTree()
+
+        expect(queryByText("$0–100")).toBeTruthy()
+        expect(queryByText("$100–200")).toBeTruthy()
+        expect(queryByText("$200–300")).toBeTruthy()
+        expect(queryByText("$300–400")).toBeTruthy()
+
+        // collector profile-sourced
+        expect(queryByText("$0–5,000")).toBeTruthy()
+
+        expect(queryByText("$400–500")).toBeNull()
+      })
+
       it("should correctly clear the recent price ranges when `Clear` button is pressed", () => {
         __globalStoreTestUtils__?.injectState({
           recentPriceRanges: {

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -316,6 +316,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
                         <Pill
                           key={recentPrice}
                           rounded
+                          accessibilityLabel="Price range pill"
                           selected={isSelectedPriceRange(recentPrice)}
                           onPress={() => handlePrevPriceRangePress(recentPrice)}
                         >

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -10,6 +10,7 @@ import {
   ArtworksFiltersStore,
   useSelectedOptionsDisplay,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { DEFAULT_PRICE_RANGE as USER_PREFERRED_DEFAULT_PRICE_RANGE } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { useRecentPriceRanges } from "app/store/RecentPriceRangesModel"
 import { useExperimentFlag } from "app/utils/experiments/hooks"
@@ -100,8 +101,8 @@ const getInputValue = (value: CustomRange[number]) => {
 
 export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = ({ navigation }) => {
   const { width } = useWindowDimensions()
-  const recentPriceRanges = useRecentPriceRanges()
   const enableRecentPriceRanges = useFeatureFlag("ARRecentPriceRanges")
+  const priceRanges = usePriceRanges()
   const color = useColor()
   const space = useSpace()
 
@@ -283,7 +284,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
 
           <Spacer mt={4} />
 
-          {!!enableRecentPriceRanges && recentPriceRanges.length > 0 && (
+          {!!enableRecentPriceRanges && priceRanges.length > 0 && (
             <>
               <Flex mx={2} flexDirection="row" justifyContent="space-between" alignItems="center">
                 <Text variant="sm">Apply a recent Price Range</Text>
@@ -304,7 +305,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
               >
                 <Flex flexDirection="row">
                   <Join separator={<Spacer ml={1} />}>
-                    {recentPriceRanges.map((recentPrice) => {
+                    {priceRanges.map((recentPrice) => {
                       const [min, max] = parseRange(recentPrice)
                       const label = parsePriceRangeLabel(min, max)
 
@@ -328,4 +329,20 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
       </Flex>
     </Flex>
   )
+}
+
+const usePriceRanges = () => {
+  let recentPriceRanges = useRecentPriceRanges()
+  const userPreferredPriceRange = GlobalStore.useAppState((state) => state.userPrefs.priceRange)
+
+  if (userPreferredPriceRange !== USER_PREFERRED_DEFAULT_PRICE_RANGE) {
+    // Remove duplicate price ranges
+    recentPriceRanges = recentPriceRanges.filter((priceRange) => {
+      return priceRange !== userPreferredPriceRange
+    })
+
+    return [...recentPriceRanges, userPreferredPriceRange]
+  }
+
+  return recentPriceRanges
 }

--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -12,7 +12,10 @@ import {
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { DEFAULT_PRICE_RANGE as USER_PREFERRED_DEFAULT_PRICE_RANGE } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
-import { useRecentPriceRanges } from "app/store/RecentPriceRangesModel"
+import {
+  MAX_SHOWN_RECENT_PRICE_RANGES,
+  useRecentPriceRanges,
+} from "app/store/RecentPriceRangesModel"
 import { useExperimentFlag } from "app/utils/experiments/hooks"
 import { debounce, sortBy } from "lodash"
 import {
@@ -336,8 +339,10 @@ const usePriceRanges = () => {
   const userPreferredPriceRange = GlobalStore.useAppState((state) => state.userPrefs.priceRange)
 
   if (userPreferredPriceRange !== USER_PREFERRED_DEFAULT_PRICE_RANGE) {
-    // Remove duplicate price ranges
-    recentPriceRanges = recentPriceRanges.filter((priceRange) => {
+    const slicedRecentPriceRanges = recentPriceRanges.slice(0, MAX_SHOWN_RECENT_PRICE_RANGES - 1)
+
+    // Remove duplicate price range that matches collector profile-sourced price
+    recentPriceRanges = slicedRecentPriceRanges.filter((priceRange) => {
       return priceRange !== userPreferredPriceRange
     })
 

--- a/src/app/Scenes/Search/UserPrefsModel.tsx
+++ b/src/app/Scenes/Search/UserPrefsModel.tsx
@@ -22,7 +22,7 @@ const DEFAULT_CURRENCY =
   ) as Currency) ?? "USD"
 const DEFAULT_METRIC = "in"
 const DEFAULT_VIEW_OPTION = "grid"
-const DEFAULT_PRICE_RANGE = "*-*"
+export const DEFAULT_PRICE_RANGE = "*-*"
 // please update this when adding new user preferences
 export interface UserPrefs {
   pricePaidCurrency: Currency

--- a/src/app/Scenes/Search/UserPrefsModel.tsx
+++ b/src/app/Scenes/Search/UserPrefsModel.tsx
@@ -130,7 +130,7 @@ const parsePriceRange = (priceRange: string) => {
   }
 
   if (min === -1) {
-    return [0, max].join("-")
+    return ["*", max].join("-")
   }
 
   return [min, max].join("-")

--- a/src/app/Scenes/Search/UserPrefsModel.tsx
+++ b/src/app/Scenes/Search/UserPrefsModel.tsx
@@ -75,8 +75,6 @@ export const getUserPrefsModel = (): UserPrefsModel => ({
     GlobalStore.actions.userPrefs.setMetric(me?.lengthUnitPreference.toLowerCase() as Metric)
     GlobalStore.actions.userPrefs.setCurrency(me?.currencyPreference as Currency)
 
-    console.log("[debug] me.priceRange", me.priceRange)
-
     if (me.priceRange) {
       const priceRange = parsePriceRange(me.priceRange)
       GlobalStore.actions.userPrefs.setPriceRange(priceRange)

--- a/src/app/Scenes/Search/UserPrefsModel.tsx
+++ b/src/app/Scenes/Search/UserPrefsModel.tsx
@@ -22,6 +22,7 @@ const DEFAULT_CURRENCY =
   ) as Currency) ?? "USD"
 const DEFAULT_METRIC = "in"
 const DEFAULT_VIEW_OPTION = "grid"
+const DEFAULT_PRICE_RANGE = "*-*"
 // please update this when adding new user preferences
 export interface UserPrefs {
   pricePaidCurrency: Currency
@@ -32,9 +33,11 @@ export interface UserPrefs {
 export interface UserPrefsModel {
   currency: Currency
   metric: Metric | ""
+  priceRange: string
   artworkViewOption: ViewOption
   setCurrency: Action<this, Currency>
   setMetric: Action<this, Metric>
+  setPriceRange: Action<this, string>
   fetchRemoteUserPrefs: Thunk<UserPrefsModel>
   didRehydrate: ThunkOn<UserPrefsModel, {}, GlobalStoreModel>
   setArtworkViewOption: Action<this, ViewOption>
@@ -44,6 +47,7 @@ export const getUserPrefsModel = (): UserPrefsModel => ({
   currency: DEFAULT_CURRENCY,
   metric: DEFAULT_METRIC,
   artworkViewOption: DEFAULT_VIEW_OPTION,
+  priceRange: DEFAULT_PRICE_RANGE,
   setCurrency: action((state, currency) => {
     if (currencies.includes(currency)) {
       state.currency = currency
@@ -58,14 +62,25 @@ export const getUserPrefsModel = (): UserPrefsModel => ({
       console.warn("Metric/Dimension Unit not supported")
     }
   }),
+  setPriceRange: action((state, priceRange) => {
+    state.priceRange = priceRange
+  }),
   fetchRemoteUserPrefs: thunk(async () => {
     const me = await fetchMe()
 
     if (!me) {
       return
     }
+
     GlobalStore.actions.userPrefs.setMetric(me?.lengthUnitPreference.toLowerCase() as Metric)
     GlobalStore.actions.userPrefs.setCurrency(me?.currencyPreference as Currency)
+
+    console.log("[debug] me.priceRange", me.priceRange)
+
+    if (me.priceRange) {
+      const priceRange = parsePriceRange(me.priceRange)
+      GlobalStore.actions.userPrefs.setPriceRange(priceRange)
+    }
   }),
   didRehydrate: thunkOn(
     (_, storeActions) => storeActions.rehydrate,
@@ -90,6 +105,7 @@ const fetchMe = async () => {
         me {
           lengthUnitPreference
           currencyPreference
+          priceRange
         }
       }
     `,
@@ -97,4 +113,27 @@ const fetchMe = async () => {
   ).toPromise()
 
   return result?.me
+}
+
+const parsePriceRange = (priceRange: string) => {
+  const [min, max] = priceRange.split(":").map((v) => {
+    const value = parseInt(v, 10)
+
+    if (isNaN(value)) {
+      return "*"
+    }
+
+    return value
+  })
+
+  // "No budget in mind" option is selected
+  if (min === -1 && max === 1000000000000) {
+    return DEFAULT_PRICE_RANGE
+  }
+
+  if (min === -1) {
+    return [0, max].join("-")
+  }
+
+  return [min, max].join("-")
 }

--- a/src/app/store/RecentPriceRangesModel.ts
+++ b/src/app/store/RecentPriceRangesModel.ts
@@ -1,7 +1,7 @@
 import { action, Action } from "easy-peasy"
 import { GlobalStore } from "./GlobalStore"
 
-export const MAX_SHOWN_RECENT_PRICE_RANGES = 3
+export const MAX_SHOWN_RECENT_PRICE_RANGES = 5
 
 export interface RecentPriceRangesModel {
   ranges: string[]

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -748,3 +748,21 @@ describe("App version Versions.AddRecentPriceRangesModel", () => {
     expect(migratedState.recentPriceRanges.ranges).toEqual([])
   })
 })
+
+describe("App version Versions.AddUserPreferredPriceRange", () => {
+  const migrationToTest = Versions.AddUserPreferredPriceRange
+
+  it("adds priceRange details to state", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    }) as any
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect(migratedState.userPrefs.priceRange).toEqual("*-*")
+  })
+})

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -41,9 +41,10 @@ export const Versions = {
   RemoveDeviceId: 29,
   AddSubmissionIdForMyCollection: 30,
   AddRecentPriceRangesModel: 31,
+  AddUserPreferredPriceRange: 32,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddRecentPriceRangesModel
+export const CURRENT_APP_VERSION = Versions.AddUserPreferredPriceRange
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -245,6 +246,9 @@ export const artsyAppMigrations: Migrations = {
     state.recentPriceRanges = {
       ranges: [],
     }
+  },
+  [Versions.AddUserPreferredPriceRange]: (state) => {
+    state.userPrefs.priceRange = "*-*"
   },
 }
 


### PR DESCRIPTION
This PR resolves [FX-4440] <!-- eg [PROJECT-XXXX] -->

### Demo
https://user-images.githubusercontent.com/3513494/203063717-5cce14ab-ff6b-4257-89d5-6e8f2756f618.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Pin Collector Profile-sourced price range as the last "recent" price range - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4440]: https://artsyproduct.atlassian.net/browse/FX-4440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ