### PR TITLE
chore(FX-4470): Convert Artsy Curated Collections list into a rail

### DIFF
--- a/src/app/Scenes/Search/CuratedCollections.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tsx
@@ -2,15 +2,18 @@ import { CuratedCollections_collections$key } from "__generated__/CuratedCollect
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { compact } from "lodash"
-import { Box, Spacer } from "palette"
+import { Box, BoxProps, Spacer } from "palette"
 import { graphql, useFragment } from "react-relay"
 import { CuratedCollectionItem } from "./CuratedCollectionItem"
 
-interface CuratedCollectionsProps {
+interface CuratedCollectionsProps extends BoxProps {
   collections: CuratedCollections_collections$key
 }
 
-export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collections }) => {
+export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({
+  collections,
+  ...boxProps
+}) => {
   const data = useFragment(CuratedCollectionsFragment, collections)
   const filledCollections = compact(data.collections)
 
@@ -19,7 +22,7 @@ export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collecti
   }
 
   return (
-    <>
+    <Box {...boxProps}>
       <Box mx={2}>
         <SectionTitle title="Artsy Collections" />
       </Box>
@@ -32,7 +35,7 @@ export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collecti
         }}
         ItemSeparatorComponent={() => <Spacer ml={1} />}
       />
-    </>
+    </Box>
   )
 }
 

--- a/src/app/Scenes/Search/CuratedCollections.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tsx
@@ -1,6 +1,8 @@
 import { CuratedCollections_collections$key } from "__generated__/CuratedCollections_collections.graphql"
+import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { Join, Spacer } from "palette"
+import { compact } from "lodash"
+import { Box, Spacer } from "palette"
 import { graphql, useFragment } from "react-relay"
 import { CuratedCollectionItem } from "./CuratedCollectionItem"
 
@@ -10,20 +12,26 @@ interface CuratedCollectionsProps {
 
 export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collections }) => {
   const data = useFragment(CuratedCollectionsFragment, collections)
+  const filledCollections = compact(data.collections)
+
+  if (filledCollections.length === 0) {
+    return null
+  }
 
   return (
     <>
-      <SectionTitle title="Artsy Curated Collections" />
+      <Box mx={2}>
+        <SectionTitle title="Artsy Curated Collections" />
+      </Box>
 
-      <Join separator={<Spacer mb={2} />}>
-        {data.collections?.map((collection, position) => (
-          <CuratedCollectionItem
-            key={collection!.internalID}
-            collection={collection!}
-            position={position}
-          />
-        ))}
-      </Join>
+      <CardRailFlatList
+        data={filledCollections}
+        keyExtractor={(node) => node.internalID}
+        renderItem={({ item, index }) => {
+          return <CuratedCollectionItem collection={item} position={index} />
+        }}
+        ItemSeparatorComponent={() => <Spacer ml={1} />}
+      />
     </>
   )
 }

--- a/src/app/Scenes/Search/CuratedCollections.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tsx
@@ -21,7 +21,7 @@ export const CuratedCollections: React.FC<CuratedCollectionsProps> = ({ collecti
   return (
     <>
       <Box mx={2}>
-        <SectionTitle title="Artsy Curated Collections" />
+        <SectionTitle title="Artsy Collections" />
       </Box>
 
       <CardRailFlatList

--- a/src/app/Scenes/Search/Search.tests.tsx
+++ b/src/app/Scenes/Search/Search.tests.tsx
@@ -695,7 +695,7 @@ describe("Search Screen", () => {
       })
     })
 
-    describe("Artsy curated collections section", () => {
+    describe("Artsy Collections section", () => {
       it("should NOT be rendered when feature flag is disabled", async () => {
         __globalStoreTestUtils__?.injectFeatureFlags({
           AREnableSearchDiscoveryContentIOS: false,
@@ -711,7 +711,7 @@ describe("Search Screen", () => {
 
         await flushPromiseQueue()
 
-        expect(screen.queryByText("Artsy Curated Collections")).toBeNull()
+        expect(screen.queryByText("Artsy Collections")).toBeNull()
       })
 
       it("should be rendered when feature flag is enabled", async () => {
@@ -729,7 +729,7 @@ describe("Search Screen", () => {
 
         await flushPromiseQueue()
 
-        expect(screen.getByText("Artsy Curated Collections")).toBeTruthy()
+        expect(screen.getByText("Artsy Collections")).toBeTruthy()
       })
     })
   })

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -240,11 +240,7 @@ export const Search: React.FC = () => {
                   <>
                     <Spacer mb={4} />
                     <TrendingArtists data={queryData} mb={4} />
-
-                    {/* TODO: Display curated collections as scrollable rail */}
-                    <HorizontalPadding>
-                      <CuratedCollections collections={queryData} />
-                    </HorizontalPadding>
+                    <CuratedCollections collections={queryData} />
                   </>
                 )}
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -236,15 +236,15 @@ export const Search: React.FC = () => {
                   <RecentSearches />
                 </HorizontalPadding>
 
-                {!!isSearchDiscoveryContentEnabled && (
+                {!!isSearchDiscoveryContentEnabled ? (
                   <>
                     <Spacer mb={4} />
                     <TrendingArtists data={queryData} mb={4} />
-                    <CuratedCollections collections={queryData} />
+                    <CuratedCollections collections={queryData} mb={4} />
                   </>
+                ) : (
+                  <Spacer mb={4} />
                 )}
-
-                <Spacer mb={3} />
 
                 <HorizontalPadding>
                   {!!enableMaps ? (
@@ -256,7 +256,7 @@ export const Search: React.FC = () => {
                   )}
                 </HorizontalPadding>
 
-                <Spacer mb="40px" />
+                <Spacer mb={4} />
               </Scrollable>
             )}
           </Flex>

--- a/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
+++ b/src/app/Scenes/Search/components/placeholders/SearchPlaceholder.tsx
@@ -1,3 +1,4 @@
+import { CARD_WIDTH } from "app/Components/Home/CardRailCard"
 import { isPad } from "app/utils/hardware"
 import {
   PlaceholderBox,
@@ -49,7 +50,7 @@ const TrendingArtistLargeCard = () => {
       <PlaceholderBox width={295} height={180} />
       <Spacer mt={1} />
       <PlaceholderText width={120} height={20} />
-      <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} />
+      <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} marginBottom={0} />
     </>
   )
 }
@@ -60,7 +61,7 @@ const TrendingArtistSmallCard = () => {
       <PlaceholderBox width={140} height={105} />
       <Spacer mt={1} />
       <PlaceholderText width={120} height={15} />
-      <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={15} />
+      <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={15} marginBottom={0} />
     </>
   )
 }
@@ -84,6 +85,33 @@ const TrendingArtistPlaceholder = () => {
   )
 }
 
+const CuratedCollectionCardPlaceholder: React.FC = (props) => {
+  return (
+    <Box borderRadius={4} border="1px solid" borderColor="black10" overflow="hidden" {...props}>
+      <PlaceholderBox width={CARD_WIDTH} borderRadius={0} height={180} />
+      <Box m={15} mb={1}>
+        <PlaceholderText width={120} height={20} />
+        <RandomWidthPlaceholderText minWidth={30} maxWidth={90} height={20} />
+      </Box>
+    </Box>
+  )
+}
+
+const CuratedCollectionsPlaceholder = () => {
+  return (
+    <>
+      <PlaceholderText width="50%" height={25} />
+      <Flex flexDirection="row" mt={1}>
+        <Join separator={<Spacer ml={1} />}>
+          {times(3).map((index) => (
+            <CuratedCollectionCardPlaceholder key={`curated-collaction-card-${index}`} />
+          ))}
+        </Join>
+      </Flex>
+    </>
+  )
+}
+
 export const SearchPlaceholder: React.FC = () => {
   const isSearchDiscoveryContentEnabled = useSearchDiscoveryContentEnabled()
 
@@ -97,7 +125,13 @@ export const SearchPlaceholder: React.FC = () => {
         <RecentSearchesPlaceholder />
         <Spacer mt={4} />
 
-        {!!isSearchDiscoveryContentEnabled && <TrendingArtistPlaceholder />}
+        {!!isSearchDiscoveryContentEnabled && (
+          <>
+            <TrendingArtistPlaceholder />
+            <Spacer mt={4} />
+            <CuratedCollectionsPlaceholder />
+          </>
+        )}
       </Box>
     </ProvidePlaceholderContext>
   )


### PR DESCRIPTION
This PR resolves [FX-4470] <!-- eg [PROJECT-XXXX] -->

### Demo
https://user-images.githubusercontent.com/3513494/203847369-37dafe41-b003-4f57-915d-ea85731d0492.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Convert Artsy Curated Collections list into a rail - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4470]: https://artsyproduct.atlassian.net/browse/FX-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ