### PR TITLE
refactor(FX-4498): remove AREnableActivity feature flag

### DIFF
--- a/src/app/Scenes/Home/Components/ActivityIndicator.tests.tsx
+++ b/src/app/Scenes/Home/Components/ActivityIndicator.tests.tsx
@@ -1,46 +1,26 @@
 import { fireEvent } from "@testing-library/react-native"
-import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 describe("ActivityIndicator", () => {
-  it("should not be displayed by default", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({
-      AREnableActivity: false,
-    })
+  it("should be displayed", () => {
     const { queryByLabelText } = renderWithWrappers(<ActivityIndicator hasNotifications={false} />)
 
-    expect(queryByLabelText("Activity")).toBeNull()
+    expect(queryByLabelText("Activity")).toBeDefined()
   })
 
-  describe("when feature flag is enabled", () => {
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({
-        AREnableActivity: true,
-      })
-    })
+  it("should track event when the bell icon is tapped", () => {
+    const { getByLabelText } = renderWithWrappers(<ActivityIndicator hasNotifications={false} />)
 
-    it("should be displayed", () => {
-      const { queryByLabelText } = renderWithWrappers(
-        <ActivityIndicator hasNotifications={false} />
-      )
+    fireEvent.press(getByLabelText("Activity"))
 
-      expect(queryByLabelText("Activity")).toBeDefined()
-    })
-
-    it("should track event when the bell icon is tapped", () => {
-      const { getByLabelText } = renderWithWrappers(<ActivityIndicator hasNotifications={false} />)
-
-      fireEvent.press(getByLabelText("Activity"))
-
-      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       Array [
         Object {
           "action": "clickedNotificationsBell",
         },
       ]
     `)
-    })
   })
 })

--- a/src/app/Scenes/Home/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/Home/Components/ActivityIndicator.tsx
@@ -1,7 +1,6 @@
 import { ActionType } from "@artsy/cohesion"
 import { ClickedNotificationsBell } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
 import { navigate } from "app/navigation/navigate"
-import { useFeatureFlag } from "app/store/GlobalStore"
 import { BellIcon, Box, useTheme } from "palette"
 import { VisualClueDot } from "palette/elements/VisualClue"
 import { TouchableOpacity } from "react-native"
@@ -13,7 +12,6 @@ interface ActivityIndicatorProps {
 
 export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasNotifications }) => {
   const tracking = useTracking()
-  const enableActivity = useFeatureFlag("AREnableActivity")
   const { space } = useTheme()
 
   const navigateToActivityPanel = () => {
@@ -21,37 +19,33 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasNotific
     tracking.trackEvent(tracks.clickedNotificationsBell())
   }
 
-  if (enableActivity) {
-    return (
-      <Box position="absolute" right={2} top={0} bottom={0} justifyContent="center">
-        <TouchableOpacity
-          accessibilityLabel="Activity"
-          onPress={navigateToActivityPanel}
-          hitSlop={{
-            top: space(1),
-            bottom: space(1),
-            left: space(1),
-            right: space(1),
-          }}
-        >
-          <BellIcon height={24} width={24} />
+  return (
+    <Box position="absolute" right={2} top={0} bottom={0} justifyContent="center">
+      <TouchableOpacity
+        accessibilityLabel="Activity"
+        onPress={navigateToActivityPanel}
+        hitSlop={{
+          top: space(1),
+          bottom: space(1),
+          left: space(1),
+          right: space(1),
+        }}
+      >
+        <BellIcon height={24} width={24} />
 
-          {!!hasNotifications && (
-            <Box
-              position="absolute"
-              top={0}
-              right={0}
-              accessibilityLabel="Unread Activities Indicator"
-            >
-              <VisualClueDot diameter={4} />
-            </Box>
-          )}
-        </TouchableOpacity>
-      </Box>
-    )
-  }
-
-  return null
+        {!!hasNotifications && (
+          <Box
+            position="absolute"
+            top={0}
+            right={0}
+            accessibilityLabel="Unread Activities Indicator"
+          >
+            <VisualClueDot diameter={4} />
+          </Box>
+        )}
+      </TouchableOpacity>
+    </Box>
+  )
 }
 
 const tracks = {

--- a/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
@@ -10,12 +10,6 @@ describe("HomeHeader", () => {
   }
 
   describe("Activity", () => {
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({
-        AREnableActivity: true,
-      })
-    })
-
     it("should NOT render unread indicator when there are no unread notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -178,12 +178,6 @@ export const features = defineFeatures({
     description: "Use artworksConnection for Auction screen",
     echoFlagKey: "AREnableArtworksConnectionForAuction",
   },
-  AREnableActivity: {
-    readyForRelease: true,
-    description: "Enable Activity",
-    showInDevMenu: true,
-    echoFlagKey: "AREnableActivity",
-  },
   AREnableMyCollectionHFOnboarding: {
     readyForRelease: true,
     description: "Enable My Collection home feed onboarding",


### PR DESCRIPTION
This PR resolves [FX-4498] <!-- eg [PROJECT-XXXX] -->

Echo PR: artsy/echo#381

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Remove `AREnableActivity` feature flag - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4498]: https://artsyproduct.atlassian.net/browse/FX-4498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ