### PR TITLE
chore(devMenu): Move RN dev menu button to top

### DIFF
--- a/src/app/utils/DevMenu.tsx
+++ b/src/app/utils/DevMenu.tsx
@@ -86,6 +86,10 @@ export const DevMenu = ({ onClose = () => dismissModal() }: { onClose(): void })
         <Text variant="xs" color="grey" mx={2}>
           {userEmail}
         </Text>
+        <FeatureFlagMenuItem
+          title="Open RN Dev Menu"
+          onPress={() => NativeModules.DevMenu.show()}
+        />
         {Platform.OS === "ios" && (
           <FeatureFlagMenuItem
             title="Go to old Dev Menu"
@@ -197,10 +201,7 @@ export const DevMenu = ({ onClose = () => dismissModal() }: { onClose(): void })
               Keychain.resetInternetCredentials(server)
             }}
           />
-          <FeatureFlagMenuItem
-            title="Open RN Dev Menu"
-            onPress={() => NativeModules.DevMenu.show()}
-          />
+
           <FeatureFlagMenuItem
             title="Clear AsyncStorage"
             onPress={() => {


### PR DESCRIPTION
### Description

Unburies the RN dev menu now that the debugger is no longer broken and moves it to the top to encourage more use: 

<img width="368" alt="Screenshot 2023-02-16 at 10 45 56 AM" src="https://user-images.githubusercontent.com/236943/219459022-143acf71-834f-4031-a42b-c13022730c03.png">

cc @artsy/mobile-platform 