### PR TITLE
chore: remove extra padding from artwork page when no sale message

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkTombstone.tsx
@@ -22,6 +22,9 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork, ref
     !artwork.sale.isClosed &&
     !enableArtworkRedesign
 
+  const shouldDisplaySaleMessage =
+    !!enableArtworkRedesign && !artwork.isForSale && !!artwork.saleMessage
+
   return (
     <Box textAlign="left">
       {!!displayAuctionLotLabel && (
@@ -47,8 +50,7 @@ export const ArtworkTombstone: React.FC<ArtworkTombstoneProps> = ({ artwork, ref
           {!!artwork.date && <Text variant="lg-display">{artwork.date}</Text>}
         </Text>
       </Flex>
-
-      {!!enableArtworkRedesign && !artwork.isForSale && (
+      {!!shouldDisplaySaleMessage && (
         <>
           <Spacer mt={2} />
           <Text variant="md" color="black100">


### PR DESCRIPTION
This PR resolves [FX-4499] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

 remove extra padding from artwork page when no sale message

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2022-12-15 at 16 53 50](https://user-images.githubusercontent.com/21178754/207907211-9866de75-6a07-4db4-8af1-4135ff02fb10.png)|![Simulator Screen Shot - iPhone 14 - 2022-12-15 at 16 53 41](https://user-images.githubusercontent.com/21178754/207907223-f43dfa40-204a-4812-b87a-cf9f61fb1717.png)|

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4499]: https://artsyproduct.atlassian.net/browse/FX-4499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ