### PR TITLE
chore(scripts): Rename palette dev scrip to `yarn local-palette-dev`

### DIFF
--- a/docs/developing_local_palette.md
+++ b/docs/developing_local_palette.md
@@ -16,14 +16,14 @@ yarn global add yalc
 
 ```sh
 cd palette-mobile
-yarn sync-after-change
+yarn local-palette-dev
 ```
 
 - Navigate back to Eigen and link:
 
 ```sh
 cd eigen
-yarn link-local-palette
+yarn local-palette-dev
 yarn start
 ```
 
@@ -32,5 +32,5 @@ This will update `package.json` to point at the yalc-published version of palett
 - When done developing your local palette feature, be sure to unlink:
 
 ```sh
-yarn unlink-local-palette
+yarn local-palette-dev:stop
 ```

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "init-metaflags": "jq -Rn '{ startStorybook: false }' | sponge metaflags.json",
     "install:all": "./scripts/install",
     "ios": "react-native run-ios --udid=\"$(xcrun simctl list | awk -F'[()]' '/(Booted)/ { print $2 }')\"",
-    "link-local-palette": "./scripts/yalc-link-local-palette",
+    "local-palette-dev": "./scripts/yalc-link-local-palette",
+    "local-palette-dev:stop": "./scripts/yalc-unlink-local-palette",
     "lint": "eslint --cache --cache-location '.cache/eslint/' --ext .ts,.tsx --fix",
     "lint:all": "yarn lint .",
     "open-sim": "open -a Simulator",
@@ -71,7 +72,6 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "test:watch": "jest --watch",
     "type-check": "yarn relay; yarn tsc",
-    "unlink-local-palette": "./scripts/yalc-unlink-local-palette",
     "update-metaphysics": "node scripts/update-metaphysics.js"
   },
   "repository": {


### PR DESCRIPTION
### Description

This renames our local palette dev scripts to 
```
yarn local-palette-dev
```
in concert with the corresponding script in `palette-mobile`. This makes things easier to remember; go over there, run the command, come over here, run the command. 

cc @artsy/mobile-platform 
