### PR TITLE
chore: Release My Collection artworks from non-Artsy artists feature flag

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -103,7 +103,7 @@ export const features = defineFeatures({
     echoFlagKey: "AREnableConversationalBuyNow",
   },
   AREnableArtworksFromNonArtsyArtists: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Enable My Collection artworks from non-Artsy artists",
     showInDevMenu: true,
     echoFlagKey: "AREnableArtworksFromNonArtsyArtists",


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Release My Collection artworks from non-Artsy artists feature flag. I'm not sure why this flag isn't overridden by Echo ([Echo flag set to true](https://github.com/artsy/echo/blob/508dd2cac9473c98e7b10b67b37243835742b900/Echo.json5#L116)).

### PR Checklist

- [ ] I tested my changes on **iOS** / **Android**.
- [ ] I added screenshots or videos to illustrate my changes.
- [ ] I added Tests and Stories for my changes.
- [ ] I added an [app state migration].
- [ ] I hid my changes behind a [feature flag].
- [ ] I have prefixed changes that need to be tested during a release QA with **[NEEDS EXTERNAL QA]** on the changelog.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to run this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
