### PR TITLE
fix: wait for tab instantiation in navActions, handle empty nav state

### DIFF
--- a/src/app/NativeModules/ARScreenPresenterModule.tsx
+++ b/src/app/NativeModules/ARScreenPresenterModule.tsx
@@ -1,4 +1,5 @@
 import {
+  NavigationAction,
   NavigationContainerRef,
   NavigationState,
   StackActions,
@@ -43,6 +44,9 @@ function updateTabStackState(
   updater: (draft: Mutable<NavigationState>) => void
 ) {
   updateNavigationState((state) => {
+    if (!state) {
+      return
+    }
     const tabs = state.routes[0].state?.routes
     const tabState = (
       tabs as Array<{ name: BottomTabType; state: Mutable<NavigationState> }>
@@ -72,20 +76,33 @@ function getCurrentlyPresentedModalNavStackKey() {
   return key
 }
 
+// When coming from a killed state our nav stack may not be
+// set up yet, we check and wait for animations to finish
+// to more reliably navigate
+function dispatchNavAction(action: NavigationAction) {
+  if (!__unsafe_mainModalStackRef.current) {
+    requestAnimationFrame(() => {
+      __unsafe_mainModalStackRef.current?.dispatch(action)
+    })
+  } else {
+    __unsafe_mainModalStackRef.current?.dispatch(action)
+  }
+}
+
 export const ARScreenPresenterModule: typeof NativeModules["ARScreenPresenterModule"] = {
   switchTab(tab: BottomTabType) {
-    __unsafe_mainModalStackRef.current?.dispatch(TabActions.jumpTo(tab))
+    dispatchNavAction(TabActions.jumpTo(tab))
   },
   presentModal(viewDescriptor: ViewDescriptor) {
     if (viewDescriptor.replace) {
-      __unsafe_mainModalStackRef.current?.dispatch(
+      dispatchNavAction(
         StackActions.replace("modal", {
           rootModuleName: viewDescriptor.moduleName,
           rootModuleProps: viewDescriptor.props,
         })
       )
     } else {
-      __unsafe_mainModalStackRef.current?.dispatch(
+      dispatchNavAction(
         StackActions.push("modal", {
           rootModuleName: viewDescriptor.moduleName,
           rootModuleProps: viewDescriptor.props,
@@ -118,26 +135,12 @@ export const ARScreenPresenterModule: typeof NativeModules["ARScreenPresenterMod
   },
   pushView(selectedTab: BottomTabType, viewDescriptor: ViewDescriptor) {
     const stackKey = getCurrentlyPresentedModalNavStackKey() ?? selectedTab
-
-    if (!__unsafe_mainModalStackRef.current) {
-      // modal stack has not yet been instantiated
-      // try to delay nav to after animations
-      requestAnimationFrame(() => {
-        __unsafe_mainModalStackRef.current?.dispatch(
-          StackActions.push("screen:" + stackKey, {
-            moduleName: viewDescriptor.moduleName,
-            props: viewDescriptor.props,
-          })
-        )
+    dispatchNavAction(
+      StackActions.push("screen:" + stackKey, {
+        moduleName: viewDescriptor.moduleName,
+        props: viewDescriptor.props,
       })
-    } else {
-      __unsafe_mainModalStackRef.current?.dispatch(
-        StackActions.push("screen:" + stackKey, {
-          moduleName: viewDescriptor.moduleName,
-          props: viewDescriptor.props,
-        })
-      )
-    }
+    )
   },
   popStack(selectedTab: BottomTabType) {
     updateTabStackState(selectedTab, (state) => {

--- a/src/app/NativeModules/ARScreenPresenterModule.tsx
+++ b/src/app/NativeModules/ARScreenPresenterModule.tsx
@@ -9,7 +9,7 @@ import { ViewDescriptor } from "app/navigation/navigate"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import immer from "immer-peasy"
 import { last } from "lodash"
-import { NativeModules, StatusBar } from "react-native"
+import { InteractionManager, NativeModules, StatusBar } from "react-native"
 /**
  * Here we maintain references to all the navigators in the main app navigation hierarchy, which are:
  * - tab nav stacks
@@ -81,7 +81,7 @@ function getCurrentlyPresentedModalNavStackKey() {
 // to more reliably navigate
 function dispatchNavAction(action: NavigationAction) {
   if (!__unsafe_mainModalStackRef.current) {
-    requestAnimationFrame(() => {
+    InteractionManager.runAfterInteractions(() => {
       __unsafe_mainModalStackRef.current?.dispatch(action)
     })
   } else {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Fixes deeplinks that switch tabs not working when the app is in a killed state:
- Adds request animation frame wrapper to all nav calls to wait for instantiation
- Handles update navState calls before navState exists


#### Before

https://user-images.githubusercontent.com/49686530/210377836-4a6d4c13-41b3-4c34-b4d9-e28f9333c419.mov

#### After

https://user-images.githubusercontent.com/49686530/210377790-4eb60123-aa43-42e0-a816-c924dab8a2ab.mov

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix tab switching deeplinks from a killed state - Brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
