### PR TITLE
chore: More closely match designs for content cards on larger devices GRO-1438

### DIFF
--- a/src/app/Scenes/Home/Components/ContentCards.tsx
+++ b/src/app/Scenes/Home/Components/ContentCards.tsx
@@ -19,6 +19,7 @@ const DESCRIPTION_LINES = fontScale > 1 ? 4 : 3
 
 const ContentCard: React.FC<CardProps> = ({ item }) => {
   const { width: screenWidth } = useScreenDimensions()
+  const cardImageWidth = screenWidth > 700 ? screenWidth / 2 : CARD_IMAGE_WIDTH
   const handlePress = () => {
     ReactAppboy.logContentCardClicked(item.id)
 
@@ -34,9 +35,9 @@ const ContentCard: React.FC<CardProps> = ({ item }) => {
           height={CARD_HEIGHT}
           imageURL={item.image}
           resizeMode="cover"
-          width={CARD_IMAGE_WIDTH}
+          width={cardImageWidth}
         />
-        <Box p={2} width={screenWidth - CARD_IMAGE_WIDTH}>
+        <Box p={2} width={screenWidth - cardImageWidth}>
           <Text color="white100" mb={1} numberOfLines={2} variant="lg-display">
             {item.title}
           </Text>


### PR DESCRIPTION
This PR introduces a "breakpoint" where larger devices get content cards images that are half the width of the screen. This was something we meant to return to after the cards were launched but are just now getting to. Looks like this:

<img width="994" alt="Screen Shot 2023-01-04 at 2 15 47 PM" src="https://user-images.githubusercontent.com/79799/210642459-2b7b7db0-ba8c-40f6-8e1b-d8bd0b50af18.png">

I looked at this live with Lois and we picked 700 as the magic number but if anybody has a better idea I'm open to it!

https://artsyproduct.atlassian.net/browse/GRO-1438

/cc @artsy/grow-devs @kathytafel 

[GRO-1438]: https://artsyproduct.atlassian.net/browse/GRO-1438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ