### PR TITLE
chore: sort upcoming auction results by date asc

### DIFF
--- a/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
@@ -149,9 +149,12 @@ export const AuctionResultsScreenWrapperContainer = createPaginationContainer(
 )
 
 const AuctionResultsScreenWrapperQuery = graphql`
-  query AuctionResultsScreenWrapperContainerQuery($state: AuctionResultsState!) {
+  query AuctionResultsScreenWrapperContainerQuery(
+    $state: AuctionResultsState!
+    $sort: AuctionResultSorts
+  ) {
     me {
-      ...AuctionResultsScreenWrapper_me @arguments(state: $state)
+      ...AuctionResultsScreenWrapper_me @arguments(state: $state, sort: $sort)
     }
   }
 `
@@ -160,6 +163,11 @@ export enum AuctionResultsState {
   PAST = "PAST",
   UPCOMING = "UPCOMING",
   ALL = "ALL",
+}
+
+export enum AuctionResultsSorts {
+  DATE_ASC = "DATE_ASC",
+  DATE_DESC = "DATE_DESC",
 }
 
 const getTitleByState = (state: AuctionResultsState) => {
@@ -187,12 +195,17 @@ const getDescriptionByState = (state: AuctionResultsState) => {
 export const AuctionResultsScreenScreenWrapperQueryQueryRenderer: React.FC<{
   state: AuctionResultsState
 }> = ({ state = AuctionResultsState.ALL }) => {
+  const sort =
+    state === AuctionResultsState.UPCOMING
+      ? AuctionResultsSorts.DATE_ASC
+      : AuctionResultsSorts.DATE_DESC
   return (
     <QueryRenderer<AuctionResultsScreenWrapperContainerQuery>
       environment={defaultEnvironment}
       query={AuctionResultsScreenWrapperQuery}
       variables={{
         state,
+        sort,
       }}
       cacheConfig={{
         force: true,
@@ -209,6 +222,7 @@ export const AuctionResultsScreenScreenWrapperQueryQueryRenderer: React.FC<{
         },
         initialProps: {
           state,
+          sort,
         },
       })}
     />

--- a/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
@@ -104,8 +104,9 @@ export const AuctionResultsScreenWrapperContainer = createPaginationContainer(
         first: { type: "Int", defaultValue: 10 }
         after: { type: "String" }
         state: { type: "AuctionResultsState", defaultValue: ALL }
+        sort: { type: "AuctionResultSorts", defaultValue: DATE_DESC }
       ) {
-        auctionResultsByFollowedArtists(first: $first, after: $after, state: $state)
+        auctionResultsByFollowedArtists(first: $first, after: $after, state: $state, sort: $sort)
           @connection(key: "AuctionResultsScreenWrapperContainer_auctionResultsByFollowedArtists") {
           totalCount
           edges {
@@ -136,9 +137,11 @@ export const AuctionResultsScreenWrapperContainer = createPaginationContainer(
         $first: Int!
         $after: String
         $state: AuctionResultsState!
+        $sort: AuctionResultSorts!
       ) {
         me {
-          ...AuctionResultsScreenWrapper_me @arguments(first: $first, after: $after, state: $state)
+          ...AuctionResultsScreenWrapper_me
+            @arguments(first: $first, after: $after, state: $state, sort: $sort)
         }
       }
     `,

--- a/src/app/Scenes/AuctionResults/AuctionResultsUpcoming.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsUpcoming.tsx
@@ -13,7 +13,7 @@ export const AuctionResultsUpcomingQueryRenderer = () => {
 export const AuctionResultsUpcomingPrefetchQuery = graphql`
   query AuctionResultsUpcomingPrefetchQuery {
     me {
-      ...AuctionResultsScreenWrapper_me @arguments(state: UPCOMING)
+      ...AuctionResultsScreenWrapper_me @arguments(state: UPCOMING, sort: DATE_ASC)
     }
   }
 `

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -476,6 +476,7 @@ export const HomeFragmentContainer = memo(
           auctionResultsByFollowedArtistsUpcoming: auctionResultsByFollowedArtists(
             first: 12
             state: UPCOMING
+            sort: DATE_ASC
           ) {
             totalCount
             ...AuctionResultsRail_auctionResults


### PR DESCRIPTION
This PR resolves [CX-3533] <!-- eg [PROJECT-XXXX] -->

### Description


Sort upcoming auction results by date asc



https://user-images.githubusercontent.com/11945712/230016209-65e95f93-487b-410f-9312-9d60492a5d8a.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Revert sorting date on upcoming auction results - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3533]: https://artsyproduct.atlassian.net/browse/CX-3533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ