### PR TITLE
feat(FX-4274): Artwork screen header

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -330,7 +330,7 @@ export const modules = defineModules({
   ArtistShows: reactModule(ArtistShows2QueryRenderer),
   ArtistArticles: reactModule(ArtistArticlesQueryRenderer),
   ArtistSeries: reactModule(ArtistSeriesQueryRenderer),
-  Artwork: reactModule(Artwork, {}, [ArtworkScreenQuery]),
+  Artwork: reactModule(Artwork, { hidesBackButton: true }, [ArtworkScreenQuery]),
   ArtworkMedium: reactModule(ArtworkMediumQueryRenderer),
   ArtworkAttributionClassFAQ: reactModule(ArtworkAttributionClassFAQQueryRenderer),
   ArtworkCertificateAuthenticity: reactModule(CertificateOfAuthenticity),

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -2,7 +2,7 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { ArtworkActions_artwork$data } from "__generated__/ArtworkActions_artwork.graphql"
 import { ArtworkActionsSaveMutation } from "__generated__/ArtworkActionsSaveMutation.graphql"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import { unsafe__getEnvironment } from "app/store/GlobalStore"
+import { unsafe__getEnvironment, unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import { cm2in } from "app/utils/conversions"
 import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
 import { Schema, track } from "app/utils/track"
@@ -125,10 +125,10 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
     } = this.props
 
     const isOpenSale = sale && sale.isAuction && !sale.isClosed
-
+    const enableArtworkRedesign = unsafe_getFeatureFlag("ARArtworkRedesingPhase2")
     return (
       <Flex justifyContent="center" flexDirection="row" width="100%">
-        {isOpenSale ? (
+        {!!enableArtworkRedesign ? null : isOpenSale ? (
           <Touchable haptic onPress={() => this.handleArtworkSave()}>
             <UtilButton pr={2}>
               {is_saved ? (

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { ArtworkScreenHeaderTestQuery } from "__generated__/ArtworkScreenHeaderTestQuery.graphql"
+import { goBack } from "app/navigation/navigate"
+import { flushPromiseQueue } from "app/tests/flushPromiseQueue"
+import { mockTrackEvent } from "app/tests/globallyMockedStuff"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
+import { graphql, QueryRenderer } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+import { ArtworkScreenHeaderFragmentContainer } from "./ArtworkScreenHeader"
+
+jest.unmock("react-relay")
+
+describe("ArtworkScreenHeader", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = createMockEnvironment()
+  })
+
+  const TestRenderer = () => (
+    <QueryRenderer<ArtworkScreenHeaderTestQuery>
+      environment={mockEnvironment}
+      query={graphql`
+        query ArtworkScreenHeaderTestQuery @relay_test_operation @raw_response_type {
+          artwork(id: "some-artwork") {
+            ...ArtworkScreenHeader_artwork
+          }
+        }
+      `}
+      variables={{}}
+      render={({ props, error }) => {
+        if (props?.artwork) {
+          return <ArtworkScreenHeaderFragmentContainer artwork={props.artwork} />
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
+
+  it("renders the header", async () => {
+    renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => ({
+        isSaved: false,
+        isForSale: true,
+        artists: [{ name: "test" }],
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByLabelText("Artwork page header")).toBeTruthy()
+    expect(screen.queryByLabelText("Go back")).toBeTruthy()
+    expect(screen.queryByText("Save")).toBeTruthy()
+    expect(screen.queryByText("Create Alert")).toBeTruthy()
+  })
+
+  it("calls go back when the back button is pressed", async () => {
+    renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {})
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByLabelText("Go back")).toBeTruthy()
+
+    fireEvent.press(screen.getByLabelText("Go back"))
+
+    expect(goBack).toHaveBeenCalledTimes(1)
+  })
+
+  describe("Create alert button", () => {
+    it("renders the header but not the create alert button if the artwork doesn't have an associated artist", async () => {
+      renderWithWrappers(<TestRenderer />)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          isSaved: false,
+          isForSale: false,
+          artists: [],
+        }),
+      })
+
+      await flushPromiseQueue()
+
+      expect(screen.queryByLabelText("Go back")).toBeTruthy()
+      expect(screen.queryByText("Save")).toBeTruthy()
+      expect(screen.queryByText("Create Alert")).toBeFalsy()
+    })
+
+    it("should correctly track event when `Create Alert` button is pressed", () => {
+      const { getByText } = renderWithWrappers(<TestRenderer />)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          artists: [{ name: "some-artist-name" }],
+        }),
+      })
+
+      fireEvent.press(getByText("Create Alert"))
+
+      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "action": "tappedCreateAlert",
+          "context_module": "ArtworkScreenHeader",
+          "context_screen_owner_id": "internalID-1",
+          "context_screen_owner_slug": "slug-1",
+          "context_screen_owner_type": "artwork",
+        },
+      ]
+    `)
+    })
+  })
+
+  describe("Save button", () => {
+    it("renders Watch lot text if the artwork is an open sale", async () => {
+      renderWithWrappers(<TestRenderer />)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          isSaved: false,
+          isForSale: false,
+          sale: {
+            isAuction: true,
+            isClosed: false,
+          },
+        }),
+      })
+
+      await flushPromiseQueue()
+
+      expect(screen.queryByText("Watch lot")).toBeTruthy()
+      expect(screen.queryByText(/Save/)).toBeNull()
+    })
+
+    it("should trigger save mutation when user presses save button", async () => {
+      renderWithWrappers(<TestRenderer />)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          isSaved: false,
+        }),
+      })
+
+      await flushPromiseQueue()
+
+      expect(screen.queryByText("Save")).toBeTruthy()
+
+      fireEvent.press(screen.getByText("Save"))
+
+      expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(
+        "ArtworkScreenHeaderSaveMutation"
+      )
+    })
+
+    it("should track save event when user saves and artwork successfully", async () => {
+      renderWithWrappers(<TestRenderer />)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          isSaved: false,
+        }),
+      })
+
+      await flushPromiseQueue()
+
+      fireEvent.press(screen.getByText("Save"))
+
+      resolveMostRecentRelayOperation(mockEnvironment, {})
+
+      await flushPromiseQueue()
+
+      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "action_name": "artworkSave",
+            "action_type": "success",
+            "context_module": "ArtworkActions",
+          },
+        ]
+      `)
+    })
+  })
+
+  it("renders Save text if the artwork is a closed sale", async () => {
+    renderWithWrappers(<TestRenderer />)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Artwork: () => ({
+        isSaved: false,
+        isForSale: false,
+        sale: {
+          isAuction: true,
+          isClosed: true,
+        },
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Watch lot")).toBeNull()
+    expect(screen.queryByText(/Save/)).toBeTruthy()
+  })
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -124,7 +124,7 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
               {saveButtonText()}
               {/* this is a hacky way of preventing the save text / button to be jumpy when it changes to saved */}
               {!isSaved && !__TEST__ && (
-                <Text variant="sm-display" color="transparent">
+                <Text accessibilityElementsHidden variant="sm-display" color="transparent">
                   d
                 </Text>
               )}

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -17,7 +17,7 @@ interface SaveIconProps {
 }
 
 const SaveIcon: React.FC<SaveIconProps> = ({ isSaved }) =>
-  isSaved ? <HeartFillIcon fill="blue100" mr={1} /> : <HeartIcon mr={1} />
+  isSaved ? <HeartFillIcon fill="blue100" mr={0.5} /> : <HeartIcon mr={0.5} />
 
 interface ArtworkScreenHeaderProps {
   artwork: ArtworkScreenHeader_artwork$data

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -5,18 +5,25 @@ import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { userHadMeaningfulInteraction } from "app/utils/userHadMeaningfulInteraction"
 import { isEmpty } from "lodash"
-import { BackButton, Button, Flex, HeartFillIcon, HeartIcon, Text, useSpace } from "palette"
+import { BackButton, Flex, HeartFillIcon, HeartIcon, Text, Touchable, useSpace } from "palette"
 import { createFragmentContainer, graphql, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ArtworkScreenHeaderCreateAlertFragmentContainer } from "./ArtworkScreenHeaderCreateAlert"
 
 const HEADER_HEIGHT = 44
 
+interface SaveIconProps {
+  isSaved: boolean
+}
+
+const SaveIcon: React.FC<SaveIconProps> = ({ isSaved }) =>
+  isSaved ? <HeartFillIcon fill="blue100" mr={1} /> : <HeartIcon mr={1} />
+
 interface ArtworkScreenHeaderProps {
   artwork: ArtworkScreenHeader_artwork$data
 }
 
-export const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) => {
+const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) => {
   const { trackEvent } = useTracking()
   const space = useSpace()
 
@@ -103,16 +110,27 @@ export const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwor
         />
       </Flex>
 
-      <Flex flexDirection="row">
-        <Button
-          icon={isSaved ? <HeartFillIcon fill="blue100" /> : <HeartIcon />}
-          variant="fillLight"
-          size="small"
+      <Flex flexDirection="row" alignItems="center">
+        <Touchable
+          accessibilityRole="button"
+          accessibilityLabel={saveButtonText()}
+          haptic
           onPress={handleArtworkSave}
-          loading={isInFlight}
+          disabled={isInFlight}
         >
-          <Text variant="sm-display">{saveButtonText()}</Text>
-        </Button>
+          <Flex flexDirection="row" alignItems="center">
+            <SaveIcon isSaved={!!isSaved} />
+            <Text variant="sm-display" color={isSaved ? "blue100" : "black100"}>
+              {saveButtonText()}
+              {/* this is a hacky way of preventing the save text / button to be jumpy when it changes to saved */}
+              {!isSaved && !__TEST__ && (
+                <Text variant="sm-display" color="transparent">
+                  d
+                </Text>
+              )}
+            </Text>
+          </Flex>
+        </Touchable>
         <ArtworkScreenHeaderCreateAlertFragmentContainer artwork={artwork} />
       </Flex>
     </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -1,0 +1,135 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { ArtworkScreenHeader_artwork$data } from "__generated__/ArtworkScreenHeader_artwork.graphql"
+import { goBack } from "app/navigation/navigate"
+import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
+import { Schema } from "app/utils/track"
+import { userHadMeaningfulInteraction } from "app/utils/userHadMeaningfulInteraction"
+import { isEmpty } from "lodash"
+import { BackButton, Button, Flex, HeartFillIcon, HeartIcon, Text, useSpace } from "palette"
+import { createFragmentContainer, graphql, useMutation } from "react-relay"
+import { useTracking } from "react-tracking"
+import { ArtworkScreenHeaderCreateAlertFragmentContainer } from "./ArtworkScreenHeaderCreateAlert"
+
+const HEADER_HEIGHT = 44
+
+interface ArtworkScreenHeaderProps {
+  artwork: ArtworkScreenHeader_artwork$data
+}
+
+export const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) => {
+  const { trackEvent } = useTracking()
+  const space = useSpace()
+
+  const { isSaved, sale } = artwork
+
+  const [commit, isInFlight] = useMutation(graphql`
+    mutation ArtworkScreenHeaderSaveMutation($input: SaveArtworkInput!) {
+      saveArtwork(input: $input) {
+        artwork {
+          id
+          isSaved
+        }
+      }
+    }
+  `)
+
+  const handleArtworkSave = () => {
+    commit({
+      variables: {
+        input: {
+          artworkID: artwork.internalID,
+          remove: isSaved,
+        },
+      },
+      optimisticResponse: {
+        saveArtwork: {
+          artwork: {
+            id: artwork.internalID,
+            isSaved: !artwork.isSaved,
+          },
+        },
+      },
+      onCompleted: () => {
+        refreshFavoriteArtworks()
+
+        userHadMeaningfulInteraction({
+          contextModule: ContextModule.artworkMetadata,
+          contextOwnerType: OwnerType.artwork,
+          contextOwnerId: artwork.internalID,
+          contextOwnerSlug: artwork.slug,
+        })
+
+        trackEvent({
+          action_name: isSaved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
+          action_type: Schema.ActionTypes.Success,
+          context_module: Schema.ContextModules.ArtworkActions,
+        })
+      },
+      onError: () => {
+        refreshFavoriteArtworks()
+      },
+    })
+  }
+
+  const isOpenSale = !isEmpty(sale) && sale?.isAuction && !sale.isClosed
+
+  const saveButtonText = () => {
+    if (isOpenSale) {
+      return "Watch lot"
+    }
+
+    return isSaved ? "Saved" : "Save"
+  }
+
+  return (
+    <Flex
+      height={HEADER_HEIGHT}
+      justifyContent="space-between"
+      alignItems="center"
+      flexDirection="row"
+      px={2}
+      accessibilityRole="header"
+      accessibilityLabel="Artwork page header"
+    >
+      <Flex>
+        <BackButton
+          onPress={goBack}
+          hitSlop={{
+            top: space(2),
+            left: space(2),
+            right: space(2),
+            bottom: space(2),
+          }}
+        />
+      </Flex>
+
+      <Flex flexDirection="row">
+        <Button
+          icon={isSaved ? <HeartFillIcon fill="blue100" /> : <HeartIcon />}
+          variant="fillLight"
+          size="small"
+          onPress={handleArtworkSave}
+          loading={isInFlight}
+        >
+          <Text variant="sm-display">{saveButtonText()}</Text>
+        </Button>
+        <ArtworkScreenHeaderCreateAlertFragmentContainer artwork={artwork} />
+      </Flex>
+    </Flex>
+  )
+}
+
+export const ArtworkScreenHeaderFragmentContainer = createFragmentContainer(ArtworkScreenHeader, {
+  artwork: graphql`
+    fragment ArtworkScreenHeader_artwork on Artwork {
+      ...ArtworkScreenHeaderCreateAlert_artwork
+      internalID
+      slug
+      isSaved
+      sale {
+        isAuction
+        isClosed
+      }
+    }
+  `,
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -118,7 +118,7 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
           onPress={handleArtworkSave}
           disabled={isInFlight}
         >
-          <Flex flexDirection="row" alignItems="center">
+          <Flex flexDirection="row" alignItems="center" pr={0.5}>
             <SaveIcon isSaved={!!isSaved} />
             <Text variant="sm-display" color={isSaved ? "blue100" : "black100"}>
               {saveButtonText()}

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -99,7 +99,7 @@ const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateAlertPro
         variant={isForSale ? "fillLight" : "fillDark"}
         onPress={handleCreateAlertPress}
       >
-        <Text variant="sm-display">Create Alert</Text>
+        <Text variant={isForSale ? "sm-display" : "xs"}>Create Alert</Text>
       </Button>
       <CreateSavedSearchModal
         visible={isCreateAlertModalVisible}

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -1,0 +1,164 @@
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  ScreenOwnerType,
+  TappedCreateAlert,
+} from "@artsy/cohesion"
+import { ArtworkScreenHeaderCreateAlert_artwork$data } from "__generated__/ArtworkScreenHeaderCreateAlert_artwork.graphql"
+import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
+import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import {
+  SavedSearchEntity,
+  SavedSearchEntityArtist,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
+import { compact, isEmpty } from "lodash"
+import { BellIcon, Button, Spacer, Text } from "palette"
+import { useState } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface ArtworkScreenHeaderCreateAlertProps {
+  artwork: ArtworkScreenHeaderCreateAlert_artwork$data
+}
+
+const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateAlertProps> = ({
+  artwork,
+}) => {
+  const { isForSale } = artwork
+  const { trackEvent } = useTracking()
+  const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
+
+  const hasArtists = !isEmpty(artwork.artists) && artwork.artists!.length > 0
+
+  if (!hasArtists) {
+    return null
+  }
+
+  let aggregations: Aggregations = []
+  let additionalGeneIDs: string[] = []
+
+  const artists = compact(artwork?.artists)
+  const attributionClass = compact([artwork?.attributionClass?.internalID])
+  const formattedArtists: SavedSearchEntityArtist[] = artists.map((artist) => ({
+    id: artist.internalID,
+    name: artist.name!,
+  }))
+
+  const entity: SavedSearchEntity = {
+    placeholder: `Artworks like: ${artwork?.title!}`,
+    artists: formattedArtists,
+    owner: {
+      type: OwnerType.artwork,
+      id: artwork?.internalID ?? "",
+      slug: artwork?.slug ?? "",
+    },
+  }
+
+  if (artwork?.mediumType?.filterGene?.name && artwork?.mediumType?.filterGene.slug) {
+    additionalGeneIDs = [artwork.mediumType.filterGene.slug]
+    aggregations = [
+      {
+        slice: "MEDIUM",
+        counts: [
+          {
+            name: artwork.mediumType.filterGene.name,
+            value: artwork.mediumType.filterGene.slug,
+            count: 0,
+          },
+        ],
+      },
+    ]
+  }
+
+  const attributes: SearchCriteriaAttributes = {
+    artistIDs: formattedArtists.map((artist) => artist.id),
+    attributionClass,
+    additionalGeneIDs,
+  }
+
+  const handleCreateAlertPress = () => {
+    setIsCreateAlertModalVisible(true)
+
+    const event = tracks.tappedCreateAlert({
+      ownerId: entity.owner.id,
+      ownerType: entity.owner.type,
+      ownerSlug: entity.owner.slug,
+    })
+
+    trackEvent(event)
+  }
+
+  return (
+    <>
+      <Spacer mr={0.5} />
+      <Button
+        icon={<BellIcon fill={isForSale ? "black100" : "white100"} />}
+        size="small"
+        variant={isForSale ? "fillLight" : "fillDark"}
+        onPress={handleCreateAlertPress}
+      >
+        <Text variant="sm-display">Create Alert</Text>
+      </Button>
+      <CreateSavedSearchModal
+        visible={isCreateAlertModalVisible}
+        entity={entity}
+        attributes={attributes}
+        aggregations={aggregations}
+        closeModal={() => setIsCreateAlertModalVisible(false)}
+      />
+    </>
+  )
+}
+
+export const ArtworkScreenHeaderCreateAlertFragmentContainer = createFragmentContainer(
+  ArtworkScreenHeaderCreateAlert,
+  {
+    artwork: graphql`
+      fragment ArtworkScreenHeaderCreateAlert_artwork on Artwork {
+        title
+        internalID
+        slug
+        isForSale
+        sale {
+          isAuction
+          isClosed
+        }
+        artists {
+          internalID
+          name
+        }
+        attributionClass {
+          internalID
+        }
+        mediumType {
+          filterGene {
+            slug
+            name
+          }
+        }
+      }
+    `,
+  }
+)
+
+interface TappedCreateAlertOptions {
+  ownerType: ScreenOwnerType
+  ownerId: string
+  ownerSlug: string
+}
+
+const tracks = {
+  tappedCreateAlert: ({
+    ownerType,
+    ownerId,
+    ownerSlug,
+  }: TappedCreateAlertOptions): TappedCreateAlert => ({
+    action: ActionType.tappedCreateAlert,
+    context_screen_owner_type: ownerType,
+    context_screen_owner_id: ownerId,
+    context_screen_owner_slug: ownerSlug,
+    context_module: "ArtworkScreenHeader" as ContextModule,
+  }),
+}

--- a/src/app/navigation/navigate.tests.tsx
+++ b/src/app/navigation/navigate.tests.tsx
@@ -42,6 +42,7 @@ describe(navigate, () => {
         Array [
           "home",
           Object {
+            "hidesBackButton": true,
             "moduleName": "Artwork",
             "props": Object {
               "artworkID": "josef-albers-homage-to-the-square",

--- a/src/palette/atoms/BackButton/BackButton.tsx
+++ b/src/palette/atoms/BackButton/BackButton.tsx
@@ -18,7 +18,14 @@ export const BackButton: React.FC<BackButtonProps> = ({
   hitSlop,
 }) => {
   return (
-    <TouchableOpacity hitSlop={hitSlop} style={containerStyle} onPress={onPress}>
+    <TouchableOpacity
+      hitSlop={hitSlop}
+      style={containerStyle}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={showX ? "Close" : "Go back"}
+      accessibilityHint={showX ? "Dismiss this screen" : "Go back to the previous screen"}
+    >
       {showX ? (
         <CloseIcon fill={color} width={26} height={26} />
       ) : (
@@ -30,7 +37,12 @@ export const BackButton: React.FC<BackButtonProps> = ({
 
 export const BackButtonWithBackground: React.FC<BackButtonProps> = ({ onPress, showX = false }) => {
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={showX ? "Close" : "Go back"}
+      accessibilityHint={showX ? "Dismiss this screen" : "Go back to the previous screen"}
+    >
       <Flex
         backgroundColor="white100"
         width={40}


### PR DESCRIPTION
This PR resolves [FX-4274] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- creates new header for artwork screen
- hides it behind a ff
- bonus: add accessibility props to palette back buttons

|With ff false (same as before) |With ff true (after)|
|---|---|
|https://user-images.githubusercontent.com/21178754/204510396-ef9b65b3-42fa-468c-b69c-f302a5205f44.mp4|https://user-images.githubusercontent.com/21178754/204510438-4334d6e2-ae5e-48be-9ed8-637ddaa1c07b.mp4|

When artwork is sold
|Android|iOS|
|---|---|
|![Screenshot_1669720388](https://user-images.githubusercontent.com/21178754/204514708-fabff24e-3de9-42f1-a048-9360e031809c.png)|![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-11-29 at 12 12 04](https://user-images.githubusercontent.com/21178754/204514577-82306d13-48c1-4367-97a3-f56655beeae4.png)|


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- new artwork screen header (behind a ff) - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4274]: https://artsyproduct.atlassian.net/browse/FX-4274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ