### PR TITLE
feat(CX-3229): separate between past and future auction results

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
@@ -4,12 +4,13 @@ import {
   ArtworkFiltersStoreProvider,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
-import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
 import { extractText } from "app/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
-import { mockEdges } from "app/tests/resolveMostRecentRelayOperation"
-import { resolveMostRecentRelayOperation } from "app/tests/resolveMostRecentRelayOperation"
-import { FlatList } from "react-native"
+import {
+  mockEdges,
+  resolveMostRecentRelayOperation,
+} from "app/tests/resolveMostRecentRelayOperation"
+import { SectionList } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
 import {
@@ -69,19 +70,92 @@ describe("ArtistInsightsAuctionResults", () => {
     />
   )
 
-  it("renders list auction results when auction results are available", () => {
-    const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artist: () => ({
-        auctionResultsConnection: {
-          totalCount: 5,
-          edges: mockEdges(5),
+  describe("Upcoming auction reuslt", () => {
+    it("are shown when upcoming auction results are available", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        AuctionResultConnection: (context) => {
+          if (context.alias === "upcomingAuctionResults") {
+            return {
+              totalCount: 2,
+              edges: mockEdges(2),
+            }
+          }
+          return {
+            totalCount: 5,
+            edges: mockEdges(5),
+          }
         },
-      }),
+      })
+
+      expect(tree.root.findAllByType(SectionList).length).toEqual(1)
+      expect(extractText(tree.root.findByType(SectionList))).toContain("Upcoming Auctions")
     })
 
-    expect(tree.root.findAllByType(FlatList).length).toEqual(1)
-    expect(tree.root.findAllByType(AuctionResultListItemFragmentContainer).length).toEqual(5)
+    it("are hidden when no upcoming auction results are available", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        AuctionResultConnection: (context) => {
+          if (context.alias === "upcomingAuctionResults") {
+            return {
+              totalCount: 0,
+              edges: mockEdges(0),
+            }
+          }
+          return {
+            totalCount: 5,
+            edges: mockEdges(5),
+          }
+        },
+      })
+
+      expect(tree.root.findAllByType(SectionList).length).toEqual(1)
+      expect(extractText(tree.root.findByType(SectionList))).not.toContain("Upcoming Auctions")
+    })
+  })
+
+  describe("Past auction reuslt", () => {
+    it("are shown when past auction results are available", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        AuctionResultConnection: (context) => {
+          if (context.alias === "pastAuctionResults") {
+            return {
+              totalCount: 2,
+              edges: mockEdges(2),
+            }
+          }
+          return {
+            totalCount: 5,
+            edges: mockEdges(5),
+          }
+        },
+      })
+
+      expect(tree.root.findAllByType(SectionList).length).toEqual(1)
+      expect(extractText(tree.root.findByType(SectionList))).toContain("Past Auctions")
+    })
+
+    it("are hidden when no past auction results are available", () => {
+      const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        AuctionResultConnection: (context) => {
+          if (context.alias === "pastAuctionResults") {
+            return {
+              totalCount: 0,
+              edges: mockEdges(0),
+            }
+          }
+          return {
+            totalCount: 5,
+            edges: mockEdges(5),
+          }
+        },
+      })
+
+      expect(tree.root.findAllByType(SectionList).length).toEqual(1)
+      expect(extractText(tree.root.findByType(SectionList))).not.toContain("Past Auctions")
+    })
   })
 
   it("renders FilteredArtworkGridZeroState when no auction results are available", () => {

--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
@@ -70,7 +70,7 @@ describe("ArtistInsightsAuctionResults", () => {
     />
   )
 
-  describe("Upcoming auction reuslt", () => {
+  describe("Upcoming auction results", () => {
     it("are shown when upcoming auction results are available", () => {
       const tree = renderWithWrappersLEGACY(<TestRenderer initialData={initialState} />)
       resolveMostRecentRelayOperation(mockEnvironment, {

--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -277,10 +277,28 @@ export const ArtistInsightsAuctionResultsPaginationContainer = createPaginationC
         slug
         id
         internalID
-        pastAuctionResults: auctionResultsConnection(state: PAST) {
+        pastAuctionResults: auctionResultsConnection(
+          state: PAST
+          allowEmptyCreatedDates: $allowEmptyCreatedDates
+          categories: $categories
+          earliestCreatedYear: $earliestCreatedYear
+          keyword: $keyword
+          latestCreatedYear: $latestCreatedYear
+          organizations: $organizations
+          sizes: $sizes
+        ) {
           totalCount
         }
-        upcomingAuctionResults: auctionResultsConnection(state: UPCOMING) {
+        upcomingAuctionResults: auctionResultsConnection(
+          state: UPCOMING
+          allowEmptyCreatedDates: $allowEmptyCreatedDates
+          categories: $categories
+          earliestCreatedYear: $earliestCreatedYear
+          keyword: $keyword
+          latestCreatedYear: $latestCreatedYear
+          organizations: $organizations
+          sizes: $sizes
+        ) {
           totalCount
         }
         auctionResultsConnection(


### PR DESCRIPTION
This PR resolves [CX-3229] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR separates between past and future auction results.


https://user-images.githubusercontent.com/11945712/208971597-10e9e046-ea83-4bc0-baa8-b1e6a831281a.mov




### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- separate between past and future auction results - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3229]: https://artsyproduct.atlassian.net/browse/CX-3229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ