### PR TITLE
fix: padding on mid estimate comp

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -217,40 +217,38 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay, scrollTo
         />
       </Flex>
       {auctionResults.length ? (
-        <Flex py={2}>
-          <SectionList
-            sections={auctionResultsByState}
-            keyExtractor={(item) => item.id}
-            renderItem={({ item }) => (
-              <AuctionResultListItemFragmentContainer
-                auctionResult={item}
-                onPress={() => {
-                  tracking.trackEvent(tracks.tapAuctionGroup(item.internalID, artist.internalID))
-                  navigate(`/artist/${artist?.slug!}/auction-result/${item.internalID}`)
-                }}
-              />
-            )}
-            renderSectionHeader={({ section: { title, count } }) => (
-              <Flex px={2} mb={2}>
-                <Text variant="sm-display">{title}</Text>
-                <Text variant="xs" color="black60">
-                  {count} result{count > 1 ? "s" : ""}
-                </Text>
+        <SectionList
+          sections={auctionResultsByState}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <AuctionResultListItemFragmentContainer
+              auctionResult={item}
+              onPress={() => {
+                tracking.trackEvent(tracks.tapAuctionGroup(item.internalID, artist.internalID))
+                navigate(`/artist/${artist?.slug!}/auction-result/${item.internalID}`)
+              }}
+            />
+          )}
+          renderSectionHeader={({ section: { title, count } }) => (
+            <Flex px={2} my={2}>
+              <Text variant="sm-display">{title}</Text>
+              <Text variant="xs" color="black60">
+                {count} result{count > 1 ? "s" : ""}
+              </Text>
+            </Flex>
+          )}
+          ItemSeparatorComponent={AuctionResultListSeparator}
+          style={{ width: useScreenDimensions().width, left: -20 }}
+          onEndReached={loadMoreAuctionResults}
+          ListFooterComponent={
+            loadingMoreData ? (
+              <Flex my={4}>
+                <Spinner />
               </Flex>
-            )}
-            ItemSeparatorComponent={AuctionResultListSeparator}
-            style={{ width: useScreenDimensions().width, left: -20 }}
-            onEndReached={loadMoreAuctionResults}
-            ListFooterComponent={
-              loadingMoreData ? (
-                <Flex my={4}>
-                  <Spinner />
-                </Flex>
-              ) : null
-            }
-            contentContainerStyle={{ paddingBottom: 20 }}
-          />
-        </Flex>
+            ) : null
+          }
+          contentContainerStyle={{ paddingBottom: 20 }}
+        />
       ) : (
         <Box my="80px">
           <FilteredArtworkGridZeroState

--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -231,7 +231,7 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({ artist, relay, scrollTo
               />
             )}
             renderSectionHeader={({ section: { title, count } }) => (
-              <Flex px={2}>
+              <Flex px={2} mb={2}>
                 <Text variant="sm-display">{title}</Text>
                 <Text variant="xs" color="black60">
                   {count} result{count > 1 ? "s" : ""}

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tests.tsx
@@ -1,5 +1,5 @@
 import { renderWithWrappersLEGACY } from "app/tests/renderWithWrappers"
-import { Flex, Text } from "palette"
+import { Text } from "react-native"
 import { extractText } from "../../tests/extractText"
 import { AuctionResultsMidEstimate } from "./AuctionResultMidEstimate"
 
@@ -8,17 +8,17 @@ describe("AuctionResultMidEstimate", () => {
     const tree = renderWithWrappersLEGACY(
       <AuctionResultsMidEstimate value="25%" shortDescription="short description" />
     )
-    expect(extractText(tree.root.findAllByType(Flex)[0])).toContain("short description")
+    expect(extractText(tree.root.findAllByType(Text)[0])).toContain("short description")
   })
   it("renders properly when the percentage is greater than 5", () => {
     const tree = renderWithWrappersLEGACY(<AuctionResultsMidEstimate value="25%" />)
-    expect(extractText(tree.root.findAllByType(Flex)[0])).toEqual("(+25%)")
+    expect(extractText(tree.root.findAllByType(Text)[0])).toEqual("(+25%)")
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("green100")
   })
 
   it("renders properly when the percentage is less than -5", () => {
     const tree = renderWithWrappersLEGACY(<AuctionResultsMidEstimate value="-25%" />)
-    expect(extractText(tree.root.findAllByType(Flex)[0])).toEqual("(-25%)")
+    expect(extractText(tree.root.findAllByType(Text)[0])).toEqual("(-25%)")
     expect(tree.root.findAllByType(Text)[0].props.color).toEqual("red100")
   })
 
@@ -29,8 +29,8 @@ describe("AuctionResultMidEstimate", () => {
     expect(instance1.root.findAllByType(Text)[0].props.color).toEqual("black60")
     expect(instance2.root.findAllByType(Text)[0].props.color).toEqual("black60")
     expect(instance3.root.findAllByType(Text)[0].props.color).toEqual("black60")
-    expect(extractText(instance1.root.findAllByType(Flex)[0])).toEqual("(+2%)")
-    expect(extractText(instance2.root.findAllByType(Flex)[0])).toEqual("(+2%)")
-    expect(extractText(instance3.root.findAllByType(Flex)[0])).toEqual("(-2%)")
+    expect(extractText(instance1.root.findAllByType(Text)[0])).toEqual("(+2%)")
+    expect(extractText(instance2.root.findAllByType(Text)[0])).toEqual("(+2%)")
+    expect(extractText(instance3.root.findAllByType(Text)[0])).toEqual("(-2%)")
   })
 })

--- a/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
+++ b/src/app/Components/AuctionResult/AuctionResultMidEstimate.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, TextProps } from "palette"
+import { Text, TextProps } from "palette"
 
 interface AuctionResultsMidEstimateProps {
   value: string
@@ -14,21 +14,11 @@ export const AuctionResultsMidEstimate: React.FC<AuctionResultsMidEstimateProps>
   const color = ratioColor(value)
 
   return (
-    <Flex flexDirection="row" pt="3px">
-      <Text variant={textVariant} color={color} fontWeight="500">
-        ({value[0] === "-" ? "-" : "+"}
-        {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
-      </Text>
-      {!!shortDescription && (
-        <Text variant={textVariant} color={color} fontWeight="500">
-          {" "}
-          {shortDescription}
-        </Text>
-      )}
-      <Text variant={textVariant} color={color} fontWeight="500">
-        )
-      </Text>
-    </Flex>
+    <Text variant={textVariant} color={color} fontWeight="500">
+      ({value[0] === "-" ? "-" : "+"}
+      {new Intl.NumberFormat().format(Number(value.replace(/%|-/gm, "")))}%
+      {!!shortDescription && ` ${shortDescription}`})
+    </Text>
   )
 }
 

--- a/src/app/Components/AuctionResultsList.tsx
+++ b/src/app/Components/AuctionResultsList.tsx
@@ -71,6 +71,7 @@ export const AuctionResultsList: React.FC<AuctionResultsListProps> = ({
         keyExtractor={(item) => item.internalID}
         stickySectionHeadersEnabled
         ListHeaderComponent={ListHeaderComponent}
+        ItemSeparatorComponent={() => <Flex mt={2} />}
         renderSectionHeader={({ section: { sectionTitle } }) => (
           <Flex bg="white" mx="2">
             <Text my="2" variant="sm-display">

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -24,7 +24,6 @@ const IMAGE_HEIGHT = 130
 
 const AuctionResultListItem: React.FC<Props> = ({
   auctionResult,
-  first,
   onPress,
   showArtistName,
   width,
@@ -49,13 +48,7 @@ const AuctionResultListItem: React.FC<Props> = ({
         }
       }}
     >
-      <Flex
-        px={withHorizontalPadding ? 2 : 0}
-        pb={1}
-        pt={first ? 0 : 1}
-        flexDirection="row"
-        width={width}
-      >
+      <Flex px={withHorizontalPadding ? 2 : 0} flexDirection="row" width={width}>
         {/* Sale Artwork Thumbnail Image */}
         {!auctionResult.images?.thumbnail?.url ? (
           <Flex
@@ -174,8 +167,8 @@ const AuctionResultPriceSection = ({
 
   if (auctionResultHasPrice(auctionResult)) {
     return (
-      <Text>
-        <Text variant="xs" fontWeight="500" testID="price">
+      <Text testID="price">
+        <Text variant="xs" fontWeight="500">
           {auctionResult.priceRealized?.display}
           {!!showPriceUSD && auctionResult.priceRealized?.display ? ` ${bullet} ` : ""}
           {!!showPriceUSD && (
@@ -201,7 +194,7 @@ const AuctionResultPriceSection = ({
   )
 }
 
-export const AuctionResultListSeparator = () => <Spacer px={2} />
+export const AuctionResultListSeparator = () => <Spacer px={2} pt={2} />
 
 export const AuctionResultListItemFragmentContainer = createFragmentContainer(
   AuctionResultListItem,

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -174,7 +174,7 @@ const AuctionResultPriceSection = ({
 
   if (auctionResultHasPrice(auctionResult)) {
     return (
-      <Flex>
+      <Text>
         <Text variant="xs" fontWeight="500" testID="price">
           {auctionResult.priceRealized?.display}
           {!!showPriceUSD && auctionResult.priceRealized?.display ? ` ${bullet} ` : ""}
@@ -183,14 +183,11 @@ const AuctionResultPriceSection = ({
               {auctionResult.priceRealized?.displayUSD}
             </Text>
           )}{" "}
-          {!!auctionResult.performance?.mid && (
-            <AuctionResultsMidEstimate
-              value={auctionResult.performance.mid}
-              shortDescription="est"
-            />
-          )}
         </Text>
-      </Flex>
+        {!!auctionResult.performance?.mid && (
+          <AuctionResultsMidEstimate value={auctionResult.performance.mid} shortDescription="est" />
+        )}
+      </Text>
     )
   }
 


### PR DESCRIPTION
This PR resolves an issue with padding broken inside the mid-price estimate

![simulator_screenshot_0F6FA44F-32C4-4071-9BC4-68A059444011](https://user-images.githubusercontent.com/11945712/209362094-fde8e200-bbff-4af4-a115-8e5a2fb33650.png)


### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

#nochanges

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
