### PR TITLE
feat(CX-3272): Remove Zipcode in SWA artwork details form

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetailsForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetailsForm.tsx
@@ -24,16 +24,14 @@ import {
   AcceptableCategoryValue,
 } from "./utils/acceptableCategoriesForSubmission"
 import { limitedEditionValue, rarityOptions } from "./utils/rarityOptions"
-import { ArtworkDetailsFormModel, countriesRequirePostalCode } from "./validation"
+import { ArtworkDetailsFormModel } from "./validation"
 
 const StandardSpace = () => <Spacer mt={4} />
 
 export const ArtworkDetailsForm: React.FC = () => {
-  const { values, errors, setFieldValue, touched, handleBlur, setFieldTouched } =
-    useFormikContext<ArtworkDetailsFormModel>()
+  const { values, setFieldValue } = useFormikContext<ArtworkDetailsFormModel>()
   const [isRarityInfoModalVisible, setIsRarityInfoModalVisible] = useState(false)
   const [isProvenanceInfoModalVisible, setIsProvenanceInfoModalVisible] = useState(false)
-  const [isZipInputFocused, setIsZipInputFocused] = useState(false)
 
   useEffect(() => {
     if (values) {
@@ -238,35 +236,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             country: country ?? "",
             countryCode: countryCode ?? "",
           })
-
-          if (!countryCode) {
-            setFieldValue("location.zipCode", "")
-            setFieldTouched("location.zipCode", false)
-          }
         }}
       />
-      {countriesRequirePostalCode.includes(values.location.countryCode.toUpperCase()) && (
-        <>
-          <Spacer m={2} />
-          <Input
-            title="Zip/Postal code"
-            placeholder="Zip/postal code where artwork is located"
-            testID="Submission_ZipInput"
-            value={values.location.zipCode}
-            onBlur={(e) => {
-              setIsZipInputFocused(false)
-              handleBlur("location.zipCode")(e)
-            }}
-            onFocus={() => setIsZipInputFocused(true)}
-            error={
-              !isZipInputFocused && touched.location?.zipCode && errors.location?.zipCode
-                ? errors.location.zipCode
-                : ""
-            }
-            onChangeText={(e) => setFieldValue("location.zipCode", e)}
-          />
-        </>
-      )}
       <StandardSpace />
     </>
   )

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation.ts
@@ -102,8 +102,6 @@ export const countriesRequirePostalCode = [
   "NL", // Netherlands
 ]
 
-const usPostalCodeErrorMessage = "Please enter a 5-digit US zip code."
-
 export const artworkDetailsValidationSchema = Yup.object().shape({
   artist: Yup.string().trim(),
   artistId: Yup.string().required(
@@ -134,16 +132,5 @@ export const artworkDetailsValidationSchema = Yup.object().shape({
     city: Yup.string().required().trim(),
     state: Yup.string(),
     country: Yup.string(),
-    zipCode: Yup.string().when("countryCode", {
-      is: (countryCode) => countryCode?.toUpperCase() === "US",
-      then: Yup.string()
-        .required(usPostalCodeErrorMessage)
-        .matches(/^[0-9]{5}$/, usPostalCodeErrorMessage)
-        .trim(),
-      otherwise: Yup.string().when("countryCode", {
-        is: (countryCode) => countriesRequirePostalCode.includes(countryCode?.toUpperCase()),
-        then: Yup.string().required("Please enter a valid zip/postal code for your region").trim(),
-      }),
-    }),
   }),
 })


### PR DESCRIPTION
This PR resolves [CX-3272] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- Removes Zipcode inn SWA artwork details form

<p>
<img src="https://user-images.githubusercontent.com/18648835/209857209-14e42ab8-fd0c-4115-bebf-9db0bf96cccf.png" width="45%" />
</p>
### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Remove Zipcode in SWA artwork details form - kizito

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3272]: https://artsyproduct.atlassian.net/browse/CX-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ