### PR TITLE
fix: Refetch artwork after editing

### DIFF
--- a/src/app/utils/relayHelpers.ts
+++ b/src/app/utils/relayHelpers.ts
@@ -1,4 +1,5 @@
 import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { useReducer } from "react"
 import { Record } from "relay-runtime/lib/store/RelayStoreTypes"
 
 export type CleanRelayFragment<T> = Omit<
@@ -39,4 +40,13 @@ export const findRelayRecordByDataID = (id: string): Record | undefined | null =
   const record = store.getSource().get(id)
 
   return record
+}
+
+/**
+ * Returns a fetchKey and a refetch function that can be used to force a refetch of a relay query
+ */
+export const useRefetch = () => {
+  const [fetchKey, refetch] = useReducer((state: number) => state + 1, 0)
+
+  return { fetchKey, refetch }
 }


### PR DESCRIPTION
This PR resolves [CX-3357] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Refetch artwork after editing

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3357]: https://artsyproduct.atlassian.net/browse/CX-3357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ