### PR TITLE
chore: decreased padding between the histogram and the latest price ranges

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/PriceRangeOptions.tsx
@@ -301,7 +301,7 @@ export const PriceRangeOptionsScreen: React.FC<PriceRangeOptionsScreenProps> = (
             </Flex>
           </Flex>
 
-          <Spacer mt={4} />
+          <Spacer mt={2} />
 
           {!!enableRecentPriceRanges && priceRanges.length > 0 && (
             <>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
The spacing between the histogram and the latest price ranges has been reduced, since on devices with a small screen, the price ranges were placed too close to the bottom container

### Demo
| Before | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-11-25 at 14 45 41](https://user-images.githubusercontent.com/3513494/203979493-7f355844-220f-463c-8f6a-ca31ebaa1a11.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-11-25 at 14 46 13](https://user-images.githubusercontent.com/3513494/203979519-1540fec3-01c5-45cc-9090-89b20e619ec2.png) | 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
