### PR TITLE
fix: Do not allow submiting the artwork form multiple times

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -107,6 +107,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
   const { showActionSheetWithOptions } = useActionSheet()
 
   const handleSubmit = async (values: ArtworkFormValues) => {
+    if (loading) {
+      return
+    }
+
     setLoading(true)
 
     updateMyUserProfile({
@@ -154,6 +158,8 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     InteractionManager.runAfterInteractions(() => {
       props.onSuccess?.()
     })
+
+    setLoading(false)
   }
 
   useEffect(() => {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -158,8 +158,6 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     InteractionManager.runAfterInteractions(() => {
       props.onSuccess?.()
     })
-
-    setLoading(false)
   }
 
   useEffect(() => {


### PR DESCRIPTION
This PR resolves [CX-3089] <!-- eg [PROJECT-XXXX] -->

### Description
Do not allow submiting the artwork form multiple times.



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3089]: https://artsyproduct.atlassian.net/browse/CX-3089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ