### PR TITLE
feat(FX-4537): Manage top-level activity panel indicator (blue dot) based on if there any entries more recent than the last time the activity panel was opened

### DIFF
--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -36,7 +36,7 @@ export const ActivityContent: React.FC<ActivityProps> = ({ type }) => {
 
 export const ActivityContainer: React.FC<ActivityProps> = (props) => {
   useEffect(() => {
-    GlobalStore.actions.bottomTabs.displayUnreadActivityPanelIndicatorChanged(false)
+    GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
   }, [])
 
   return (

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -8,6 +8,7 @@ import {
   StickyTabSection,
 } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
+import { GlobalStore } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Separator, Spinner } from "palette"
 import { useContext, useEffect, useState } from "react"
@@ -43,6 +44,9 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
     return true
   })
 
+  const recentNotification = notifications[0]
+  const recentNotificationPublishedAt = recentNotification?.rawPublishedAt
+
   const sections: StickyTabSection[] = notifications.map((notification) => ({
     key: notification.internalID,
     content: <ActivityItem item={notification} />,
@@ -77,6 +81,14 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
       </>
     )
   }, [hasUnreadNotifications])
+
+  useEffect(() => {
+    if (type === "all" && recentNotificationPublishedAt) {
+      GlobalStore.actions.bottomTabs.setLastSeendNotificationPublishedAt(
+        recentNotificationPublishedAt
+      )
+    }
+  }, [type, recentNotificationPublishedAt])
 
   if (notifications.length === 0) {
     return (
@@ -130,6 +142,7 @@ const notificationsConnectionFragment = graphql`
         node {
           internalID
           notificationType
+          rawPublishedAt: publishedAt
           artworks: artworksConnection {
             totalCount
           }

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -84,7 +84,7 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
 
   useEffect(() => {
     if (type === "all" && recentNotificationPublishedAt) {
-      GlobalStore.actions.bottomTabs.setLastSeendNotificationPublishedAt(
+      GlobalStore.actions.bottomTabs.setLastSeenNotificationPublishedAt(
         recentNotificationPublishedAt
       )
     }

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -73,12 +73,12 @@ describe(BottomTabs, () => {
 
   describe("a blue dot on home icon", () => {
     describe("should be displayed if there are unread notifications", () => {
-      it("`lastSeendNotificationPublishedAt` is empty", async () => {
+      it("`lastSeenNotificationPublishedAt` is empty", async () => {
         const currentDate = DateTime.local()
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastSeendNotificationPublishedAt: null,
+            lastSeenNotificationPublishedAt: null,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -116,7 +116,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastSeendNotificationPublishedAt: prevNotificationPublishedAt,
+            lastSeenNotificationPublishedAt: prevNotificationPublishedAt,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -155,12 +155,12 @@ describe(BottomTabs, () => {
     })
 
     describe("should NOT be displayed if there are NO unread notifications", () => {
-      it("`lastSeendNotificationPublishedAt` is empty", async () => {
+      it("`lastSeenNotificationPublishedAt` is empty", async () => {
         const publishedAt = DateTime.local().toISO()
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastSeendNotificationPublishedAt: null,
+            lastSeenNotificationPublishedAt: null,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -194,7 +194,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastSeendNotificationPublishedAt: publishedAt,
+            lastSeenNotificationPublishedAt: publishedAt,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -228,7 +228,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastSeendNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
+            lastSeenNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -74,81 +74,248 @@ describe(BottomTabs, () => {
     await flushPromiseQueue()
   })
 
-  it(`displays a blue dot on home icon if there are unread notifications`, async () => {
-    const currentDate = DateTime.local()
+  describe("a blue dot on home icon", () => {
+    describe("should be displayed if there are unread notifications", () => {
+      it("`lastNotificationPublishedAt` has default value", async () => {
+        const currentDate = DateTime.local()
 
-    __globalStoreTestUtils__?.injectState({
-      bottomTabs: {
-        lastNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
-      },
-    })
-    const tree = renderWithWrappersLEGACY(<TestWrapper />)
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: null,
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    const prevHomeButton = findButtonByTab(tree, "home")
-    expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+        const prevHomeButton = findButtonByTab(tree, "home")
+        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
 
-    resolveNotificationsInfoQuery({
-      Me: () => ({
-        unreadConversationCount: 5,
-        unreadNotificationsCount: 1,
-      }),
-      Viewer: () => ({
-        notificationsConnection: {
-          edges: [
-            {
-              node: {
-                publishedAt: currentDate.toISO(),
-              },
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 1,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: currentDate.toISO(),
+                  },
+                },
+              ],
             },
-          ],
-        },
-      }),
-    })
+          }),
+        })
 
-    await flushPromiseQueue()
+        await flushPromiseQueue()
 
-    const currentHomeButton = findButtonByTab(tree, "home")
-    expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
 
-    // need to prevent this test's requests from leaking into the next test
-    await flushPromiseQueue()
-  })
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
 
-  it(`doesn't display a blue dot on home icon if there are no unread notifications`, async () => {
-    const publishedAt = DateTime.local().toISO()
+      // TODO: Fix this test case
+      it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
+        const publishedAt = DateTime.local().toISO()
 
-    __globalStoreTestUtils__?.injectState({
-      bottomTabs: {
-        lastNotificationPublishedAt: publishedAt,
-      },
-    })
-    const tree = renderWithWrappersLEGACY(<TestWrapper />)
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: publishedAt,
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    resolveNotificationsInfoQuery({
-      Me: () => ({
-        unreadConversationCount: 5,
-        unreadNotificationsCount: 0,
-      }),
-      Viewer: () => ({
-        notificationsConnection: {
-          edges: [
-            {
-              node: {
-                publishedAt: publishedAt,
-              },
+        const prevHomeButton = findButtonByTab(tree, "home")
+        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 1,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: publishedAt,
+                  },
+                },
+              ],
             },
-          ],
-        },
-      }),
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
+
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
+
+      it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
+        const currentDate = DateTime.local()
+        const prevNotificationPublishedAt = currentDate.minus({ hour: 1 }).toISO()
+
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: prevNotificationPublishedAt,
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
+
+        const prevHomeButton = findButtonByTab(tree, "home")
+        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 1,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: currentDate.toISO(),
+                  },
+                },
+                {
+                  node: {
+                    publishedAt: prevNotificationPublishedAt,
+                  },
+                },
+              ],
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
+
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
     })
 
-    await flushPromiseQueue()
+    describe("should NOT be displayed if there are NO unread notifications", () => {
+      it("`lastNotificationPublishedAt` has default value", async () => {
+        const publishedAt = DateTime.local().toISO()
 
-    const currentHomeButton = findButtonByTab(tree, "home")
-    expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: null,
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    // need to prevent this test's requests from leaking into the next test
-    await flushPromiseQueue()
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 0,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: publishedAt,
+                  },
+                },
+              ],
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
+
+      it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
+        const publishedAt = DateTime.local().toISO()
+
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: publishedAt,
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
+
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 0,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: publishedAt,
+                  },
+                },
+              ],
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
+
+      it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
+        const currentDate = DateTime.local()
+
+        __globalStoreTestUtils__?.injectState({
+          bottomTabs: {
+            lastNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
+          },
+        })
+        const tree = renderWithWrappersLEGACY(<TestWrapper />)
+
+        resolveNotificationsInfoQuery({
+          Me: () => ({
+            unreadConversationCount: 5,
+            unreadNotificationsCount: 0,
+          }),
+          Viewer: () => ({
+            notificationsConnection: {
+              edges: [
+                {
+                  node: {
+                    publishedAt: currentDate.toISO(),
+                  },
+                },
+              ],
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        const currentHomeButton = findButtonByTab(tree, "home")
+        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+
+        // need to prevent this test's requests from leaking into the next test
+        await flushPromiseQueue()
+      })
+    })
   })
 
   it(`fetches the notifications info on mount`, async () => {

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -69,9 +69,6 @@ describe(BottomTabs, () => {
 
     const inboxButton = findButtonByTab(tree, "inbox")
     expect((inboxButton!.props as ButtonProps).badgeCount).toBe(4)
-
-    // need to prevent this test's requests from leaking into the next test
-    await flushPromiseQueue()
   })
 
   describe("a blue dot on home icon", () => {
@@ -111,9 +108,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
 
       it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
@@ -151,9 +145,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
 
       it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
@@ -197,9 +188,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
     })
 
@@ -236,9 +224,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
 
       it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
@@ -273,9 +258,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
 
       it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
@@ -310,9 +292,6 @@ describe(BottomTabs, () => {
 
         const currentHomeButton = findButtonByTab(tree, "home")
         expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        // need to prevent this test's requests from leaking into the next test
-        await flushPromiseQueue()
       })
     })
   })

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -72,7 +72,7 @@ describe(BottomTabs, () => {
   })
 
   describe("a blue dot on home icon", () => {
-    describe("should be displayed if there are unread notifications", () => {
+    describe("should be displayed if there are unseen notifications", () => {
       it("`lastSeenNotificationPublishedAt` is empty", async () => {
         const currentDate = DateTime.local()
 
@@ -154,7 +154,7 @@ describe(BottomTabs, () => {
       })
     })
 
-    describe("should NOT be displayed if there are NO unread notifications", () => {
+    describe("should NOT be displayed if there are NO unseen notifications", () => {
       it("`lastSeenNotificationPublishedAt` is empty", async () => {
         const publishedAt = DateTime.local().toISO()
 

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -116,7 +116,6 @@ describe(BottomTabs, () => {
         await flushPromiseQueue()
       })
 
-      // TODO: Fix this test case
       it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
         const publishedAt = DateTime.local().toISO()
 

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -39,6 +39,13 @@ function resolveNotificationsInfoQuery(resolvers: MockResolvers) {
   )
 }
 
+const findButtonByTab = (tree: ReactTestRenderer, tab: ButtonProps["tab"]) => {
+  const buttons = tree.root.findAllByType(BottomTabsButton)
+  const buttonByTab = buttons.find((button) => (button.props as ButtonProps).tab === tab)
+
+  return buttonByTab
+}
+
 const TestWrapper: React.FC<Partial<BottomTabBarProps>> = (props) => {
   return (
     <GlobalStoreProvider>
@@ -59,9 +66,7 @@ describe(BottomTabs, () => {
     })
     const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    const inboxButton = tree.root
-      .findAllByType(BottomTabsButton)
-      .find((button) => (button.props as ButtonProps).tab === "inbox")
+    const inboxButton = findButtonByTab(tree, "inbox")
     expect((inboxButton!.props as ButtonProps).badgeCount).toBe(4)
 
     // need to prevent this test's requests from leaking into the next test
@@ -74,9 +79,7 @@ describe(BottomTabs, () => {
     })
     const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    const homeButton = tree.root
-      .findAllByType(BottomTabsButton)
-      .find((button) => (button.props as ButtonProps).tab === "home")
+    const homeButton = findButtonByTab(tree, "home")
     expect((homeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
 
     // need to prevent this test's requests from leaking into the next test
@@ -89,9 +92,7 @@ describe(BottomTabs, () => {
     })
     const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-    const homeButton = tree.root
-      .findAllByType(BottomTabsButton)
-      .find((button) => (button.props as ButtonProps).tab === "home")
+    const homeButton = findButtonByTab(tree, "home")
     expect((homeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
 
     // need to prevent this test's requests from leaking into the next test
@@ -114,16 +115,10 @@ describe(BottomTabs, () => {
 
     await flushPromiseQueue()
 
-    const inboxButton = tree.root
-      .findAllByType(BottomTabsButton)
-      .find((button) => (button.props as ButtonProps).tab === "inbox")
-
+    const inboxButton = findButtonByTab(tree, "inbox")
     expect((inboxButton!.props as ButtonProps).badgeCount).toBe(5)
 
-    const homeButton = tree.root
-      .findAllByType(BottomTabsButton)
-      .find((button) => (button.props as ButtonProps).tab === "home")
-
+    const homeButton = findButtonByTab(tree, "home")
     expect((homeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
   })
 
@@ -185,19 +180,11 @@ describe(BottomTabs, () => {
     await flushPromiseQueue()
 
     // @ts-ignore
-    const inboxButton = tree.root
-      .findAllByType(BottomTabsButton)
-      // @ts-ignore
-      .find((button) => (button.props as ButtonProps).tab === "inbox")
-
+    const inboxButton = findButtonByTab(tree, "inbox")
     expect((inboxButton!.props as ButtonProps).badgeCount).toBe(3)
 
     // @ts-ignore
-    const homeButton = tree.root
-      .findAllByType(BottomTabsButton)
-      // @ts-ignore
-      .find((button) => (button.props as ButtonProps).tab === "home")
-
+    const homeButton = findButtonByTab(tree, "home")
     expect((homeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
   })
 

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -73,12 +73,12 @@ describe(BottomTabs, () => {
 
   describe("a blue dot on home icon", () => {
     describe("should be displayed if there are unread notifications", () => {
-      it("`lastNotificationPublishedAt` has default value", async () => {
+      it("`lastSeendNotificationPublishedAt` has default value", async () => {
         const currentDate = DateTime.local()
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: null,
+            lastSeendNotificationPublishedAt: null,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -115,7 +115,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: publishedAt,
+            lastSeendNotificationPublishedAt: publishedAt,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -153,7 +153,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: prevNotificationPublishedAt,
+            lastSeendNotificationPublishedAt: prevNotificationPublishedAt,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -192,12 +192,12 @@ describe(BottomTabs, () => {
     })
 
     describe("should NOT be displayed if there are NO unread notifications", () => {
-      it("`lastNotificationPublishedAt` has default value", async () => {
+      it("`lastSeendNotificationPublishedAt` has default value", async () => {
         const publishedAt = DateTime.local().toISO()
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: null,
+            lastSeendNotificationPublishedAt: null,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -231,7 +231,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: publishedAt,
+            lastSeendNotificationPublishedAt: publishedAt,
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)
@@ -265,7 +265,7 @@ describe(BottomTabs, () => {
 
         __globalStoreTestUtils__?.injectState({
           bottomTabs: {
-            lastNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
+            lastSeendNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
           },
         })
         const tree = renderWithWrappersLEGACY(<TestWrapper />)

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -73,7 +73,7 @@ describe(BottomTabs, () => {
 
   describe("a blue dot on home icon", () => {
     describe("should be displayed if there are unread notifications", () => {
-      it("`lastSeendNotificationPublishedAt` has default value", async () => {
+      it("`lastSeendNotificationPublishedAt` is empty", async () => {
         const currentDate = DateTime.local()
 
         __globalStoreTestUtils__?.injectState({
@@ -97,43 +97,6 @@ describe(BottomTabs, () => {
                 {
                   node: {
                     publishedAt: currentDate.toISO(),
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
-      })
-
-      it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
-        const publishedAt = DateTime.local().toISO()
-
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeendNotificationPublishedAt: publishedAt,
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
-
-        const prevHomeButton = findButtonByTab(tree, "home")
-        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 1,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: publishedAt,
                   },
                 },
               ],
@@ -192,7 +155,7 @@ describe(BottomTabs, () => {
     })
 
     describe("should NOT be displayed if there are NO unread notifications", () => {
-      it("`lastSeendNotificationPublishedAt` has default value", async () => {
+      it("`lastSeendNotificationPublishedAt` is empty", async () => {
         const publishedAt = DateTime.local().toISO()
 
         __globalStoreTestUtils__?.injectState({

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -24,11 +24,11 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
   )
 
   useEffect(() => {
-    GlobalStore.actions.bottomTabs.fetchAllNotificationsCounts()
+    GlobalStore.actions.bottomTabs.fetchNotificationsInfo()
   }, [])
 
   useInterval(() => {
-    GlobalStore.actions.bottomTabs.fetchAllNotificationsCounts()
+    GlobalStore.actions.bottomTabs.fetchNotificationsInfo()
     // run this every 60 seconds
   }, 1000 * 60)
 

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -19,8 +19,8 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
     (state) => state.bottomTabs.sessionState.unreadCounts.unreadConversation
   )
 
-  const displayUnreadActivityPanelIndicator = GlobalStore.useAppState(
-    (state) => state.bottomTabs.sessionState.displayUnreadActivityPanelIndicator
+  const displayUnseenNotificationsIndicator = GlobalStore.useAppState(
+    (state) => state.bottomTabs.sessionState.displayUnseenNotificationsIndicator
   )
 
   useEffect(() => {
@@ -48,7 +48,7 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
         }}
       />
       <Flex flexDirection="row" height={ICON_HEIGHT} px={1}>
-        <BottomTabsButton tab="home" forceDisplayVisualClue={displayUnreadActivityPanelIndicator} />
+        <BottomTabsButton tab="home" forceDisplayVisualClue={displayUnseenNotificationsIndicator} />
         <BottomTabsButton tab="search" />
         <BottomTabsButton tab="inbox" badgeCount={unreadConversationCount} />
         <BottomTabsButton tab="sell" />

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -36,8 +36,8 @@ export interface BottomTabsModel {
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
-  lastSeendNotificationPublishedAt: string | null
-  setLastSeendNotificationPublishedAt: Action<BottomTabsModel, string | null>
+  lastSeenNotificationPublishedAt: string | null
+  setLastSeenNotificationPublishedAt: Action<BottomTabsModel, string | null>
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   syncActivityPanelState: Action<
@@ -61,9 +61,9 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     tabProps: {},
     selectedTab: "home",
   },
-  lastSeendNotificationPublishedAt: null,
-  setLastSeendNotificationPublishedAt: action((state, payload) => {
-    state.lastSeendNotificationPublishedAt = payload
+  lastSeenNotificationPublishedAt: null,
+  setLastSeenNotificationPublishedAt: action((state, payload) => {
+    state.lastSeenNotificationPublishedAt = payload
   }),
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
@@ -199,9 +199,9 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     const lastNotification = notifications[0] as NotificationNode | undefined
     const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
     const isLastSeenPublishedAtEmpty =
-      state.lastSeendNotificationPublishedAt === null && lastNotificationPublishedAt
+      state.lastSeenNotificationPublishedAt === null && lastNotificationPublishedAt
     const isNewPublishedAtAvailable = checkIsNewPublishedAt(
-      state.lastSeendNotificationPublishedAt,
+      state.lastSeenNotificationPublishedAt,
       lastNotificationPublishedAt
     )
 

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -39,7 +39,10 @@ export interface BottomTabsModel {
   lastNotificationPublishedAt: string | null
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
-  actionChanged: Action<BottomTabsModel, { notifications: NotificationNode[]; unreadCount: number }>
+  syncActivityPanelState: Action<
+    BottomTabsModel,
+    { notifications: NotificationNode[]; unreadCount: number }
+  >
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   unreadActivityPanelNotificationsCountChanged: Action<BottomTabsModel, number>
   fetchNotificationsInfo: Thunk<BottomTabsModel>
@@ -158,7 +161,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
 
       GlobalStore.actions.bottomTabs.unreadConversationCountChanged(conversations)
       GlobalStore.actions.bottomTabs.unreadActivityPanelNotificationsCountChanged(notifications)
-      GlobalStore.actions.bottomTabs.actionChanged({
+      GlobalStore.actions.bottomTabs.syncActivityPanelState({
         notifications: formattedNotificationNodes,
         unreadCount: notifications,
       })
@@ -181,7 +184,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
   }),
-  actionChanged: action((state, payload) => {
+  syncActivityPanelState: action((state, payload) => {
     const notifications = payload.notifications.filter((node) => {
       if (isArtworksBasedNotification(node.notificationType)) {
         return node.artworksCount > 0

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -196,22 +196,18 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
     const isLastPublishedAtEmpty =
       state.lastNotificationPublishedAt === null && lastNotificationPublishedAt
-    const isSameOrAfterPublishedAt = checkSameOrAfterPublishedAt(
+    const isNewPublishedAtAvailable = checkIsNewPublishedAt(
       state.lastNotificationPublishedAt,
       lastNotificationPublishedAt
     )
 
-    if (isLastPublishedAtEmpty || isSameOrAfterPublishedAt) {
-      state.lastNotificationPublishedAt = lastNotificationPublishedAt
+    if (isLastPublishedAtEmpty || isNewPublishedAtAvailable) {
       state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
     }
   }),
 })
 
-const checkSameOrAfterPublishedAt = (
-  prevPublishedAt: string | null,
-  newPublishedAt: string | null
-) => {
+const checkIsNewPublishedAt = (prevPublishedAt: string | null, newPublishedAt: string | null) => {
   if (prevPublishedAt === null || newPublishedAt === null) {
     return false
   }
@@ -219,5 +215,5 @@ const checkSameOrAfterPublishedAt = (
   const prevPublishedDate = DateTime.fromISO(prevPublishedAt)
   const newPublishedDate = DateTime.fromISO(newPublishedAt)
 
-  return newPublishedDate >= prevPublishedDate
+  return newPublishedDate > prevPublishedDate
 }

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -37,6 +37,7 @@ export interface BottomTabsModel {
     selectedTab: BottomTabType
   }
   lastSeendNotificationPublishedAt: string | null
+  setLastSeendNotificationPublishedAt: Action<BottomTabsModel, string | null>
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   syncActivityPanelState: Action<
@@ -61,6 +62,9 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     selectedTab: "home",
   },
   lastSeendNotificationPublishedAt: null,
+  setLastSeendNotificationPublishedAt: action((state, payload) => {
+    state.lastSeendNotificationPublishedAt = payload
+  }),
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
       actions.unreadConversationCountChanged,

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -1,6 +1,6 @@
 import { captureException } from "@sentry/react-native"
-import { BottomTabsModelFetchAllNotificationsCountsQuery } from "__generated__/BottomTabsModelFetchAllNotificationsCountsQuery.graphql"
 import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__generated__/BottomTabsModelFetchCurrentUnreadConversationCountQuery.graphql"
+import { BottomTabsModelFetchNotificationsInfoQuery } from "__generated__/BottomTabsModelFetchNotificationsInfoQuery.graphql"
 import { GlobalStore } from "app/store/GlobalStore"
 import { createEnvironment } from "app/system/relay/createEnvironment"
 import {
@@ -29,7 +29,7 @@ export interface BottomTabsModel {
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   unreadActivityPanelNotificationsCountChanged: Action<BottomTabsModel, number>
-  fetchAllNotificationsCounts: Thunk<BottomTabsModel>
+  fetchNotificationsInfo: Thunk<BottomTabsModel>
   displayUnreadActivityPanelIndicatorChanged: Action<BottomTabsModel, boolean>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
 }
@@ -108,14 +108,14 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
 
     state.sessionState.unreadCounts.unreadActivityPanelNotifications = unreadCount
   }),
-  fetchAllNotificationsCounts: thunk(async () => {
+  fetchNotificationsInfo: thunk(async () => {
     try {
-      const query = fetchQuery<BottomTabsModelFetchAllNotificationsCountsQuery>(
+      const query = fetchQuery<BottomTabsModelFetchNotificationsInfoQuery>(
         createEnvironment([
           [persistedQueryMiddleware(), metaphysicsURLMiddleware(), simpleLoggerMiddleware()],
         ]),
         graphql`
-          query BottomTabsModelFetchAllNotificationsCountsQuery {
+          query BottomTabsModelFetchNotificationsInfoQuery {
             me @principalField {
               unreadConversationCount
               unreadNotificationsCount

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -110,7 +110,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   fetchAllNotificationsCounts: thunk(async () => {
     try {
-      const result = await fetchQuery<BottomTabsModelFetchAllNotificationsCountsQuery>(
+      const query = fetchQuery<BottomTabsModelFetchAllNotificationsCountsQuery>(
         createEnvironment([
           [persistedQueryMiddleware(), metaphysicsURLMiddleware(), simpleLoggerMiddleware()],
         ]),
@@ -126,15 +126,14 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
         {
           fetchPolicy: "network-only",
         }
-      ).toPromise()
-
-      const conversationsCount = result?.me?.unreadConversationCount
-      const notificationsCount = result?.me?.unreadNotificationsCount
-
-      GlobalStore.actions.bottomTabs.unreadConversationCountChanged(conversationsCount ?? 0)
-      GlobalStore.actions.bottomTabs.unreadActivityPanelNotificationsCountChanged(
-        notificationsCount ?? 0
       )
+      const result = await query.toPromise()
+
+      const conversations = result?.me?.unreadConversationCount ?? 0
+      const notifications = result?.me?.unreadNotificationsCount ?? 0
+
+      GlobalStore.actions.bottomTabs.unreadConversationCountChanged(conversations)
+      GlobalStore.actions.bottomTabs.unreadActivityPanelNotificationsCountChanged(notifications)
     } catch (e) {
       if (__DEV__) {
         console.warn(

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -36,7 +36,7 @@ export interface BottomTabsModel {
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
-  lastNotificationPublishedAt: string | null
+  lastSeendNotificationPublishedAt: string | null
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   syncActivityPanelState: Action<
@@ -60,7 +60,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     tabProps: {},
     selectedTab: "home",
   },
-  lastNotificationPublishedAt: null,
+  lastSeendNotificationPublishedAt: null,
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
       actions.unreadConversationCountChanged,
@@ -194,14 +194,14 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     })
     const lastNotification = notifications[0] as NotificationNode | undefined
     const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
-    const isLastPublishedAtEmpty =
-      state.lastNotificationPublishedAt === null && lastNotificationPublishedAt
+    const isLastSeenPublishedAtEmpty =
+      state.lastSeendNotificationPublishedAt === null && lastNotificationPublishedAt
     const isNewPublishedAtAvailable = checkIsNewPublishedAt(
-      state.lastNotificationPublishedAt,
+      state.lastSeendNotificationPublishedAt,
       lastNotificationPublishedAt
     )
 
-    if (isLastPublishedAtEmpty || isNewPublishedAtAvailable) {
+    if (isLastSeenPublishedAtEmpty || isNewPublishedAtAvailable) {
       state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
     }
   }),

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -32,7 +32,7 @@ interface NotificationNode {
 export interface BottomTabsModel {
   sessionState: {
     unreadCounts: UnreadCounts
-    displayUnreadActivityPanelIndicator: boolean
+    displayUnseenNotificationsIndicator: boolean
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
@@ -47,7 +47,7 @@ export interface BottomTabsModel {
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   unreadActivityPanelNotificationsCountChanged: Action<BottomTabsModel, number>
   fetchNotificationsInfo: Thunk<BottomTabsModel>
-  displayUnreadActivityPanelIndicatorChanged: Action<BottomTabsModel, boolean>
+  setDisplayUnseenNotificationsIndicator: Action<BottomTabsModel, boolean>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
 }
 
@@ -57,7 +57,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
       unreadConversation: 0,
       unreadActivityPanelNotifications: 0,
     },
-    displayUnreadActivityPanelIndicator: false,
+    displayUnseenNotificationsIndicator: false,
     tabProps: {},
     selectedTab: "home",
   },
@@ -180,11 +180,9 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
       }
     }
   }),
-  displayUnreadActivityPanelIndicatorChanged: action(
-    (state, displayUnreadActivityPanelIndicator) => {
-      state.sessionState.displayUnreadActivityPanelIndicator = displayUnreadActivityPanelIndicator
-    }
-  ),
+  setDisplayUnseenNotificationsIndicator: action((state, payload) => {
+    state.sessionState.displayUnseenNotificationsIndicator = payload
+  }),
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
   }),
@@ -206,7 +204,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     )
 
     if (isLastSeenPublishedAtEmpty || isNewPublishedAtAvailable) {
-      state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
+      state.sessionState.displayUnseenNotificationsIndicator = payload.unreadCount > 0
     }
   }),
 })

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -24,7 +24,7 @@ export interface BottomTabsModel {
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
-  lastNotificationPublishedAtByUserId: Record<string, string>
+  lastNotificationPublishedAt: string | null
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
@@ -44,7 +44,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     tabProps: {},
     selectedTab: "home",
   },
-  lastNotificationPublishedAtByUserId: {},
+  lastNotificationPublishedAt: null,
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
       actions.unreadConversationCountChanged,

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -196,19 +196,19 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
     const isLastPublishedAtEmpty =
       state.lastNotificationPublishedAt === null && lastNotificationPublishedAt
-    const isNewPublishedAtAvaiable = checkNewPublishedAtAvaiable(
+    const isSameOrAfterPublishedAt = checkSameOrAfterPublishedAt(
       state.lastNotificationPublishedAt,
       lastNotificationPublishedAt
     )
 
-    if (isLastPublishedAtEmpty || isNewPublishedAtAvaiable) {
+    if (isLastPublishedAtEmpty || isSameOrAfterPublishedAt) {
       state.lastNotificationPublishedAt = lastNotificationPublishedAt
       state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
     }
   }),
 })
 
-const checkNewPublishedAtAvaiable = (
+const checkSameOrAfterPublishedAt = (
   prevPublishedAt: string | null,
   newPublishedAt: string | null
 ) => {
@@ -219,5 +219,5 @@ const checkNewPublishedAtAvaiable = (
   const prevPublishedDate = DateTime.fromISO(prevPublishedAt)
   const newPublishedDate = DateTime.fromISO(newPublishedAt)
 
-  return newPublishedDate > prevPublishedDate
+  return newPublishedDate >= prevPublishedDate
 }

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -24,6 +24,7 @@ export interface BottomTabsModel {
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
+  lastNotificationPublishedAtByUserId: Record<string, string>
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   unreadConversationCountChanged: Action<BottomTabsModel, number>
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
@@ -43,6 +44,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     tabProps: {},
     selectedTab: "home",
   },
+  lastNotificationPublishedAtByUserId: {},
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
       actions.unreadConversationCountChanged,

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -189,28 +189,32 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
 
       return true
     })
-    const notification = notifications[0]
-    const lastPublishedAt = state.lastNotificationPublishedAt
+    const lastNotification = notifications[0] as NotificationNode | undefined
+    const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
+    const isLastPublishedAtEmpty =
+      state.lastNotificationPublishedAt === null && lastNotificationPublishedAt
+    const isNewPublishedAtAvaiable = checkNewPublishedAtAvaiable(
+      state.lastNotificationPublishedAt,
+      lastNotificationPublishedAt
+    )
 
-    console.log("[debug] lastPublishedAt", lastPublishedAt)
-    console.log("[debug] notification.publishedAt", notification.publishedAt)
-
-    if (lastPublishedAt === null && notification.publishedAt) {
-      console.log("[debug] step 1")
-      state.lastNotificationPublishedAt = notification.publishedAt
+    if (isLastPublishedAtEmpty || isNewPublishedAtAvaiable) {
+      state.lastNotificationPublishedAt = lastNotificationPublishedAt
       state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
-    }
-
-    if (lastPublishedAt && notification.publishedAt) {
-      console.log("[debug] compare dates")
-      const prevPublishedDate = DateTime.fromISO(lastPublishedAt)
-      const currentPublishedDate = DateTime.fromISO(notification.publishedAt)
-
-      if (currentPublishedDate > prevPublishedDate) {
-        console.log("[debug] step 2")
-        state.lastNotificationPublishedAt = notification.publishedAt
-        state.sessionState.displayUnreadActivityPanelIndicator = payload.unreadCount > 0
-      }
     }
   }),
 })
+
+const checkNewPublishedAtAvaiable = (
+  prevPublishedAt: string | null,
+  newPublishedAt: string | null
+) => {
+  if (prevPublishedAt === null || newPublishedAt === null) {
+    return false
+  }
+
+  const prevPublishedDate = DateTime.fromISO(prevPublishedAt)
+  const newPublishedDate = DateTime.fromISO(newPublishedAt)
+
+  return newPublishedDate > prevPublishedDate
+}

--- a/src/app/Scenes/Home/Components/ActivityIndicator.tests.tsx
+++ b/src/app/Scenes/Home/Components/ActivityIndicator.tests.tsx
@@ -5,13 +5,17 @@ import { ActivityIndicator } from "./ActivityIndicator"
 
 describe("ActivityIndicator", () => {
   it("should be displayed", () => {
-    const { queryByLabelText } = renderWithWrappers(<ActivityIndicator hasNotifications={false} />)
+    const { queryByLabelText } = renderWithWrappers(
+      <ActivityIndicator hasUnseenNotifications={false} />
+    )
 
     expect(queryByLabelText("Activity")).toBeDefined()
   })
 
   it("should track event when the bell icon is tapped", () => {
-    const { getByLabelText } = renderWithWrappers(<ActivityIndicator hasNotifications={false} />)
+    const { getByLabelText } = renderWithWrappers(
+      <ActivityIndicator hasUnseenNotifications={false} />
+    )
 
     fireEvent.press(getByLabelText("Activity"))
 

--- a/src/app/Scenes/Home/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/Home/Components/ActivityIndicator.tsx
@@ -7,10 +7,10 @@ import { TouchableOpacity } from "react-native"
 import { useTracking } from "react-tracking"
 
 interface ActivityIndicatorProps {
-  hasNotifications: boolean
+  hasUnseenNotifications: boolean
 }
 
-export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasNotifications }) => {
+export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasUnseenNotifications }) => {
   const tracking = useTracking()
   const { space } = useTheme()
 
@@ -33,12 +33,12 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasNotific
       >
         <BellIcon height={24} width={24} />
 
-        {!!hasNotifications && (
+        {!!hasUnseenNotifications && (
           <Box
             position="absolute"
             top={0}
             right={0}
-            accessibilityLabel="Unread Activities Indicator"
+            accessibilityLabel="Unseen Notifications Indicator"
           >
             <VisualClueDot diameter={4} />
           </Box>

--- a/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
@@ -10,29 +10,29 @@ describe("HomeHeader", () => {
   }
 
   describe("Activity", () => {
-    it("should NOT render unread indicator when there are no unread notifications", async () => {
+    it("should NOT render unseen indicator when there are no unseen notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { displayUnreadActivityPanelIndicator: false },
+          sessionState: { displayUnseenNotificationsIndicator: false },
         },
       })
 
       const { queryByLabelText } = renderWithWrappers(<TestRenderer />)
 
-      const indicator = queryByLabelText("Unread Activities Indicator")
+      const indicator = queryByLabelText("Unseen Notifications Indicator")
       expect(indicator).toBeNull()
     })
 
-    it("should render unread indicator when there are unread notifications", async () => {
+    it("should render unseen indicator when there are unseen notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { displayUnreadActivityPanelIndicator: true },
+          sessionState: { displayUnseenNotificationsIndicator: true },
         },
       })
 
       const { getByLabelText } = renderWithWrappers(<TestRenderer />)
 
-      const indicator = getByLabelText("Unread Activities Indicator")
+      const indicator = getByLabelText("Unseen Notifications Indicator")
       expect(indicator).toBeTruthy()
     })
   })

--- a/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
@@ -13,7 +13,7 @@ describe("HomeHeader", () => {
     it("should NOT render unread indicator when there are no unread notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { unreadCounts: { unreadActivityPanelNotifications: 0 } },
+          sessionState: { displayUnreadActivityPanelIndicator: false },
         },
       })
 
@@ -26,7 +26,7 @@ describe("HomeHeader", () => {
     it("should render unread indicator when there are unread notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { unreadCounts: { unreadActivityPanelNotifications: 1 } },
+          sessionState: { displayUnreadActivityPanelIndicator: true },
         },
       })
 

--- a/src/app/Scenes/Home/Components/HomeHeader.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tsx
@@ -3,15 +3,15 @@ import { ArtsyLogoIcon, Box, Flex, Spacer } from "palette"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
-  const shouldDisplayActivityPanelIndicator = GlobalStore.useAppState(
-    (state) => state.bottomTabs.sessionState.displayUnreadActivityPanelIndicator
+  const hasUnseenNotifications = GlobalStore.useAppState(
+    (state) => state.bottomTabs.sessionState.displayUnseenNotificationsIndicator
   )
 
   return (
     <Box mb={1} mt={2}>
       <Flex alignItems="center">
         <ArtsyLogoIcon scale={0.75} />
-        <ActivityIndicator hasNotifications={shouldDisplayActivityPanelIndicator} />
+        <ActivityIndicator hasUnseenNotifications={hasUnseenNotifications} />
       </Flex>
       <Spacer mb="1" />
     </Box>

--- a/src/app/Scenes/Home/Components/HomeHeader.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tsx
@@ -3,7 +3,7 @@ import { ArtsyLogoIcon, Box, Flex, Spacer } from "palette"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
-  const shouldUnreadActivityPanelIndicator = GlobalStore.useAppState(
+  const shouldDisplayActivityPanelIndicator = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.displayUnreadActivityPanelIndicator
   )
 
@@ -11,7 +11,7 @@ export const HomeHeader: React.FC = () => {
     <Box mb={1} mt={2}>
       <Flex alignItems="center">
         <ArtsyLogoIcon scale={0.75} />
-        <ActivityIndicator hasNotifications={shouldUnreadActivityPanelIndicator} />
+        <ActivityIndicator hasNotifications={shouldDisplayActivityPanelIndicator} />
       </Flex>
       <Spacer mb="1" />
     </Box>

--- a/src/app/Scenes/Home/Components/HomeHeader.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tsx
@@ -3,15 +3,15 @@ import { ArtsyLogoIcon, Box, Flex, Spacer } from "palette"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
-  const hasNotifications = GlobalStore.useAppState(
-    (state) => state.bottomTabs.sessionState.unreadCounts.unreadActivityPanelNotifications > 0
+  const shouldUnreadActivityPanelIndicator = GlobalStore.useAppState(
+    (state) => state.bottomTabs.sessionState.displayUnreadActivityPanelIndicator
   )
 
   return (
     <Box mb={1} mt={2}>
       <Flex alignItems="center">
         <ArtsyLogoIcon scale={0.75} />
-        <ActivityIndicator hasNotifications={hasNotifications} />
+        <ActivityIndicator hasNotifications={shouldUnreadActivityPanelIndicator} />
       </Flex>
       <Spacer mb="1" />
     </Box>

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -577,7 +577,7 @@ const HomePlaceholder: React.FC = () => {
       <Box mb={1} mt={2}>
         <Flex alignItems="center">
           <ArtsyLogoIcon scale={0.75} />
-          <ActivityIndicator hasNotifications={false} />
+          <ActivityIndicator hasUnseenNotifications={false} />
         </Flex>
       </Box>
       <Spacer mb={4} />

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -814,22 +814,22 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
   })
 })
 
-describe("App version Versions.AddLastNotificationPublishedAt", () => {
-  const migrationToTest = Versions.AddLastNotificationPublishedAt
+describe("App version Versions.AddLastSeendNotificationPublishedAt", () => {
+  const migrationToTest = Versions.AddLastSeendNotificationPublishedAt
 
-  it("add lastNotificationPublishedAt", () => {
+  it("add lastSeendNotificationPublishedAt", () => {
     const previousState = migrate({
       state: { version: 0 },
       toVersion: migrationToTest - 1,
     }) as any
 
-    expect(previousState.bottomTabs.lastNotificationPublishedAt).toEqual(undefined)
+    expect(previousState.bottomTabs.lastSeendNotificationPublishedAt).toEqual(undefined)
 
     const migratedState = migrate({
       state: previousState,
       toVersion: migrationToTest,
     }) as any
 
-    expect(migratedState.bottomTabs.lastNotificationPublishedAt).toEqual(null)
+    expect(migratedState.bottomTabs.lastSeendNotificationPublishedAt).toEqual(null)
   })
 })

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -814,22 +814,22 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
   })
 })
 
-describe("App version Versions.AddLastNotificationPublishedAtByUserId", () => {
-  const migrationToTest = Versions.AddLastNotificationPublishedAtByUserId
+describe("App version Versions.AddLastNotificationPublishedAt", () => {
+  const migrationToTest = Versions.AddLastNotificationPublishedAt
 
-  it("add lastNotificationPublishedAtByUserId", () => {
+  it("add lastNotificationPublishedAt", () => {
     const previousState = migrate({
       state: { version: 0 },
       toVersion: migrationToTest - 1,
     }) as any
 
-    expect(previousState.bottomTabs.lastNotificationPublishedAtByUserId).toEqual(undefined)
+    expect(previousState.bottomTabs.lastNotificationPublishedAt).toEqual(undefined)
 
     const migratedState = migrate({
       state: previousState,
       toVersion: migrationToTest,
     }) as any
 
-    expect(migratedState.bottomTabs.lastNotificationPublishedAtByUserId).toEqual({})
+    expect(migratedState.bottomTabs.lastNotificationPublishedAt).toEqual({})
   })
 })

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -814,8 +814,8 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
   })
 })
 
-describe("App version Versions.AddLastSeendNotificationPublishedAt", () => {
-  const migrationToTest = Versions.AddLastSeendNotificationPublishedAt
+describe("App version Versions.AddLastSeenNotificationPublishedAt", () => {
+  const migrationToTest = Versions.AddLastSeenNotificationPublishedAt
 
   it("add lastSeendNotificationPublishedAt", () => {
     const previousState = migrate({

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -112,7 +112,7 @@ describe(migrate, () => {
           },
         },
       })
-    }).toThrowErrorMatchingInlineSnapshot(`"Bad state.version {"version":"0"}"`)
+    }).toThrowErrorMatchingInlineSnapshot(`"Bad state.version {\\"version\\":\\"0\\"}"`)
   })
 
   it("throws an error if there is no valid migration", () => {
@@ -811,5 +811,25 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
     expect(migratedState.devicePrefs.environment.localOverrides).toEqual({ testKey: true })
     expect(migratedState.devicePrefs.environment.adminOverrides).toEqual(undefined)
     expect(migratedState.artsyPrefs.environment).toEqual(undefined)
+  })
+})
+
+describe("App version Versions.AddLastNotificationPublishedAtByUserId", () => {
+  const migrationToTest = Versions.AddLastNotificationPublishedAtByUserId
+
+  it("add lastNotificationPublishedAtByUserId", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    }) as any
+
+    expect(previousState.bottomTabs.lastNotificationPublishedAtByUserId).toEqual(undefined)
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect(migratedState.bottomTabs.lastNotificationPublishedAtByUserId).toEqual({})
   })
 })

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -112,7 +112,7 @@ describe(migrate, () => {
           },
         },
       })
-    }).toThrowErrorMatchingInlineSnapshot(`"Bad state.version {\\"version\\":\\"0\\"}"`)
+    }).toThrowErrorMatchingInlineSnapshot(`"Bad state.version {"version":"0"}"`)
   })
 
   it("throws an error if there is no valid migration", () => {
@@ -830,6 +830,6 @@ describe("App version Versions.AddLastNotificationPublishedAt", () => {
       toVersion: migrationToTest,
     }) as any
 
-    expect(migratedState.bottomTabs.lastNotificationPublishedAt).toEqual({})
+    expect(migratedState.bottomTabs.lastNotificationPublishedAt).toEqual(null)
   })
 })

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -817,19 +817,19 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
 describe("App version Versions.AddLastSeenNotificationPublishedAt", () => {
   const migrationToTest = Versions.AddLastSeenNotificationPublishedAt
 
-  it("add lastSeendNotificationPublishedAt", () => {
+  it("add lastSeenNotificationPublishedAt", () => {
     const previousState = migrate({
       state: { version: 0 },
       toVersion: migrationToTest - 1,
     }) as any
 
-    expect(previousState.bottomTabs.lastSeendNotificationPublishedAt).toEqual(undefined)
+    expect(previousState.bottomTabs.lastSeenNotificationPublishedAt).toEqual(undefined)
 
     const migratedState = migrate({
       state: previousState,
       toVersion: migrationToTest,
     }) as any
 
-    expect(migratedState.bottomTabs.lastSeendNotificationPublishedAt).toEqual(null)
+    expect(migratedState.bottomTabs.lastSeenNotificationPublishedAt).toEqual(null)
   })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,10 +45,10 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
-  AddLastNotificationPublishedAt: 36,
+  AddLastSeenNotificationPublishedAt: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddLastNotificationPublishedAt
+export const CURRENT_APP_VERSION = Versions.AddLastSeenNotificationPublishedAt
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -268,8 +268,8 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
-  [Versions.AddLastNotificationPublishedAt]: (state) => {
-    state.bottomTabs.lastNotificationPublishedAt = null
+  [Versions.AddLastSeenNotificationPublishedAt]: (state) => {
+    state.bottomTabs.AddLastSeenNotificationPublishedAt = null
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -269,7 +269,7 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
   [Versions.AddLastSeenNotificationPublishedAt]: (state) => {
-    state.bottomTabs.lastSeendNotificationPublishedAt = null
+    state.bottomTabs.lastSeenNotificationPublishedAt = null
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,9 +45,10 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
+  AddLastNotificationPublishedAtByUserId: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddCategoryToSubmissionArtworkDetails
+export const CURRENT_APP_VERSION = Versions.AddLastNotificationPublishedAtByUserId
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -266,6 +267,9 @@ export const artsyAppMigrations: Migrations = {
   [Versions.AddCategoryToSubmissionArtworkDetails]: (state) => {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
+  },
+  [Versions.AddLastNotificationPublishedAtByUserId]: (state) => {
+    state.bottomTabs.lastNotificationPublishedAtByUserId = {}
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,10 +45,10 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
-  AddLastNotificationPublishedAtByUserId: 36,
+  AddLastNotificationPublishedAt: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddLastNotificationPublishedAtByUserId
+export const CURRENT_APP_VERSION = Versions.AddLastNotificationPublishedAt
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -268,8 +268,8 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
-  [Versions.AddLastNotificationPublishedAtByUserId]: (state) => {
-    state.bottomTabs.lastNotificationPublishedAtByUserId = {}
+  [Versions.AddLastNotificationPublishedAt]: (state) => {
+    state.bottomTabs.lastNotificationPublishedAt = {}
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -269,7 +269,7 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
   [Versions.AddLastSeenNotificationPublishedAt]: (state) => {
-    state.bottomTabs.AddLastSeenNotificationPublishedAt = null
+    state.bottomTabs.lastSeendNotificationPublishedAt = null
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -269,7 +269,7 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
   [Versions.AddLastNotificationPublishedAt]: (state) => {
-    state.bottomTabs.lastNotificationPublishedAt = {}
+    state.bottomTabs.lastNotificationPublishedAt = null
   },
 }
 


### PR DESCRIPTION
This PR resolves [FX-4537] <!-- eg [FX-4537] -->

### Description
We want to handle seen vs unread differently. When the activity panel is opened, we set the most recent notification (top of the list) as the last seen notification. This will inform how we set the top-level bell indicator.

### Acceptance Criteria
* As a user
* Given I have unseen notifications
* When I visit the activity panel
* The top-level indicator goes away
* And I continue to see unread indicators to individual notifications.

### Demo
https://user-images.githubusercontent.com/3513494/214305576-f536bd84-5145-4c50-bcac-4fb54978fa22.mp4

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [x] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4537]: https://artsyproduct.atlassian.net/browse/FX-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ