### PR TITLE
chore(FX-4540): Change "Default" sort option to "Recommended"

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -227,7 +227,7 @@ export const selectedOptionsUnion = ({
     artwork: {
       paramName: FilterParamName.sort,
       paramValue: "-decayed_merch",
-      displayText: "Default",
+      displayText: "Recommended",
     },
     saleArtwork: {
       paramName: FilterParamName.sort,
@@ -253,17 +253,17 @@ export const selectedOptionsUnion = ({
     geneArtwork: {
       paramName: FilterParamName.sort,
       paramValue: "-partner_updated_at",
-      displayText: "Default",
+      displayText: "Recommended",
     },
     tagArtwork: {
       paramName: FilterParamName.sort,
       paramValue: "-partner_updated_at",
-      displayText: "Default",
+      displayText: "Recommended",
     },
     local: {
       paramName: FilterParamName.sort,
       paramValue: "",
-      displayText: "Default",
+      displayText: "Recommendeds",
     },
   }[filterType]
 

--- a/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterStore.tsx
@@ -263,7 +263,7 @@ export const selectedOptionsUnion = ({
     local: {
       paramName: FilterParamName.sort,
       paramValue: "",
-      displayText: "Recommendeds",
+      displayText: "Recommended",
     },
   }[filterType]
 

--- a/src/app/Components/ArtworkFilter/ArtworkFiltersStore.tests.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFiltersStore.tests.tsx
@@ -543,7 +543,7 @@ describe("Select Filters", () => {
 
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
-      displayText: "Default",
+      displayText: "Recommended",
       paramValue: "-decayed_merch",
       paramName: FilterParamName.sort,
     })
@@ -586,7 +586,7 @@ describe("Select Filters", () => {
 
     const filterArtworksStore = getFilterArtworksStore(filterState)
     filterArtworksStore.getActions().selectFiltersAction({
-      displayText: "Default",
+      displayText: "Recommended",
       paramValue: "-decayed_merch",
       paramName: FilterParamName.sort,
     })
@@ -1282,7 +1282,7 @@ describe("selectedOptionsUnion", () => {
           displayText: "Artist 1",
         },
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramName: "sort",
           paramValue: "-decayed_merch",
         },
@@ -1400,7 +1400,7 @@ describe("selectedOptionsUnion", () => {
           displayText: "Artist 1, Artist 2",
         },
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramName: "sort",
           paramValue: "-decayed_merch",
         },
@@ -1524,7 +1524,7 @@ describe("selectedOptionsUnion", () => {
           displayText: "Artist 1, Artist 2",
         },
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramName: "sort",
           paramValue: "-decayed_merch",
         },
@@ -1648,7 +1648,7 @@ describe("selectedOptionsUnion", () => {
           displayText: "Artist 1, Artist 2",
         },
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramName: "sort",
           paramValue: "-decayed_merch",
         },
@@ -1787,7 +1787,7 @@ describe("selectedOptionsUnion", () => {
           displayText: "Artist 1",
         },
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramName: "sort",
           paramValue: "-decayed_merch",
         },

--- a/src/app/Components/ArtworkFilter/FilterArtworksHelpers.tests.tsx
+++ b/src/app/Components/ArtworkFilter/FilterArtworksHelpers.tests.tsx
@@ -17,7 +17,7 @@ describe("changedFiltersParams helper", () => {
   it("when a medium selection changed and sort selection unchanged", () => {
     const appliedFilters = filterArtworksParams([
       {
-        displayText: "Default",
+        displayText: "Recommended",
         paramValue: "-decayed_merch",
         paramName: FilterParamName.sort,
       },
@@ -30,7 +30,7 @@ describe("changedFiltersParams helper", () => {
     expect(
       changedFiltersParams(appliedFilters, [
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramValue: "-decayed_merch",
           paramName: FilterParamName.sort,
         },
@@ -64,7 +64,7 @@ describe("changedFiltersParams helper", () => {
   it("when medium selection and sort selection changed", () => {
     const appliedFilters = filterArtworksParams([
       {
-        displayText: "Default",
+        displayText: "Recommended",
         paramValue: "-decayed_merch",
         paramName: FilterParamName.sort,
       },
@@ -132,7 +132,7 @@ describe("changedFiltersParams helper", () => {
     expect(
       changedFiltersParams(appliedFilters, [
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramValue: "-decayed_merch",
           paramName: FilterParamName.sort,
         },
@@ -158,7 +158,7 @@ describe("changedFiltersParams helper", () => {
     expect(
       changedFiltersParams(appliedFilters, [
         {
-          displayText: "Default",
+          displayText: "Recommended",
           paramValue: "-decayed_merch",
           paramName: FilterParamName.sort,
         },
@@ -178,7 +178,7 @@ describe("filterArtworksParams helper", () => {
   it("maps applied filters to relay params when default filters", () => {
     appliedFilters = [
       {
-        displayText: "Default",
+        displayText: "Recommended",
         paramValue: "-decayed_merch",
         paramName: FilterParamName.sort,
       },

--- a/src/app/Components/ArtworkFilter/Filters/SortOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SortOptions.tests.tsx
@@ -51,7 +51,7 @@ describe("Sort Options Screen", () => {
     it("returns the default option if there are no selected or applied filters", () => {
       const tree = renderWithWrappersLEGACY(<MockSortScreen initialData={initialState} />)
       const selectedOption = selectedSortOption(tree)
-      expect(extractText(selectedOption)).toContain("Default")
+      expect(extractText(selectedOption)).toContain("Recommended")
     })
 
     it("prefers an applied filter over the default filter", () => {

--- a/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SortOptions.tsx
@@ -17,7 +17,7 @@ interface SortOptionsScreenProps
 // Sorting types
 enum ArtworkSorts {
   "Gallery Curated" = "partner_show_position",
-  "Default" = "-decayed_merch",
+  "Recommended" = "-decayed_merch",
   "Price (High to Low)" = "sold,-has_price,-prices",
   "Price (Low to High)" = "sold,-has_price,prices",
   "Recently Updated" = "-partner_updated_at",
@@ -29,7 +29,7 @@ enum ArtworkSorts {
 export type SortOption = keyof typeof ArtworkSorts
 
 export const DEFAULT_ARTWORK_SORT = {
-  displayText: "Default",
+  displayText: "Recommended",
   paramName: FilterParamName.sort,
   paramValue: "-decayed_merch",
 }
@@ -41,13 +41,13 @@ const GALLERY_CURATED_ARTWORK_SORT = {
 }
 
 const DEFAULT_GENE_SORT = {
-  displayText: "Default",
+  displayText: "Recommended",
   paramName: FilterParamName.sort,
   paramValue: "-partner_updated_at",
 }
 
 const DEFAULT_TAG_SORT = {
-  displayText: "Default",
+  displayText: "Recommended",
   paramName: FilterParamName.sort,
   paramValue: "-partner_updated_at",
 }


### PR DESCRIPTION
This PR resolves [FX-4540] <!-- eg [PROJECT-XXXX] -->

### Demo
| Before | After |
| ------------- | ------------- |
| <img width="503" alt="before" src="https://user-images.githubusercontent.com/3513494/212112123-47bcc2ba-6f57-4a62-87ce-8bd5ca75a4f4.png"> | <img width="503" alt="after-1" src="https://user-images.githubusercontent.com/3513494/212112162-10142345-b1a5-48d8-8547-524e5a881ded.png"> | 

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4540]: https://artsyproduct.atlassian.net/browse/FX-4540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ