### PR TITLE
fix: add isSold to unavailable for sale checks

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -26,7 +26,7 @@ interface ArtworkScreenHeaderCreateAlertProps {
 const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateAlertProps> = ({
   artwork,
 }) => {
-  const { isForSale } = artwork
+  const { isForSale, isSold } = artwork
   const { trackEvent } = useTracking()
   const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
@@ -90,16 +90,18 @@ const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateAlertPro
     trackEvent(event)
   }
 
+  const isAvailableForSale = isForSale && !isSold
+
   return (
     <>
       <Spacer mr={0.5} />
       <Button
-        icon={<BellIcon fill={isForSale ? "black100" : "white100"} />}
+        icon={<BellIcon fill={isAvailableForSale ? "black100" : "white100"} />}
         size="small"
-        variant={isForSale ? "fillLight" : "fillDark"}
+        variant={isAvailableForSale ? "text" : "fillDark"}
         onPress={handleCreateAlertPress}
       >
-        <Text variant={isForSale ? "sm-display" : "xs"}>Create Alert</Text>
+        <Text variant={isAvailableForSale ? "sm-display" : "xs"}>Create Alert</Text>
       </Button>
       <CreateSavedSearchModal
         visible={isCreateAlertModalVisible}
@@ -121,6 +123,7 @@ export const ArtworkScreenHeaderCreateAlertFragmentContainer = createFragmentCon
         internalID
         slug
         isForSale
+        isSold
         artists {
           internalID
           name

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -170,6 +170,7 @@ const artworkTombstoneArtwork: ArtworkTombstone_artwork$data = {
   title: "Hello im a title",
   date: "1992",
   isForSale: true,
+  isSold: false,
 }
 
 const artworkTombstoneAuctionArtwork = {

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tests.tsx
@@ -122,15 +122,28 @@ describe("ArtworkTombstone", () => {
         expect(screen.queryByText("On loan")).toBeTruthy()
       })
 
-      it("should not render the sale message when artwork is not for sale", () => {
+      it("should not render the sale message when artwork is for sale", () => {
         renderWithRelay({
           Artwork: () => ({
             isForSale: true,
+            isSold: false,
             saleMessage: "For sale",
           }),
         })
 
         expect(screen.queryByText("For sale")).toBeNull()
+      })
+
+      it("should render the sale message when artwork is not for sale and sold", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isForSale: false,
+            isSold: true,
+            saleMessage: "Sold",
+          }),
+        })
+
+        expect(screen.queryByText("Sold")).toBeTruthy()
       })
     })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -14,6 +14,8 @@ export interface ArtworkTombstoneProps {
 export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork, refetchArtwork }) => {
   const enableArtworkRedesign = useFeatureFlag("ARArtworkRedesingPhase2")
 
+  const isUnavailableForSale = !artwork.isForSale || artwork.isSold
+
   const displayAuctionLotLabel =
     artwork.isInAuction &&
     artwork.saleArtwork &&
@@ -48,7 +50,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork, ref
         </Text>
       </Flex>
 
-      {!!enableArtworkRedesign && !artwork.isForSale && (
+      {!!enableArtworkRedesign && !!isUnavailableForSale && (
         <>
           <Spacer mt={2} />
           <Text variant="md" color="black100">
@@ -95,6 +97,7 @@ export const ArtworkTombstoneFragmentContainer = createFragmentContainer(Artwork
       isInAuction
       date
       isForSale
+      isSold
       saleMessage
       saleArtwork {
         lotLabel


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Paired on this with @nickskalkin 

[Notion card 1](https://www.notion.so/artsy/Sold-mention-does-not-show-on-sold-artwork-be63304387104b14b2b539687b46e14d)

[Notion card 2](https://www.notion.so/artsy/Create-alert-CTA-should-be-black-filled-not-outlined-when-artwork-is-sold-a9aeba7a3077491d9115abf06d6a224e)

This pr adds `isSold` to the checks we do for `isForSale` for artworks because there are some cases where in metaphysics we have the following:

`isForSale: true` while `isSold: true`.

[Slack thread](https://artsy.slack.com/archives/CP9P4KR35/p1669977785252689) where this was discussed a while ago

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add isSold to unavailable for sale checks - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
