### PR TITLE
feat(FX-4452): display trending artists

### DIFF
--- a/src/app/Components/Home/ArtistRails/ArtistCard.tsx
+++ b/src/app/Components/Home/ArtistRails/ArtistCard.tsx
@@ -60,9 +60,11 @@ export const ArtistCard: React.FC<ArtistCardProps> = ({ artist, onDismiss, onFol
               </Text>
             )}
           </Flex>
-          <Flex>
-            <FollowButton isFollowed={!!artist.isFollowed} onPress={onFollow} />
-          </Flex>
+          {!!onFollow && (
+            <Flex>
+              <FollowButton isFollowed={!!artist.isFollowed} onPress={onFollow} />
+            </Flex>
+          )}
         </Flex>
         {!!onDismiss && (
           <Flex

--- a/src/app/Scenes/Search/PopularSearches.tsx
+++ b/src/app/Scenes/Search/PopularSearches.tsx
@@ -1,0 +1,53 @@
+import { PopularSearches_query$key } from "__generated__/PopularSearches_query.graphql"
+import { navigate } from "app/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { Join, Spacer, Text } from "palette"
+import { TouchableOpacity } from "react-native"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface PopularSearchesProps {
+  data: PopularSearches_query$key
+}
+
+export const PopularSearches: React.FC<PopularSearchesProps> = ({ data }) => {
+  const result = useFragment(popularSearchesFragment, data)
+  const nodes = extractNodes(result.curatedTrendingArtists)
+
+  const handlePress = (slug: string) => {
+    navigate(`/artist/${slug}`)
+  }
+
+  return (
+    <>
+      <Text variant="sm">Popular Searches</Text>
+      <Spacer mb={2} />
+      <Join separator={<Spacer mb={2} />}>
+        {nodes.map((node) => {
+          return (
+            <TouchableOpacity key={node.internalID} onPress={() => handlePress(node.slug)}>
+              <Text variant="xs">{node.name}</Text>
+              <Text variant="xs" color="black60">
+                Artist
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </Join>
+    </>
+  )
+}
+
+const popularSearchesFragment = graphql`
+  fragment PopularSearches_query on Query {
+    curatedTrendingArtists(first: 3) {
+      edges {
+        node {
+          internalID
+          slug
+          name
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Search/PopularSearches.tsx
+++ b/src/app/Scenes/Search/PopularSearches.tsx
@@ -1,10 +1,10 @@
 import { PopularSearches_query$key } from "__generated__/PopularSearches_query.graphql"
-import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { Join, Spacer, Text } from "palette"
-import { TouchableOpacity } from "react-native"
+import { Spacer, Text } from "palette"
 import { useFragment } from "react-relay"
 import { graphql } from "relay-runtime"
+import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
+import { SearchResultList } from "./components/SearchResultList"
 
 interface PopularSearchesProps {
   data: PopularSearches_query$key
@@ -14,26 +14,20 @@ export const PopularSearches: React.FC<PopularSearchesProps> = ({ data }) => {
   const result = useFragment(popularSearchesFragment, data)
   const nodes = extractNodes(result.curatedTrendingArtists)
 
-  const handlePress = (slug: string) => {
-    navigate(`/artist/${slug}`)
-  }
-
   return (
     <>
       <Text variant="sm">Popular Searches</Text>
       <Spacer mb={2} />
-      <Join separator={<Spacer mb={2} />}>
-        {nodes.map((node) => {
-          return (
-            <TouchableOpacity key={node.internalID} onPress={() => handlePress(node.slug)}>
-              <Text variant="xs">{node.name}</Text>
-              <Text variant="xs" color="black60">
-                Artist
-              </Text>
-            </TouchableOpacity>
-          )
-        })}
-      </Join>
+      <SearchResultList
+        results={nodes.map((node) => (
+          <AutosuggestSearchResult
+            key={node.internalID}
+            result={node as any}
+            showResultType
+            updateRecentSearchesOnTap={false}
+          />
+        ))}
+      />
     </>
   )
 }
@@ -43,9 +37,12 @@ const popularSearchesFragment = graphql`
     curatedTrendingArtists(first: 3) {
       edges {
         node {
+          __typename
           internalID
           slug
-          name
+          displayLabel
+          imageUrl
+          href
         }
       }
     }

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -232,23 +232,33 @@ export const Search: React.FC = () => {
               </>
             ) : (
               <Scrollable>
-                <RecentSearches />
-                {!!displayCuratedCollections && (
-                  <>
-                    <Spacer mb={3} />
-                    <CuratedCollections collections={queryData} />
-                  </>
-                )}
-                <Spacer mb={3} />
+                <HorizontalPadding>
+                  <RecentSearches />
+
+                  {!!displayCuratedCollections && (
+                    <>
+                      <Spacer mb={3} />
+                      <CuratedCollections collections={queryData} />
+                    </>
+                  )}
+
+                  <Spacer mb={3} />
+                </HorizontalPadding>
+
                 <TrendingArtists data={queryData} />
+
                 <Spacer mb={3} />
-                {!!enableMaps ? (
-                  <Touchable onPress={() => navigate("/map")}>
-                    <CityGuideCTANew />
-                  </Touchable>
-                ) : (
-                  !isPad() && Platform.OS === "ios" && <CityGuideCTA />
-                )}
+
+                <HorizontalPadding>
+                  {!!enableMaps ? (
+                    <Touchable onPress={() => navigate("/map")}>
+                      <CityGuideCTANew />
+                    </Touchable>
+                  ) : (
+                    !isPad() && Platform.OS === "ios" && <CityGuideCTA />
+                  )}
+                </HorizontalPadding>
+
                 <Spacer mb="40px" />
               </Scrollable>
             )}
@@ -315,9 +325,12 @@ const Scrollable = styled(ScrollView).attrs(() => ({
   keyboardShouldPersistTaps: "handled",
 }))`
   flex: 1;
-  padding: 0 20px;
   padding-top: 20px;
 `
+
+const HorizontalPadding: React.FC = ({ children }) => {
+  return <Box px={2}>{children}</Box>
+}
 
 const tracks = {
   tappedPill: (contextModule: ContextModule, subject: string, query: string) => ({

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -34,6 +34,7 @@ import { SearchPills } from "./components/SearchPills"
 import { ALLOWED_ALGOLIA_KEYS, DEFAULT_PILLS, TOP_PILL } from "./constants"
 import { CuratedCollections } from "./CuratedCollections"
 import { getContextModuleByPillName, isAlgoliaApiKeyExpiredError } from "./helpers"
+import { PopularSearches } from "./PopularSearches"
 import { RecentSearches } from "./RecentSearches"
 import { RefetchWhenApiKeyExpiredContainer } from "./RefetchWhenApiKeyExpired"
 import { SearchContext, useSearchProviderValues } from "./SearchContext"
@@ -239,6 +240,8 @@ export const Search: React.FC = () => {
                   </>
                 )}
                 <Spacer mb={3} />
+                <PopularSearches data={queryData} />
+                <Spacer mb={3} />
                 {!!enableMaps ? (
                   <Touchable onPress={() => navigate("/map")}>
                     <CityGuideCTANew />
@@ -296,8 +299,8 @@ export const SearchScreenQuery = graphql`
         }
       }
     }
-
     ...CuratedCollections_collections
+    ...PopularSearches_query
   }
 `
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -234,18 +234,19 @@ export const Search: React.FC = () => {
               <Scrollable>
                 <HorizontalPadding>
                   <RecentSearches />
-
-                  {!!displayCuratedCollections && (
-                    <>
-                      <Spacer mb={3} />
-                      <CuratedCollections collections={queryData} />
-                    </>
-                  )}
-
-                  <Spacer mb={3} />
                 </HorizontalPadding>
 
-                <TrendingArtists data={queryData} />
+                {!!displayCuratedCollections && (
+                  <>
+                    <Spacer mb={2} />
+                    <TrendingArtists data={queryData} mb={2} />
+
+                    {/* TODO: Display curated collections as scrollable rail */}
+                    <HorizontalPadding>
+                      <CuratedCollections collections={queryData} />
+                    </HorizontalPadding>
+                  </>
+                )}
 
                 <Spacer mb={3} />
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -41,6 +41,7 @@ import { SearchResults } from "./SearchResults"
 import { TrendingArtists } from "./TrendingArtists"
 import { AlgoliaIndexKey } from "./types"
 import { PillType } from "./types"
+import { useDisplayCuratedCollections } from "./useDisplayCuratedCollections"
 
 const SearchInputContainer = connectSearchBox(SearchInput)
 
@@ -63,8 +64,7 @@ export const Search: React.FC = () => {
   const indices = system?.algolia?.indices ?? []
   const indiceNames = indices.map((indice) => indice.name)
   const enableMaps = useFeatureFlag("AREnableMapScreen")
-  const displayCuratedCollections =
-    Platform.OS !== "ios" || useFeatureFlag("ARIosSearchTabCuratedCollections")
+  const displayCuratedCollections = useDisplayCuratedCollections()
   const onRefetch = () => {
     if (isRefreshing) {
       return

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -238,8 +238,8 @@ export const Search: React.FC = () => {
 
                 {!!displayCuratedCollections && (
                   <>
-                    <Spacer mb={2} />
-                    <TrendingArtists data={queryData} mb={2} />
+                    <Spacer mb={4} />
+                    <TrendingArtists data={queryData} mb={4} />
 
                     {/* TODO: Display curated collections as scrollable rail */}
                     <HorizontalPadding>

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -34,11 +34,11 @@ import { SearchPills } from "./components/SearchPills"
 import { ALLOWED_ALGOLIA_KEYS, DEFAULT_PILLS, TOP_PILL } from "./constants"
 import { CuratedCollections } from "./CuratedCollections"
 import { getContextModuleByPillName, isAlgoliaApiKeyExpiredError } from "./helpers"
-import { PopularSearches } from "./PopularSearches"
 import { RecentSearches } from "./RecentSearches"
 import { RefetchWhenApiKeyExpiredContainer } from "./RefetchWhenApiKeyExpired"
 import { SearchContext, useSearchProviderValues } from "./SearchContext"
 import { SearchResults } from "./SearchResults"
+import { TrendingArtists } from "./TrendingArtists"
 import { AlgoliaIndexKey } from "./types"
 import { PillType } from "./types"
 
@@ -240,7 +240,7 @@ export const Search: React.FC = () => {
                   </>
                 )}
                 <Spacer mb={3} />
-                <PopularSearches data={queryData} />
+                <TrendingArtists data={queryData} />
                 <Spacer mb={3} />
                 {!!enableMaps ? (
                   <Touchable onPress={() => navigate("/map")}>
@@ -300,7 +300,7 @@ export const SearchScreenQuery = graphql`
       }
     }
     ...CuratedCollections_collections
-    ...PopularSearches_query
+    ...TrendingArtists_query
   }
 `
 

--- a/src/app/Scenes/Search/TrendingArtists.tests.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tests.tsx
@@ -1,0 +1,78 @@
+import { fireEvent } from "@testing-library/react-native"
+import { TrendingArtists_Test_Query } from "__generated__/TrendingArtists_Test_Query.graphql"
+import { navigate } from "app/navigation/navigate"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { renderWithHookWrappersTL } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { TrendingArtists } from "./TrendingArtists"
+
+jest.unmock("react-relay")
+
+describe("TrendingArtists", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  const TestRenderer = () => {
+    const data = useLazyLoadQuery<TrendingArtists_Test_Query>(
+      graphql`
+        query TrendingArtists_Test_Query {
+          ...TrendingArtists_query
+        }
+      `,
+      {}
+    )
+
+    return <TrendingArtists data={data} />
+  }
+
+  it("should render all artists", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Query: () => ({
+        curatedTrendingArtists,
+      }),
+    })
+    await flushPromiseQueue()
+
+    expect(getByText("Artist One")).toBeTruthy()
+    expect(getByText("Artist Two")).toBeTruthy()
+  })
+
+  it("should navigate to the artist screen", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Query: () => ({
+        curatedTrendingArtists,
+      }),
+    })
+
+    await flushPromiseQueue()
+    await fireEvent.press(getByText("Artist One"))
+
+    expect(navigate).toHaveBeenCalledWith("/artist/artist-one")
+  })
+})
+
+const curatedTrendingArtists = {
+  edges: [
+    {
+      node: {
+        href: "/artist/artist-one",
+        name: "Artist One",
+      },
+    },
+    {
+      node: {
+        href: "/artist/artist-two",
+        name: "Artist Two",
+      },
+    },
+  ],
+}

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -42,7 +42,7 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxPr
 
   return (
     <Box {...boxProps}>
-      <Box mx={2} mb={1}>
+      <Box mx={2}>
         <SectionTitle title="Trending Artists" />
       </Box>
 

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -4,7 +4,7 @@ import { ArtistCardContainer as ArtistCard } from "app/Components/Home/ArtistRai
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { Box, Flex, Spacer, Spinner, Text } from "palette"
+import { Flex, Spacer, Spinner, Text } from "palette"
 import { usePaginationFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 
@@ -36,7 +36,7 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
   }
 
   return (
-    <Box mx={-2}>
+    <>
       <Text variant="sm" mx={2}>
         Trending Artists
       </Text>
@@ -61,7 +61,7 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
           </>
         }
       />
-    </Box>
+    </>
   )
 }
 

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -1,48 +1,80 @@
+import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { TrendingArtists_query$key } from "__generated__/TrendingArtists_query.graphql"
+import { ArtistCardContainer as ArtistCard } from "app/Components/Home/ArtistRails/ArtistCard"
+import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
+import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { Spacer, Text } from "palette"
-import { useFragment } from "react-relay"
+import { Box, Flex, Spacer, Spinner, Text } from "palette"
+import { usePaginationFragment } from "react-relay"
 import { graphql } from "relay-runtime"
-import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
-import { SearchResultList } from "./components/SearchResultList"
+
+const MAX_TRENDING_ARTTISTS = 20
 
 interface TrendingArtistsProps {
   data: TrendingArtists_query$key
 }
 
 export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
-  const result = useFragment(trendingArtistsFragment, data)
+  const {
+    data: result,
+    hasNext,
+    isLoadingNext,
+    loadNext,
+  } = usePaginationFragment<SearchQuery, TrendingArtists_query$key>(trendingArtistsFragment, data)
   const nodes = extractNodes(result.curatedTrendingArtists)
 
+  const handleCardPress = (slug: string) => {
+    navigate(`/artist/${slug}`)
+  }
+
+  const loadMore = () => {
+    if (!hasNext || isLoadingNext || nodes.length >= MAX_TRENDING_ARTTISTS) {
+      return
+    }
+
+    loadNext(5)
+  }
+
   return (
-    <>
-      <Text variant="sm">Trending Artists</Text>
+    <Box mx={-2}>
+      <Text variant="sm" mx={2}>
+        Trending Artists
+      </Text>
       <Spacer mb={2} />
-      <SearchResultList
-        results={nodes.map((node) => (
-          <AutosuggestSearchResult
-            key={node.internalID}
-            result={node as any}
-            showResultType
-            updateRecentSearchesOnTap={false}
-          />
-        ))}
+
+      <CardRailFlatList
+        data={nodes}
+        keyExtractor={(node) => node.internalID}
+        onEndReached={loadMore}
+        renderItem={({ item }) => {
+          return <ArtistCard artist={item} onPress={() => handleCardPress(item.slug)} />
+        }}
+        ItemSeparatorComponent={() => <Spacer width={15} />}
+        ListFooterComponent={isLoadingNext ? <LoadingIndicator /> : <Spacer mr={2} />}
       />
-    </>
+    </Box>
+  )
+}
+
+const LoadingIndicator = () => {
+  return (
+    <Flex justifyContent="center" ml={3} mr={5} height="200">
+      <Spinner />
+    </Flex>
   )
 }
 
 const trendingArtistsFragment = graphql`
-  fragment TrendingArtists_query on Query {
-    curatedTrendingArtists(first: 3) {
+  fragment TrendingArtists_query on Query
+  @refetchable(queryName: "TrendingArtists_queryRefetch")
+  @argumentDefinitions(count: { type: "Int", defaultValue: 5 }, cursor: { type: "String" }) {
+    curatedTrendingArtists(first: $count, after: $cursor)
+      @connection(key: "TrendingArtists_curatedTrendingArtists") {
       edges {
         node {
-          __typename
           internalID
           slug
-          displayLabel
-          imageUrl
-          href
+          ...ArtistCard_artist
         }
       }
     }

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -1,4 +1,4 @@
-import { PopularSearches_query$key } from "__generated__/PopularSearches_query.graphql"
+import { TrendingArtists_query$key } from "__generated__/TrendingArtists_query.graphql"
 import { extractNodes } from "app/utils/extractNodes"
 import { Spacer, Text } from "palette"
 import { useFragment } from "react-relay"
@@ -6,17 +6,17 @@ import { graphql } from "relay-runtime"
 import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
 import { SearchResultList } from "./components/SearchResultList"
 
-interface PopularSearchesProps {
-  data: PopularSearches_query$key
+interface TrendingArtistsProps {
+  data: TrendingArtists_query$key
 }
 
-export const PopularSearches: React.FC<PopularSearchesProps> = ({ data }) => {
-  const result = useFragment(popularSearchesFragment, data)
+export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
+  const result = useFragment(trendingArtistsFragment, data)
   const nodes = extractNodes(result.curatedTrendingArtists)
 
   return (
     <>
-      <Text variant="sm">Popular Searches</Text>
+      <Text variant="sm">Trending Artists</Text>
       <Spacer mb={2} />
       <SearchResultList
         results={nodes.map((node) => (
@@ -32,8 +32,8 @@ export const PopularSearches: React.FC<PopularSearchesProps> = ({ data }) => {
   )
 }
 
-const popularSearchesFragment = graphql`
-  fragment PopularSearches_query on Query {
+const trendingArtistsFragment = graphql`
+  fragment TrendingArtists_query on Query {
     curatedTrendingArtists(first: 3) {
       edges {
         node {

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -4,10 +4,12 @@ import { ArtistCardContainer as ArtistCard } from "app/Components/Home/ArtistRai
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { navigate } from "app/navigation/navigate"
+import { useFeatureFlag } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { Box, BoxProps, Flex, Spacer, Spinner } from "palette"
 import { usePaginationFragment } from "react-relay"
 import { graphql } from "relay-runtime"
+import { TrendingArtistCard } from "./components/TrendingArtistCard"
 
 const MAX_TRENDING_ARTTISTS_PER_RAIL = 20
 
@@ -16,6 +18,7 @@ interface TrendingArtistsProps extends BoxProps {
 }
 
 export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxProps }) => {
+  const useSmallSizeCard = useFeatureFlag("AREnableSmallTredingArtistCardSize")
   const {
     data: result,
     hasNext,
@@ -48,16 +51,21 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxPr
 
       <CardRailFlatList
         data={nodes}
+        initialNumToRender={useSmallSizeCard ? 3 : 2}
         keyExtractor={(node) => node.internalID}
         onEndReached={loadMore}
         renderItem={({ item }) => {
+          if (useSmallSizeCard) {
+            return <TrendingArtistCard artist={item} />
+          }
+
           return <ArtistCard artist={item} onPress={() => handleCardPress(item.href!)} />
         }}
         ItemSeparatorComponent={() => <Spacer ml={1} />}
         ListFooterComponent={
           <>
             {!!hasNext && (
-              <Flex justifyContent="center" mx={3} height="200">
+              <Flex justifyContent="center" mx={3} height={useSmallSizeCard ? 125 : 200}>
                 <Spinner />
               </Flex>
             )}
@@ -80,6 +88,7 @@ const trendingArtistsFragment = graphql`
           internalID
           href
           ...ArtistCard_artist
+          ...TrendingArtistCard_artist
         }
       }
     }

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -50,17 +50,18 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
           return <ArtistCard artist={item} onPress={() => handleCardPress(item.slug)} />
         }}
         ItemSeparatorComponent={() => <Spacer width={15} />}
-        ListFooterComponent={isLoadingNext ? <LoadingIndicator /> : <Spacer mr={2} />}
+        ListFooterComponent={
+          <>
+            {!!hasNext && (
+              <Flex justifyContent="center" mx={3} height="200">
+                <Spinner />
+              </Flex>
+            )}
+            <Spacer mr={2} />
+          </>
+        }
       />
     </Box>
-  )
-}
-
-const LoadingIndicator = () => {
-  return (
-    <Flex justifyContent="center" ml={3} mr={5} height="200">
-      <Spinner />
-    </Flex>
   )
 }
 

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -23,8 +23,8 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
   } = usePaginationFragment<SearchQuery, TrendingArtists_query$key>(trendingArtistsFragment, data)
   const nodes = extractNodes(result.curatedTrendingArtists)
 
-  const handleCardPress = (slug: string) => {
-    navigate(`/artist/${slug}`)
+  const handleCardPress = (href: string) => {
+    navigate(href)
   }
 
   const loadMore = () => {
@@ -47,9 +47,9 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
         keyExtractor={(node) => node.internalID}
         onEndReached={loadMore}
         renderItem={({ item }) => {
-          return <ArtistCard artist={item} onPress={() => handleCardPress(item.slug)} />
+          return <ArtistCard artist={item} onPress={() => handleCardPress(item.href!)} />
         }}
-        ItemSeparatorComponent={() => <Spacer width={15} />}
+        ItemSeparatorComponent={() => <Spacer ml={1} />}
         ListFooterComponent={
           <>
             {!!hasNext && (
@@ -74,7 +74,7 @@ const trendingArtistsFragment = graphql`
       edges {
         node {
           internalID
-          slug
+          href
           ...ArtistCard_artist
         }
       }

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -62,18 +62,17 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxPr
           return <ArtistCard artist={item} onPress={() => handleCardPress(item.href!)} />
         }}
         ItemSeparatorComponent={() => <Spacer ml={1} />}
-        ListFooterComponent={
-          <>
-            {!!hasNext && (
-              <Flex justifyContent="center" mx={3} height={useSmallSizeCard ? 125 : 200}>
-                <Spinner />
-              </Flex>
-            )}
-            <Spacer mr={2} />
-          </>
-        }
+        ListFooterComponent={!!hasNext ? <LoadingIndicator /> : null}
       />
     </Box>
+  )
+}
+
+const LoadingIndicator = () => {
+  return (
+    <Flex flex={1} flexDirection="row" alignItems="center" justifyContent="center" px={3}>
+      <Spinner />
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -2,9 +2,10 @@ import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { TrendingArtists_query$key } from "__generated__/TrendingArtists_query.graphql"
 import { ArtistCardContainer as ArtistCard } from "app/Components/Home/ArtistRails/ArtistCard"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
+import { SectionTitle } from "app/Components/SectionTitle"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { Box, BoxProps, Flex, Spacer, Spinner, Text } from "palette"
+import { Box, BoxProps, Flex, Spacer, Spinner } from "palette"
 import { usePaginationFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 
@@ -41,10 +42,9 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxPr
 
   return (
     <Box {...boxProps}>
-      <Text variant="sm" mx={2}>
-        Trending Artists
-      </Text>
-      <Spacer mb={1} />
+      <Box mx={2} mb={1}>
+        <SectionTitle title="Trending Artists" />
+      </Box>
 
       <CardRailFlatList
         data={nodes}

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -4,17 +4,17 @@ import { ArtistCardContainer as ArtistCard } from "app/Components/Home/ArtistRai
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { navigate } from "app/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { Flex, Spacer, Spinner, Text } from "palette"
+import { Box, BoxProps, Flex, Spacer, Spinner, Text } from "palette"
 import { usePaginationFragment } from "react-relay"
 import { graphql } from "relay-runtime"
 
-const MAX_TRENDING_ARTTISTS = 20
+const MAX_TRENDING_ARTTISTS_PER_RAIL = 20
 
-interface TrendingArtistsProps {
+interface TrendingArtistsProps extends BoxProps {
   data: TrendingArtists_query$key
 }
 
-export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
+export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxProps }) => {
   const {
     data: result,
     hasNext,
@@ -28,19 +28,23 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
   }
 
   const loadMore = () => {
-    if (!hasNext || isLoadingNext || nodes.length >= MAX_TRENDING_ARTTISTS) {
+    if (!hasNext || isLoadingNext || nodes.length >= MAX_TRENDING_ARTTISTS_PER_RAIL) {
       return
     }
 
     loadNext(5)
   }
 
+  if (nodes.length === 0) {
+    return null
+  }
+
   return (
-    <>
+    <Box {...boxProps}>
       <Text variant="sm" mx={2}>
         Trending Artists
       </Text>
-      <Spacer mb={2} />
+      <Spacer mb={1} />
 
       <CardRailFlatList
         data={nodes}
@@ -61,7 +65,7 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data }) => {
           </>
         }
       />
-    </>
+    </Box>
   )
 }
 

--- a/src/app/Scenes/Search/components/TrendingArtistCard.tsx
+++ b/src/app/Scenes/Search/components/TrendingArtistCard.tsx
@@ -1,0 +1,58 @@
+import { TrendingArtistCard_artist$key } from "__generated__/TrendingArtistCard_artist.graphql"
+import { navigate } from "app/navigation/navigate"
+import { Flex, OpaqueImageView, Text, useColor } from "palette"
+import { TouchableHighlight } from "react-native"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface TrendingArtistCardProps {
+  artist: TrendingArtistCard_artist$key
+}
+
+const CARD_WIDTH = 140
+const CARD_HEIGHT = 105
+
+export const TrendingArtistCard: React.FC<TrendingArtistCardProps> = ({ artist }) => {
+  const color = useColor()
+  const data = useFragment(TrendingArtistCardFragment, artist)
+
+  const handlePress = () => {
+    navigate(data.href!)
+  }
+
+  return (
+    <TouchableHighlight
+      underlayColor={color("white100")}
+      activeOpacity={0.8}
+      style={{ width: CARD_WIDTH, overflow: "hidden" }}
+      onPress={handlePress}
+    >
+      <Flex>
+        <OpaqueImageView imageURL={data.image?.url} width={CARD_WIDTH} height={CARD_HEIGHT} />
+
+        <Flex>
+          <Text variant="xs" numberOfLines={1}>
+            {data.name}
+          </Text>
+
+          {!!data.formattedNationalityAndBirthday && (
+            <Text variant="xs" numberOfLines={1} color="black60">
+              {data.formattedNationalityAndBirthday}
+            </Text>
+          )}
+        </Flex>
+      </Flex>
+    </TouchableHighlight>
+  )
+}
+
+const TrendingArtistCardFragment = graphql`
+  fragment TrendingArtistCard_artist on Artist {
+    href
+    name
+    formattedNationalityAndBirthday
+    image {
+      url(version: "small")
+    }
+  }
+`

--- a/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
+++ b/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
@@ -9,6 +9,7 @@ import { times } from "lodash"
 import { Box, Flex, Join, Spacer } from "palette"
 import { MAX_SHOWN_RECENT_SEARCHES, useRecentSearches } from "../../SearchModel"
 import { useDisplayCuratedCollections } from "../../useDisplayCuratedCollections"
+import { IMAGE_SIZE } from "../SearchResultImage"
 
 const RecentSearchesPlaceholder = () => {
   const recentSearches = useRecentSearches(MAX_SHOWN_RECENT_SEARCHES)
@@ -26,16 +27,18 @@ const RecentSearchesPlaceholder = () => {
 
   return (
     <>
-      <PlaceholderText width="50%" height={20} />
+      <PlaceholderText width="50%" height={25} />
       <Spacer mt={1} />
-      {times(recentSearches.length).map((index) => (
-        <Flex key={`search-placeholder-${index}`} flexDirection="row" mb={2}>
-          <PlaceholderBox width={40} height={40} />
-          <Flex flex={1} ml={1}>
-            <PlaceholderRaggedText textHeight={15} numLines={2} />
+      <Join separator={<Spacer mt={2} />}>
+        {times(recentSearches.length).map((index) => (
+          <Flex key={`search-placeholder-${index}`} height={IMAGE_SIZE} flexDirection="row">
+            <PlaceholderBox width={IMAGE_SIZE} height={IMAGE_SIZE} />
+            <Flex flex={1} ml={1}>
+              <PlaceholderRaggedText textHeight={15} numLines={2} />
+            </Flex>
           </Flex>
-        </Flex>
-      ))}
+        ))}
+      </Join>
     </>
   )
 }
@@ -44,7 +47,7 @@ const TrendingArtistPlaceholder = () => {
   return (
     <>
       <PlaceholderText width="50%" height={25} />
-      <Flex flexDirection="row" mt={2}>
+      <Flex flexDirection="row" mt={1}>
         <Join separator={<Spacer ml={1} />}>
           {times(3).map((index) => (
             <Flex key={index}>
@@ -71,6 +74,7 @@ export const SearchPlaceholder: React.FC = () => {
         <Spacer mt={2} />
 
         <RecentSearchesPlaceholder />
+        <Spacer mt={4} />
 
         {!!displayCuratedCollections && <TrendingArtistPlaceholder />}
       </Box>

--- a/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
+++ b/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
@@ -3,19 +3,23 @@ import {
   PlaceholderRaggedText,
   PlaceholderText,
   ProvidePlaceholderContext,
+  RandomWidthPlaceholderText,
+  useMemoizedRandom,
 } from "app/utils/placeholders"
 import { times } from "lodash"
-import { Box, Flex, Spacer } from "palette"
+import { Box, Flex, Join, Spacer } from "palette"
+import { useDisplayCuratedCollections } from "../../useDisplayCuratedCollections"
 
 export const SearchPlaceholder: React.FC = () => {
+  const displayCuratedCollections = useDisplayCuratedCollections()
+
   return (
     <ProvidePlaceholderContext>
-      <Box p={2}>
+      <Box p={2} pb={0}>
         <PlaceholderBox height={46} />
-        <Spacer mt={2} />
-        <Spacer mt={1} />
+        <Spacer mt={30} />
         <PlaceholderText width="50%" height={20} />
-        <Spacer mt={2} />
+        <Spacer mt={1} />
         {times(4).map((index) => (
           <Flex key={`search-placeholder-${index}`} flexDirection="row" mb={2}>
             <PlaceholderBox width={40} height={40} />
@@ -25,6 +29,24 @@ export const SearchPlaceholder: React.FC = () => {
           </Flex>
         ))}
       </Box>
+
+      {!!displayCuratedCollections && (
+        <Box mx={2}>
+          <PlaceholderText width="50%" height={20} />
+          <Flex flexDirection="row" mt={2}>
+            <Join separator={<Spacer ml={1} />}>
+              {times(3 + useMemoizedRandom() * 10).map((index) => (
+                <Flex key={index}>
+                  <PlaceholderBox key={index} height={180} width={295} />
+                  <Spacer mt={1} />
+                  <PlaceholderText width={120} height={20} />
+                  <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} />
+                </Flex>
+              ))}
+            </Join>
+          </Flex>
+        </Box>
+      )}
     </ProvidePlaceholderContext>
   )
 }

--- a/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
+++ b/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
@@ -4,49 +4,76 @@ import {
   PlaceholderText,
   ProvidePlaceholderContext,
   RandomWidthPlaceholderText,
-  useMemoizedRandom,
 } from "app/utils/placeholders"
 import { times } from "lodash"
 import { Box, Flex, Join, Spacer } from "palette"
+import { MAX_SHOWN_RECENT_SEARCHES, useRecentSearches } from "../../SearchModel"
 import { useDisplayCuratedCollections } from "../../useDisplayCuratedCollections"
+
+const RecentSearchesPlaceholder = () => {
+  const recentSearches = useRecentSearches(MAX_SHOWN_RECENT_SEARCHES)
+
+  if (recentSearches.length === 0) {
+    return (
+      <>
+        <PlaceholderText width="50%" height={25} />
+        <Spacer mt={1} />
+        <PlaceholderText height={67} />
+        <Spacer mt={1} />
+      </>
+    )
+  }
+
+  return (
+    <>
+      <PlaceholderText width="50%" height={20} />
+      <Spacer mt={1} />
+      {times(recentSearches.length).map((index) => (
+        <Flex key={`search-placeholder-${index}`} flexDirection="row" mb={2}>
+          <PlaceholderBox width={40} height={40} />
+          <Flex flex={1} ml={1}>
+            <PlaceholderRaggedText textHeight={15} numLines={2} />
+          </Flex>
+        </Flex>
+      ))}
+    </>
+  )
+}
+
+const TrendingArtistPlaceholder = () => {
+  return (
+    <>
+      <PlaceholderText width="50%" height={25} />
+      <Flex flexDirection="row" mt={2}>
+        <Join separator={<Spacer ml={1} />}>
+          {times(3).map((index) => (
+            <Flex key={index}>
+              <PlaceholderBox key={index} height={180} width={295} />
+              <Spacer mt={1} />
+              <PlaceholderText width={120} height={20} />
+              <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} />
+            </Flex>
+          ))}
+        </Join>
+      </Flex>
+    </>
+  )
+}
 
 export const SearchPlaceholder: React.FC = () => {
   const displayCuratedCollections = useDisplayCuratedCollections()
 
   return (
     <ProvidePlaceholderContext>
-      <Box p={2} pb={0}>
-        <PlaceholderBox height={46} />
-        <Spacer mt={30} />
-        <PlaceholderText width="50%" height={20} />
-        <Spacer mt={1} />
-        {times(4).map((index) => (
-          <Flex key={`search-placeholder-${index}`} flexDirection="row" mb={2}>
-            <PlaceholderBox width={40} height={40} />
-            <Flex flex={1} ml={1}>
-              <PlaceholderRaggedText textHeight={15} numLines={2} />
-            </Flex>
-          </Flex>
-        ))}
-      </Box>
+      <Box m={2} mb={0}>
+        {/* Search input */}
+        <PlaceholderBox height={50} />
+        <Spacer mt={2} />
 
-      {!!displayCuratedCollections && (
-        <Box mx={2}>
-          <PlaceholderText width="50%" height={20} />
-          <Flex flexDirection="row" mt={2}>
-            <Join separator={<Spacer ml={1} />}>
-              {times(3 + useMemoizedRandom() * 10).map((index) => (
-                <Flex key={index}>
-                  <PlaceholderBox key={index} height={180} width={295} />
-                  <Spacer mt={1} />
-                  <PlaceholderText width={120} height={20} />
-                  <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} />
-                </Flex>
-              ))}
-            </Join>
-          </Flex>
-        </Box>
-      )}
+        <RecentSearchesPlaceholder />
+
+        {!!displayCuratedCollections && <TrendingArtistPlaceholder />}
+      </Box>
     </ProvidePlaceholderContext>
   )
 }

--- a/src/app/Scenes/Search/useDisplayCuratedCollections.ts
+++ b/src/app/Scenes/Search/useDisplayCuratedCollections.ts
@@ -1,0 +1,12 @@
+import { useFeatureFlag } from "app/store/GlobalStore"
+import { Platform } from "react-native"
+
+export const useDisplayCuratedCollections = () => {
+  const isFeatureFlagEnabled = useFeatureFlag("ARIosSearchTabCuratedCollections")
+
+  if (Platform.OS === "ios") {
+    return isFeatureFlagEnabled
+  }
+
+  return true
+}

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -233,6 +233,11 @@ export const features = defineFeatures({
     readyForRelease: true,
     echoFlagKey: "AREnableArtworkGridSaveIcon",
   },
+  AREnableSmallTredingArtistCardSize: {
+    description: "Use small size card for treding artists",
+    showInAdminMenu: true,
+    readyForRelease: false,
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [FX-4452] <!-- eg [PROJECT-XXXX] -->

### Demo
#### Empty recent searches
https://user-images.githubusercontent.com/3513494/203583781-d1191052-ef36-4291-ad1e-f29c60ff61d9.mp4

#### Filled recent searches
https://user-images.githubusercontent.com/3513494/203583854-0287c63a-51ae-448b-a1c1-14c0636e2696.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Display trending artists on search screen - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4452]: https://artsyproduct.atlassian.net/browse/FX-4452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ