### PR TITLE
feat(TX-1053): Get versioned artwork image for order history

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -14,20 +14,22 @@ interface OrderHistoryRowProps {
 
 export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const [lineItem] = extractNodes(order?.lineItems)
-  const { artwork } = lineItem || {}
+  const { artwork, artworkVersion } = lineItem || {}
   const trackingUrl = getTrackingUrl(lineItem)
   const orderStatus = getOrderStatus(order.state as OrderState, lineItem)
   const orderIsInactive = orderStatus === "canceled" || orderStatus === "refunded"
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
+
+  const artworkImageUrl = artworkVersion?.image?.resized?.url
 
   return (
     <Flex width="100%" testID="order-container">
       <Flex mb={1}>
         <Flex flexDirection="row" justifyContent="space-between">
           <Flex justifyContent="center" testID="image-container" mr={2}>
-            {!!artwork?.image ? (
+            {!!artworkImageUrl ? (
               <Image
-                source={{ uri: artwork?.image?.resized?.url }}
+                source={{ uri: artworkImageUrl }}
                 style={{ height: 50, width: 50 }}
                 testID="image"
               />
@@ -119,12 +121,14 @@ export const OrderHistoryRowContainer = createFragmentContainer(OrderHistoryRow,
               trackingUrl
               trackingNumber
             }
-            artwork {
+            artworkVersion {
               image {
                 resized(width: 55) {
                   url
                 }
               }
+            }
+            artwork {
               partner {
                 name
               }


### PR DESCRIPTION
This PR resolves [TX-1053]

### Description

This PR gets the artwork image, displayed in the order row in user purchases, from the artwork version, since this section can now include private sale orders.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Affects all users on each platform. 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
