### PR TITLE
chore: remove user existence check on sign up

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1371,21 +1371,21 @@
         "filename": "src/app/store/AuthModel.tests.ts",
         "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
         "is_verified": false,
-        "line_number": 144
+        "line_number": 97
       },
       {
         "type": "Secret Keyword",
         "filename": "src/app/store/AuthModel.tests.ts",
         "hashed_secret": "54e9af600f3bcfd1153b00430b345fcb68c8efc2",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 109
       },
       {
         "type": "Secret Keyword",
         "filename": "src/app/store/AuthModel.tests.ts",
         "hashed_secret": "bb21216b09d3be2d9e40beab38ae57af2b11d081",
         "is_verified": false,
-        "line_number": 348
+        "line_number": 301
       }
     ],
     "src/app/utils/PushNotification.tests.ts": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-18T16:35:09Z"
+  "generated_at": "2022-11-30T19:30:40Z"
 }

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
@@ -73,8 +73,6 @@ export const getCurrentRoute = () =>
     | keyof OnboardingCreateAccountNavigationStack
     | undefined
 
-const EMAIL_EXISTS_ERROR_MESSAGE = "We found an account with this email"
-
 export const OnboardingCreateAccountWithEmail: React.FC<OnboardingCreateAccountProps> = ({
   navigation,
 }) => {
@@ -94,10 +92,7 @@ export const OnboardingCreateAccountWithEmail: React.FC<OnboardingCreateAccountP
       agreedToReceiveEmails: false,
     },
     initialErrors: {},
-    onSubmit: async (
-      { email, password, name, agreedToReceiveEmails, acceptedTerms },
-      { setErrors }
-    ) => {
+    onSubmit: async ({ email, password, name, agreedToReceiveEmails, acceptedTerms }) => {
       switch (currentRoute) {
         case "OnboardingCreateAccountEmail":
           // continue with the sign up
@@ -177,16 +172,7 @@ export const OnboardingCreateAccountWithEmail: React.FC<OnboardingCreateAccountP
               />
               <StackNavigator.Screen name="OnboardingWebView" component={OnboardingWebView} />
             </StackNavigator.Navigator>
-            {currentRoute !== "OnboardingWebView" && (
-              <OnboardingCreateAccountButton
-                navigateToLoginWithEmail={() => {
-                  navigation.replace("OnboardingLoginWithEmail", {
-                    withFadeAnimation: true,
-                    email: formik.values.email,
-                  })
-                }}
-              />
-            )}
+            {currentRoute !== "OnboardingWebView" && <OnboardingCreateAccountButton />}
           </NavigationContainer>
         </FormikProvider>
       </ArtsyKeyboardAvoidingView>
@@ -235,48 +221,18 @@ export const OnboardingCreateAccountScreenWrapper: React.FC<
   )
 }
 
-export interface OnboardingCreateAccountButtonProps {
-  navigateToLoginWithEmail: () => void
-}
-
-export const OnboardingCreateAccountButton: React.FC<OnboardingCreateAccountButtonProps> = ({
-  navigateToLoginWithEmail,
-}) => {
+export const OnboardingCreateAccountButton: React.FC = () => {
   const { values, handleSubmit, isSubmitting, errors } = useFormikContext<FormikSchema>()
 
   const isLastStep = getCurrentRoute() === "OnboardingCreateAccountName"
   const yTranslateAnim = useRef(new Animated.Value(0))
 
   useEffect(() => {
-    if (errors.email === EMAIL_EXISTS_ERROR_MESSAGE) {
-      Animated.timing(yTranslateAnim.current, {
-        toValue: -50,
-        duration: 500,
-        useNativeDriver: true,
-      }).start()
-    } else {
-      yTranslateAnim.current = new Animated.Value(0)
-    }
+    yTranslateAnim.current = new Animated.Value(0)
   }, [errors.email])
 
   return (
     <Flex px={2} paddingBottom={2} backgroundColor="white" pt={0.5}>
-      {errors.email === EMAIL_EXISTS_ERROR_MESSAGE && (
-        <Animated.View style={{ bottom: -50, transform: [{ translateY: yTranslateAnim.current }] }}>
-          <Button
-            onPress={navigateToLoginWithEmail}
-            block
-            haptic="impactMedium"
-            mb={1}
-            mt={1.5}
-            variant="outline"
-            testID="loginButton"
-          >
-            Go to Login
-          </Button>
-        </Animated.View>
-      )}
-
       <Button
         onPress={handleSubmit}
         block

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccount.tsx
@@ -100,19 +100,8 @@ export const OnboardingCreateAccountWithEmail: React.FC<OnboardingCreateAccountP
     ) => {
       switch (currentRoute) {
         case "OnboardingCreateAccountEmail":
-          const userExists = await GlobalStore.actions.auth.userExists({ email })
-
-          if (userExists) {
-            // When the user exists already we want to take them to the login screen
-            setErrors({
-              email: EMAIL_EXISTS_ERROR_MESSAGE,
-            })
-          } else {
-            // If the email is new continue with the sign up
-            __unsafe__createAccountNavigationRef.current?.navigate(
-              "OnboardingCreateAccountPassword"
-            )
-          }
+          // continue with the sign up
+          __unsafe__createAccountNavigationRef.current?.navigate("OnboardingCreateAccountPassword")
           break
         case "OnboardingCreateAccountPassword":
           __unsafe__createAccountNavigationRef.current?.navigate("OnboardingCreateAccountName")

--- a/src/app/store/AuthModel.tests.ts
+++ b/src/app/store/AuthModel.tests.ts
@@ -69,53 +69,6 @@ describe("AuthModel", () => {
     })
   })
 
-  describe("userExists", () => {
-    beforeEach(async () => {
-      mockFetchJsonOnce({
-        xapp_token: "my-special-token",
-        expires_in: "never",
-      })
-      await GlobalStore.actions.auth.getXAppToken()
-      mockFetch.mockClear()
-    })
-
-    it("makes a request to gravity's /user endpoint", async () => {
-      mockFetchResponseOnce({ status: 200 })
-      await GlobalStore.actions.auth.userExists({ email: "user@example.com" })
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(mockFetch.mock.calls[0][0]).toMatchInlineSnapshot(
-        `"https://stagingapi.artsy.net/api/v1/user?email=user%40example.com"`
-      )
-    })
-
-    it("returns true if response is 200", async () => {
-      mockFetchResponseOnce({ status: 200 })
-      const result = await GlobalStore.actions.auth.userExists({ email: "user@example.com" })
-
-      expect(result).toBe(true)
-    })
-
-    it("returns false if response is 404", async () => {
-      mockFetchResponseOnce({ status: 404 })
-      const result = await GlobalStore.actions.auth.userExists({ email: "user@example.com" })
-
-      expect(result).toBe(false)
-    })
-
-    it("throws an error if something else happened", async () => {
-      mockFetchResponseOnce({ status: 500, json: () => Promise.resolve({ error: "bad times" }) })
-      let error: Error | null = null
-      try {
-        await GlobalStore.actions.auth.userExists({ email: "user@example.com" })
-      } catch (e) {
-        error = e as Error
-      }
-
-      expect(error).not.toBe(null)
-      expect(error).toMatchInlineSnapshot(`[Error: {"error":"bad times"}]`)
-    })
-  })
-
   describe("signIn", () => {
     beforeEach(async () => {
       mockFetchJsonOnce({

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -163,7 +163,6 @@ export interface AuthModel {
   setState: Action<this, Partial<StateMapper<this, "1">>>
   getXAppToken: Thunk<this, void, {}, GlobalStoreModel, Promise<string>>
   getUser: Thunk<this, { accessToken: string }, {}, GlobalStoreModel>
-  userExists: Thunk<this, { email: string }, {}, GlobalStoreModel>
   signIn: Thunk<
     this,
     { email: string; onboardingState?: OnboardingState; onSignIn?: () => void } & OAuthParams,
@@ -281,18 +280,6 @@ export const getAuthModel = (): AuthModel => ({
       },
       body: payload.body ? JSON.stringify(payload.body) : undefined,
     })
-  }),
-  userExists: thunk(async (actions, { email }) => {
-    const result = await actions.gravityUnauthenticatedRequest({
-      path: `/api/v1/user?${stringify({ email })}`,
-    })
-    if (result.status === 200) {
-      return true
-    } else if (result.status === 404) {
-      return false
-    } else {
-      throw new Error(JSON.stringify(await result.json()))
-    }
   }),
   forgotPassword: thunk(async (actions, { email }) => {
     const result = await actions.gravityUnauthenticatedRequest({


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This endpoint will no longer be supported in the near future:
https://artsyproduct.atlassian.net/browse/PLATFORM-4668

Removing the logic from the client. 



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Remove user existence check on sign up - Brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
