### PR TITLE
feat(FX-4076): improvements for live auction modal

### DIFF
--- a/ios/Artsy/View_Controllers/ARSerifNavigationViewController.m
+++ b/ios/Artsy/View_Controllers/ARSerifNavigationViewController.m
@@ -179,9 +179,10 @@ static CGFloat exitButtonDimension = 40;
 
             CGRect labelFrame = label.bounds;
             CGFloat idealWidth = CGRectGetWidth(labelFrame) + xOffset;
+            CGFloat labelHeight = CGRectGetHeight(labelFrame);
             CGFloat max = CGRectGetWidth(navigationController.view.bounds) - (rightButtonsCount * 48) - ((rightButtonsCount - 1) * 10) - 20;
 
-            label.frame = CGRectMake(xOffset, 0, MIN(idealWidth, max), 20);
+            label.frame = CGRectMake(xOffset, 0, MIN(idealWidth, max), MAX(labelHeight, 20));
             UIView *titleMarginWrapper = [[UIView alloc] initWithFrame:(CGRect){CGPointZero, {MIN(idealWidth, max), CGRectGetHeight(labelFrame)}}];
             [titleMarginWrapper addSubview:label];
 

--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionViewController.swift
@@ -189,6 +189,9 @@ class LiveAuctionViewController: UIViewController {
     @objc func dismissLiveAuctionsModal() {
         overlaySubscription?.unsubscribe()
         saleOnHoldSubscription?.unsubscribe()
+
+        AREmission.sharedInstance().notificationsManagerModule.requestModalDismiss()
+        // TODO: AppShell, don't need the below code once app shell is done
         self.presentingViewController?.dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
This PR resolves [FX-4076] <!-- eg [PROJECT-XXXX] -->

### Changes
* Added the ability to close the modal during loading state
* Fixed the problem when title gets truncated

### Demo (title)
| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/3513494/207865481-8f55c61b-34ff-43a6-8c0a-928fe168ba0a.png) | ![after](https://user-images.githubusercontent.com/3513494/207865600-46868420-57bd-40ab-8032-8e08b9db27c6.png) | 

### Demo (close modal during loading)
#### Before
https://user-images.githubusercontent.com/3513494/207865217-b789dde0-da8e-4138-ae97-30d92e628a9f.mp4

#### After
https://user-images.githubusercontent.com/3513494/207865240-0fd634a0-13ad-47c9-90fa-40928a50a9a8.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Improvements for live auction modal - dimatretyak

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4076]: https://artsyproduct.atlassian.net/browse/FX-4076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ