### PR TITLE
feat(CX-3158): add screen tracking

### DIFF
--- a/src/app/Scenes/Home/Components/HomeFeedModalCarousel/HomeFeedModalCarouselContainer.tsx
+++ b/src/app/Scenes/Home/Components/HomeFeedModalCarousel/HomeFeedModalCarouselContainer.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { navigate, popToRoot, switchTab } from "app/navigation/navigate"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
+import { screen } from "app/utils/track/helpers"
 import { BackButton, Button, Flex, useSpace } from "palette"
 import { useEffect, useRef, useState } from "react"
 import { BackHandler, LayoutAnimation, Modal, TouchableOpacity } from "react-native"
@@ -49,7 +50,7 @@ export const HomeFeedModalCarouselContainer: React.FC<FullScreenCarouselProps> =
     if (isLastStep) {
       trackEvent(tracks.myCollectionOnboardingCompleted())
     }
-    trackEvent(tracks.visitMyCollectionOnboardingSlide(activeStep))
+    trackEvent(tracks.screen(activeStep.toString()))
   }, [activeStep])
 
   useEffect(() => {
@@ -270,4 +271,9 @@ const tracks = {
     context_module: ContextModule.myCollectionOnboarding,
     index: slideIndex,
   }),
+  screen: (slideIndex: string) =>
+    screen({
+      context_screen_owner_type: OwnerType.myCollectionOnboarding,
+      context_screen_owner_id: slideIndex,
+    }),
 }


### PR DESCRIPTION
This PR resolves [CX-3158] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add screen tracking to my collection home feed onboarding -daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3158]: https://artsyproduct.atlassian.net/browse/CX-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ