### PR TITLE
chore: raise alert on podfile change instead of installing pods

### DIFF
--- a/package.json
+++ b/package.json
@@ -329,6 +329,6 @@
   },
   "pull-lock": {
     "yarn.lock": "yarn install",
-    "ios/Podfile.lock": "yarn install:all"
+    "ios/Podfile.lock": "🚨 New Podfile.lock detected!, you might need to run yarn install:all 🚨"
   }
 }


### PR DESCRIPTION
### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR raises an alert on Podfile.lock changes instead of installing pods. This will still let those unfamiliar with Eigen know that they need to run `yarn install:all` without running it for them. 

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- raise alert on podfile change instead of installing pods - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
