### PR TITLE
feat: use displayState (instead of state + shipment status) for order status calculations

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsHeader.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsHeader.tsx
@@ -1,7 +1,6 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { OrderDetailsHeader_info$data } from "__generated__/OrderDetailsHeader_info.graphql"
-import { extractNodes } from "app/utils/extractNodes"
-import { getOrderStatus, OrderState } from "app/utils/getOrderStatus"
+import { getOrderStatus } from "app/utils/getOrderStatus"
 import { DateTime } from "luxon"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -14,9 +13,8 @@ export const OrderDetailsHeader: React.FC<Props> = ({ info }) => {
     return null
   }
 
-  const [lineItem] = extractNodes(info?.lineItems)
-  const { createdAt, requestedFulfillment, code, state } = info
-  const orderStatus = getOrderStatus(state as OrderState, lineItem)
+  const { createdAt, requestedFulfillment, code, displayState } = info
+  const orderStatus = getOrderStatus(displayState)
   const isPickupOrder = requestedFulfillment?.__typename === "CommercePickup"
 
   return (
@@ -64,7 +62,7 @@ export const OrderDetailsHeaderFragmentContainer = createFragmentContainer(Order
     fragment OrderDetailsHeader_info on CommerceOrder {
       createdAt
       code
-      state
+      displayState
       requestedFulfillment {
         ... on CommerceShip {
           __typename
@@ -74,15 +72,6 @@ export const OrderDetailsHeaderFragmentContainer = createFragmentContainer(Order
         }
         ... on CommerceShipArta {
           __typename
-        }
-      }
-      lineItems(first: 1) {
-        edges {
-          node {
-            shipment {
-              status
-            }
-          }
         }
       }
     }

--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -31,18 +31,21 @@ export const TrackOrderSection: React.FC<Props> = ({ section }) => {
         <Text testID="orderStatus" variant="sm" style={{ textTransform: "capitalize" }}>
           {orderStatus}
         </Text>
-        {!!shipment?.trackingNumber ? (
+        {!!shipment?.trackingNumber && (
           <Text testID="trackingNumber" variant="sm" color="black60">
             Tracking:&nbsp;
             <Text variant="sm" color="black60" weight="medium">
               {shipment?.trackingNumber}
             </Text>
           </Text>
-        ) : (
+        )}
+
+        {!!trackingUrl === false && (
           <Text testID="noTrackingNumber" variant="sm" color="black60">
             Tracking not available
           </Text>
         )}
+
         {(!!shipment?.deliveryStart || !!createdAt) && (
           <Text testID="shippedOn" variant="sm" color="black60">
             Shipped on&nbsp;

--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { TrackOrderSection_section$data } from "__generated__/TrackOrderSection_section.graphql"
 import { extractNodes } from "app/utils/extractNodes"
-import { getOrderStatus, OrderState } from "app/utils/getOrderStatus"
+import { getOrderStatus } from "app/utils/getOrderStatus"
 import { getTrackingUrl } from "app/utils/getTrackingUrl"
 import { DateTime } from "luxon"
 import { Button } from "palette"
@@ -22,7 +22,7 @@ export const TrackOrderSection: React.FC<Props> = ({ section }) => {
   const [fulfillment] = extractNodes(fulfillments)
   const { estimatedDelivery, createdAt } = fulfillment || {}
   const trackingUrl = getTrackingUrl(lineItem)
-  const orderStatus = getOrderStatus(section.state as OrderState, lineItem)
+  const orderStatus = getOrderStatus(section.displayState)
   const deliveredStatus = orderStatus === "delivered"
 
   return (
@@ -96,7 +96,7 @@ export const TrackOrderSection: React.FC<Props> = ({ section }) => {
 export const TrackOrderSectionFragmentContainer = createFragmentContainer(TrackOrderSection, {
   section: graphql`
     fragment TrackOrderSection_section on CommerceOrder {
-      state
+      displayState
       lineItems(first: 1) {
         edges {
           node {

--- a/src/app/Scenes/OrderHistory/OrderDetails/OrderDetailsHeader.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/OrderDetailsHeader.tests.tsx
@@ -7,7 +7,6 @@ import { OrderDetailsHeaderFragmentContainer } from "./Components/OrderDetailsHe
 const mockInfo = {
   createdAt: "2021-06-02T14:51:19+03:00",
   code: "075381384",
-  state: "SUBMITTED",
   requestedFulfillment: { __typename: "CommerceShip" },
   lineItems: { edges: [{ node: { shipment: null } }] },
 }
@@ -30,7 +29,9 @@ describe("OrderDetailsHeader", () => {
   })
 
   it("renders date, code, status, fulfillment fields", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockInfo })
+    const tree = renderWithRelay({
+      CommerceOrder: () => ({ ...mockInfo, displayState: "SUBMITTED" }),
+    })
 
     expect(extractText(tree.UNSAFE_getByProps({ testID: "date" }))).toBe("Jun 2, 2021")
     expect(extractText(tree.UNSAFE_getByProps({ testID: "code" }))).toBe("075381384")
@@ -41,25 +42,27 @@ describe("OrderDetailsHeader", () => {
   describe("Renders correctly status and fulfillment fields", () => {
     describe("Renders correctly status and fulfillment fields", () => {
       describe("CommerceShip", () => {
-        it("SUBMITTED state", () => {
-          const tree = renderWithRelay({ CommerceOrder: () => mockInfo })
+        it("SUBMITTED displayState", () => {
+          const tree = renderWithRelay({
+            CommerceOrder: () => ({ ...mockInfo, displayState: "SUBMITTED" }),
+          })
 
           expect(extractText(tree.UNSAFE_getByProps({ testID: "status" }))).toBe("pending")
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
         })
 
-        it("APPROVED state", () => {
+        it("APPROVED displayState", () => {
           const tree = renderWithRelay({
-            CommerceOrder: () => ({ ...mockInfo, state: "APPROVED" }),
+            CommerceOrder: () => ({ ...mockInfo, displayState: "APPROVED" }),
           })
 
           expect(extractText(tree.UNSAFE_getByProps({ testID: "status" }))).toBe("confirmed")
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
         })
 
-        it("FULFILLED state", () => {
+        it("FULFILLED displayState", () => {
           const tree = renderWithRelay({
-            CommerceOrder: () => ({ ...mockInfo, state: "FULFILLED" }),
+            CommerceOrder: () => ({ ...mockInfo, displayState: "FULFILLED" }),
           })
 
           expect(extractText(tree.UNSAFE_getByProps({ testID: "status" }))).toBe("delivered")
@@ -68,11 +71,11 @@ describe("OrderDetailsHeader", () => {
       })
 
       describe("CommerceShipArtA", () => {
-        it("PENDING status", () => {
+        it("PROCESSING displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "pending" } } }] },
+              displayState: "PROCESSING",
             }),
           })
 
@@ -80,23 +83,11 @@ describe("OrderDetailsHeader", () => {
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
         })
 
-        it("CONFIRMED status", () => {
+        it("IN_TRANSIT displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "confirmed" } } }] },
-            }),
-          })
-
-          expect(extractText(tree.UNSAFE_getByProps({ testID: "status" }))).toBe("processing")
-          expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
-        })
-
-        it("COLLECTED status", () => {
-          const tree = renderWithRelay({
-            CommerceOrder: () => ({
-              ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "collected" } } }] },
+              displayState: "IN_TRANSIT",
             }),
           })
 
@@ -104,23 +95,11 @@ describe("OrderDetailsHeader", () => {
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
         })
 
-        it("IN_TRANSIT status", () => {
+        it("FULFILLED displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "in_transit" } } }] },
-            }),
-          })
-
-          expect(extractText(tree.UNSAFE_getByProps({ testID: "status" }))).toBe("in transit")
-          expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
-        })
-
-        it("COMPLETED status", () => {
-          const tree = renderWithRelay({
-            CommerceOrder: () => ({
-              ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "completed" } } }] },
+              displayState: "FULFILLED",
             }),
           })
 
@@ -128,11 +107,11 @@ describe("OrderDetailsHeader", () => {
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Delivery")
         })
 
-        it("CANCELED status", () => {
+        it("CANCELED displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              lineItems: { edges: [{ node: { shipment: { status: "canceled" } } }] },
+              displayState: "CANCELED",
             }),
           })
 
@@ -142,10 +121,11 @@ describe("OrderDetailsHeader", () => {
       })
 
       describe("CommercePickup", () => {
-        it("SUBMITTED state", () => {
+        it("SUBMITTED displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
+              displayState: "SUBMITTED",
               requestedFulfillment: { __typename: "CommercePickup" },
             }),
           })
@@ -154,11 +134,11 @@ describe("OrderDetailsHeader", () => {
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Pickup")
         })
 
-        it("APPROVED state", () => {
+        it("APPROVED displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              state: "APPROVED",
+              displayState: "APPROVED",
               requestedFulfillment: { __typename: "CommercePickup" },
             }),
           })
@@ -167,11 +147,11 @@ describe("OrderDetailsHeader", () => {
           expect(extractText(tree.UNSAFE_getByProps({ testID: "fulfillment" }))).toBe("Pickup")
         })
 
-        it("FULFILLED state", () => {
+        it("FULFILLED displayState", () => {
           const tree = renderWithRelay({
             CommerceOrder: () => ({
               ...mockInfo,
-              state: "FULFILLED",
+              displayState: "FULFILLED",
               requestedFulfillment: { __typename: "CommercePickup" },
             }),
           })

--- a/src/app/Scenes/OrderHistory/OrderDetails/TrackOrderSection.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/TrackOrderSection.tests.tsx
@@ -1,14 +1,11 @@
+import { screen } from "@testing-library/react-native"
 import { TrackOrderSectionTestsQuery } from "__generated__/TrackOrderSectionTestsQuery.graphql"
-import { extractText } from "app/utils/tests/extractText"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { graphql, QueryRenderer } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
 import { TrackOrderSectionFragmentContainer } from "./Components/TrackOrderSection"
 
 const CommerceShipOrder = {
-  state: "SUBMITTED",
-  requestedFulfillment: { __typename: "CommerceShip" },
+  displayState: "SUBMITTED",
   lineItems: {
     edges: [
       {
@@ -32,14 +29,12 @@ const CommerceShipOrder = {
 }
 
 const CommerceShipArtaOrder = {
-  state: "APPROVED",
-  requestedFulfillment: { __typename: "CommerceShipArta" },
+  displayState: "IN_TRANSIT",
   lineItems: {
     edges: [
       {
         node: {
           shipment: {
-            status: "in_transit",
             trackingUrl: "https://google.com",
             trackingNumber: "12345678910",
             deliveryStart: "2021-10-03T14:51:19+03:00",
@@ -54,158 +49,82 @@ const CommerceShipArtaOrder = {
 }
 
 describe("TrackOrderSection", () => {
-  let mockEnvironment: ReturnType<typeof createMockEnvironment>
-  beforeEach(() => (mockEnvironment = createMockEnvironment()))
-
-  const TestRenderer = () => (
-    <QueryRenderer<TrackOrderSectionTestsQuery>
-      environment={mockEnvironment}
-      query={graphql`
-        query TrackOrderSectionTestsQuery @relay_test_operation {
-          commerceOrder(id: "some-id") {
-            internalID
-            ...TrackOrderSection_section
-          }
+  const { renderWithRelay } = setupTestWrapper<TrackOrderSectionTestsQuery>({
+    Component: (props) => <TrackOrderSectionFragmentContainer section={props.commerceOrder!} />,
+    query: graphql`
+      query TrackOrderSectionTestsQuery @relay_test_operation {
+        commerceOrder(id: "some-id") {
+          internalID
+          ...TrackOrderSection_section
         }
-      `}
-      variables={{}}
-      render={({ props }) => {
-        if (props?.commerceOrder) {
-          return <TrackOrderSectionFragmentContainer section={props.commerceOrder} />
-        }
-        return null
-      }}
-    />
-  )
-
-  describe("when CommerceShip", () => {
-    it("renders section", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, { CommerceOrder: () => CommerceShipOrder })
-
-      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
-      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe(
-        "Tracking not available"
-      )
-      expect(extractText(tree.findByProps({ testID: "shippedOn" }))).toContain("Sep 2, 2021")
-      expect(extractText(tree.findByProps({ testID: "estimatedDelivery" }))).toContain(
-        "Oct 2, 2021"
-      )
-      expect(extractText(tree.findByProps({ testID: "trackingUrl" }))).toContain(
-        "View full tracking details"
-      )
-    })
-
-    it("not renders fields without data", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        CommerceOrder: () => ({
-          ...CommerceShipOrder,
-          lineItems: { edges: [{ node: { shipment: null, fulfillments: null } }] },
-        }),
-      })
-
-      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("pending")
-      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe(
-        "Tracking not available"
-      )
-      expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
-      expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
-      expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)
-    })
+      }
+    `,
+    variables: {},
   })
 
-  describe("when CommerceShipArta", () => {
-    it("renders section", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        CommerceOrder: () => CommerceShipArtaOrder,
-      })
+  describe("with shipment/fulfillment data", () => {
+    describe("when shipped by partner (fulfillment type CommerceShip)", () => {
+      it("renders fulfillment details", () => {
+        renderWithRelay({ CommerceOrder: () => CommerceShipOrder })
 
-      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("in transit")
-      expect(extractText(tree.findByProps({ testID: "trackingNumber" }))).toContain("12345678910")
-      expect(tree.findAllByProps({ testID: "noTrackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "shippedOn" }))).toContain("Oct 3, 2021")
-      expect(extractText(tree.findByProps({ testID: "estimatedDelivery" }))).toContain(
-        "on September 20, 2021"
-      )
-      expect(extractText(tree.findByProps({ testID: "trackingUrl" }))).toContain(
-        "View full tracking details"
-      )
+        expect(screen.getByTestId("orderStatus")).toHaveTextContent("pending")
+        expect(screen.queryByTestId("trackingNumber")).toBeFalsy()
+        expect(screen.queryByTestId("noTrackingNumber")).toBeFalsy()
+        expect(screen.getByTestId("shippedOn")).toHaveTextContent("Sep 2, 2021")
+        expect(screen.getByTestId("estimatedDelivery")).toHaveTextContent("Oct 2, 2021")
+        expect(screen.getByTestId("trackingUrl")).toHaveTextContent("View full tracking details")
+      })
     })
 
-    it("not renders fields without data", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        CommerceOrder: () => ({
-          ...CommerceShipArtaOrder,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  shipment: {
-                    status: "in_transit",
-                    trackingUrl: null,
-                    trackingNumber: null,
-                    deliveryStart: null,
-                    deliveryEnd: null,
-                    estimatedDeliveryWindow: null,
+    describe("when shipped with Arta (fulfillment type CommerceShipArta)", () => {
+      it("renders shipment details", () => {
+        renderWithRelay({ CommerceOrder: () => CommerceShipArtaOrder })
+
+        expect(screen.getByTestId("orderStatus")).toHaveTextContent("in transit")
+        expect(screen.queryByTestId("trackingNumber")).toHaveTextContent("12345678910")
+        expect(screen.queryByTestId("noTrackingNumber")).toBeFalsy()
+        expect(screen.getByTestId("shippedOn")).toHaveTextContent("Oct 3, 2021")
+        expect(screen.getByTestId("estimatedDelivery")).toHaveTextContent("on September 20, 2021")
+        expect(screen.getByTestId("trackingUrl")).toHaveTextContent("View full tracking details")
+      })
+
+      it("when delivered", () => {
+        renderWithRelay({
+          CommerceOrder: () => ({
+            ...CommerceShipArtaOrder,
+            displayState: "FULFILLED",
+            lineItems: {
+              edges: [
+                {
+                  node: {
+                    shipment: { deliveryEnd: "2021-09-02T14:51:19+03:00" },
                   },
-                  fulfillments: null,
                 },
-              },
-            ],
-          },
-        }),
+              ],
+            },
+          }),
+        })
+
+        expect(screen.getByTestId("deliveredStatus")).toHaveTextContent("Delivered on Sep 2, 2021")
       })
-
-      expect(extractText(tree.findByProps({ testID: "orderStatus" }))).toBe("in transit")
-      expect(tree.findAllByProps({ testID: "trackingNumber" })).toHaveLength(0)
-      expect(extractText(tree.findByProps({ testID: "noTrackingNumber" }))).toBe(
-        "Tracking not available"
-      )
-      expect(tree.findAllByProps({ testID: "shippedOn" })).toHaveLength(0)
-      expect(tree.findAllByProps({ testID: "estimatedDelivery" })).toHaveLength(0)
-      expect(tree.findAllByProps({ testID: "trackingUrl" })).toHaveLength(0)
-    })
-
-    it("when delivered", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        CommerceOrder: () => ({
-          ...CommerceShipArtaOrder,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  shipment: { status: "completed", deliveryEnd: "2021-09-02T14:51:19+03:00" },
-                },
-              },
-            ],
-          },
-        }),
-      })
-
-      expect(extractText(tree.findByProps({ testID: "deliveredStatus" }))).toBe(
-        "Delivered on Sep 2, 2021"
-      )
     })
   })
 
-  describe("when CommercePickup", () => {
-    it("not renders section", () => {
-      const tree = renderWithWrappersLEGACY(<TestRenderer />).root
-      resolveMostRecentRelayOperation(mockEnvironment, {
+  describe("without shipment/fulfillment data", () => {
+    it("doesn't render fields when fulfillment is null", () => {
+      renderWithRelay({
         CommerceOrder: () => ({
           ...CommerceShipOrder,
-          requestedFulfillment: { __typename: "CommercePickup" },
           lineItems: { edges: [{ node: { shipment: null, fulfillments: null } }] },
         }),
       })
 
-      expect(tree.instance).toBeNull()
+      expect(screen.getByTestId("orderStatus")).toHaveTextContent("pending")
+      expect(screen.queryByTestId("trackingNumber")).toBeFalsy()
+      expect(screen.getByTestId("noTrackingNumber")).toHaveTextContent("Tracking not available")
+      expect(screen.queryByTestId("shippedOn")).toBeFalsy()
+      expect(screen.queryByTestId("estimatedDelivery")).toBeFalsy()
+      expect(screen.queryByTestId("trackingUrl")).toBeFalsy()
     })
   })
 })

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -3,13 +3,12 @@ import { OrderHistoryRowTestsQuery } from "__generated__/OrderHistoryRowTestsQue
 import { navigate } from "app/system/navigation/navigate"
 import { extractText } from "app/utils/tests/extractText"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
-import { Button } from "palette"
 import { graphql } from "react-relay"
 import { OrderHistoryRowContainer } from "./OrderHistoryRow"
 
 const mockOrder = {
   internalID: "d1105415-4a55-4c3b-b71d-bfae06ec92df",
-  state: "SUBMITTED",
+  displayState: "SUBMITTED",
   buyerTotal: "11,200",
   createdAt: "2021-05-18T14:45:20+03:00",
   itemsTotal: "€11,000",
@@ -35,7 +34,7 @@ const mockOrder = {
   },
 }
 
-describe("Order history row", () => {
+describe("OrderHistoryRow", () => {
   const { renderWithRelay } = setupTestWrapper<OrderHistoryRowTestsQuery>({
     Component: (props) => {
       if (props?.commerceOrder) {
@@ -52,346 +51,258 @@ describe("Order history row", () => {
     `,
   })
 
-  describe("Render Order", () => {
-    it("with all fields", () => {
+  it("displays the artist name", () => {
+    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+
+    expect(tree.queryByTestId("artist-names")?.children[0]).toBe("Torbjørn Rødland")
+  })
+
+  it("displays the partner name", () => {
+    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+
+    expect(tree.queryByTestId("partner-name")?.children[0]).toBe("Andrea Festa Fine Art")
+  })
+
+  it("displays the order creation date", () => {
+    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+
+    expect(tree.queryByTestId("date")?.children[0]).toBe("5/18/2021")
+  })
+
+  it("displays the price", () => {
+    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+
+    expect(tree.queryByTestId("price")?.children[0]).toBe("11,200")
+  })
+
+  it("displays the display state", () => {
+    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+
+    expect(tree.queryByTestId("order-status")?.children[0]).toBe("pending")
+  })
+
+  describe("artwork image", () => {
+    it("displays the image", () => {
       const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "artist-names" }))).toBe(
-        "Torbjørn Rødland"
-      )
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "partner-name" }))).toBe(
-        "Andrea Festa Fine Art"
-      )
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "date" }))).toBe("5/18/2021")
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "price" }))).toBe("11,200")
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("pending")
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "view-order-button" }))).toContain(
-        "View Order"
-      )
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "track-package-button" }))).toContain(
-        "Track Package"
-      )
-      expect(
-        tree.UNSAFE_getByProps({ testID: "image-container" }).findByProps({ testID: "image" })
-      ).toBeTruthy()
+      expect(tree.queryByTestId("image")).toBeTruthy()
     })
 
-    describe("Offer mode", () => {
-      it("View Offer button when SUBMITTED state", () => {
-        const tree = renderWithRelay({
-          CommerceOrder: () => ({ ...mockOrder, mode: "OFFER" }),
-        })
-
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "view-order-button" }))).toContain(
-          "View Offer"
-        )
-      })
-
-      it("View Order button when APPROVED state", () => {
-        const tree = renderWithRelay({
-          CommerceOrder: () => ({ ...mockOrder, state: "APPROVED", mode: "OFFER" }),
-        })
-
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "view-order-button" }))).toContain(
-          "View Order"
-        )
-      })
-    })
-
-    it("with gray box if no image", () => {
-      const order = {
-        ...mockOrder,
-        lineItems: {
-          edges: [
-            {
-              node: {
-                ...mockOrder.lineItems.edges[0].node,
-                artwork: {
-                  ...mockOrder.lineItems.edges[0].node.artwork,
-                  image: null,
-                },
-                artworkVersion: {
-                  image: null,
+    it("displays a gray box unless there is an image", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  ...mockOrder.lineItems.edges[0].node,
+                  artwork: {
+                    ...mockOrder.lineItems.edges[0].node.artwork,
+                    image: null,
+                  },
+                  artworkVersion: {
+                    image: null,
+                  },
                 },
               },
-            },
-          ],
-        },
-      }
-      const tree = renderWithRelay({ CommerceOrder: () => order })
+            ],
+          },
+        }),
+      })
 
-      expect(
-        tree.UNSAFE_getByProps({ testID: "image-container" }).findByProps({ testID: "image-box" })
-      ).toBeTruthy()
+      expect(tree.queryByTestId("image-box")).toBeTruthy()
     })
   })
 
-  describe("Orders without shipment status", () => {
-    it("SUBMITTED order", () => {
-      const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("pending")
-    })
-
-    it("APPROVED order", () => {
+  describe("track package button", () => {
+    it("is visible when a tracking URL is provided", () => {
       const tree = renderWithRelay({
-        CommerceOrder: () => ({ ...mockOrder, state: "APPROVED" }),
-      })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("confirmed")
-    })
-
-    it("PROCESSING_APPROVAL order", () => {
-      const tree = renderWithRelay({
-        CommerceOrder: () => ({ ...mockOrder, state: "PROCESSING_APPROVAL" }),
-      })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toContain(
-        "payment processing"
-      )
-    })
-
-    it("FULFILLED order", () => {
-      const tree = renderWithRelay({
-        CommerceOrder: () => ({ ...mockOrder, state: "FULFILLED" }),
-      })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("delivered")
-    })
-
-    it("CANCELED order", () => {
-      const tree = renderWithRelay({
-        CommerceOrder: () => ({ ...mockOrder, state: "CANCELED" }),
-      })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("canceled")
-    })
-
-    describe("CANCELED/REFUNDED orders overrides any shipment status", () => {
-      const order = {
-        ...mockOrder,
-        state: "CANCELED",
-        lineItems: {
-          edges: [
-            {
-              node: {
-                ...mockOrder.lineItems.edges[0].node,
-                shipment: { status: "in_transit", trackingUrl: null, trackingNumber: null },
-                fulfillments: { edges: [{ node: { trackingId: null } }] },
+        CommerceOrder: () => ({
+          ...mockOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  ...mockOrder.lineItems.edges[0].node,
+                  shipment: { trackingUrl: "https://tracking.com", trackingNumber: null },
+                  fulfillments: { edges: [{ node: { trackingId: null } }] },
+                },
               },
-            },
-          ],
-        },
-      }
-      it("CANCELED order without trackingId", () => {
-        const tree = renderWithRelay({ CommerceOrder: () => order })
-
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("canceled")
-        expect(tree.UNSAFE_getByProps({ testID: "view-order-button-box" })).not.toContain(Button)
+            ],
+          },
+        }),
       })
 
-      it("REFUNDED order without trackingId", () => {
-        const tree = renderWithRelay({
-          CommerceOrder: () => ({ ...order, state: "REFUNDED" }),
-        })
+      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+    })
 
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("refunded")
-        expect(tree.UNSAFE_getByProps({ testID: "view-order-button-box" })).not.toContain(Button)
+    it("is visible when a tracking number is provided", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  ...mockOrder.lineItems.edges[0].node,
+                  shipment: { trackingUrl: null, trackingNumber: "12345" },
+                  fulfillments: { edges: [{ node: { trackingId: null } }] },
+                },
+              },
+            ],
+          },
+        }),
       })
+
+      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+    })
+
+    it("is visible when a tracking ID is provided", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  ...mockOrder.lineItems.edges[0].node,
+                  shipment: { trackingUrl: null, trackingNumber: null },
+                  fulfillments: { edges: [{ node: { trackingId: "tracking-id" } }] },
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+    })
+
+    it("is not visible unless tracking information is provided", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          lineItems: {
+            edges: [
+              {
+                node: {
+                  ...mockOrder.lineItems.edges[0].node,
+                  shipment: { trackingUrl: null, trackingNumber: null },
+                  fulfillments: { edges: [{ node: { trackingId: null } }] },
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(tree.queryByTestId("track-package-button")).toBeNull()
     })
   })
 
-  describe("Offers with shipments", () => {
-    describe("when offer is still in negotiation with draft shipment status", () => {
-      const order = {
-        ...mockOrder,
-        mode: "OFFER",
-        state: "SUBMITTED",
-        lineItems: {
-          edges: [
-            {
-              node: {
-                ...mockOrder.lineItems.edges[0].node,
-                shipment: { status: "draft" },
-              },
-            },
-          ],
-        },
-      }
-
-      it("displays the correct order status", () => {
-        const tree = renderWithRelay({ CommerceOrder: () => order })
-
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("pending")
-      })
-
-      it("directs user to the orders counter offer modal on button press", () => {
-        const tree = renderWithRelay({ CommerceOrder: () => order })
-        const button = tree.UNSAFE_getByProps({ testID: "view-order-button" })
-
-        fireEvent.press(button)
-
-        expect(navigate).toHaveBeenCalledWith(`/orders/${mockOrder.internalID}`, {
-          modal: true,
-          passProps: { orderID: `${mockOrder.internalID}`, title: "Make Offer" },
-        })
-      })
-    })
-
-    describe("Approved Offers with shipment status", () => {
-      const order = {
-        ...mockOrder,
-        mode: "OFFER",
-        state: "APPROVED",
-        lineItems: {
-          edges: [
-            {
-              node: {
-                ...mockOrder.lineItems.edges[0].node,
-                shipment: { status: "pending" },
-              },
-            },
-          ],
-        },
-      }
-
-      it("directs user to the purchase summary screen on button press", () => {
-        const tree = renderWithRelay({ CommerceOrder: () => order })
-        const button = tree.UNSAFE_getByProps({ testID: "view-order-button" })
-
-        fireEvent.press(button)
-
-        expect(navigate).toHaveBeenCalledWith(`/user/purchases/${order.internalID}`)
-      })
-
-      it("displays the correct order status", () => {
-        const tree = renderWithRelay({ CommerceOrder: () => order })
-
-        expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("processing")
-      })
-    })
-  })
-
-  describe("Orders with shipment status", () => {
-    const order = {
-      ...mockOrder,
-      state: "APPROVED",
-      lineItems: {
-        edges: [
-          {
-            node: {
-              ...mockOrder.lineItems.edges[0].node,
-              shipment: { status: "pending" },
-            },
-          },
-        ],
-      },
-    }
-
-    it("PENDING shipment status", () => {
-      const tree = renderWithRelay({ CommerceOrder: () => order })
-
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("processing")
-    })
-
-    it("CONFIRMED shipment status", () => {
+  describe("view order button", () => {
+    it("is visible when the order is submitted", () => {
       const tree = renderWithRelay({
         CommerceOrder: () => ({
-          ...order,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  ...mockOrder.lineItems.edges[0].node,
-                  shipment: { status: "confirmed" },
-                },
-              },
-            ],
-          },
+          ...mockOrder,
+          displayState: "SUBMITTED",
         }),
       })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("processing")
+      expect(tree.queryByTestId("view-order-button")).toBeTruthy()
     })
 
-    it("COLLECTED shipment status", () => {
+    it("is not visible when the order is canceled", () => {
       const tree = renderWithRelay({
         CommerceOrder: () => ({
-          ...order,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  ...mockOrder.lineItems.edges[0].node,
-                  shipment: { status: "collected" },
-                },
-              },
-            ],
-          },
+          ...mockOrder,
+          displayState: "CANCELED",
         }),
       })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("in transit")
+      expect(tree.queryByTestId("view-order-button")).toBeNull()
     })
 
-    it("IN_TRANSIT shipment status", () => {
+    it("is not visible when the order is refunded", () => {
       const tree = renderWithRelay({
         CommerceOrder: () => ({
-          ...order,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  ...mockOrder.lineItems.edges[0].node,
-                  shipment: { status: "in_transit" },
-                },
-              },
-            ],
-          },
+          ...mockOrder,
+          displayState: "REFUNDED",
         }),
       })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("in transit")
+      expect(tree.queryByTestId("view-order-button")).toBeNull()
     })
 
-    it("COMPLETE shipment status", () => {
+    it("shows 'view order' when the order is submitted", () => {
       const tree = renderWithRelay({
         CommerceOrder: () => ({
-          ...order,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  ...mockOrder.lineItems.edges[0].node,
-                  shipment: { status: "completed" },
-                },
-              },
-            ],
-          },
+          ...mockOrder,
+          displayState: "SUBMITTED",
+          mode: "BUY",
         }),
       })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("delivered")
+      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Order")
     })
 
-    it("CANCELED shipment status", () => {
+    it("shows 'view offer' when the order has a submitted offer", () => {
       const tree = renderWithRelay({
         CommerceOrder: () => ({
-          ...order,
-          lineItems: {
-            edges: [
-              {
-                node: {
-                  ...mockOrder.lineItems.edges[0].node,
-                  shipment: { status: "canceled" },
-                },
-              },
-            ],
-          },
+          ...mockOrder,
+          displayState: "SUBMITTED",
+          mode: "OFFER",
         }),
       })
 
-      expect(extractText(tree.UNSAFE_getByProps({ testID: "order-status" }))).toBe("canceled")
+      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Offer")
+    })
+
+    it("shows 'view order' when the order has an approved offer", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          displayState: "APPROVED",
+          mode: "OFFER",
+        }),
+      })
+
+      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Order")
+    })
+
+    it("navigates to the counteroffer when the order has a submitted offer", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          internalID: "internal-id",
+          displayState: "SUBMITTED",
+          mode: "OFFER",
+        }),
+      })
+      const button = tree.UNSAFE_getByProps({ testID: "view-order-button" })
+
+      fireEvent.press(button)
+
+      expect(navigate).toHaveBeenCalledWith("/orders/internal-id", {
+        modal: true,
+        passProps: { orderID: "internal-id", title: "Make Offer" },
+      })
+    })
+
+    it("navigates to the purchase summary when the order has a processing offer", () => {
+      const tree = renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          internalID: "internal-id",
+          displayState: "PROCESSING",
+          mode: "OFFER",
+        }),
+      })
+
+      const button = tree.getByTestId("view-order-button")
+      fireEvent.press(button)
+      expect(navigate).toHaveBeenCalledWith("/user/purchases/internal-id")
     })
   })
 })

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Text } from "@artsy/palette-mobile"
 import { OrderHistoryRow_order$data } from "__generated__/OrderHistoryRow_order.graphql"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
-import { getOrderStatus, OrderState } from "app/utils/getOrderStatus"
+import { getOrderStatus } from "app/utils/getOrderStatus"
 import { getTrackingUrl } from "app/utils/getTrackingUrl"
 import moment from "moment"
 import { Button } from "palette"
@@ -17,7 +17,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const [lineItem] = extractNodes(order?.lineItems)
   const { artwork, artworkVersion } = lineItem || {}
   const trackingUrl = getTrackingUrl(lineItem)
-  const orderStatus = getOrderStatus(order.state as OrderState, lineItem)
+  const orderStatus = getOrderStatus(order.displayState, lineItem)
   const orderIsInactive = orderStatus === "canceled" || orderStatus === "refunded"
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
@@ -105,11 +105,12 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
     </Flex>
   )
 }
+
 export const OrderHistoryRowContainer = createFragmentContainer(OrderHistoryRow, {
   order: graphql`
     fragment OrderHistoryRow_order on CommerceOrder {
       internalID
-      state
+      displayState
       mode
       buyerTotal(precision: 2)
       createdAt

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -17,7 +17,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const [lineItem] = extractNodes(order?.lineItems)
   const { artwork, artworkVersion } = lineItem || {}
   const trackingUrl = getTrackingUrl(lineItem)
-  const orderStatus = getOrderStatus(order.displayState, lineItem)
+  const orderStatus = getOrderStatus(order.displayState)
   const orderIsInactive = orderStatus === "canceled" || orderStatus === "refunded"
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
@@ -119,7 +119,6 @@ export const OrderHistoryRowContainer = createFragmentContainer(OrderHistoryRow,
         edges {
           node {
             shipment {
-              status
               trackingUrl
               trackingNumber
             }

--- a/src/app/utils/getOrderStatus.tests.ts
+++ b/src/app/utils/getOrderStatus.tests.ts
@@ -1,66 +1,19 @@
 import { getOrderStatus } from "./getOrderStatus"
 
 describe(getOrderStatus, () => {
-  let mockLineItem: any
-  describe("without shipment status", () => {
-    mockLineItem = { shipment: null }
-    it("returns correct statuses", () => {
-      expect(getOrderStatus("SUBMITTED", mockLineItem)).toBe("pending")
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("confirmed")
-      expect(getOrderStatus("FULFILLED", mockLineItem)).toBe("delivered")
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-    })
+  it("returns human-readable versions of order states", () => {
+    expect(getOrderStatus("SUBMITTED")).toBe("pending")
+    expect(getOrderStatus("APPROVED")).toBe("confirmed")
+    expect(getOrderStatus("FULFILLED")).toBe("delivered")
+    expect(getOrderStatus("CANCELED")).toBe("canceled")
+    expect(getOrderStatus("REFUNDED")).toBe("refunded")
+    expect(getOrderStatus("PROCESSING")).toBe("processing")
+    expect(getOrderStatus("PROCESSING_APPROVAL")).toBe("payment processing")
+    expect(getOrderStatus("IN_TRANSIT")).toBe("in transit")
+    expect(getOrderStatus("CANCELED")).toBe("canceled")
   })
-
-  describe("with shipment status", () => {
-    it("returns correct statuses", () => {
-      mockLineItem = { shipment: { status: "draft" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("pending")
-      mockLineItem = { shipment: { status: "pending" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("processing")
-      mockLineItem = { shipment: { status: "confirmed" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("processing")
-      mockLineItem = { shipment: { status: "collected" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("in transit")
-      mockLineItem = { shipment: { status: "in_transit" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("in transit")
-      mockLineItem = { shipment: { status: "completed" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("delivered")
-      mockLineItem = { shipment: { status: "canceled" } }
-      expect(getOrderStatus("APPROVED", mockLineItem)).toBe("canceled")
-    })
-  })
-
-  describe("CANCELED/REFUNDED order states", () => {
-    it("CANCELED overrides any shipment status", () => {
-      mockLineItem = { shipment: { status: "pending" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      mockLineItem = { shipment: { status: "confirmed" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      mockLineItem = { shipment: { status: "collected" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      mockLineItem = { shipment: { status: "in_transit" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      mockLineItem = { shipment: { status: "completed" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-      mockLineItem = { shipment: { status: "canceled" } }
-      expect(getOrderStatus("CANCELED", mockLineItem)).toBe("canceled")
-    })
-
-    it("REFUNDED overrides any shipment status", () => {
-      mockLineItem = { shipment: { status: "pending" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-      mockLineItem = { shipment: { status: "confirmed" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-      mockLineItem = { shipment: { status: "collected" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-      mockLineItem = { shipment: { status: "in_transit" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-      mockLineItem = { shipment: { status: "completed" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-      mockLineItem = { shipment: { status: "canceled" } }
-      expect(getOrderStatus("REFUNDED", mockLineItem)).toBe("refunded")
-    })
+  it("returns 'unknown' for order states that are not displayed", () => {
+    expect(getOrderStatus("ABANDONED")).toBe("unknown")
+    expect(getOrderStatus("PENDING")).toBe("unknown")
   })
 })

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,69 +1,28 @@
-import {
-  CommerceOrderStateEnum,
-  OrderDetailsHeader_info$data,
-} from "__generated__/OrderDetailsHeader_info.graphql"
-import { OrderHistoryRowLineItem } from "./getTrackingUrl"
-
-export type OrderDetailsHeaderLineItem = NonNullable<
-  NonNullable<NonNullable<OrderDetailsHeader_info$data["lineItems"]>["edges"]>[0]
->["node"]
-
-export type OrderState = Exclude<
-  CommerceOrderStateEnum,
-  "ABANDONED" | "PENDING" | "%future added value"
->
-export type ShipmentStatus =
-  | "DRAFT"
-  | "PENDING"
-  | "CONFIRMED"
-  | "COLLECTED"
-  | "IN_TRANSIT"
-  | "COMPLETED"
-  | "CANCELED"
-
-enum ORDER_STATUSES {
-  Pending = "Pending",
-  Confirmed = "Confirmed",
-  Delivered = "Delivered",
-  Canceled = "Canceled",
-  Refunded = "Refunded",
-  PaymentProcessing = "Payment processing",
-}
-
-enum SHIPMENT_STATUSES {
-  Processing = "Processing",
-  InTransit = "In transit",
-  Delivered = "Delivered",
-  Canceled = "Canceled",
-}
+import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
 const orderStatusesMap = {
-  SUBMITTED: ORDER_STATUSES.Pending,
-  APPROVED: ORDER_STATUSES.Confirmed,
-  FULFILLED: ORDER_STATUSES.Delivered,
-  CANCELLED: ORDER_STATUSES.Canceled,
-  REFUNDED: ORDER_STATUSES.Refunded,
-  PENDING: SHIPMENT_STATUSES.Processing,
-  CONFIRMED: SHIPMENT_STATUSES.Processing,
-  DRAFT: ORDER_STATUSES.Pending,
-  PROCESSING_APPROVAL: ORDER_STATUSES.PaymentProcessing,
-  COLLECTED: SHIPMENT_STATUSES.InTransit,
-  IN_TRANSIT: SHIPMENT_STATUSES.InTransit,
-  COMPLETED: SHIPMENT_STATUSES.Delivered,
-  CANCELED: SHIPMENT_STATUSES.Canceled,
+  SUBMITTED: "Pending",
+  APPROVED: "Confirmed",
+  FULFILLED: "Delivered",
+  REFUNDED: "Refunded",
+  PROCESSING: "Processing",
+  PROCESSING_APPROVAL: "Payment processing",
+  IN_TRANSIT: "In transit",
+  CANCELED: "Canceled",
 }
 
-type OrderStatus = keyof typeof orderStatusesMap
-
-export function getOrderStatus(
-  orderState: OrderState,
-  orderLineItem?: OrderHistoryRowLineItem | OrderDetailsHeaderLineItem
-): string {
-  if (orderState === "CANCELED" || orderState === "REFUNDED" || !orderLineItem?.shipment?.status) {
-    return orderStatusesMap[orderState as OrderStatus].toLowerCase()
+export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum) {
+  switch (displayState) {
+    case "SUBMITTED":
+    case "APPROVED":
+    case "FULFILLED":
+    case "REFUNDED":
+    case "PROCESSING":
+    case "PROCESSING_APPROVAL":
+    case "IN_TRANSIT":
+    case "CANCELED":
+      return orderStatusesMap[displayState].toLowerCase()
+    default:
+      return "unknown"
   }
-
-  const shipment: ShipmentStatus = orderLineItem.shipment.status.toUpperCase() as ShipmentStatus
-
-  return orderStatusesMap[shipment]?.toLowerCase()
 }

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,27 +1,23 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
-const orderStatusesMap = {
-  SUBMITTED: "Pending",
-  APPROVED: "Confirmed",
-  FULFILLED: "Delivered",
-  REFUNDED: "Refunded",
-  PROCESSING: "Processing",
-  PROCESSING_APPROVAL: "Payment processing",
-  IN_TRANSIT: "In transit",
-  CANCELED: "Canceled",
-}
-
 export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum) {
   switch (displayState) {
     case "SUBMITTED":
+      return "pending"
     case "APPROVED":
+      return "confirmed"
     case "FULFILLED":
+      return "delivered"
     case "REFUNDED":
+      return "refunded"
     case "PROCESSING":
+      return "processing"
     case "PROCESSING_APPROVAL":
+      return "payment processing"
     case "IN_TRANSIT":
+      return "in transit"
     case "CANCELED":
-      return orderStatusesMap[displayState].toLowerCase()
+      return "canceled"
     default:
       return "unknown"
   }


### PR DESCRIPTION
### Description

Exchange exposes a `displayState` field that obviates the need for the calculations currently being performed by Eigen's `getOrderStatus` 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

use displayState (instead of state + shipment status) for order status calculations - matt & adam

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
