### PR TITLE
fix: Always use local image for My Collection images when available

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -54,6 +54,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   }, [])
 
   const renderImage = () => {
+    // Use local image if it exists to avoid images being displayed with a wrong aspect ratio while they are being processed by Gemini
     if (localImage) {
       return (
         <RNImage

--- a/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionImageView.tsx
@@ -54,20 +54,7 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
   }, [])
 
   const renderImage = () => {
-    // prioritise imageURL
-    if (imageURL) {
-      const targetURL = imageURL.replace(":version", "square")
-      return (
-        <OpaqueImageView
-          testID="Image-Remote"
-          imageURL={targetURL}
-          retryFailedURLs
-          height={imageHeight}
-          width={imageWidth}
-          aspectRatio={aspectRatio}
-        />
-      )
-    } else if (localImage) {
+    if (localImage) {
       return (
         <RNImage
           testID="Image-Local"
@@ -93,6 +80,18 @@ export const MyCollectionImageView: React.FC<MyCollectionImageViewProps> = ({
           source={{
             uri: localImageConsignments.path,
           }}
+        />
+      )
+    } else if (imageURL) {
+      const targetURL = imageURL.replace(":version", "square")
+      return (
+        <OpaqueImageView
+          testID="Image-Remote"
+          imageURL={targetURL}
+          retryFailedURLs
+          height={imageHeight}
+          width={imageWidth}
+          aspectRatio={aspectRatio}
         />
       )
     } else {


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description
Always use the local image for My Collection images when available to avoid images being shown with a wrong aspect ratio during image processing.



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix My Collection grid view image stretching - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
