### PR TITLE
chore: do not minify classnames and function names in release apps

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -14,6 +14,16 @@ module.exports = {
         inlineRequires: true,
       },
     }),
+    // When bundling for production, React Native will minify class names and function names.
+    // This makes it not possible to use the class names and function names in error messages.
+    minifierConfig: {
+      keep_classnames: true,
+      keep_fnames: true,
+      mangle: {
+        keep_classnames: true,
+        keep_fnames: true,
+      },
+    },
   },
 
   resolver: {


### PR DESCRIPTION
This PR resolves the issue of having a "non readable" error in Sentry


<img width="1695" alt="Screenshot 2023-01-24 at 19 09 44" src="https://user-images.githubusercontent.com/11945712/214373626-cfc2231c-8a98-41b1-8126-519924f089ec.png">

### Description

- Followed the instructions here:
https://docs.sentry.io/platforms/react-native/performance/instrumentation/automatic-instrumentation/#androidx-support

**I will create a build from the PR and see the impact on the bundle size**


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- do not minify function and class names in releases - Mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
