### PR TITLE
chore: set deep zoom as ready for release

### DIFF
--- a/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ImageCarousel/ImageCarouselEmbedded.tests.tsx
@@ -1,6 +1,5 @@
 import { fireEvent } from "@testing-library/react-native"
 import { renderWithWrappers } from "app/tests/renderWithWrappers"
-import { Platform } from "react-native"
 import { ImageCarouselContext, useNewImageCarouselContext } from "./ImageCarouselContext"
 import { ImageCarouselEmbedded } from "./ImageCarouselEmbedded"
 
@@ -89,24 +88,5 @@ describe("ImageCarouselEmbedded", () => {
 
     fireEvent.press(getAllByLabelText("Image with Loading State")[0])
     expect(context.fullScreenState.current).toBe("none")
-  })
-
-  describe("deepZoom on Android", () => {
-    beforeAll(() => {
-      Platform.OS = "android"
-    })
-
-    afterAll(() => {
-      Platform.OS = "ios"
-    })
-
-    it("suppresses fullScreen when you tap an image with deepZoom because it would fail", () => {
-      const { getAllByLabelText } = renderWithWrappers(<TestWrapper />)
-
-      expect(context.fullScreenState.current).toBe("none")
-
-      fireEvent.press(getAllByLabelText("Image with Loading State")[0])
-      expect(context.fullScreenState.current).toBe("none")
-    })
   })
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -173,7 +173,8 @@ export const features = defineFeatures({
   AREnableAndroidImagesGallery: {
     description: "Enable images gallery on Android",
     showInDevMenu: true,
-    readyForRelease: false,
+    readyForRelease: true,
+    echoFlagKey: "AREnableAndroidImagesGallery",
   },
   AREnableLargeArtworkRailSaveIcon: {
     description: "Enable save icon for large artwork rails",


### PR DESCRIPTION
This PR set the images deep zoom as ready for release on Android

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->



### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Release deep zoom - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
