### PR TITLE
feat: add purple line on RetryErrorBoundary screen

### DIFF
--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -1,6 +1,6 @@
-import { useDevToggle } from "app/store/GlobalStore"
+import { useDevToggle, useIsStaging } from "app/store/GlobalStore"
 import { debounce } from "lodash"
-import { BoxProps, Flex, Text, Touchable, useColor } from "palette"
+import { Box, BoxProps, Flex, Text, Touchable, useColor } from "palette"
 import { ReloadIcon } from "palette/svgs/ReloadIcon"
 import React, { useRef, useState } from "react"
 import { Animated, Easing } from "react-native"
@@ -34,6 +34,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   }
 
   const showErrorMessage = __DEV__ || useDevToggle("DTShowErrorInLoadFailureView")
+  const isStaging = useIsStaging()
 
   return (
     <Flex flex={1} alignItems="center" justifyContent="center" {...restProps}>
@@ -41,6 +42,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
       <Text variant="sm-display" mb="1">
         Please try again
       </Text>
+      {isStaging && <Box mb={1} border={2} width={200} borderColor="devpurple" />}
       <Touchable
         onPress={debounce(() => {
           if (!isAnimating) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Adds `devpurple` line on RetryErrorBoundary **when staging** to be able to distinguish if it is staging environment quickly.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
#### Screenshot 
<img width="450" src="https://user-images.githubusercontent.com/21178754/214548819-4f2efe91-d036-4902-a919-5445352899af.png" />


### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add purple line on RetryErrorBoundary screen - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
