### PR TITLE
chore: add save icon to artwork grids

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -204,7 +204,6 @@ const ArtistArtworksContainer: React.FC<ArtworksGridProps & ArtistArtworksContai
             contextScreenOwnerType={OwnerType.artist}
             contextScreenOwnerId={artist.internalID}
             contextScreenOwnerSlug={artist.slug}
-            showSaveIcon
           />
         </>
       )

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -243,7 +243,7 @@ describe("save artworks", () => {
     })
   })
 
-  it("is not possible when hideSaveIcon prop is specified", () => {
+  it("is not visible when hideSaveIcon prop is specified", () => {
     const { getByTestId } = renderWithHookWrappersTL(
       <Artwork hideSaveIcon artwork={artworkProps({}) as any} />
     )

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -242,21 +242,6 @@ describe("save artworks", () => {
       expect(getByTestId("filled-heart-icon")).toBeTruthy()
     })
   })
-
-  it("is hidden for lots", () => {
-    const saleArtwork = {
-      lotLabel: "Lot 1",
-      sale: {
-        isClosed: false,
-        cascadingEndTimeIntervalMinutes: 1,
-      },
-    }
-    const { getByTestId } = renderWithHookWrappersTL(
-      <Artwork showLotLabel showSaveIcon artwork={artworkProps({ saleArtwork }) as any} />
-    )
-
-    expect(() => getByTestId("save-artwork-icon")).toThrow()
-  })
 })
 
 const artworkProps = ({

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -229,7 +229,7 @@ describe("save artworks", () => {
 
   it("favourites works", () => {
     const { getByTestId } = renderWithHookWrappersTL(
-      <Artwork showLotLabel showSaveIcon artwork={artworkProps({}) as any} />
+      <Artwork showLotLabel artwork={artworkProps({}) as any} />
     )
 
     expect(getByTestId("empty-heart-icon")).toBeTruthy()
@@ -241,6 +241,14 @@ describe("save artworks", () => {
     waitFor(() => {
       expect(getByTestId("filled-heart-icon")).toBeTruthy()
     })
+  })
+
+  it("is not possible when hideSaveIcon prop is specified", () => {
+    const { getByTestId } = renderWithHookWrappersTL(
+      <Artwork hideSaveIcon artwork={artworkProps({}) as any} />
+    )
+
+    expect(() => getByTestId("empty-heart-icon")).toThrow()
   })
 })
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -205,8 +205,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const canShowAuctionProgressBar =
     !!artwork.sale?.extendedBiddingPeriodMinutes && !!artwork.sale?.extendedBiddingIntervalMinutes
 
-  const isBiddableLot = artwork?.sale?.isAuction && !artwork.sale.isClosed
-
   return (
     <Touchable onPress={handleTap} testID={`artworkGridItem-${artwork.title}`}>
       <View ref={itemRef}>
@@ -327,7 +325,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
               </Text>
             )}
           </Flex>
-          {!!showSaveIcon && !!eableArtworkGridSaveIcon && !isBiddableLot && (
+          {!!showSaveIcon && !!eableArtworkGridSaveIcon && (
             <Flex ml={0.2}>
               <Touchable haptic onPress={handleArtworkSave} testID="save-artwork-icon">
                 {artwork.isSaved ? (

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -56,7 +56,7 @@ export interface ArtworkProps {
   hidePartner?: boolean
   /** Hide sale info */
   hideSaleInfo?: boolean
-  showSaveIcon?: boolean
+  hideSaveIcon?: boolean
   height?: number
   /** Show the lot number (Lot 213) */
   showLotLabel?: boolean
@@ -85,7 +85,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
   hideUrgencyTags = false,
   hidePartner = false,
   hideSaleInfo = false,
-  showSaveIcon = false,
+  hideSaveIcon = false,
   showLotLabel = false,
   urgencyTagTextStyle,
   lotLabelTextStyle,
@@ -325,7 +325,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
               </Text>
             )}
           </Flex>
-          {!!showSaveIcon && !!eableArtworkGridSaveIcon && (
+          {!!eableArtworkGridSaveIcon && !hideSaveIcon && (
             <Flex ml={0.2}>
               <Touchable haptic onPress={handleArtworkSave} testID="save-artwork-icon">
                 {artwork.isSaved ? (

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -85,7 +85,7 @@ export interface Props {
   contextScreen?: string
 
   /** Allow users to save artworks that are not lots to their saves & follows */
-  showSaveIcon?: boolean
+  hideSaveIcon?: boolean
 
   /** An array of child indices determining which children get docked to the top of the screen when scrolling.  */
   stickyHeaderIndices?: number[]
@@ -179,7 +179,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   isMyCollection = false,
   useParentAwareScrollView = Platform.OS === "android",
   showLoadingSpinner = false,
-  showSaveIcon = false,
+  hideSaveIcon = false,
   updateRecentSearchesOnTap = false,
   itemComponentProps,
   width,
@@ -307,7 +307,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
         const componentSpecificProps = isMyCollection
           ? {}
           : {
-              showSaveIcon,
+              hideSaveIcon,
             }
         const ItemComponent = isMyCollection
           ? MyCollectionArtworkGridItemFragmentContainer


### PR DESCRIPTION
This PR resolves [CX-3188] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds the save icon to artwork grids


![Group 1 1](https://user-images.githubusercontent.com/11945712/204773210-6a20c00f-a0e2-4805-b1bd-aa496b4172de.png)


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Add save icon to artworks grid - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3188]: https://artsyproduct.atlassian.net/browse/CX-3188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ