### PR TITLE
fix: Update the performance sign condition in auction result screen

### DIFF
--- a/src/app/Scenes/AuctionResult/AuctionResult.tsx
+++ b/src/app/Scenes/AuctionResult/AuctionResult.tsx
@@ -172,9 +172,9 @@ export const AuctionResult: React.FC<Props> = (props) => {
                 {!!auctionResult?.performance?.mid && (
                   <Text color={ratioColor(auctionResult.performance.mid)}>
                     {"    "}
-                    {auctionResult?.priceRealized?.display[0] === "-" ? "-" : "+"}
+                    {auctionResult.performance.mid[0] === "-" ? "-" : "+"}
                     {new Intl.NumberFormat().format(
-                      Number(auctionResult.performance?.mid.replace(/%|-/gm, ""))
+                      Number(auctionResult.performance.mid.replace(/%|-/gm, ""))
                     )}
                     % est
                   </Text>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR updates the condition to show which sign (`-` OR `+`) for the performance in the auction result screen


### Screenshot

| - | iOS | Android |
| -- | -- | -- |
| Before | ![image](https://user-images.githubusercontent.com/20655703/229824272-e0ae054f-f673-4f95-b0e5-3fe76d81d250.png) | <img width="418" alt="image" src="https://user-images.githubusercontent.com/20655703/229824228-51b595cb-ec95-4805-80f8-0fec66b14873.png"> |
| After | ![image](https://user-images.githubusercontent.com/20655703/229824321-294f2ebb-c799-4324-86b8-ba452dd93ea7.png) | <img width="418" alt="image" src="https://user-images.githubusercontent.com/20655703/229824394-a41f14df-65df-4144-a155-97c58b0aa07b.png"> |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Update sign condition for the performance in the auction result screen - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
