### PR TITLE
feat: Use trending artists on home feed GRO-1381

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -190,7 +190,7 @@ const Home = (props: Props) => {
       type: "fairs",
       data: homePageBelow?.fairsModule,
     },
-    { title: "Popular Artists", type: "artist", data: homePageBelow?.popularArtistsArtistModule },
+    { title: "Trending Artists", type: "artist", data: homePageBelow?.popularArtistsArtistModule },
     {
       title: "Recently Viewed",
       type: "artwork",
@@ -430,7 +430,7 @@ export const HomeFragmentContainer = createRefetchContainer(
           id
           ...ArtworkModuleRail_rail
         }
-        popularArtistsArtistModule: artistModule(key: POPULAR) {
+        popularArtistsArtistModule: artistModule(key: CURATED_TRENDING) {
           id
           ...ArtistRail_rail
         }


### PR DESCRIPTION
This is a sibling PR of https://github.com/artsy/metaphysics/pull/4605 and just updates Eigen to label the artists rail with Trending and use that type when querying MP. That other PR does the actual work of resolving differently.

https://artsyproduct.atlassian.net/browse/GRO-1381

/cc @artsy/grow-devs