### PR TITLE
fix: Adjust dirty form check when uploading a new artwork

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -76,22 +76,40 @@ export const MyCollectionArtworkFormMain: React.FC<
       }
     })
     return backListener
-  }, [navigation, artworkState.sessionState.dirtyFormCheckValues])
+  }, [
+    navigation,
+    artworkState.sessionState.formValues,
+    artworkState.sessionState.dirtyFormCheckValues,
+  ])
 
   const isFormDirty = () => {
-    // if you fill an empty field then delete it again, it changes from null to ""
-    const isEqual = (aVal: any, bVal: any) =>
-      (aVal === "" || aVal === null) && (bVal === "" || bVal === null) ? true : aVal === bVal
     const { formValues, dirtyFormCheckValues } = artworkState.sessionState
-    return Object.getOwnPropertyNames(dirtyFormCheckValues).reduce(
-      (accum: boolean, key: string) =>
-        accum ||
-        !isEqual(
-          (formValues as { [key: string]: any })[key],
-          (dirtyFormCheckValues as { [key: string]: any })[key]
-        ),
-      false
-    )
+
+    // Check if any fields are filled out when adding a new artwork
+    if (modalType === "add") {
+      return Object.getOwnPropertyNames(formValues).find(
+        (key) =>
+          !["pricePaidCurrency", "metric", "photos"].includes(key) &&
+          !key.startsWith("artist") &&
+          (formValues as { [key: string]: any })[key]
+      )
+
+      // Check if any fields are different from the original values when editing an artwork
+    } else {
+      // if you fill an empty field then delete it again, it changes from null to ""
+      const isEqual = (aVal: any, bVal: any) =>
+        (aVal === "" || aVal === null) && (bVal === "" || bVal === null) ? true : aVal === bVal
+
+      return Object.getOwnPropertyNames(dirtyFormCheckValues).reduce(
+        (accum: boolean, key: string) =>
+          accum ||
+          !isEqual(
+            (formValues as { [key: string]: any })[key],
+            (dirtyFormCheckValues as { [key: string]: any })[key]
+          ),
+        false
+      )
+    }
   }
 
   const handleCategory = (category: string) => {


### PR DESCRIPTION
This PR resolves [CX-3160] <!-- eg [PROJECT-XXXX] -->

### Description
fix dirty form check when uploading a new artwork.


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- Fix dirty form check when uploading a new artwork - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3160]: https://artsyproduct.atlassian.net/browse/CX-3160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ