### PR TITLE
chore(scripts): Add `yarn navigate-to-route` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "flip_table_extreme": "./scripts/flip-table-extreme",
     "generate-cities-cache": "node scripts/generate-cities-cache.js",
     "generate-cities-objc": "node scripts/generate-cities-objc.js",
+    "navigate-to-route": "./scripts/navigate-to-route",
     "init-metaflags": "jq -Rn '{ startStorybook: false }' | sponge metaflags.json",
     "install:all": "./scripts/install",
     "ios": "react-native run-ios --udid=\"$(xcrun simctl list | awk -F'[()]' '/(Booted)/ { print $2 }')\"",

--- a/scripts/navigate-to-route
+++ b/scripts/navigate-to-route
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Navigate to a specific route in Eigen:
+# $ ./scripts/navigate-to-route /artwork/sadaharu-horio-ku-wei-zhen-zhi-untitled-73
+xcrun simctl openurl booted "artsy://${1}"


### PR DESCRIPTION
### Description

This adds a helpful new command to our `package.json` scripts so that we can navigate directly to a route in eigen:

```
yarn navigate-to-route /artist/andy-warhol
```

cc @artsy/mobile-platform 