### PR TITLE
chore: Update Widget for Trove name change GRO-1489

### DIFF
--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
@@ -10,8 +10,8 @@ extension FeaturedArtworks {
             StaticConfiguration(kind: Widget.kind, provider: Provider()) { entry in
                 View(entry: entry)
             }
-            .configurationDisplayName("Trove")
-            .description("The best works on Artsy this week.")
+            .configurationDisplayName("New This Week")
+            .description("A curated selection of newly uploaded works from galleries, fairs, and auctions.")
             .supportedFamilies(View.supportedFamilies)
         }
     }

--- a/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
+++ b/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
@@ -10,8 +10,8 @@ extension FullBleed {
             StaticConfiguration(kind: Widget.kind, provider: Provider()) { entry in
                 View(entry: entry)
             }
-            .configurationDisplayName("Trove")
-            .description("The best works on Artsy this week.")
+            .configurationDisplayName("New This Week")
+            .description("A curated selection of newly uploaded works from galleries, fairs, and auctions.")
             .supportedFamilies(View.supportedFamilies)
         }
     }


### PR DESCRIPTION
Just a minor PR to update some copy for the Trove name change. There will be a follow up ticket over on Gravity to alter how the artworks are picked but this at least gets the words to match.

https://artsyproduct.atlassian.net/browse/GRO-1489

/cc @artsy/grow-devs