### PR TITLE
fix: Address QA comments on auction results

### DIFF
--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
@@ -1,5 +1,5 @@
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
-import { Text } from "palette"
+import { Flex, Text } from "palette"
 import { extractText } from "../../tests/extractText"
 import { AuctionResultsMidEstimate } from "./AuctionResultMidEstimate"
 
@@ -8,17 +8,17 @@ describe("AuctionResultMidEstimate", () => {
     const tree = renderWithWrappersLEGACY(
       <AuctionResultsMidEstimate value="25%" shortDescription="short description" />
     )
-    expect(extractText(tree.root.findAllByType(Text)[0])).toContain("short description")
+    expect(extractText(tree.root.findAllByType(Flex)[0])).toContain("short description")
   })
   it("renders properly when the percentage is greater than 5", () => {
     const tree = renderWithWrappersLEGACY(<AuctionResultsMidEstimate value="25%" />)
-    expect(extractText(tree.root.findAllByType(Text)[0])).toEqual("(+25%)")
+    expect(extractText(tree.root.findAllByType(Flex)[0])).toEqual("(+25%)")
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("green100")
   })
 
   it("renders properly when the percentage is less than -5", () => {
     const tree = renderWithWrappersLEGACY(<AuctionResultsMidEstimate value="-25%" />)
-    expect(extractText(tree.root.findAllByType(Text)[0])).toEqual("(-25%)")
+    expect(extractText(tree.root.findAllByType(Flex)[0])).toEqual("(-25%)")
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("red100")
   })
 
@@ -29,8 +29,8 @@ describe("AuctionResultMidEstimate", () => {
     expect(instance1.root.findAllByType(Text)[0].props.color).toEqual("black60")
     expect(instance2.root.findAllByType(Text)[0].props.color).toEqual("black60")
     expect(instance3.root.findAllByType(Text)[0].props.color).toEqual("black60")
-    expect(extractText(instance1.root.findAllByType(Text)[0])).toEqual("(+2%)")
-    expect(extractText(instance2.root.findAllByType(Text)[0])).toEqual("(+2%)")
-    expect(extractText(instance3.root.findAllByType(Text)[0])).toEqual("(-2%)")
+    expect(extractText(instance1.root.findAllByType(Flex)[0])).toEqual("(+2%)")
+    expect(extractText(instance2.root.findAllByType(Flex)[0])).toEqual("(+2%)")
+    expect(extractText(instance3.root.findAllByType(Flex)[0])).toEqual("(-2%)")
   })
 })

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -22,9 +22,12 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
       {!!shortDescription && (
         <Text variant={textVariant} color={color} fontWeight="500">
           {" "}
-          {shortDescription})
+          {shortDescription}
         </Text>
       )}
+      <Text variant={textVariant} color={color} fontWeight="500">
+        )
+      </Text>
     </Flex>
   )
 }

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -1,4 +1,4 @@
-import { Text, TextProps } from "palette"
+import { Flex, Text, TextProps } from "palette"
 
 interface AuctionResultsMidEstimateProps {
   value: string
@@ -14,11 +14,18 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
   const color = ratioColor(value)
 
   return (
-    <Text variant={textVariant} color={color} fontWeight="500">
-      ({value[0] === "-" ? "-" : "+"}
-      {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
-      {!!shortDescription && ` ${shortDescription}`})
-    </Text>
+    <Flex flexDirection="row" pt="3px">
+      <Text variant={textVariant} color={color} fontWeight="500">
+        ({value[0] === "-" ? "-" : "+"}
+        {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
+      </Text>
+      {!!shortDescription && (
+        <Text variant={textVariant} color={color} fontWeight="500">
+          {" "}
+          {shortDescription})
+        </Text>
+      )}
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/AuctionResults/AuctionResultsForArtistsYouFollow.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsForArtistsYouFollow.tsx
@@ -5,7 +5,7 @@ import {
 } from "./AuctionResultsScreenWrapper"
 
 export const AuctionResultsForArtistsYouFollowQueryRenderer = () => {
-  return <AuctionResultsScreenScreenWrapperQueryQueryRenderer state={AuctionResultsState.ALL} />
+  return <AuctionResultsScreenScreenWrapperQueryQueryRenderer state={AuctionResultsState.PAST} />
 }
 
 export const AuctionResultsForArtistsYouFollowPrefetchQuery = graphql`

--- a/src/app/Scenes/AuctionResults/AuctionResultsForArtistsYouFollow.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsForArtistsYouFollow.tsx
@@ -11,7 +11,7 @@ export const AuctionResultsForArtistsYouFollowQueryRenderer = () => {
 export const AuctionResultsForArtistsYouFollowPrefetchQuery = graphql`
   query AuctionResultsForArtistsYouFollowPrefetchQuery {
     me {
-      ...AuctionResultsScreenWrapper_me @arguments(state: ALL)
+      ...AuctionResultsScreenWrapper_me @arguments(state: PAST)
     }
   }
 `

--- a/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
@@ -162,7 +162,7 @@ export enum AuctionResultsState {
 const getTitleByState = (state: AuctionResultsState) => {
   switch (state) {
     case AuctionResultsState.PAST:
-      return "Past Auction Results"
+      return "Latest Auction Results"
     case AuctionResultsState.UPCOMING:
       return "Upcoming Auction Results"
     case AuctionResultsState.ALL:
@@ -173,7 +173,7 @@ const getTitleByState = (state: AuctionResultsState) => {
 const getDescriptionByState = (state: AuctionResultsState) => {
   switch (state) {
     case AuctionResultsState.PAST:
-      return "See past auction results for the artists you follow"
+      return "See auction results for the artists you follow"
     case AuctionResultsState.UPCOMING:
       return "Discover upcoming auctions for artists you follow"
     case AuctionResultsState.ALL:

--- a/src/app/Scenes/Home/Components/AuctionResultsRail.tsx
+++ b/src/app/Scenes/Home/Components/AuctionResultsRail.tsx
@@ -69,7 +69,7 @@ const AuctionResultsRail: React.FC<{ me: AuctionResultsRail_me$data } & Props> =
 export const AuctionResultsRailFragmentContainer = createFragmentContainer(AuctionResultsRail, {
   me: graphql`
     fragment AuctionResultsRail_me on Me {
-      auctionResultsByFollowedArtists(first: 3) {
+      auctionResultsByFollowedArtists(first: 3, state: PAST) {
         totalCount
         edges {
           cursor

--- a/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
+++ b/src/app/Scenes/Home/Components/HomeUpcomingAuctionsRail.tsx
@@ -46,7 +46,11 @@ export const HomeUpcomingAuctionsRail: React.FC<HomeUpcomingAuctionsRailProps> =
         showsHorizontalScrollIndicator={false}
         initialNumToRender={3}
         renderItem={({ item }) => (
-          <AuctionResultListItemFragmentContainer auctionResult={item} width={screenWidth * 0.9} />
+          <AuctionResultListItemFragmentContainer
+            showArtistName
+            auctionResult={item}
+            width={screenWidth * 0.9}
+          />
         )}
       />
     </Flex>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -255,7 +255,8 @@ export const features = defineFeatures({
   ARShowUpcomingAuctionResultsRails: {
     description: "Show upcoming auction rails",
     showInDevMenu: true,
-    readyForRelease: false,
+    readyForRelease: true,
+    echoFlagKey: "ARShowUpcomingAuctionResultsRails",
   },
 })
 


### PR DESCRIPTION
### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR makes the following changes:
- Show artist's name within the upcoming auction results rail
- Enable the ff for the upcoming auction results rail
- Shows only past auction results in the latest auction results rail
- Makes sure that the mid estimate is shown together if it spans across two lines


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

#nochanges

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
