### PR TITLE
fix: remove duplicate filter for upcoming auctio nresults

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -199,7 +199,6 @@ export const getStaticFilterOptionsByMode = (
         filterOptionToDisplayConfigMap.organizations,
         filterOptionToDisplayConfigMap.sizes,
         filterOptionToDisplayConfigMap.sort,
-        filterOptionToDisplayConfigMap.state,
         filterOptionToDisplayConfigMap.year,
       ]
 

--- a/src/app/Components/ArtworkFilter/components/ArtworkFilterOptionCheckboxItem.tsx
+++ b/src/app/Components/ArtworkFilter/components/ArtworkFilterOptionCheckboxItem.tsx
@@ -58,9 +58,10 @@ export const ArtworkFilterOptionCheckboxItem: React.FC<ArtworkFilterOptionCheckb
 
   const hasAggregation = aggregation !== undefined
 
-  if (hasAggregation && !aggregation.counts[0].value) {
+  if (hasAggregation && !aggregation.counts[0].value && item.filterType === "state") {
     return null
   }
+
   return (
     <ArtworkFilterOptionItem
       item={item}


### PR DESCRIPTION
This PR resolves [CX-3416] <!-- eg [PROJECT-XXXX] -->

### Description

**Before**
<img width="317" alt="Screenshot 2023-03-21 at 14 05 18" src="https://user-images.githubusercontent.com/11945712/226614695-72825975-05d9-4cb4-a626-b6e7ba111c82.png">


**After**

https://user-images.githubusercontent.com/11945712/226614546-7c7ac58e-7b51-4d9e-8109-ede144a4a7dd.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3416]: https://artsyproduct.atlassian.net/browse/CX-3416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ