### PR TITLE
refactor(FX-4682): Move save artwork button to artwork actions

### DIFF
--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -14,7 +14,7 @@ const ArtworkActionsPlaceholder = () => {
 
   return (
     <Flex flexDirection="row" justifyContent="center">
-      {times(2).map((index) => (
+      {times(3).map((index) => (
         <PlaceholderBox
           key={`auction-${index}`}
           width={50}

--- a/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
+++ b/src/app/Scenes/Artwork/Components/AboveTheFoldArtworkPlaceholder.tsx
@@ -54,7 +54,6 @@ const ArtworkDetailsPlaceholder = () => {
 }
 
 export const AboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = ({ artworkID }) => {
-  const space = useSpace()
   const { width, height } = useImagePlaceholderDimensions(artworkID)
 
   return (
@@ -65,7 +64,6 @@ export const AboveTheFoldPlaceholder: React.FC<AboveTheFoldPlaceholderProps> = (
           <PlaceholderBox width={20} height={20} />
 
           <Flex flexDirection="row" alignItems="center">
-            <PlaceholderBox width={105} height={25} marginRight={space(1)} />
             <PlaceholderBox width={105} height={25} />
           </Flex>
         </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
@@ -116,17 +116,7 @@ describe("ArtworkActions", () => {
 
 const artworkActionsArtwork: ArtworkActions_artwork$data = {
   id: "artwork12345",
-  title: "test title",
   slug: "andreas-rod-prinzknecht",
-  href: "/artwork/andreas-rod-prinzknecht",
-  artists: [
-    {
-      name: "Andreas Rod",
-    },
-    {
-      name: "Arthur Sopin",
-    },
-  ],
   image: {
     url: "image.com/image",
   },

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
@@ -30,7 +30,7 @@ describe("ArtworkActions", () => {
   })
 
   describe("share button message", () => {
-    it("displays only 3 artists when there are more than 3 artist", async () => {
+    it("displays only 3 artists when there are more than 3 artist", () => {
       const content = shareContent("Title 1", "/artwork/title-1", [
         { name: "Artist 1" },
         { name: "Artist 2" },
@@ -44,7 +44,7 @@ describe("ArtworkActions", () => {
       })
     })
 
-    it("displays 1 artists", async () => {
+    it("displays 1 artists", () => {
       const content = shareContent("Title 1", "/artwork/title-1", [{ name: "Artist 1" }])
       expect(content).toMatchObject({
         title: "Title 1 by Artist 1 on Artsy",
@@ -53,7 +53,7 @@ describe("ArtworkActions", () => {
       })
     })
 
-    it("displays only the title if there's no artists", async () => {
+    it("displays only the title if there's no artists", () => {
       const content = shareContent("Title 1", "/artwork/title-1", null)
       expect(content).toMatchObject({
         title: "Title 1 on Artsy",
@@ -135,7 +135,7 @@ describe("ArtworkActions", () => {
   })
 
   describe("Save button", () => {
-    it("should trigger save mutation when user presses save button", async () => {
+    it("should trigger save mutation when user presses save button", () => {
       const { env } = renderWithRelay({
         Artwork: () => ({
           isSaved: false,
@@ -151,7 +151,7 @@ describe("ArtworkActions", () => {
       )
     })
 
-    it("should track save event when user saves and artwork successfully", async () => {
+    it("should track save event when user saves and artwork successfully", () => {
       const { env } = renderWithRelay({
         Artwork: () => ({
           isSaved: false,

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -134,13 +134,11 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({
         accessibilityLabel="Save artwork"
         onPress={handleArtworkSave}
       >
-        {/* <Flex flex={1} justifyContent="center" alignItems="center" flexDirection="row" pr={2}> */}
         <UtilButton pr={2}>
           <SaveIcon isSaved={!!isSaved} />
           <Spacer x={0.5} />
           {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}
           <Text variant="sm">{isSaved ? "Saved" : "Save   "}</Text>
-          {/* </Flex> */}
         </UtilButton>
       </Touchable>
       {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -1,4 +1,4 @@
-import { EyeOpenedIcon, ShareIcon, Flex, Text, useSpace } from "@artsy/palette-mobile"
+import { EyeOpenedIcon, ShareIcon, Flex, Text, useSpace, Join, Spacer } from "@artsy/palette-mobile"
 import { ArtworkActions_artwork$data } from "__generated__/ArtworkActions_artwork.graphql"
 import { ArtworkHeader_artwork$data } from "__generated__/ArtworkHeader_artwork.graphql"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
@@ -64,36 +64,38 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOn
 
   return (
     <Flex justifyContent="center" flexDirection="row" width="100%">
-      <ArtworkSaveButton artwork={artwork} />
-      {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
+      <Join separator={<Spacer x={2} />}>
+        <ArtworkSaveButton artwork={artwork} />
+        {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
+          <Touchable
+            hitSlop={{
+              top: space(1),
+              bottom: space(1),
+            }}
+            haptic
+            onPress={() => openViewInRoom()}
+          >
+            <UtilButton>
+              <EyeOpenedIcon mr={0.5} />
+              <Text variant="sm">View in Room</Text>
+            </UtilButton>
+          </Touchable>
+        )}
         <Touchable
           hitSlop={{
             top: space(1),
             bottom: space(1),
+            right: space(1),
           }}
           haptic
-          onPress={() => openViewInRoom()}
+          onPress={() => shareOnPress()}
         >
-          <UtilButton pr={2}>
-            <EyeOpenedIcon mr={0.5} />
-            <Text variant="sm">View in Room</Text>
+          <UtilButton>
+            <ShareIcon mr={0.5} />
+            <Text variant="sm">Share</Text>
           </UtilButton>
         </Touchable>
-      )}
-      <Touchable
-        hitSlop={{
-          top: space(1),
-          bottom: space(1),
-          right: space(1),
-        }}
-        haptic
-        onPress={() => shareOnPress()}
-      >
-        <UtilButton>
-          <ShareIcon mr={0.5} />
-          <Text variant="sm">Share</Text>
-        </UtilButton>
-      </Touchable>
+      </Join>
     </Flex>
   )
 }

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -1,5 +1,6 @@
 import { EyeOpenedIcon, ShareIcon, Flex, Text } from "@artsy/palette-mobile"
 import { ArtworkActions_artwork$data } from "__generated__/ArtworkActions_artwork.graphql"
+import { ArtworkHeader_artwork$data } from "__generated__/ArtworkHeader_artwork.graphql"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { cm2in } from "app/utils/conversions"
@@ -11,7 +12,6 @@ import { TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
-
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork$data
   shareOnPress: () => void
@@ -20,7 +20,7 @@ interface ArtworkActionsProps {
 export const shareContent = (
   title: string,
   href: string,
-  artists: ArtworkActions_artwork$data["artists"]
+  artists: ArtworkHeader_artwork$data["artists"]
 ) => {
   let computedTitle: string | null = null
 
@@ -94,12 +94,7 @@ export const ArtworkActionsFragmentContainer = createFragmentContainer(ArtworkAc
     fragment ArtworkActions_artwork on Artwork {
       id
       slug
-      title
-      href
       isHangable
-      artists {
-        name
-      }
       image {
         url
       }

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -3,17 +3,17 @@ import { ArtworkActions_artwork$data } from "__generated__/ArtworkActions_artwor
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { cm2in } from "app/utils/conversions"
-import { Schema, track } from "app/utils/track"
+import { Schema } from "app/utils/track"
 import { take } from "lodash"
 import { Touchable } from "palette"
 import React from "react"
 import { TouchableWithoutFeedback } from "react-native"
-import { createFragmentContainer, graphql, RelayProp } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 
 interface ArtworkActionsProps {
   artwork: ArtworkActions_artwork$data
-  relay?: RelayProp
   shareOnPress: () => void
 }
 
@@ -38,19 +38,21 @@ export const shareContent = (
   }
 }
 
-@track()
-export class ArtworkActions extends React.Component<ArtworkActionsProps> {
-  @track(() => ({
-    action_name: Schema.ActionNames.ViewInRoom,
-    action_type: Schema.ActionTypes.Tap,
-    context_module: Schema.ContextModules.ArtworkActions,
-  }))
-  openViewInRoom() {
-    const {
-      artwork: { image, id, slug, heightCm, widthCm },
-    } = this.props
+export const ArtworkActions: React.FC<ArtworkActionsProps> = ({
+  artwork: { image, id, slug, heightCm, widthCm, isHangable },
+  shareOnPress,
+}) => {
+  const { trackEvent } = useTracking()
+
+  const openViewInRoom = () => {
     const heightIn = cm2in(heightCm!)
     const widthIn = cm2in(widthCm!)
+
+    trackEvent({
+      action_name: Schema.ActionNames.ViewInRoom,
+      action_type: Schema.ActionTypes.Tap,
+      context_module: Schema.ContextModules.ArtworkActions,
+    })
 
     LegacyNativeModules.ARTNativeScreenPresenterModule.presentAugmentedRealityVIR(
       image?.url!,
@@ -61,30 +63,24 @@ export class ArtworkActions extends React.Component<ArtworkActionsProps> {
     )
   }
 
-  render() {
-    const {
-      artwork: { isHangable },
-    } = this.props
-
-    return (
-      <Flex justifyContent="center" flexDirection="row" width="100%">
-        {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
-          <TouchableWithoutFeedback onPress={() => this.openViewInRoom()}>
-            <UtilButton pr={2}>
-              <EyeOpenedIcon mr={0.5} />
-              <Text variant="sm">View in Room</Text>
-            </UtilButton>
-          </TouchableWithoutFeedback>
-        )}
-        <Touchable haptic onPress={() => this.props.shareOnPress()}>
-          <UtilButton>
-            <ShareIcon mr={0.5} />
-            <Text variant="sm">Share</Text>
+  return (
+    <Flex justifyContent="center" flexDirection="row" width="100%">
+      {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
+        <TouchableWithoutFeedback onPress={() => openViewInRoom()}>
+          <UtilButton pr={2}>
+            <EyeOpenedIcon mr={0.5} />
+            <Text variant="sm">View in Room</Text>
           </UtilButton>
-        </Touchable>
-      </Flex>
-    )
-  }
+        </TouchableWithoutFeedback>
+      )}
+      <Touchable haptic onPress={() => shareOnPress()}>
+        <UtilButton>
+          <ShareIcon mr={0.5} />
+          <Text variant="sm">Share</Text>
+        </UtilButton>
+      </Touchable>
+    </Flex>
+  )
 }
 
 const UtilButton = styled(Flex)`

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -18,7 +18,6 @@ import { Schema } from "app/utils/track"
 import { take } from "lodash"
 import { Touchable } from "palette"
 import React from "react"
-import { TouchableWithoutFeedback } from "react-native"
 import { createFragmentContainer, graphql, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -129,30 +128,45 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({
         hitSlop={{
           top: space(1),
           left: space(1),
-          right: space(1),
           bottom: space(1),
         }}
-        haptic
         accessibilityRole="button"
         accessibilityLabel="Save artwork"
         onPress={handleArtworkSave}
       >
-        <Flex flex={1} justifyContent="center" alignItems="center" flexDirection="row" pr={2}>
+        {/* <Flex flex={1} justifyContent="center" alignItems="center" flexDirection="row" pr={2}> */}
+        <UtilButton pr={2}>
           <SaveIcon isSaved={!!isSaved} />
           <Spacer x={0.5} />
           {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}
           <Text variant="sm">{isSaved ? "Saved" : "Save   "}</Text>
-        </Flex>
+          {/* </Flex> */}
+        </UtilButton>
       </Touchable>
       {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
-        <TouchableWithoutFeedback onPress={() => openViewInRoom()}>
+        <Touchable
+          hitSlop={{
+            top: space(1),
+            bottom: space(1),
+          }}
+          haptic
+          onPress={() => openViewInRoom()}
+        >
           <UtilButton pr={2}>
             <EyeOpenedIcon mr={0.5} />
             <Text variant="sm">View in Room</Text>
           </UtilButton>
-        </TouchableWithoutFeedback>
+        </Touchable>
       )}
-      <Touchable haptic onPress={() => shareOnPress()}>
+      <Touchable
+        hitSlop={{
+          top: space(1),
+          bottom: space(1),
+          right: space(1),
+        }}
+        haptic
+        onPress={() => shareOnPress()}
+      >
         <UtilButton>
           <ShareIcon mr={0.5} />
           <Text variant="sm">Share</Text>

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -57,7 +57,7 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork })
       accessibilityLabel="Save artwork"
       onPress={handleArtworkSave}
     >
-      <Flex flexDirection="row" justifyContent="flex-start" alignItems="center" pr={2}>
+      <Flex flexDirection="row" justifyContent="flex-start" alignItems="center">
         {isSaved ? <HeartFillIcon fill="blue100" /> : <HeartIcon />}
         <Spacer x={0.5} />
         {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -1,8 +1,9 @@
-import { Flex, HeartFillIcon, HeartIcon, Spacer, Text, useSpace } from "@artsy/palette-mobile"
+import { Box, Flex, HeartFillIcon, HeartIcon, Spacer, Text, useSpace } from "@artsy/palette-mobile"
 import { ArtworkSaveButton_artwork$key } from "__generated__/ArtworkSaveButton_artwork.graphql"
 import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { Touchable } from "palette"
+import { StyleSheet } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -60,8 +61,19 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork })
       <Flex flexDirection="row" justifyContent="flex-start" alignItems="center">
         {isSaved ? <HeartFillIcon fill="blue100" /> : <HeartIcon />}
         <Spacer x={0.5} />
-        {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}
-        <Text variant="sm">{isSaved ? "Saved" : "Save   "}</Text>
+
+        <Box position="relative">
+          {/* Longest text transparent to prevent changing text pushing elements on the right */}
+          {/* Hiding it in the testing environment since it is not visible to the users */}
+          {!__TEST__ && (
+            <Text variant="sm" color="transparent">
+              Saved
+            </Text>
+          )}
+          <Box {...StyleSheet.absoluteFillObject}>
+            <Text variant="sm">{isSaved ? "Saved" : "Save"}</Text>
+          </Box>
+        </Box>
       </Flex>
     </Touchable>
   )

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -1,0 +1,87 @@
+import { Flex, HeartFillIcon, HeartIcon, Spacer, Text, useSpace } from "@artsy/palette-mobile"
+import { ArtworkSaveButton_artwork$key } from "__generated__/ArtworkSaveButton_artwork.graphql"
+import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
+import { Schema } from "app/utils/track"
+import { Touchable } from "palette"
+import { graphql, useFragment, useMutation } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface ArtworkSaveButtonProps {
+  artwork: ArtworkSaveButton_artwork$key
+}
+
+export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork }) => {
+  const space = useSpace()
+  const { trackEvent } = useTracking()
+  const { isSaved, internalID, id } = useFragment(ArtworkSaveButtonFragment, artwork)
+  const [commit] = useMutation(ArtworkSaveMutation)
+
+  const handleArtworkSave = () => {
+    commit({
+      variables: {
+        input: {
+          artworkID: internalID,
+          remove: isSaved,
+        },
+      },
+      optimisticResponse: {
+        saveArtwork: {
+          artwork: {
+            id,
+            isSaved: !isSaved,
+          },
+        },
+      },
+      onCompleted: () => {
+        refreshFavoriteArtworks()
+        trackEvent({
+          action_name: isSaved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
+          action_type: Schema.ActionTypes.Success,
+          context_module: Schema.ContextModules.ArtworkActions,
+        })
+      },
+      onError: () => {
+        refreshFavoriteArtworks()
+      },
+    })
+  }
+
+  return (
+    <Touchable
+      hitSlop={{
+        top: space(1),
+        left: space(1),
+        bottom: space(1),
+      }}
+      accessibilityRole="button"
+      accessibilityLabel="Save artwork"
+      onPress={handleArtworkSave}
+    >
+      <Flex flexDirection="row" justifyContent="flex-start" alignItems="center" pr={2}>
+        {isSaved ? <HeartFillIcon fill="blue100" /> : <HeartIcon />}
+        <Spacer x={0.5} />
+        {/* the spaces below are to not make the icon jumpy when changing from save to saved will work on a more permanent fix */}
+        <Text variant="sm">{isSaved ? "Saved" : "Save   "}</Text>
+      </Flex>
+    </Touchable>
+  )
+}
+
+const ArtworkSaveButtonFragment = graphql`
+  fragment ArtworkSaveButton_artwork on Artwork {
+    id
+    internalID
+    isSaved
+  }
+`
+
+const ArtworkSaveMutation = graphql`
+  mutation ArtworkSaveButtonMutation($input: SaveArtworkInput!) {
+    saveArtwork(input: $input) {
+      artwork {
+        id
+        isSaved
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -4,7 +4,6 @@ import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { goBack } from "app/system/navigation/navigate"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 import { ArtworkScreenHeaderFragmentContainer } from "./ArtworkScreenHeader"
@@ -93,52 +92,6 @@ describe("ArtworkScreenHeader", () => {
             "context_screen_owner_id": "internalID-1",
             "context_screen_owner_slug": "slug-1",
             "context_screen_owner_type": "artwork",
-          },
-        ]
-      `)
-    })
-  })
-
-  describe("Save button", () => {
-    it("should trigger save mutation when user presses save button", async () => {
-      const { env } = renderWithRelay({
-        Artwork: () => ({
-          isSaved: false,
-        }),
-      })
-
-      await flushPromiseQueue()
-
-      expect(screen.getByLabelText("Save artwork")).toBeTruthy()
-
-      fireEvent.press(screen.getByLabelText("Save artwork"))
-
-      expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
-        "ArtworkScreenHeaderSaveMutation"
-      )
-    })
-
-    it("should track save event when user saves and artwork successfully", async () => {
-      const { env } = renderWithRelay({
-        Artwork: () => ({
-          isSaved: false,
-        }),
-      })
-
-      await flushPromiseQueue()
-
-      fireEvent.press(screen.getByLabelText("Save artwork"))
-
-      resolveMostRecentRelayOperation(env, {})
-
-      await flushPromiseQueue()
-
-      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
-        [
-          {
-            "action_name": "artworkSave",
-            "action_type": "success",
-            "context_module": "ArtworkActions",
           },
         ]
       `)

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -2,7 +2,6 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkScreenHeaderTestQuery } from "__generated__/ArtworkScreenHeaderTestQuery.graphql"
 import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { goBack } from "app/system/navigation/navigate"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -32,23 +31,17 @@ describe("ArtworkScreenHeader", () => {
   it("renders the header", async () => {
     renderWithRelay({
       Artwork: () => ({
-        isSaved: false,
         artists: [{ name: "test" }],
       }),
     })
 
-    await flushPromiseQueue()
-
     expect(screen.queryByLabelText("Artwork page header")).toBeTruthy()
     expect(screen.queryByLabelText("Go back")).toBeTruthy()
-    expect(screen.queryByLabelText("Save artwork")).toBeTruthy()
     expect(screen.queryByText("Create Alert")).toBeTruthy()
   })
 
   it("calls go back when the back button is pressed", async () => {
     renderWithRelay({})
-
-    await flushPromiseQueue()
 
     expect(screen.queryByLabelText("Go back")).toBeTruthy()
 
@@ -61,15 +54,11 @@ describe("ArtworkScreenHeader", () => {
     it("renders the header but not the create alert button if the artwork doesn't have an associated artist", async () => {
       renderWithRelay({
         Artwork: () => ({
-          isSaved: false,
           artists: [],
         }),
       })
 
-      await flushPromiseQueue()
-
       expect(screen.queryByLabelText("Go back")).toBeTruthy()
-      expect(screen.queryByLabelText("Save artwork")).toBeTruthy()
       expect(screen.queryByText("Create Alert")).toBeFalsy()
     })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -28,7 +28,7 @@ describe("ArtworkScreenHeader", () => {
     `,
   })
 
-  it("renders the header", async () => {
+  it("renders the header", () => {
     renderWithRelay({
       Artwork: () => ({
         artists: [{ name: "test" }],
@@ -40,7 +40,7 @@ describe("ArtworkScreenHeader", () => {
     expect(screen.queryByText("Create Alert")).toBeTruthy()
   })
 
-  it("calls go back when the back button is pressed", async () => {
+  it("calls go back when the back button is pressed", () => {
     renderWithRelay({})
 
     expect(screen.queryByLabelText("Go back")).toBeTruthy()
@@ -51,7 +51,7 @@ describe("ArtworkScreenHeader", () => {
   })
 
   describe("Create alert button", () => {
-    it("renders the header but not the create alert button if the artwork doesn't have an associated artist", async () => {
+    it("renders the header but not the create alert button if the artwork doesn't have an associated artist", () => {
       renderWithRelay({
         Artwork: () => ({
           artists: [],


### PR DESCRIPTION
This PR resolves [FX-4682] <!-- eg [PROJECT-XXXX] -->

### Description

After the redesign of the Artwork Page we noticed a significant drop on artwork saves, so we decided to move it where it was placed before (under the artwork image -> ArtworkActions component)

This pr includes the following:
- [x] refactored artwork action screen -> functional component
- [x] moves save button to artworkActions (below artwork image)
- [x] update tests to reflect the changes
- [x] update the artwork screen placeholders to reflect the changes
- [x] **bonus** increased the hitslop of the artwork action buttons to make them more easily pressable
- [x] cleanup dead code from artworkscreenheader 
  

| Before | After |
|---|---|
|![Simulator Screen Shot - iPhone 13 - 2023-03-15 at 16 19 01](https://user-images.githubusercontent.com/21178754/225368362-21bb89b9-af1a-4a6b-942b-8e141dd58a5c.png)|![Simulator Screen Shot - iPhone 13 - 2023-03-15 at 16 38 48](https://user-images.githubusercontent.com/21178754/225368445-fb1a6179-2f5e-4d72-b4cf-87c0a6c550e1.png)|
|![IMG_C2A093B6FDA1-1](https://user-images.githubusercontent.com/21178754/225369113-da6adb0c-d3f3-4c5c-a954-1f0fea7a2c98.jpeg)|![Simulator Screen Shot - iPhone 13 - 2023-03-15 at 16 51 37](https://user-images.githubusercontent.com/21178754/225368718-b909ce45-4630-4ec3-9790-b397f4cafdfa.png)|
|![Simulator Screen Shot - iPhone 13 - 2023-03-15 at 17 06 03](https://user-images.githubusercontent.com/21178754/225370033-a43f7141-7831-445f-a6d9-6b2c4fa08289.png)|![Simulator Screen Shot - iPhone 13 - 2023-03-15 at 16 53 53](https://user-images.githubusercontent.com/21178754/225368618-56313ba0-54fa-4168-9635-b46ba67c7b85.png)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Artwork Screen moved save artwork button to artwork actions - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4682]: https://artsyproduct.atlassian.net/browse/FX-4682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ