### PR TITLE
fix(FX-4606): Don't display +n text in activity panel for non-artwork-based notifications

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -295,6 +295,21 @@ describe("ActivityItem", () => {
       expect(queryByLabelText("Remaining artworks count")).toBeFalsy()
     })
 
+    it("should NOT be rendered if notification is not artwork-based", async () => {
+      const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Notification: () => ({
+          ...notification,
+          notificationType: "PARTNER_SHOW_OPENED",
+          objectsCount: 5,
+        }),
+      })
+      await flushPromiseQueue()
+
+      expect(queryByLabelText("Remaining artworks count")).toBeFalsy()
+    })
+
     it("should be rendered if there are more than 4", async () => {
       const { getByText, getByLabelText } = renderWithHookWrappersTL(
         <TestRenderer />,

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -19,6 +19,7 @@ import { TouchableOpacity } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 import { RecordSourceSelectorProxy } from "relay-runtime"
+import { isArtworksBasedNotification } from "./utils/isArtworksBasedNotification"
 
 interface ActivityItemProps {
   item: ActivityItem_item$key
@@ -42,6 +43,8 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const item = useFragment(activityItemFragment, props.item)
   const artworks = extractNodes(item.artworksConnection)
   const remainingArtworksCount = item.objectsCount - 4
+  const shouldDisplayCounts =
+    isArtworksBasedNotification(item.notificationType) && remainingArtworksCount > 0
 
   const getNotificationType = () => {
     if (item.notificationType === "ARTWORK_ALERT") {
@@ -141,7 +144,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
               )
             })}
 
-            {remainingArtworksCount > 0 && (
+            {shouldDisplayCounts && (
               <Text variant="xs" color="black60" accessibilityLabel="Remaining artworks count">
                 + {remainingArtworksCount}
               </Text>


### PR DESCRIPTION
This PR resolves [FX-4606]

### Description

Notice tiny +3 counter on CAMERA WORKS notification:

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/3934579/217271981-64b6de79-43a8-4210-8270-c8fe569766aa.png) | ![after](https://user-images.githubusercontent.com/3934579/217272003-fcf2d54f-85d9-4184-b1ce-a7afe4e7bd9f.png)  |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4606]: https://artsyproduct.atlassian.net/browse/FX-4606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ