### PR TITLE
refactor(FX-4396): Optimization for "Artists" filter screen

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/ArtistIDsArtworksOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ArtistIDsArtworksOptions.tsx
@@ -13,7 +13,7 @@ import {
 
 import { ArtworkFilterNavigationStack } from "app/Components/ArtworkFilter"
 import { sortBy } from "lodash"
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { MultiSelectOptionScreen } from "./MultiSelectOption"
 import { useMultiSelect } from "./useMultiSelect"
 
@@ -70,17 +70,20 @@ export const ArtistIDsArtworksOptionsScreen: React.FC<ArtistIDsArtworksOptionsSc
     ]
   }
 
-  const selectOption = (option: FilterData, updatedValue: boolean) => {
-    if (option.paramName === FilterParamName.artistsIFollow) {
-      selectFiltersAction({
-        displayText: "All Artists I Follow",
-        paramName: FilterParamName.artistsIFollow,
-        paramValue: !selectedArtistIFollowOption?.paramValue,
-      })
-    } else {
-      handleSelect(option, updatedValue)
-    }
-  }
+  const selectOption = useCallback(
+    (option: FilterData, updatedValue: boolean) => {
+      if (option.paramName === FilterParamName.artistsIFollow) {
+        selectFiltersAction({
+          displayText: "All Artists I Follow",
+          paramName: FilterParamName.artistsIFollow,
+          paramValue: !selectedArtistIFollowOption?.paramValue,
+        })
+      } else {
+        handleSelect(option, updatedValue)
+      }
+    },
+    [selectedArtistIFollowOption, handleSelect]
+  )
 
   return (
     <MultiSelectOptionScreen

--- a/src/app/Components/ArtworkFilter/Filters/ArtistIDsArtworksOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/ArtistIDsArtworksOptions.tsx
@@ -28,29 +28,12 @@ export const ArtistIDsArtworksOptionsScreen: React.FC<ArtistIDsArtworksOptionsSc
     (state) => state.selectFiltersAction
   )
   const counts = ArtworksFiltersStore.useStoreState((state) => state.counts)
-  const filterType = ArtworksFiltersStore.useStoreState((state) => state.filterType)
-  const localFilterOptions = ArtworksFiltersStore.useStoreState((state) => state.filterOptions)
 
   const selectedArtistIFollowOption = selectedOptions.find((value) => {
     return value.paramName === FilterParamName.artistsIFollow
   })
 
-  let artistDisplayOptions: FilterData[] = []
-  if (filterType === "local") {
-    artistDisplayOptions = (localFilterOptions ?? []).find((o) => o.filterType === "artistIDs")!
-      .values!
-  } else {
-    const aggregation = aggregationForFilter(FilterParamName.artistIDs, aggregations)
-    artistDisplayOptions =
-      aggregation?.counts.map((aggCount) => {
-        return {
-          displayText: aggCount.name,
-          paramName: FilterParamName.artistIDs,
-          paramValue: aggCount.value,
-          filterKey: "artist",
-        }
-      }) ?? []
-  }
+  const artistDisplayOptions = useDisplayOptions()
 
   const { handleSelect, isSelected } = useMultiSelect({
     options: artistDisplayOptions,
@@ -104,4 +87,33 @@ export const ArtistIDsArtworksOptionsScreen: React.FC<ArtistIDsArtworksOptionsSc
       navigation={navigation}
     />
   )
+}
+
+const useDisplayOptions = () => {
+  const filterType = ArtworksFiltersStore.useStoreState((state) => state.filterType)
+  const localFilterOptions = ArtworksFiltersStore.useStoreState((state) => state.filterOptions)
+  const aggregations = ArtworksFiltersStore.useStoreState((state) => state.aggregations)
+
+  let artistDisplayOptions: FilterData[] = []
+
+  if (filterType === "local") {
+    const localArtistFilterOption = (localFilterOptions ?? []).find((filterOption) => {
+      return filterOption.filterType === "artistIDs"
+    })
+    artistDisplayOptions = localArtistFilterOption?.values ?? []
+  } else {
+    const aggregation = aggregationForFilter(FilterParamName.artistIDs, aggregations)
+    const counts = aggregation?.counts ?? []
+
+    artistDisplayOptions = counts.map((aggCount) => {
+      return {
+        displayText: aggCount.name,
+        paramName: FilterParamName.artistIDs,
+        paramValue: aggCount.value,
+        filterKey: "artist",
+      }
+    })
+  }
+
+  return artistDisplayOptions
 }

--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -12,6 +12,7 @@ import styled from "styled-components/native"
 
 const OPTIONS_MARGIN_LEFT = 0.5
 const OPTION_PADDING = 15
+const OPTION_HEIGHT = 50
 
 interface MultiSelectOptionScreenProps {
   navigation: StackNavigationProp<ParamListBase>
@@ -27,6 +28,11 @@ interface MultiSelectOptionScreenProps {
   isDisabled?: (item: FilterData) => boolean
   onSelect: (filterData: FilterData, updatedValue: boolean) => void
   onRightButtonPress?: () => void
+}
+
+interface RenderItemProps {
+  item: FilterData
+  index: number
 }
 
 export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = ({
@@ -69,13 +75,10 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
     }
   }
 
-  const keyExtractor = (_item: FilterData, index: number) => {
-    return String(index)
-  }
-
-  const renderItem = (item: FilterData) => {
+  const renderItem = ({ item, index }: RenderItemProps) => {
     const disabled = itemIsDisabled(item)
     const selected = itemIsSelected(item)
+    const key = `multie-select-option-item-${index}`
 
     const handlePress = () => {
       const currentParamValue = item.paramValue as boolean
@@ -84,6 +87,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 
     return (
       <MultiSelectOptionItem
+        key={key}
         item={item}
         selected={selected}
         disabled={disabled}
@@ -122,20 +126,21 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
       <Flex flexGrow={1}>
         {useScrollView ? (
           <ScrollView style={{ flex: 1 }}>
-            {filteredOptions.map((option, index) => (
-              <React.Fragment key={keyExtractor(option, index)}>
-                {renderItem(option)}
-              </React.Fragment>
-            ))}
+            {filteredOptions.map((option, index) => renderItem({ item: option, index }))}
             {footerComponent}
           </ScrollView>
         ) : (
           <FlatList<FilterData>
             style={{ flex: 1 }}
-            keyExtractor={keyExtractor}
             data={filteredOptions}
             ListFooterComponent={footerComponent}
-            renderItem={({ item }) => renderItem(item)}
+            renderItem={renderItem}
+            windowSize={11}
+            getItemLayout={(_, index) => ({
+              length: OPTION_HEIGHT,
+              offset: index * OPTION_HEIGHT,
+              index,
+            })}
           />
         )}
       </Flex>
@@ -161,7 +166,7 @@ const MultiSelectOptionItem: React.FC<MultiSelectOptionItemProps> = ({
   const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
 
   return (
-    <Box ml={OPTIONS_MARGIN_LEFT} height={50}>
+    <Box ml={OPTIONS_MARGIN_LEFT} height={OPTION_HEIGHT}>
       <TouchableRow
         onPress={onPress}
         disabled={disabled}

--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -3,16 +3,10 @@ import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFilterBackHeader } from "app/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
 import { SearchInput } from "app/Components/SearchInput"
-import { TouchableRow } from "app/Components/TouchableRow"
-import { Box, Check, CHECK_SIZE, Flex, Text, useSpace } from "palette"
-import React, { memo, useCallback, useState } from "react"
+import { Flex, Text } from "palette"
+import React, { useCallback, useState } from "react"
 import { FlatList, ScrollView } from "react-native"
-import { useScreenDimensions } from "shared/hooks"
-import styled from "styled-components/native"
-
-const OPTIONS_MARGIN_LEFT = 0.5
-const OPTION_PADDING = 15
-const OPTION_HEIGHT = 50
+import { MULTI_SELECT_OPTION_ITEM_HEIGHT, MultiSelectOptionItem } from "./MultiSelectOptionItem"
 
 interface MultiSelectOptionScreenProps {
   navigation: StackNavigationProp<ParamListBase>
@@ -140,8 +134,8 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
             renderItem={renderItem}
             windowSize={11}
             getItemLayout={(_, index) => ({
-              length: OPTION_HEIGHT,
-              offset: index * OPTION_HEIGHT,
+              length: MULTI_SELECT_OPTION_ITEM_HEIGHT,
+              offset: index * MULTI_SELECT_OPTION_ITEM_HEIGHT,
               index,
             })}
           />
@@ -150,57 +144,3 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
     </Flex>
   )
 }
-
-interface MultiSelectOptionItemProps {
-  item: FilterData
-  selected: boolean
-  disabled: boolean
-  onPress: (item: FilterData) => void
-}
-
-const areEqual = (prevProps: MultiSelectOptionItemProps, nextProps: MultiSelectOptionItemProps) => {
-  return (
-    prevProps.selected === nextProps.selected &&
-    prevProps.disabled === nextProps.disabled &&
-    prevProps.item.displayText === nextProps.item.displayText &&
-    prevProps.onPress === nextProps.onPress
-  )
-}
-
-const MultiSelectOptionItem: React.FC<MultiSelectOptionItemProps> = memo(
-  ({ item, disabled, selected, onPress }) => {
-    const space = useSpace()
-    const { width } = useScreenDimensions()
-    const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
-
-    return (
-      <Box ml={OPTIONS_MARGIN_LEFT} height={OPTION_HEIGHT}>
-        <TouchableRow
-          onPress={() => onPress(item)}
-          disabled={disabled}
-          testID="multi-select-option-button"
-          accessibilityState={{ checked: selected }}
-        >
-          <OptionListItem>
-            <Box maxWidth={optionTextMaxWidth}>
-              <Text variant="xs" color="black100">
-                {item.displayText}
-              </Text>
-            </Box>
-
-            <Check selected={selected} disabled={disabled} />
-          </OptionListItem>
-        </TouchableRow>
-      </Box>
-    )
-  },
-  areEqual
-)
-
-export const OptionListItem = styled(Flex)`
-  flex-direction: row;
-  justify-content: space-between;
-  flex-grow: 1;
-  align-items: flex-start;
-  padding: ${OPTION_PADDING}px;
-`

--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -43,10 +43,7 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
   onRightButtonPress,
   rightButtonText,
 }) => {
-  const space = useSpace()
-  const { width } = useScreenDimensions()
   const [query, setQuery] = useState("")
-  const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
 
   const filteredOptions = filterOptions.filter((option) =>
     option.displayText.toLowerCase().includes(query.toLowerCase())
@@ -80,28 +77,18 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
     const disabled = itemIsDisabled(item)
     const selected = itemIsSelected(item)
 
-    return (
-      <Box ml={OPTIONS_MARGIN_LEFT}>
-        <TouchableRow
-          onPress={() => {
-            const currentParamValue = item.paramValue as boolean
-            onSelect(item, !currentParamValue)
-          }}
-          disabled={disabled}
-          testID="multi-select-option-button"
-          accessibilityState={{ checked: selected }}
-        >
-          <OptionListItem>
-            <Box maxWidth={optionTextMaxWidth}>
-              <Text variant="xs" color="black100">
-                {item.displayText}
-              </Text>
-            </Box>
+    const handlePress = () => {
+      const currentParamValue = item.paramValue as boolean
+      onSelect(item, !currentParamValue)
+    }
 
-            <Check selected={selected} disabled={disabled} />
-          </OptionListItem>
-        </TouchableRow>
-      </Box>
+    return (
+      <MultiSelectOptionItem
+        item={item}
+        selected={selected}
+        disabled={disabled}
+        onPress={handlePress}
+      />
     )
   }
 
@@ -153,6 +140,45 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
         )}
       </Flex>
     </Flex>
+  )
+}
+
+interface MultiSelectOptionItemProps {
+  item: FilterData
+  selected: boolean
+  disabled: boolean
+  onPress: () => void
+}
+
+const MultiSelectOptionItem: React.FC<MultiSelectOptionItemProps> = ({
+  item,
+  disabled,
+  selected,
+  onPress,
+}) => {
+  const space = useSpace()
+  const { width } = useScreenDimensions()
+  const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
+
+  return (
+    <Box ml={OPTIONS_MARGIN_LEFT} height={50}>
+      <TouchableRow
+        onPress={onPress}
+        disabled={disabled}
+        testID="multi-select-option-button"
+        accessibilityState={{ checked: selected }}
+      >
+        <OptionListItem>
+          <Box maxWidth={optionTextMaxWidth}>
+            <Text variant="xs" color="black100">
+              {item.displayText}
+            </Text>
+          </Box>
+
+          <Check selected={selected} disabled={disabled} />
+        </OptionListItem>
+      </TouchableRow>
+    </Box>
   )
 }
 

--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectOptionItem.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectOptionItem.tsx
@@ -1,0 +1,64 @@
+import { FilterData } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import { TouchableRow } from "app/Components/TouchableRow"
+import { Box, Check, CHECK_SIZE, Flex, Text, useSpace } from "palette"
+import React, { memo } from "react"
+import { useScreenDimensions } from "shared/hooks"
+import styled from "styled-components/native"
+
+const OPTIONS_MARGIN_LEFT = 0.5
+const OPTION_PADDING = 15
+export const MULTI_SELECT_OPTION_ITEM_HEIGHT = 50
+
+interface MultiSelectOptionItemProps {
+  item: FilterData
+  selected: boolean
+  disabled: boolean
+  onPress: (item: FilterData) => void
+}
+
+const areEqual = (prevProps: MultiSelectOptionItemProps, nextProps: MultiSelectOptionItemProps) => {
+  return (
+    prevProps.selected === nextProps.selected &&
+    prevProps.disabled === nextProps.disabled &&
+    prevProps.item.displayText === nextProps.item.displayText &&
+    prevProps.onPress === nextProps.onPress
+  )
+}
+
+export const MultiSelectOptionItem: React.FC<MultiSelectOptionItemProps> = memo(
+  ({ item, disabled, selected, onPress }) => {
+    const space = useSpace()
+    const { width } = useScreenDimensions()
+    const optionTextMaxWidth = width - OPTION_PADDING * 3 - space(OPTIONS_MARGIN_LEFT) - CHECK_SIZE
+
+    return (
+      <Box ml={OPTIONS_MARGIN_LEFT} height={MULTI_SELECT_OPTION_ITEM_HEIGHT}>
+        <TouchableRow
+          onPress={() => onPress(item)}
+          disabled={disabled}
+          testID="multi-select-option-button"
+          accessibilityState={{ checked: selected }}
+        >
+          <OptionListItem>
+            <Box maxWidth={optionTextMaxWidth}>
+              <Text variant="xs" color="black100">
+                {item.displayText}
+              </Text>
+            </Box>
+
+            <Check selected={selected} disabled={disabled} />
+          </OptionListItem>
+        </TouchableRow>
+      </Box>
+    )
+  },
+  areEqual
+)
+
+export const OptionListItem = styled(Flex)`
+  flex-direction: row;
+  justify-content: space-between;
+  flex-grow: 1;
+  align-items: flex-start;
+  padding: ${OPTION_PADDING}px;
+`

--- a/src/app/Components/ArtworkFilter/Filters/useMultiSelect.ts
+++ b/src/app/Components/ArtworkFilter/Filters/useMultiSelect.ts
@@ -50,42 +50,48 @@ export const useMultiSelect = ({
     [nextParamValues, options]
   )
 
-  const getParamValue = (option: FilterData) => {
-    // (property) FilterData.paramValue?: string | number | boolean | string[] | undefined
-    switch (typeof option.paramValue) {
-      case "undefined":
-      case "boolean":
-      case "object": // string[]
-        // For dealing with things like our MultiSelectOptionScreen which
-        // requires options with boolean paramValues:
-        // Find the string paramValue within options using the displayText
-        return String(
-          options.find(({ displayText }) => {
-            return displayText === option.displayText
-          })!.paramValue
-        )
+  const getParamValue = useCallback(
+    (option: FilterData) => {
+      // (property) FilterData.paramValue?: string | number | boolean | string[] | undefined
+      switch (typeof option.paramValue) {
+        case "undefined":
+        case "boolean":
+        case "object": // string[]
+          // For dealing with things like our MultiSelectOptionScreen which
+          // requires options with boolean paramValues:
+          // Find the string paramValue within options using the displayText
+          return String(
+            options.find(({ displayText }) => {
+              return displayText === option.displayText
+            })!.paramValue
+          )
 
-      case "string":
-      case "number":
-        return String(option.paramValue)
-    }
-  }
+        case "string":
+        case "number":
+          return String(option.paramValue)
+      }
+    },
+    [options]
+  )
 
-  const handleSelect = useCallback((option: FilterData, updatedValue: boolean) => {
-    if (updatedValue) {
-      // Append the paramValue
-      setNextParamValues((prev) => {
-        return [...prev, getParamValue(option)]
-      })
-    } else {
-      // Remove the paramValue
-      setNextParamValues((prev) => {
-        return prev.filter((value) => {
-          return value !== getParamValue(option)
+  const handleSelect = useCallback(
+    (option: FilterData, updatedValue: boolean) => {
+      if (updatedValue) {
+        // Append the paramValue
+        setNextParamValues((prev) => {
+          return [...prev, getParamValue(option)]
         })
-      })
-    }
-  }, [])
+      } else {
+        // Remove the paramValue
+        setNextParamValues((prev) => {
+          return prev.filter((value) => {
+            return value !== getParamValue(option)
+          })
+        })
+      }
+    },
+    [getParamValue]
+  )
 
   const isSelected = (option: FilterData) => {
     return nextParamValues.includes(getParamValue(option))

--- a/src/app/Components/ArtworkFilter/Filters/useMultiSelect.ts
+++ b/src/app/Components/ArtworkFilter/Filters/useMultiSelect.ts
@@ -71,24 +71,21 @@ export const useMultiSelect = ({
     }
   }
 
-  const handleSelect = useCallback(
-    (option: FilterData, updatedValue: boolean) => {
-      if (updatedValue) {
-        // Append the paramValue
-        setNextParamValues((prev) => {
-          return [...prev, getParamValue(option)]
+  const handleSelect = useCallback((option: FilterData, updatedValue: boolean) => {
+    if (updatedValue) {
+      // Append the paramValue
+      setNextParamValues((prev) => {
+        return [...prev, getParamValue(option)]
+      })
+    } else {
+      // Remove the paramValue
+      setNextParamValues((prev) => {
+        return prev.filter((value) => {
+          return value !== getParamValue(option)
         })
-      } else {
-        // Remove the paramValue
-        setNextParamValues((prev) => {
-          return prev.filter((value) => {
-            return value !== getParamValue(option)
-          })
-        })
-      }
-    },
-    [getParamValue]
-  )
+      })
+    }
+  }, [])
 
   const isSelected = (option: FilterData) => {
     return nextParamValues.includes(getParamValue(option))


### PR DESCRIPTION
This PR resolves [FX-4396] <!-- eg [PROJECT-XXXX] -->

### Demo
#### Before
https://user-images.githubusercontent.com/3513494/208473840-bc210706-c18b-414b-9332-b588fb7c5526.mp4

#### After
https://user-images.githubusercontent.com/3513494/208473866-a34b6430-91ad-45ef-9c6f-efa225c486a4.mp4


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Optimization for "Artists" filter screen - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4396]: https://artsyproduct.atlassian.net/browse/FX-4396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ