### PR TITLE
fix: Art quiz navigations

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,10 @@
                 <data android:scheme="http" />
                 <data android:pathPrefix="/about" />
                 <data android:pathPrefix="/activity" />
+                <data android:pathPrefix="/art-quiz" />
+                <!-- this might need to be removed breaks some things -->
+                <data android:pathPrefix="/art-quiz/artworks" />
+                <data android:pathPrefix="/art-quiz/results" />
                 <data android:pathPrefix="/artist-series" />
                 <data android:pathPrefix="/article" />
                 <data android:pathPrefix="/articles" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
                 <data android:pathPrefix="/about" />
                 <data android:pathPrefix="/activity" />
                 <data android:pathPrefix="/art-quiz" />
+                <data android:pathPrefix="/art-quiz/artworks" />
                 <data android:pathPrefix="/art-quiz/results" />
                 <data android:pathPrefix="/artist-series" />
                 <data android:pathPrefix="/article" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -71,8 +71,6 @@
                 <data android:pathPrefix="/about" />
                 <data android:pathPrefix="/activity" />
                 <data android:pathPrefix="/art-quiz" />
-                <!-- this might need to be removed breaks some things -->
-                <data android:pathPrefix="/art-quiz/artworks" />
                 <data android:pathPrefix="/art-quiz/results" />
                 <data android:pathPrefix="/artist-series" />
                 <data android:pathPrefix="/article" />

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -360,7 +360,6 @@ function defineModules<T extends string>(obj: Record<T, ModuleDescriptor>) {
 }
 
 const artQuizScreenOptions = {
-  hidesBottomTabs: true,
   hidesBackButton: true,
   fullBleed: true,
   screenOptions: {
@@ -379,15 +378,9 @@ export const modules = defineModules({
   DevMenu: reactModule(DevMenu, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   About: reactModule(About),
   AddOrEditMyCollectionArtwork: reactModule(MyCollectionArtworkForm, { hidesBackButton: true }),
-  ArtQuiz: reactModule(ArtQuiz, artQuizScreenOptions),
-  ArtQuizArtworks: reactModule(ArtQuizArtworks, artQuizScreenOptions),
-  ArtQuizResults: reactModule(ArtQuizResults, {
-    hidesBackButton: true,
-    fullBleed: true,
-    screenOptions: {
-      gestureEnabled: false,
-    },
-  }),
+  ArtQuiz: reactModule(ArtQuiz, { ...artQuizScreenOptions, hidesBottomTabs: true }),
+  ArtQuizArtworks: reactModule(ArtQuizArtworks, { ...artQuizScreenOptions, hidesBottomTabs: true }),
+  ArtQuizResults: reactModule(ArtQuizResults, artQuizScreenOptions),
   Articles: reactModule(ArticlesScreen, {}, [ArticlesScreenQuery]),
   Artist: reactModule(ArtistQueryRenderer, { hidesBackButton: true }, [ArtistScreenQuery]),
   ArtistShows: reactModule(ArtistShows2QueryRenderer),

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -10,7 +10,6 @@ import {
 import { FadeIn } from "app/Components/FadeIn"
 import { PageableScreensView } from "app/Components/PageableScreensView/PageableScreensView"
 import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
-import { ArtQuizArtworks } from "app/Scenes/ArtQuiz/ArtQuizArtworks"
 import { ArtQuizResults } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults"
 import { ArtworkRecommendationsScreen } from "app/Scenes/ArtworkRecommendations/ArtworkRecommendations"
 import { HomeContainer } from "app/Scenes/Home/HomeContainer"
@@ -379,7 +378,6 @@ export const modules = defineModules({
   About: reactModule(About),
   AddOrEditMyCollectionArtwork: reactModule(MyCollectionArtworkForm, { hidesBackButton: true }),
   ArtQuiz: reactModule(ArtQuiz, { ...artQuizScreenOptions, hidesBottomTabs: true }),
-  ArtQuizArtworks: reactModule(ArtQuizArtworks, { ...artQuizScreenOptions, hidesBottomTabs: true }),
   ArtQuizResults: reactModule(ArtQuizResults, artQuizScreenOptions),
   Articles: reactModule(ArticlesScreen, {}, [ArticlesScreenQuery]),
   Artist: reactModule(ArtistQueryRenderer, { hidesBackButton: true }, [ArtistScreenQuery]),

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -9,8 +9,8 @@ import {
 } from "app/Components/Containers/WorksForYou"
 import { FadeIn } from "app/Components/FadeIn"
 import { PageableScreensView } from "app/Components/PageableScreensView/PageableScreensView"
+import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
 import { ArtQuizArtworks } from "app/Scenes/ArtQuiz/ArtQuizArtworks"
-import { ArtQuizNavigation } from "app/Scenes/ArtQuiz/ArtQuizNavigation"
 import { ArtQuizResults } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults"
 import { ArtworkRecommendationsScreen } from "app/Scenes/ArtworkRecommendations/ArtworkRecommendations"
 import {
@@ -376,7 +376,7 @@ export const modules = defineModules({
   DevMenu: reactModule(DevMenu, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   About: reactModule(About),
   AddOrEditMyCollectionArtwork: reactModule(MyCollectionArtworkForm, { hidesBackButton: true }),
-  ArtQuiz: reactModule(ArtQuizNavigation, artQuizScreenOptions),
+  ArtQuiz: reactModule(ArtQuiz, artQuizScreenOptions),
   ArtQuizArtworks: reactModule(ArtQuizArtworks, artQuizScreenOptions),
   ArtQuizResults: reactModule(ArtQuizResults, { hidesBackButton: true, fullBleed: true }),
   Articles: reactModule(ArticlesScreen, {}, [ArticlesScreenQuery]),

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -363,6 +363,9 @@ const artQuizScreenOptions = {
   hidesBottomTabs: true,
   hidesBackButton: true,
   fullBleed: true,
+  screenOptions: {
+    gestureEnabled: false,
+  },
 }
 
 export type AppModule = keyof typeof modules
@@ -378,7 +381,13 @@ export const modules = defineModules({
   AddOrEditMyCollectionArtwork: reactModule(MyCollectionArtworkForm, { hidesBackButton: true }),
   ArtQuiz: reactModule(ArtQuiz, artQuizScreenOptions),
   ArtQuizArtworks: reactModule(ArtQuizArtworks, artQuizScreenOptions),
-  ArtQuizResults: reactModule(ArtQuizResults, { hidesBackButton: true, fullBleed: true }),
+  ArtQuizResults: reactModule(ArtQuizResults, {
+    hidesBackButton: true,
+    fullBleed: true,
+    screenOptions: {
+      gestureEnabled: false,
+    },
+  }),
   Articles: reactModule(ArticlesScreen, {}, [ArticlesScreenQuery]),
   Artist: reactModule(ArtistQueryRenderer, { hidesBackButton: true }, [ArtistScreenQuery]),
   ArtistShows: reactModule(ArtistShows2QueryRenderer),
@@ -454,12 +463,8 @@ export const modules = defineModules({
   FullFeaturedArtistList: reactModule(CollectionFullFeaturedArtistListQueryRenderer),
   Gene: reactModule(GeneQueryRenderer),
   Tag: reactModule(TagQueryRenderer),
-  // Home: reactModule(HomeQueryRenderer),
   Home: reactModule(HomeContainer, {
     isRootViewForTabName: "home",
-    hidesBottomTabs: true,
-    hidesBackButton: true,
-    fullBleed: true,
   }),
   Inbox: reactModule(InboxQueryRenderer, { isRootViewForTabName: "inbox" }, [InboxScreenQuery]),
   Inquiry: reactModule(Inquiry, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -13,6 +13,7 @@ import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
 import { ArtQuizArtworks } from "app/Scenes/ArtQuiz/ArtQuizArtworks"
 import { ArtQuizResults } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults"
 import { ArtworkRecommendationsScreen } from "app/Scenes/ArtworkRecommendations/ArtworkRecommendations"
+import { HomeContainer } from "app/Scenes/Home/HomeContainer"
 import {
   RecentlyViewedScreen,
   RecentlyViewedScreenQuery,
@@ -72,7 +73,6 @@ import { FairMoreInfoQueryRenderer } from "./Scenes/Fair/FairMoreInfo"
 import { Favorites } from "./Scenes/Favorites/Favorites"
 import { FeatureQueryRenderer } from "./Scenes/Feature/Feature"
 import { GeneQueryRenderer } from "./Scenes/Gene/Gene"
-import { HomeQueryRenderer } from "./Scenes/Home/Home"
 import { MakeOfferModalQueryRenderer } from "./Scenes/Inbox/Components/Conversations/MakeOfferModal"
 import { PurchaseModalQueryRenderer } from "./Scenes/Inbox/Components/Conversations/PurchaseModal"
 import { ConversationNavigator } from "./Scenes/Inbox/ConversationNavigator"
@@ -454,7 +454,13 @@ export const modules = defineModules({
   FullFeaturedArtistList: reactModule(CollectionFullFeaturedArtistListQueryRenderer),
   Gene: reactModule(GeneQueryRenderer),
   Tag: reactModule(TagQueryRenderer),
-  Home: reactModule(HomeQueryRenderer, { isRootViewForTabName: "home" }),
+  // Home: reactModule(HomeQueryRenderer),
+  Home: reactModule(HomeContainer, {
+    isRootViewForTabName: "home",
+    hidesBottomTabs: true,
+    hidesBackButton: true,
+    fullBleed: true,
+  }),
   Inbox: reactModule(InboxQueryRenderer, { isRootViewForTabName: "inbox" }, [InboxScreenQuery]),
   Inquiry: reactModule(Inquiry, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   LiveAuction: reactModule(LiveAuctionView, {

--- a/src/app/Scenes/ArtQuiz/ArtQuiz.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuiz.tsx
@@ -1,5 +1,7 @@
-import { createStackNavigator } from "@react-navigation/stack"
+import { NavigationContainer } from "@react-navigation/native"
+import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import { ArtQuizNavigationQuery } from "__generated__/ArtQuizNavigationQuery.graphql"
+import { ArtQuizArtworks } from "app/Scenes/ArtQuiz/ArtQuizArtworks"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { ArtQuizWelcome } from "app/Scenes/ArtQuiz/ArtQuizWelcome"
 import { navigate } from "app/system/navigation/navigate"
@@ -23,7 +25,21 @@ const ArtQuizScreen: React.FC = () => {
     }
   }, [isQuizCompleted])
 
-  return <ArtQuizWelcome />
+  return (
+    <NavigationContainer independent>
+      <StackNavigator.Navigator
+        screenOptions={{
+          ...TransitionPresets.DefaultTransition,
+          headerShown: false,
+          headerMode: "screen",
+          gestureEnabled: false,
+        }}
+      >
+        <StackNavigator.Screen name="ArtQuizWelcome" component={ArtQuizWelcome} />
+        <StackNavigator.Screen name="ArtQuizArtworks" component={ArtQuizArtworks} />
+      </StackNavigator.Navigator>
+    </NavigationContainer>
+  )
 }
 
 export const ArtQuiz = () => {

--- a/src/app/Scenes/ArtQuiz/ArtQuiz.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuiz.tsx
@@ -1,7 +1,5 @@
-import { NavigationContainer } from "@react-navigation/native"
-import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
+import { createStackNavigator } from "@react-navigation/stack"
 import { ArtQuizNavigationQuery } from "__generated__/ArtQuizNavigationQuery.graphql"
-import { ArtQuizArtworks } from "app/Scenes/ArtQuiz/ArtQuizArtworks"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { ArtQuizWelcome } from "app/Scenes/ArtQuiz/ArtQuizWelcome"
 import { navigate } from "app/system/navigation/navigate"
@@ -15,14 +13,9 @@ export type ArtQuizNavigationStack = {
 
 export const StackNavigator = createStackNavigator<ArtQuizNavigationStack>()
 
-const ArtQuiz: React.FC = () => {
+const ArtQuizScreen: React.FC = () => {
   const queryResult = useLazyLoadQuery<ArtQuizNavigationQuery>(artQuizNavigationQuery, {}).me?.quiz
-
   const isQuizCompleted = !!queryResult?.completedAt
-  const lastInteractedArtworkIndex = queryResult?.quizArtworkConnection?.edges?.findIndex(
-    (edge) => edge?.interactedAt === null
-  )
-  const isQuizStartedButIncomplete = !!lastInteractedArtworkIndex
 
   useEffect(() => {
     if (isQuizCompleted) {
@@ -30,31 +23,13 @@ const ArtQuiz: React.FC = () => {
     }
   }, [isQuizCompleted])
 
-  if (isQuizStartedButIncomplete) {
-    return <ArtQuizArtworks />
-  }
-
-  return (
-    <NavigationContainer independent>
-      <StackNavigator.Navigator
-        screenOptions={{
-          ...TransitionPresets.DefaultTransition,
-          headerShown: false,
-          headerMode: "screen",
-          gestureEnabled: false,
-        }}
-      >
-        <StackNavigator.Screen name="ArtQuizWelcome" component={ArtQuizWelcome} />
-        <StackNavigator.Screen name="ArtQuizArtworks" component={ArtQuizArtworks} />
-      </StackNavigator.Navigator>
-    </NavigationContainer>
-  )
+  return <ArtQuizWelcome />
 }
 
-export const ArtQuizNavigation = () => {
+export const ArtQuiz = () => {
   return (
     <Suspense fallback={<ArtQuizLoader />}>
-      <ArtQuiz />
+      <ArtQuizScreen />
     </Suspense>
   )
 }

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -1,5 +1,4 @@
 import { Touchable, Flex, Screen, Text, BackButton } from "@artsy/palette-mobile"
-import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { ArtQuizArtworksDislikeMutation } from "__generated__/ArtQuizArtworksDislikeMutation.graphql"
 import { ArtQuizArtworksQuery } from "__generated__/ArtQuizArtworksQuery.graphql"
 import { ArtQuizArtworksSaveMutation } from "__generated__/ArtQuizArtworksSaveMutation.graphql"
@@ -7,10 +6,8 @@ import { ArtQuizArtworksUpdateQuizMutation } from "__generated__/ArtQuizArtworks
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { ArtQuizButton } from "app/Scenes/ArtQuiz/ArtQuizButton"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
-import { ArtQuizNavigationStack } from "app/Scenes/ArtQuiz/ArtQuizNavigation"
-import { useOnboardingContext } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
 import { GlobalStore } from "app/store/GlobalStore"
-import { navigate as globalNavigate } from "app/system/navigation/navigate"
+import { goBack, navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Suspense, useEffect, useRef, useState } from "react"
 import { Image } from "react-native"
@@ -29,9 +26,6 @@ const ArtQuizArtworksScreen = () => {
   const [activeCardIndex, setActiveCardIndex] = useState(lastInteractedArtworkIndex ?? 0)
   const pagerViewRef = useRef<PagerView>(null)
   const popoverMessage = usePopoverMessage()
-
-  const { goBack } = useNavigation<NavigationProp<ArtQuizNavigationStack>>()
-  const { onDone } = useOnboardingContext()
 
   const [submitDislike] = useMutation<ArtQuizArtworksDislikeMutation>(DislikeArtworkMutation)
   const [submitSave] = useMutation<ArtQuizArtworksSaveMutation>(SaveArtworkMutation)
@@ -96,7 +90,7 @@ const ArtQuizArtworksScreen = () => {
     })
 
     if (activeCardIndex + 1 === artworks.length) {
-      globalNavigate("/art-quiz/results", {
+      navigate("/art-quiz/results", {
         passProps: {
           isCalculatingResult: true,
         },
@@ -150,9 +144,9 @@ const ArtQuizArtworksScreen = () => {
   }
 
   const handleOnSkip = () => {
-    onDone?.()
     popoverMessage.hide()
-    globalNavigate("/")
+    GlobalStore.actions.auth.setArtQuizState("close")
+    navigate("/")
   }
 
   return (

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -11,7 +11,6 @@ import { goBack, navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { Suspense, useEffect, useRef, useState } from "react"
 import { Image } from "react-native"
-
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 import { graphql, useLazyLoadQuery, useMutation } from "react-relay"
 
@@ -36,7 +35,7 @@ const ArtQuizArtworksScreen = () => {
       title: `Like it? Hit the heart.${"\n"}Not for you? Choose X.`,
       placement: "bottom",
       withPointer: "bottom",
-      style: { width: "70%", marginBottom: 100, left: 55 },
+      style: { width: "70%", marginBottom: 70, left: 55 },
     })
     if (activeCardIndex !== 0) {
       popoverMessage.hide()
@@ -95,7 +94,6 @@ const ArtQuizArtworksScreen = () => {
           isCalculatingResult: true,
         },
       })
-      return
     }
   }
 
@@ -166,7 +164,7 @@ const ArtQuizArtworksScreen = () => {
           <Touchable haptic="impactLight" onPress={handleOnSkip}>
             <Flex height="100%" justifyContent="center">
               <Text textAlign="right" variant="xs">
-                Skip
+                Close
               </Text>
             </Flex>
           </Touchable>
@@ -178,6 +176,7 @@ const ArtQuizArtworksScreen = () => {
             ref={pagerViewRef}
             style={{ flex: 1 }}
             initialPage={activeCardIndex}
+            scrollEnabled={false}
             onPageScroll={handleIndexChange}
             overdrag
           >
@@ -185,7 +184,7 @@ const ArtQuizArtworksScreen = () => {
               return (
                 <Flex key={artwork.internalID}>
                   <Image
-                    source={{ uri: artwork.imageUrl! }}
+                    source={{ uri: artwork.image?.resized?.src }}
                     style={{ flex: 1 }}
                     resizeMode="contain"
                   />
@@ -194,7 +193,7 @@ const ArtQuizArtworksScreen = () => {
             })}
           </PagerView>
         </Flex>
-        <Flex flexDirection="row" justifyContent="space-around" mb={6} mx={4}>
+        <Flex flexDirection="row" justifyContent="space-around" mb={4} mx={4}>
           <ArtQuizButton variant="Dislike" onPress={() => handleNext("Dislike")} />
           <ArtQuizButton variant="Like" onPress={() => handleNext("Like")} />
         </Flex>
@@ -221,7 +220,11 @@ const artQuizArtworksQuery = graphql`
             position
             node {
               internalID
-              imageUrl
+              image {
+                resized(width: 900, height: 900, version: ["normalized", "larger", "large"]) {
+                  src
+                }
+              }
               isDisliked
               isSaved
             }

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -145,7 +145,7 @@ const ArtQuizArtworksScreen = () => {
 
   const handleOnSkip = () => {
     popoverMessage.hide()
-    GlobalStore.actions.auth.setArtQuizState("close")
+    GlobalStore.actions.auth.setArtQuizState("complete")
     navigate("/")
   }
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
@@ -4,8 +4,12 @@ import { ArtQuizResultsEmptyTabs } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQu
 import { ArtQuizResultsTabs } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs"
 import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
+import { useBackHandler } from "shared/hooks/useBackHandler"
 
 const ResultsScreen = () => {
+  // prevents Android users from going back with hardware button
+  useBackHandler(() => true)
+
   const queryResult = useLazyLoadQuery<ArtQuizResultsQuery>(artQuizResultsQuery, {})
   const hasSavedArtworks = queryResult.me?.quiz.savedArtworks.length
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
@@ -2,7 +2,8 @@ import { ArtQuizResultsQuery } from "__generated__/ArtQuizResultsQuery.graphql"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { ArtQuizResultsEmptyTabs } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs"
 import { ArtQuizResultsTabs } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs"
-import { Suspense } from "react"
+import { GlobalStore } from "app/store/GlobalStore"
+import { Suspense, useEffect } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { useBackHandler } from "shared/hooks/useBackHandler"
 
@@ -12,6 +13,10 @@ const ResultsScreen = () => {
 
   const queryResult = useLazyLoadQuery<ArtQuizResultsQuery>(artQuizResultsQuery, {})
   const hasSavedArtworks = queryResult.me?.quiz.savedArtworks.length
+
+  useEffect(() => {
+    GlobalStore.actions.auth.setArtQuizState("complete")
+  }, [])
 
   if (hasSavedArtworks) {
     return <ArtQuizResultsTabs me={queryResult.me} />

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizArtist.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizArtist.tsx
@@ -11,6 +11,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { debounce } from "lodash"
 import { FollowButton } from "palette"
+import { TouchableOpacity } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
 
 export const ArtQuizArtist = ({ artistData }: { artistData: ArtQuizArtist_artist$key | null }) => {
@@ -40,37 +41,43 @@ export const ArtQuizArtist = ({ artistData }: { artistData: ArtQuizArtist_artist
 
   return (
     <Flex pt={2}>
-      <Flex px={2} flexDirection="row" justifyContent="space-between">
-        <Flex flex={1}>
-          <Text variant="lg-display">{artist?.name}</Text>
-          <Text variant="lg-display" color="black60">
-            {artist?.formattedNationalityAndBirthday}
-          </Text>
+      <TouchableOpacity
+        onPress={() => {
+          navigate(`/artist/${artist?.slug}`)
+        }}
+      >
+        <Flex px={2} flexDirection="row" justifyContent="space-between">
+          <Flex flex={1}>
+            <Text variant="lg-display">{artist?.name}</Text>
+            <Text variant="lg-display" color="black60">
+              {artist?.formattedNationalityAndBirthday}
+            </Text>
+          </Flex>
+          <Flex>
+            <FollowButton
+              isFollowed={!!artist?.isFollowed}
+              onPress={() => handleFollowChange(artist!)}
+            />
+          </Flex>
         </Flex>
-        <Flex>
-          <FollowButton
-            isFollowed={!!artist?.isFollowed}
-            onPress={() => handleFollowChange(artist!)}
+        <Spacer y={1} />
+        <Flex px={2}>
+          <ReadMore
+            content={artist?.biographyBlurb?.text!}
+            maxChars={textLimit}
+            textStyle="new"
+            textVariant="sm"
+            linkTextVariant="sm-display"
           />
         </Flex>
-      </Flex>
-      <Spacer y={1} />
-      <Flex px={2}>
-        <ReadMore
-          content={artist?.biographyBlurb?.text!}
-          maxChars={textLimit}
-          textStyle="new"
-          textVariant="sm"
-          linkTextVariant="sm-display"
+        <Spacer y={2} />
+        <SmallArtworkRail
+          artworks={artworks}
+          onPress={(artwork) => {
+            navigate(artwork?.href!)
+          }}
         />
-      </Flex>
-      <Spacer y={1} />
-      <SmallArtworkRail
-        artworks={artworks}
-        onPress={(artwork) => {
-          navigate(artwork?.href!)
-        }}
-      />
+      </TouchableOpacity>
     </Flex>
   )
 }

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
@@ -1,10 +1,10 @@
-import { Screen } from "@artsy/palette-mobile"
 import { ArtQuizResultsEmptyTabsQuery } from "__generated__/ArtQuizResultsEmptyTabsQuery.graphql"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { ArtQuizResultsTabsHeader } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader"
 import { ArtQuizTrendingArtists } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingArtists"
 import { ArtQuizTrendingCollections } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollections"
 import { compact } from "lodash"
+import { Screen } from "palette"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
 enum Tab {
@@ -20,7 +20,7 @@ export const ArtQuizResultsEmptyTabs = () => {
 
   return (
     <Screen>
-      <Screen.Body fullwidth>
+      <Screen.Body fullwidth noBottomSafe>
         <StickyTabPage
           disableBackButtonUpdate
           tabs={compact([

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
@@ -3,6 +3,7 @@ import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { ArtQuizResultsTabsHeader } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader"
 import { ArtQuizTrendingArtists } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingArtists"
 import { ArtQuizTrendingCollections } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollections"
+import { navigate } from "app/system/navigation/navigate"
 import { compact } from "lodash"
 import { Screen } from "palette"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -20,6 +21,7 @@ export const ArtQuizResultsEmptyTabs = () => {
 
   return (
     <Screen>
+      <Screen.Header onBack={() => navigate("/")} />
       <Screen.Body fullwidth noBottomSafe>
         <StickyTabPage
           disableBackButtonUpdate

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
@@ -1,4 +1,3 @@
-import { Screen } from "@artsy/palette-mobile"
 import { ArtQuizResultsQuery$data } from "__generated__/ArtQuizResultsQuery.graphql"
 import { ArtQuizResultsTabs_me$key } from "__generated__/ArtQuizResultsTabs_me.graphql"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
@@ -7,6 +6,7 @@ import { ArtQuizExploreArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQui
 import { ArtQuizLikedArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizLikedArtworks"
 import { ArtQuizResultsTabsHeader } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader"
 import { compact } from "lodash"
+import { Screen } from "palette"
 import { graphql, useFragment } from "react-relay"
 
 enum Tab {
@@ -23,7 +23,7 @@ export const ArtQuizResultsTabs = ({ me }: { me: ArtQuizResultsQuery$data["me"] 
 
   return (
     <Screen>
-      <Screen.Body fullwidth>
+      <Screen.Body fullwidth noBottomSafe>
         <StickyTabPage
           disableBackButtonUpdate
           tabs={compact([

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
@@ -5,6 +5,7 @@ import { ArtQuizExploreArtists } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuiz
 import { ArtQuizExploreArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizExploreArtworks"
 import { ArtQuizLikedArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizLikedArtworks"
 import { ArtQuizResultsTabsHeader } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader"
+import { navigate } from "app/system/navigation/navigate"
 import { compact } from "lodash"
 import { Screen } from "palette"
 import { graphql, useFragment } from "react-relay"
@@ -23,6 +24,7 @@ export const ArtQuizResultsTabs = ({ me }: { me: ArtQuizResultsQuery$data["me"] 
 
   return (
     <Screen>
+      <Screen.Header onBack={() => navigate("/")} />
       <Screen.Body fullwidth noBottomSafe>
         <StickyTabPage
           disableBackButtonUpdate

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
@@ -32,8 +32,8 @@ export const ArtQuizTrendingCollection = ({
           maxChars={textLimit}
           textStyle="new"
           color="black60"
-          textVariant="md"
-          linkTextVariant="md"
+          textVariant="sm"
+          linkTextVariant="sm"
         />
       </Flex>
       <Spacer y={1} />

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
@@ -2,8 +2,10 @@ import { Spacer, Flex, Text } from "@artsy/palette-mobile"
 import { ArtQuizTrendingCollection_collection$key } from "__generated__/ArtQuizTrendingCollection_collection.graphql"
 import { ArtQuizTrendingCollections_viewer$data } from "__generated__/ArtQuizTrendingCollections_viewer.graphql"
 import { SmallArtworkRail } from "app/Components/ArtworkRail/SmallArtworkRail"
+import { ReadMore } from "app/Components/ReadMore"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { truncatedTextLimit } from "app/utils/hardware"
 import { graphql, useFragment } from "react-relay"
 
 export const ArtQuizTrendingCollection = ({
@@ -11,6 +13,7 @@ export const ArtQuizTrendingCollection = ({
 }: {
   collectionData: NonNullable<ArtQuizTrendingCollections_viewer$data["marketingCollections"]>[0]
 }) => {
+  const textLimit = truncatedTextLimit()
   const collection = useFragment<ArtQuizTrendingCollection_collection$key>(
     artQuizTrendingCollectionFragment,
     collectionData
@@ -23,10 +26,15 @@ export const ArtQuizTrendingCollection = ({
   return (
     <Flex pt={2}>
       <Flex px={2}>
-        <Text variant="sm">{collection?.title}</Text>
-        <Text variant="sm" color="black60">
-          {collection?.description}
-        </Text>
+        <Text variant="md">{collection?.title}</Text>
+        <ReadMore
+          content={collection?.description!}
+          maxChars={textLimit}
+          textStyle="new"
+          color="black60"
+          textVariant="md"
+          linkTextVariant="md"
+        />
       </Flex>
       <Spacer y={1} />
       <SmallArtworkRail

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -31,7 +31,7 @@ export const ArtQuizWelcome = () => {
             block
             variant="text"
             onPress={() => {
-              GlobalStore.actions.auth.setArtQuizState("close")
+              GlobalStore.actions.auth.setArtQuizState("complete")
             }}
           >
             Skip

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -32,7 +32,6 @@ export const ArtQuizWelcome = () => {
             variant="text"
             onPress={() => {
               GlobalStore.actions.auth.setArtQuizState("close")
-              navigate("/")
             }}
           >
             Skip

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -1,4 +1,6 @@
 import { Spacer, Flex, Screen, Text, ArtsyLogoBlackIcon } from "@artsy/palette-mobile"
+import { useNavigation, NavigationProp } from "@react-navigation/native"
+import { ArtQuizNavigationStack } from "app/Scenes/ArtQuiz/ArtQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { Button } from "palette"
@@ -7,6 +9,8 @@ import { useBackHandler } from "shared/hooks/useBackHandler"
 export const ArtQuizWelcome = () => {
   // prevents Android users from going back with hardware button
   useBackHandler(() => true)
+
+  const { navigate: quizStackNavigate } = useNavigation<NavigationProp<ArtQuizNavigationStack>>()
 
   return (
     <Screen>
@@ -23,7 +27,7 @@ export const ArtQuizWelcome = () => {
           </Text>
         </Flex>
         <Flex justifyContent="flex-end">
-          <Button block onPress={() => navigate("/art-quiz/artworks")}>
+          <Button block onPress={() => quizStackNavigate("ArtQuizArtworks")}>
             Start the Quiz
           </Button>
           <Spacer y={1} />

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -32,6 +32,7 @@ export const ArtQuizWelcome = () => {
             variant="text"
             onPress={() => {
               GlobalStore.actions.auth.setArtQuizState("complete")
+              navigate("/")
             }}
           >
             Skip

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -1,14 +1,9 @@
 import { Spacer, Flex, Screen, Text, ArtsyLogoBlackIcon } from "@artsy/palette-mobile"
-import { NavigationProp, useNavigation } from "@react-navigation/native"
-import { ArtQuizNavigationStack } from "app/Scenes/ArtQuiz/ArtQuizNavigation"
-import { useOnboardingContext } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
-import { navigate as globalNavigate } from "app/system/navigation/navigate"
+import { GlobalStore } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 import { Button } from "palette"
 
 export const ArtQuizWelcome = () => {
-  const { onDone } = useOnboardingContext()
-  const { navigate } = useNavigation<NavigationProp<ArtQuizNavigationStack>>()
-
   return (
     <Screen>
       <Screen.Body>
@@ -24,12 +19,7 @@ export const ArtQuizWelcome = () => {
           </Text>
         </Flex>
         <Flex justifyContent="flex-end">
-          <Button
-            block
-            onPress={() => {
-              return navigate("ArtQuizArtworks")
-            }}
-          >
+          <Button block onPress={() => navigate("/art-quiz/artworks")}>
             Start the Quiz
           </Button>
           <Spacer y={1} />
@@ -37,8 +27,8 @@ export const ArtQuizWelcome = () => {
             block
             variant="text"
             onPress={() => {
-              onDone?.()
-              globalNavigate("/")
+              GlobalStore.actions.auth.setArtQuizState("close")
+              navigate("/")
             }}
           >
             Skip

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -2,8 +2,12 @@ import { Spacer, Flex, Screen, Text, ArtsyLogoBlackIcon } from "@artsy/palette-m
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { Button } from "palette"
+import { useBackHandler } from "shared/hooks/useBackHandler"
 
 export const ArtQuizWelcome = () => {
+  // prevents Android users from going back with hardware button
+  useBackHandler(() => true)
+
   return (
     <Screen>
       <Screen.Body>

--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -36,7 +36,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const isActive = selectedTab === tab
   const timeout = useRef<ReturnType<typeof setTimeout>>()
   const [isBeingPressed, setIsBeingPressed] = useState(false)
-
+  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
   const showActiveState = isActive || isBeingPressed
 
   const activeProgress = useRef(new Animated.Value(showActiveState ? 1 : 0)).current
@@ -55,7 +55,9 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const tracking = useTracking()
 
   const onPress = () => {
-    GlobalStore.actions.auth.setArtQuizState("close")
+    if (artQuizState === "open") {
+      GlobalStore.actions.auth.setArtQuizState("close")
+    }
     if (tab === unsafe__getSelectedTab()) {
       LegacyNativeModules.ARScreenPresenterModule.popToRootOrScrollToTop(tab)
     } else {

--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -1,7 +1,12 @@
 import { tappedTabBar } from "@artsy/cohesion"
 import { useColor, Text } from "@artsy/palette-mobile"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import { unsafe__getSelectedTab, useSelectedTab, useVisualClue } from "app/store/GlobalStore"
+import {
+  GlobalStore,
+  unsafe__getSelectedTab,
+  useSelectedTab,
+  useVisualClue,
+} from "app/store/GlobalStore"
 import { VisualClueName } from "app/store/config/visualClues"
 import { switchTab } from "app/system/navigation/navigate"
 import { PopIn } from "palette"
@@ -50,6 +55,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const tracking = useTracking()
 
   const onPress = () => {
+    GlobalStore.actions.auth.setArtQuizState("close")
     if (tab === unsafe__getSelectedTab()) {
       LegacyNativeModules.ARScreenPresenterModule.popToRootOrScrollToTop(tab)
     } else {

--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -1,12 +1,7 @@
 import { tappedTabBar } from "@artsy/cohesion"
 import { useColor, Text } from "@artsy/palette-mobile"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import {
-  GlobalStore,
-  unsafe__getSelectedTab,
-  useSelectedTab,
-  useVisualClue,
-} from "app/store/GlobalStore"
+import { unsafe__getSelectedTab, useSelectedTab, useVisualClue } from "app/store/GlobalStore"
 import { VisualClueName } from "app/store/config/visualClues"
 import { switchTab } from "app/system/navigation/navigate"
 import { PopIn } from "palette"
@@ -36,7 +31,6 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const isActive = selectedTab === tab
   const timeout = useRef<ReturnType<typeof setTimeout>>()
   const [isBeingPressed, setIsBeingPressed] = useState(false)
-  const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
   const showActiveState = isActive || isBeingPressed
 
   const activeProgress = useRef(new Animated.Value(showActiveState ? 1 : 0)).current
@@ -55,9 +49,6 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const tracking = useTracking()
 
   const onPress = () => {
-    if (artQuizState === "incomplete") {
-      GlobalStore.actions.auth.setArtQuizState("complete")
-    }
     if (tab === unsafe__getSelectedTab()) {
       LegacyNativeModules.ARScreenPresenterModule.popToRootOrScrollToTop(tab)
     } else {

--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -36,7 +36,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const isActive = selectedTab === tab
   const timeout = useRef<ReturnType<typeof setTimeout>>()
   const [isBeingPressed, setIsBeingPressed] = useState(false)
-  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
+  const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
   const showActiveState = isActive || isBeingPressed
 
   const activeProgress = useRef(new Animated.Value(showActiveState ? 1 : 0)).current
@@ -55,8 +55,8 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   const tracking = useTracking()
 
   const onPress = () => {
-    if (artQuizState === "open") {
-      GlobalStore.actions.auth.setArtQuizState("close")
+    if (artQuizState === "incomplete") {
+      GlobalStore.actions.auth.setArtQuizState("complete")
     }
     if (tab === unsafe__getSelectedTab()) {
       LegacyNativeModules.ARScreenPresenterModule.popToRootOrScrollToTop(tab)

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -49,7 +49,6 @@ import {
 import { search2QueryDefaultVariables } from "app/Scenes/Search/Search2"
 import { ViewingRoomsHomeMainRail } from "app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail"
 import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
-import { navigate } from "app/system/navigation/navigate"
 import { defaultEnvironment } from "app/system/relay/createEnvironment"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
@@ -123,7 +122,6 @@ export interface HomeProps extends ViewProps {
 
 const Home = memo((props: HomeProps) => {
   const viewedRails = useRef<Set<string>>(new Set()).current
-  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
   const isESOnlySearchEnabled = useFeatureFlag("AREnableESOnlySearch")
   const prefetchUrl = usePrefetch()
@@ -145,12 +143,6 @@ const Home = memo((props: HomeProps) => {
     prefetchUrl("inbox")
     prefetchUrl("sales")
   }, [])
-
-  useEffect(() => {
-    if (artQuizState === "open") {
-      navigate("/art-quiz")
-    }
-  }, [artQuizState])
 
   const { loading, relay } = props
 

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -49,6 +49,7 @@ import {
 import { search2QueryDefaultVariables } from "app/Scenes/Search/Search2"
 import { ViewingRoomsHomeMainRail } from "app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail"
 import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 import { defaultEnvironment } from "app/system/relay/createEnvironment"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
@@ -122,7 +123,7 @@ export interface HomeProps extends ViewProps {
 
 const Home = memo((props: HomeProps) => {
   const viewedRails = useRef<Set<string>>(new Set()).current
-
+  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
   const isESOnlySearchEnabled = useFeatureFlag("AREnableESOnlySearch")
   const prefetchUrl = usePrefetch()
@@ -144,6 +145,12 @@ const Home = memo((props: HomeProps) => {
     prefetchUrl("inbox")
     prefetchUrl("sales")
   }, [])
+
+  useEffect(() => {
+    if (artQuizState === "open") {
+      navigate("/art-quiz")
+    }
+  }, [artQuizState])
 
   const { loading, relay } = props
 

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -11,7 +11,7 @@ export const HomeContainer = () => {
     await navigate("/art-quiz")
   }
 
-  if (artQuizState === "incomplete" && shouldShowArtQuiz) {
+  if (shouldShowArtQuiz && artQuizState === "incomplete") {
     navigateToArtQuiz()
     return null
   }

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -1,14 +1,17 @@
-import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
 import { HomeQueryRenderer } from "app/Scenes/Home/Home"
 import { GlobalStore } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 
 export const HomeContainer = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
 
-  console.log({ artQuizState })
+  const navigateToArtQuiz = async () => {
+    await navigate("/art-quiz")
+  }
 
   if (artQuizState === "open") {
-    return <ArtQuiz />
+    navigateToArtQuiz()
+    return null
   }
 
   return <HomeQueryRenderer />

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -1,15 +1,17 @@
 import { HomeQueryRenderer } from "app/Scenes/Home/Home"
-import { GlobalStore } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 
 export const HomeContainer = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
 
+  const shouldShowArtQuiz = useFeatureFlag("ARShowArtQuizApp")
+
   const navigateToArtQuiz = async () => {
     await navigate("/art-quiz")
   }
 
-  if (artQuizState === "incomplete") {
+  if (artQuizState === "incomplete" && shouldShowArtQuiz) {
     navigateToArtQuiz()
     return null
   }

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -1,0 +1,15 @@
+import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
+import { HomeQueryRenderer } from "app/Scenes/Home/Home"
+import { GlobalStore } from "app/store/GlobalStore"
+
+export const HomeContainer = () => {
+  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
+
+  console.log({ artQuizState })
+
+  if (artQuizState === "open") {
+    return <ArtQuiz />
+  }
+
+  return <HomeQueryRenderer />
+}

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -3,13 +3,13 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 
 export const HomeContainer = () => {
-  const artQuizState = GlobalStore.useAppState((state) => state.auth.artQuizState)
+  const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
 
   const navigateToArtQuiz = async () => {
     await navigate("/art-quiz")
   }
 
-  if (artQuizState === "open") {
+  if (artQuizState === "incomplete") {
     navigateToArtQuiz()
     return null
   }

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Hooks/useNextOnboardingScreen.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Hooks/useNextOnboardingScreen.tsx
@@ -3,7 +3,6 @@ import {
   OPTION_ARTISTS_ON_THE_RISE,
   OPTION_FOLLOW_ARTISTS_I_WANT_TO_COLLECT,
   OPTION_FOLLOW_GALLERIES_IM_INTERESTED_IN,
-  OPTION_THE_ART_TASTE_QUIZ,
   OPTION_TOP_AUCTION_LOTS,
 } from "app/Scenes/Onboarding/OnboardingQuiz/config"
 import { useOnboardingContext } from "./useOnboardingContext"
@@ -34,10 +33,5 @@ export const useNextOnboardingScreen = () => {
 
     case OPTION_FOLLOW_GALLERIES_IM_INTERESTED_IN:
       return screenNames.OnboardingFollowGalleries
-
-    case OPTION_THE_ART_TASTE_QUIZ:
-      return screenNames.OnboardingArtTasteQuiz
   }
 }
-
-// Loading screens??

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingArtTasteQuiz.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingArtTasteQuiz.tsx
@@ -1,5 +1,0 @@
-import { ArtQuizNavigation } from "app/Scenes/ArtQuiz/ArtQuizNavigation"
-
-export const OnboardingArtTasteQuiz: React.FC = () => {
-  return <ArtQuizNavigation />
-}

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
@@ -12,7 +12,7 @@ import {
   OPTION_TOP_AUCTION_LOTS,
   OPTION_THE_ART_TASTE_QUIZ,
 } from "app/Scenes/Onboarding/OnboardingQuiz/config"
-import { useFeatureFlag } from "app/store/GlobalStore"
+import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { useCallback, useMemo } from "react"
 import { OnboardingQuestionTemplate } from "./Components/OnboardingQuestionTemplate"
 import { useNextOnboardingScreen } from "./Hooks/useNextOnboardingScreen"
@@ -34,6 +34,7 @@ export const OnboardingQuestionThree = () => {
       trackAnsweredQuestionThree(questionThree)
     }
     if (questionThree === OPTION_THE_ART_TASTE_QUIZ) {
+      GlobalStore.actions.auth.setArtQuizState("incomplete")
       onDone()
     } else {
       // @ts-expect-error

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
@@ -23,6 +23,7 @@ export const OnboardingQuestionThree = () => {
   const { navigate } = useNavigation()
   const {
     state: { questionTwo, questionThree },
+    onDone,
   } = useOnboardingContext()
   const nextScreen = useNextOnboardingScreen()
 
@@ -32,8 +33,12 @@ export const OnboardingQuestionThree = () => {
     if (!!questionThree) {
       trackAnsweredQuestionThree(questionThree)
     }
-    // @ts-expect-error
-    navigate(nextScreen!)
+    if (questionThree === OPTION_THE_ART_TASTE_QUIZ) {
+      onDone()
+    } else {
+      // @ts-expect-error
+      navigate(nextScreen!)
+    }
   }, [navigate, nextScreen, questionThree, trackAnsweredQuestionThree])
 
   const options = useMemo(() => {

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
@@ -4,7 +4,6 @@ import { useOnboardingTracking } from "app/Scenes/Onboarding/OnboardingQuiz/Hook
 import { GlobalStore } from "app/store/GlobalStore"
 import { OnboardingProvider } from "./Hooks/useOnboardingContext"
 import { useUpdateUserProfile } from "./Hooks/useUpdateUserProfile"
-import { OnboardingArtTasteQuiz } from "./OnboardingArtTasteQuiz"
 import { OnboardingArtistsOnTheRise } from "./OnboardingArtistsOnTheRise"
 import { OnboardingCuratedArtworks } from "./OnboardingCuratedArtworks"
 import { OnboardingFollowArtists } from "./OnboardingFollowArtists"
@@ -24,7 +23,6 @@ export type OnboardingNavigationStack = {
   OnboardingArtistsOnTheRise: undefined
   OnboardingCuratedArtworks: undefined
   OnboardingTopAuctionLots: undefined
-  OnboardingArtTasteQuiz: undefined
   OnboardingFollowArtists: undefined
   OnboardingFollowGalleries: undefined
   OnboardingPostFollowLoadingScreen: undefined
@@ -46,6 +44,7 @@ export const OnboardingQuiz = () => {
     commitMutation({
       completedOnboarding: true,
     })
+    GlobalStore.actions.auth.setArtQuizState("open")
   }
 
   return (
@@ -95,8 +94,6 @@ export const OnboardingQuiz = () => {
             name="OnboardingPostFollowLoadingScreen"
             component={OnboardingPostFollowLoadingScreen}
           />
-
-          <StackNavigator.Screen name="OnboardingArtTasteQuiz" component={OnboardingArtTasteQuiz} />
         </StackNavigator.Navigator>
       </NavigationContainer>
     </OnboardingProvider>

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
@@ -44,7 +44,6 @@ export const OnboardingQuiz = () => {
     commitMutation({
       completedOnboarding: true,
     })
-    GlobalStore.actions.auth.setArtQuizState("open")
   }
 
   return (

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -208,6 +208,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     ),
 
     addRoute("/art-quiz", "ArtQuiz"),
+    addRoute("/art-quiz/artworks", "ArtQuiz"),
     addRoute("/art-quiz/results", "ArtQuizResults"),
 
     // TODO: Follow-up about below route names

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -208,7 +208,6 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     ),
 
     addRoute("/art-quiz", "ArtQuiz"),
-    addRoute("/art-quiz/artworks", "ArtQuizArtworks"),
     addRoute("/art-quiz/results", "ArtQuizResults"),
 
     // TODO: Follow-up about below route names

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -152,7 +152,7 @@ interface SignUpParams {
 type OAuthParams = EmailOAuthParams | FacebookOAuthParams | GoogleOAuthParams | AppleOAuthParams
 
 type OnboardingState = "none" | "incomplete" | "complete"
-type ArtQuizState = "none" | "open" | "close"
+type OnboardingArtQuizState = "none" | "incomplete" | "complete"
 
 export interface AuthPromiseResolveType {
   success: boolean
@@ -182,7 +182,7 @@ export interface AuthModel {
   xAppToken: string | null
   xApptokenExpiresIn: string | null
   onboardingState: OnboardingState
-  artQuizState: ArtQuizState
+  onboardingArtQuizState: OnboardingArtQuizState
   userEmail: string | null
   previousSessionUserID: string | null
 
@@ -242,7 +242,7 @@ export interface AuthModel {
     GlobalStoreModel,
     ReturnType<typeof fetch>
   >
-  setArtQuizState: Action<this, ArtQuizState>
+  setArtQuizState: Action<this, OnboardingArtQuizState>
   signOut: Thunk<this>
 }
 
@@ -261,7 +261,7 @@ export const getAuthModel = (): AuthModel => ({
   xAppToken: null,
   xApptokenExpiresIn: null,
   onboardingState: "none",
-  artQuizState: "none",
+  onboardingArtQuizState: "none",
   userEmail: null,
   previousSessionUserID: null,
   userHasArtsyEmail: computed((state) => isArtsyEmail(state.userEmail ?? "")),
@@ -893,7 +893,7 @@ export const getAuthModel = (): AuthModel => ({
     })
   }),
   setArtQuizState: action((state, artQuizState) => {
-    state.artQuizState = artQuizState
+    state.onboardingArtQuizState = artQuizState
   }),
   signOut: thunk(async () => {
     const signOutGoogle = async () => {

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -152,6 +152,7 @@ interface SignUpParams {
 type OAuthParams = EmailOAuthParams | FacebookOAuthParams | GoogleOAuthParams | AppleOAuthParams
 
 type OnboardingState = "none" | "incomplete" | "complete"
+type ArtQuizState = "none" | "open" | "close"
 
 export interface AuthPromiseResolveType {
   success: boolean
@@ -181,6 +182,7 @@ export interface AuthModel {
   xAppToken: string | null
   xApptokenExpiresIn: string | null
   onboardingState: OnboardingState
+  artQuizState: ArtQuizState
   userEmail: string | null
   previousSessionUserID: string | null
 
@@ -240,6 +242,7 @@ export interface AuthModel {
     GlobalStoreModel,
     ReturnType<typeof fetch>
   >
+  setArtQuizState: Action<this, ArtQuizState>
   signOut: Thunk<this>
 }
 
@@ -258,6 +261,7 @@ export const getAuthModel = (): AuthModel => ({
   xAppToken: null,
   xApptokenExpiresIn: null,
   onboardingState: "none",
+  artQuizState: "none",
   userEmail: null,
   previousSessionUserID: null,
   userHasArtsyEmail: computed((state) => isArtsyEmail(state.userEmail ?? "")),
@@ -887,6 +891,9 @@ export const getAuthModel = (): AuthModel => ({
         }
       }
     })
+  }),
+  setArtQuizState: action((state, artQuizState) => {
+    state.artQuizState = artQuizState
   }),
   signOut: thunk(async () => {
     const signOutGoogle = async () => {

--- a/src/app/store/migration.tests.ts
+++ b/src/app/store/migration.tests.ts
@@ -731,6 +731,7 @@ describe("App version Versions.AddSubmissionIdForMyCollection", () => {
     expect(migratedState.artworkSubmission.submission.submissionIdForMyCollection).toEqual("")
   })
 })
+
 describe("App version Versions.AddRecentPriceRangesModel", () => {
   const migrationToTest = Versions.AddRecentPriceRangesModel
 
@@ -811,5 +812,23 @@ describe("App version Versions.MoveEnvironmentToDevicePrefsAndRenameAdminToLocal
     expect(migratedState.devicePrefs.environment.localOverrides).toEqual({ testKey: true })
     expect(migratedState.devicePrefs.environment.adminOverrides).toEqual(undefined)
     expect(migratedState.artsyPrefs.environment).toEqual(undefined)
+  })
+})
+
+describe("App version Versions.AddOnboardingArtQuizStateToAuthModel", () => {
+  const migrationToTest = Versions.AddOnboardingArtQuizStateToAuthModel
+
+  it("removes deviceId", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    }) as any
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect(migratedState.auth.onboardingArtQuizState).toEqual("none")
   })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,9 +45,10 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
+  AddArtQuizStateToAuthModel: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddCategoryToSubmissionArtworkDetails
+export const CURRENT_APP_VERSION = Versions.AddArtQuizStateToAuthModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -266,6 +267,9 @@ export const artsyAppMigrations: Migrations = {
   [Versions.AddCategoryToSubmissionArtworkDetails]: (state) => {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
+  },
+  [Versions.AddArtQuizStateToAuthModel]: (state) => {
+    state.auth.artQuizState = "none"
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -45,10 +45,10 @@ export const Versions = {
   RenameAdminToLocalOverridesForFeatures: 33,
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
-  AddArtQuizStateToAuthModel: 36,
+  AddOnboardingArtQuizStateToAuthModel: 36,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddArtQuizStateToAuthModel
+export const CURRENT_APP_VERSION = Versions.AddOnboardingArtQuizStateToAuthModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -268,8 +268,8 @@ export const artsyAppMigrations: Migrations = {
     state.artworkSubmission.submission.artworkDetails.category = null
     state.artworkSubmission.submission.dirtyArtworkDetailsValues.category = null
   },
-  [Versions.AddArtQuizStateToAuthModel]: (state) => {
-    state.auth.artQuizState = "none"
+  [Versions.AddOnboardingArtQuizStateToAuthModel]: (state) => {
+    state.auth.onboardingArtQuizState = "none"
   },
 }
 

--- a/src/app/utils/DevMenu.tsx
+++ b/src/app/utils/DevMenu.tsx
@@ -194,6 +194,7 @@ export const DevMenu = ({ onClose = () => dismissModal() }: { onClose(): void })
           <FeatureFlagMenuItem
             title="Open Art Quiz"
             onPress={() => {
+              GlobalStore.actions.auth.setArtQuizState("open")
               dismissModal(() => navigate("/art-quiz"))
             }}
           />

--- a/src/app/utils/DevMenu.tsx
+++ b/src/app/utils/DevMenu.tsx
@@ -194,7 +194,6 @@ export const DevMenu = ({ onClose = () => dismissModal() }: { onClose(): void })
           <FeatureFlagMenuItem
             title="Open Art Quiz"
             onPress={() => {
-              GlobalStore.actions.auth.setArtQuizState("open")
               dismissModal(() => navigate("/art-quiz"))
             }}
           />

--- a/src/palette/organisms/screenStructure/Screen.stories.tsx
+++ b/src/palette/organisms/screenStructure/Screen.stories.tsx
@@ -108,7 +108,7 @@ export const ScrollScreenWithRegularHeader: ScreenStory = () => (
 export const ScrollScreenWithFloatingHeader: ScreenStory = () => (
   <Screen>
     <Screen.FloatingHeader onBack={() => {}} />
-    <Screen.Body scroll nosafe>
+    <Screen.Body scroll noTopSafe noBottomSafe>
       <Text>Hello</Text>
     </Screen.Body>
   </Screen>

--- a/src/palette/organisms/screenStructure/Screen.tsx
+++ b/src/palette/organisms/screenStructure/Screen.tsx
@@ -151,13 +151,15 @@ const SCREEN_HORIZONTAL_PADDING: SpacingUnitDSValueNumber = 2
 interface BodyProps extends Pick<FlexProps, "backgroundColor"> {
   children?: React.ReactNode
   scroll?: boolean
-  nosafe?: boolean
+  noTopSafe?: boolean
+  noBottomSafe?: boolean
   fullwidth?: boolean
 }
 
 const Body = ({
   scroll = false,
-  nosafe = false,
+  noTopSafe = false,
+  noBottomSafe = false,
   fullwidth = false,
   children,
   ...restFlexProps
@@ -166,8 +168,8 @@ const Body = ({
   const bottomView = getChildrenByType(children, Screen.BottomView)
   const { options } = useScreenContext()
   const insets = useSafeAreaInsets()
-  const withTopSafeArea = options.handleTopSafeArea && !nosafe
-  const withBottomSafeArea = !nosafe
+  const withTopSafeArea = options.handleTopSafeArea && !noTopSafe
+  const withBottomSafeArea = !noBottomSafe
 
   return (
     <>


### PR DESCRIPTION
This PR fixes the navigation issue on Art Quiz

Steps involved : 

1.  Adding `artQuizState` with `none|open|close` states in AuthModel, which separates it from `onboardingState` and has its own. 
2. Once the user clicks on `Art Taste Quiz` pill option, on the Question 3 screen of OnboaringQuiz,  it will close the onboarding with `onDone()` prop from `useOnboardingContext()`. 
3. `onDone()` completes the Onboarding flow and opens the Art Quiz.  
4. Removing `ArtQuizNavigation` that has its own stack navigation and appending it with the global navigation which makes it easier to navigate to different artists and artwork on the results screen.
5. Adding `useEffect()` in Home.tsx where it navigates to the Art Quiz landing screen. 
6. Pressing on BottomTabs can also close the Art quiz
7. Art Quiz can also be opened from Dev Menu


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **ARShowArtQuizApp**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Art Quiz App navigation flow

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
