### PR TITLE
chore(FX-4211): sort artists by name in "Artists" filter when artwork is in auction

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ArtistIDsSaleArtworksOptionsScreen.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ArtistIDsSaleArtworksOptionsScreen.tests.tsx
@@ -1,0 +1,187 @@
+import { fireEvent } from "@testing-library/react-native"
+import { Aggregations, FilterParamName } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import {
+  ArtworkFiltersState,
+  ArtworkFiltersStoreProvider,
+} from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { renderWithWrappers } from "app/tests/renderWithWrappers"
+import { ArtistIDsSaleArtworksOptionsScreen } from "./ArtistIDsSaleArtworksOptionsScreen"
+import { getEssentialProps } from "./helper"
+
+describe("ArtistIDsSaleArtworksOptionsScreen", () => {
+  const TestRenderer = ({ initialData }: { initialData?: ArtworkFiltersState }) => {
+    return (
+      <ArtworkFiltersStoreProvider initialData={initialData ?? mockedState}>
+        <ArtistIDsSaleArtworksOptionsScreen {...getEssentialProps()} />
+      </ArtworkFiltersStoreProvider>
+    )
+  }
+
+  it("should render all artist options", () => {
+    const { getByText } = renderWithWrappers(<TestRenderer />)
+
+    expect(getByText("Artists You Follow")).toBeTruthy()
+    expect(getByText("All Artists")).toBeTruthy()
+    expect(getByText(/Artist A/)).toBeTruthy()
+    expect(getByText(/Artist B/)).toBeTruthy()
+    expect(getByText(/Artist C/)).toBeTruthy()
+    expect(getByText(/Artist D/)).toBeTruthy()
+  })
+
+  it("should render artist options sorted by name", () => {
+    const { getAllByA11yState } = renderWithWrappers(<TestRenderer />)
+    const options = getAllByA11yState({ checked: false })
+
+    expect(options[0]).toHaveTextContent("Artists You Follow")
+    expect(options[1]).toHaveTextContent("Artist A")
+    expect(options[2]).toHaveTextContent("Artist B")
+    expect(options[3]).toHaveTextContent("Artist C")
+    expect(options[4]).toHaveTextContent("Artist D")
+  })
+
+  it("should render the followed artists count", () => {
+    const injectedState: ArtworkFiltersState = {
+      ...mockedState,
+      counts: {
+        ...mockedState.counts,
+        followedArtists: 2,
+      },
+    }
+
+    const { getByText } = renderWithWrappers(<TestRenderer initialData={injectedState} />)
+
+    expect(getByText("Artists You Follow (2)")).toBeTruthy()
+  })
+
+  describe("Selecting", () => {
+    it("when the single option is selected", () => {
+      const { getAllByA11yState, getByText } = renderWithWrappers(<TestRenderer />)
+
+      const prevSelectedOptions = getAllByA11yState({ checked: true })
+      expect(prevSelectedOptions).toHaveLength(1)
+      expect(prevSelectedOptions[0]).toHaveTextContent("All Artists")
+
+      fireEvent.press(getByText(/Artist B/))
+
+      const selectedOptions = getAllByA11yState({ checked: true })
+      expect(selectedOptions).toHaveLength(1)
+      expect(selectedOptions[0]).toHaveTextContent(/Artist B/)
+    })
+
+    it("when multiple options are selected", () => {
+      const { getByText, getAllByA11yState } = renderWithWrappers(<TestRenderer />)
+
+      const prevSelectedOptions = getAllByA11yState({ checked: true })
+      expect(prevSelectedOptions).toHaveLength(1)
+      expect(prevSelectedOptions[0]).toHaveTextContent("All Artists")
+
+      fireEvent.press(getByText(/Artist A/))
+      fireEvent.press(getByText(/Artist B/))
+
+      const selectedOptions = getAllByA11yState({ checked: true })
+
+      expect(selectedOptions).toHaveLength(2)
+      expect(selectedOptions[0]).toHaveTextContent(/Artist A/)
+      expect(selectedOptions[1]).toHaveTextContent(/Artist B/)
+    })
+  })
+
+  describe("Deselecting", () => {
+    it("when the single option is selected", () => {
+      const injectedState: ArtworkFiltersState = {
+        ...mockedState,
+        selectedFilters: [
+          {
+            paramName: FilterParamName.artistIDs,
+            paramValue: ["artist-b"],
+            displayText: "Artist B",
+          },
+        ],
+      }
+
+      const { getAllByA11yState, getByText } = renderWithWrappers(
+        <TestRenderer initialData={injectedState} />
+      )
+
+      const prevSelectedOptions = getAllByA11yState({ checked: true })
+      expect(prevSelectedOptions).toHaveLength(1)
+      expect(prevSelectedOptions[0]).toHaveTextContent("Artist B")
+
+      fireEvent.press(getByText(/Artist B/))
+
+      const selectedOptions = getAllByA11yState({ checked: true })
+      expect(selectedOptions).toHaveLength(1)
+      expect(selectedOptions[0]).toHaveTextContent("All Artists")
+    })
+
+    it("when multiple options are selected", () => {
+      const injectedState: ArtworkFiltersState = {
+        ...mockedState,
+        selectedFilters: [
+          {
+            paramName: FilterParamName.artistIDs,
+            paramValue: ["artist-a", "artist-b"],
+            displayText: "Artist A, Artist B",
+          },
+        ],
+      }
+
+      const { getAllByA11yState, getByText } = renderWithWrappers(
+        <TestRenderer initialData={injectedState} />
+      )
+
+      const prevSelectedOptions = getAllByA11yState({ checked: true })
+      expect(prevSelectedOptions).toHaveLength(2)
+      expect(prevSelectedOptions[0]).toHaveTextContent("Artist A")
+      expect(prevSelectedOptions[1]).toHaveTextContent("Artist B")
+
+      fireEvent.press(getByText(/Artist B/))
+
+      const selectedOptions = getAllByA11yState({ checked: true })
+      expect(selectedOptions).toHaveLength(1)
+      expect(selectedOptions[0]).toHaveTextContent("Artist A")
+    })
+  })
+})
+
+const mockAggregations: Aggregations = [
+  {
+    slice: "ARTIST",
+    counts: [
+      {
+        name: "Artist B",
+        count: 20,
+        value: "artist-b",
+      },
+      {
+        name: "Artist A",
+        count: 10,
+        value: "artist-a",
+      },
+      {
+        name: "Artist D",
+        count: 30,
+        value: "artist-d",
+      },
+      {
+        name: "Artist C",
+        count: 40,
+        value: "artist-c",
+      },
+    ],
+  },
+]
+
+const mockedState: ArtworkFiltersState = {
+  selectedFilters: [],
+  appliedFilters: [],
+  previouslyAppliedFilters: [],
+  applyFilters: false,
+  aggregations: mockAggregations,
+  filterType: "artwork",
+  counts: {
+    total: null,
+    followedArtists: null,
+  },
+  sizeMetric: "cm",
+}

--- a/src/app/Components/ArtworkFilter/Filters/ArtistIDsSaleArtworksOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ArtistIDsSaleArtworksOptionsScreen.tsx
@@ -10,6 +10,7 @@ import {
   ArtworksFiltersStore,
   useSelectedOptionsDisplay,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { sortBy } from "lodash"
 import { MultiSelectCheckOptionScreen } from "./MultiSelectCheckOption"
 import { useMultiSelect } from "./useMultiSelect"
 
@@ -34,15 +35,16 @@ export const ArtistIDsSaleArtworksOptionsScreen: React.FC<
   const aggregations = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
   const aggregation = aggregationForFilter(paramName, aggregations)
 
-  const options: FilterData[] | undefined =
-    aggregation?.counts.map((aggCount) => {
-      return {
-        displayText: aggCount.name,
-        paramName,
-        paramValue: aggCount.value,
-        count: aggCount.count,
-      }
-    }) ?? []
+  const aggregationCounts = aggregation?.counts ?? []
+  const rawOptions: FilterData[] = aggregationCounts.map((aggCount) => {
+    return {
+      displayText: aggCount.name,
+      paramName,
+      paramValue: aggCount.value,
+      count: aggCount.count,
+    }
+  })
+  const options = sortBy(rawOptions, ["displayText"])
 
   const selectedOptions = useSelectedOptionsDisplay()
   const { handleSelect, handleClear, isActive, isSelected } = useMultiSelect({

--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectCheckOption.tsx
@@ -51,16 +51,20 @@ export const MultiSelectCheckOptionScreen: React.FC<MultiSelectOptionScreenProps
           keyExtractor={(_item, index) => String(index)}
           data={filterOptions}
           ItemSeparatorComponent={() => <Separator />}
-          renderItem={({ item }) => (
-            <Box ml={0.5}>
-              <CheckMarkOptionListItem
-                hasExtraLeftPadding={shouldAddIndent?.(item)}
-                item={item}
-                onSelect={onSelect}
-                selected={isSelected(item) as boolean}
-              />
-            </Box>
-          )}
+          renderItem={({ item }) => {
+            const selected = isSelected(item) as boolean
+
+            return (
+              <Box ml={0.5} accessibilityState={{ checked: selected }}>
+                <CheckMarkOptionListItem
+                  hasExtraLeftPadding={shouldAddIndent?.(item)}
+                  item={item}
+                  onSelect={onSelect}
+                  selected={selected}
+                />
+              </Box>
+            )
+          }}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
This PR resolves [FX-4211] <!-- eg [PROJECT-XXXX] -->

### Before
| Before | After |
| ------------- | ------------- |
| ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-12-12 at 19 18 08](https://user-images.githubusercontent.com/3513494/207109749-ca1875a7-3807-4b7d-9873-5c206afad32f.png) | ![Simulator Screen Shot - iPhone SE (3rd generation) - 2022-12-12 at 19 18 16](https://user-images.githubusercontent.com/3513494/207109714-98f83afa-843b-41cf-8586-650279a41b2f.png)| 


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Sort artists by name in "Artists" filter when artwork is in auction - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4211]: https://artsyproduct.atlassian.net/browse/FX-4211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ