### PR TITLE
fix: avoid double tracking marketing links

### DIFF
--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -30,7 +30,10 @@ export function useDeepLinks() {
   }, [isHydrated, isLoggedIn])
 
   const handleDeepLink = (url: string) => {
-    trackEvent(tracks.deepLink(url))
+    // These will be redirected, avoided double tracking
+    if (!url.includes("click.artsy.net")) {
+      trackEvent(tracks.deepLink(url))
+    }
 
     // If the state is hydrated and the user is logged in
     // We navigate them to the the deep link
@@ -45,7 +48,11 @@ export function useDeepLinks() {
 
   useEffect(() => {
     if (isLoggedIn && launchURL.current) {
-      trackEvent(tracks.deepLink(launchURL.current))
+      // These will be redirected, avoided double tracking
+      if (!launchURL.current.includes("click.artsy.net")) {
+        trackEvent(tracks.deepLink(launchURL.current))
+      }
+
       // Navigate to the saved launch url
       navigate(launchURL.current)
       // Reset the launchURL


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Marketing deeplinks are handled and redirected and we were tracking twice, once with encoded url and once with decoded url. This checks the url before tracking to avoid this. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fix double tracking of marketing deeplinks - Brian

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
