### PR TITLE
fix: remove entities from ESSearchPills query

### DIFF
--- a/src/app/Scenes/Search/ElasticSearchPills.tsx
+++ b/src/app/Scenes/Search/ElasticSearchPills.tsx
@@ -69,7 +69,7 @@ export const ElasticSearchPills = React.forwardRef<ScrollView, ElasticSearchPill
 export const ElasticSearchPillsQuery = graphql`
   fragment ElasticSearchPills_viewer on Viewer
   @argumentDefinitions(term: { type: "String!", defaultValue: "" }) {
-    searchConnection(first: 1, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {
+    searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {
       aggregations {
         counts {
           count

--- a/src/app/Scenes/Search/ElasticSearchPills.tsx
+++ b/src/app/Scenes/Search/ElasticSearchPills.tsx
@@ -69,13 +69,7 @@ export const ElasticSearchPills = React.forwardRef<ScrollView, ElasticSearchPill
 export const ElasticSearchPillsQuery = graphql`
   fragment ElasticSearchPills_viewer on Viewer
   @argumentDefinitions(term: { type: "String!", defaultValue: "" }) {
-    searchConnection(
-      first: 1
-      mode: AUTOSUGGEST
-      query: $term
-      aggregations: [TYPE]
-      entities: [ARTWORK, ARTIST, ARTICLE, SALE, ARTIST_SERIES, COLLECTION, FAIR, SHOW, GALLERY]
-    ) {
+    searchConnection(first: 1, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {
       aggregations {
         counts {
           count


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Removes entities from searchConnection when requesting for aggregations because of [this](https://github.com/artsy/gravity/blob/main/app/models/search/queries/global_search_query.rb#L133-L134)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- remove entities from ESSearchPills query - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
