### PR TITLE
feat(CX-3466): Add edition number to My Collection artworks

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
@@ -46,7 +46,7 @@ export const MyCollectionArtworkAboutWork: React.FC<MyCollectionArtworkAboutWork
   })
 
   const rarityText = `${capitalize(attributionClass?.shortDescription || undefined)}${
-    editionOf && "\n" + editionOf
+    editionOf ? `\n ${editionOf}` : ""
   }`
 
   return (

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork.tsx
@@ -30,6 +30,7 @@ export const MyCollectionArtworkAboutWork: React.FC<MyCollectionArtworkAboutWork
     confidentialNotes,
     medium,
     attributionClass,
+    editionOf,
     dimensions,
     artworkLocation,
     date,
@@ -44,12 +45,16 @@ export const MyCollectionArtworkAboutWork: React.FC<MyCollectionArtworkAboutWork
     highRangeCents: Number(marketPriceInsights?.highRangeCents),
   })
 
+  const rarityText = `${capitalize(attributionClass?.shortDescription || undefined)}${
+    editionOf && "\n" + editionOf
+  }`
+
   return (
     <Flex mb={4}>
       {!!enablePriceEstimateRange && <Field label="Estimate Range" value={estimatePrice} />}
       <MetaDataField label="Medium" value={capitalize(category!)} />
       <MetaDataField label="Materials" value={capitalize(medium!)} />
-      <MetaDataField label="Rarity" value={capitalize(attributionClass?.name || undefined)} />
+      <MetaDataField label="Rarity" value={rarityText} />
       <MetaDataField label="Dimensions" value={metric === "in" ? dimensions?.in : dimensions?.cm} />
       <MetaDataField label="Location" value={artworkLocation} />
       <MetaDataField label="Year created" value={date} />
@@ -75,8 +80,9 @@ const artworkFragment = graphql`
     date
     provenance
     attributionClass {
-      name
+      shortDescription
     }
+    editionOf
     artworkLocation
     pricePaid {
       display

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/Field.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/Field.tsx
@@ -26,8 +26,8 @@ export const Field: React.FC<{
   }
 
   return (
-    <Flex flexDirection="row" justifyContent="space-between" my={1}>
-      <Text variant="xs" color="black100" pr={1}>
+    <Flex flexDirection="row" my={1}>
+      <Text variant="xs" color="black100" pr={1} style={{ minWidth: 120 }}>
         {label}
       </Text>
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
@@ -56,7 +56,7 @@ describe("MyCollectionArtworkAbout", () => {
       expect(getByText("Materials")).toBeTruthy()
       expect(getByText("Painting")).toBeTruthy()
       expect(getByText("Rarity")).toBeTruthy()
-      expect(getByText("Unique")).toBeTruthy()
+      expect(getByText("Unique work")).toBeTruthy()
       expect(getByText("Dimensions")).toBeTruthy()
       expect(getByText("Location")).toBeTruthy()
       expect(getByText("Berlin")).toBeTruthy()
@@ -178,8 +178,9 @@ const artworkDataAvailable = {
       cm: "100 × 104 cm",
     },
     attributionClass: {
-      name: "Unique",
+      shortDescription: "Unique work",
     },
+    editionOf: null,
     artworkLocation: "Berlin",
     pricePaid: {
       display: "$12,000",
@@ -208,6 +209,7 @@ const artworkDataNotAvailable = {
       cm: null,
     },
     attributionClass: null,
+    editionOf: null,
     artworkLocation: "",
     pricePaid: null,
   },

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tests.tsx
@@ -69,6 +69,35 @@ describe("MyCollectionArtworkAbout", () => {
       expect(getByText("$12,000")).toBeTruthy()
     })
 
+    it("renders the edition information when the artwork is part of limited edition", () => {
+      const { getByText } = renderWithRelay({
+        Query: () => ({
+          artwork: {
+            ...artworkDataAvailable.artwork,
+            attributionClass: { shortDescription: "Part of a limited edition set" },
+            editionOf: "Edition 3/10",
+          },
+        }),
+      })
+
+      expect(getByText("Medium")).toBeTruthy()
+      expect(getByText("Oil on canvas")).toBeTruthy()
+      expect(getByText("Materials")).toBeTruthy()
+      expect(getByText("Painting")).toBeTruthy()
+      expect(getByText("Rarity")).toBeTruthy()
+      expect(getByText("Part of a limited edition set\nEdition 3/10")).toBeTruthy()
+      expect(getByText("Dimensions")).toBeTruthy()
+      expect(getByText("Location")).toBeTruthy()
+      expect(getByText("Berlin")).toBeTruthy()
+      expect(getByText("39 2/5 × 40 9/10 in")).toBeTruthy()
+      expect(getByText("Year created")).toBeTruthy()
+      expect(getByText("2007")).toBeTruthy()
+      expect(getByText("Provenance")).toBeTruthy()
+      expect(getByText("Signed, Sealed, Delivered!")).toBeTruthy()
+      expect(getByText("Price Paid")).toBeTruthy()
+      expect(getByText("$12,000")).toBeTruthy()
+    })
+
     it("renders the lables and the empty value when the data is not available", () => {
       const { getAllByText } = renderWithRelay({
         Query: () => artworkDataNotAvailable,


### PR DESCRIPTION
This PR resolves [CX-3466] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR adds the edition number in My Collection artwork details if the artwork is part of a limited edition

### Screenshots

| Edition | iOS | Android |
| -- | -- | -- |
| Unique (before) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223118764-d493eda7-cf3f-4d02-ab70-f3bf9bb1b565.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134613-926b17f8-f84f-4d27-b5f6-9d18799e914d.png"> |
| Unique (after) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223119110-f7091d4a-eca9-4614-bba2-40519629ba80.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134847-7f23d226-57ec-4d94-b4b9-be6e42f926ec.png"> |
| Limited (before) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223118804-c98f3d07-66bf-423e-9118-77c24acdf078.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134660-22ba6631-5f27-4d77-aa3f-57d768c3911f.png"> |
| Limited (after) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223119140-6e7d74fb-802e-4e9b-8258-eecc80455e29.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134937-f6e0c8bb-2c40-41eb-a3a3-69a9214ae2e6.png"> |
| Open (before) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223118844-728ef485-7177-4110-b03f-4c71071e6306.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134749-6470f9f7-281a-40e3-b228-cfd8f213080d.png"> |
| Open (after) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223119225-aacb6359-15b1-4ef4-9fc0-f720c31ce800.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223135003-c8e29028-9e03-4218-8f27-6ac28286201b.png"> |
| Unknown (before) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223118883-eb483b7a-9b92-411a-8139-6208d8ee4195.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223134787-30e2c3b2-3e36-46ba-9e67-9ffa9a47ba29.png"> |
| Unknown (after) | <img width="394" alt="image" src="https://user-images.githubusercontent.com/20655703/223119263-afb227c9-1229-4212-b0f5-037d0981fc5d.png"> | <img width="416" alt="image" src="https://user-images.githubusercontent.com/20655703/223135043-b6503b50-e573-4e5d-95ee-633e1ad55726.png"> |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add edition number to My Collection artwork details - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3466]: https://artsyproduct.atlassian.net/browse/CX-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ