### PR TITLE
Fix(CX-3099): Do not display Banner after submitting a MyCollectionArtwork

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
@@ -197,4 +197,88 @@ describe(SubmitArtwork, () => {
       )
     })
   })
+
+  describe("Submission VisualClues", () => {
+    const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+
+    let addClueSpy = jest
+      .spyOn(GlobalStore.actions.visualClue, "addClue")
+      .mockImplementation(() => null)
+    beforeEach(() => {
+      addClueSpy = jest
+        .spyOn(GlobalStore.actions.visualClue, "addClue")
+        .mockImplementation(() => null)
+    })
+    afterEach(() => {
+      GlobalStore.actions.artworkSubmission.submission.resetSessionState()
+    })
+
+    it("does not addClue ArtworkSubmissionMessage when submitting MyCollectionArtwork", async () => {
+      GlobalStore.actions.artworkSubmission.submission.initializeArtworkDetailsForm({
+        myCollectionArtworkID: "my-collection-artwork-id",
+      })
+
+      const { getByTestId } = renderWithWrappers(
+        <SubmitSWAArtworkFlow
+          navigation={jest.fn() as any}
+          stepsInOrder={[STEPS.ContactInformation]}
+        />
+      )
+
+      await flushPromiseQueue()
+
+      mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation, {
+          Me: () => ({
+            name: "User",
+            email: "user@user.com",
+            phoneNumber: { isValid: true, originalNumber: "+49 1753627282" },
+          }),
+        })
+      )
+
+      await flushPromiseQueue()
+
+      const contactInfoCTA = getByTestId("Submission_ContactInformation_Button")
+      fireEvent.press(contactInfoCTA)
+
+      await flushPromiseQueue()
+
+      expect(addClueSpy).not.toHaveBeenCalled()
+    })
+
+    it("addClue ArtworkSubmissionMessage when submitting other Artworks that are not MyCollectionArtwork", async () => {
+      GlobalStore.actions.artworkSubmission.submission.initializeArtworkDetailsForm({
+        myCollectionArtworkID: null,
+      })
+
+      const { getByTestId } = renderWithWrappers(
+        <SubmitSWAArtworkFlow
+          navigation={jest.fn() as any}
+          stepsInOrder={[STEPS.ContactInformation]}
+        />
+      )
+
+      await flushPromiseQueue()
+
+      mockEnvironment.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation, {
+          Me: () => ({
+            name: "User",
+            email: "user@user.com",
+            phoneNumber: { isValid: true, originalNumber: "+49 1753627282" },
+          }),
+        })
+      )
+
+      await flushPromiseQueue()
+
+      const contactInfoCTA = getByTestId("Submission_ContactInformation_Button")
+      fireEvent.press(contactInfoCTA)
+
+      await flushPromiseQueue()
+
+      expect(addClueSpy).toHaveBeenCalledWith("ArtworkSubmissionMessage")
+    })
+  })
 })

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -9,7 +9,7 @@ import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { BackButton } from "app/navigation/BackButton"
 import { goBack } from "app/navigation/navigate"
-import { addClue, GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
@@ -124,10 +124,13 @@ export const SubmitSWAArtworkFlow: React.FC<SubmitSWAArtworkFlowProps> = ({
       if (id) {
         track(id, email)
 
-        if (activeStep === stepsInOrder.length - 1) {
+        if (isLastStep) {
           refreshMyCollection()
           GlobalStore.actions.artworkSubmission.submission.resetSessionState()
-          addClue("ArtworkSubmissionMessage")
+          if (!values.myCollectionArtworkID) {
+            // add clue only if it is not MyCollectionArtwork that was submitted
+            GlobalStore.actions.visualClue.addClue("ArtworkSubmissionMessage")
+          }
           return navigation.navigate("ArtworkSubmittedScreen", { submissionId: id })
         }
 


### PR DESCRIPTION
This PR resolves [CX-3099] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- This PR ensures we don't add visual clue that displays the "The new artwork added to your Collection" banner when a user submits an Artwork that is already in their MyCollection

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Do not display Banner after submitting a MyCollectionArtwork - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3099]: https://artsyproduct.atlassian.net/browse/CX-3099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ