### PR TITLE
fix(CX-3188): padding issue on large rail

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
@@ -41,15 +41,17 @@ describe("Notable Works Rail", () => {
   })
 
   it("renders without throwing an error when 3 or more notable artworks", async () => {
-    const { getByText } = renderWithWrappers(<TestWrapper />)
+    const { getByText, getAllByText } = renderWithWrappers(<TestWrapper />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artist: () => artistMockData,
     })
 
-    expect(getByText("My Second Greatest Art, 2020")).toBeTruthy()
-    expect(getByText("My Greatest Art, 2020")).toBeTruthy()
-    expect(getByText("My Third Greatest Art, 2020")).toBeTruthy()
+    expect(getByText("My Second Greatest Art")).toBeTruthy()
+    expect(getByText("My Second Greatest Art").props.fontStyle).toEqual("italic")
+    expect(getAllByText(", 2020").length).toEqual(3)
+    expect(getByText("My Greatest Art")).toBeTruthy()
+    expect(getByText("My Third Greatest Art")).toBeTruthy()
   })
 
   describe("Notable artwork metadata", () => {

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -92,15 +92,34 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
             </Text>
           )}
           {!hideArtistName && !!artistNames && (
-            <Text numberOfLines={size === "small" ? 2 : 1} lineHeight="20" variant="sm">
+            <Text numberOfLines={size === "small" ? 2 : 1} lineHeight="20" variant="xs">
               {artistNames}
             </Text>
           )}
-          {!!(title || date) && (
-            <Text lineHeight="20" color="black60" numberOfLines={size === "small" ? 2 : 1}>
-              {[title, date].filter(Boolean).join(", ")}
-            </Text>
-          )}
+          <Flex flexDirection="row">
+            {!!title && (
+              <Text
+                lineHeight="20"
+                color="black60"
+                numberOfLines={size === "small" ? 2 : 1}
+                variant="xs"
+                fontStyle="italic"
+              >
+                {title}
+              </Text>
+            )}
+            {!!date && (
+              <Text
+                lineHeight="20"
+                color="black60"
+                numberOfLines={size === "small" ? 2 : 1}
+                variant="xs"
+              >
+                {title && date ? ", " : ""}
+                {date}
+              </Text>
+            )}
+          </Flex>
           {!hidePartnerName && !!partner?.name && (
             <Text lineHeight="20" color="black60" numberOfLines={1}>
               {partner?.name}
@@ -129,7 +148,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
           )}
 
           {!!saleMessage && !isRecentlySoldArtwork && (
-            <Text lineHeight="20" variant="xs" color="black60" numberOfLines={1}>
+            <Text lineHeight="20" variant="xs" color="black100" numberOfLines={1} fontWeight={500}>
               {saleMessage}
             </Text>
           )}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -12,7 +12,8 @@ import styled from "styled-components/native"
 import { saleMessageOrBidInfo as defaultSaleMessageOrBidInfo } from "../ArtworkGrids/ArtworkGridItem"
 import OpaqueImageView from "../OpaqueImageView/OpaqueImageView"
 
-export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = 90
+export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = 60
+
 export const ARTWORK_RAIL_CARD_IMAGE_HEIGHT = {
   small: 230,
   large: 320,
@@ -60,6 +61,13 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
       ? getUrgencyTag(artwork?.sale?.endAt)
       : null
 
+  const getTextHeightByArtworkSize = (cardSize: ArtworkCardSize) => {
+    if (cardSize === "small") {
+      return ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + 30
+    }
+    return ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + (isRecentlySoldArtwork ? 30 : 0)
+  }
+
   return (
     <ArtworkCard onPress={onPress || undefined} testID={testID}>
       <Flex alignItems="flex-end">
@@ -75,8 +83,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
           // Recently sold artworks require more space for the text container
           // to accommodate the estimate and realized price
           style={{
-            height:
-              fontScale * (ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + (isRecentlySoldArtwork ? 10 : 0)),
+            height: fontScale * getTextHeightByArtworkSize(size),
           }}
         >
           {!!lotLabel && (

--- a/src/app/Components/ArtworkRail/LargeArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/LargeArtworkRail.tsx
@@ -16,7 +16,7 @@ type LargeArtworkRailProps = Omit<ArtworkRailProps, "artworks" | "size"> & {
   artworks: LargeArtworkRail_artworks$key
 }
 
-const IMAGE_WIDTH = 295
+export const LARGE_RAIL_IMAGE_WIDTH = 295
 
 export const LargeArtworkRail: React.FC<LargeArtworkRailProps> = ({ artworks, ...restProps }) => {
   const artworksData = useFragment(largeArtworksFragment, artworks)
@@ -37,7 +37,10 @@ export const LargeArtworkRailPlaceholder: React.FC = () => (
   <Join separator={<Spacer width={15} />}>
     {times(3 + useMemoizedRandom() * 10).map((index) => (
       <Flex key={index}>
-        <PlaceholderBox height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT.large} width={IMAGE_WIDTH} />
+        <PlaceholderBox
+          height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT.large}
+          width={LARGE_RAIL_IMAGE_WIDTH}
+        />
         <Spacer mb={2} />
         <PlaceholderText width={295} />
         <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />

--- a/src/app/Components/ArtworkRail/SmallArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/SmallArtworkRail.tsx
@@ -20,7 +20,7 @@ type SmallArtworkRailProps = Omit<ArtworkRailProps, "artworks" | "size"> & {
   artworks: SmallArtworkRail_artworks$key
 }
 
-const IMAGE_WIDTH = 155
+export const SMALL_RAIL_IMAGE_WIDTH = 155
 
 export const SmallArtworkRail: React.FC<SmallArtworkRailProps> = ({ artworks, ...restProps }) => {
   const artworksData = useFragment(smallArtworksFragment, artworks)
@@ -44,11 +44,14 @@ export const SmallArtworkRailPlaceholder: React.FC = () => {
     <Join separator={<Spacer width={15} />}>
       {times(3 + useMemoizedRandom() * 10).map((index) => (
         <Flex key={index}>
-          <PlaceholderBox height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT.small} width={IMAGE_WIDTH} />
+          <PlaceholderBox
+            height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT.small}
+            width={SMALL_RAIL_IMAGE_WIDTH}
+          />
           <Spacer mb={2} />
           <Flex height={fontScale * ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT}>
             <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />
-            <PlaceholderText width={IMAGE_WIDTH} />
+            <PlaceholderText width={SMALL_RAIL_IMAGE_WIDTH} />
             <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />
           </Flex>
         </Flex>

--- a/src/app/Scenes/Home/Components/HomeHeader.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tsx
@@ -17,8 +17,7 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({ me }) => {
         <ArtsyLogoIcon scale={0.75} />
         <ActivityIndicator hasNotifications={hasNotifications} />
       </Flex>
-      <Spacer mb="15px" />
-      <Spacer mb="2" />
+      <Spacer mb="1" />
     </Box>
   )
 }

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -50,7 +50,7 @@ import { NewWorksForYouRail } from "./Components/NewWorksForYouRail"
 import { ShowsRailFragmentContainer } from "./Components/ShowsRail"
 import { RailScrollRef } from "./Components/types"
 
-const MODULE_SEPARATOR_HEIGHT = 6
+const MODULE_SEPARATOR_HEIGHT = 4
 
 interface HomeModule {
   title: string

--- a/src/app/Scenes/Sale/Components/NewBuyNowArtworksRail.tests.tsx
+++ b/src/app/Scenes/Sale/Components/NewBuyNowArtworksRail.tests.tsx
@@ -32,11 +32,11 @@ describe("NewBuyNowArtworksRail", () => {
     mockEnvironment = createMockEnvironment()
   })
   it(`renders "Buy now" rail and artworks`, () => {
-    const { getByText, queryByText } = renderWithWrappers(<TestRenderer />)
+    const { getByText, getAllByText } = renderWithWrappers(<TestRenderer />)
     resolveMostRecentRelayOperation(mockEnvironment, mockProps)
 
     expect(getByText("Artworks Available to Buy Now")).toBeDefined()
-    expect(queryByText("Best artwork ever")).toBeDefined()
+    expect(getAllByText("Best artwork ever")).toBeDefined()
   })
 
   it("renders nothing if there are no artworks", () => {


### PR DESCRIPTION
This PR resolves [CX-3188] <!-- eg [PROJECT-XXXX] -->

### Description


Fix padding issue on Large rail


https://user-images.githubusercontent.com/11945712/204767812-6bc841cd-63c8-44a4-b898-6ff7e5acb952.mov


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3188]: https://artsyproduct.atlassian.net/browse/CX-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ