### PR TITLE
fix(FX-4619): reduce the initial fetched artwork results

### DIFF
--- a/src/app/Scenes/Search/SearchArtworksContainer.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tsx
@@ -26,7 +26,7 @@ export const SearchArtworksQueryRenderer: React.FC<{ keyword: string }> = ({ key
           initialProps: { keyword },
           renderFallback: ({ retry }) => <LoadFailureView onRetry={retry!} />,
         })}
-        variables={{ count: 20, keyword }}
+        variables={{ count: 10, keyword }}
         cacheConfig={{ force: true }}
       />
     </ArtworkFiltersStoreProvider>

--- a/src/app/Scenes/Search/SearchArtworksGrid.tsx
+++ b/src/app/Scenes/Search/SearchArtworksGrid.tsx
@@ -126,7 +126,7 @@ export const SearchArtworksGridPaginationContainer = createPaginationContainer(
     viewer: graphql`
       fragment SearchArtworksGrid_viewer on Viewer
       @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
+        count: { type: "Int", defaultValue: 10 }
         cursor: { type: "String" }
         keyword: { type: "String" }
         input: { type: "FilterArtworksInput" }


### PR DESCRIPTION
This PR resolves [FX-4619] <!-- eg [PROJECT-XXXX] -->

### Description

Reduces the amount of artworks that we are initially fetching as results on the artwork pill in order to boost the **TTI** of the artwork result list.

### Screenshots

|Before|After|
|---|---|
|<img width="816" alt="Screenshot 2023-02-16 at 12 23 41" src="https://user-images.githubusercontent.com/21178754/219363404-11a4f039-9cf6-48ab-83f2-b83c145a6b07.png">|<img width="1053" alt="Screenshot 2023-02-16 at 12 24 38" src="https://user-images.githubusercontent.com/21178754/219363401-37209ed8-1287-4752-904a-3fd8c1d95fe8.png">|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-  reduce the initial fetched artwork results - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4619]: https://artsyproduct.atlassian.net/browse/FX-4619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ