### PR TITLE
feat(FX-4486): add sale message for not for sale artworks

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -101,6 +101,64 @@ describe("ArtworkTombstone", () => {
       expect(screen.queryByText("Lots will close at 1-minute intervals.")).toBeNull()
     })
   })
+
+  describe("Sale Message for not for sale artworks", () => {
+    describe("with ARArtworkRedesingPhase2 switched set to true", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ ARArtworkRedesingPhase2: true })
+      })
+
+      it("should render the sale message when artwork is not for sale", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isForSale: false,
+            saleMessage: "On loan",
+          }),
+        })
+
+        expect(screen.queryByText("On loan")).toBeTruthy()
+      })
+
+      it("should not render the sale message when artwork is not for sale", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isForSale: true,
+            saleMessage: "For sale",
+          }),
+        })
+
+        expect(screen.queryByText("For sale")).toBeNull()
+      })
+    })
+
+    describe("with ARArtworkRedesingPhase2 switched set to false", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ ARArtworkRedesingPhase2: false })
+      })
+
+      it("should not render the sale message when artwork is not for sale", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isForSale: false,
+            saleMessage: "On loan",
+          }),
+        })
+
+        expect(screen.queryByText("On loan")).toBeNull()
+      })
+
+      it("should not render the sale message when artwork is not for sale", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isForSale: true,
+            saleMessage: "For sale",
+          }),
+        })
+
+        expect(screen.queryByText("For sale")).toBeNull()
+      })
+    })
+  })
 })
 
 const artworkTombstoneArtwork: ArtworkTombstone_artwork$data = {
@@ -108,6 +166,7 @@ const artworkTombstoneArtwork: ArtworkTombstone_artwork$data = {
   title: "Hello im a title",
   medium: "Painting",
   date: "1992",
+  isForSale: true,
 }
 
 const artworkTombstoneAuctionArtwork = {

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -48,6 +48,15 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork }) =
           {getArtworkTitleAndMaybeDate()}
         </Text>
       </Flex>
+
+      {!!enableArtworkRedesign && !artwork.isForSale && (
+        <>
+          <Spacer mt={2} />
+          <Text variant="md" color="black100">
+            {artwork.saleMessage}
+          </Text>
+        </>
+      )}
       {!!artwork.isInAuction && !artwork.sale?.isClosed && (
         <>
           {!!(artwork.sale?.cascadingEndTimeIntervalMinutes && !enableArtworkRedesign) && (
@@ -82,6 +91,8 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
       isInAuction
       medium
       date
+      isForSale
+      saleMessage
       saleArtwork {
         lotLabel
         estimate


### PR DESCRIPTION
This PR resolves [FX-4486] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

 add sale message for not for sale artworks

> ⚠️ note that the sale message from the commercial information section that is being displayed under the new one (which is the one under the artwork title and artist name) is to be removed in another pr

|Screenshots|||
|---|---|---|
|![Simulator Screen Shot - iPhone 14 - 2022-12-02 at 16 59 12](https://user-images.githubusercontent.com/21178754/205334023-aea617b7-af27-4d63-98b3-a45f1b37ace2.png)|![Simulator Screen Shot - iPhone 14 - 2022-12-02 at 16 59 21](https://user-images.githubusercontent.com/21178754/205334011-4d6c2f96-fcf8-44d4-b3fa-1cfe9ae0aeaa.png)|![Simulator Screen Shot - iPhone 14 - 2022-12-02 at 16 59 03](https://user-images.githubusercontent.com/21178754/205333997-0360de60-a4fd-46bd-96dd-bd939db808a9.png)|


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add sale message for not for sale artworks (artwork page redesign behind a ff) - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4486]: https://artsyproduct.atlassian.net/browse/FX-4486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ