### PR TITLE
fix: show only past auction results on my collection insights

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Insights/AuctionResultsForArtistsYouCollectRail.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/AuctionResultsForArtistsYouCollectRail.tsx
@@ -26,6 +26,8 @@ export const AuctionResultsForArtistsYouCollectRail: React.FC<
   const fragmentData = useFragment(auctionResultsForArtistsYouCollectRailFragment, me)
   const auctionResultsData = extractNodes(fragmentData.myCollectionAuctionResults)
 
+  const { width } = useScreenDimensions()
+
   if (!auctionResultsData.length) {
     return null
   }
@@ -54,7 +56,7 @@ export const AuctionResultsForArtistsYouCollectRail: React.FC<
           />
         )}
         ItemSeparatorComponent={AuctionResultListSeparator}
-        style={{ width: useScreenDimensions().width, left: -20 }}
+        style={{ width, left: -20 }}
       />
     </Flex>
   )
@@ -62,7 +64,7 @@ export const AuctionResultsForArtistsYouCollectRail: React.FC<
 
 const auctionResultsForArtistsYouCollectRailFragment = graphql`
   fragment AuctionResultsForArtistsYouCollectRail_me on Me {
-    myCollectionAuctionResults(first: 3) {
+    myCollectionAuctionResults(first: 3, state: PAST) {
       totalCount
       edges {
         node {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

show only past auction results on my collection insights rails preview

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
