### PR TITLE
fix(FX-4617): position reset search result screen on query change

### DIFF
--- a/src/app/Scenes/Search/AutosuggestResults.tsx
+++ b/src/app/Scenes/Search/AutosuggestResults.tsx
@@ -82,10 +82,14 @@ const AutosuggestResultsFlatList: React.FC<{
       loadMore()
     }
   }, [])
+
   useEffect(() => {
     if (query) {
       // the query changed, prevent loading more pages until the user starts scrolling
       userHasStartedScrolling.current = false
+    }
+    if (flatListRef.current) {
+      flatListRef.current.scrollToOffset({ offset: 0, animated: true })
     }
   }, [query])
 

--- a/src/app/Scenes/Search/components/ElasticSearchResults.tsx
+++ b/src/app/Scenes/Search/components/ElasticSearchResults.tsx
@@ -10,7 +10,7 @@ import { PillType } from "app/Scenes/Search/types"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { isPad } from "app/utils/hardware"
-import { Suspense, useContext, useRef } from "react"
+import { Suspense, useContext, useEffect, useRef } from "react"
 import { FlatList, Keyboard } from "react-native"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
@@ -57,6 +57,12 @@ export const SearchResults2: React.FC<SearchResults2Props> = ({ query, selectedP
     inputRef.current?.blur()
     Keyboard.dismiss()
   }
+
+  useEffect(() => {
+    if (flatListRef.current) {
+      flatListRef.current.scrollToOffset({ offset: 0, animated: true })
+    }
+  }, [query])
 
   return (
     <FlatList


### PR DESCRIPTION
This PR resolves [FX-4617] <!-- eg [PROJECT-XXXX] -->

### Description

Paired on this with @nickskalkin 

Changes behavior of the search results list: if the user has scrolled down and changed the query  we want to return them to the beggining of the list.

⚠️ This affects also the artist results on mycollection flow (added @olerichter00 / @MounirDhahri for this reason and a video of the behavior there)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

##### Demo of behavior

Search Results:

Top Pill:
https://user-images.githubusercontent.com/21178754/219343334-58e20261-4af4-4d79-9a6e-bdceba276ec5.mp4

ES rest of the Pills:
https://user-images.githubusercontent.com/21178754/219343348-7ece16f4-5e17-402e-bdd7-84d4cc679741.mp4

My collection artist search:
https://user-images.githubusercontent.com/21178754/219340686-e7361a0b-f3a6-43a8-b1b5-2772c9d88715.mp4


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- position reset search result screen on query change - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4617]: https://artsyproduct.atlassian.net/browse/FX-4617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ