### PR TITLE
feat(FX-4537): Hide the global blue dot indicator if there are no unseen notifications

### DIFF
--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -3,10 +3,9 @@ import { ClickedActivityPanelTab } from "@artsy/cohesion/dist/Schema/Events/Acti
 import { ActivityQuery } from "__generated__/ActivityQuery.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage, TabProps } from "app/Components/StickyTabPage/StickyTabPage"
-import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { Flex } from "palette"
-import { Suspense, useEffect } from "react"
+import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ActivityList } from "./ActivityList"
@@ -35,10 +34,6 @@ export const ActivityContent: React.FC<ActivityProps> = ({ type }) => {
 }
 
 export const ActivityContainer: React.FC<ActivityProps> = (props) => {
-  useEffect(() => {
-    GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
-  }, [])
-
   return (
     <Suspense fallback={<ActivityTabPlaceholder />}>
       <ActivityContent {...props} />

--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -1,20 +1,14 @@
 import { ActionType } from "@artsy/cohesion"
 import { ClickedActivityPanelTab } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
-import {
-  ActivityMarkNotificationsAsSeenMutation,
-  ActivityMarkNotificationsAsSeenMutation$data,
-} from "__generated__/ActivityMarkNotificationsAsSeenMutation.graphql"
 import { ActivityQuery } from "__generated__/ActivityQuery.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { StickyTabPage, TabProps } from "app/Components/StickyTabPage/StickyTabPage"
-import { GlobalStore } from "app/store/GlobalStore"
+import { useMarkNotificationsAsSeen } from "app/Scenes/Activity/hooks/useMarkNotificationsAsSeen"
 import { goBack } from "app/system/navigation/navigate"
-import { DateTime } from "luxon"
 import { Flex } from "palette"
-import { Suspense, useEffect } from "react"
-import { graphql, useLazyLoadQuery, useMutation } from "react-relay"
+import { Suspense } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
-import { RecordSourceSelectorProxy } from "relay-runtime"
 import { ActivityList } from "./ActivityList"
 import { ActivityTabPlaceholder } from "./ActivityTabPlaceholder"
 import { NotificationType } from "./types"
@@ -26,9 +20,6 @@ interface ActivityProps {
 
 export const ActivityContent: React.FC<ActivityProps> = ({ type }) => {
   const types = getNotificationTypes(type)
-  const [commit] = useMutation<ActivityMarkNotificationsAsSeenMutation>(
-    MarkNotificationsAsSeenMutation
-  )
   const queryData = useLazyLoadQuery<ActivityQuery>(
     ActivityScreenQuery,
     {
@@ -40,37 +31,7 @@ export const ActivityContent: React.FC<ActivityProps> = ({ type }) => {
     }
   )
 
-  useEffect(() => {
-    const updater = (
-      store: RecordSourceSelectorProxy<ActivityMarkNotificationsAsSeenMutation$data>
-    ) => {
-      const root = store.getRoot()
-      const me = root.getLinkedRecord("me")
-
-      // Set unseen notifications count to 0
-      me?.setValue(0, "unseenNotificationsCount")
-    }
-
-    commit({
-      variables: {
-        input: {
-          until: DateTime.local().toISO(),
-        },
-      },
-      updater,
-      optimisticUpdater: updater,
-      onCompleted: (response) => {
-        const result = response.markNotificationsAsSeen?.responseOrError
-        const errorMessage = result?.mutationError?.message
-
-        if (errorMessage) {
-          throw new Error(errorMessage)
-        }
-
-        GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
-      },
-    })
-  }, [])
+  useMarkNotificationsAsSeen()
 
   return <ActivityList viewer={queryData.viewer} me={queryData.me} type={type} />
 }
@@ -127,23 +88,6 @@ const ActivityScreenQuery = graphql`
     }
     me {
       ...ActivityList_me
-    }
-  }
-`
-
-const MarkNotificationsAsSeenMutation = graphql`
-  mutation ActivityMarkNotificationsAsSeenMutation($input: MarkNotificationsAsSeenInput!) {
-    markNotificationsAsSeen(input: $input) {
-      responseOrError {
-        ... on MarkNotificationsAsSeenSuccess {
-          success
-        }
-        ... on MarkNotificationsAsSeenFailure {
-          mutationError {
-            message
-          }
-        }
-      }
     }
   }
 `

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -8,7 +8,6 @@ import {
   StickyTabSection,
 } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
-import { GlobalStore } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { Flex, Separator, Spinner } from "palette"
 import { useContext, useEffect, useState } from "react"
@@ -43,10 +42,6 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
 
     return true
   })
-
-  const recentNotification = notifications[0]
-  const recentNotificationPublishedAt = recentNotification?.rawPublishedAt
-
   const sections: StickyTabSection[] = notifications.map((notification) => ({
     key: notification.internalID,
     content: <ActivityItem item={notification} />,
@@ -81,14 +76,6 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
       </>
     )
   }, [hasUnreadNotifications])
-
-  useEffect(() => {
-    if (type === "all" && recentNotificationPublishedAt) {
-      GlobalStore.actions.bottomTabs.setLastSeenNotificationPublishedAt(
-        recentNotificationPublishedAt
-      )
-    }
-  }, [type, recentNotificationPublishedAt])
 
   if (notifications.length === 0) {
     return (
@@ -142,7 +129,6 @@ const notificationsConnectionFragment = graphql`
         node {
           internalID
           notificationType
-          rawPublishedAt: publishedAt
           artworks: artworksConnection {
             totalCount
           }

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -1,0 +1,60 @@
+import {
+  useMarkNotificationsAsSeenMutation,
+  useMarkNotificationsAsSeenMutation$data,
+} from "__generated__/useMarkNotificationsAsSeenMutation.graphql"
+import { GlobalStore } from "app/store/GlobalStore"
+import { DateTime } from "luxon"
+import { useEffect } from "react"
+import { graphql, useMutation } from "react-relay"
+import { RecordSourceSelectorProxy } from "relay-runtime"
+
+export const useMarkNotificationsAsSeen = () => {
+  const [commit] = useMutation<useMarkNotificationsAsSeenMutation>(MarkNotificationsAsSeenMutation)
+
+  useEffect(() => {
+    commit({
+      variables: {
+        input: {
+          until: DateTime.local().toISO(),
+        },
+      },
+      updater,
+      optimisticUpdater: updater,
+      onCompleted: (response) => {
+        const result = response.markNotificationsAsSeen?.responseOrError
+        const errorMessage = result?.mutationError?.message
+
+        if (errorMessage) {
+          throw new Error(errorMessage)
+        }
+
+        GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
+      },
+    })
+  }, [])
+}
+
+const MarkNotificationsAsSeenMutation = graphql`
+  mutation useMarkNotificationsAsSeenMutation($input: MarkNotificationsAsSeenInput!) {
+    markNotificationsAsSeen(input: $input) {
+      responseOrError {
+        ... on MarkNotificationsAsSeenSuccess {
+          success
+        }
+        ... on MarkNotificationsAsSeenFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+const updater = (store: RecordSourceSelectorProxy<useMarkNotificationsAsSeenMutation$data>) => {
+  const root = store.getRoot()
+  const me = root.getLinkedRecord("me")
+
+  // Set unseen notifications count to 0
+  me?.setValue(0, "unseenNotificationsCount")
+}

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from "@sentry/react-native"
 import {
   useMarkNotificationsAsSeenMutation,
   useMarkNotificationsAsSeenMutation$data,
@@ -12,10 +13,12 @@ export const useMarkNotificationsAsSeen = () => {
   const [commit] = useMutation<useMarkNotificationsAsSeenMutation>(MarkNotificationsAsSeenMutation)
 
   useEffect(() => {
+    const until = DateTime.local().toISO()
+
     commit({
       variables: {
         input: {
-          until: DateTime.local().toISO(),
+          until,
         },
       },
       updater,
@@ -29,6 +32,13 @@ export const useMarkNotificationsAsSeen = () => {
         }
 
         GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
+      },
+      onError: (error) => {
+        if (__DEV__) {
+          console.error(error)
+        } else {
+          captureMessage(error?.stack!)
+        }
       },
     })
   }, [])

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -28,7 +28,13 @@ export const useMarkNotificationsAsSeen = () => {
         const errorMessage = result?.mutationError?.message
 
         if (errorMessage) {
-          throw new Error(errorMessage)
+          if (__DEV__) {
+            console.error(errorMessage)
+          } else {
+            captureMessage(errorMessage)
+          }
+
+          return
         }
 
         GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)

--- a/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tests.tsx
@@ -5,7 +5,6 @@ import { ModalStack } from "app/system/navigation/ModalStack"
 import { createEnvironment } from "app/system/relay/createEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { DateTime } from "luxon"
 import { act, ReactTestRenderer } from "react-test-renderer"
 import useInterval from "react-use/lib/useInterval"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
@@ -71,190 +70,42 @@ describe(BottomTabs, () => {
   })
 
   describe("a blue dot on home icon", () => {
-    describe("should be displayed if there are unseen notifications", () => {
-      it("`lastSeenNotificationPublishedAt` is empty", async () => {
-        const currentDate = DateTime.local()
+    it("should be displayed if there are unseen notifications", async () => {
+      const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeenNotificationPublishedAt: null,
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
+      const prevHomeButton = findButtonByTab(tree, "home")
+      expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
 
-        const prevHomeButton = findButtonByTab(tree, "home")
-        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 1,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: currentDate.toISO(),
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
+      resolveNotificationsInfoQuery({
+        Me: () => ({
+          unreadConversationCount: 5,
+          unseenNotificationsCount: 1,
+        }),
       })
 
-      it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
-        const currentDate = DateTime.local()
-        const prevNotificationPublishedAt = currentDate.minus({ hour: 1 }).toISO()
+      await flushPromiseQueue()
 
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeenNotificationPublishedAt: prevNotificationPublishedAt,
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
-
-        const prevHomeButton = findButtonByTab(tree, "home")
-        expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 1,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: currentDate.toISO(),
-                  },
-                },
-                {
-                  node: {
-                    publishedAt: prevNotificationPublishedAt,
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
-      })
+      const currentHomeButton = findButtonByTab(tree, "home")
+      expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(true)
     })
 
-    describe("should NOT be displayed if there are NO unseen notifications", () => {
-      it("`lastSeenNotificationPublishedAt` is empty", async () => {
-        const publishedAt = DateTime.local().toISO()
+    it("should NOT be displayed if there are NO unseen notifications", async () => {
+      const tree = renderWithWrappersLEGACY(<TestWrapper />)
 
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeenNotificationPublishedAt: null,
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
+      const prevHomeButton = findButtonByTab(tree, "home")
+      expect((prevHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
 
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 0,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: publishedAt,
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
+      resolveNotificationsInfoQuery({
+        Me: () => ({
+          unreadConversationCount: 5,
+          unseenNotificationsCount: 0,
+        }),
       })
 
-      it("the latest notification `publishedAt` is equal to the locally persisted `publishedAt`", async () => {
-        const publishedAt = DateTime.local().toISO()
+      await flushPromiseQueue()
 
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeenNotificationPublishedAt: publishedAt,
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
-
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 0,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: publishedAt,
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-      })
-
-      it("the latest notification `publishedAt` is more recent than the locally persisted `publishedAt`", async () => {
-        const currentDate = DateTime.local()
-
-        __globalStoreTestUtils__?.injectState({
-          bottomTabs: {
-            lastSeenNotificationPublishedAt: currentDate.minus({ hour: 1 }).toISO(),
-          },
-        })
-        const tree = renderWithWrappersLEGACY(<TestWrapper />)
-
-        resolveNotificationsInfoQuery({
-          Me: () => ({
-            unreadConversationCount: 5,
-            unreadNotificationsCount: 0,
-          }),
-          Viewer: () => ({
-            notificationsConnection: {
-              edges: [
-                {
-                  node: {
-                    publishedAt: currentDate.toISO(),
-                  },
-                },
-              ],
-            },
-          }),
-        })
-
-        await flushPromiseQueue()
-
-        const currentHomeButton = findButtonByTab(tree, "home")
-        expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
-      })
+      const currentHomeButton = findButtonByTab(tree, "home")
+      expect((currentHomeButton!.props as ButtonProps).forceDisplayVisualClue).toBe(false)
     })
   })
 
@@ -268,7 +119,7 @@ describe(BottomTabs, () => {
     resolveNotificationsInfoQuery({
       Me: () => ({
         unreadConversationCount: 5,
-        unreadNotificationsCount: 1,
+        unseenNotificationsCount: 1,
       }),
     })
 
@@ -314,7 +165,7 @@ describe(BottomTabs, () => {
     resolveNotificationsInfoQuery({
       Me: () => ({
         unreadConversationCount: 1,
-        unreadNotificationsCount: 1,
+        unseenNotificationsCount: 1,
       }),
     })
 
@@ -332,7 +183,7 @@ describe(BottomTabs, () => {
     resolveNotificationsInfoQuery({
       Me: () => ({
         unreadConversationCount: 3,
-        unreadNotificationsCount: 1,
+        unseenNotificationsCount: 1,
       }),
     })
 

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -9,7 +9,6 @@ import {
 } from "app/system/relay/middlewares/metaphysicsMiddleware"
 import { simpleLoggerMiddleware } from "app/system/relay/middlewares/simpleLoggerMiddleware"
 import { Action, action, Thunk, thunk, ThunkOn, thunkOn } from "easy-peasy"
-import { DateTime } from "luxon"
 import { fetchQuery, graphql } from "react-relay"
 import { BottomTabType } from "./BottomTabType"
 
@@ -130,11 +129,10 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
       const conversations = result?.me?.unreadConversationCount ?? 0
       const notifications = result?.me?.unreadNotificationsCount ?? 0
       const unseenNotifications = result?.me?.unseenNotificationsCount ?? 0
-      const shouldDisplayIndicator = unseenNotifications > 0 && notifications > 0
 
       GlobalStore.actions.bottomTabs.setUnreadConversationsCount(conversations)
       GlobalStore.actions.bottomTabs.setUnreadNotificationsCount(notifications)
-      GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(shouldDisplayIndicator)
+      GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(unseenNotifications > 0)
     } catch (e) {
       if (__DEV__) {
         console.warn(
@@ -153,14 +151,3 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     state.sessionState.tabProps[tab] = props
   }),
 })
-
-const checkIsNewPublishedAt = (prevPublishedAt: string | null, newPublishedAt: string | null) => {
-  if (prevPublishedAt === null || newPublishedAt === null) {
-    return false
-  }
-
-  const prevPublishedDate = DateTime.fromISO(prevPublishedAt)
-  const newPublishedDate = DateTime.fromISO(newPublishedAt)
-
-  return newPublishedDate > prevPublishedDate
-}

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -1,10 +1,6 @@
 import { captureException } from "@sentry/react-native"
 import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__generated__/BottomTabsModelFetchCurrentUnreadConversationCountQuery.graphql"
-import {
-  BottomTabsModelFetchNotificationsInfoQuery,
-  NotificationTypesEnum,
-} from "__generated__/BottomTabsModelFetchNotificationsInfoQuery.graphql"
-import { isArtworksBasedNotification } from "app/Scenes/Activity/utils/isArtworksBasedNotification"
+import { BottomTabsModelFetchNotificationsInfoQuery } from "__generated__/BottomTabsModelFetchNotificationsInfoQuery.graphql"
 import { GlobalStore } from "app/store/GlobalStore"
 import { createEnvironment } from "app/system/relay/createEnvironment"
 import {
@@ -12,7 +8,6 @@ import {
   persistedQueryMiddleware,
 } from "app/system/relay/middlewares/metaphysicsMiddleware"
 import { simpleLoggerMiddleware } from "app/system/relay/middlewares/simpleLoggerMiddleware"
-import { extractNodes } from "app/utils/extractNodes"
 import { Action, action, Thunk, thunk, ThunkOn, thunkOn } from "easy-peasy"
 import { DateTime } from "luxon"
 import { fetchQuery, graphql } from "react-relay"
@@ -23,12 +18,6 @@ export interface UnreadCounts {
   notifications: number
 }
 
-interface NotificationNode {
-  notificationType: NotificationTypesEnum
-  publishedAt: string
-  artworksCount: number
-}
-
 export interface BottomTabsModel {
   sessionState: {
     unreadCounts: UnreadCounts
@@ -36,14 +25,8 @@ export interface BottomTabsModel {
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
-  lastSeenNotificationPublishedAt: string | null
-  setLastSeenNotificationPublishedAt: Action<BottomTabsModel, string | null>
   syncApplicationIconBadgeNumber: ThunkOn<BottomTabsModel>
   setUnreadConversationsCount: Action<BottomTabsModel, number>
-  syncActivityPanelState: Action<
-    BottomTabsModel,
-    { notifications: NotificationNode[]; unreadCount: number }
-  >
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   setUnreadNotificationsCount: Action<BottomTabsModel, number>
   decreaseUnreadNotificationsCount: Action<BottomTabsModel>
@@ -62,10 +45,6 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     tabProps: {},
     selectedTab: "home",
   },
-  lastSeenNotificationPublishedAt: null,
-  setLastSeenNotificationPublishedAt: action((state, payload) => {
-    state.lastSeenNotificationPublishedAt = payload
-  }),
   syncApplicationIconBadgeNumber: thunkOn(
     (actions) => [
       actions.setUnreadConversationsCount,
@@ -137,21 +116,7 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
             me @principalField {
               unreadConversationCount
               unreadNotificationsCount
-            }
-
-            viewer {
-              notificationsConnection(first: 5) {
-                edges {
-                  node {
-                    notificationType
-                    publishedAt
-
-                    artworks: artworksConnection {
-                      totalCount
-                    }
-                  }
-                }
-              }
+              unseenNotificationsCount
             }
           }
         `,
@@ -164,19 +129,12 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
 
       const conversations = result?.me?.unreadConversationCount ?? 0
       const notifications = result?.me?.unreadNotificationsCount ?? 0
-      const nodes = extractNodes(result?.viewer?.notificationsConnection)
-      const formattedNotificationNodes: NotificationNode[] = nodes.map((node) => ({
-        publishedAt: node.publishedAt,
-        notificationType: node.notificationType,
-        artworksCount: node.artworks?.totalCount ?? 0,
-      }))
+      const unseenNotifications = result?.me?.unseenNotificationsCount ?? 0
+      const shouldDisplayIndicator = unseenNotifications > 0 && notifications > 0
 
       GlobalStore.actions.bottomTabs.setUnreadConversationsCount(conversations)
       GlobalStore.actions.bottomTabs.setUnreadNotificationsCount(notifications)
-      GlobalStore.actions.bottomTabs.syncActivityPanelState({
-        notifications: formattedNotificationNodes,
-        unreadCount: notifications,
-      })
+      GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(shouldDisplayIndicator)
     } catch (e) {
       if (__DEV__) {
         console.warn(
@@ -193,27 +151,6 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
-  }),
-  syncActivityPanelState: action((state, payload) => {
-    const notifications = payload.notifications.filter((node) => {
-      if (isArtworksBasedNotification(node.notificationType)) {
-        return node.artworksCount > 0
-      }
-
-      return true
-    })
-    const lastNotification = notifications[0] as NotificationNode | undefined
-    const lastNotificationPublishedAt = lastNotification?.publishedAt ?? null
-    const isLastSeenPublishedAtEmpty =
-      state.lastSeenNotificationPublishedAt === null && lastNotificationPublishedAt
-    const isNewPublishedAtAvailable = checkIsNewPublishedAt(
-      state.lastSeenNotificationPublishedAt,
-      lastNotificationPublishedAt
-    )
-
-    if (isLastSeenPublishedAtEmpty || isNewPublishedAtAvailable) {
-      state.sessionState.displayUnseenNotificationsIndicator = payload.unreadCount > 0
-    }
   }),
 })
 

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -813,23 +813,3 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
     expect(migratedState.artsyPrefs.environment).toEqual(undefined)
   })
 })
-
-describe("App version Versions.AddLastSeenNotificationPublishedAt", () => {
-  const migrationToTest = Versions.AddLastSeenNotificationPublishedAt
-
-  it("add lastSeenNotificationPublishedAt", () => {
-    const previousState = migrate({
-      state: { version: 0 },
-      toVersion: migrationToTest - 1,
-    }) as any
-
-    expect(previousState.bottomTabs.lastSeenNotificationPublishedAt).toEqual(undefined)
-
-    const migratedState = migrate({
-      state: previousState,
-      toVersion: migrationToTest,
-    }) as any
-
-    expect(migratedState.bottomTabs.lastSeenNotificationPublishedAt).toEqual(null)
-  })
-})

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,10 +45,9 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
-  AddLastSeenNotificationPublishedAt: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddLastSeenNotificationPublishedAt
+export const CURRENT_APP_VERSION = Versions.AddCategoryToSubmissionArtworkDetails
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -267,9 +266,6 @@ export const artsyAppMigrations: Migrations = {
   [Versions.AddCategoryToSubmissionArtworkDetails]: (state) => {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
-  },
-  [Versions.AddLastSeenNotificationPublishedAt]: (state) => {
-    state.bottomTabs.lastSeenNotificationPublishedAt = null
   },
 }
 


### PR DESCRIPTION
This PR resolves [FX-4537] <!-- eg [PROJECT-XXXX] -->

### Demo
https://user-images.githubusercontent.com/3513494/216047480-4f051593-0d18-4fd9-89e2-ebe18b5681c7.mp4


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Hide the global blue dot indicator if there are no unseen notifications - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4537]: https://artsyproduct.atlassian.net/browse/FX-4537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ