### PR TITLE
toolchain(android): Add `yarn navigate-to-route-android` cli command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "generate-cities-cache": "node scripts/generate-cities-cache.js",
     "generate-cities-objc": "node scripts/generate-cities-objc.js",
     "navigate-to-route": "./scripts/navigate-to-route",
+    "navigate-to-route-android": "./scripts/navigate-to-route-android",
     "init-metaflags": "jq -Rn '{ startStorybook: false }' | sponge metaflags.json",
     "install:all": "./scripts/install",
     "ios": "react-native run-ios --udid=\"$(xcrun simctl list | awk -F'[()]' '/(Booted)/ { print $2 }')\"",

--- a/scripts/navigate-to-route-android
+++ b/scripts/navigate-to-route-android
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# Navigate to a specific route in Eigen:
+# $ ./scripts/navigate-to-route-android /artwork/sadaharu-horio-ku-wei-zhen-zhi-untitled-73
+npx uri-scheme open "artsy://${1}" --android


### PR DESCRIPTION
Related https://github.com/artsy/eigen/pull/8061

### Description

Adds a new `yarn navigate-to-route-android` cli command for quickly jumping into deeply nested screens on Android devices. 

**Use**:
- `yarn navigate-to-route-android /artist/andy-warhol`

cc @artsy/mobile-platform 