### PR TITLE
fix: load asdf from brew prefix + /libexec + /asdf.sh

### DIFF
--- a/patches/react-native+0.66.5.patch
+++ b/patches/react-native+0.66.5.patch
@@ -142,9 +142,9 @@ index c498ba6..11338d0 100755
 +if [[ -f "$HOME/.asdf/asdf.sh" ]]; then
 +  # shellcheck source=/dev/null
 +  . "$HOME/.asdf/asdf.sh"
-+elif [[ -x "$(command -v brew)" && -f "$(brew --prefix asdf)/asdf.sh" ]]; then
++elif [[ -x "$(command -v brew)" && -f "$(brew --prefix asdf)/libexec/asdf.sh" ]]; then
 +  # shellcheck source=/dev/null
-+  . "$(brew --prefix asdf)/asdf.sh"
++  . "$(brew --prefix asdf)/libexec/asdf.sh"
 +fi
 +
 +# Set up volta if present


### PR DESCRIPTION
This PR resolves an issue with building the app when node versions are managed with a brew-installed asdf.
It would be good to have another asdf-user test this. It may also require re-installing the package.

For reference, the oh-my-zsh plugin loads asdf [here](https://github.com/ohmyzsh/ohmyzsh/blob/master/plugins/asdf/asdf.plugin.zsh#L11-L17) from the `/libexec` subdirectory. I suppose we should check that the non-brew method is similarly the same. At first glance, it appears to be the same.