### PR TITLE
fix: flaky tests on artwork page

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -269,29 +269,27 @@ describe("Artwork", () => {
     expect(tree.root.findAllByType(ArtworkDetails)).toHaveLength(1)
   })
 
-  // TODO: This test keeps failing randomly on CI, so we're disabling it for now.
-  xit("marks the artwork as viewed", () => {
+  it("marks the artwork as viewed", () => {
     renderWithWrappersLEGACY(<TestRenderer />)
-    const slug = "test artwork id"
 
-    mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
-      Artwork() {
-        return { slug }
-      },
-    })
+    mockMostRecentOperation("ArtworkAboveTheFoldQuery")
+
+    expect(environment.mock.getMostRecentOperation().request.node.operation.name).toEqual(
+      "ArtworkMarkAsRecentlyViewedQuery"
+    )
 
     expect(environment.mock.getMostRecentOperation()).toMatchObject({
       request: {
         variables: {
           input: {
-            artwork_id: slug,
+            artwork_id: '<mock-value-for-field-"slug">',
           },
         },
       },
     })
   })
 
-  xit("updates the above-the-fold content on re-appear", async () => {
+  it("updates the above-the-fold content on re-appear", async () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer />)
 
     mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
@@ -325,6 +323,9 @@ describe("Artwork", () => {
     mockMostRecentOperation("RequestConditionReportQuery")
 
     navigationEvents.emit("modalDismissed")
+
+    await flushPromiseQueue()
+
     mockMostRecentOperation("ArtworkRefetchQuery", {
       Artwork() {
         return { slug: "completely-different-slug" }
@@ -417,7 +418,7 @@ describe("Artwork", () => {
         expect(extractText(tree.root.findByType(BidButton))).toContain("Enter live bidding")
       })
 
-      xit("for which I am not registered and registration is open", () => {
+      it("for which I am not registered and registration is open", async () => {
         const tree = renderWithWrappersLEGACY(<TestRenderer />)
 
         mockMostRecentOperation("ArtworkAboveTheFoldQuery", {
@@ -430,6 +431,8 @@ describe("Artwork", () => {
             )
           },
         })
+
+        await flushPromiseQueue()
 
         expect(tree.root.findAllByType(Countdown)).toHaveLength(1)
         expect(tree.root.findByType(Countdown).props.label).toBe("In progress")


### PR DESCRIPTION
This PR resolves [FX-4394] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Attempt to fix the flaky tests on the artwork page

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix the flaky tests on the artwork page - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4394]: https://artsyproduct.atlassian.net/browse/FX-4394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ