### PR TITLE
chore: execute "mark as read" mutation only when notification is unread

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -149,6 +149,22 @@ describe("ActivityItem", () => {
     })
   })
 
+  it("should NOT call `mark as read` mutation if the notification has already been read", async () => {
+    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Notification: () => notification,
+    })
+    await flushPromiseQueue()
+
+    fireEvent.press(getByText("Notification Title"))
+
+    await flushPromiseQueue()
+
+    const recentOperations = mockEnvironment.mock.getAllOperations()
+    expect(recentOperations).toHaveLength(0)
+  })
+
   describe("Unread notification indicator", () => {
     it("should NOT be rendered by default", async () => {
       const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)

--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -161,8 +161,9 @@ describe("ActivityItem", () => {
 
     await flushPromiseQueue()
 
-    const recentOperations = mockEnvironment.mock.getAllOperations()
-    expect(recentOperations).toHaveLength(0)
+    expect(() => mockEnvironment.mock.getMostRecentOperation()).toThrowError(
+      "There are no pending operations in the list"
+    )
   })
 
   describe("Unread notification indicator", () => {

--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -105,8 +105,6 @@ describe("ActivityItem", () => {
 
     fireEvent.press(getByText("Notification Title"))
 
-    // resolving the mark as read mutation
-    resolveMostRecentRelayOperation(mockEnvironment)
     await flushPromiseQueue()
 
     expect(navigate).toHaveBeenCalledWith(targetUrl, {
@@ -135,8 +133,6 @@ describe("ActivityItem", () => {
 
     fireEvent.press(getByText("Notification Title"))
 
-    // resolving the mark as read mutation
-    resolveMostRecentRelayOperation(mockEnvironment)
     await flushPromiseQueue()
 
     expect(navigate).toHaveBeenCalledWith(alertTargetUrl, {

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -71,22 +71,24 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
 
     navigateToActivityItem()
 
-    markAsRead({
-      variables: {
-        input: {
-          id: item.internalID,
+    if (item.isUnread) {
+      markAsRead({
+        variables: {
+          input: {
+            id: item.internalID,
+          },
         },
-      },
-      optimisticUpdater: (store) => {
-        updater(item.id, store)
-      },
-      updater: (store) => {
-        updater(item.id, store)
-      },
-      onError: (error) => {
-        captureMessage(error?.stack!)
-      },
-    })
+        optimisticUpdater: (store) => {
+          updater(item.id, store)
+        },
+        updater: (store) => {
+          updater(item.id, store)
+        },
+        onError: (error) => {
+          captureMessage(error?.stack!)
+        },
+      })
+    }
   }
 
   return (


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
