### PR TITLE
fix(CX-2493): Fix Photo Added in Edit mode not updated on MyCollectionArtwork

### DIFF
--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -127,6 +127,7 @@ interface PrivateProps {
   loadMore: RelayPaginationProp["loadMore"]
   hasMore: RelayPaginationProp["hasMore"]
   isLoading?: RelayPaginationProp["isLoading"]
+  myCollectionIsRefreshing?: boolean
 }
 
 interface MapperProps extends Omit<PrivateProps, "connection"> {
@@ -195,6 +196,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   contextScreenOwnerSlug,
   contextScreenOwnerId,
   contextScreenOwnerType,
+  myCollectionIsRefreshing,
 }) => {
   const getSectionDimension = (gridWidth: number | null | undefined) => {
     // Setting the dimension to 1 for tests to avoid adjusting the screen width
@@ -320,6 +322,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
             updateRecentSearchesOnTap={updateRecentSearchesOnTap}
             {...itemComponentProps}
             height={imgHeight}
+            myCollectionIsRefreshing={myCollectionIsRefreshing}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -13,6 +13,7 @@ export interface MyCollectionImageViewProps {
   aspectRatio?: number
   artworkSlug: string
   artworkSubmissionId?: string | null
+  myCollectionIsRefreshing?: boolean
 }
 
 export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
@@ -22,6 +23,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   aspectRatio,
   artworkSlug,
   artworkSubmissionId,
+  myCollectionIsRefreshing,
 }) => {
   const color = useColor()
   const [localImage, setLocalImage] = useState<LocalImage | null>(null)
@@ -33,7 +35,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
         setLocalImage(images[0])
       }
     })
-  }, [])
+  }, [myCollectionIsRefreshing])
 
   const {
     photosForMyCollection: { photos },
@@ -52,7 +54,20 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   }, [])
 
   const renderImage = () => {
-    if (localImage) {
+    // prioritise imageURL
+    if (imageURL) {
+      const targetURL = imageURL.replace(":version", "square")
+      return (
+        <OpaqueImageView
+          testID="Image-Remote"
+          imageURL={targetURL}
+          retryFailedURLs
+          height={imageHeight}
+          width={imageWidth}
+          aspectRatio={aspectRatio}
+        />
+      )
+    } else if (localImage) {
       return (
         <RNImage
           testID="Image-Local"
@@ -78,18 +93,6 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           source={{
             uri: localImageConsignments.path,
           }}
-        />
-      )
-    } else if (imageURL) {
-      const targetURL = imageURL.replace(":version", "square")
-      return (
-        <OpaqueImageView
-          testID="Image-Remote"
-          imageURL={targetURL}
-          retryFailedURLs
-          height={imageHeight}
-          width={imageWidth}
-          aspectRatio={aspectRatio}
         />
       )
     } else {

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -216,6 +216,7 @@ const MyCollection: React.FC<{
           relay={relay}
           showSearchBar={showSearchBar}
           setShowSearchBar={setShowSearchBar}
+          myCollectionIsRefreshing={isRefreshing}
         />
         {!!showDevAddButton && (
           <Button

--- a/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
+++ b/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
@@ -34,6 +34,7 @@ interface MyCollectionArtworksProps {
   relay: RelayPaginationProp
   showSearchBar: boolean
   setShowSearchBar: (show: boolean) => void
+  myCollectionIsRefreshing?: boolean
 }
 
 export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({
@@ -41,6 +42,7 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({
   relay,
   showSearchBar,
   setShowSearchBar,
+  myCollectionIsRefreshing,
 }) => {
   const { height: screenHeight } = useScreenDimensions()
   const enabledSearchBar = useFeatureFlag("AREnableMyCollectionSearchBar")
@@ -149,6 +151,7 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({
       {filteredArtworks.length > 0 ? (
         viewOption === "grid" ? (
           <InfiniteScrollMyCollectionArtworksGridContainer
+            myCollectionIsRefreshing={myCollectionIsRefreshing}
             myCollectionConnection={me.myCollectionConnection!}
             hasMore={relay.hasMore}
             loadMore={relay.loadMore}

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -105,7 +105,7 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
   return (
     <Join separator={<Spacer my={1} />}>
       {/* ImageCarousel */}
-      {!!imagesToDisplay ? (
+      {!!imagesToDisplay && imagesToDisplay.length ? (
         <ImagesToDisplayCarousel
           images={imagesToDisplay as any}
           cardHeight={dimensions.height / 3.5}

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -35,7 +35,7 @@ import { ArtworkFormValues } from "../../State/MyCollectionArtworkModel"
 import { deletedPhotos } from "../../utils/deletedPhotos"
 import { SavingArtworkModal } from "./Components/SavingArtworkModal"
 import { artworkSchema, validateArtworkSchema } from "./Form/artworkSchema"
-import { removeLocalPhotos, storeLocalPhotos, uploadPhotos } from "./MyCollectionImageUtil"
+import { storeLocalPhotos, uploadPhotos } from "./MyCollectionImageUtil"
 import { MyCollectionAddPhotos } from "./Screens/MyCollectionArtworkFormAddPhotos"
 import { MyCollectionArtworkFormArtist } from "./Screens/MyCollectionArtworkFormArtist"
 import { MyCollectionArtworkFormArtwork } from "./Screens/MyCollectionArtworkFormArtwork"
@@ -365,13 +365,14 @@ export const updateArtwork = async (
       ...explicitlyClearedFields(others, dirtyFormCheckValues),
     })
 
+    const slug = response.myCollectionUpdateArtwork?.artworkOrError?.artwork?.slug
+    // if the user has updated images, save to local store
+    if (slug) {
+      storeLocalPhotos(slug, photos)
+    }
     const deletedImages = deletedPhotos(dirtyFormCheckValues.photos, photos)
     for (const photo of deletedImages) {
       await deleteArtworkImage(props.artwork.internalID, photo.id)
-    }
-    const slug = response.myCollectionUpdateArtwork?.artworkOrError?.artwork?.slug
-    if (slug) {
-      removeLocalPhotos(slug)
     }
   }
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tsx
@@ -16,9 +16,13 @@ import { MyCollectionImageView } from "../../Components/MyCollectionImageView"
 
 interface MyCollectionArtworkGridItemProps {
   artwork: MyCollectionArtworkGridItem_artwork$data
+  myCollectionIsRefreshing?: boolean
 }
 
-const MyCollectionArtworkGridItem: React.FC<MyCollectionArtworkGridItemProps> = ({ artwork }) => {
+const MyCollectionArtworkGridItem: React.FC<MyCollectionArtworkGridItemProps> = ({
+  artwork,
+  myCollectionIsRefreshing,
+}) => {
   const { trackEvent } = useTracking()
   const imageURL =
     artwork.images?.find((i: any) => i?.isDefault)?.url ||
@@ -74,6 +78,7 @@ const MyCollectionArtworkGridItem: React.FC<MyCollectionArtworkGridItemProps> = 
           aspectRatio={image?.aspectRatio}
           artworkSlug={slug}
           artworkSubmissionId={submissionId}
+          myCollectionIsRefreshing={myCollectionIsRefreshing}
         />
         <Box maxWidth={width} mt={1} style={{ flex: 1 }}>
           <Text lineHeight="18" weight="regular" variant="xs" numberOfLines={2}>

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -110,6 +110,7 @@ jest.mock("@react-navigation/native", () => {
     useNavigation: () => ({
       navigate: mockNavigate,
       dispatch: jest.fn(),
+      addListener: jest.fn(),
     }),
   }
 })


### PR DESCRIPTION
This PR resolves [CX-2493] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR fixes a bug where NoImage Component continues to show after a user adds new images to a MyCollectionArtwork that previously had no images.

#### Before

https://user-images.githubusercontent.com/18648835/203365183-d8fa4b3a-6e22-46d1-96fe-29cae35ba2be.mp4

#### After

https://user-images.githubusercontent.com/18648835/203365834-c3b72ddd-57ad-44a7-ac57-6dadcdb76f3e.mov






### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix Photo Added in Edit mode not updated on MyCollectionArtwork - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2493]: https://artsyproduct.atlassian.net/browse/CX-2493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ