### PR TITLE
feat(FX-4558): add save/saved label to save artwork button

### DIFF
--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -68,7 +68,7 @@ const RedesignedAboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> 
           <PlaceholderBox width={20} height={20} />
 
           <Flex flexDirection="row" alignItems="center">
-            <PlaceholderBox width={25} height={25} marginRight={space("2")} />
+            <PlaceholderBox width={105} height={25} marginRight={space("1")} />
             <PlaceholderBox width={105} height={25} />
           </Flex>
         </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -40,6 +40,8 @@ describe("ArtworkScreenHeader", () => {
 
     await flushPromiseQueue()
 
+    screen.debug()
+
     expect(screen.queryByLabelText("Artwork page header")).toBeTruthy()
     expect(screen.queryByLabelText("Go back")).toBeTruthy()
     expect(screen.queryByLabelText("Save artwork")).toBeTruthy()

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -40,8 +40,6 @@ describe("ArtworkScreenHeader", () => {
 
     await flushPromiseQueue()
 
-    screen.debug()
-
     expect(screen.queryByLabelText("Artwork page header")).toBeTruthy()
     expect(screen.queryByLabelText("Go back")).toBeTruthy()
     expect(screen.queryByLabelText("Save artwork")).toBeTruthy()

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -105,6 +105,8 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
           size="small"
           variant="outlineLight"
           haptic
+          accessibilityRole="button"
+          accessibilityLabel="Save artwork"
           onPress={handleArtworkSave}
           icon={<SaveIcon isSaved={!!isSaved} />}
           longestText="Savedd"

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -1,4 +1,4 @@
-import { Spacer, HeartIcon, HeartFillIcon, Text } from "@artsy/palette-mobile"
+import { HeartIcon, HeartFillIcon } from "@artsy/palette-mobile"
 import { ArtworkScreenHeader_artwork$data } from "__generated__/ArtworkScreenHeader_artwork.graphql"
 import { useIsStaging } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
@@ -103,18 +103,17 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
       <Flex flexDirection="row" alignItems="center">
         <Button
           size="small"
-          variant="outlineLight"
+          variant="text"
+          textVariant="sm-display"
           haptic
           accessibilityRole="button"
           accessibilityLabel="Save artwork"
           onPress={handleArtworkSave}
           icon={<SaveIcon isSaved={!!isSaved} />}
-          longestText="Savedd"
+          longestText="Saved"
         >
-          <Text variant="sm-display">{isSaved ? "Saved" : "Save"}</Text>
+          {isSaved ? "Saved" : "Save"}
         </Button>
-
-        <Spacer x={1} />
 
         <ArtworkScreenHeaderCreateAlertFragmentContainer artwork={artwork} />
       </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -1,16 +1,16 @@
-import { Spacer, HeartIcon, HeartFillIcon } from "@artsy/palette-mobile"
+import { Spacer, HeartIcon, HeartFillIcon, Text } from "@artsy/palette-mobile"
 import { ArtworkScreenHeader_artwork$data } from "__generated__/ArtworkScreenHeader_artwork.graphql"
 import { useIsStaging } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
-import { BackButton, Flex, Touchable, useSpace } from "palette"
+import { BackButton, Flex, useSpace, Button } from "palette"
 import { createFragmentContainer, graphql, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ArtworkScreenHeaderCreateAlertFragmentContainer } from "./ArtworkScreenHeaderCreateAlert"
 
 const HEADER_HEIGHT = 44
-const SAVE_ICON_SIZE = 25
+const SAVE_ICON_SIZE = 20
 
 interface SaveIconProps {
   isSaved: boolean
@@ -101,16 +101,18 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
       </Flex>
 
       <Flex flexDirection="row" alignItems="center">
-        <Touchable
-          accessibilityRole="button"
-          accessibilityLabel="Save artwork"
+        <Button
+          size="small"
+          variant="outlineLight"
           haptic
           onPress={handleArtworkSave}
+          icon={<SaveIcon isSaved={!!isSaved} />}
+          longestText="Savedd"
         >
-          <SaveIcon isSaved={!!isSaved} />
-        </Touchable>
+          <Text variant="sm-display">{isSaved ? "Saved" : "Save"}</Text>
+        </Button>
 
-        <Spacer x={2} />
+        <Spacer x={1} />
 
         <ArtworkScreenHeaderCreateAlertFragmentContainer artwork={artwork} />
       </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -5,6 +5,7 @@ import {
   ScreenOwnerType,
   TappedCreateAlert,
 } from "@artsy/cohesion"
+import { BellIcon } from "@artsy/palette-mobile"
 import { ArtworkScreenHeaderCreateAlert_artwork$data } from "__generated__/ArtworkScreenHeaderCreateAlert_artwork.graphql"
 import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
 import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
@@ -98,6 +99,7 @@ const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateAlertPro
         textVariant="xs"
         haptic
         onPress={handleCreateAlertPress}
+        icon={<BellIcon />}
       >
         Create Alert
       </Button>


### PR DESCRIPTION
This PR resolves [FX-4558] <!-- eg [PROJECT-XXXX] -->

### Description

On Artwork screen:
- [x] Adds Save/Saved label next to save artwork button 
- [x] Adds `BellIcon` to the create alert button
- [x] Updates placeholder to match new design 

#### Screenshots:

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 14 27 21](https://user-images.githubusercontent.com/21178754/218752339-e25740ef-18ac-4859-a7cb-fdf17a20406d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 12 52 02](https://user-images.githubusercontent.com/21178754/218731019-aa9e369f-56f9-4ce2-a7e0-7a69ce0178e0.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 14 26 27](https://user-images.githubusercontent.com/21178754/218752340-53976ff7-21bd-4b98-8d28-cbe6e77aa3d1.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 12 52 06](https://user-images.githubusercontent.com/21178754/218731009-746da1f7-82d8-4349-905f-09abe109e6f2.png)|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 14 27 29](https://user-images.githubusercontent.com/21178754/218752333-d01d1df0-0319-4962-9b7a-5dcc5a7a3a97.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 12 52 08](https://user-images.githubusercontent.com/21178754/218730991-d9a07b22-d32e-4e5c-948b-6f8d702ba77c.png)|


#### Demo video

https://user-images.githubusercontent.com/21178754/218760935-1e4ae0bb-0c21-406d-b5bc-681154d1bf75.mp4


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add save/saved label to save artwork button - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4558]: https://artsyproduct.atlassian.net/browse/FX-4558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ