### PR TITLE
fix: save button not easily pressed on android

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tsx
@@ -1,16 +1,16 @@
-import { HeartIcon, HeartFillIcon, Flex, useSpace } from "@artsy/palette-mobile"
+import { HeartIcon, HeartFillIcon, Flex, useSpace, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkScreenHeader_artwork$data } from "__generated__/ArtworkScreenHeader_artwork.graphql"
 import { useIsStaging } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
-import { BackButton, Button } from "palette"
+import { BackButton, Touchable } from "palette"
 import { createFragmentContainer, graphql, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ArtworkScreenHeaderCreateAlertFragmentContainer } from "./ArtworkScreenHeaderCreateAlert"
 
 const HEADER_HEIGHT = 44
-const SAVE_ICON_SIZE = 20
+const SAVE_ICON_SIZE = 22
 
 interface SaveIconProps {
   isSaved: boolean
@@ -101,24 +101,27 @@ const ArtworkScreenHeader: React.FC<ArtworkScreenHeaderProps> = ({ artwork }) =>
       </Flex>
 
       <Flex flexDirection="row" alignItems="center">
-        <Button
+        <Touchable
           hitSlop={{
             top: space(1),
             left: space(1),
-            right: 0,
+            right: space(1),
             bottom: space(1),
           }}
-          size="small"
-          variant="text"
           haptic
           accessibilityRole="button"
           accessibilityLabel="Save artwork"
           onPress={handleArtworkSave}
-          icon={<SaveIcon isSaved={!!isSaved} />}
-          longestText="Saved"
         >
-          {isSaved ? "Saved" : "Save"}
-        </Button>
+          <Flex flex={1} justifyContent="center" alignItems="center" flexDirection="row">
+            <SaveIcon isSaved={!!isSaved} />
+            <Spacer x={0.5} />
+            {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}
+            <Text variant="sm">{isSaved ? "Saved" : "Save   "}</Text>
+          </Flex>
+        </Touchable>
+
+        <Spacer x={2} />
 
         <ArtworkScreenHeaderCreateAlertFragmentContainer artwork={artwork} />
       </Flex>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Came out of QA Session today, the button wasn't  easily pressed on Android only so switched to Touchable and it works correctly now.

There is a hack in place to prevent the jumpy behavior but will fix it properly after the release

|Demo||
|---|---|
|iOS||
|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 17 47 56](https://user-images.githubusercontent.com/21178754/220975231-cef91ab6-d9b4-4a12-a3e3-16fff73143f0.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-02-23 at 17 48 00](https://user-images.githubusercontent.com/21178754/220975236-7c5df705-4d63-4b12-9d79-08462f72d169.png)|
|Android||
|![Screenshot_1677170940](https://user-images.githubusercontent.com/21178754/220975285-d0032859-7503-4bcb-bbed-cd3107440c2a.png)|![Screenshot_1677170943](https://user-images.githubusercontent.com/21178754/220975293-b931543f-2c72-40fa-b93a-2ef4e23c5ed3.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-  fix: save button not easily pressed on android - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
