### PR TITLE
fix: error with old opaque image view in search

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -1740,8 +1740,8 @@ exports[`Avoid using class components`] = {
     "src/app/Components/Modal.tsx:1394418038": [
       [38, 19, 23, "Try using a functional component.", "3210885008"]
     ],
-    "src/app/Components/OpaqueImageView/OpaqueImageView.tsx:1665090421": [
-      [79, 37, 23, "Try using a functional component.", "3210885008"]
+    "src/app/Components/OpaqueImageView/OpaqueImageView.tsx:3978137333": [
+      [80, 37, 23, "Try using a functional component.", "3210885008"]
     ],
     "src/app/Components/RelatedArtists/RelatedArtist.tsx:2207857089": [
       [15, 20, 17, "Try using a functional component.", "3548830911"]

--- a/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -1,6 +1,7 @@
 import { isALocalImage } from "app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel"
 import React from "react"
 import {
+  ColorValue,
   Image,
   ImageResizeMode,
   LayoutChangeEvent,
@@ -32,7 +33,7 @@ interface Props extends ViewProps {
   retryFailedURLs?: boolean
 
   /** The background color for the image view */
-  placeholderBackgroundColor?: string
+  placeholderBackgroundColor?: ColorValue
 
   width?: number
   height?: number
@@ -79,7 +80,7 @@ interface State {
  */
 export default class OpaqueImageView extends React.Component<Props, State> {
   static defaultProps: Props = {
-    placeholderBackgroundColor: "#E7E7E7", // this is black10. Change it to that when this component becomes a function component.
+    placeholderBackgroundColor: processColor("#E7E7E7") as ColorValue, // this is black10. Change it to that when this component becomes a function component.
   }
 
   constructor(props: Props) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the annoying type issue coming from old opaque image view comp

| Before | After |
|---|---|
|https://user-images.githubusercontent.com/21178754/215467437-9552c72f-d166-4a2a-bd61-1e25b1ccf65f.mp4|https://user-images.githubusercontent.com/21178754/215467798-f6150b2e-788a-4f58-a9c0-12a39da301d2.mp4|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix: error with old opaque image view in search - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
