### PR TITLE
fix: display contact gallery button on inquireable partners

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -418,7 +418,7 @@ describe("Artwork", () => {
       renderWithWrappers(<TestRenderer />)
 
       // ArtworkAboveTheFoldQuery
-      resolveMostRecentRelayOperation(environment, {})
+      resolveMostRecentRelayOperation(environment)
 
       // ArtworkMarkAsRecentlyViewedQuery
       resolveMostRecentRelayOperation(environment)
@@ -446,7 +446,7 @@ describe("Artwork", () => {
       renderWithWrappers(<TestRenderer />)
 
       // ArtworkAboveTheFoldQuery
-      resolveMostRecentRelayOperation(environment, {})
+      resolveMostRecentRelayOperation(environment)
 
       // ArtworkMarkAsRecentlyViewedQuery
       resolveMostRecentRelayOperation(environment)

--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -13,7 +13,6 @@ import {
 } from "app/__fixtures__/ArtworkBidAction"
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 
-import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { ModalStack } from "app/system/navigation/ModalStack"
 import { navigationEvents } from "app/system/navigation/navigate"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -415,17 +414,11 @@ describe("Artwork", () => {
   })
 
   describe("Partner Section", () => {
-    it("should display questions section", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: true })
-
+    it("should display contact gallery button when partner is inquireable", () => {
       renderWithWrappers(<TestRenderer />)
 
       // ArtworkAboveTheFoldQuery
-      resolveMostRecentRelayOperation(environment, {
-        Artwork: () => ({
-          isAcquireable: true,
-        }),
-      })
+      resolveMostRecentRelayOperation(environment, {})
 
       // ArtworkMarkAsRecentlyViewedQuery
       resolveMostRecentRelayOperation(environment)
@@ -435,6 +428,7 @@ describe("Artwork", () => {
         Artwork: () => ({
           partner: {
             type: "Gallery",
+            isInquireable: true,
           },
           sale: {
             isBenefit: false,
@@ -448,17 +442,11 @@ describe("Artwork", () => {
       expect(screen.queryByText("Contact Gallery")).toBeTruthy()
     })
 
-    it("should not display questions section", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationalBuyNow: false })
-
+    it("should not display contact gallery button when partner is not inquireable", () => {
       renderWithWrappers(<TestRenderer />)
 
       // ArtworkAboveTheFoldQuery
-      resolveMostRecentRelayOperation(environment, {
-        Artwork: () => ({
-          isAcquireable: true,
-        }),
-      })
+      resolveMostRecentRelayOperation(environment, {})
 
       // ArtworkMarkAsRecentlyViewedQuery
       resolveMostRecentRelayOperation(environment)
@@ -468,6 +456,7 @@ describe("Artwork", () => {
         Artwork: () => ({
           partner: {
             type: "Gallery",
+            isInquireable: false,
           },
           sale: {
             isBenefit: false,
@@ -477,8 +466,8 @@ describe("Artwork", () => {
       })
 
       expect(screen.queryByText("Gallery")).toBeTruthy()
-      expect(screen.queryByText("Questions about this piece?")).toBeFalsy()
-      expect(screen.queryByText("Contact Gallery")).toBeFalsy()
+      expect(screen.queryByText("Questions about this piece?")).toBeNull()
+      expect(screen.queryByText("Contact Gallery")).toBeNull()
     })
   })
 

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -10,7 +10,7 @@ import { AuctionTimerState, currentTimerState } from "app/Components/Bidding/Com
 import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { OfferSubmittedModal } from "app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal"
-import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore } from "app/store/GlobalStore"
 import { navigationEvents } from "app/system/navigation/navigate"
 import { defaultEnvironment } from "app/system/relay/createEnvironment"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
@@ -70,7 +70,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const space = useSpace()
   const [refreshing, setRefreshing] = useState(false)
   const [fetchingData, setFetchingData] = useState(false)
-  const enableConversationalBuyNow = useFeatureFlag("AREnableConversationalBuyNow")
   const isDeepZoomModalVisible = GlobalStore.useAppState(
     (store) => store.devicePrefs.sessionState.isDeepZoomModalVisible
   )
@@ -304,14 +303,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
         key: "partnerCard",
         element: (
           <PartnerCard
-            shouldShowQuestions={
-              !!(
-                enableConversationalBuyNow &&
-                artworkBelowTheFold &&
-                (artworkAboveTheFold?.isAcquireable ||
-                  (!artworkAboveTheFold?.isInquireable && artworkAboveTheFold?.isOfferable))
-              )
-            }
+            shouldShowQuestions={!!artworkBelowTheFold.partner?.isInquireable}
             artwork={artworkBelowTheFold}
           />
         ),
@@ -518,6 +510,7 @@ export const ArtworkContainer = createRefetchContainer(
         isForSale
         partner {
           type
+          isInquireable
         }
         artist {
           biographyBlurb {


### PR DESCRIPTION
This PR resolves [FX-4626] <!-- eg [PROJECT-XXXX] -->

### Description

- [x] clean up `AREnableConversationalBuyNow` from artwork page (**only**)
- [x] display contact gallery button on partner section when artworks partner is inquireable 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### Demo


https://user-images.githubusercontent.com/21178754/220890327-4c7c8337-a67a-4891-84c0-d5080f7aafa0.mp4


https://user-images.githubusercontent.com/21178754/220890360-bbae1d1a-34f7-407d-82a8-64f1ce6f7151.mp4


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- display contact gallery button on inquireable partners - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4626]: https://artsyproduct.atlassian.net/browse/FX-4626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ