### PR TITLE
fix(flipper): add react devtools as a dev dep to make flipper work

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,6 +308,7 @@
     "prettier": "2.5.1",
     "prompt-sync": "4.2.0",
     "pull-lock": "1.0.0",
+    "react-devtools-core": "4.27.4",
     "react-dom": "17.0.2",
     "react-native-flipper": "0.131.1",
     "react-native-flipper-relay-devtools": "1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13753,6 +13753,14 @@ react-devtools-core@4.19.1:
     shell-quote "^1.6.1"
     ws "^7"
 
+react-devtools-core@4.27.4:
+  version "4.27.4"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-4.27.4.tgz#987f678a0e6658fd6f8fa0b8b2be191cf6984b68"
+  integrity sha512-dvZjrAJjahd6NNl7dDwEk5TyHsWJxDpYL7VnD9jdEr98EEEsVhw9G8JDX54Nrb3XIIOBlJDpjo3AuBuychX9zg==
+  dependencies:
+    shell-quote "^1.6.1"
+    ws "^7"
+
 react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

react dev tools are broken in flipper due to latest react native update, added `react-devtools-core` to devDeps to fix that

|Before|After|
|---|---|
|<img width="1459" alt="Screenshot 2023-03-29 at 14 13 01" src="https://user-images.githubusercontent.com/21178754/228532507-8a1864c4-0422-42d2-aef6-d22393762db1.png">|<img width="1454" alt="Screenshot 2023-03-29 at 14 13 26" src="https://user-images.githubusercontent.com/21178754/228532487-ec9482e8-d8b4-4843-9949-be5e9552ea12.png">|



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog