### PR TITLE
chore: Make Storybook work again

### DIFF
--- a/src/app/Components/PopoverMessage/PopoverMessage.tsx
+++ b/src/app/Components/PopoverMessage/PopoverMessage.tsx
@@ -32,7 +32,7 @@ export interface PopoverMessageProps {
   onUndoPress?: () => void
 }
 
-export const getColorsByType = (type?: PopoverMessageType) => {
+export const useColorsByType = (type?: PopoverMessageType) => {
   const color = useColor()
 
   if (type === "success") {
@@ -78,7 +78,7 @@ export const PopoverMessage: React.FC<PopoverMessageProps> = (props) => {
   } = props
   const { safeAreaInsets } = useScreenDimensions()
   const { hide } = usePopoverMessage()
-  const colors = getColorsByType(type)
+  const colors = useColorsByType(type)
 
   const handlePopoverMessagePress = () => {
     hide()

--- a/src/palette/elements/BorderBox/BorderBox.tsx
+++ b/src/palette/elements/BorderBox/BorderBox.tsx
@@ -14,7 +14,7 @@ export interface BorderBoxProps extends FlexProps, BorderProps {
 export const BorderBox = styled(Flex)<BorderBoxProps>`
   border: 1px solid ${themeGet("colors.black10")};
   border-radius: 2px;
-  padding: ${themeGet("space.2")};
+  padding: 20px;
   ${border}
   ${styledSpace}
 `

--- a/src/palette/elements/Input/Input.tsx
+++ b/src/palette/elements/Input/Input.tsx
@@ -378,7 +378,7 @@ export const computeBorderColor = (inputStatus: InputStatus): Color => {
 }
 
 const StyledInput = styled(TextInput)`
-  padding: ${themeGet("space.1")};
+  padding: 10px;
   font-family: ${themeGet("fonts.sans.regular")};
 `
 StyledInput.displayName = "StyledInput"


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Loading storybook with `yarn start-storybook` failed because `themeGet("space.1")` returns `10` instead of `10px`. Not sure if there is a better way to fix this 🤔 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
