### PR TITLE
feat(FX-4305): add ability to hide bottom tabs on specific screen

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -28,7 +28,6 @@ import usePrevious from "react-use/lib/usePrevious"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useScreenDimensions } from "shared/hooks"
 import { ResponsiveValue } from "styled-system"
-import { setBottomTabVisibilityForCurrentScreen } from "../BottomTabs/setBottomTabVisibilityForCurrentScreen"
 import { OfferSubmittedModal } from "../Inbox/Components/Conversations/OfferSubmittedModal"
 import { AboutArtistFragmentContainer as AboutArtist } from "./Components/AboutArtist"
 import { AboutWorkFragmentContainer as AboutWork } from "./Components/AboutWork"
@@ -151,11 +150,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
     return () => {
       navigationEvents.removeListener("modalDismissed", handleModalDismissed)
     }
-  }, [])
-
-  // TODO: Remove this before the PR is merged
-  useLayoutEffect(() => {
-    setBottomTabVisibilityForCurrentScreen(false)
   }, [])
 
   // This is a hack to make useEffect behave exactly like didComponentUpdate.

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -7,6 +7,7 @@ import { ArtworkBelowTheFoldQuery } from "__generated__/ArtworkBelowTheFoldQuery
 import { ArtworkMarkAsRecentlyViewedQuery } from "__generated__/ArtworkMarkAsRecentlyViewedQuery.graphql"
 import { AuctionTimerState, currentTimerState } from "app/Components/Bidding/Components/Timer"
 import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
+import { __unsafe_mainModalStackRef } from "app/NativeModules/ARScreenPresenterModule"
 import { BackButton } from "app/navigation/BackButton"
 import { navigationEvents } from "app/navigation/navigate"
 import { defaultEnvironment } from "app/relay/createEnvironment"
@@ -149,6 +150,12 @@ export const Artwork: React.FC<ArtworkProps> = ({
     return () => {
       navigationEvents.removeListener("modalDismissed", handleModalDismissed)
     }
+  }, [])
+
+  useLayoutEffect(() => {
+    __unsafe_mainModalStackRef.current?.setParams({
+      shouldHideBottomTab: true,
+    })
   }, [])
 
   // This is a hack to make useEffect behave exactly like didComponentUpdate.

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -153,6 +153,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
     }
   }, [])
 
+  // TODO: Remove this before the PR is merged
   useLayoutEffect(() => {
     setBottomTabVisibilityForCurrentScreen(false)
   }, [])

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -28,6 +28,7 @@ import usePrevious from "react-use/lib/usePrevious"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useScreenDimensions } from "shared/hooks"
 import { ResponsiveValue } from "styled-system"
+import { setBottomTabVisibilityForCurrentScreen } from "../BottomTabs/setBottomTabVisibilityForCurrentScreen"
 import { OfferSubmittedModal } from "../Inbox/Components/Conversations/OfferSubmittedModal"
 import { AboutArtistFragmentContainer as AboutArtist } from "./Components/AboutArtist"
 import { AboutWorkFragmentContainer as AboutWork } from "./Components/AboutWork"
@@ -153,9 +154,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
   }, [])
 
   useLayoutEffect(() => {
-    __unsafe_mainModalStackRef.current?.setParams({
-      shouldHideBottomTab: true,
-    })
+    setBottomTabVisibilityForCurrentScreen(false)
   }, [])
 
   // This is a hack to make useEffect behave exactly like didComponentUpdate.

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -47,6 +47,7 @@ const TestWrapper: React.FC<{}> = ({}) => {
   return (
     <GlobalStoreProvider>
       <ModalStack>
+        {/* @ts-ignore */}
         <BottomTabs />
       </ModalStack>
     </GlobalStoreProvider>

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -1,3 +1,4 @@
+import { BottomTabBarProps } from "@react-navigation/bottom-tabs"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { ModalStack } from "app/navigation/ModalStack"
 import { createEnvironment } from "app/relay/createEnvironment"
@@ -43,12 +44,12 @@ function resolveUnreadConversationCountQuery(unreadConversationCount: number) {
   )
 }
 
-const TestWrapper: React.FC<{}> = ({}) => {
+const TestWrapper: React.FC<Partial<BottomTabBarProps>> = (props) => {
   return (
     <GlobalStoreProvider>
       <ModalStack>
         {/* @ts-ignore */}
-        <BottomTabs />
+        <BottomTabs {...props} />
       </ModalStack>
     </GlobalStoreProvider>
   )
@@ -156,5 +157,35 @@ describe(BottomTabs, () => {
       .find((button) => (button.props as ButtonProps).tab === "inbox")
 
     expect((inboxButton!.props as ButtonProps).badgeCount).toBe(3)
+  })
+
+  it("should not be rendered if the `shouldHideBottomTab` param is specified", async () => {
+    const state: BottomTabBarProps["state"] = {
+      history: [
+        {
+          key: "route-key",
+          type: "route",
+        },
+      ],
+      index: 0,
+      key: "tab-key",
+      routeNames: ["route-name"],
+      routes: [
+        {
+          key: "route-key",
+          name: "route",
+          params: {
+            shouldHideBottomTab: true,
+          },
+        },
+      ],
+      stale: false,
+      type: "tab",
+    }
+
+    const tree = renderWithWrappersLEGACY(<TestWrapper state={state} />)
+    const buttons = tree.root.findAllByType(BottomTabsButton)
+
+    expect(buttons).toHaveLength(0)
   })
 })

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -30,11 +30,11 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
   const { bottom } = useScreenDimensions().safeAreaInsets
 
   if ((focusedRoute?.params as any)?.shouldHideBottomTab) {
-    return null
+    return <></>
   }
 
   return (
-    <Flex style={{ paddingBottom: bottom }}>
+    <Flex position="absolute" left={0} right={0} bottom={0} paddingBottom={bottom} bg="white100">
       <Separator
         style={{
           borderColor: isStaging ? color("devpurple") : color("black10"),

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -30,7 +30,7 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
   const { bottom } = useScreenDimensions().safeAreaInsets
 
   if ((focusedRoute?.params as any)?.shouldHideBottomTab) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -1,3 +1,5 @@
+import { BottomTabBarProps } from "@react-navigation/bottom-tabs"
+import { findFocusedRoute } from "@react-navigation/native"
 import { GlobalStore, useFeatureFlag, useIsStaging } from "app/store/GlobalStore"
 import { Flex, Separator, useTheme } from "palette"
 import React, { useEffect } from "react"
@@ -6,9 +8,9 @@ import { useScreenDimensions } from "shared/hooks"
 import { BottomTabsButton } from "./BottomTabsButton"
 import { ICON_HEIGHT } from "./BottomTabsIcon"
 
-export const BottomTabs: React.FC = () => {
+export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
   const { color } = useTheme()
-
+  const focusedRoute = findFocusedRoute(props.state)
   const unreadConversationCount = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.unreadConversationCount
   )
@@ -26,6 +28,11 @@ export const BottomTabs: React.FC = () => {
   const enableMyCollectionInsights = useFeatureFlag("AREnableMyCollectionInsights")
 
   const { bottom } = useScreenDimensions().safeAreaInsets
+
+  if ((focusedRoute?.params as any)?.shouldHideBottomTab) {
+    return null
+  }
+
   return (
     <Flex style={{ paddingBottom: bottom }}>
       <Separator

--- a/src/app/Scenes/BottomTabs/BottomTabsNavigator.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsNavigator.tsx
@@ -18,7 +18,7 @@ const TabContent = ({
 export const BottomTabsNavigator = () => {
   return (
     <Tab.Navigator
-      tabBar={() => <BottomTabs />}
+      tabBar={(props) => <BottomTabs {...props} />}
       backBehavior="firstRoute"
       screenOptions={{ headerShown: false }}
     >

--- a/src/app/Scenes/BottomTabs/setBottomTabVisibilityForCurrentScreen.ts
+++ b/src/app/Scenes/BottomTabs/setBottomTabVisibilityForCurrentScreen.ts
@@ -1,0 +1,11 @@
+import { __unsafe_mainModalStackRef } from "app/NativeModules/ARScreenPresenterModule"
+
+export const setBottomTabVisibilityForCurrentScreen = (isVisible: boolean) => {
+  if (__unsafe_mainModalStackRef.current) {
+    __unsafe_mainModalStackRef.current.setParams({
+      shouldHideBottomTab: !isVisible,
+    })
+  } else {
+    console.error("ModalStack reference is NULL")
+  }
+}

--- a/src/app/Scenes/BottomTabs/useBottomTabBarHeight.ts
+++ b/src/app/Scenes/BottomTabs/useBottomTabBarHeight.ts
@@ -1,0 +1,10 @@
+import { useScreenDimensions } from "shared/hooks"
+import { ICON_HEIGHT } from "./BottomTabsIcon"
+
+const BOTTOM_TAB_SEPARATOR_HEIGHT = 1
+
+export const useBottomTabBarHeight = () => {
+  const { safeAreaInsets } = useScreenDimensions()
+
+  return ICON_HEIGHT + safeAreaInsets.bottom + BOTTOM_TAB_SEPARATOR_HEIGHT
+}

--- a/src/app/navigation/NavStack.tsx
+++ b/src/app/navigation/NavStack.tsx
@@ -1,6 +1,8 @@
-import { Route, useIsFocused, useNavigationState } from "@react-navigation/native"
+import { findFocusedRoute, Route, useIsFocused, useNavigationState } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { AppModule, modules } from "app/AppRegistry"
+import { ICON_HEIGHT } from "app/Scenes/BottomTabs/BottomTabsIcon"
+import { useBottomTabBarHeight } from "app/Scenes/BottomTabs/useBottomTabBarHeight"
 import { isPad } from "app/utils/hardware"
 import { createContext, useState } from "react"
 import { View } from "react-native"
@@ -76,6 +78,7 @@ export const NavStack: React.FC<{
   rootModuleName: AppModule
   rootModuleProps?: any
 }> = ({ id, rootModuleName, rootModuleProps }) => {
+  const bottomTabBarHeight = useBottomTabBarHeight()
   const initialParams: ScreenProps = {
     moduleName: rootModuleName,
     props: rootModuleProps,
@@ -84,10 +87,18 @@ export const NavStack: React.FC<{
 
   return (
     <Stack.Navigator
-      screenOptions={{
-        headerShown: false,
-        contentStyle: { backgroundColor: "white" },
-        orientation: isPad() ? "default" : "portrait",
+      screenOptions={(props) => {
+        const focusedRoute = findFocusedRoute(props.navigation.getState())
+        const shouldHideBottomTab = (focusedRoute?.params as any)?.shouldHideBottomTab
+
+        return {
+          headerShown: false,
+          contentStyle: {
+            backgroundColor: "white",
+            marginBottom: shouldHideBottomTab ? 0 : bottomTabBarHeight,
+          },
+          orientation: isPad() ? "default" : "portrait",
+        }
       }}
     >
       <Stack.Screen name={"screen:" + id} component={ScreenWrapper} initialParams={initialParams} />

--- a/src/app/navigation/NavStack.tsx
+++ b/src/app/navigation/NavStack.tsx
@@ -1,7 +1,6 @@
 import { findFocusedRoute, Route, useIsFocused, useNavigationState } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { AppModule, modules } from "app/AppRegistry"
-import { ICON_HEIGHT } from "app/Scenes/BottomTabs/BottomTabsIcon"
 import { useBottomTabBarHeight } from "app/Scenes/BottomTabs/useBottomTabBarHeight"
 import { isPad } from "app/utils/hardware"
 import { createContext, useState } from "react"


### PR DESCRIPTION
This PR resolves [FX-4305] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/205075962-6e138520-1512-43ee-b33b-6ce760de1e22.mp4

#### Android
https://user-images.githubusercontent.com/3513494/205077788-d45d93b6-cf39-4449-b8df-f309818a7c95.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add ability to hide bottom tabs on specific screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4305]: https://artsyproduct.atlassian.net/browse/FX-4305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ