### PR TITLE
ci(builder): Wait until tests pass before build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,6 +578,7 @@ workflows:
                 - beta-android
                 - update-changelog
           requires:
+            - test-js
             - build-test-js
             - horizon/block
 
@@ -590,6 +591,7 @@ workflows:
                 - beta-ios
                 - update-changelog
           requires:
+            - test-js
             - build-test-js
             - horizon/block
 


### PR DESCRIPTION
### Description

Noticed that we still proceed with the ios and android builds even if tests don't pass; this fixes that. 

cc @artsy/mobile-platform 