### PR TITLE
feat: art quiz icon animation

### DIFF
--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Touchable, Flex, Screen, Text, BackButton } from "@artsy/palette-mobile"
+import { Touchable, Flex, Screen, Text, BackButton } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { ArtQuizArtworksDislikeMutation } from "__generated__/ArtQuizArtworksDislikeMutation.graphql"
 import { ArtQuizArtworksQuery } from "__generated__/ArtQuizArtworksQuery.graphql"
@@ -192,12 +192,9 @@ export const ArtQuizResultsScreen = () => {
             })}
           </PagerView>
         </Flex>
-        <Flex justifyContent="flex-end">
-          <Flex flexDirection="row" justifyContent="center" px={4}>
-            <ArtQuizButton variant="Dislike" onPress={() => handleNext("Dislike")} />
-            <Spacer y={2} />
-            <ArtQuizButton variant="Like" onPress={() => handleNext("Like")} />
-          </Flex>
+        <Flex flexDirection="row" justifyContent="space-around" mb={6} mx={4}>
+          <ArtQuizButton variant="Dislike" onPress={() => handleNext("Dislike")} />
+          <ArtQuizButton variant="Like" onPress={() => handleNext("Like")} />
         </Flex>
       </Screen.Body>
     </Screen>

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -1,19 +1,11 @@
-import {
-  Spacer,
-  Touchable,
-  CloseIcon,
-  Flex,
-  HeartIcon,
-  Screen,
-  Text,
-  BackButton,
-} from "@artsy/palette-mobile"
+import { Spacer, Touchable, Flex, Screen, Text, BackButton } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { ArtQuizArtworksDislikeMutation } from "__generated__/ArtQuizArtworksDislikeMutation.graphql"
 import { ArtQuizArtworksQuery } from "__generated__/ArtQuizArtworksQuery.graphql"
 import { ArtQuizArtworksSaveMutation } from "__generated__/ArtQuizArtworksSaveMutation.graphql"
 import { ArtQuizArtworksUpdateQuizMutation } from "__generated__/ArtQuizArtworksUpdateQuizMutation.graphql"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
+import { ArtQuizButton } from "app/Scenes/ArtQuiz/ArtQuizButton"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { ArtQuizNavigationStack } from "app/Scenes/ArtQuiz/ArtQuizNavigation"
 import { useOnboardingContext } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
@@ -200,14 +192,12 @@ export const ArtQuizResultsScreen = () => {
             })}
           </PagerView>
         </Flex>
-        <Flex flexDirection="row" justifyContent="center" mb={6}>
-          <Touchable onPress={() => handleNext("Dislike")} style={{ marginHorizontal: 40 }}>
-            <CloseIcon height={40} width={50} />
-          </Touchable>
-          <Spacer y={2} />
-          <Touchable onPress={() => handleNext("Like")} style={{ marginHorizontal: 40 }}>
-            <HeartIcon height={40} width={50} />
-          </Touchable>
+        <Flex justifyContent="flex-end">
+          <Flex flexDirection="row" justifyContent="center" px={4}>
+            <ArtQuizButton variant="Dislike" onPress={() => handleNext("Dislike")} />
+            <Spacer y={2} />
+            <ArtQuizButton variant="Like" onPress={() => handleNext("Like")} />
+          </Flex>
         </Flex>
       </Screen.Body>
     </Screen>

--- a/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
@@ -1,4 +1,4 @@
-import { CloseIcon, HeartIcon, Touchable } from "palette"
+import { CloseIcon, HeartIcon, Touchable } from "@artsy/palette-mobile"
 
 interface ArtQuizButtonProps {
   variant: "Like" | "Dislike"

--- a/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
@@ -1,0 +1,18 @@
+import { CloseIcon, HeartIcon, Touchable } from "palette"
+
+interface ArtQuizButtonProps {
+  variant: "Like" | "Dislike"
+  onPress: () => void
+}
+
+export const ArtQuizButton = ({ variant, onPress }: ArtQuizButtonProps) => {
+  return (
+    <Touchable onPress={onPress}>
+      {variant === "Like" ? (
+        <HeartIcon height={40} width={50} />
+      ) : (
+        <CloseIcon height={40} width={50} />
+      )}
+    </Touchable>
+  )
+}

--- a/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
@@ -1,18 +1,55 @@
-import { CloseIcon, HeartIcon, Touchable } from "@artsy/palette-mobile"
+import { CloseIcon, HeartFillIcon, HeartIcon } from "@artsy/palette-mobile"
+import { Touchable } from "palette"
+import { useState } from "react"
+import Animated, {
+  Easing,
+  Extrapolate,
+  interpolate,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated"
 
 interface ArtQuizButtonProps {
   variant: "Like" | "Dislike"
   onPress: () => void
 }
 
+const TimingConfig = { duration: 50, easing: Easing.linear }
+
 export const ArtQuizButton = ({ variant, onPress }: ArtQuizButtonProps) => {
+  const [isAnimating, setIsAnimating] = useState(false)
+  const pressed = useSharedValue(false)
+  const progress = useDerivedValue(() => {
+    return pressed.value ? withTiming(1, TimingConfig) : withTiming(0, TimingConfig)
+  })
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const scale = interpolate(progress.value, [0, 1], [1, 1.25], Extrapolate.CLAMP)
+    return {
+      transform: [{ scale }],
+    }
+  })
+
+  const hanldeOnPressIn = () => {
+    setIsAnimating(true)
+    pressed.value = true
+  }
+
+  const hanldeOnPressOut = () => {
+    setIsAnimating(false)
+    onPress()
+    pressed.value = false
+  }
+
   return (
-    <Touchable onPress={onPress}>
-      {variant === "Like" ? (
-        <HeartIcon height={40} width={50} />
-      ) : (
-        <CloseIcon height={40} width={50} />
-      )}
+    <Touchable onPressIn={hanldeOnPressIn} onPressOut={hanldeOnPressOut}>
+      <Animated.View style={animatedStyle}>
+        {variant === "Dislike" && <CloseIcon height={40} width={50} />}
+        {variant === "Like" && isAnimating && <HeartFillIcon height={40} width={50} />}
+        {variant === "Like" && !isAnimating && <HeartIcon height={40} width={50} />}
+      </Animated.View>
     </Touchable>
   )
 }

--- a/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizButton.tsx
@@ -32,19 +32,19 @@ export const ArtQuizButton = ({ variant, onPress }: ArtQuizButtonProps) => {
     }
   })
 
-  const hanldeOnPressIn = () => {
+  const handleOnPressIn = () => {
     setIsAnimating(true)
     pressed.value = true
   }
 
-  const hanldeOnPressOut = () => {
+  const handleOnPressOut = () => {
     setIsAnimating(false)
     onPress()
     pressed.value = false
   }
 
   return (
-    <Touchable onPressIn={hanldeOnPressIn} onPressOut={hanldeOnPressOut}>
+    <Touchable onPressIn={handleOnPressIn} onPressOut={handleOnPressOut}>
       <Animated.View style={animatedStyle}>
         {variant === "Dislike" && <CloseIcon height={40} width={50} />}
         {variant === "Like" && isAnimating && <HeartFillIcon height={40} width={50} />}


### PR DESCRIPTION
This PR resolves [GRO-1266] <!-- eg [PROJECT-XXXX] -->

https://user-images.githubusercontent.com/17421923/221200910-5c63cf64-e132-457e-8e37-946b21ece901.mov



### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[GRO-1266]: https://artsyproduct.atlassian.net/browse/GRO-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ