### PR TITLE
feat(FX-4536): mark single activity item notification as read when pressed

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -107,6 +107,10 @@ describe("ActivityItem", () => {
 
     fireEvent.press(getByText("Notification Title"))
 
+    // resolving the mark as read mutation
+    resolveMostRecentRelayOperation(mockEnvironment)
+    await flushPromiseQueue()
+
     expect(navigate).toHaveBeenCalledWith(targetUrl, {
       passProps: {
         predefinedFilters: [
@@ -132,6 +136,10 @@ describe("ActivityItem", () => {
     await flushPromiseQueue()
 
     fireEvent.press(getByText("Notification Title"))
+
+    // resolving the mark as read mutation
+    resolveMostRecentRelayOperation(mockEnvironment)
+    await flushPromiseQueue()
 
     expect(navigate).toHaveBeenCalledWith(alertTargetUrl, {
       passProps: {

--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -182,6 +182,30 @@ describe("ActivityItem", () => {
       const indicator = getByLabelText("Unread notification indicator")
       expect(indicator).toBeTruthy()
     })
+
+    it("should be removed after the activity item is pressed", async () => {
+      const { getByText, queryByLabelText } = renderWithHookWrappersTL(
+        <TestRenderer />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Notification: () => ({
+          ...notification,
+          isUnread: true,
+        }),
+      })
+      await flushPromiseQueue()
+
+      expect(queryByLabelText("Unread notification indicator")).toBeTruthy()
+      fireEvent.press(getByText("Notification Title"))
+
+      // resolving the mark as read mutation
+      resolveMostRecentRelayOperation(mockEnvironment)
+      await flushPromiseQueue()
+
+      expect(queryByLabelText("Unread notification indicator")).toBeFalsy()
+    })
   })
 
   describe("Notification type", () => {

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -33,11 +33,6 @@ const updater = (
 const UNREAD_INDICATOR_SIZE = 8
 const ARTWORK_IMAGE_SIZE = 55
 
-interface NavigateToActivityItemProps {
-  predefinedFilters: FilterArray
-  searchCriteriaID: string
-}
-
 export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const [markAsRead] = useMutation<ActivityItemMarkAsReadMutation>(markNotificationAsRead)
   const tracking = useTracking()
@@ -54,9 +49,6 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   }
   const notificationTypeLabel = getNotificationType()
 
-  const navigateToActivityItem = (passProps: NavigateToActivityItemProps) =>
-    navigate(item.targetHref, { passProps })
-
   const handlePress = () => {
     const splittedQueryParams = item.targetHref.split("?")
     const queryParams = last(splittedQueryParams) ?? ""
@@ -66,12 +58,20 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
       (sortEntity) => sortEntity.paramValue === "-published_at"
     )!
 
+    const navigateToActivityItem = () =>
+      navigate(item.targetHref, {
+        passProps: {
+          predefinedFilters: [sortFilterItem] as FilterArray,
+          searchCriteriaID: parsed.search_criteria_id,
+        },
+      })
+
     tracking.trackEvent(tracks.tappedNotification(item.notificationType))
 
     markAsRead({
       variables: {
         input: {
-          id: item.internalID,
+          id: "item.internalID",
         },
       },
       optimisticUpdater: (store) => {
@@ -81,16 +81,10 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
         updater(item.id, store)
       },
       onCompleted: () => {
-        navigateToActivityItem({
-          predefinedFilters: [sortFilterItem] as FilterArray,
-          searchCriteriaID: parsed.search_criteria_id,
-        })
+        navigateToActivityItem()
       },
       onError: () => {
-        navigateToActivityItem({
-          predefinedFilters: [sortFilterItem] as FilterArray,
-          searchCriteriaID: parsed.search_criteria_id,
-        })
+        navigateToActivityItem()
       },
     })
   }

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -1,5 +1,6 @@
 import { ActionType } from "@artsy/cohesion"
 import { ClickedActivityPanelNotificationItem } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
+import { captureMessage } from "@sentry/react-native"
 import { ActivityItem_item$key } from "__generated__/ActivityItem_item.graphql"
 import {
   ActivityItemMarkAsReadMutation,
@@ -68,10 +69,12 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
 
     tracking.trackEvent(tracks.tappedNotification(item.notificationType))
 
+    navigateToActivityItem()
+
     markAsRead({
       variables: {
         input: {
-          id: "item.internalID",
+          id: item.internalID,
         },
       },
       optimisticUpdater: (store) => {
@@ -80,11 +83,8 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
       updater: (store) => {
         updater(item.id, store)
       },
-      onCompleted: () => {
-        navigateToActivityItem()
-      },
-      onError: () => {
-        navigateToActivityItem()
+      onError: (error) => {
+        captureMessage(error?.stack!)
       },
     })
   }


### PR DESCRIPTION
This PR resolves [FX-4536] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds mutation to mark single notification as read.

#### Video

https://user-images.githubusercontent.com/21178754/213689656-b3edf869-e245-4a4f-8aa9-44707760ba62.mp4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

- mark single activity item notification as read when pressed - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4536]: https://artsyproduct.atlassian.net/browse/FX-4536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ