### PR TITLE
fix: Move Home screen articles field to below query

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -687,10 +687,6 @@ export const HomeQueryRenderer: React.FC = () => {
             me @optionalField {
               ...Home_meAbove
             }
-            articlesConnection(first: 10, sort: PUBLISHED_AT_DESC, inEditorialFeed: true)
-              @optionalField {
-              ...Home_articlesConnection
-            }
             newWorksForYou: viewer @optionalField {
               ...Home_newWorksForYou
             }
@@ -720,6 +716,10 @@ export const HomeQueryRenderer: React.FC = () => {
                 ...Home_showsByFollowedArtists
               }
             }
+            articlesConnection(first: 10, sort: PUBLISHED_AT_DESC, inEditorialFeed: true)
+              @optionalField {
+              ...Home_articlesConnection
+            }
           }
         `,
         variables: {
@@ -734,7 +734,7 @@ export const HomeQueryRenderer: React.FC = () => {
 
           return (
             <HomeFragmentContainer
-              articlesConnection={above?.articlesConnection ?? null}
+              articlesConnection={below?.articlesConnection ?? null}
               emergingPicks={below?.emergingPicks ?? null}
               showsByFollowedArtists={below?.me?.showsByFollowedArtists ?? null}
               featured={below ? below.featured : null}


### PR DESCRIPTION

### Description

Move Home screen articles field to below query because the rail appears below the fold.
### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixing home screen by moving articles field to below query - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
