### PR TITLE
test: add elastic search list and result element tests

### DIFF
--- a/src/app/Scenes/Search/components/ElasticSearchResult.tests.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResult.tests.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import {
+  ElasticSearchResult,
+  ElasticSearchResultItemProps,
+} from "app/Scenes/Search/components/ElasticSearchResult"
+import { ARTIST_PILL } from "app/Scenes/Search/constants"
+import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+const initialProps: ElasticSearchResultItemProps = {
+  selectedPill: ARTIST_PILL,
+  result: {
+    __typename: "Artist",
+    displayLabel: "Banksy",
+    href: "/artist/banksy",
+    imageUrl: "https://oneimage.jpg",
+    slug: "banksy",
+    internalID: "banksy12512",
+  },
+  position: 1,
+  query: "Banksy",
+}
+
+describe("ElasticSearchResult", () => {
+  it("renders the expected information", () => {
+    renderWithWrappers(<ElasticSearchResult {...initialProps} />)
+
+    expect(screen.queryByText("Banksy")).toBeTruthy()
+    expect(screen.queryByTestId("search-result-image-Banksy")).toBeTruthy()
+
+    fireEvent.press(screen.getByText("Banksy"))
+
+    // navigates to the artist page
+    expect(navigate).toHaveBeenCalledTimes(1)
+    expect(navigate).toHaveBeenCalledWith("/artist/banksy")
+
+    // tracks the press event
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "action": "selectedResultFromSearchScreen",
+          "context_module": "artistsTab",
+          "context_screen": "Search",
+          "context_screen_owner_type": "Search",
+          "position": 1,
+          "query": "Banksy",
+          "selected_object_slug": "banksy",
+          "selected_object_type": "Artist",
+        },
+      ]
+    `)
+  })
+})

--- a/src/app/Scenes/Search/components/ElasticSearchResult.tests.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResult.tests.tsx
@@ -28,12 +28,22 @@ describe("ElasticSearchResult", () => {
 
     expect(screen.queryByText("Banksy")).toBeTruthy()
     expect(screen.queryByTestId("search-result-image-Banksy")).toBeTruthy()
+  })
+
+  it("navigates to the artist page when the result is pressed", () => {
+    renderWithWrappers(<ElasticSearchResult {...initialProps} />)
 
     fireEvent.press(screen.getByText("Banksy"))
 
     // navigates to the artist page
     expect(navigate).toHaveBeenCalledTimes(1)
     expect(navigate).toHaveBeenCalledWith("/artist/banksy")
+  })
+
+  it("tracks the tap event", () => {
+    renderWithWrappers(<ElasticSearchResult {...initialProps} />)
+
+    fireEvent.press(screen.getByText("Banksy"))
 
     // tracks the press event
     expect(mockTrackEvent).toHaveBeenCalledTimes(1)

--- a/src/app/Scenes/Search/components/ElasticSearchResult.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResult.tsx
@@ -13,7 +13,7 @@ import { Flex, Touchable } from "palette"
 import { useTracking } from "react-tracking"
 import { IMAGE_SIZE, SearchResultImage } from "./SearchResultImage"
 
-interface ElasticSearchResultItemProps {
+export interface ElasticSearchResultItemProps {
   result: ElasticSearchResultInterface
   selectedPill: PillType
   query?: string
@@ -73,7 +73,11 @@ export const ElasticSearchResult: React.FC<ElasticSearchResultItemProps> = ({
   return (
     <Touchable onPress={onPress}>
       <Flex height={IMAGE_SIZE} flexDirection="row" alignItems="center">
-        <SearchResultImage imageURL={result.imageUrl} resultType={selectedPill.displayName} />
+        <SearchResultImage
+          imageURL={result.imageUrl}
+          resultType={selectedPill.displayName}
+          testID={`search-result-image-${result.displayLabel}`}
+        />
 
         <Spacer x={1} />
 

--- a/src/app/Scenes/Search/components/ElasticSearchResult.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResult.tsx
@@ -71,7 +71,11 @@ export const ElasticSearchResult: React.FC<ElasticSearchResultItemProps> = ({
   }
 
   return (
-    <Touchable onPress={onPress}>
+    <Touchable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Search Result for ${result.displayLabel}`}
+    >
       <Flex height={IMAGE_SIZE} flexDirection="row" alignItems="center">
         <SearchResultImage
           imageURL={result.imageUrl}

--- a/src/app/Scenes/Search/components/ElasticSearchResults.tests.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResults.tests.tsx
@@ -1,0 +1,206 @@
+import { Spinner } from "@artsy/palette-mobile"
+import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { ElasticSearchResultsQuery } from "__generated__/ElasticSearchResultsQuery.graphql"
+import { ElasticSearchResults2Screen } from "app/Scenes/Search/components/ElasticSearchResults"
+import { ARTIST_PILL } from "app/Scenes/Search/constants"
+import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+
+const eventData = {
+  nativeEvent: {
+    contentOffset: {
+      y: 500,
+    },
+    contentSize: {
+      // Dimensions of the scrollable content
+      height: 500,
+      width: 100,
+    },
+    layoutMeasurement: {
+      // Dimensions of the device
+      height: 100,
+      width: 100,
+    },
+  },
+}
+
+describe("ElasticSearchResults", () => {
+  const initialProps = {
+    query: "Banksy",
+    selectedPill: ARTIST_PILL,
+  }
+
+  const { renderWithRelay } = setupTestWrapper<ElasticSearchResultsQuery>({
+    Component: () => <ElasticSearchResults2Screen {...initialProps} />,
+  })
+
+  it("renders without throwing an error", async () => {
+    renderWithRelay({
+      Query: () => ({
+        searchConnection: {
+          totalCount: 10,
+          ...mockEdges,
+        },
+      }),
+    })
+
+    expect(screen.getByTestId("SingleIndexSearchPlaceholder")).toBeTruthy()
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("SingleIndexSearchPlaceholder"))
+
+    expect(screen.queryByLabelText("Artist search results list")).toBeTruthy()
+
+    mockEdges.edges.forEach((edge) => {
+      expect(screen.queryByLabelText(`Search Result for ${edge.node.displayLabel}`)).toBeTruthy()
+      expect(
+        screen.getByLabelText(`Search Result for ${edge.node.displayLabel}`)
+      ).toHaveTextContent(edge.node.displayLabel)
+    })
+
+    expect(screen.queryByTestId("SingleIndexEmptyResultsMessage")).toBeFalsy()
+    expect(screen.UNSAFE_queryByType(Spinner)).toBeFalsy()
+  })
+
+  it("renders the empty message when no results", async () => {
+    renderWithRelay({
+      Query: () => ({
+        searchConnection: {
+          totalCount: 0,
+          edges: [],
+        },
+      }),
+    })
+
+    expect(screen.getByTestId("SingleIndexSearchPlaceholder")).toBeTruthy()
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("SingleIndexSearchPlaceholder"))
+
+    expect(screen.queryByLabelText("Artist search results list")).toBeTruthy()
+
+    expect(screen.queryByText("Sorry, we couldn’t find an Artist for “Banksy.”"))
+    expect(screen.queryByText("Please try searching again with a different spelling."))
+  })
+
+  it("renders the spinner when fetching more results, and hides it when done", async () => {
+    const { env } = renderWithRelay({
+      Query: () => ({
+        searchConnection: {
+          totalCount: 16,
+          ...mockEdges,
+          pageInfo: {
+            hasNextPage: true,
+          },
+        },
+      }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("SingleIndexSearchPlaceholder"))
+
+    expect(screen.queryByLabelText("Artist search results list")).toBeTruthy()
+
+    expect(screen.UNSAFE_queryByType(Spinner)).toBeFalsy()
+
+    fireEvent.scroll(screen.getByLabelText("Artist search results list"), eventData)
+
+    expect(screen.UNSAFE_queryByType(Spinner)).toBeTruthy()
+
+    resolveMostRecentRelayOperation(env, {
+      Query: () => ({
+        searchConnection: {
+          totalCount: 16,
+          ...extraMockEdges,
+          pageInfo: {
+            hasNextPage: false,
+          },
+        },
+      }),
+    })
+
+    expect(screen.UNSAFE_queryByType(Spinner)).toBeFalsy()
+  })
+})
+
+const mockEdges = {
+  edges: [
+    {
+      node: {
+        displayLabel: "Banksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Hanksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Not Banksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X Banksy of England",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X Bristol Riots",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy Hates Me",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X Third Planet",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X Third Planet International",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X DMS new",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Banksy X Andy Warhol",
+      },
+    },
+  ],
+}
+
+const extraMockEdges = {
+  edges: [
+    {
+      node: {
+        displayLabel: "Extra Banksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Extra Hanksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Extra Not Banksy",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Extra Banksy X Banksy of England",
+      },
+    },
+    {
+      node: {
+        displayLabel: "Extra Banksy X Bristol Riots",
+      },
+    },
+  ],
+}

--- a/src/app/Scenes/Search/components/ElasticSearchResults.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResults.tsx
@@ -53,6 +53,8 @@ export const SearchResults2: React.FC<SearchResults2Props> = ({ query, selectedP
 
   return (
     <FlatList
+      accessibilityRole="list"
+      accessibilityLabel={`${selectedPill.displayName} search results list`}
       ref={flatListRef}
       contentContainerStyle={{ paddingVertical: space(1), paddingHorizontal: space(2) }}
       data={hits}

--- a/src/app/Scenes/Search/components/SearchResultImage.tsx
+++ b/src/app/Scenes/Search/components/SearchResultImage.tsx
@@ -7,7 +7,8 @@ export const SearchResultImage: React.FC<{
   imageURL: string | null
   resultType: string
   initials?: string | null
-}> = ({ imageURL, resultType, initials }) => {
+  testID?: string
+}> = ({ imageURL, resultType, initials, testID }) => {
   const round = resultType === "Artist"
 
   if (!imageURL && initials) {
@@ -16,6 +17,7 @@ export const SearchResultImage: React.FC<{
 
   return (
     <OpaqueImageView
+      testID={testID}
       useRawURL={resultType === "Article"}
       imageURL={imageURL}
       style={{

--- a/src/app/Scenes/Search/components/placeholders/SingleIndexSearchPlaceholder.tsx
+++ b/src/app/Scenes/Search/components/placeholders/SingleIndexSearchPlaceholder.tsx
@@ -15,7 +15,7 @@ export const SingleIndexSearchPlaceholder: React.FC<SingleIndexSearchPlaceholder
   hasRoundedImages,
 }) => (
   <ProvidePlaceholderContext>
-    <Box px={2}>
+    <Box px={2} testID="SingleIndexSearchPlaceholder">
       {times(20).map((index) => (
         <Flex key={`algolia-search-placeholder-${index}`} flexDirection="row" my={1}>
           <PlaceholderBox


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Just adds some tests for the `ElasticSearchResults` and `ElasticSearchResult` components

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add elastic search list and result element tests - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
