### PR TITLE
chore(FX-4399): display the empty state for the partner artworks tab if there are no artworks

### DIFF
--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tests.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tests.tsx
@@ -61,7 +61,8 @@ describe("PartnerArtwork", () => {
       }),
     })
 
-    const emptyText = "There is no artwork from this gallery yet"
+    const emptyText =
+      "There are no matching works from this gallery.\nTry changing your search filters"
     expect(screen.getByText(emptyText)).toBeTruthy()
   })
 })

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -28,6 +28,8 @@ export const PartnerArtwork: React.FC<{
 
   const artworks = get(partner, (p) => p.artworks)
   const artworksCount = (artworks?.edges ?? []).length
+  const emptyText =
+    "There are no matching works from this gallery.\nTry changing your search filters"
 
   return (
     <>
@@ -41,7 +43,7 @@ export const PartnerArtwork: React.FC<{
             hasMore={relay.hasMore}
           />
         ) : (
-          <TabEmptyState text="There is no artwork from this gallery yet" />
+          <TabEmptyState text={emptyText} />
         )}
       </StickyTabPageScrollView>
 

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -27,15 +27,16 @@ export const PartnerArtwork: React.FC<{
   const [isFilterArtworksModalVisible, setIsFilterArtworksModalVisible] = useState(false)
 
   const artworks = get(partner, (p) => p.artworks)
+  const artworksCount = (artworks?.edges ?? []).length
 
   return (
     <>
       <StickyTabPageScrollView>
         <Spacer mb={2} />
 
-        {artworks ? (
+        {artworksCount > 0 ? (
           <InfiniteScrollArtworksGrid
-            connection={artworks}
+            connection={artworks!}
             loadMore={relay.loadMore}
             hasMore={relay.hasMore}
           />


### PR DESCRIPTION
This PR resolves [FX-4399] <!-- eg [PROJECT-XXXX] -->

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/207589838-b1365f07-13e8-46df-bd87-37bfe3434d38.mp4

#### After
https://user-images.githubusercontent.com/3513494/207599363-fc2c025a-ba4c-49cf-b6dc-5e936dd2ad6c.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Display the empty state for the partner artworks tab if there are no artworks - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4399]: https://artsyproduct.atlassian.net/browse/FX-4399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ