### PR TITLE
fix: not being prompted for push on sign up

### DIFF
--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -1,9 +1,11 @@
 import { HomeQueryRenderer } from "app/Scenes/Home/Home"
 import { GlobalStore, useFeatureFlag } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
+import { requestPushNotificationsPermission } from "app/utils/PushNotification"
 
 export const HomeContainer = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
+  const onboardingState = GlobalStore.useAppState((state) => state.auth.onboardingState)
 
   const shouldShowArtQuiz = useFeatureFlag("ARShowArtQuizApp")
 
@@ -14,6 +16,10 @@ export const HomeContainer = () => {
   if (shouldShowArtQuiz && artQuizState === "incomplete") {
     navigateToArtQuiz()
     return null
+  }
+
+  if (!onboardingState || onboardingState === "complete" || onboardingState === "none") {
+    requestPushNotificationsPermission()
   }
 
   return <HomeQueryRenderer />

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -5,7 +5,6 @@ import { GoogleSignin } from "@react-native-google-signin/google-signin"
 import { captureMessage } from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import * as RelayCache from "app/system/relay/RelayCache"
-import { requestPushNotificationsPermission } from "app/utils/PushNotification"
 import { isArtsyEmail } from "app/utils/general"
 import { postEventToProviders } from "app/utils/track/providers"
 import { action, Action, Computed, computed, StateMapper, thunk, Thunk } from "easy-peasy"
@@ -407,10 +406,6 @@ export const getAuthModel = (): AuthModel => ({
       }
 
       postEventToProviders(tracks.loggedIn(oauthProvider))
-
-      if (!onboardingState || onboardingState === "complete" || onboardingState === "none") {
-        requestPushNotificationsPermission()
-      }
 
       onSignIn?.()
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

After we introduced the art quiz this broke, the push prompt was being call in the onSignIn action but in the case of a new user who see the art quiz onboarding status will be `incomplete` at the time of the call. This moves the request to the home container to make it more reliable. The check inside the native code should prevent the dialog from showing multiple times. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix push prompt for new users - Brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
