### PR TITLE
feat: display unable to load error message always on staging

### DIFF
--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -22,6 +22,10 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   const [isAnimating, setIsAnimating] = useState(false)
   const showErrorInLoadFailureViewToggle = useDevToggle("DTShowErrorInLoadFailureView")
 
+  const isStaging = useIsStaging()
+
+  const showErrorMessage = __DEV__ || isStaging || showErrorInLoadFailureViewToggle
+
   const playAnimation = () => {
     setIsAnimating(true)
     Animated.loop(
@@ -33,9 +37,6 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
       })
     ).start()
   }
-
-  const showErrorMessage = __DEV__ || showErrorInLoadFailureViewToggle
-  const isStaging = useIsStaging()
 
   return (
     <Flex flex={1} alignItems="center" justifyContent="center" {...restProps}>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Displays the Unable to load error message by default ALWAYS on Staging environment.

Benefits:

- we will be able to immediately see whats the exact error when testing Betas
- Applause unable to load errors that are not reproducible will include the message in the already included video / screenshot that they submit

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- display unable to load error message always on staging - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
