### PR TITLE
chore: track Sentry screen navigation

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -504,7 +504,7 @@ exports[`Finish our strictness migration`] = {
       [49, 56, 40, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "1708246099"],
       [65, 52, 40, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "1708246099"]
     ],
-    "src/app/system/relay/middlewares/metaphysicsMiddleware.ts:702430560": [
+    "src/app/system/relay/middlewares/metaphysicsMiddleware.ts:1634627424": [
       [13, 50, 40, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "1708246099"],
       [15, 52, 40, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "1708246099"]
     ],
@@ -1487,7 +1487,7 @@ exports[`Fix all STRICTNESS_MIGRATION`] = {
     "src/app/Scenes/ViewingRoom/Components/ViewingRoomSubsections.tsx:4227710958": [
       [10, 56, 20, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "273977750"]
     ],
-    "src/app/system/relay/middlewares/metaphysicsMiddleware.ts:702430560": [
+    "src/app/system/relay/middlewares/metaphysicsMiddleware.ts:1634627424": [
       [13, 22, 20, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "273977750"],
       [15, 24, 20, "These comments were added when we switched on TypeScript\'s strict mode, and their number should only ever go down.", "273977750"]
     ],

--- a/.betterer.results
+++ b/.betterer.results
@@ -668,6 +668,9 @@ exports[`Avoid using test-renderer`] = {
     "src/app/Components/Home/ArtistRails/ArtistCard.tests.tsx:3488289762": [
       [0, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
     ],
+    "src/app/Components/Lists/AuctionResultListItem.tests.tsx:2328333107": [
+      [4, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
+    ],
     "src/app/Components/Lists/SavedItemRow.tests.tsx:3450992164": [
       [0, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
     ],
@@ -959,8 +962,11 @@ exports[`Avoid using test-renderer`] = {
     "src/app/Scenes/Onboarding/OnboardingLogin.tests.tsx:927225381": [
       [0, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
     ],
-    "src/app/Scenes/OrderHistory/OrderDetails/OrderDetails.tests.tsx:826183475": [
-      [1, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
+    "src/app/Scenes/OrderHistory/OrderDetails/OrderDetails.tests.tsx:1323552499": [
+      [2, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
+    ],
+    "src/app/Scenes/OrderHistory/OrderDetails/TrackOrderSection.tests.tsx:1314268179": [
+      [2, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]
     ],
     "src/app/Scenes/OrderHistory/OrderHistory.tests.tsx:2734769865": [
       [3, 9, 68, "We are migrating away from \`react-test-renderer\`, towards \`@testing-library/react-native\`.", "2624109799"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -1583,8 +1583,8 @@ exports[`Avoid using class components`] = {
     "src/ambient.d.ts:123000066": [
       [28, 25, 23, "Try using a functional component.", "3210885008"]
     ],
-    "src/app/AppRegistry.tsx:2866048822": [
-      [244, 18, 23, "Try using a functional component.", "3210885008"]
+    "src/app/AppRegistry.tsx:3716522364": [
+      [241, 18, 23, "Try using a functional component.", "3210885008"]
     ],
     "src/app/Components/Artist/Articles/Articles.tsx:1150831805": [
       [13, 15, 17, "Try using a functional component.", "3548830911"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -101,8 +101,8 @@ exports[`Stop using moment, use luxon instead`] = {
     "src/app/Components/Countdown/Ticker.tsx:1619936038": [
       [2, 20, 13, "We are migrating away from \`moment\`, towards \`luxon\`.", "3265611491"]
     ],
-    "src/app/Components/Lists/AuctionResultListItem.tests.tsx:1548682260": [
-      [5, 14, 13, "We are migrating away from \`moment\`, towards \`luxon\`.", "3265611491"]
+    "src/app/Components/Lists/AuctionResultListItem.tests.tsx:2328333107": [
+      [6, 14, 13, "We are migrating away from \`moment\`, towards \`luxon\`.", "3265611491"]
     ],
     "src/app/Components/Lists/AuctionResultListItem.tsx:288945715": [
       [6, 14, 13, "We are migrating away from \`moment\`, towards \`luxon\`.", "3265611491"]
@@ -1561,8 +1561,8 @@ exports[`Avoid having skipped tests`] = {
     "src/app/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tests.tsx:2878120211": [
       [27, 2, 8, "Is this skipped on purpose, or accidentally?", "593069535"]
     ],
-    "src/app/Scenes/MyCollection/MyCollection.tests.tsx:4100351617": [
-      [104, 4, 8, "Is this skipped on purpose, or accidentally?", "593069535"]
+    "src/app/Scenes/MyCollection/MyCollection.tests.tsx:527886401": [
+      [106, 4, 8, "Is this skipped on purpose, or accidentally?", "593069535"]
     ],
     "src/app/Scenes/Sale/SaleLotsList.tests.tsx:29178689": [
       [97, 2, 8, "Is this skipped on purpose, or accidentally?", "593069535"]

--- a/metaflags.example.json
+++ b/metaflags.example.json
@@ -3,10 +3,11 @@
   "logAction": true,
   "logDatadog": true,
   "logEventTracked": true,
+  "logNavitation": true,
   "logNotification": true,
   "logOperation": true,
   "logPrefetching": true,
+  "logQueryPath": true,
   "logRelay": true,
-  "logRoute": true,
   "logRunningRequest": true
 }

--- a/metaflags.example.json
+++ b/metaflags.example.json
@@ -3,7 +3,7 @@
   "logAction": true,
   "logDatadog": true,
   "logEventTracked": true,
-  "logNavitation": true,
+  "logNavigation": true,
   "logNotification": true,
   "logOperation": true,
   "logPrefetching": true,

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -103,10 +103,7 @@ import { MyProfilePaymentQueryRenderer } from "./Scenes/MyProfile/MyProfilePayme
 import { MyProfilePaymentNewCreditCard } from "./Scenes/MyProfile/MyProfilePaymentNewCreditCard"
 import { MyProfilePushNotificationsQueryRenderer } from "./Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "./Scenes/MyProfile/MyProfileSettings"
-import {
-  NewWorksForYouQueryRenderer,
-  NewWorksForYouScreenQuery,
-} from "./Scenes/NewWorksForYou/NewWorksForYou"
+import { NewWorksForYouQueryRenderer } from "./Scenes/NewWorksForYou/NewWorksForYou"
 import { OrderDetailsQueryRender } from "./Scenes/OrderHistory/OrderDetails/Components/OrderDetails"
 import { OrderHistoryQueryRender } from "./Scenes/OrderHistory/OrderHistory"
 import { PartnerQueryRenderer } from "./Scenes/Partner/Partner"
@@ -506,7 +503,7 @@ export const modules = defineModules({
   ViewingRoomArtworks: reactModule(ViewingRoomArtworksQueryRenderer),
   ViewingRooms: reactModule(ViewingRoomsListScreen, {}, [viewingRoomsListScreenQuery]),
   WorksForYou: reactModule(WorksForYouQueryRenderer, {}, [WorksForYouScreenQuery]),
-  NewWorksForYou: reactModule(NewWorksForYouQueryRenderer, {}, [NewWorksForYouScreenQuery]),
+  NewWorksForYou: reactModule(NewWorksForYouQueryRenderer),
   LotsByArtistsYouFollow: reactModule(LotsByArtistsYouFollowQueryRenderer, {}, [
     LotsByArtistsYouFollowScreenQuery,
   ]),

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -122,7 +122,6 @@ const Home = (props: Props) => {
       title: "New Works for You",
       type: "newWorksForYou",
       data: newWorksForYou,
-      prefetchUrl: "/new-for-you",
     },
     {
       title: "",

--- a/src/app/system/navigation/NavStack.tsx
+++ b/src/app/system/navigation/NavStack.tsx
@@ -119,7 +119,11 @@ export const NavStack: React.FC<{
           const params = focusedRoute?.params as any
 
           if (__DEV__ && logNavitation) {
-            console.log(`navigated to ${params.moduleName}: ${JSON.stringify(params.props)}`)
+            console.log(
+              `navigated to ${params.moduleName} ${
+                params.props ? JSON.stringify(params.props) : ""
+              } `
+            )
           }
 
           addBreadcrumb({

--- a/src/app/system/navigation/NavStack.tsx
+++ b/src/app/system/navigation/NavStack.tsx
@@ -1,9 +1,11 @@
 import { findFocusedRoute, Route, useIsFocused, useNavigationState } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { addBreadcrumb, Severity } from "@sentry/react-native"
 import { AppModule, modules } from "app/AppRegistry"
 import { useBottomTabBarHeight } from "app/Scenes/BottomTabs/useBottomTabBarHeight"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { isPad } from "app/utils/hardware"
+import { logNavitation } from "app/utils/loggers"
 import { createContext, useState } from "react"
 import { View } from "react-native"
 import { ProvideScreenDimensions, useScreenDimensions } from "shared/hooks"
@@ -115,6 +117,18 @@ export const NavStack: React.FC<{
         options={(props) => {
           const focusedRoute = findFocusedRoute(props.navigation.getState())
           const params = focusedRoute?.params as any
+
+          if (__DEV__ && logNavitation) {
+            console.log(`navigated to ${params.moduleName}: ${JSON.stringify(params.props)}`)
+          }
+
+          addBreadcrumb({
+            message: `navigated to ${params.moduleName}`,
+            category: "navigation",
+            data: { ...params },
+            level: Severity.Info,
+          })
+
           const screenOptions = modules[params.moduleName as AppModule]?.options?.screenOptions
 
           return { ...screenOptions }

--- a/src/app/system/navigation/NavStack.tsx
+++ b/src/app/system/navigation/NavStack.tsx
@@ -1,11 +1,9 @@
 import { findFocusedRoute, Route, useIsFocused, useNavigationState } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
-import { addBreadcrumb, Severity } from "@sentry/react-native"
 import { AppModule, modules } from "app/AppRegistry"
 import { useBottomTabBarHeight } from "app/Scenes/BottomTabs/useBottomTabBarHeight"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { isPad } from "app/utils/hardware"
-import { logNavitation } from "app/utils/loggers"
 import { createContext, useState } from "react"
 import { View } from "react-native"
 import { ProvideScreenDimensions, useScreenDimensions } from "shared/hooks"
@@ -117,21 +115,6 @@ export const NavStack: React.FC<{
         options={(props) => {
           const focusedRoute = findFocusedRoute(props.navigation.getState())
           const params = focusedRoute?.params as any
-
-          if (__DEV__ && logNavitation) {
-            console.log(
-              `navigated to ${params.moduleName} ${
-                params.props ? JSON.stringify(params.props) : ""
-              } `
-            )
-          }
-
-          addBreadcrumb({
-            message: `navigated to ${params.moduleName}`,
-            category: "navigation",
-            data: { ...params },
-            level: Severity.Info,
-          })
 
           const screenOptions = modules[params.moduleName as AppModule]?.options?.screenOptions
 

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events"
 import { ActionType, OwnerType, Screen } from "@artsy/cohesion"
-import { addBreadcrumb } from "@sentry/react-native"
+import { Severity, addBreadcrumb } from "@sentry/react-native"
 import { AppModule, modules, ViewOptions } from "app/AppRegistry"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
@@ -42,6 +42,13 @@ let lastInvocation = { url: "", timestamp: 0 }
 export async function navigate(url: string, options: NavigateOptions = {}) {
   let targetURL = url
 
+  addBreadcrumb({
+    message: `navigate to ${url}`,
+    category: "navigation",
+    data: { url, options },
+    level: Severity.Info,
+  })
+
   // handle artsy:// urls, we can just remove it
   targetURL = url.replace("artsy://", "")
 
@@ -73,11 +80,6 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
     Linking.openURL(result.url)
     return
   }
-
-  addBreadcrumb({
-    message: `user navigated to ${url}`,
-    category: "navigation",
-  })
 
   const module = modules[result.module]
   const presentModally = options.modal ?? module.options.alwaysPresentModally ?? false

--- a/src/app/system/relay/middlewares/metaphysicsMiddleware.ts
+++ b/src/app/system/relay/middlewares/metaphysicsMiddleware.ts
@@ -1,7 +1,7 @@
 import { captureMessage } from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { getCurrentEmissionState, unsafe__getEnvironment } from "app/store/GlobalStore"
-import { logRoute } from "app/utils/loggers"
+import { logQueryPath } from "app/utils/loggers"
 import _ from "lodash"
 import { Middleware, urlMiddleware } from "react-relay-network-modern/node8"
 
@@ -50,7 +50,7 @@ export function metaphysicsExtensionsLoggerMiddleware() {
         const title = `%cMetaphysics API -${requestSummary}${stitchSummary}`
 
         // Make sure we have something to show
-        if (logRoute && (requestCount || stitchCount)) {
+        if (logQueryPath && (requestCount || stitchCount)) {
           // The main title for the metaphysics section
           console.groupCollapsed(title, noBold, colorForRequests, noColor)
 

--- a/src/app/utils/loggers.ts
+++ b/src/app/utils/loggers.ts
@@ -2,12 +2,13 @@ let metaflags = {
   logAction: false,
   logDatadog: false,
   logEventTracked: false,
+  logNavitation: false,
   logNotification: false,
   logOperation: false,
   logPrefetching: false,
+  logQueryPath: false,
   logRelay: false,
   logRelayVerbose: false,
-  logRoute: false,
   logRunningRequest: false,
 }
 if (__DEV__ || __TEST__) {
@@ -22,10 +23,11 @@ if (__DEV__ || __TEST__) {
 export const logAction = metaflags.logAction
 export const logDatadog = metaflags.logDatadog
 export const logEventTracked = metaflags.logEventTracked
+export const logNavitation = metaflags.logNavitation
 export const logNotification = metaflags.logNotification
 export const logOperation = metaflags.logOperation
 export const logPrefetching = metaflags.logPrefetching
+export const logQueryPath = metaflags.logQueryPath
 export const logRelay = metaflags.logRelay
 export const logRelayVerbose = metaflags.logRelayVerbose
-export const logRoute = metaflags.logRoute
 export const logRunningRequest = metaflags.logRunningRequest

--- a/src/app/utils/loggers.ts
+++ b/src/app/utils/loggers.ts
@@ -2,7 +2,7 @@ let metaflags = {
   logAction: false,
   logDatadog: false,
   logEventTracked: false,
-  logNavitation: false,
+  logNavigation: false,
   logNotification: false,
   logOperation: false,
   logPrefetching: false,
@@ -23,7 +23,7 @@ if (__DEV__ || __TEST__) {
 export const logAction = metaflags.logAction
 export const logDatadog = metaflags.logDatadog
 export const logEventTracked = metaflags.logEventTracked
-export const logNavitation = metaflags.logNavitation
+export const logNavigation = metaflags.logNavigation
 export const logNotification = metaflags.logNotification
 export const logOperation = metaflags.logOperation
 export const logPrefetching = metaflags.logPrefetching

--- a/src/setupJest.ts
+++ b/src/setupJest.ts
@@ -195,6 +195,7 @@ jest.mock("@sentry/react-native", () => ({
   setUser() {},
   addBreadcrumb() {},
   withScope() {},
+  Severity: "info",
 }))
 
 // Needing to mock react-native-scrollable-tab-view due to Flow issue


### PR DESCRIPTION
### Description

<img width="1650" alt="Screenshot 2023-01-31 at 08 44 46" src="https://user-images.githubusercontent.com/11945712/215710918-57d8f6fe-f6ce-40d6-936e-693296e18adc.png">

After noticing the above error and some worrying errors inside Sentry ([here](https://sentry.io/organizations/artsynet/issues/3389526194/?environment=production&project=5867225&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d)), I wanted to know which screens this error is happening at. Unfortunately, it turned out that the old tracking was broken and it was also not capturing all screens (for example if you switch tabs.). This PR adds tracking on Intent (when the `navigate` method is used), and also after successful navigation. 

<img width="701" alt="Screenshot 2023-01-31 at 09 40 55" src="https://user-images.githubusercontent.com/11945712/215710695-591b38f2-e02f-4da3-ba98-b6d9053dd170.png">


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
