### PR TITLE
feat(FX-4446): tracks tap on curated collection

### DIFF
--- a/src/app/Scenes/Search/CuratedCollectionItem.tsx
+++ b/src/app/Scenes/Search/CuratedCollectionItem.tsx
@@ -1,23 +1,35 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { TappedCuratedCollection } from "@artsy/cohesion/dist/Schema/Events/Tap"
 import { CuratedCollectionItem_collection$key } from "__generated__/CuratedCollectionItem_collection.graphql"
 import { navigate } from "app/navigation/navigate"
 import { Flex, Spacer, Text, Touchable } from "palette"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 import { IMAGE_SIZE, SearchResultImage } from "./components/SearchResultImage"
 
 interface CuratedCollectionItemProps {
   collection: CuratedCollectionItem_collection$key
+  position: number
 }
 
-export const CuratedCollectionItem: React.FC<CuratedCollectionItemProps> = ({ collection }) => {
+export const CuratedCollectionItem: React.FC<CuratedCollectionItemProps> = ({
+  collection,
+  position,
+}) => {
+  const tracking = useTracking()
   const item = useFragment(CuratedCollectionItemFragment, collection)
   const thumbnail = item.thumbnailImage?.resized?.url || null
 
-  const onPress = (slug: string) => {
-    navigate(`/collection/${slug}`)
+  const onPress = (collectionId: string, collectionSlug: string) => {
+    tracking.trackEvent(
+      trackingEvent.tappedCuratedCollection(collectionId, collectionSlug, position)
+    )
+
+    navigate(`/collection/${collectionSlug}`)
   }
 
   return (
-    <Touchable key={item.internalID} onPress={() => onPress(item.slug)}>
+    <Touchable key={item.internalID} onPress={() => onPress(item.internalID, item.slug)}>
       <Flex height={IMAGE_SIZE} flexDirection="row" alignItems="center">
         <SearchResultImage imageURL={thumbnail} resultType="Collection" />
 
@@ -49,3 +61,19 @@ const CuratedCollectionItemFragment = graphql`
     }
   }
 `
+
+const trackingEvent = {
+  tappedCuratedCollection: (
+    collectionId: string,
+    collectionSlug: string,
+    position: number
+  ): TappedCuratedCollection => ({
+    action: ActionType.tappedCuratedCollection,
+    context_module: ContextModule.curatedCollections,
+    context_screen_owner_type: OwnerType.search,
+    destination_screen_owner_type: OwnerType.collection,
+    destination_screen_owner_slug: collectionSlug,
+    destination_screen_owner_id: collectionId,
+    position,
+  }),
+}

--- a/src/app/Scenes/Search/CuratedCollections.tests.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react-native"
 import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { navigate } from "app/navigation/navigate"
 import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { renderWithHookWrappersTL } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -58,6 +59,34 @@ describe("CuratedCollections", () => {
 
     fireEvent.press(getByText("Blue-Chip Artists"))
     expect(navigate).toHaveBeenCalledWith(`/collection/blue-chip-artists`)
+  })
+
+  it("tracks an event when an item is tapped", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Query: () => ({
+        collections,
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    fireEvent.press(getByText("Blue-Chip Artists"))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "tappedCuratedCollection",
+          "context_module": "curatedCollections",
+          "context_screen_owner_type": "search",
+          "destination_screen_owner_id": "8fbef3cc-9c4a-4baf-81e2-276724341ae8",
+          "destination_screen_owner_slug": "blue-chip-artists",
+          "destination_screen_owner_type": "collection",
+          "position": 0,
+        },
+      ]
+    `)
   })
 })
 

--- a/src/app/Scenes/Search/CuratedCollections.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tsx
@@ -16,8 +16,12 @@ export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collecti
       <SectionTitle title="Artsy Curated Collections" />
 
       <Join separator={<Spacer mb={2} />}>
-        {data.collections?.map((collection) => (
-          <CuratedCollectionItem key={collection!.internalID} collection={collection!} />
+        {data.collections?.map((collection, position) => (
+          <CuratedCollectionItem
+            key={collection!.internalID}
+            collection={collection!}
+            position={position}
+          />
         ))}
       </Join>
     </>


### PR DESCRIPTION
This PR resolves [FX-4446]

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Add analytics tracking when user taps on a curated collection on the Search tab.

### Demo

https://user-images.githubusercontent.com/3934579/203538018-d99281d2-a5a6-4713-886d-d1190981cdd8.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4446]: https://artsyproduct.atlassian.net/browse/FX-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ