### PR TITLE
fix(stack-traces): Disable sentry in __DEV__, fix console and error stack traces

### DIFF
--- a/src/app/system/errorReporting/sentrySetup.ts
+++ b/src/app/system/errorReporting/sentrySetup.ts
@@ -13,6 +13,12 @@ export const eigenSentryReleaseName = () => {
 }
 
 export function setupSentry(props: Partial<Sentry.ReactNativeOptions> = {}) {
+  // In DEV, enabling this will clober stack traces in errors and logs, obscuring
+  // the source of the error. So we disable it in dev mode.
+  if (__DEV__) {
+    console.log("[dev] Sentry disabled in dev mode.")
+    return
+  }
   if (!Config.SENTRY_DSN) {
     console.error("Sentry DSN not set!!")
     return


### PR DESCRIPTION
### Description

This fixes an issue that surfaced after we got the debugger working in eigen, which is stack and log traces were being obscured by Sentry tapping into the JS pipeline. Now, we disable the hook in `__DEV__`.

**Before**: 

<img width="449" alt="Screenshot 2023-01-24 at 1 12 59 PM" src="https://user-images.githubusercontent.com/236943/214418737-ef38d089-b5e1-4b88-99b3-775518f42cc9.png">

**After**: 

<img width="442" alt="Screenshot 2023-01-24 at 1 08 25 PM" src="https://user-images.githubusercontent.com/236943/214418760-ec1e47b1-f2db-4dd4-8ae4-73a129526e14.png">

cc @artsy/mobile-platform 