### PR TITLE
feat: use cost Major for price paid in MyC

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -325,11 +325,6 @@ export const updateArtwork = async (
   } = values
   const externalImageUrls = await uploadPhotos(photos)
 
-  let pricePaidCents
-  if (pricePaidDollars && !isNaN(Number(pricePaidDollars))) {
-    pricePaidCents = Number(pricePaidDollars) * 100
-  }
-
   if (values.attributionClass !== "LIMITED_EDITION") {
     others.editionNumber = ""
     others.editionSize = ""
@@ -340,7 +335,7 @@ export const updateArtwork = async (
       artistIds: artistSearchResult?.internalID ? [artistSearchResult?.internalID] : undefined,
       artists: artistDisplayName ? [{ displayName: artistDisplayName }] : undefined,
       externalImageUrls,
-      pricePaidCents,
+      costMajor: pricePaidDollars,
       pricePaidCurrency,
       ...cleanArtworkPayload(others),
     })
@@ -359,7 +354,7 @@ export const updateArtwork = async (
       artistIds: artistSearchResult?.internalID ? [artistSearchResult?.internalID] : [],
       artworkId: props.artwork.internalID,
       externalImageUrls,
-      pricePaidCents: pricePaidCents ?? null,
+      costMajor: pricePaidDollars,
       pricePaidCurrency,
       ...cleanArtworkPayload(others),
       ...explicitlyClearedFields(others, dirtyFormCheckValues),


### PR DESCRIPTION
This PR resolves [CX-2847] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Blocked by https://github.com/artsy/metaphysics/pull/4565

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-2847]: https://artsyproduct.atlassian.net/browse/CX-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ