### PR TITLE
fix: Adjust New Works rail artwork rail save icon tracking

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -3,6 +3,7 @@ import { SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$data } from
 import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
 import { ArtworkCardSize, ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import { PrefetchFlatList } from "app/Components/PrefetchFlatList"
+import { Schema } from "app/utils/track"
 import { Spacer } from "palette"
 import React, { ReactElement } from "react"
 import { FlatList } from "react-native"
@@ -18,6 +19,7 @@ interface CommonArtworkRailProps {
   onEndReachedThreshold?: number
   size: ArtworkCardSize
   showSaveIcon?: boolean
+  trackingContextScreenOwnerType?: Schema.OwnerEntityTypes
 }
 
 export interface ArtworkRailProps extends CommonArtworkRailProps {
@@ -39,6 +41,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
   hideArtistName = false,
   artworks,
   showSaveIcon = false,
+  trackingContextScreenOwnerType,
 }) => {
   return (
     <PrefetchFlatList
@@ -66,6 +69,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
           }}
           showSaveIcon={showSaveIcon}
           size={size}
+          trackingContextScreenOwnerType={trackingContextScreenOwnerType}
         />
       )}
       keyExtractor={(item, index) => String(item.slug || index)}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -41,6 +41,7 @@ export interface ArtworkRailCardProps {
   showSaveIcon?: boolean
   size: ArtworkCardSize
   testID?: string
+  trackingContextScreenOwnerType?: Schema.OwnerEntityTypes
 }
 
 export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
@@ -55,6 +56,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   showSaveIcon = false,
   size,
   testID,
+  trackingContextScreenOwnerType,
   ...restProps
 }) => {
   const { trackEvent } = useTracking()
@@ -127,7 +129,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
       },
     })
 
-    trackEvent(tracks.saveOrUnsave(isSaved, internalID, slug))
+    trackEvent(tracks.saveOrUnsave(isSaved, internalID, slug, trackingContextScreenOwnerType))
   }
 
   return (
@@ -392,9 +394,14 @@ const ArtworkCard = styled.TouchableHighlight.attrs(() => ({
 }))``
 
 const tracks = {
-  saveOrUnsave: (isSaved?: boolean | null, internalID?: string, slug?: string) => ({
+  saveOrUnsave: (
+    isSaved?: boolean | null,
+    internalID?: string,
+    slug?: string,
+    contextScreenOwnerType: Schema.OwnerEntityTypes | undefined = Schema.OwnerEntityTypes.Artwork
+  ) => ({
     action_name: isSaved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
-    context_screen_owner_type: Schema.OwnerEntityTypes.Artwork,
+    context_screen_owner_type: contextScreenOwnerType,
     context_module: Schema.ContextModules.ArtworkActions,
     context_screen_owner_id: internalID,
     context_screen_owner_slug: slug,

--- a/src/app/Scenes/Home/Components/NewWorksForYouRail.tsx
+++ b/src/app/Scenes/Home/Components/NewWorksForYouRail.tsx
@@ -57,6 +57,18 @@ export const NewWorksForYouRail: React.FC<NewWorksForYouRailProps & RailScrollPr
     return null
   }
 
+  const handleOnArtworkPress = (artwork: any, position: any) => {
+    trackEvent(
+      HomeAnalytics.artworkThumbnailTapEvent(
+        ContextModule.newWorksForYouRail,
+        artwork.slug,
+        position,
+        "single"
+      )
+    )
+    navigate(artwork.href!)
+  }
+
   return (
     <Flex mb={mb}>
       <View ref={railRef}>
@@ -72,33 +84,15 @@ export const NewWorksForYouRail: React.FC<NewWorksForYouRailProps & RailScrollPr
         {railVariant.variant === "experiment" || enforceLargeRail ? (
           <LargeArtworkRail
             artworks={artworks}
-            onPress={(artwork, position) => {
-              trackEvent(
-                HomeAnalytics.artworkThumbnailTapEvent(
-                  ContextModule.newWorksForYouRail,
-                  artwork.slug,
-                  position,
-                  "single"
-                )
-              )
-              navigate(artwork.href!)
-            }}
+            onPress={handleOnArtworkPress}
             showSaveIcon={enableSaveIcon}
+            trackingContextScreenOwnerType={Schema.OwnerEntityTypes.Home}
           />
         ) : (
           <SmallArtworkRail
             artworks={smallArtworks}
-            onPress={(artwork, position) => {
-              trackEvent(
-                HomeAnalytics.artworkThumbnailTapEvent(
-                  ContextModule.newWorksForYouRail,
-                  artwork.slug,
-                  position,
-                  "single"
-                )
-              )
-              navigate(artwork.href!)
-            }}
+            onPress={handleOnArtworkPress}
+            trackingContextScreenOwnerType={Schema.OwnerEntityTypes.Home}
           />
         )}
       </View>


### PR DESCRIPTION
This PR resolves [this](https://artsyproduct.atlassian.net/browse/CX-3196?focusedCommentId=53440) comment about tracking in [CX-3196] <!-- eg [PROJECT-XXXX] -->

### Description
Adjust New Works For You rail artwork rail save icon tracking (`context_screen_owner_type = “artwork”` => `context_screen_owner_type = “home”`).

**New Tracking Event:**
```
{
  "context_screen": "Home",
  "context_screen_owner_type": "home",
  "action_name": "artworkSave",
  "context_module": "ArtworkActions",
  "context_screen_owner_id": "63963d73856331000b892b42",
  "context_screen_owner_slug": "richard-hambleton-untitled-bright-red"
}
```

**Old Tracking Event:**
```
{
  "context_screen": "Artwork",
  "context_screen_owner_type": "artwork",
  "action_name": "artworkSave",
  "context_module": "ArtworkActions",
  "context_screen_owner_id": "63963d73856331000b892b42",
  "context_screen_owner_slug": "richard-hambleton-untitled-bright-red"
}
```





### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3196]: https://artsyproduct.atlassian.net/browse/CX-3196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ