### PR TITLE
chore: reverse order of pull lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -331,7 +331,7 @@
     "bracketSpacing": true
   },
   "pull-lock": {
-    "yarn.lock": "yarn install",
-    "ios/Podfile.lock": "echo \"🚨 New Podfile.lock detected!, you might need to run yarn install:all\" 🚨"
+    "ios/Podfile.lock": "echo \"🚨 New Podfile.lock detected!, you might need to run yarn install:all\" 🚨",
+    "yarn.lock": "yarn install"
   }
 }


### PR DESCRIPTION
### Description


After switching branches, I noticed that Podfile warning that we added happens before the `yarn install` step which makes it hard to notice it. This PR reverts it order

<img width="613" alt="Screenshot 2023-01-16 at 16 16 12" src="https://user-images.githubusercontent.com/11945712/212713257-f076d9e8-21a1-49d9-925a-02f11a3f7df7.png">

#nochanges