### PR TITLE
fix: Remove internal artist rail state to update content correctly

### DIFF
--- a/src/app/Components/Home/ArtistRails/ArtistRail.tsx
+++ b/src/app/Components/Home/ArtistRails/ArtistRail.tsx
@@ -14,7 +14,7 @@ import { defaultArtistVariables } from "app/Scenes/Artist/Artist"
 import { RailScrollProps } from "app/Scenes/Home/Components/types"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { Schema } from "app/utils/track"
-import React, { useImperativeHandle, useRef, useState } from "react"
+import React, { useImperativeHandle, useRef } from "react"
 import { FlatList, View, ViewProps } from "react-native"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -40,9 +40,7 @@ const ArtistRail: React.FC<Props & RailScrollProps> = (props) => {
     scrollToTop: () => listRef.current?.scrollToOffset({ offset: 0, animated: false }),
   }))
 
-  const [artists, setArtists] = useState<SuggestedArtist[]>(
-    props.rail.results?.map((a) => ({ ...a, _ref: null })) ?? ([] as any)
-  )
+  const artists = props.rail.results?.map((a) => ({ ...a, _ref: null })) ?? ([] as any)
 
   const followOrUnfollowArtist = (followArtist: SuggestedArtist) => {
     return new Promise<void>((resolve, reject) => {
@@ -81,17 +79,6 @@ const ArtistRail: React.FC<Props & RailScrollProps> = (props) => {
               source_screen: "home page",
               context_module: "artist rail",
             })
-            // since we manage the artists array ourselves we can't rely on the relay cache to keep the isFollowed
-            // field up-to-date.
-            setArtists((_artists) =>
-              _artists.map((a) => {
-                if (a.internalID === followArtist.internalID) {
-                  return { ...a, isFollowed: !followArtist.isFollowed }
-                } else {
-                  return a
-                }
-              })
-            )
             resolve()
           }
         },


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Removes the internal artist rail state in order to update the content correctly. This logic was needed for the Dismiss button which isn't in use anymore.

This change fixes a bug where the following state isn't updated after following/unfollowing an artist on the artist screen.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix trending artist home screen rail follow status updates - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
