### PR TITLE
feat(FX-4569): Decrease the counter on the app icon by 1 when the user clicks on the activity panel item and this notification is marked as read

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -8,6 +8,7 @@ import {
 import { ActivityItem_item$key } from "__generated__/ActivityItem_item.graphql"
 import { FilterArray } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ORDERED_ARTWORK_SORTS } from "app/Components/ArtworkFilter/Filters/SortOptions"
+import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { last } from "lodash"
@@ -83,6 +84,9 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
         },
         updater: (store) => {
           updater(item.id, store)
+        },
+        onCompleted: () => {
+          GlobalStore.actions.bottomTabs.decreaseUnreadNotificationsCount()
         },
         onError: (error) => {
           captureMessage(error?.stack!)

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -46,6 +46,7 @@ export interface BottomTabsModel {
   >
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   setUnreadNotificationsCount: Action<BottomTabsModel, number>
+  decreaseUnreadNotificationsCount: Action<BottomTabsModel>
   fetchNotificationsInfo: Thunk<BottomTabsModel>
   setDisplayUnseenNotificationsIndicator: Action<BottomTabsModel, boolean>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
@@ -113,6 +114,13 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   setUnreadNotificationsCount: action((state, payload) => {
     state.sessionState.unreadCounts.notifications = payload
+  }),
+  decreaseUnreadNotificationsCount: action((state) => {
+    const nextValue = state.sessionState.unreadCounts.notifications - 1
+
+    if (nextValue >= 0) {
+      state.sessionState.unreadCounts.notifications = nextValue
+    }
   }),
   fetchNotificationsInfo: thunk(async () => {
     try {

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -67,7 +67,11 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     state.lastSeenNotificationPublishedAt = payload
   }),
   syncApplicationIconBadgeNumber: thunkOn(
-    (actions) => [actions.setUnreadConversationsCount, actions.setUnreadNotificationsCount],
+    (actions) => [
+      actions.setUnreadConversationsCount,
+      actions.setUnreadNotificationsCount,
+      actions.decreaseUnreadNotificationsCount,
+    ],
     (_actions, _payload, { getState }) => {
       const { notifications, conversations } = getState().sessionState.unreadCounts
       const totalCount = notifications + conversations


### PR DESCRIPTION
This PR resolves [FX-4569] <!-- eg [PROJECT-XXXX] -->

### Demo
https://user-images.githubusercontent.com/3513494/214825542-09a07326-3e61-47b5-a05c-69db9eb92c69.MP4

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Decrease the counter on the app icon by 1 when the user clicks on the activity panel item and this notification is marked as read - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4569]: https://artsyproduct.atlassian.net/browse/FX-4569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ