### PR TITLE
fix: handle marketing deeplinks on typescript side

### DIFF
--- a/src/app/navigation/navigate.tests.tsx
+++ b/src/app/navigation/navigate.tests.tsx
@@ -122,6 +122,38 @@ describe(navigate, () => {
       `)
   })
 
+  describe("marketing links", async () => {
+    const fetch = jest.fn((_url, _init) =>
+      Promise.resolve({ url: "https://artsy.net/artist/kaws" })
+    )
+    // @ts-ignore
+    global.fetch = fetch
+    beforeEach(() => {
+      fetch.mockClear()
+    })
+
+    it("reroutes marketing links", async () => {
+      await navigate("https://click.artsy.net/artist/kaws")
+      expect(fetch).toHaveBeenCalledTimes(1)
+      expect(LegacyNativeModules.ARScreenPresenterModule.pushView).toHaveBeenCalled()
+      expect(args(LegacyNativeModules.ARScreenPresenterModule.pushView as any))
+        .toMatchInlineSnapshot(`
+          Array [
+            "home",
+            Object {
+              "hidesBackButton": true,
+              "moduleName": "Artist",
+              "props": Object {
+                "artistID": "kaws",
+              },
+              "replace": false,
+              "type": "react",
+            },
+          ]
+        `)
+    })
+  })
+
   describe("presents modals", () => {
     it("when the screen requires it", () => {
       navigate("https://live.artsy.net/blah")

--- a/src/app/navigation/navigate.ts
+++ b/src/app/navigation/navigate.ts
@@ -40,24 +40,34 @@ export interface NavigateOptions {
 let lastInvocation = { url: "", timestamp: 0 }
 
 export async function navigate(url: string, options: NavigateOptions = {}) {
-  // handle artsy:// urls, we can just remove it
-  url = url.replace("artsy://", "")
+  let targetURL = url
 
-  visualize("NAV", url, { url, options }, "DTShowNavigationVisualiser")
+  // handle artsy:// urls, we can just remove it
+  targetURL = url.replace("artsy://", "")
+
+  visualize("NAV", targetURL, { targetURL, options }, "DTShowNavigationVisualiser")
 
   // Debounce double taps
   const ignoreDebounce = options.ignoreDebounce ?? false
   if (
-    lastInvocation.url === url &&
+    lastInvocation.url === targetURL &&
     Date.now() - lastInvocation.timestamp < 1000 &&
     !ignoreDebounce
   ) {
     return
   }
 
-  lastInvocation = { url, timestamp: Date.now() }
+  lastInvocation = { url: targetURL, timestamp: Date.now() }
 
-  const result = matchRoute(url)
+  // marketing url requires redirect
+  if (targetURL.startsWith("https://click.artsy.net")) {
+    const response = await fetch(targetURL)
+    if (response.url) {
+      targetURL = response.url
+    }
+  }
+
+  const result = matchRoute(targetURL)
 
   if (result.type === "external_url") {
     Linking.openURL(result.url)


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Follow-up to https://github.com/artsy/eigen/pull/7705

Fixes a bug where marketing deeplinks would open safari if app was in a killed state.

So it turns out that our deeplinks are being handled by both typescript and native code. 
In my testing when the app is killed the deeplink code here gets fired and calls navigate: 
https://github.com/artsy/eigen/blob/f462ca578be55a3e83c946941d5e118c0b80169a/src/app/utils/useDeepLinks.ts#L17

And when the app is in the background it is handled here and calls navigate: 
https://github.com/artsy/eigen/blob/f462ca578be55a3e83c946941d5e118c0b80169a/ios/Artsy/App/ARAppActivityContinuationDelegate.m#L49

I am guessing we can move this all to typescript and it is probably the reason we get double navigation on deeplinks from time to time and need the weird ignoreDebounce code in our navigation. 

But for now just handling the marketing links on the typescript side as well and following redirects. 

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
