### PR TITLE
fix: space between text

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -38,7 +38,7 @@ const showError = (
     if (res.error_description.includes("no account linked to oauth token")) {
       const message =
         `Your ${providerName} account is not linked to any Artsy account. ` +
-        `If you already have an Artsy account and you want to log in to it via ${providerName},` +
+        `If you already have an Artsy account and you want to log in to it via ${providerName}, ` +
         `you will first need to sign up with ${providerName}. ` +
         `You will then have the option to link the two accounts.
         `


### PR DESCRIPTION
This PR resolves [MOPLAT-501] 

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/17421923/211855587-1d34ccf1-203f-4586-ae70-4f85d39f1477.png)|![image](https://user-images.githubusercontent.com/17421923/211855439-7be02a1c-c807-4cbf-b867-22e0ccda5c56.png)|


### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-501]: https://artsyproduct.atlassian.net/browse/MOPLAT-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ