### PR TITLE
fix(FX-4616): remove top padding from top pill results

### DIFF
--- a/src/app/Scenes/Search/SearchResults.tsx
+++ b/src/app/Scenes/Search/SearchResults.tsx
@@ -65,7 +65,7 @@ export const SearchResults: React.FC<SearchResultsProps> = ({ selectedPill, quer
 
   if (isTopPillSelected) {
     return (
-      <Flex p={2}>
+      <Flex p={2} pt={0}>
         <AutosuggestResults
           query={query}
           showResultType


### PR DESCRIPTION
This PR resolves [FX-4616] <!-- eg [PROJECT-XXXX] -->

### Description

Found during search QA session, top pill had extra 2 top padding when it wasn't supposed to, edited to match the other search result screens.

|Before|After|
|---|---|
|![Simulator Screen Shot - iPhone 14 - 2023-02-15 at 11 10 59](https://user-images.githubusercontent.com/21178754/219000606-ffc8d016-d785-4a93-9c99-951400aa1451.png)|![Simulator Screen Shot - iPhone 14 - 2023-02-15 at 11 18 00](https://user-images.githubusercontent.com/21178754/219000516-e3028abb-212a-46d8-9f61-62cb3e67802f.png)|
|![Simulator Screen Shot - iPhone 14 - 2023-02-15 at 11 22 12](https://user-images.githubusercontent.com/21178754/219001100-92b35cc6-f932-452a-bde1-46e5238b53bc.png)|![Simulator Screen Shot - iPhone 14 - 2023-02-15 at 11 21 52](https://user-images.githubusercontent.com/21178754/219001103-678c1e6b-a629-4fc9-a7e5-5958875a662b.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- remove top padding from top pill results - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4616]: https://artsyproduct.atlassian.net/browse/FX-4616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ