### PR TITLE
fix: Hide collections in collection rail on home screen if the collection is empty

### DIFF
--- a/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
+++ b/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
@@ -65,6 +65,10 @@ export const MarketingCollectionRail: React.FC<MarketingCollectionRailProps> = m
       navigate(`/collection/${marketingCollection.slug}`)
     }
 
+    if (!artworks.length) {
+      return null
+    }
+
     return (
       <Flex py={2} backgroundColor="black100">
         <TouchableOpacity onPress={handleHeaderPress} activeOpacity={0.7}>


### PR DESCRIPTION
Addresses [CX-3479]
 <!-- eg [PROJECT-XXXX] -->

### Description

Hide collections in collection rail on home screen if the collection is empty to avoid:

![simulator_screenshot_A59048CE-428C-43F2-AD59-8A79DF9E9E46](https://user-images.githubusercontent.com/4691889/222768024-54386821-091c-4750-9901-1342e1354e18.png)

### PR Checklist



- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- hide collections in collection rail on home screen if the collection is empty

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3479]: https://artsyproduct.atlassian.net/browse/CX-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ