### PR TITLE
chore: update auction result list item component

### DIFF
--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
@@ -1,5 +1,5 @@
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
-import { DecreaseIcon, IncreaseIcon, Text } from "palette"
+import { Text } from "palette"
 import { AuctionResultsMidEstimate } from "./AuctionResultMidEstimate"
 
 describe("AuctionResultMidEstimate", () => {
@@ -7,7 +7,6 @@ describe("AuctionResultMidEstimate", () => {
     const tree = renderWithWrappersLEGACY(
       <AuctionResultsMidEstimate value="25%" shortDescription="mid-estimate" />
     )
-    expect(tree.root.findAllByType(IncreaseIcon).length).toEqual(1)
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("green100")
   })
 
@@ -15,7 +14,6 @@ describe("AuctionResultMidEstimate", () => {
     const tree = renderWithWrappersLEGACY(
       <AuctionResultsMidEstimate value="-25%" shortDescription="mid-estimate" />
     )
-    expect(tree.root.findAllByType(DecreaseIcon).length).toEqual(1)
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("red100")
   })
 
@@ -30,13 +28,7 @@ describe("AuctionResultMidEstimate", () => {
       <AuctionResultsMidEstimate value="-2%" shortDescription="mid-estimate" />
     )
     expect(instance1.root.findAllByType(Text)[0].props.color).toEqual("black60")
-    expect(instance1.root.findAllByType(IncreaseIcon).length).toEqual(1)
-    expect(instance1.root.findAllByType(IncreaseIcon)[0].props.fill).toEqual("black60")
     expect(instance2.root.findAllByType(Text)[0].props.color).toEqual("black60")
-    expect(instance2.root.findAllByType(IncreaseIcon).length).toEqual(1)
-    expect(instance2.root.findAllByType(IncreaseIcon)[0].props.fill).toEqual("black60")
     expect(instance3.root.findAllByType(Text)[0].props.color).toEqual("black60")
-    expect(instance3.root.findAllByType(DecreaseIcon).length).toEqual(1)
-    expect(instance3.root.findAllByType(DecreaseIcon)[0].props.fill).toEqual("black60")
   })
 })

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -6,20 +6,16 @@ interface AuctionResultsMidEstimateProps {
   textVariant?: TextProps["variant"]
 }
 
-type ArrowDirections = "up" | "down"
-
 export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps> = ({
   value,
   textVariant = "xs",
   shortDescription,
 }) => {
-  const prefix: ArrowDirections = value[0] !== "-" ? "up" : "down"
-
   const color = ratioColor(value)
 
   return (
     <Text variant={textVariant} color={color} fontWeight="500">
-      ({prefix === "up" ? "+" : "-"}
+      ({value[0] === "-" ? "+" : "-"}
       {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
       {!!shortDescription && ` ${shortDescription}`})
     </Text>

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -1,4 +1,4 @@
-import { DecreaseIcon, Flex, IncreaseIcon, Text, TextProps } from "palette"
+import { Text, TextProps } from "palette"
 
 interface AuctionResultsMidEstimateProps {
   value: string
@@ -13,23 +13,16 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
   textVariant = "xs",
   shortDescription,
 }) => {
-  const arrowDirection: ArrowDirections = value[0] !== "-" ? "up" : "down"
+  const prefix: ArrowDirections = value[0] !== "-" ? "up" : "down"
 
   const color = ratioColor(value)
 
   return (
-    <Flex flexDirection="row" alignItems="center">
-      {/* Up arrow is heavier toward bottom so appears off center without padding */}
-      {arrowDirection === "up" ? (
-        <IncreaseIcon height={10} fill={color} />
-      ) : (
-        <DecreaseIcon height={10} fill={color} />
-      )}
-      <Text variant={textVariant} color={color}>
-        {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
-        {!!shortDescription && ` ${shortDescription}`}
-      </Text>
-    </Flex>
+    <Text variant={textVariant} color={color} fontWeight="500">
+      ({prefix === "up" ? "+" : "-"}
+      {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
+      {!!shortDescription && ` ${shortDescription}`})
+    </Text>
   )
 }
 

--- a/src/app/Components/Lists/AuctionResultListItem.tests.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tests.tsx
@@ -76,11 +76,11 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findByProps({ testID: "price" }).props.children).toBe("$one gazillion")
+    expect(extractText(tree.findByProps({ testID: "price" }))).toBe("$one gazillion (-10% est)")
     expect(tree.findAllByProps({ testID: "priceUSD" }).length).toBe(0)
   })
 
-  it.only("renders price in USD when currency is not USD", () => {
+  it("renders price in USD when currency is not USD", () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer />).root
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artist: () => ({

--- a/src/app/Components/Lists/AuctionResultListItem.tests.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tests.tsx
@@ -1,5 +1,6 @@
 import { AuctionResultListItemTestsQuery } from "__generated__/AuctionResultListItemTestsQuery.graphql"
 import { AuctionResultsMidEstimate } from "app/Components/AuctionResult/AuctionResultMidEstimate"
+import { extractText } from "app/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
 import { extractNodes } from "app/utils/extractNodes"
@@ -61,6 +62,9 @@ describe("AuctionResults", () => {
                   display: "$one gazillion",
                   displayUSD: "$one gazillion",
                 },
+                performance: {
+                  mid: "10",
+                },
                 artist: {
                   name: "artist-name",
                   slug: "artist-slug",
@@ -76,7 +80,7 @@ describe("AuctionResults", () => {
     expect(tree.findAllByProps({ testID: "priceUSD" }).length).toBe(0)
   })
 
-  it("renders price in USD when currency is not USD", () => {
+  it.only("renders price in USD when currency is not USD", () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer />).root
     resolveMostRecentRelayOperation(mockEnvironment, {
       Artist: () => ({
@@ -90,6 +94,9 @@ describe("AuctionResults", () => {
                   display: "€one gazillion",
                   displayUSD: "$one gazillion",
                 },
+                performance: {
+                  mid: "10",
+                },
                 artist: {
                   name: "artist-name",
                   slug: "artist-slug",
@@ -101,8 +108,10 @@ describe("AuctionResults", () => {
       }),
     })
 
-    expect(tree.findByProps({ testID: "price" }).props.children).toBe("€one gazillion")
-    expect(tree.findByProps({ testID: "priceUSD" }).props.children).toBe("$one gazillion")
+    expect(extractText(tree.findByProps({ testID: "price" }))).toBe(
+      "€one gazillion • $one gazillion (-10% est)"
+    )
+    expect(extractText(tree.findByProps({ testID: "priceUSD" }))).toBe("$one gazillion")
   })
 
   it("renders auction result when auction results are not available yet", () => {
@@ -117,6 +126,9 @@ describe("AuctionResults", () => {
                 priceRealized: {
                   display: null,
                   displayUSD: null,
+                },
+                performance: {
+                  mid: "10",
                 },
                 saleDate: moment().subtract(1, "day").toISOString(),
               },
@@ -142,6 +154,9 @@ describe("AuctionResults", () => {
                 priceRealized: {
                   display: null,
                   displayUSD: null,
+                },
+                performance: {
+                  mid: "10",
                 },
                 saleDate: moment().subtract(2, "months").toISOString(),
                 boughtIn: true,

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -121,9 +121,9 @@ const AuctionResultListItem: React.FC<Props> = ({
               <Flex>
                 <Text variant="xs" fontWeight="500" testID="price">
                   {auctionResult.priceRealized?.display}
+                  {!!showPriceUSD && auctionResult.priceRealized?.display ? ` ${bullet} ` : ""}
                   {!!showPriceUSD && (
                     <Text variant="xs" testID="priceUSD">
-                      {` ${bullet} `}
                       {auctionResult.priceRealized?.displayUSD}
                     </Text>
                   )}{" "}

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -91,7 +91,6 @@ const AuctionResultListItem: React.FC<Props> = ({
                 {!!auctionResult.dateText &&
                   auctionResult.dateText !== "" &&
                   `, ${auctionResult.dateText}`}
-                {/* </Text> */}
               </Text>
             </Flex>
 

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -1,10 +1,11 @@
 import { AuctionResultListItem_auctionResult$data } from "__generated__/AuctionResultListItem_auctionResult.graphql"
-import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { auctionResultHasPrice, auctionResultText } from "app/Scenes/AuctionResult/helpers"
 import { QAInfoManualPanel, QAInfoRow } from "app/utils/QAInfo"
 import { capitalize } from "lodash"
 import moment from "moment"
 import { bullet, Flex, NoArtworkIcon, Spacer, Text, Touchable, useColor } from "palette"
+import { Stopwatch } from "palette/svgs/sf"
+import FastImage from "react-native-fast-image"
 import { createFragmentContainer, graphql } from "react-relay"
 import { AuctionResultsMidEstimate } from "../AuctionResult/AuctionResultMidEstimate"
 
@@ -39,28 +40,34 @@ const AuctionResultListItem: React.FC<Props> = ({
         {/* Sale Artwork Thumbnail Image */}
         {!auctionResult.images?.thumbnail?.url ? (
           <Flex
-            width={60}
-            height={60}
+            width={100}
+            height={130}
             borderRadius={2}
-            backgroundColor="black10"
+            backgroundColor="black5"
             alignItems="center"
             justifyContent="center"
           >
-            <NoArtworkIcon width={28} height={28} opacity={0.3} />
+            <NoArtworkIcon width={30} height={30} fill="black60" />
           </Flex>
         ) : (
           <Flex
-            width={60}
-            height={60}
+            width={100}
+            height={130}
             borderRadius={2}
-            backgroundColor="black"
+            backgroundColor="bla ck"
             alignItems="center"
             justifyContent="center"
             overflow="hidden"
             // To align the image with the text we have to add top margin to compensate the line height.
             style={{ marginTop: 3 }}
           >
-            <OpaqueImageView width={60} height={60} imageURL={auctionResult.images.thumbnail.url} />
+            <FastImage
+              style={{ backgroundColor: color("black5"), height: 130, width: 100 }}
+              source={{
+                uri: auctionResult.images.thumbnail.url,
+              }}
+              resizeMode={FastImage.resizeMode.contain}
+            />
           </Flex>
         )}
 
@@ -69,31 +76,38 @@ const AuctionResultListItem: React.FC<Props> = ({
           <Flex flex={3}>
             <Flex>
               {!!showArtistName && !!auctionResult.artist?.name && (
-                <Text variant="xs" ellipsizeMode="middle" numberOfLines={2}>
+                <Text variant="xs" color="black100" numberOfLines={2}>
                   {auctionResult.artist?.name}
                 </Text>
               )}
               <Text
                 variant="xs"
                 ellipsizeMode="middle"
-                color="black60"
-                numberOfLines={2}
-                italic
+                color="black100"
+                numberOfLines={1}
                 style={{ flexShrink: 1 }}
               >
                 {auctionResult.title}
-                <Text variant="xs" color="black60">
-                  {!!auctionResult.dateText &&
-                    auctionResult.dateText !== "" &&
-                    `, ${auctionResult.dateText}`}
-                </Text>
+                {!!auctionResult.dateText &&
+                  auctionResult.dateText !== "" &&
+                  `, ${auctionResult.dateText}`}
+                {/* </Text> */}
               </Text>
             </Flex>
+
             {!!auctionResult.mediumText && (
               <Text variant="xs" color="black60" numberOfLines={1}>
                 {capitalize(auctionResult.mediumText)}
               </Text>
             )}
+
+            {!!auctionResult.dimensionText && (
+              <Text variant="xs" color="black60" numberOfLines={1}>
+                {auctionResult.dimensionText}
+              </Text>
+            )}
+
+            <Spacer mt={1} />
 
             {!!auctionResult.saleDate && (
               <Text variant="xs" color="black60" numberOfLines={1} testID="saleInfo">
@@ -102,36 +116,29 @@ const AuctionResultListItem: React.FC<Props> = ({
                 {auctionResult.organization}
               </Text>
             )}
-          </Flex>
 
-          {/* Sale Artwork Auction Result */}
-          <Flex alignItems="flex-end" pl={15}>
             {auctionResultHasPrice(auctionResult) ? (
-              <Flex alignItems="flex-end">
+              <Flex>
                 <Text variant="xs" fontWeight="500" testID="price">
                   {auctionResult.priceRealized?.display}
+                  {!!showPriceUSD && (
+                    <Text variant="xs" testID="priceUSD">
+                      {` ${bullet} `}
+                      {auctionResult.priceRealized?.displayUSD}
+                    </Text>
+                  )}{" "}
+                  {!!auctionResult.performance?.mid && (
+                    <AuctionResultsMidEstimate
+                      value={auctionResult.performance.mid}
+                      shortDescription="est"
+                    />
+                  )}
                 </Text>
-                {!!showPriceUSD && (
-                  <Text variant="xs" color="black60" testID="priceUSD">
-                    {auctionResult.priceRealized?.displayUSD}
-                  </Text>
-                )}
-                {!!auctionResult.performance?.mid && (
-                  <AuctionResultsMidEstimate
-                    value={auctionResult.performance.mid}
-                    shortDescription="est"
-                  />
-                )}
               </Flex>
             ) : (
-              <Flex alignItems="flex-end">
-                <Text
-                  variant="xs"
-                  fontWeight="bold"
-                  style={{ width: 100 }}
-                  textAlign="right"
-                  testID="price"
-                >
+              <Flex flexDirection="row" alignItems="center">
+                <Stopwatch height={15} width={15} mr={0.5} />
+                <Text variant="xs" testID="price" italic>
                   {auctionResultText(auctionResult)}
                 </Text>
               </Flex>
@@ -169,6 +176,7 @@ export const AuctionResultListItemFragmentContainer = createFragmentContainer(
         estimate {
           low
         }
+        dimensionText
         mediumText
         organization
         boughtIn


### PR DESCRIPTION
This PR resolves [CX-3226] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR updates the auction result list item component to match the new designs

https://user-images.githubusercontent.com/11945712/208158210-5ad0e897-d0cb-4cd3-b8e9-d5040948afed.mov




### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- update auction result list item component - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3226]: https://artsyproduct.atlassian.net/browse/CX-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ