### PR TITLE
fix: JSON value ‘#E7E7E7’ of type NSString cannot be converted to a U…

### DIFF
--- a/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -78,10 +78,6 @@ interface State {
  * Use `OpaqueImageView` from palette instead.
  */
 export default class OpaqueImageView extends React.Component<Props, State> {
-  static defaultProps: Props = {
-    placeholderBackgroundColor: "#E7E7E7", // this is black10. Change it to that when this component becomes a function component.
-  }
-
   constructor(props: Props) {
     super(props)
 
@@ -168,11 +164,13 @@ export default class OpaqueImageView extends React.Component<Props, State> {
     let remainderProps = props
     if (Platform.OS === "ios" && this.props.imageURL) {
       const anyProps = props as any
-      anyProps.placeholderBackgroundColor = processColor(props.placeholderBackgroundColor)
+      anyProps.placeholderBackgroundColor = processColor(
+        props.placeholderBackgroundColor ?? "#E7E7E7"
+      )
     } else {
       const { ...remainder } = props
       remainderProps = remainder
-      backgroundColorStyle = { backgroundColor: props.placeholderBackgroundColor }
+      backgroundColorStyle = { backgroundColor: props.placeholderBackgroundColor ?? "#E7E7E7" }
     }
 
     if (React.Children.count(remainderProps.children) > 0) {


### PR DESCRIPTION
…IColor.

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Re fixes the issue after the revert that we did because it was causing red background

revert -> https://github.com/artsy/eigen/pull/8154
original fix (that was problematic and was causing red background) -> https://github.com/artsy/eigen/pull/8086

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog
<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
