### PR TITLE
feat(TX-1032): Different bank account details per order currency

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/WirePaymentSection.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/WirePaymentSection.tsx
@@ -48,79 +48,141 @@ const CopySection: React.FC<{ value: string }> = ({ value }) => {
   )
 }
 
-const WirePaymentSection: React.FC<Props> = ({ order: { code } }) => (
-  <Flex>
-    <Flex my={2} bg="orange10" p={2}>
-      <Text color="orange150">Proceed with the wire transfer to complete your purchase</Text>
-      <Text>
-        Please provide your proof of payment within 7 days. After this period, your order will be
-        eligible for cancellation by the gallery.
-      </Text>
-      <Spacer mt={2} />
+const WirePaymentSection: React.FC<Props> = ({ order: { code, currencyCode, source } }) => {
+  const emailAddressToUse =
+    source === "private_sale" ? "privatesales@artsy.net" : "orders@artsy.net"
 
-      <NumberedListItem index={1}>
-        <Text>Find the order total and Artsy’s banking details below.</Text>
-      </NumberedListItem>
-
-      <NumberedListItem index={2}>
+  return (
+    <Flex>
+      <Flex my={2} bg="orange10" p={2}>
+        <Text color="orange150">Proceed with the wire transfer to complete your purchase</Text>
         <Text>
-          Please inform your bank that you will be responsible for all wire transfer fees.
+          Please provide your proof of payment within 7 days. After this period, your order will be
+          eligible for cancellation by the gallery.
         </Text>
-      </NumberedListItem>
+        <Spacer mt={2} />
 
-      <NumberedListItem index={3}>
+        <NumberedListItem index={1}>
+          <Text>Find the order total and Artsy’s banking details below.</Text>
+        </NumberedListItem>
+
+        <NumberedListItem index={2}>
+          <Text>
+            Please inform your bank that you will be responsible for all wire transfer fees.
+          </Text>
+        </NumberedListItem>
+
+        <NumberedListItem index={3}>
+          <Text>
+            Once you have made the transfer, please email{" "}
+            <Text
+              color="blue100"
+              onPress={() =>
+                sendEmail(emailAddressToUse, {
+                  subject: `Proof of wire transfer payment (#${code})`,
+                })
+              }
+            >
+              {emailAddressToUse}
+            </Text>{" "}
+            with your proof of payment.
+          </Text>
+        </NumberedListItem>
+      </Flex>
+
+      <Flex borderWidth={1} borderColor="black10" p={2}>
+        <Text fontWeight="bold" color="black100">
+          Send wire transfer to
+        </Text>
+
+        {wireTransferArtsyBankDetails(currencyCode)}
+
         <Text>
-          Once you have made the transfer, please email{" "}
-          <Text
-            color="blue100"
-            onPress={() =>
-              sendEmail("orders@artsy.net", {
-                subject: `Proof of wire transfer payment (#${code})`,
-              })
-            }
-          >
-            orders@artsy.net
-          </Text>{" "}
-          with your proof of payment.
+          <Text fontStyle="italic">Add order number #</Text>
+          <CopySection value={code} />
+          <Text fontStyle="italic"> to the notes section in your wire transfer.</Text>
         </Text>
-      </NumberedListItem>
+      </Flex>
     </Flex>
+  )
+}
 
-    <Flex borderWidth={1} borderColor="black10" p={2}>
-      <Text fontWeight="bold" color="black100">
-        Send wire transfer to
-      </Text>
-      <Spacer mt={1} />
+const wireTransferArtsyBankDetails = (currencyCode: string) => {
+  switch (currencyCode) {
+    case "GBP":
+      return (
+        <>
+          <Spacer mt={1} />
+          <PaymentInfoItem label="Account name" value="Art.sy Inc." />
+          <PaymentInfoItem label="Account number" value="88005417" />
+          <PaymentInfoItem label="IBAN" value="GB30PNBP16567188005417" />
+          <PaymentInfoItem label="SWIFT" value="PNBPGB2L" />
+          <PaymentInfoItem label="Sort Code" value="16-56-71" />
 
-      <PaymentInfoItem label="Account name" value="Art.sy Inc." />
-      <PaymentInfoItem label="Account number" value="4243851425" />
-      <PaymentInfoItem label="Routing number" value="121000248" />
-      <PaymentInfoItem label="International SWIFT" value="WFBIUS6S" />
+          <Spacer mt={2} />
 
-      <Spacer mt={2} />
+          <Text fontWeight="bold" color="black100">
+            Bank address
+          </Text>
+          <Spacer mt={1} />
+          <Text>Wells Fargo Bank, N.A. London Branch</Text>
+          <Text>1 Planation Place</Text>
+          <Text>30 Fenchurch Street</Text>
+          <Text>London, United Kingdom, EC3M 3BD</Text>
+          <Spacer mt={2} />
+        </>
+      )
+    case "EUR":
+      return (
+        <>
+          <Spacer mt={1} />
+          <PaymentInfoItem label="Account name" value="Art.sy Inc." />
+          <PaymentInfoItem label="IBAN" value="GB73PNBP16567188005419" />
+          <PaymentInfoItem label="BIC" value="PNBPGB2LXXX" />
 
-      <Text fontWeight="bold" color="black100">
-        Bank address
-      </Text>
-      <Spacer mt={1} />
-      <Text>Wells Fargo Bank, N.A.</Text>
-      <Text>420 Montgomery Street</Text>
-      <Text>San Francisco, CA 9410</Text>
-      <Spacer mt={2} />
+          <Spacer mt={2} />
 
-      <Text>
-        <Text fontStyle="italic">Add order number #</Text>
-        <CopySection value={code} />
-        <Text fontStyle="italic"> to the notes section in your wire transfer.</Text>
-      </Text>
-    </Flex>
-  </Flex>
-)
+          <Text fontWeight="bold" color="black100">
+            Bank address
+          </Text>
+          <Spacer mt={1} />
+          <Text>Wells Fargo Bank, N.A. London Branch</Text>
+          <Text>1 Planation Place</Text>
+          <Text>30 Fenchurch Street</Text>
+          <Text>London, United Kingdom, EC3M 3BD</Text>
+          <Spacer mt={2} />
+        </>
+      )
+    default:
+      return (
+        <>
+          <Spacer mt={1} />
+          <PaymentInfoItem label="Account name" value="Art.sy Inc." />
+          <PaymentInfoItem label="Account number" value="4243851425" />
+          <PaymentInfoItem label="Routing number" value="121000248" />
+          <PaymentInfoItem label="International SWIFT" value="WFBIUS6S" />
+
+          <Spacer mt={2} />
+
+          <Text fontWeight="bold" color="black100">
+            Bank address
+          </Text>
+          <Spacer mt={1} />
+          <Text>Wells Fargo Bank, N.A.</Text>
+          <Text>420 Montgomery Street</Text>
+          <Text>San Francisco, CA 9410</Text>
+          <Spacer mt={2} />
+        </>
+      )
+  }
+}
 
 export const WirePaymentSectionFragmentContainer = createFragmentContainer(WirePaymentSection, {
   order: graphql`
     fragment WirePaymentSection_order on CommerceOrder {
       code
+      currencyCode
+      source
     }
   `,
 })

--- a/src/app/Scenes/OrderHistory/OrderDetails/WirePaymentSection.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/WirePaymentSection.tests.tsx
@@ -3,8 +3,26 @@ import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 import { WirePaymentSectionFragmentContainer } from "./Components/WirePaymentSection"
 
-const order = {
+const orderInUSD = {
   code: "111111111",
+  currencyCode: "USD",
+  source: "artwork_page",
+}
+
+const orderInGBP = {
+  code: "22222222",
+  currencyCode: "GBP",
+}
+
+const orderInEUR = {
+  code: "33333333",
+  currencyCode: "EUR",
+}
+
+const privateSaleOrder = {
+  code: "44444444",
+  currencyCode: "USD",
+  source: "private_sale",
 }
 
 describe("WirePaymentSection", () => {
@@ -25,11 +43,66 @@ describe("WirePaymentSection", () => {
   })
 
   it("renders section", async () => {
-    const { getByText } = renderWithRelay({ CommerceOrder: () => order })
+    const { getByText } = renderWithRelay({ CommerceOrder: () => orderInUSD })
 
     expect(getByText("Proceed with the wire transfer to complete your purchase")).toBeTruthy()
     expect(getByText("Send wire transfer to")).toBeTruthy()
     expect(getByText("Bank address")).toBeTruthy()
-    expect(getByText(order.code)).toBeTruthy()
+    expect(getByText(orderInUSD.code)).toBeTruthy()
+  })
+
+  it("renders Artsy USD bank account details when order currency is USD", async () => {
+    const artsyBankAccountUSD = {
+      accountNo: "4243851425",
+      routingNo: "121000248",
+      swift: "WFBIUS6S",
+      addressLine: "420 Montgomery Street",
+    }
+    const { getByText } = renderWithRelay({ CommerceOrder: () => orderInUSD })
+
+    expect(getByText(artsyBankAccountUSD.accountNo)).toBeTruthy()
+    expect(getByText(artsyBankAccountUSD.routingNo)).toBeTruthy()
+    expect(getByText(artsyBankAccountUSD.swift)).toBeTruthy()
+    expect(getByText(artsyBankAccountUSD.addressLine)).toBeTruthy()
+  })
+
+  it("renders Artsy GBP bank account details when order currency is GBP", async () => {
+    const artsyBankAccountGBP = {
+      accountNo: "88005417",
+      iban: "GB30PNBP16567188005417",
+      swift: "PNBPGB2L",
+      sortCode: "16-56-71",
+      addressLine: "30 Fenchurch Street",
+    }
+    const { getByText } = renderWithRelay({ CommerceOrder: () => orderInGBP })
+
+    expect(getByText(artsyBankAccountGBP.accountNo)).toBeTruthy()
+    expect(getByText(artsyBankAccountGBP.iban)).toBeTruthy()
+    expect(getByText(artsyBankAccountGBP.swift)).toBeTruthy()
+    expect(getByText(artsyBankAccountGBP.sortCode)).toBeTruthy()
+    expect(getByText(artsyBankAccountGBP.addressLine)).toBeTruthy()
+  })
+
+  it("renders Artsy EUR bank account details when order currency is EUR", async () => {
+    const artsyBankAccountEUR = {
+      iban: "GB73PNBP16567188005419",
+      bic: "PNBPGB2LXXX",
+      addressLine: "30 Fenchurch Street",
+    }
+    const { getByText } = renderWithRelay({ CommerceOrder: () => orderInEUR })
+
+    expect(getByText(artsyBankAccountEUR.iban)).toBeTruthy()
+    expect(getByText(artsyBankAccountEUR.bic)).toBeTruthy()
+    expect(getByText(artsyBankAccountEUR.addressLine)).toBeTruthy()
+  })
+
+  it("renders correct email address to send payment receipt for private sale orders", async () => {
+    const { getByText } = renderWithRelay({ CommerceOrder: () => privateSaleOrder })
+    expect(getByText("privatesales@artsy.net")).toBeTruthy()
+  })
+
+  it("renders correct email address to send payment receipt for non-private sale orders", async () => {
+    const { getByText } = renderWithRelay({ CommerceOrder: () => orderInUSD })
+    expect(getByText("orders@artsy.net")).toBeTruthy()
   })
 })


### PR DESCRIPTION
This PR resolves [TX-1032]

### Description

This PR updates the bank account details that we show to buyers in their Order History. 

The update is that we display a different bank account detail, depending on order's currency (GBP, EUR, and default USD).

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [x] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes
The changes are cross-platform, applicable to all users. 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[TX-1032]: https://artsyproduct.atlassian.net/browse/TX-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ