### PR TITLE
chore(relay): Add verbose relay logging

### DIFF
--- a/docs/metaflags.md
+++ b/docs/metaflags.md
@@ -34,6 +34,7 @@ You can turn off various loggers by setting the according values to false on `me
   "logOperation": false,
   "logPrefetching": false,
   "logRelay": false,
+  "logRelayVerbose": false,
   "logRoute": false,
   "logRunningRequest": false
 }

--- a/src/app/system/relay/createEnvironment.ts
+++ b/src/app/system/relay/createEnvironment.ts
@@ -1,4 +1,6 @@
+import { logRelayVerbose } from "app/utils/loggers"
 import {
+  loggerMiddleware,
   errorMiddleware as relayErrorMiddleware,
   RelayNetworkLayer,
 } from "react-relay-network-modern/node8"
@@ -36,6 +38,7 @@ export function createEnvironment(
       checkAuthenticationMiddleware(),
       metaphysicsExtensionsLoggerMiddleware(),
       simpleLoggerMiddleware(),
+      __DEV__ && logRelayVerbose ? loggerMiddleware() : null,
       __DEV__ ? relayErrorMiddleware() : null,
       timingMiddleware(),
     ],

--- a/src/app/utils/loggers.ts
+++ b/src/app/utils/loggers.ts
@@ -6,6 +6,7 @@ let metaflags = {
   logOperation: false,
   logPrefetching: false,
   logRelay: false,
+  logRelayVerbose: false,
   logRoute: false,
   logRunningRequest: false,
 }
@@ -25,5 +26,6 @@ export const logNotification = metaflags.logNotification
 export const logOperation = metaflags.logOperation
 export const logPrefetching = metaflags.logPrefetching
 export const logRelay = metaflags.logRelay
+export const logRelayVerbose = metaflags.logRelayVerbose
 export const logRoute = metaflags.logRoute
 export const logRunningRequest = metaflags.logRunningRequest


### PR DESCRIPTION
### Description

This adds a new metaflag, `logRelayVerbose`, which outputs the full output of a relay query, per `relayLoggingMiddleware`.

cc @artsy/mobile-platform 