### PR TITLE
feat: add upcoming auctions rails to the home page

### DIFF
--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -6,9 +6,9 @@ import { capitalize } from "lodash"
 import moment from "moment"
 import { bullet, Flex, NoArtworkIcon, Spacer, Text, Touchable, useColor } from "palette"
 import { Stopwatch } from "palette/svgs/sf"
+import { Dimensions } from "react-native"
 import FastImage from "react-native-fast-image"
 import { createFragmentContainer, graphql } from "react-relay"
-import { useScreenDimensions } from "shared/hooks/useScreenDimensions"
 import { AuctionResultsMidEstimate } from "../AuctionResult/AuctionResultMidEstimate"
 
 interface Props {
@@ -30,7 +30,7 @@ const AuctionResultListItem: React.FC<Props> = ({
 }) => {
   const color = useColor()
 
-  const { width: screenWidth } = useScreenDimensions()
+  const { width: screenWidth } = Dimensions.get("screen")
 
   const showPriceUSD = auctionResult.priceRealized?.displayUSD && auctionResult.currency !== "USD"
 

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -1,4 +1,5 @@
 import { AuctionResultListItem_auctionResult$data } from "__generated__/AuctionResultListItem_auctionResult.graphql"
+import { navigate } from "app/navigation/navigate"
 import { auctionResultHasPrice, auctionResultText } from "app/Scenes/AuctionResult/helpers"
 import { QAInfoManualPanel, QAInfoRow } from "app/utils/QAInfo"
 import { capitalize } from "lodash"
@@ -7,24 +8,29 @@ import { bullet, Flex, NoArtworkIcon, Spacer, Text, Touchable, useColor } from "
 import { Stopwatch } from "palette/svgs/sf"
 import FastImage from "react-native-fast-image"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useScreenDimensions } from "shared/hooks/useScreenDimensions"
 import { AuctionResultsMidEstimate } from "../AuctionResult/AuctionResultMidEstimate"
 
 interface Props {
   auctionResult: AuctionResultListItem_auctionResult$data
-  onPress: () => void
-  showArtistName?: boolean
-  withHorizontalPadding?: boolean
   first?: boolean
+  onPress?: () => void
+  showArtistName?: boolean
+  width?: number
+  withHorizontalPadding?: boolean
 }
 
 const AuctionResultListItem: React.FC<Props> = ({
   auctionResult,
+  first,
   onPress,
   showArtistName,
+  width,
   withHorizontalPadding = true,
-  first,
 }) => {
   const color = useColor()
+
+  const { width: screenWidth } = useScreenDimensions()
 
   const showPriceUSD = auctionResult.priceRealized?.displayUSD && auctionResult.currency !== "USD"
 
@@ -35,8 +41,23 @@ const AuctionResultListItem: React.FC<Props> = ({
   )
 
   return (
-    <Touchable underlayColor={color("black5")} onPress={onPress}>
-      <Flex px={withHorizontalPadding ? 2 : 0} pb={1} pt={first ? 0 : 1} flexDirection="row">
+    <Touchable
+      underlayColor={color("black5")}
+      onPress={() => {
+        if (onPress) {
+          onPress()
+        } else {
+          navigate(`/artist/${auctionResult.artistID}/auction-result/${auctionResult.internalID}`)
+        }
+      }}
+    >
+      <Flex
+        px={withHorizontalPadding ? 2 : 0}
+        pb={1}
+        pt={first ? 0 : 1}
+        flexDirection="row"
+        width={width || screenWidth}
+      >
         {/* Sale Artwork Thumbnail Image */}
         {!auctionResult.images?.thumbnail?.url ? (
           <Flex
@@ -161,6 +182,7 @@ export const AuctionResultListItemFragmentContainer = createFragmentContainer(
         dateText
         id
         internalID
+        artistID
         artist {
           name
         }

--- a/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
+++ b/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
@@ -1,0 +1,67 @@
+import { HomeUpcomingAuctionsRail_me$key } from "__generated__/HomeUpcomingAuctionsRail_me.graphql"
+import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
+import { SectionTitle } from "app/Components/SectionTitle"
+import { extractNodes } from "app/utils/extractNodes"
+import { Flex } from "palette"
+import { FlatList } from "react-native"
+import { graphql, useFragment } from "react-relay"
+import { useScreenDimensions } from "shared/hooks"
+
+interface HomeUpcomingAuctionsRailProps {
+  me: HomeUpcomingAuctionsRail_me$key
+  mb?: number
+  title: string
+}
+
+export const HomeUpcomingAuctionsRail: React.FC<HomeUpcomingAuctionsRailProps> = ({
+  me,
+  mb,
+  title,
+}) => {
+  const meRes = useFragment(meFragment, me)
+
+  const { width: screenWidth } = useScreenDimensions()
+
+  const filteredAuctionResults = extractNodes(meRes.upcomingAuctionResults).filter(
+    (auctionResult) => auctionResult
+  )
+
+  if (!meRes?.upcomingAuctionResults || meRes?.upcomingAuctionResults?.totalCount === 0) {
+    return null
+  }
+  return (
+    <Flex mb={mb}>
+      <Flex pl="2" pr="2">
+        <SectionTitle
+          title={title}
+          onPress={() => {
+            // do nothing
+          }}
+        />
+      </Flex>
+      <FlatList
+        horizontal
+        data={filteredAuctionResults}
+        showsVerticalScrollIndicator={false}
+        initialNumToRender={3}
+        renderItem={({ item }) => (
+          <AuctionResultListItemFragmentContainer auctionResult={item} width={screenWidth * 0.9} />
+        )}
+      />
+    </Flex>
+  )
+}
+
+const meFragment = graphql`
+  fragment HomeUpcomingAuctionsRail_me on Me {
+    upcomingAuctionResults: auctionResultsByFollowedArtists(first: 10, state: UPCOMING) {
+      totalCount
+      edges {
+        node {
+          ...AuctionResultListItem_auctionResult
+          internalID
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
+++ b/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
@@ -42,7 +42,7 @@ export const HomeUpcomingAuctionsRail: React.FC<HomeUpcomingAuctionsRailProps> =
       <FlatList
         horizontal
         data={filteredAuctionResults}
-        showsVerticalScrollIndicator={false}
+        showsHorizontalScrollIndicator={false}
         initialNumToRender={3}
         renderItem={({ item }) => (
           <AuctionResultListItemFragmentContainer auctionResult={item} width={screenWidth * 0.9} />

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -48,6 +48,7 @@ import { ArtworkRecommendationsRail } from "./Components/ArtworkRecommendationsR
 import { ContentCards } from "./Components/ContentCards"
 import { HomeFeedOnboardingRailFragmentContainer } from "./Components/HomeFeedOnboardingRail"
 import { HomeHeader } from "./Components/HomeHeader"
+import { HomeUpcomingAuctionsRail } from "./Components/HomeUpcomingAuctionsRail"
 import { NewWorksForYouRail } from "./Components/NewWorksForYouRail"
 import { ShowsRailFragmentContainer } from "./Components/ShowsRail"
 import { RailScrollRef } from "./Components/types"
@@ -136,6 +137,11 @@ const Home = (props: Props) => {
       prefetchUrl: "/auctions",
     },
     // Below-The-Fold Modules
+    {
+      title: "Upcoming Auctions",
+      type: "upcoming-auctions",
+      data: meBelow,
+    },
     {
       title: "Latest Auction Results",
       type: "auction-results",
@@ -347,6 +353,14 @@ const Home = (props: Props) => {
                     mb={MODULE_SEPARATOR_HEIGHT}
                   />
                 )
+              case "upcoming-auctions":
+                return (
+                  <HomeUpcomingAuctionsRail
+                    title={item.title}
+                    me={item.data}
+                    mb={MODULE_SEPARATOR_HEIGHT}
+                  />
+                )
               case "viewing-rooms":
                 return (
                   <ViewingRoomsHomeMainRail
@@ -456,6 +470,7 @@ export const HomeFragmentContainer = createRefetchContainer(
         ...AuctionResultsRail_me
         ...RecommendedArtistsRail_me
         ...ArtworkRecommendationsRail_me
+        ...HomeUpcomingAuctionsRail_me
       }
     `,
     articlesConnection: graphql`

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -142,6 +142,7 @@ const Home = (props: Props) => {
       title: "Upcoming Auctions",
       type: "upcoming-auctions",
       data: meBelow,
+      hidden: !showUpcomingAuctionResultsRail,
     },
     {
       title: "Latest Auction Results",
@@ -207,7 +208,6 @@ const Home = (props: Props) => {
       title: "Similar to Works You've Viewed",
       type: "artwork",
       data: homePageBelow?.similarToRecentlyViewedArtworkModule,
-      hidden: !showUpcomingAuctionResultsRail,
     },
   ])
 

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -104,6 +104,7 @@ const Home = (props: Props) => {
 
   const enableArtworkRecommendations = useFeatureFlag("AREnableHomeScreenArtworkRecommendations")
   const enableMyCollectionHFOnboarding = useFeatureFlag("AREnableMyCollectionHFOnboarding")
+  const showUpcomingAuctionResultsRail = useFeatureFlag("ARShowUpcomingAuctionResultsRails")
   const enableLargeNewWorksForYouRail = useLargeNewWorksForYouRail()
 
   // Make sure to include enough modules in the above-the-fold query to cover the whole screen!.
@@ -206,6 +207,7 @@ const Home = (props: Props) => {
       title: "Similar to Works You've Viewed",
       type: "artwork",
       data: homePageBelow?.similarToRecentlyViewedArtworkModule,
+      hidden: !showUpcomingAuctionResultsRail,
     },
   ])
 

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -252,6 +252,11 @@ export const features = defineFeatures({
     readyForRelease: true,
     echoFlagKey: "AREnableConsignmentInquiryFlow",
   },
+  ARShowUpcomingAuctionResultsRails: {
+    description: "Show upcoming auction rails",
+    showInDevMenu: true,
+    readyForRelease: false,
+  },
 })
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [CX-3228] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds upcoming auction results rails to the home page.


https://user-images.githubusercontent.com/11945712/208906298-eeae1cfb-a8fc-4968-9eef-9b3d0dde7246.mov


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes. // will add with the home screen ticket
- [ ] I added an [app state migration].
- [x] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- add upcoming auction results rail - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3228]: https://artsyproduct.atlassian.net/browse/CX-3228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ