### PR TITLE
feat: add a way to enter recovery codes

### DIFF
--- a/ios/Artsy.xcodeproj/project.pbxproj
+++ b/ios/Artsy.xcodeproj/project.pbxproj
@@ -3513,8 +3513,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Artsy" */;
 			buildPhases = (
-				1A08BBFB291E6B7000062A70 /* Setup .env from react-native-config */,
 				400905DA34751CB03A2B22D1 /* [CP] Check Pods Manifest.lock */,
+				1A08BBFB291E6B7000062A70 /* Setup .env from react-native-config */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,

--- a/src/app/Scenes/Onboarding/OnboardingLoginWithOTP.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingLoginWithOTP.tsx
@@ -93,7 +93,7 @@ export const OnboardingLoginWithOTPForm: React.FC<OnboardingLoginWithOTPFormProp
             />
             <Spacer mt={1} />
             <LinkText variant="sm" color="black60" onPress={() => setRecoveryCodeMode((v) => !v)}>
-              {recoveryCodeMode ? "Back to authentication code" : "Enter recovery code instead"}
+              {recoveryCodeMode ? "Enter authentication code" : "Enter recovery code instead"}
             </LinkText>
 
             {otpMode === "on_demand" ? (

--- a/src/app/Scenes/Onboarding/OnboardingLoginWithOTP.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingLoginWithOTP.tsx
@@ -2,8 +2,8 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { BackButton } from "app/navigation/BackButton"
 import { GlobalStore } from "app/store/GlobalStore"
 import { FormikProvider, useFormik, useFormikContext } from "formik"
-import { Box, Button, Flex, Input, SimpleMessage, Spacer, Text, useColor } from "palette"
-import React, { useRef } from "react"
+import { Box, Button, Flex, Input, LinkText, SimpleMessage, Spacer, Text, useColor } from "palette"
+import React, { useRef, useState } from "react"
 import { ScrollView } from "react-native"
 import { useScreenDimensions } from "shared/hooks"
 import { ArtsyKeyboardAvoidingView } from "shared/utils"
@@ -53,6 +53,7 @@ export const OnboardingLoginWithOTPForm: React.FC<OnboardingLoginWithOTPFormProp
   } = useFormikContext<OnboardingLoginWithOTPValuesSchema>()
 
   const otpInputRef = useRef<Input>(null)
+  const [recoveryCodeMode, setRecoveryCodeMode] = useState(false)
 
   return (
     <Flex flex={1} backgroundColor="white" flexGrow={1} paddingBottom={10}>
@@ -73,13 +74,11 @@ export const OnboardingLoginWithOTPForm: React.FC<OnboardingLoginWithOTPFormProp
               autoCapitalize="none"
               autoCorrect={false}
               autoFocus
-              keyboardType="numeric"
+              keyboardType={recoveryCodeMode ? "ascii-capable" : "number-pad"}
               onChangeText={(text) => {
                 // Hide error when the user starts to type again
                 if (errors.otp) {
-                  setErrors({
-                    otp: undefined,
-                  })
+                  setErrors({ otp: undefined })
                   validateForm()
                 }
                 handleChange("otp")(text)
@@ -87,11 +86,16 @@ export const OnboardingLoginWithOTPForm: React.FC<OnboardingLoginWithOTPFormProp
               onBlur={() => validateForm()}
               placeholder="Enter an authentication code"
               placeholderTextColor={color("black30")}
-              title="Authentication Code"
+              title={recoveryCodeMode ? "Recovery code" : "Authentication code"}
               returnKeyType="done"
               value={values.otp}
               error={errors.otp}
             />
+            <Spacer mt={1} />
+            <LinkText variant="sm" color="black60" onPress={() => setRecoveryCodeMode((v) => !v)}>
+              {recoveryCodeMode ? "Back to authentication code" : "Enter recovery code instead"}
+            </LinkText>
+
             {otpMode === "on_demand" ? (
               <>
                 <Spacer mb={20} />


### PR DESCRIPTION
This PR resolves [MOPLAT-489] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Final design pending. Logic ready.


https://user-images.githubusercontent.com/100233/202164088-2cb11f72-2f29-437e-909e-3f56d9bb2dc7.mov


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-489]: https://artsyproduct.atlassian.net/browse/MOPLAT-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ