### PR TITLE
chore: add deprecated flag to old opaque image view

### DIFF
--- a/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -73,6 +73,10 @@ interface State {
   height?: number
 }
 
+/**
+ * @deprecated
+ * Use `OpaqueImageView` from palette instead.
+ */
 export default class OpaqueImageView extends React.Component<Props, State> {
   static defaultProps: Props = {
     placeholderBackgroundColor: "#E7E7E7", // this is black10. Change it to that when this component becomes a function component.


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Marks old opaqueImageView as deprecated in order to use the palette one as the preferred one 

![Screenshot 2022-11-24 at 18 16 38](https://user-images.githubusercontent.com/21178754/203839282-645f97d6-2b88-47c3-94f0-7e23f2cfe2be.png)


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add deprecated flag to old opaque image view - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
