### PR TITLE
fix: Revert "ci: android specific releases (#7913)"

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -163,6 +163,12 @@ lane :ship_beta_android_play_store do
   sh("yarn jetifier")
   sh("yarn relay")
 
+  # upload will overwrite past versions unless we explicitly tell it to retain some
+  # cap at 20 for now, if we need more feel free to update!
+  past_version_codes = google_play_track_version_codes(
+    track: "alpha",
+  ).first(20)
+
   vname, vcode = set_build_version_android
   tag_and_push(tag: "android-#{vname}-#{vcode}")
 
@@ -180,8 +186,6 @@ lane :ship_beta_android_play_store do
   )
 
   upload_sentry_artifacts(sentry_release_name: sentry_release_name, dist_version: "#{vcode}", platform: "android")
-
-  s3_upload_android_build(app_version: vcode, app_path: "../android/app/build/outputs/bundle/release/app-release.aab")
 
   supply(
     track: "alpha",
@@ -219,58 +223,34 @@ lane :ship_beta_android_firebase do
 end
 
 lane :promote_beta_android do
-  selected_version_code = select_android_build()
-
-  vname, vcode = set_build_version_android
-
-  supply(
-    track: "production",
-    rollout: "0.1",
-    aab: "./android/app/build/outputs/bundle/release/app-release.aab",
-    skip_upload_apk: true,
-    skip_upload_metadata: true,
-    skip_upload_changelogs: true,
-    skip_upload_images: true,
-    skip_upload_screenshots: true
-  )
-
-  tag_and_push(tag: "android-#{vname}-#{vcode}-submission")
-end
-
-lane :s3_upload_android_build do |options|
-  app_version = options[:app_version]
-  app_path = options[:app_path]
-  sh("aws s3 cp " + app_path + " s3://artsy-citadel/dev/eigen/builds/android/" + app_version.to_s + ".aab")
-end
-
-lane :select_android_build do
-  s3_files_output = sh("aws s3 ls s3://artsy-citadel/dev/eigen/builds/android/")
-
-  aab_filename_regex = /\d+\.aab/
-  matches = s3_files_output.scan(aab_filename_regex)
-
-  # sort in descending order
-  sorted_matches = matches.sort_by { |s| s.scan(/\d+/).first.to_i }.reverse
-
-  # android builds are listed most recent first, limit to 20
-  builds = sorted_matches.first(20)
+  # android versions are listed most recent first, limit to 20
+  version_codes = google_play_track_version_codes(
+    track: "alpha",
+  ).first(20)
 
   UI.header "Last 20 Android builds"
 
-  selected_build = UI.select("Which build would you like to release?: ", builds)
+  selected_version_code = UI.select("Which build would you like to release?: ", version_codes)
 
-  if UI.confirm("Are you sure you would like to release '#{selected_build}'?")
+  if UI.confirm("Are you sure you would like to release '#{selected_version_code}'?")
     UI.success "Continuing the release!"
   else
     UI.user_error!("Stopping the train!")
   end
 
-  # download the selected build to the typical build output directory
-  output_app_path = "../android/app/build/outputs/bundle/release/app-release.aab"
-  sh("aws s3 cp s3://artsy-citadel/dev/eigen/builds/android/" + selected_build + " " + output_app_path)
+  supply(
+    track: 'alpha',
+    version_code: selected_version_code,
+    track_promote_to: 'production',
+    rollout: '0.1',
+    skip_upload_metadata: true,
+    skip_upload_changelogs: true,
+    skip_upload_images: true,
+    skip_upload_screenshots: true,
+  )
 
-  # return the selected version num
-  selected_build.scan(/\d+/).first
+  vname, vcode = set_build_version_android(version_code: selected_version_code)
+  tag_and_push(tag: "android-#{vname}-#{vcode}-submission")
 end
 
 lane :promote_beta_ios do


### PR DESCRIPTION
This reverts commit 065a39e838b053317d5df9520ef1e1460f76dc6e.

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Sorry reverting this for now as it is causing problems with betas, will look to fix tomorrow. 

Reverts the android specific builds pr while I fix the issue. 

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
