### PR TITLE
feat(FX-4477): add counts to activity panel items

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -204,6 +204,40 @@ describe("ActivityItem", () => {
       expect(label).toBeTruthy()
     })
   })
+
+  describe("remaining artworks count", () => {
+    it("should NOT be rendered if there are less or equal to 4", async () => {
+      const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Notification: () => ({
+          ...notification,
+          objectsCount: 4,
+        }),
+      })
+      await flushPromiseQueue()
+
+      expect(queryByLabelText("Remaining artworks count")).toBeFalsy()
+    })
+
+    it("should be rendered if there are more than 4", async () => {
+      const { getByText, getByLabelText } = renderWithHookWrappersTL(
+        <TestRenderer />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Notification: () => ({
+          ...notification,
+          objectsCount: 5,
+        }),
+      })
+      await flushPromiseQueue()
+
+      expect(getByLabelText("Remaining artworks count")).toBeTruthy()
+      expect(getByText("+ 1")).toBeTruthy()
+    })
+  })
 })
 
 const artworks = [
@@ -264,8 +298,8 @@ const notification = {
   isUnread: false,
   notificationType: "ARTWORK_PUBLISHED",
   targetHref: targetUrl,
+  objectsCount: 4,
   artworksConnection: {
-    totalCount: 4,
     edges: artworks,
   },
 }

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -23,6 +23,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const tracking = useTracking()
   const item = useFragment(activityItemFragment, props.item)
   const artworks = extractNodes(item.artworksConnection)
+  const remainingArtworksCount = item.objectsCount - 4
 
   const getNotificationType = () => {
     if (item.notificationType === "ARTWORK_ALERT") {
@@ -95,6 +96,12 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
                 </Flex>
               )
             })}
+
+            {remainingArtworksCount > 0 && (
+              <Text variant="xs" color="black60" accessibilityLabel="Remaining artworks count">
+                + {remainingArtworksCount}
+              </Text>
+            )}
           </Flex>
         </Flex>
 
@@ -121,6 +128,7 @@ const activityItemFragment = graphql`
     targetHref
     isUnread
     notificationType
+    objectsCount
     artworksConnection(first: 4) {
       edges {
         node {


### PR DESCRIPTION
This PR resolves [FX-4477]

### Description

Add artworks counts to activity panel notifications

https://user-images.githubusercontent.com/3934579/205677203-441d7382-8778-499f-8058-91f4dcd3bdc2.mp4

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Added artworks counts to activity panel notifications

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4477]: https://artsyproduct.atlassian.net/browse/FX-4477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ