### PR TITLE
fix: Update home screen on artist follow and artwork save

### DIFF
--- a/src/app/Components/Artist/ArtistHeader.tsx
+++ b/src/app/Components/Artist/ArtistHeader.tsx
@@ -2,6 +2,7 @@ import { Spacer, bullet, Flex, Box, Text } from "@artsy/palette-mobile"
 import { ArtistHeaderFollowArtistMutation } from "__generated__/ArtistHeaderFollowArtistMutation.graphql"
 import { ArtistHeader_artist$data } from "__generated__/ArtistHeader_artist.graphql"
 import { formatLargeNumberOfItems } from "app/utils/formatLargeNumberOfItems"
+import { refreshOnArtistFollow } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { FollowButton } from "palette"
 import { useState } from "react"
@@ -55,7 +56,6 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
     setIsFollowedChanging(true)
 
     commitMutation<ArtistHeaderFollowArtistMutation>(relay.environment, {
-      onCompleted: () => successfulFollowChange(),
       mutation: graphql`
         mutation ArtistHeaderFollowArtistMutation($input: FollowArtistInput!) {
           followArtist(input: $input) {
@@ -81,11 +81,13 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
           },
         },
       },
+      onCompleted: () => successfulFollowChange(),
       onError: () => failedFollowChange(),
     })
   }
 
   const successfulFollowChange = () => {
+    refreshOnArtistFollow()
     trackEvent({
       action_name: artist.isFollowed
         ? Schema.ActionNames.ArtistUnfollow

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -1,5 +1,5 @@
 import { ScreenOwnerType, tappedMainArtworkGrid } from "@artsy/cohesion"
-import { Spacer, HeartIcon, HeartFillIcon, Flex, Box, Text, TextProps } from "@artsy/palette-mobile"
+import { Box, Flex, HeartFillIcon, HeartIcon, Spacer, Text, TextProps } from "@artsy/palette-mobile"
 import { ArtworkGridItem_artwork$data } from "__generated__/ArtworkGridItem_artwork.graphql"
 import { filterArtworksParams } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
@@ -15,7 +15,7 @@ import {
   PlaceholderRaggedText,
   RandomNumberGenerator,
 } from "app/utils/placeholders"
-import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
+import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
 import { OpaqueImageView as NewOpaqueImageView, Touchable } from "palette"
 import React, { useRef } from "react"
 import { View } from "react-native"
@@ -148,10 +148,10 @@ export const Artwork: React.FC<ArtworkProps> = ({
         },
       },
       onCompleted: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
       },
       onError: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
       },
     })
   }

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -10,16 +10,16 @@ import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { PageableRouteProps } from "app/system/navigation/useNavigateToPageableRoute"
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
+import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import {
   PlaceholderBox,
   PlaceholderRaggedText,
   RandomNumberGenerator,
 } from "app/utils/placeholders"
-import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
 import { OpaqueImageView as NewOpaqueImageView, Touchable } from "palette"
 import React, { useRef } from "react"
 import { View } from "react-native"
-import { createFragmentContainer, graphql, useMutation } from "react-relay"
+import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { LotCloseInfo } from "./LotCloseInfo"
 import { LotProgressBar } from "./LotProgressBar"
@@ -91,7 +91,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const tracking = useTracking()
   const eableArtworkGridSaveIcon = useFeatureFlag("AREnableArtworkGridSaveIcon")
   const enableNewOpaqueImageView = useFeatureFlag("AREnableNewOpaqueImageComponent")
-  const [saveArtwork] = useMutation(SaveArtworkMutation)
 
   let filterParams: any = undefined
 
@@ -129,32 +128,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
     }
   }
 
-  const handleArtworkSave = () => {
-    const { id, internalID, isSaved } = artwork
+  const { id, internalID, isSaved } = artwork
 
-    saveArtwork({
-      variables: {
-        input: {
-          artworkID: internalID,
-          remove: isSaved,
-        },
-      },
-      optimisticResponse: {
-        saveArtwork: {
-          artwork: {
-            id,
-            isSaved: !isSaved,
-          },
-        },
-      },
-      onCompleted: () => {
-        refreshOnArtworkSave()
-      },
-      onError: () => {
-        refreshOnArtworkSave()
-      },
-    })
-  }
+  const handleArtworkSave = useSaveArtwork({
+    id,
+    internalID,
+    isSaved,
+  })
 
   const handleTap = () => {
     if (onPress) {
@@ -452,17 +432,6 @@ export default createFragmentContainer(Artwork, {
     }
   `,
 })
-
-const SaveArtworkMutation = graphql`
-  mutation ArtworkGridItemSaveArtworkMutation($input: SaveArtworkInput!) {
-    saveArtwork(input: $input) {
-      artwork {
-        id
-        isSaved
-      }
-    }
-  }
-`
 
 export const ArtworkGridItemPlaceholder: React.FC<{ seed?: number }> = ({
   seed = Math.random(),

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -9,14 +9,14 @@ import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidt
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
-import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
+import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { compact } from "lodash"
 import { Touchable } from "palette"
 import { useMemo } from "react"
 import { GestureResponderEvent, PixelRatio } from "react-native"
-import { graphql, useFragment, useMutation } from "react-relay"
+import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
 import { LARGE_RAIL_IMAGE_WIDTH } from "./LargeArtworkRail"
@@ -76,7 +76,6 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
 
   const { trackEvent } = useTracking()
   const fontScale = PixelRatio.getFontScale()
-  const [saveArtwork] = useMutation(SaveArtworkMutation)
   const artwork = useFragment(artworkFragment, restProps.artwork)
 
   const { artistNames, date, id, image, internalID, isSaved, partner, slug, title } = artwork
@@ -142,32 +141,15 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
     }
   }, [image?.resized?.height, image?.resized?.width])
 
-  const handleArtworkSave = () => {
-    saveArtwork({
-      variables: {
-        input: {
-          artworkID: internalID,
-          remove: isSaved,
-        },
-      },
-      optimisticResponse: {
-        saveArtwork: {
-          artwork: {
-            id,
-            isSaved: !isSaved,
-          },
-        },
-      },
-      onCompleted: () => {
-        refreshOnArtworkSave()
-      },
-      onError: () => {
-        refreshOnArtworkSave()
-      },
-    })
-
-    trackEvent(tracks.saveOrUnsave(isSaved, internalID, slug, trackingContextScreenOwnerType))
-  }
+  const handleArtworkSave = useSaveArtwork({
+    id,
+    internalID,
+    isSaved,
+    onCompleted: () => {
+      trackEvent(tracks.saveOrUnsave(isSaved, internalID, slug, trackingContextScreenOwnerType))
+    },
+    contextScreen: trackingContextScreenOwnerType,
+  })
 
   const displayForRecentlySoldArtwork =
     !!isRecentlySoldArtwork &&
@@ -438,17 +420,6 @@ const RecentlySoldCardSection: React.FC<
     </>
   )
 }
-
-const SaveArtworkMutation = graphql`
-  mutation ArtworkRailCardSaveArtworkMutation($input: SaveArtworkInput!) {
-    saveArtwork(input: $input) {
-      artwork {
-        id
-        isSaved
-      }
-    }
-  }
-`
 
 const artworkFragment = graphql`
   fragment ArtworkRailCard_artwork on Artwork @argumentDefinitions(width: { type: "Int" }) {

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -9,7 +9,7 @@ import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidt
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { useFeatureFlag } from "app/store/GlobalStore"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
-import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
+import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { compact } from "lodash"
@@ -159,10 +159,10 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
         },
       },
       onCompleted: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
       },
       onError: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
       },
     })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
@@ -147,7 +147,7 @@ describe("ArtworkActions", () => {
       fireEvent.press(screen.getByLabelText("Save artwork"))
 
       expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
-        "ArtworkSaveButtonMutation"
+        "useSaveArtworkMutation"
       )
     })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDetailsRow.tsx
@@ -25,7 +25,7 @@ export const ArtworkDetailsRow: React.FC<ArtworkDetailsRowProps> = ({
 }) => {
   return (
     <Flex flexDirection="row" key={key}>
-      <Box flex={1} maxWidth="128">
+      <Box flex={1} maxWidth={128}>
         <Text variant="sm" color="black60">
           {title}
         </Text>

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -10,7 +10,7 @@ import {
   useSpace,
 } from "@artsy/palette-mobile"
 import { ArtworkSaveButton_artwork$key } from "__generated__/ArtworkSaveButton_artwork.graphql"
-import { refreshFavoriteArtworks } from "app/utils/refreshHelpers"
+import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { isEmpty } from "lodash"
 import { Touchable } from "palette"
@@ -87,7 +87,7 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork })
         },
       },
       onCompleted: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
         trackEvent({
           action_name: isSaved ? Schema.ActionNames.ArtworkUnsave : Schema.ActionNames.ArtworkSave,
           action_type: Schema.ActionTypes.Success,
@@ -95,7 +95,7 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork })
         })
       },
       onError: () => {
-        refreshFavoriteArtworks()
+        refreshOnArtworkSave()
       },
     })
   }

--- a/src/app/Scenes/Home/Components/ArtworkModuleRail.tsx
+++ b/src/app/Scenes/Home/Components/ArtworkModuleRail.tsx
@@ -5,6 +5,7 @@ import { SectionTitle } from "app/Components/SectionTitle"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { navigate } from "app/system/navigation/navigate"
 import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToPageableRoute"
+import { Schema } from "app/utils/track"
 import { compact } from "lodash"
 import React, { memo, useImperativeHandle, useRef } from "react"
 import { FlatList, View } from "react-native"
@@ -126,6 +127,7 @@ const ArtworkModuleRail: React.FC<ArtworkModuleRailProps & RailScrollProps> = ({
           navigateToPageableRoute(artwork.href!)
         }}
         onMorePress={handlePressMore}
+        trackingContextScreenOwnerType={Schema.OwnerEntityTypes.Home}
       />
     </Flex>
   )

--- a/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
+++ b/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
@@ -14,13 +14,14 @@ import { graphql } from "relay-runtime"
 
 interface MarketingCollectionRailProps {
   home: MarketingCollectionRail_home$key | null
+  contextScreenOwnerType: Schema.OwnerEntityTypes
   contextModuleKey: string
   marketingCollection: MarketingCollectionRail_marketingCollection$key
   marketingCollectionSlug: string
 }
 
 export const MarketingCollectionRail: React.FC<MarketingCollectionRailProps> = memo(
-  ({ contextModuleKey, marketingCollectionSlug, ...restProps }) => {
+  ({ contextScreenOwnerType, contextModuleKey, marketingCollectionSlug, ...restProps }) => {
     const { trackEvent } = useTracking()
     const contextModule = HomeAnalytics.artworkRailContextModule(contextModuleKey)
 
@@ -94,7 +95,7 @@ export const MarketingCollectionRail: React.FC<MarketingCollectionRailProps> = m
         <LargeArtworkRail
           artworks={artworks}
           onPress={handleArtworkPress}
-          trackingContextScreenOwnerType={Schema.OwnerEntityTypes.Home}
+          trackingContextScreenOwnerType={contextScreenOwnerType}
           dark
           showPartnerName
           onMorePress={handleMorePress}

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -197,6 +197,7 @@ const Home = memo((props: HomeProps) => {
         case "marketingCollection":
           return (
             <MarketingCollectionRail
+              contextScreenOwnerType={Schema.OwnerEntityTypes.Home}
               contextModuleKey="curators-picks-emerging"
               home={props.homePageAbove}
               marketingCollection={item.data}

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -61,6 +61,7 @@ import {
   useMemoizedRandom,
 } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
+import { RefreshEvents, HOME_SCREEN_REFRESH_KEY } from "app/utils/refreshHelpers"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
 import { times } from "lodash"
@@ -177,6 +178,14 @@ const Home = memo((props: HomeProps) => {
   ).current
 
   const { isRefreshing, handleRefresh, scrollRefs } = useHandleRefresh(relay, modules)
+
+  useEffect(() => {
+    RefreshEvents.addListener(HOME_SCREEN_REFRESH_KEY, handleRefresh)
+
+    return () => {
+      RefreshEvents.removeListener(HOME_SCREEN_REFRESH_KEY, handleRefresh)
+    }
+  }, [])
 
   const renderItem: ListRenderItem<HomeModule> | null | undefined = useCallback(
     ({ item, index }) => {

--- a/src/app/utils/mutations/useSaveArtwork.ts
+++ b/src/app/utils/mutations/useSaveArtwork.ts
@@ -1,0 +1,59 @@
+import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
+import { Schema } from "app/utils/track"
+import { useMutation } from "react-relay"
+import { graphql } from "relay-runtime"
+
+export const useSaveArtwork = ({
+  id,
+  internalID,
+  isSaved,
+  onCompleted,
+  onError,
+  contextScreen,
+}: {
+  id: string
+  internalID: string
+  isSaved: boolean | null
+  onCompleted?: () => void
+  onError?: () => void
+  contextScreen?: Schema.OwnerEntityTypes
+}) => {
+  const [commit] = useMutation(SaveArtworkMutation)
+
+  return () => {
+    commit({
+      variables: {
+        input: {
+          artworkID: internalID,
+          remove: isSaved,
+        },
+      },
+      optimisticResponse: {
+        saveArtwork: {
+          artwork: {
+            id,
+            isSaved: !isSaved,
+          },
+        },
+      },
+      onCompleted: () => {
+        refreshOnArtworkSave(contextScreen)
+        onCompleted?.()
+      },
+      onError: () => {
+        onError?.()
+      },
+    })
+  }
+}
+
+const SaveArtworkMutation = graphql`
+  mutation useSaveArtworkMutation($input: SaveArtworkInput!) {
+    saveArtwork(input: $input) {
+      artwork {
+        id
+        isSaved
+      }
+    }
+  }
+`

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -1,5 +1,6 @@
 import EventEmitter from "events"
 import { PAGE_SIZE } from "app/Components/constants"
+import { Schema } from "app/utils/track"
 import { useState } from "react"
 import { RefreshControl } from "react-native"
 
@@ -11,16 +12,20 @@ export const MY_COLLECTION_REFRESH_KEY = "refreshMyCollection"
 export const MY_COLLECTION_INSIGHTS_REFRESH_KEY = "refreshMyCollectionInsights"
 export const HOME_SCREEN_REFRESH_KEY = "refreshHomeScreen"
 
-export const refreshOnArtworkSave = () => {
+export const refreshOnArtworkSave = (contextScreen?: Schema.OwnerEntityTypes) => {
   refreshFavoriteArtworks()
-  refreshHomeScreen()
+
+  refreshHomeScreen(contextScreen)
 }
 
-export const refreshOnArtistFollow = () => {
-  refreshHomeScreen()
+export const refreshOnArtistFollow = (contextScreen?: Schema.OwnerEntityTypes) => {
+  refreshHomeScreen(contextScreen)
 }
 
-export const refreshHomeScreen = () => {
+export const refreshHomeScreen = (contextScreen?: Schema.OwnerEntityTypes) => {
+  // Only refresh home screen if we are not on the home screen
+  if (contextScreen === Schema.OwnerEntityTypes.Home) return
+
   RefreshEvents.emit(HOME_SCREEN_REFRESH_KEY)
 }
 

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -9,6 +9,16 @@ RefreshEvents.setMaxListeners(20)
 export const FAVORITE_ARTWORKS_REFRESH_KEY = "refreshFavoriteArtworks"
 export const MY_COLLECTION_REFRESH_KEY = "refreshMyCollection"
 export const MY_COLLECTION_INSIGHTS_REFRESH_KEY = "refreshMyCollectionInsights"
+export const HOME_SCREEN_REFRESH_KEY = "refreshHomeScreen"
+
+export const refreshOnArtworkSave = () => {
+  refreshFavoriteArtworks()
+  refreshHomeScreen()
+}
+
+export const refreshHomeScreen = () => {
+  RefreshEvents.emit(HOME_SCREEN_REFRESH_KEY)
+}
 
 export const refreshMyCollection = () => {
   RefreshEvents.emit(MY_COLLECTION_REFRESH_KEY)

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -16,6 +16,10 @@ export const refreshOnArtworkSave = () => {
   refreshHomeScreen()
 }
 
+export const refreshOnArtistFollow = () => {
+  refreshHomeScreen()
+}
+
 export const refreshHomeScreen = () => {
   RefreshEvents.emit(HOME_SCREEN_REFRESH_KEY)
 }


### PR DESCRIPTION
This PR resolves [CX-3586] <!-- eg [PROJECT-XXXX] -->

### Description

Update home screen on artist follow and artwork save to refresh the state on the rails showing the follow/save state.

I will try to find out if we can update artwork and artists directly in the store in the next step ([Docs](https://relay.dev/docs/guided-tour/updating-data/local-data-updates/)).

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Update home screen on artist follow and artwork save - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add saveArtwork mutation helper that replaces all save artwork mutations - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3586]: https://artsyproduct.atlassian.net/browse/CX-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ