### PR TITLE
fix: blank screen on career highlights

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsBigCardsSwiper.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsBigCardsSwiper.tsx
@@ -31,11 +31,17 @@ interface Slides {
   content: JSX.Element
 }
 
-export const CareerHighlightsBigCardsSwiper: React.FC<{
+interface CareerHighlightsBigCardsSwiperScreenProps {
   type: CareerHighlightKind
   careerHighlightsAvailableTypes: CareerHighlightKind[]
   openPromoCard?: boolean
-}> = ({ type, careerHighlightsAvailableTypes, openPromoCard }) => {
+}
+
+const CareerHighlightsBigCardsSwiperScreen: React.FC<CareerHighlightsBigCardsSwiperScreenProps> = ({
+  type,
+  careerHighlightsAvailableTypes,
+  openPromoCard,
+}) => {
   const color = useColor()
   const space = useSpace()
   const insets = useSafeAreaInsets()
@@ -51,20 +57,21 @@ export const CareerHighlightsBigCardsSwiper: React.FC<{
 
   const myCollectionInfo = data.me?.myCollectionInfo
 
+  const openedCardIndex = openPromoCard
+    ? careerHighlightsAvailableTypes.length
+    : careerHighlightsAvailableTypes.indexOf(type)
+
+  const [sliderState, setSliderState] = useState({ currentPage: openedCardIndex })
+
   if (!myCollectionInfo) {
     return null
   }
 
   const numberOfSlides = careerHighlightsAvailableTypes.length + 1
-  const openedCardIndex = openPromoCard
-    ? careerHighlightsAvailableTypes.length
-    : careerHighlightsAvailableTypes.indexOf(type)
 
   // 18 is the close button size, 20 is screen margin and 10 is the spase between the
   // close button and the bar
   const barWidth = (screenWidth - 18 - 20 - 20 - 10) / numberOfSlides
-
-  const [sliderState, setSliderState] = useState({ currentPage: openedCardIndex })
 
   const shouldShowSlide = (slide: CareerHighlightKind) => {
     return careerHighlightsAvailableTypes.includes(slide)
@@ -120,6 +127,23 @@ export const CareerHighlightsBigCardsSwiper: React.FC<{
     // TODO: not to forget to mark the initial slide as seen as well
   }
 
+  const StepDot = ({ index }: { index: number }) => {
+    const opacityAnim = useSpringValue(sliderState.currentPage === index ? 1 : 0.2)
+    return (
+      <Animated.View
+        accessibilityLabel="Career Highlights Pagination Scroll Bar"
+        style={{
+          height: 2,
+          width: barWidth - space(1),
+          marginRight: space(1),
+          borderRadius: 2,
+          backgroundColor: color("black100"),
+          opacity: opacityAnim,
+        }}
+      />
+    )
+  }
+
   return (
     <>
       <Flex mt={Platform.OS === "android" ? insets.top : 0}>
@@ -139,40 +163,37 @@ export const CareerHighlightsBigCardsSwiper: React.FC<{
             testID="career-highlighs-big-cards-swiper"
           >
             {Array.from(Array(numberOfSlides).keys()).map((key, index) => (
-              <Animated.View
-                accessibilityLabel="Career Highlights Pagination Scroll Bar"
-                key={key}
-                style={{
-                  height: 2,
-                  width: barWidth - space(1),
-                  marginRight: space(1),
-                  borderRadius: 2,
-                  backgroundColor: color("black100"),
-                  opacity: useSpringValue(sliderState.currentPage === index ? 1 : 0.2),
-                }}
-              />
+              <StepDot key={key} index={index} />
             ))}
           </Flex>
         </FancyModalHeader>
       </Flex>
-      <Suspense fallback={openPromoCard ? <LoadingSkeletonPromoCard /> : <LoadingSkeleton />}>
-        <ScrollView
-          horizontal
-          scrollEventThrottle={10}
-          pagingEnabled
-          snapToAlignment="center"
-          showsHorizontalScrollIndicator={false}
-          contentOffset={{ x: screenWidth * openedCardIndex, y: 0 }}
-          onMomentumScrollEnd={(event: NativeSyntheticEvent<NativeScrollEvent>) =>
-            setSliderPage(event)
-          }
-        >
-          {slides.map(({ key, content }) => {
-            return <Flex key={key}>{content}</Flex>
-          })}
-        </ScrollView>
-      </Suspense>
+      <ScrollView
+        horizontal
+        scrollEventThrottle={10}
+        pagingEnabled
+        snapToAlignment="center"
+        showsHorizontalScrollIndicator={false}
+        contentOffset={{ x: screenWidth * openedCardIndex, y: 0 }}
+        onMomentumScrollEnd={(event: NativeSyntheticEvent<NativeScrollEvent>) =>
+          setSliderPage(event)
+        }
+      >
+        {slides.map(({ key, content }) => {
+          return <Flex key={key}>{content}</Flex>
+        })}
+      </ScrollView>
     </>
+  )
+}
+
+export const CareerHighlightsBigCardsSwiper = (
+  props: CareerHighlightsBigCardsSwiperScreenProps
+) => {
+  return (
+    <Suspense fallback={props.openPromoCard ? <LoadingSkeletonPromoCard /> : <LoadingSkeleton />}>
+      <CareerHighlightsBigCardsSwiperScreen {...props} />
+    </Suspense>
   )
 }
 


### PR DESCRIPTION
This PR resolves an issue where the career highlights cards are broken on Android

**Before**

https://user-images.githubusercontent.com/11945712/216008943-db717caa-52cd-4383-b6a6-b29edee39b29.mp4

**After**


https://user-images.githubusercontent.com/11945712/216009542-16a39cbe-85b9-454b-a911-06209f39194c.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Fix career highlights cards modal - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
