### PR TITLE
feat: add track rail viewed

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -87,6 +87,7 @@ import {
 } from "react-native"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 
+import { useTracking } from "react-tracking"
 import { useContentCards } from "./Components/ContentCards"
 import HomeAnalytics from "./homeAnalytics"
 import { useHomeModules } from "./homeModules"
@@ -125,6 +126,8 @@ const Home = memo((props: HomeProps) => {
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
   const isESOnlySearchEnabled = useFeatureFlag("AREnableESOnlySearch")
   const prefetchUrl = usePrefetch()
+  const tracking = useTracking()
+
   const { cards } = useContentCards()
 
   const viewabilityConfig = useRef<FlatListProps<HomeModule>["viewabilityConfig"]>({
@@ -161,10 +164,13 @@ const Home = memo((props: HomeProps) => {
       if (enableRailViewsTracking && enableRailViewsTrackingExperiment.enabled) {
         viewableItems.forEach(({ item: { title, contextModule } }: { item: HomeModule }) => {
           if (contextModule && !viewedRails.has(title)) {
-            HomeAnalytics.trackRailViewed({
-              contextModule: contextModule,
-              positionY: modules.findIndex((module) => module.title === title),
-            })
+            viewedRails.add(title)
+            tracking.trackEvent(
+              HomeAnalytics.trackRailViewed({
+                contextModule: contextModule,
+                positionY: modules.findIndex((module) => module.title === title),
+              })
+            )
           }
         })
       }


### PR DESCRIPTION
This PR resolves [CX-3385] <!-- eg [PROJECT-XXXX] -->

### Description

- I figured out I added the tracking event without triggering it 😅


https://user-images.githubusercontent.com/11945712/223434681-e3a1c3f4-27c3-4cc4-bd8a-0b8c7b3753c5.mov


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add track rail viewed event to home rails - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3385]: https://artsyproduct.atlassian.net/browse/CX-3385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ