### PR TITLE
ci: silence betas until var 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -622,6 +622,9 @@ end
 
 error do |lane, exception|
   if lane == :ship_beta or lane == :ship_beta_ios or lane == :ship_beta_android
+    # Set this var if you want to silence beta failure alerts for a while
+    # E.g. you are working on a ci change
+    # Takes a date of format 2023-01-01, recommend only setting for 1 day in future
     silence_beta_failures_until = ENV['FASTLANE_SILENCE_BETA_FAILURES_UNTIL']
     if silence_beta_failures_until != nil
       silence_until_date = Date.parse(silence_beta_failures_until)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -620,6 +620,22 @@ lane :check_flags do
   slack(message: message, default_payloads: [])
 end
 
+lane :test_silence_until do
+  silence_beta_failures_until = ENV['FASTLANE_SILENCE_BETA_FAILURES_UNTIL']
+  silence_until_date = Date.parse(silence_beta_failures_until)
+  today = Date.today
+
+  if silence_until_date <= today
+    puts("silence until date passed we should NOT silence")
+  else
+    puts("silence until date not yet passed we SHOULD silence")
+  end
+
+  puts("Got silence until timestamp: " + silence_beta_failures_until)
+
+  puts("Got today: " + today.to_s)
+end
+
 error do |lane, exception|
   silence_beta_failures = ENV['FASTLANE_SILENCE_BETA_FAILURES']
   if lane == :ship_beta or lane == :ship_beta_ios or lane == :ship_beta_android

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -620,26 +620,17 @@ lane :check_flags do
   slack(message: message, default_payloads: [])
 end
 
-lane :test_silence_until do
-  silence_beta_failures_until = ENV['FASTLANE_SILENCE_BETA_FAILURES_UNTIL']
-  silence_until_date = Date.parse(silence_beta_failures_until)
-  today = Date.today
-
-  if silence_until_date <= today
-    puts("silence until date passed we should NOT silence")
-  else
-    puts("silence until date not yet passed we SHOULD silence")
-  end
-
-  puts("Got silence until timestamp: " + silence_beta_failures_until)
-
-  puts("Got today: " + today.to_s)
-end
-
 error do |lane, exception|
-  silence_beta_failures = ENV['FASTLANE_SILENCE_BETA_FAILURES']
   if lane == :ship_beta or lane == :ship_beta_ios or lane == :ship_beta_android
-    if silence_beta_failures.to_s.downcase != "true"
+    silence_beta_failures_until = ENV['FASTLANE_SILENCE_BETA_FAILURES_UNTIL']
+    if silence_beta_failures_until != nil
+      silence_until_date = Date.parse(silence_beta_failures_until)
+      if silence_until_date <= Date.today
+        notify_beta_failed(exception: exception)
+      else
+        puts("Ignoring beta failure, make sure to unset FASTLANE_SILENCE_BETA_FAILURES_UNTIL to receive alerts")
+      end
+    else
       notify_beta_failed(exception: exception)
     end
   end


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Replaces the old `FASTLANE_SILENCE_BETA_FAILURES` var with `FASTLANE_SILENCE_BETA_FAILURES_UNTIL`, the var should now be populated with a date, e.g. `2023-01-11`. 

It is pretty easy to set the old var and forget about it which makes us miss beta failures which we want to know about. 
Now instead if you are working on a ci change and don't want to blow up slack with error messages you can set this var to one day in the future and after that date is passed alerts will occur again. Recommend only setting a day at a time. 

https://artsy.slack.com/archives/C02BAQ5K7/p1673264417645639

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
