### PR TITLE
feat(FX-4614): elastic pills not disabled when loading counts

### DIFF
--- a/src/app/Scenes/Search/ElasticSearchPills.tsx
+++ b/src/app/Scenes/Search/ElasticSearchPills.tsx
@@ -16,7 +16,7 @@ export interface ElasticSearchPillsProps {
 }
 
 export const ElasticSearchPills = React.forwardRef<ScrollView, ElasticSearchPillsProps>(
-  ({ pills, onPillPress, isSelected, viewer, isLoading }, ref) => {
+  ({ pills, onPillPress, isSelected, viewer }, ref) => {
     const space = useSpace()
 
     const data = useFragment<ElasticSearchPills_viewer$key>(ElasticSearchPillsQuery, viewer)
@@ -44,7 +44,7 @@ export const ElasticSearchPills = React.forwardRef<ScrollView, ElasticSearchPill
         {pills.map((pill) => {
           const { key, displayName } = pill
           const selected = isSelected(pill)
-          const disabled = !!selected || isLoading || isPillDisabled(key)
+          const disabled = !!selected || isPillDisabled(key)
 
           return (
             <Pill


### PR DESCRIPTION
This PR resolves [FX-4614] <!-- eg [PROJECT-XXXX] -->

### Description

[notion card](https://www.notion.so/artsy/pill-response-is-a-little-slow-initially-when-i-typed-in-Kaw-only-the-top-pill-worked-the-rest-we-699b611eec6f4341824a263b9189c32c?pvs=4)

Elastic Search Pills are not disabled when loading to provide a better UX.

#### Videos


##### Before

https://user-images.githubusercontent.com/21178754/218993421-2d6e4359-8e1f-42e2-b013-f60c5b778a10.mp4

##### After

https://user-images.githubusercontent.com/21178754/218993494-861abfd3-3444-4eaf-8cdc-f0d1fe2115f5.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- elastic pills not disabled when loading counts (behind ff) - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4614]: https://artsyproduct.atlassian.net/browse/FX-4614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ