### PR TITLE
refactor: analytics for search screen

### DIFF
--- a/src/app/Scenes/Search/CuratedCollectionItem.tsx
+++ b/src/app/Scenes/Search/CuratedCollectionItem.tsx
@@ -1,8 +1,5 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import {
-  TappedCollectionGroup,
-  TappedCuratedCollection,
-} from "@artsy/cohesion/dist/Schema/Events/Tap"
+import { TappedCollectionGroup } from "@artsy/cohesion/dist/Schema/Events/Tap"
 import { CuratedCollectionItem_collection$key } from "__generated__/CuratedCollectionItem_collection.graphql"
 import { navigate } from "app/navigation/navigate"
 import { Flex, Spacer, Text, Touchable } from "palette"

--- a/src/app/Scenes/Search/CuratedCollectionItem.tsx
+++ b/src/app/Scenes/Search/CuratedCollectionItem.tsx
@@ -1,5 +1,8 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import { TappedCuratedCollection } from "@artsy/cohesion/dist/Schema/Events/Tap"
+import {
+  TappedCollectionGroup,
+  TappedCuratedCollection,
+} from "@artsy/cohesion/dist/Schema/Events/Tap"
 import { CuratedCollectionItem_collection$key } from "__generated__/CuratedCollectionItem_collection.graphql"
 import { navigate } from "app/navigation/navigate"
 import { Flex, Spacer, Text, Touchable } from "palette"
@@ -21,9 +24,7 @@ export const CuratedCollectionItem: React.FC<CuratedCollectionItemProps> = ({
   const thumbnail = item.thumbnailImage?.resized?.url || null
 
   const onPress = (collectionId: string, collectionSlug: string) => {
-    tracking.trackEvent(
-      trackingEvent.tappedCuratedCollection(collectionId, collectionSlug, position)
-    )
+    tracking.trackEvent(trackingEvent.tappedCollectionGroup(collectionId, collectionSlug, position))
 
     navigate(`/collection/${collectionSlug}`)
   }
@@ -63,17 +64,18 @@ const CuratedCollectionItemFragment = graphql`
 `
 
 const trackingEvent = {
-  tappedCuratedCollection: (
+  tappedCollectionGroup: (
     collectionId: string,
     collectionSlug: string,
     position: number
-  ): TappedCuratedCollection => ({
-    action: ActionType.tappedCuratedCollection,
+  ): TappedCollectionGroup => ({
+    action: ActionType.tappedCollectionGroup,
     context_module: ContextModule.curatedCollections,
     context_screen_owner_type: OwnerType.search,
     destination_screen_owner_type: OwnerType.collection,
     destination_screen_owner_slug: collectionSlug,
     destination_screen_owner_id: collectionId,
-    position,
+    horizontal_slide_position: position,
+    type: "thumbnail",
   }),
 }

--- a/src/app/Scenes/Search/CuratedCollections.tests.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tests.tsx
@@ -77,13 +77,14 @@ describe("CuratedCollections", () => {
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         Object {
-          "action": "tappedCuratedCollection",
+          "action": "tappedCollectionGroup",
           "context_module": "curatedCollections",
           "context_screen_owner_type": "search",
           "destination_screen_owner_id": "8fbef3cc-9c4a-4baf-81e2-276724341ae8",
           "destination_screen_owner_slug": "blue-chip-artists",
           "destination_screen_owner_type": "collection",
-          "position": 0,
+          "horizontal_slide_position": 0,
+          "type": "thumbnail",
         },
       ]
     `)

--- a/src/app/Scenes/Search/TrendingArtists.tests.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tests.tsx
@@ -60,7 +60,7 @@ describe("TrendingArtists", () => {
     expect(navigate).toHaveBeenCalledWith("/artist/artist-one")
   })
 
-  it("shoudl track event when an artist is tapped", async () => {
+  it("should track event when an artist is tapped", async () => {
     const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
 
     resolveMostRecentRelayOperation(mockEnvironment, {

--- a/src/app/Scenes/Search/TrendingArtists.tests.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from "@testing-library/react-native"
 import { TrendingArtists_Test_Query } from "__generated__/TrendingArtists_Test_Query.graphql"
 import { navigate } from "app/navigation/navigate"
 import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { renderWithHookWrappersTL } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -58,19 +59,52 @@ describe("TrendingArtists", () => {
 
     expect(navigate).toHaveBeenCalledWith("/artist/artist-one")
   })
+
+  it("shoudl track event when an artist is tapped", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Query: () => ({
+        curatedTrendingArtists,
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    fireEvent.press(getByText("Artist Two"))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "tappedArtistGroup",
+          "context_module": "trendingArtistsRail",
+          "context_screen_owner_type": "search",
+          "destination_screen_owner_id": "artist-two-id",
+          "destination_screen_owner_slug": "artist-two",
+          "destination_screen_owner_type": "artist",
+          "horizontal_slide_position": 1,
+          "type": "thumbnail",
+        },
+      ]
+    `)
+  })
 })
 
 const curatedTrendingArtists = {
   edges: [
     {
       node: {
+        internalID: "artist-one-id",
         href: "/artist/artist-one",
+        slug: "artist-one",
         name: "Artist One",
       },
     },
     {
       node: {
+        internalID: "artist-two-id",
         href: "/artist/artist-two",
+        slug: "artist-two",
         name: "Artist Two",
       },
     },

--- a/src/app/Scenes/Search/components/TrendingArtistCard.tsx
+++ b/src/app/Scenes/Search/components/TrendingArtistCard.tsx
@@ -1,5 +1,4 @@
 import { TrendingArtistCard_artist$key } from "__generated__/TrendingArtistCard_artist.graphql"
-import { navigate } from "app/navigation/navigate"
 import { Flex, OpaqueImageView, Text } from "palette"
 import { TouchableHighlight } from "react-native"
 import { useFragment } from "react-relay"

--- a/src/app/Scenes/Search/components/TrendingArtistCard.tsx
+++ b/src/app/Scenes/Search/components/TrendingArtistCard.tsx
@@ -7,23 +7,20 @@ import { graphql } from "relay-runtime"
 
 interface TrendingArtistCardProps {
   artist: TrendingArtistCard_artist$key
+  onPress: () => void
 }
 
 const CARD_WIDTH = 140
 const CARD_HEIGHT = 105
 
-export const TrendingArtistCard: React.FC<TrendingArtistCardProps> = ({ artist }) => {
+export const TrendingArtistCard: React.FC<TrendingArtistCardProps> = ({ artist, onPress }) => {
   const data = useFragment(TrendingArtistCardFragment, artist)
-
-  const handlePress = () => {
-    navigate(data.href!)
-  }
 
   return (
     <TouchableHighlight
       underlayColor="transparent"
       style={{ width: CARD_WIDTH, overflow: "hidden" }}
-      onPress={handlePress}
+      onPress={onPress}
     >
       <Flex>
         <OpaqueImageView imageURL={data.image?.url} width={CARD_WIDTH} height={CARD_HEIGHT} />


### PR DESCRIPTION
Addressed PRs: [FX-4453], [FX-4446]

### Description
* use `tappedArtistGroup` for trending artists
* use `tappedCollectionGroup` for curated artsy collections

### Demo
https://user-images.githubusercontent.com/3513494/203989295-27be5aee-f735-451d-825f-7e15957d97f5.mp4

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4453]: https://artsyproduct.atlassian.net/browse/FX-4453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4446]: https://artsyproduct.atlassian.net/browse/FX-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ