### PR TITLE
feat(FX-4489): add loading placeholders for redesigned artwork screen

### DIFF
--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -1,10 +1,95 @@
-import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
-import { Flex, Separator, Spacer, useSpace } from "palette"
+import { useFeatureFlag } from "app/store/GlobalStore"
+import { PlaceholderBox, PlaceholderText, RandomWidthPlaceholderText } from "app/utils/placeholders"
+import { times } from "lodash"
+import { Flex, Join, Separator, Spacer, useSpace } from "palette"
 import { useImagePlaceholderDimensions } from "../helpers"
 
-export const AboveTheFoldPlaceholder: React.FC<{ artworkID?: string }> = ({ artworkID }) => {
+interface AboveTheFoldPlaceholderProps {
+  artworkID?: string
+}
+
+const ArtworkActionsPlaceholder = () => {
   const space = useSpace()
 
+  return (
+    <Flex flexDirection="row" justifyContent="center">
+      {times(2).map((index) => (
+        <PlaceholderBox
+          key={`auction-${index}`}
+          width={50}
+          height={18}
+          marginHorizontal={space(1)}
+        />
+      ))}
+    </Flex>
+  )
+}
+
+const ArtworkDetailsPlaceholder = () => {
+  return (
+    <Join separator={<Spacer mt={1} />}>
+      {times(10).map((index) => (
+        <Flex key={`detail-row-${index}`} flexDirection="row">
+          <PlaceholderText width={128} height={20} />
+          <Spacer mr={2} />
+          <RandomWidthPlaceholderText minWidth={100} maxWidth={250} height={20} />
+        </Flex>
+      ))}
+    </Join>
+  )
+}
+
+const RedesignedAboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = ({
+  artworkID,
+}) => {
+  const space = useSpace()
+  const { width, height } = useImagePlaceholderDimensions(artworkID)
+
+  return (
+    <Flex flex={1}>
+      {/* Header */}
+      <Flex height={44} px={2} alignItems="center" flexDirection="row">
+        <Flex flex={1} flexDirection="row" justifyContent="space-between">
+          <PlaceholderBox width={20} height={20} />
+
+          <Flex flexDirection="row">
+            <PlaceholderBox width={80} height={20} marginRight={space(1)} />
+            <PlaceholderBox width={140} height={20} />
+          </Flex>
+        </Flex>
+      </Flex>
+
+      {/* Artwork thumbnail */}
+      <Flex mx="auto">
+        <PlaceholderBox width={width} height={height} />
+      </Flex>
+
+      <Spacer mt={1} />
+
+      {/* Content */}
+      <Flex px={2}>
+        {/* save/share buttons */}
+        <ArtworkActionsPlaceholder />
+
+        <Spacer mb={4} />
+
+        {/* Artist name */}
+        <PlaceholderText width={100} height={30} />
+
+        {/* Artwork tombstone details */}
+        <PlaceholderText width={250} height={26} />
+
+        <Spacer mb={4} />
+
+        {/* Artwork details */}
+        <ArtworkDetailsPlaceholder />
+      </Flex>
+    </Flex>
+  )
+}
+
+const CurrentAboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = ({ artworkID }) => {
+  const space = useSpace()
   const { width, height } = useImagePlaceholderDimensions(artworkID)
 
   return (
@@ -45,4 +130,14 @@ export const AboveTheFoldPlaceholder: React.FC<{ artworkID?: string }> = ({ artw
       </Flex>
     </Flex>
   )
+}
+
+export const AboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = (props) => {
+  const enableArtworkRedesign = useFeatureFlag("ARArtworkRedesingPhase2")
+
+  if (enableArtworkRedesign) {
+    return <RedesignedAboveTheFoldPlaceholder {...props} />
+  }
+
+  return <CurrentAboveTheFoldPlaceholder {...props} />
 }

--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -1,7 +1,8 @@
 import { useFeatureFlag } from "app/store/GlobalStore"
-import { PlaceholderBox, PlaceholderText, RandomWidthPlaceholderText } from "app/utils/placeholders"
+import { PlaceholderBox, PlaceholderText, RandomNumberGenerator } from "app/utils/placeholders"
 import { times } from "lodash"
 import { Flex, Join, Separator, Spacer, useSpace } from "palette"
+import { useMemo } from "react"
 import { useImagePlaceholderDimensions } from "../helpers"
 
 interface AboveTheFoldPlaceholderProps {
@@ -25,6 +26,19 @@ const ArtworkActionsPlaceholder = () => {
   )
 }
 
+const ArtworkDetailPlaceholderText = () => {
+  const length = useMemo(() => {
+    const rng = new RandomNumberGenerator(Math.random())
+
+    return rng.next({
+      from: 0.2,
+      to: 1,
+    })
+  }, [])
+
+  return <PlaceholderText flex={length} height={20} />
+}
+
 const ArtworkDetailsPlaceholder = () => {
   return (
     <Join separator={<Spacer mt={1} />}>
@@ -32,7 +46,7 @@ const ArtworkDetailsPlaceholder = () => {
         <Flex key={`detail-row-${index}`} flexDirection="row">
           <PlaceholderText width={128} height={20} />
           <Spacer mr={2} />
-          <RandomWidthPlaceholderText minWidth={100} maxWidth={250} height={20} />
+          <ArtworkDetailPlaceholderText />
         </Flex>
       ))}
     </Join>

--- a/src/app/Scenes/Artwork/Components/BelowTheFoldPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/BelowTheFoldPlaceholder.tsx
@@ -1,3 +1,4 @@
+import { useFeatureFlag } from "app/store/GlobalStore"
 import {
   PlaceholderRaggedText,
   PlaceholderText,
@@ -6,7 +7,7 @@ import {
 import { Separator, Spacer } from "palette"
 import { ActivityIndicator } from "react-native"
 
-export const BelowTheFoldPlaceholder: React.FC<{}> = ({}) => {
+const CurrentBelowTheFoldPlaceholder = () => {
   return (
     <ProvidePlaceholderContext>
       <Separator />
@@ -23,4 +24,41 @@ export const BelowTheFoldPlaceholder: React.FC<{}> = ({}) => {
       <Spacer mb={3} />
     </ProvidePlaceholderContext>
   )
+}
+
+const ContentPlaceholder = () => {
+  return (
+    <>
+      <PlaceholderText width={120} height={20} />
+      <Spacer mb={2} />
+      <PlaceholderRaggedText numLines={5} />
+    </>
+  )
+}
+
+const RedesignedBelowTheFoldPlaceholder = () => {
+  return (
+    <ProvidePlaceholderContext>
+      {/* Provenance section */}
+      <ContentPlaceholder />
+
+      <Spacer mt={3} />
+
+      {/* Exhibition history */}
+      <ContentPlaceholder />
+
+      <Spacer mt={4} />
+      <ActivityIndicator />
+    </ProvidePlaceholderContext>
+  )
+}
+
+export const BelowTheFoldPlaceholder = () => {
+  const enableArtworkRedesign = useFeatureFlag("ARArtworkRedesingPhase2")
+
+  if (enableArtworkRedesign) {
+    return <RedesignedBelowTheFoldPlaceholder />
+  }
+
+  return <CurrentBelowTheFoldPlaceholder />
 }


### PR DESCRIPTION
This PR resolves [FX-4489] <!-- eg [PROJECT-XXXX] -->

### Demo
https://user-images.githubusercontent.com/3513494/205970514-0fcf0620-0c29-419b-b25e-f0673a3a29ba.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add loading placeholders for redesigned artwork screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4489]: https://artsyproduct.atlassian.net/browse/FX-4489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ