### PR TITLE
chore: track file size exceeded

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "react-native-vision-camera": "Needed for reverse image functionality, more context here: https://github.com/artsy/eigen/issues/7159"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.80.0",
+    "@artsy/cohesion": "4.81.0",
     "@artsy/palette-tokens": "4.0.1",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "3.8.0",

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -1,3 +1,4 @@
+import { ActionType, exceededUploadSize } from "@artsy/cohesion"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { captureMessage } from "@sentry/react-native"
 import { storeLocalPhotos } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionImageUtil"
@@ -11,9 +12,14 @@ import { useFormikContext } from "formik"
 import { Button, Flex, Spacer, Text } from "palette"
 import { PhotoRow } from "palette/elements/PhotoRow/PhotoRow"
 import React, { useEffect, useState } from "react"
+import { useTracking } from "react-tracking"
 import { removeAssetFromSubmission } from "../../mutations/removeAssetFromConsignmentSubmissionMutation"
 import { addPhotoToConsignment } from "./utils/addPhotoToConsignment"
-import { calculateSinglePhotoSize, isSizeLimitExceeded } from "./utils/calculatePhotoSize"
+import {
+  calculateSinglePhotoSize,
+  getPhotosSize,
+  isSizeLimitExceeded,
+} from "./utils/calculatePhotoSize"
 
 export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
   isAnyPhotoLoading,
@@ -22,6 +28,7 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
   const { submission } = GlobalStore.useAppState((state) => state.artworkSubmission)
   const { showActionSheetWithOptions } = useActionSheet()
   const [progress, setProgress] = useState<Record<string, number | undefined>>({})
+  const { trackEvent } = useTracking()
 
   useEffect(() => {
     // add initial photos when a My Collection artwork gets submitted
@@ -51,17 +58,19 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
         })
         if (uploadedPhoto?.id) {
           const sizedPhoto = calculateSinglePhotoSize(uploadedPhoto)
-          const isTotalSizeLimitExceeded = isSizeLimitExceeded([
-            ...values.photos,
-            ...processedPhotos,
-            sizedPhoto,
-          ])
+
+          const availablePhotos = [...values.photos, ...processedPhotos, sizedPhoto]
+          const isTotalSizeLimitExceeded = isSizeLimitExceeded(availablePhotos)
           // when total size limit exceeded, set photo's err state and stop the upload loop
           if (isTotalSizeLimitExceeded) {
             sizedPhoto.error = true
             sizedPhoto.errorMessage =
               "File exceeds the total size limit. Please delete photos or upload smaller file sizes."
             processedPhotos.push(sizedPhoto)
+
+            trackEvent(
+              tracks.hasExceededUploadSize(getPhotosSize(availablePhotos), availablePhotos.length)
+            )
             break
           }
           processedPhotos.push(sizedPhoto)
@@ -171,4 +180,16 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
       ))}
     </>
   )
+}
+
+export const tracks = {
+  hasExceededUploadSize: (
+    uploadSizeInBytes: number,
+    numberOfFiles: number
+  ): ExceededUploadSize => ({
+    action: ActionType.exceededUploadSize,
+    context_owner_type: OwnerType.sell,
+    upload_size_in_kb: Math.floor(Math.log2(uploadSizeInBytes) / 10),
+    number_of_files: numberOfFiles,
+  }),
 }

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -1,4 +1,5 @@
-import { ActionType, exceededUploadSize } from "@artsy/cohesion"
+import { ActionType, OwnerType } from "@artsy/cohesion"
+import { UploadSizeLimitExceeded } from "@artsy/cohesion/dist/Schema/Events/UploadSizeLimitExceeded"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { captureMessage } from "@sentry/react-native"
 import { storeLocalPhotos } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionImageUtil"
@@ -186,8 +187,8 @@ export const tracks = {
   hasExceededUploadSize: (
     uploadSizeInBytes: number,
     numberOfFiles: number
-  ): ExceededUploadSize => ({
-    action: ActionType.exceededUploadSize,
+  ): UploadSizeLimitExceeded => ({
+    action: ActionType.uploadSizeLimitExceeded,
     context_owner_type: OwnerType.sell,
     upload_size_in_kb: Math.floor(Math.log2(uploadSizeInBytes) / 10),
     number_of_files: numberOfFiles,

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/calculatePhotoSize.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/calculatePhotoSize.ts
@@ -1,7 +1,7 @@
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { transformBytesToSize } from "app/utils/transformBytesToSize"
 
-export const totalSizeLimitInBytes = 30000000
+const TOTAL_SIZE_LIMIT_IN_BYTES = 30000000
 
 // calculates a photos size from Bytes to unit and return updated photo
 export const calculateSinglePhotoSize = (photo: Photo): Photo => {
@@ -32,5 +32,5 @@ export const getPhotosSize = (photos: Photo[]) => {
 export const isSizeLimitExceeded = (photos: Photo[]): boolean => {
   const allPhotosSize = getPhotosSize(photos)
 
-  return allPhotosSize > totalSizeLimitInBytes
+  return allPhotosSize > TOTAL_SIZE_LIMIT_IN_BYTES
 }

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/calculatePhotoSize.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/calculatePhotoSize.ts
@@ -1,7 +1,7 @@
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { transformBytesToSize } from "app/utils/transformBytesToSize"
 
-const totalSizeLimitInBytes = 30000000
+export const totalSizeLimitInBytes = 30000000
 
 // calculates a photos size from Bytes to unit and return updated photo
 export const calculateSinglePhotoSize = (photo: Photo): Photo => {
@@ -20,12 +20,17 @@ export const calculateSinglePhotoSize = (photo: Photo): Photo => {
   return photo
 }
 
-// calculates all photos' size and returns if total size exceeds limit
-export const isSizeLimitExceeded = (photos: Photo[]): boolean => {
+// calculates the total size of an array of photos
+export const getPhotosSize = (photos: Photo[]) => {
   const allPhotosSize = photos.reduce((acc: number, cv: Photo) => {
     acc = acc + (cv?.size || 0)
     return acc
   }, 0)
+  return allPhotosSize
+}
+// calculates all photos' size and returns if total size exceeds limit
+export const isSizeLimitExceeded = (photos: Photo[]): boolean => {
+  const allPhotosSize = getPhotosSize(photos)
 
   return allPhotosSize > totalSizeLimitInBytes
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,10 +222,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@artsy/cohesion@4.80.0":
-  version "4.80.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.80.0.tgz#1961f68ca26916f9bec28f13689faf2346ee6097"
-  integrity sha512-LeztPSyah335wm7vyShHlLy0F2x1kB6RZz+ItJC/UrvixTlwq7rhF52/SotBq66SKuj2e+n1L+OdqUYcE+Uqnw==
+"@artsy/cohesion@4.81.0":
+  version "4.81.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.81.0.tgz#60d24598ca2f04bf78f04ed133d7be33012c9e3a"
+  integrity sha512-GlU8SOoupz0o+gSAxRpOr1jR3oSEw+A6nhlDMYaN0++MZQ9OnZvvwR9gSjDNLNx03syPEzggmdBKyOMo1vrqng==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
This PR resolves [CX-3187] <!-- eg [PROJECT-XXXX] -->

### Description

Blocked by https://github.com/artsy/cohesion/pull/374
This PR adds a track to when the file size is exceeded



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3187]: https://artsyproduct.atlassian.net/browse/CX-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ