### PR TITLE
chore: make sure app is rehydrated before initializing unleash

### DIFF
--- a/src/app/utils/experiments/hooks.ts
+++ b/src/app/utils/experiments/hooks.ts
@@ -39,9 +39,9 @@ export function useExperimentVariant(name: string): {
 
 export function useUnleashEnvironment(): { unleashEnv: "staging" | "production" } {
   const isStaging = useIsStaging()
-
+  const useProductionUnleash = useDevToggle("DTUseProductionUnleash")
   const unleashEnv = __DEV__
-    ? useDevToggle("DTUseProductionUnleash")
+    ? useProductionUnleash
       ? "production"
       : "staging"
     : isStaging

--- a/src/app/utils/useIdentifyUser.ts
+++ b/src/app/utils/useIdentifyUser.ts
@@ -19,6 +19,7 @@ export function useIdentifyUser() {
       ReactAppboy.changeUser(userId)
     }
     SegmentTrackingProvider.identify?.(userId, { is_temporary_user: userId === null ? 1 : 0 })
+
     updateExperimentsContext({ userId: nullToUndef(userId) })
   }, [userId])
 }


### PR DESCRIPTION
### Description

This PR resolves an issue where the user gets a different variant when the app state changes. 

As we were not testing if the app has finished rehydration, we were initializing unleash client without a userID. This led to sessions that can have a different variant from the variant specified to the user, which gets queried properly when the app is brought to the foreground.

**Before**


https://user-images.githubusercontent.com/11945712/215539486-02df67c4-908f-42c0-aa0e-a53d4b8df4d3.mov



**After**


https://user-images.githubusercontent.com/11945712/215539522-c9818ada-ce08-40cc-bcfe-66af90508992.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- make sure app is rehydrated before initializing unleash - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
