### PR TITLE
revert: reverts process color because the color doesn't work

### DIFF
--- a/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -1,7 +1,6 @@
 import { isALocalImage } from "app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel"
 import React from "react"
 import {
-  ColorValue,
   Image,
   ImageResizeMode,
   LayoutChangeEvent,
@@ -33,7 +32,7 @@ interface Props extends ViewProps {
   retryFailedURLs?: boolean
 
   /** The background color for the image view */
-  placeholderBackgroundColor?: ColorValue
+  placeholderBackgroundColor?: string
 
   width?: number
   height?: number
@@ -80,7 +79,7 @@ interface State {
  */
 export default class OpaqueImageView extends React.Component<Props, State> {
   static defaultProps: Props = {
-    placeholderBackgroundColor: processColor("#E7E7E7") as ColorValue, // this is black10. Change it to that when this component becomes a function component.
+    placeholderBackgroundColor: "#E7E7E7", // this is black10. Change it to that when this component becomes a function component.
   }
 
   constructor(props: Props) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

reverts https://github.com/artsy/eigen/pull/8086

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->
#nochangelog
<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
