### PR TITLE
feat(FX-4539): show unseen notifications count for app badge

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -1,6 +1,5 @@
 import { fireEvent } from "@testing-library/react-native"
 import { ActivityItem_Test_Query } from "__generated__/ActivityItem_Test_Query.graphql"
-import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -119,37 +118,6 @@ describe("ActivityItem", () => {
         ],
       },
     })
-  })
-
-  it("should decrease the unread notifications counter by 1 when the notification is marked as read", async () => {
-    __globalStoreTestUtils__?.injectState({
-      bottomTabs: {
-        sessionState: {
-          unreadCounts: {
-            notifications: 2,
-          },
-        },
-      },
-    })
-
-    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Notification: () => ({
-        ...notification,
-        isUnread: true,
-      }),
-    })
-    await flushPromiseQueue()
-
-    fireEvent.press(getByText("Notification Title"))
-
-    // resolving the mark as read mutation
-    resolveMostRecentRelayOperation(mockEnvironment)
-    await flushPromiseQueue()
-
-    const globalStoreState = __globalStoreTestUtils__?.getCurrentState()
-    expect(globalStoreState?.bottomTabs.sessionState.unreadCounts.notifications).toBe(1)
   })
 
   it("should pass search criteria id prop", async () => {

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -9,7 +9,6 @@ import {
 import { ActivityItem_item$key } from "__generated__/ActivityItem_item.graphql"
 import { FilterArray } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ORDERED_ARTWORK_SORTS } from "app/Components/ArtworkFilter/Filters/SortOptions"
-import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { last } from "lodash"
@@ -81,9 +80,6 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
         },
         updater: (store) => {
           updater(item.id, store)
-        },
-        onCompleted: () => {
-          GlobalStore.actions.bottomTabs.decreaseUnreadNotificationsCount()
         },
         onError: (error) => {
           captureMessage(error?.stack!)

--- a/src/app/Scenes/Activity/ActivityMarkAllAsReadSection.tsx
+++ b/src/app/Scenes/Activity/ActivityMarkAllAsReadSection.tsx
@@ -1,7 +1,6 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { captureException } from "@sentry/react-native"
 import { ActivityMarkAllAsReadSectionMutation } from "__generated__/ActivityMarkAllAsReadSectionMutation.graphql"
-import { GlobalStore } from "app/store/GlobalStore"
 import { Button } from "palette"
 import { useMutation } from "react-relay"
 import { ConnectionHandler, graphql, RecordSourceSelectorProxy } from "relay-runtime"
@@ -32,8 +31,6 @@ export const ActivityMarkAllAsReadSection: React.FC<ActivityMarkAllAsReadSection
           if (errorMessage) {
             throw new Error(errorMessage)
           }
-
-          GlobalStore.actions.bottomTabs.setUnreadNotificationsCount(0)
         },
       })
     } catch (e) {

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -38,7 +38,6 @@ export const useMarkNotificationsAsSeen = () => {
         }
 
         GlobalStore.actions.bottomTabs.setUnseenNotificationsCount(0)
-        GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
       },
       onError: (error) => {
         if (__DEV__) {

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -37,6 +37,7 @@ export const useMarkNotificationsAsSeen = () => {
           return
         }
 
+        GlobalStore.actions.bottomTabs.setUnseenNotificationsCount(0)
         GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(false)
       },
       onError: (error) => {

--- a/src/app/Scenes/BottomTabs/BottomTabs.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabs.tsx
@@ -20,9 +20,8 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
   const unreadConversationsCount = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.unreadCounts.conversations
   )
-
-  const displayUnseenNotificationsIndicator = GlobalStore.useAppState(
-    (state) => state.bottomTabs.sessionState.displayUnseenNotificationsIndicator
+  const hasUnseenNotifications = GlobalStore.useAppState(
+    (state) => state.bottomTabs.hasUnseenNotifications
   )
 
   useEffect(() => {
@@ -50,7 +49,7 @@ export const BottomTabs: React.FC<BottomTabBarProps> = (props) => {
         }}
       />
       <Flex flexDirection="row" height={ICON_HEIGHT} px={1}>
-        <BottomTabsButton tab="home" forceDisplayVisualClue={displayUnseenNotificationsIndicator} />
+        <BottomTabsButton tab="home" forceDisplayVisualClue={hasUnseenNotifications} />
         <BottomTabsButton tab="search" />
         <BottomTabsButton tab="inbox" badgeCount={unreadConversationsCount} />
         <BottomTabsButton tab="sell" />

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -3,7 +3,7 @@ import { BottomTabsModelFetchCurrentUnreadConversationCountQuery } from "__gener
 import { BottomTabsModelFetchNotificationsInfoQuery } from "__generated__/BottomTabsModelFetchNotificationsInfoQuery.graphql"
 import { GlobalStore } from "app/store/GlobalStore"
 import { bottomTabsRelayEnvironment } from "app/system/relay/defaultEnvironment"
-import { Action, action, Thunk, thunk, ThunkOn, thunkOn } from "easy-peasy"
+import { Action, action, computed, Computed, Thunk, thunk, ThunkOn, thunkOn } from "easy-peasy"
 import { fetchQuery, graphql } from "react-relay"
 import { BottomTabType } from "./BottomTabType"
 
@@ -19,7 +19,6 @@ export interface BottomTabsModel {
   sessionState: {
     unreadCounts: UnreadCounts
     unseenCounts: UnseenCounts
-    displayUnseenNotificationsIndicator: boolean
     tabProps: Partial<{ [k in BottomTabType]: object }>
     selectedTab: BottomTabType
   }
@@ -28,8 +27,8 @@ export interface BottomTabsModel {
   fetchCurrentUnreadConversationCount: Thunk<BottomTabsModel>
   setUnseenNotificationsCount: Action<BottomTabsModel, number>
   fetchNotificationsInfo: Thunk<BottomTabsModel>
-  setDisplayUnseenNotificationsIndicator: Action<BottomTabsModel, boolean>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
+  hasUnseenNotifications: Computed<this, boolean>
 }
 
 export const getBottomTabsModel = (): BottomTabsModel => ({
@@ -40,7 +39,6 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
     unseenCounts: {
       notifications: 0,
     },
-    displayUnseenNotificationsIndicator: false,
     tabProps: {},
     selectedTab: "home",
   },
@@ -118,7 +116,6 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
 
       GlobalStore.actions.bottomTabs.setUnreadConversationsCount(conversations)
       GlobalStore.actions.bottomTabs.setUnseenNotificationsCount(unseenNotifications)
-      GlobalStore.actions.bottomTabs.setDisplayUnseenNotificationsIndicator(unseenNotifications > 0)
     } catch (e) {
       if (__DEV__) {
         console.warn(
@@ -130,10 +127,8 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
       }
     }
   }),
-  setDisplayUnseenNotificationsIndicator: action((state, payload) => {
-    state.sessionState.displayUnseenNotificationsIndicator = payload
-  }),
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
   }),
+  hasUnseenNotifications: computed((state) => state.sessionState.unseenCounts.notifications > 0),
 })

--- a/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tests.tsx
@@ -11,7 +11,11 @@ describe("HomeHeader", () => {
     it("should NOT render unseen indicator when there are no unseen notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { displayUnseenNotificationsIndicator: false },
+          sessionState: {
+            unseenCounts: {
+              notifications: 0,
+            },
+          },
         },
       })
 
@@ -24,7 +28,11 @@ describe("HomeHeader", () => {
     it("should render unseen indicator when there are unseen notifications", async () => {
       __globalStoreTestUtils__?.injectState({
         bottomTabs: {
-          sessionState: { displayUnseenNotificationsIndicator: true },
+          sessionState: {
+            unseenCounts: {
+              notifications: 5,
+            },
+          },
         },
       })
 

--- a/src/app/Scenes/Home/Components/HomeHeader.tsx
+++ b/src/app/Scenes/Home/Components/HomeHeader.tsx
@@ -4,7 +4,7 @@ import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
   const hasUnseenNotifications = GlobalStore.useAppState(
-    (state) => state.bottomTabs.sessionState.displayUnseenNotificationsIndicator
+    (state) => state.bottomTabs.hasUnseenNotifications
   )
 
   return (


### PR DESCRIPTION
This PR resolves [FX-4539] <!-- eg [PROJECT-XXXX] -->

More context here: [Slack Thread](https://artsy.slack.com/archives/C9SATFLUU/p1676391801615959?thread_ts=1676378327.999239&cid=C9SATFLUU)

### Description
Previously, we showed the count of **unread** notifications on the app icon. With the current changes, the number of unseen notifications will be displayed

### Demo
https://user-images.githubusercontent.com/3513494/221618923-b7731cf9-f822-4049-90b4-0d2015d1391b.MP4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I tested my changes on **iOS** / **Android**.
- [x] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- show unseen notifications count for app badge - dimatretyak

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4539]: https://artsyproduct.atlassian.net/browse/FX-4539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ