### PR TITLE
fix: round up height/width sizes that we send to gemini

### DIFF
--- a/src/app/Components/OpaqueImageView/createGeminiUrl.tsx
+++ b/src/app/Components/OpaqueImageView/createGeminiUrl.tsx
@@ -18,12 +18,15 @@ export function createGeminiUrl({
 }) {
   const src = encodeURIComponent(imageURL)
 
+  const roundedHeight = Math.round(height)
+  const roundedWidth = Math.round(width)
+
   const params = [
-    `height=${height}`,
+    `height=${roundedHeight}`,
     `quality=${imageQuality}`,
     `resize_to=${resizeMode}`,
     `src=${src}`,
-    `width=${width}`,
+    `width=${roundedWidth}`,
   ]
 
   if (Platform.OS === "android" || (Platform.OS === "ios" && osMajorVersion() >= 13)) {


### PR DESCRIPTION
This PR resolves [MOPLAT-482] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Rounding the heights and widths that we send to gemini to avoid sending numbers with as much as 12 decimal points. This will help us take advantage of the Gemini cache

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- round up height/width sizes that we send to gemini - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-482]: https://artsyproduct.atlassian.net/browse/MOPLAT-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ