### PR TITLE
fix: webview should move us to native screens if we have them

### DIFF
--- a/index-common.js
+++ b/index-common.js
@@ -14,6 +14,7 @@ if (__DEV__) {
 }
 
 require("./src/app/errorReporting/sentrySetup").setupSentry({ environment: "bootstrap" })
+import "react-native-url-polyfill/auto"
 
 if (metaflags.startStorybook) {
   global.__STORYBOOK__ = true

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "react-native-shake": "5.1.1",
     "react-native-share": "7.3.6",
     "react-native-svg": "9.13.3",
+    "react-native-url-polyfill": "1.3.0",
     "react-native-view-shot": "3.4.0",
     "react-native-vision-camera": "2.14.1",
     "react-native-webview": "11.3.1",

--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -1,29 +1,20 @@
-import { waitFor } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { goBack, navigate } from "app/navigation/navigate"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { appJson } from "app/utils/jsonFiles"
 import mockFetch from "jest-fetch-mock"
 import { stringify } from "query-string"
 import Share from "react-native-share"
 import WebView, { WebViewProps } from "react-native-webview"
-import { act } from "react-test-renderer"
+import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes"
 import {
-  __webViewTestUtils__,
+  _test_expandGoogleAdLink as expandGoogleAdLink,
   ArtsyWebView,
   ArtsyWebViewPage,
   useWebViewCookies,
 } from "./ArtsyWebView"
-
-jest.mock("react-native-device-info", () => ({
-  getBuildNumber: () => "build-number",
-  getVersion: jest.fn(),
-  getModel: jest.fn(),
-  getUserAgentSync: jest.fn(),
-  getDeviceType: jest.fn(),
-  hasNotch: jest.fn(),
-}))
 
 const mockCallWebViewEventCallback = jest.fn()
 jest.mock("app/utils/useWebViewEvent", () => ({
@@ -32,105 +23,132 @@ jest.mock("app/utils/useWebViewEvent", () => ({
   }),
 }))
 
+const mockOnNavigationStateChange: WebViewNavigation = {
+  navigationType: "click",
+  url: "https://gooooogle.com",
+  title: "mock gooooogle",
+  loading: true,
+  canGoBack: false,
+  canGoForward: false,
+  lockIdentifier: 70,
+}
+
 describe("ArtsyWebView", () => {
   it("shows react-native-webview", () => {
-    const tree = renderWithWrappersLEGACY(<ArtsyWebView url="random-url" />)
-    expect(tree.root.findAllByType(WebView).length).toEqual(1)
+    renderWithWrappers(<ArtsyWebView url="random-url" />)
+    expect(screen.UNSAFE_getAllByType(WebView)).toHaveLength(1)
   })
 })
 
 describe("ArtsyWebViewPage", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
+  beforeEach(() => jest.clearAllMocks())
 
   const render = (props: Partial<React.ComponentProps<typeof ArtsyWebViewPage>> = {}) =>
-    renderWithWrappersLEGACY(<ArtsyWebViewPage url="https://staging.artsy.net/hello" {...props} />)
+    renderWithWrappers(<ArtsyWebViewPage url="https://staging.artsy.net/hello" {...props} />)
   const webViewProps = (tree: ReturnType<typeof render>) =>
-    tree.root.findByType(WebView).props as WebViewProps
-  it(`renders a WebView`, () => {
+    tree.UNSAFE_getByType(WebView).props as WebViewProps
+
+  it("renders a WebView", () => {
     const tree = render()
     expect((webViewProps(tree).source as any).uri).toEqual("https://staging.artsy.net/hello")
   })
+
   it(`renders a back button normally`, () => {
-    const tree = render()
-    expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeFalsy()
-    expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
+    render()
+    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeFalse()
+    expect(screen.UNSAFE_getByType(FancyModalHeader).props.onLeftButtonPress).not.toBeUndefined()
   })
-  it(`renders a close button when presented modally`, () => {
-    const tree = render({ isPresentedModally: true })
-    expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeTruthy()
-    expect(tree.root.findByType(FancyModalHeader).props.onLeftButtonPress).toBeTruthy()
+
+  it("renders a close button when presented modally", () => {
+    render({ isPresentedModally: true })
+    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeTrue()
+    expect(screen.UNSAFE_getByType(FancyModalHeader).props.onLeftButtonPress).not.toBeUndefined()
   })
-  it(`renders a back button when presented modally and internal navigation is has happened`, () => {
+
+  it("renders a back button when presented modally and internal navigation is has happened", () => {
     const tree = render({ isPresentedModally: true })
-    act(() => {
-      webViewProps(tree).onNavigationStateChange?.({ canGoBack: true } as any)
+    webViewProps(tree).onNavigationStateChange?.({
+      ...mockOnNavigationStateChange,
+      canGoBack: true,
     })
-    expect(tree.root.findByType(FancyModalHeader).props.useXButton).toBeFalsy()
+    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeFalsy()
   })
+
   it("shares the correct URL", () => {
-    const tree = render({ showShareButton: true })
-    tree.root.findByType(FancyModalHeader).props.onRightButtonPress()
-    waitFor(() => expect(jest.fn()).toHaveBeenCalledTimes(1))
-    expect(Share.open).toHaveBeenCalledWith({ url: "https://staging.artsy.net/hello" })
+    const tree = render({
+      showShareButton: true,
+      url: "https://staging.artsy.net/non-native/this-doesnt-have-a-native-view-1",
+    })
+
+    fireEvent.press(screen.getByTestId("fancy-modal-header-right-button"))
+    expect(Share.open).toHaveBeenLastCalledWith({
+      url: "https://staging.artsy.net/non-native/this-doesnt-have-a-native-view-1",
+    })
+
+    webViewProps(tree).onNavigationStateChange?.({
+      ...mockOnNavigationStateChange,
+      url: "https://staging.artsy.net/non-native/this-doesnt-have-a-native-view-2",
+    })
+    fireEvent.press(screen.getByTestId("fancy-modal-header-right-button"))
+    expect(Share.open).toHaveBeenLastCalledWith({
+      url: "https://staging.artsy.net/non-native/this-doesnt-have-a-native-view-2",
+    })
   })
+
   it("calls goBack when the close/back button is pressed", () => {
-    const tree = render()
+    render()
     expect(goBack).not.toHaveBeenCalled()
-    tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+
+    fireEvent.press(screen.getByTestId("fancy-modal-header-left-button"))
     expect(goBack).toHaveBeenCalled()
   })
+
   it("calls goBack with props when the close/back button is pressed", () => {
-    const tree = render({
+    render({
       backProps: {
         previousScreen: "BackScreen",
       },
     })
-
     expect(goBack).not.toHaveBeenCalled()
-    tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+
+    fireEvent.press(screen.getByTestId("fancy-modal-header-left-button"))
     expect(goBack).toHaveBeenCalledWith({
       previousScreen: "BackScreen",
     })
   })
+
   it("has a progress bar that follows page load events", () => {
-    const tree = render()
-    const getProgressBar = () => tree.root.findByType(__webViewTestUtils__?.ProgressBar!)
-    expect(getProgressBar().children).toHaveLength(0)
-    act(() => tree.root.findByType(WebView).props.onLoadStart())
-    expect(getProgressBar().children).toHaveLength(1)
-    act(() =>
-      tree.root.findByType(WebView).props.onLoadProgress({ nativeEvent: { progress: 0.5 } })
-    )
-    expect(getProgressBar().findByProps({ testID: "progress-bar" }).props.width).toBe("50%")
-    act(() => tree.root.findByType(WebView).props.onLoadEnd())
-    expect(getProgressBar().children).toHaveLength(0)
+    render()
+    expect(screen.queryByTestId("progress-bar")).toBeFalsy()
+
+    screen.UNSAFE_getByType(WebView).props.onLoadStart()
+    expect(screen.queryByTestId("progress-bar")).toBeTruthy()
+
+    screen.UNSAFE_getByType(WebView).props.onLoadProgress({ nativeEvent: { progress: 0.5 } })
+    expect(screen.getByTestId("progress-bar").props.width).toEqual("50%")
+
+    screen.UNSAFE_getByType(WebView).props.onLoadEnd()
+    expect(screen.queryByTestId("progress-bar")).toBeFalsy()
   })
+
   it("sets the user agent correctly", () => {
     const tree = render()
-    expect(tree.root.findByType(WebView).props.userAgent).toBe(
-      `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/build-number/${appJson().version}`
+    expect(webViewProps(tree).userAgent).toBe(
+      `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
+        appJson().version
+      }`
     )
   })
-  it("sets the user agent correctly", () => {
-    const tree = render()
-    expect(tree.root.findByType(WebView).props.userAgent).toBe(
-      `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/build-number/${appJson().version}`
-    )
-  })
+
   it("receives messages from the browser", () => {
     const tree = render()
-    act(() =>
-      tree.root
-        .findByType(WebView)
-        .props.onMessage({ nativeEvent: { data: '{"event":"event data"}' } })
-    )
+    webViewProps(tree).onMessage?.({ nativeEvent: { data: '{"event":"event data"}' } } as any)
     expect(mockCallWebViewEventCallback).toHaveBeenCalledWith({ event: "event data" })
   })
+
   it("doesn't call the event hook given onMessage data in the wrong format", () => {
     const tree = render()
-    act(() => tree.root.findByType(WebView).props.onMessage({ nativeEvent: { data: "some text" } }))
+    webViewProps(tree).onMessage?.({ nativeEvent: { data: "some text" } } as any)
     expect(mockCallWebViewEventCallback).not.toHaveBeenCalled()
   })
 
@@ -138,18 +156,21 @@ describe("ArtsyWebViewPage", () => {
     it("lets our native back button control the browser", () => {
       const tree = render()
       const browserGoBack = jest
-        .spyOn(tree.root.findByType(WebView).instance, "goBack")
+        .spyOn(screen.UNSAFE_getByType(WebView).instance, "goBack")
         .mockImplementation(() => undefined)
 
-      tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+      fireEvent.press(screen.getByTestId("fancy-modal-header-left-button"))
       expect(goBack).toHaveBeenCalled()
       expect(browserGoBack).not.toHaveBeenCalled()
       ;(goBack as any).mockReset()
       ;(browserGoBack as any).mockReset()
 
-      webViewProps(tree).onNavigationStateChange?.({ canGoBack: true } as any)
+      webViewProps(tree).onNavigationStateChange?.({
+        ...mockOnNavigationStateChange,
+        canGoBack: true,
+      })
 
-      tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+      fireEvent.press(screen.getByTestId("fancy-modal-header-left-button"))
       expect(browserGoBack).toHaveBeenCalled()
       expect(goBack).not.toHaveBeenCalled()
     })
@@ -157,133 +178,113 @@ describe("ArtsyWebViewPage", () => {
     it("can be overridden", () => {
       const tree = render({ mimicBrowserBackButton: false })
       const browserGoBack = jest
-        .spyOn(tree.root.findByType(WebView).instance, "goBack")
+        .spyOn(screen.UNSAFE_getByType(WebView).instance, "goBack")
         .mockImplementation(() => undefined)
 
-      webViewProps(tree).onNavigationStateChange?.({ canGoBack: true } as any)
+      webViewProps(tree).onNavigationStateChange?.({
+        ...mockOnNavigationStateChange,
+        canGoBack: true,
+      })
 
-      tree.root.findByType(FancyModalHeader).props.onLeftButtonPress()
+      fireEvent.press(screen.getByTestId("fancy-modal-header-left-button"))
       expect(browserGoBack).not.toHaveBeenCalled()
       expect(goBack).toHaveBeenCalled()
     })
   })
 
   describe("navigation interception", () => {
-    it("ignores requests that are not on the top frame", () => {
-      const tree = render()
-      // `topFrame: false` should return true (true means 'web view should load this URL')
-      expect(
-        webViewProps(tree).onShouldStartLoadWithRequest?.({
-          isTopFrame: false,
-          url: "https://staging.artsy.net/artist/banksy",
-        } as any)
-      ).toBe(true)
-      // `topFrame: true` should return false for urls we can handle in the app (false means 'web view should not load this URL')
-      expect(
-        webViewProps(tree).onShouldStartLoadWithRequest?.({
-          isTopFrame: true,
-          url: "https://staging.artsy.net/artist/banksy",
-        } as any)
-      ).toBe(false)
-    })
     it("expands google ad links", () => {
       const tree = render()
       const googleURL =
         "https://googleads.g.doubleclick.net/pcs/click?" +
         stringify({ adurl: "https://staging.artsy.net/artist/banksy" })
-      webViewProps(tree).onShouldStartLoadWithRequest?.({ url: googleURL, isTopFrame: true } as any)
+
+      webViewProps(tree).onNavigationStateChange?.({
+        ...mockOnNavigationStateChange,
+        url: googleURL,
+      })
       expect(navigate).toHaveBeenCalledWith("https://staging.artsy.net/artist/banksy")
     })
-    it("allows inner navigation by default for other web view urls", () => {
+
+    it("allows inner navigation by default for other webview urls", () => {
       const tree = render()
-      const result = webViewProps(tree).onShouldStartLoadWithRequest?.({
+      webViewProps(tree).onNavigationStateChange?.({
+        ...mockOnNavigationStateChange,
         url: "https://staging.artsy.net/orders/order-id",
-        isTopFrame: true,
-      } as any)
+      })
       expect(navigate).not.toHaveBeenCalled()
-      expect(result).toBe(true)
     })
+
     it("always calls navigate for external urls", () => {
       const tree = render()
-      const result = webViewProps(tree).onShouldStartLoadWithRequest?.({
+      webViewProps(tree).onNavigationStateChange?.({
+        ...mockOnNavigationStateChange,
         url: "https://google.com",
-        isTopFrame: true,
-      } as any)
+      })
       expect(navigate).toHaveBeenCalledWith("https://google.com")
-      expect(result).toBe(false)
-    })
-    it("always calls navigate when allowWebViewInnerNavigation is false", () => {
-      const tree = render({ allowWebViewInnerNavigation: false })
-      const result = webViewProps(tree).onShouldStartLoadWithRequest?.({
-        url: "https://staging.artsy.net/orders/order-id",
-        isTopFrame: true,
-      } as any)
-      expect(result).toBe(false)
     })
   })
 })
 
-describe(useWebViewCookies, () => {
+describe("useWebViewCookies", () => {
   beforeEach(() => {
     mockFetch.mockClear()
   })
+
   const Wrapper = () => {
     useWebViewCookies()
     return null
   }
+
   it("tries to make an authenticated HEAD request to force and prediction to make sure we get the user's coookies", () => {
     __globalStoreTestUtils__?.injectState({
-      native: { sessionState: { authenticationToken: "userAccessToken" } },
+      auth: { userAccessToken: "some-token", userID: "some-user" },
     })
-    act(() => {
-      renderWithWrappersLEGACY(<Wrapper />)
+
+    renderWithWrappers(<Wrapper />)
+
+    expect(mockFetch).toHaveBeenCalledWith("https://staging.artsy.net", {
+      method: "HEAD",
+      headers: { "X-Access-Token": "some-token" },
     })
-    waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith("https://staging.artsy.net", {
-        method: "HEAD",
-        headers: { "X-Access-Token": "userAccessToken" },
-      })
-      expect(mockFetch).toHaveBeenCalledWith("https://live-staging.artsy.net/login", {
-        method: "HEAD",
-        headers: { "X-Access-Token": "userAccessToken" },
-      })
+    expect(mockFetch).toHaveBeenCalledWith("https://live-staging.artsy.net/login", {
+      method: "HEAD",
+      headers: { "X-Access-Token": "some-token" },
     })
   })
-  it("retries if it fails", async () => {
+
+  it("retries if it fails", () => {
     __globalStoreTestUtils__?.injectState({
-      native: { sessionState: { authenticationToken: "userAccessToken" } },
+      auth: { userAccessToken: "some-token", userID: "some-user" },
     })
+
     mockFetch.mockReturnValue(Promise.resolve({ ok: false, status: 500 } as any))
-    const tree = renderWithWrappersLEGACY(<Wrapper />)
-    await act(() => undefined)
-    waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+
+    renderWithWrappers(<Wrapper />)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
 
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(4))
 
-    await act(() => undefined)
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(6))
 
-    await act(() => undefined)
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(8))
 
-    await act(() => undefined)
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(10))
 
-    tree.unmount()
+    // it stops retrying when it unmounts
+    screen.unmount()
 
-    await act(() => undefined)
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(10))
 
-    await act(() => undefined)
     waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(10))
   })
 })
 
-describe(__webViewTestUtils__?.expandGoogleAdLink!, () => {
+describe("expandGoogleAdLink", () => {
   it("expands google ad links", () => {
     const url =
       "https://googleads.g.doubleclick.net/pcs/click?xai=AKAOjssP2exGGYwg2conYwReIHcnrIYzDoHhZc7tumyovS0nFBxNMhIdz0SOMkZDA4xsyqPmiMMxYSAvlrYVuHdov-fnkhGSj-JRxbZw_1my5t4O5YJ2LrikxJGqhccHeGZg3GOPawefMpc-tBg0dxq9U-nju0-F2FVrsSgx30VxJJma3FtuHvA-60F59c-tvl2FyuZHkBWKPV4kuPBUBZi7A7gHSDBV01fP7TPn8YxjmQpygAMmQzYmQ849ROCaOPd_JRDAP40vcCxvZ-w1Ndoq3HGdUCOBv4LmVhgsxfkm466bibf1mLIXfw&sig=Cg0ArKJSzDr6b2fCnfPy&adurl=https://whitecube.viewingrooms.com/viewing-room/park-seo-bo-white-cube&nm=2&nx=730&ny=-125&mb=2"
-    expect(__webViewTestUtils__?.expandGoogleAdLink(url)).toMatchInlineSnapshot(
+    expect(expandGoogleAdLink(url)).toMatchInlineSnapshot(
       `"https://whitecube.viewingrooms.com/viewing-room/park-seo-bo-white-cube"`
     )
   })
@@ -294,13 +295,13 @@ describe(__webViewTestUtils__?.expandGoogleAdLink!, () => {
     const googleURL =
       "https://googleads.g.doubleclick.net/pcs/click?" + stringify({ adurl: targetURL })
 
-    const expanded = __webViewTestUtils__?.expandGoogleAdLink(googleURL)
+    const expanded = expandGoogleAdLink(googleURL)
     expect(expanded).toBe(targetURL)
   })
 
   it("does not touch normal links", () => {
     expect(
-      __webViewTestUtils__?.expandGoogleAdLink("https://google.com/search?q=artsy+good+website")
+      expandGoogleAdLink("https://google.com/search?q=artsy+good+website")
     ).toMatchInlineSnapshot(`"https://google.com/search?q=artsy+good+website"`)
   })
 })

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -116,8 +116,8 @@ export const ArtsyWebViewPage = ({
           isPresentedModally={isPresentedModally}
           onNavigationStateChange={
             mimicBrowserBackButton
-              ? ({ canGoBack }) => {
-                  setCanGoBack(canGoBack)
+              ? (evt) => {
+                  setCanGoBack(evt.canGoBack)
                 }
               : undefined
           }
@@ -177,10 +177,10 @@ export const ArtsyWebView = forwardRef<
             setLoadProgress(e.nativeEvent.progress)
           }
         }}
-        onNavigationStateChange={({ url, ...restEvent }) => {
-          onNavigationStateChange?.({ ...restEvent, url })
+        onNavigationStateChange={(evt) => {
+          onNavigationStateChange?.(evt)
 
-          const targetURL = expandGoogleAdLink(url)
+          const targetURL = expandGoogleAdLink(evt.url)
 
           const result = matchRoute(targetURL)
 
@@ -212,11 +212,11 @@ export const ArtsyWebView = forwardRef<
         }}
       />
       <ProgressBar loadProgress={loadProgress} />
-      {showIndicator && (
+      {showIndicator ? (
         <Flex position="absolute" top={50} left={-25} style={{ transform: [{ rotate: "90deg" }] }}>
           <Text color="red">webview</Text>
         </Flex>
-      )}
+      ) : null}
     </Flex>
   )
 })

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -204,7 +204,9 @@ export const ArtsyWebView = forwardRef<
           }
 
           // if it's an external url, or a route with a native view, use `navigate`
-          if (!__TEST__) innerRef.current?.stopLoading()
+          if (!__TEST__) {
+            innerRef.current?.stopLoading()
+          }
           navigate(targetURL)
           setLoadProgress(null)
         }}
@@ -220,7 +222,9 @@ export const ArtsyWebView = forwardRef<
 })
 
 const ProgressBar = ({ loadProgress }: { loadProgress: number | null }) => {
-  if (loadProgress === null) return null
+  if (loadProgress === null) {
+    return null
+  }
 
   const progressPercent = Math.max(loadProgress * 100, 2)
   return (
@@ -260,20 +264,28 @@ class CookieRequestAttempt {
   invalidated = false
   constructor(public url: string, public accessToken: string) {}
   async makeAttempt() {
-    if (this.invalidated) return
+    if (this.invalidated) {
+      return
+    }
 
     try {
       const res = await fetch(this.url, {
         method: "HEAD",
         headers: { "X-Access-Token": this.accessToken! },
       })
-      if (this.invalidated) return
+      if (this.invalidated) {
+        return
+      }
 
-      if (res.status > 400) throw new Error("couldn't authenticate")
+      if (res.status > 400) {
+        throw new Error("couldn't authenticate")
+      }
 
       addBreadcrumb({ message: `Successfully set up artsy web view cookies for ${this.url}` })
     } catch (e) {
-      if (this.invalidated) return
+      if (this.invalidated) {
+        return
+      }
 
       addBreadcrumb({
         message: `Retrying to set up artsy web view cookies in 20 seconds ${this.url}`,

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -13,14 +13,12 @@ import { Schema } from "app/utils/track"
 import { useWebViewCallback } from "app/utils/useWebViewEvent"
 import { Flex, Text } from "palette"
 import { parse as parseQueryString } from "query-string"
-import React, { useEffect, useRef, useState } from "react"
-import { Platform } from "react-native"
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
 import Share from "react-native-share"
 import WebView, { WebViewProps } from "react-native-webview"
 import { useTracking } from "react-tracking"
 import { useScreenDimensions } from "shared/hooks"
 import { ArtsyKeyboardAvoidingView } from "shared/utils"
-import { parse as parseURL } from "url"
 import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
 
 export interface ArtsyWebViewConfig {
@@ -32,10 +30,6 @@ export interface ArtsyWebViewConfig {
    */
   mimicBrowserBackButton?: boolean
   /**
-   * Set this to false if you want all clicked links to be handled by our `navigate` method.
-   */
-  allowWebViewInnerNavigation?: boolean
-  /**
    * Show the share URL button
    */
   showShareButton?: boolean
@@ -45,31 +39,28 @@ export interface ArtsyWebViewConfig {
   useRightCloseButton?: boolean
 }
 
-type CustomWebView = WebView & { shareTitleUrl: string }
+type WebViewWithShareTitleUrl = WebView & { shareTitleUrl: string }
 
-export const ArtsyWebViewPage: React.FC<
-  {
-    url: string
-    isPresentedModally?: boolean
-    backProps?: GoBackProps
-    backAction?: () => void
-  } & ArtsyWebViewConfig
-> = ({
+export const ArtsyWebViewPage = ({
   url,
   title,
-  isPresentedModally,
-  allowWebViewInnerNavigation = true,
+  isPresentedModally = false,
   mimicBrowserBackButton = true,
   useRightCloseButton = false,
-  showShareButton,
+  showShareButton = false,
   backProps,
   backAction,
-}) => {
+}: {
+  url: string
+  isPresentedModally?: boolean
+  backProps?: GoBackProps
+  backAction?: () => void
+} & ArtsyWebViewConfig) => {
   const paddingTop = isPresentedModally ? 0 : useScreenDimensions().safeAreaInsets.top
 
   const [canGoBack, setCanGoBack] = useState(false)
   const webURL = useEnvironment().webURL
-  const ref = useRef<CustomWebView>(null)
+  const ref = useRef<WebViewWithShareTitleUrl>(null)
 
   const tracking = useTracking()
   const handleArticleShare = async () => {
@@ -80,37 +71,23 @@ export const ArtsyWebViewPage: React.FC<
     const shareUrl = ref.current?.shareTitleUrl || uri
     tracking.trackEvent(tracks.share(shareUrl))
     try {
-      await Share.open({
-        url: shareUrl,
-      })
+      await Share.open({ url: shareUrl })
     } catch (error) {
       if (__DEV__) {
-        console.error("ArtsyWebView.tsx", error)
+        console.log("ArtsyWebView.tsx", error)
       }
     }
   }
 
-  const handleGoBack = () => {
-    if (backAction) {
-      backAction()
-    } else {
-      goBack(backProps)
-    }
-  }
+  const handleGoBack = () => (backAction ? backAction() : goBack(backProps))
 
-  const onRightButtonPress = () => {
-    if (showShareButton) {
-      return handleArticleShare()
-    } else if (useRightCloseButton) {
-      return handleGoBack()
-    }
-  }
+  const onRightButtonPress = () =>
+    showShareButton ? handleArticleShare() : useRightCloseButton ? handleGoBack() : null
 
   return (
     <Flex flex={1} pt={paddingTop} backgroundColor="white">
       <ArtsyKeyboardAvoidingView>
         <FancyModalHeader
-          rightCloseButton={useRightCloseButton}
           useXButton={isPresentedModally && !canGoBack}
           onLeftButtonPress={
             useRightCloseButton && !canGoBack
@@ -126,6 +103,7 @@ export const ArtsyWebViewPage: React.FC<
                 }
           }
           useShareButton={showShareButton}
+          rightCloseButton={useRightCloseButton}
           onRightButtonPress={
             showShareButton || useRightCloseButton ? onRightButtonPress : undefined
           }
@@ -135,12 +113,11 @@ export const ArtsyWebViewPage: React.FC<
         <ArtsyWebView
           url={url}
           ref={ref}
-          allowWebViewInnerNavigation={allowWebViewInnerNavigation}
           isPresentedModally={isPresentedModally}
           onNavigationStateChange={
             mimicBrowserBackButton
-              ? (ev) => {
-                  setCanGoBack(ev.canGoBack)
+              ? ({ canGoBack }) => {
+                  setCanGoBack(canGoBack)
                 }
               : undefined
           }
@@ -150,11 +127,10 @@ export const ArtsyWebViewPage: React.FC<
   )
 }
 
-export const ArtsyWebView = React.forwardRef<
-  CustomWebView,
+export const ArtsyWebView = forwardRef<
+  WebViewWithShareTitleUrl,
   {
     url: string
-    allowWebViewInnerNavigation?: boolean
     onNavigationStateChange?: WebViewProps["onNavigationStateChange"]
     isPresentedModally?: boolean
   }
@@ -162,12 +138,13 @@ export const ArtsyWebView = React.forwardRef<
   (
     {
       url,
-      allowWebViewInnerNavigation = true,
       onNavigationStateChange,
       isPresentedModally = false,
     },
     ref
   ) => {
+    const innerRef = useRef<WebViewWithShareTitleUrl>(null)
+    useImperativeHandle(ref, () => innerRef.current!)
     const userAgent = getCurrentEmissionState().userAgent
     const { callWebViewEventCallback } = useWebViewCallback()
 
@@ -180,7 +157,7 @@ export const ArtsyWebView = React.forwardRef<
     return (
       <Flex flex={1}>
         <WebView
-          ref={ref}
+          ref={innerRef}
           // sharedCookiesEnabled is required on iOS for the user to be implicitly logged into force/prediction
           // on android it works without it
           sharedCookiesEnabled
@@ -208,51 +185,28 @@ export const ArtsyWebView = React.forwardRef<
               setLoadProgress(e.nativeEvent.progress)
             }
           }}
-          onShouldStartLoadWithRequest={(ev) => {
-            const targetURL = expandGoogleAdLink(ev.url)
+
+          onNavigationStateChange={({ url, ...restEvent }) => {
+            onNavigationStateChange?.({ ...restEvent, url })
+
+            const targetURL = expandGoogleAdLink(url)
+
             const result = matchRoute(targetURL)
-            // On android onShouldStartLoadWithRequest is only called for actual navigation requests
-            // On iOS it is also called for other-origin script/resource requests, so we use
-            // isTopFrame to check that this request pertains to an actual navigation request
-            const isTopFrame = Platform.OS === "android" ? true : ev.isTopFrame
-            if (!isTopFrame || targetURL === uri) {
-              // we use `|| targetURL === uri` because otherwise, if the URI points to a
-              // page that can be handled natively, we'll jump directly out of a the web view.
-              return true
+
+            // if it's a route that we know we don't have a native view for, keep it in the webview
+            if (result.type === "match" && result.module === "ReactWebView") {
+              innerRef.current!.shareTitleUrl = targetURL
+              return
             }
 
-            // If the target URL points to another page that we can handle with a web view, let's go there
-            if (
-              allowWebViewInnerNavigation &&
-              result.type === "match" &&
-              result.module === "ReactWebView"
-            ) {
-              if (ref) {
-                ;(ref as any).current.shareTitleUrl = targetURL
-              }
-              return true
-            }
-
-            // In case of a webview presentaed modally, if the targetURL is a tab View,
-            // we need to dismiss the modal first to avoid having a tab rendered within the modal
-            const modulePathName = parseURL(targetURL).pathname?.split(/\/+/).filter(Boolean) ?? []
-            if (
-              isPresentedModally &&
-              result.type === "match" &&
-              modulePathName.length > 0 &&
-              BottomTabRoutes.includes("/" + modulePathName[0])
-            ) {
-              dismissModal()
-            }
-            // Otherwise use `navigate` to handle it like any other link in the app
+            // if it's an external url, or a route with a native view, use `navigate`
+            if (!__TEST__) innerRef.current?.stopLoading()
             navigate(targetURL)
             setLoadProgress(null)
-            return false
           }}
-          onNavigationStateChange={onNavigationStateChange}
         />
         <ProgressBar loadProgress={loadProgress} />
-        {showIndicator ? (
+        {showIndicator && (
           <Flex
             position="absolute"
             top={50}
@@ -261,16 +215,14 @@ export const ArtsyWebView = React.forwardRef<
           >
             <Text color="red">webview</Text>
           </Flex>
-        ) : null}
+        )}
       </Flex>
     )
   }
 )
 
-const ProgressBar: React.FC<{ loadProgress: number | null }> = ({ loadProgress }) => {
-  if (loadProgress === null) {
-    return null
-  }
+const ProgressBar = ({ loadProgress }: { loadProgress: number | null }) => {
+  if (loadProgress === null) return null
 
   const progressPercent = Math.max(loadProgress * 100, 2)
   return (
@@ -287,11 +239,11 @@ const ProgressBar: React.FC<{ loadProgress: number | null }> = ({ loadProgress }
 }
 
 export function useWebViewCookies() {
-  const accesstoken = GlobalStore.useAppState((store) => store.auth.userAccessToken)
+  const accessToken = GlobalStore.useAppState((store) => store.auth.userAccessToken)
   const isLoggedIn = GlobalStore.useAppState((state) => !!state.auth.userID)
   const { webURL, predictionURL } = useEnvironment()
-  useUrlCookies(webURL, accesstoken, isLoggedIn)
-  useUrlCookies(predictionURL + "/login", accesstoken, isLoggedIn)
+  useUrlCookies(webURL, accessToken, isLoggedIn)
+  useUrlCookies(predictionURL + "/login", accessToken, isLoggedIn)
 }
 
 function useUrlCookies(url: string, accessToken: string | null, isLoggedIn: boolean) {
@@ -310,26 +262,21 @@ class CookieRequestAttempt {
   invalidated = false
   constructor(public url: string, public accessToken: string) {}
   async makeAttempt() {
-    if (this.invalidated) {
-      return
-    }
+    if (this.invalidated) return
+
     try {
       const res = await fetch(this.url, {
         method: "HEAD",
         headers: { "X-Access-Token": this.accessToken! },
       })
-      if (this.invalidated) {
-        return
-      }
+      if (this.invalidated) return
 
-      if (res.status > 400) {
-        throw new Error("couldn't authenticate")
-      }
+      if (res.status > 400) throw new Error("couldn't authenticate")
+
       addBreadcrumb({ message: `Successfully set up artsy web view cookies for ${this.url}` })
     } catch (e) {
-      if (this.invalidated) {
-        return
-      }
+      if (this.invalidated) return
+
       addBreadcrumb({
         message: `Retrying to set up artsy web view cookies in 20 seconds ${this.url}`,
       })
@@ -339,23 +286,15 @@ class CookieRequestAttempt {
 }
 
 function expandGoogleAdLink(url: string) {
-  const parsed = parseURL(url)
+  const parsed = new URL(url)
   if (parsed.host === "googleads.g.doubleclick.net") {
-    const adurl = parseQueryString(parsed.query ?? "").adurl as string | undefined
-    if (adurl && parseURL(adurl)) {
+    const adurl = parseQueryString(parsed.search ?? "").adurl as string | undefined
+    if (adurl && new URL(adurl)) {
       return adurl
     }
   }
   return url
 }
-
-// tslint:disable-next-line:variable-name
-export const __webViewTestUtils__ = __TEST__
-  ? {
-      ProgressBar,
-      expandGoogleAdLink,
-    }
-  : null
 
 const tracks = {
   share: (slug: string) => ({
@@ -365,3 +304,6 @@ const tracks = {
     context_screen_owner_slug: slug,
   }),
 }
+
+// tslint:disable-next-line:variable-name
+export const _test_expandGoogleAdLink = expandGoogleAdLink

--- a/src/app/navigation/routes.tests.ts
+++ b/src/app/navigation/routes.tests.ts
@@ -2,7 +2,7 @@ import { addRoute, addWebViewRoute, matchRoute, replaceParams } from "app/naviga
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 
 describe("artsy.net routes", () => {
-  it(`routes to Home`, () => {
+  it("routes to Home", () => {
     const expected = {
       type: "match",
       module: "Home",
@@ -1251,7 +1251,7 @@ describe("other domains", () => {
   })
 })
 
-describe(replaceParams, () => {
+describe("replaceParams", () => {
   it("replaces the params in a url with params from an object", () => {
     expect(replaceParams("/artist/:id", { id: "banksy" })).toBe("/artist/banksy")
     expect(
@@ -1272,7 +1272,7 @@ describe(replaceParams, () => {
   })
 })
 
-describe(addWebViewRoute, () => {
+describe("addWebViewRoute", () => {
   it("returns a route matcher for web views", () => {
     const matcher = addWebViewRoute("/conditions-of-sale")
     expect(matcher.module).toBe("ReactWebView")
@@ -1301,7 +1301,7 @@ describe(addWebViewRoute, () => {
   })
 })
 
-describe(addRoute, () => {
+describe("addRoute", () => {
   it("returns a route matcher for a route", () => {
     expect(
       addRoute("/home/:id/thing/:slug/other_thing/:slug2", "Home").match([

--- a/src/app/navigation/routes.ts
+++ b/src/app/navigation/routes.ts
@@ -15,7 +15,7 @@ export function matchRoute(
   | { type: "external_url"; url: string } {
   if (isProtocolEncoded(url)) {
     // if entire url is encoded, decode!
-    // Else user will land on VanityUrlEntity for url that otherwise would have been valid
+    // else user will land on VanityUrlEntity for url that otherwise would have been valid
     url = decodeUrl(url)
   }
   let parsed = parse(url)

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -120,7 +120,7 @@ jest.mock("react-native-share", () => ({
 }))
 
 jest.mock("react-native-device-info", () => ({
-  getBuildNumber: jest.fn(),
+  getBuildNumber: () => "some-build-number",
   getVersion: jest.fn(),
   getModel: () => "testDevice",
   getUserAgentSync: jest.fn(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5757,7 +5757,7 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
 
-buffer@^5.2.0, buffer@^5.2.1, buffer@^5.5.0:
+buffer@^5.2.0, buffer@^5.2.1, buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -12666,6 +12666,13 @@ react-native-swipe-gestures@^1.0.5:
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==
 
+react-native-url-polyfill@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz#c1763de0f2a8c22cc3e959b654c8790622b6ef6a"
+  integrity sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==
+  dependencies:
+    whatwg-url-without-unicode "8.0.0-3"
+
 react-native-view-shot@3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-3.4.0.tgz#787b31b2d0525a197864e12aaea214e905e97f9a"
@@ -15549,6 +15556,15 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url-without-unicode@8.0.0-3:
+  version "8.0.0-3"
+  resolved "https://registry.yarnpkg.com/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz#ab6df4bf6caaa6c85a59f6e82c026151d4bb376b"
+  integrity sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==
+  dependencies:
+    buffer "^5.4.3"
+    punycode "^2.1.1"
+    webidl-conversions "^5.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR resolves [MOPLAT-524] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- `parseURL` was throwing `deprecated` issues, so I replaced it with the recommendation of just `URL`, and added the polyfill since RN doesn't have the complete thing.
- moved tests to new helpers, and fixed some tests that were green but not testing actually, since things were misconfigured, like `waitFor(() => { expect(..`
- moved the logic from `onShouldStartLoadWithRequest` to `onNavigationStateChange`. Some context [here](https://artsy.slack.com/archives/C02NAJ2CGLW/p1669726228778479), but the main idea is that artsy.net is an SPA, so in the webview the `onShouldStartLoadWithRequest` is mostly not called because of that. The right place to intercept navigation is on `onNavigationStateChange`, which is called always, for every navigation.

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-524]: https://artsyproduct.atlassian.net/browse/MOPLAT-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ