### PR TITLE
fix(FX-4728): inconsistency in auction countdown on home feed

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
@@ -150,6 +150,8 @@ const artistMockData: ArtistNotableWorksRailTestsQuery["rawResponse"]["artist"] 
               bidderPositions: 2,
             },
             id: "id-123",
+            endAt: null,
+            extendedBiddingEndAt: null,
           },
           sale: {
             isClosed: false,

--- a/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
@@ -112,6 +112,8 @@ const artistMockData: ArtistNotableWorksRailTestsQuery["rawResponse"]["artist"] 
           saleMessage: null,
           saleArtwork: null,
           sale: {
+            internalID: "sale-internal-id2",
+            extendedBiddingIntervalMinutes: null,
             isAuction: true,
             isClosed: true,
             id: "sale-id2",
@@ -150,8 +152,13 @@ const artistMockData: ArtistNotableWorksRailTestsQuery["rawResponse"]["artist"] 
               bidderPositions: 2,
             },
             id: "id-123",
+            lotID: "lot-id-3",
+            endAt: null,
+            extendedBiddingEndAt: null,
           },
           sale: {
+            internalID: "sale-internal-id-3",
+            extendedBiddingIntervalMinutes: null,
             isClosed: false,
             isAuction: true,
             endAt: "2020-01-01T00:00:00+00:00",

--- a/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistNotableWorksRail.tests.tsx
@@ -112,8 +112,6 @@ const artistMockData: ArtistNotableWorksRailTestsQuery["rawResponse"]["artist"] 
           saleMessage: null,
           saleArtwork: null,
           sale: {
-            internalID: "sale-internal-id2",
-            extendedBiddingIntervalMinutes: null,
             isAuction: true,
             isClosed: true,
             id: "sale-id2",
@@ -152,13 +150,8 @@ const artistMockData: ArtistNotableWorksRailTestsQuery["rawResponse"]["artist"] 
               bidderPositions: 2,
             },
             id: "id-123",
-            lotID: "lot-id-3",
-            endAt: null,
-            extendedBiddingEndAt: null,
           },
           sale: {
-            internalID: "sale-internal-id-3",
-            extendedBiddingIntervalMinutes: null,
             isClosed: false,
             isAuction: true,
             endAt: "2020-01-01T00:00:00+00:00",

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -1,4 +1,4 @@
-import { Flex, HeartFillIcon, HeartIcon, Text, useColor } from "@artsy/palette-mobile"
+import { Flex, HeartFillIcon, HeartIcon, Text, useColor, Touchable } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import {
   ArtworkRailCard_artwork$data,
@@ -12,7 +12,6 @@ import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { compact } from "lodash"
-import { Touchable } from "@artsy/palette-mobile"
 import { useMemo } from "react"
 import { GestureResponderEvent, PixelRatio } from "react-native"
 import { graphql, useFragment } from "react-relay"
@@ -75,14 +74,26 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   const fontScale = PixelRatio.getFontScale()
   const artwork = useFragment(artworkFragment, restProps.artwork)
 
-  const { artistNames, date, id, image, internalID, isSaved, partner, slug, title } = artwork
+  const {
+    artistNames,
+    date,
+    id,
+    image,
+    internalID,
+    isSaved,
+    partner,
+    slug,
+    title,
+    sale,
+    saleArtwork,
+  } = artwork
 
   const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
 
-  const urgencyTag =
-    artwork?.sale?.isAuction && !artwork?.sale?.isClosed
-      ? getUrgencyTag(artwork?.sale?.endAt)
-      : null
+  const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
+  const lotEndAt = saleArtwork?.endAt
+  const endAt = extendedBiddingEndAt ?? lotEndAt ?? sale?.endAt
+  const urgencyTag = sale?.isAuction && !sale?.isClosed ? getUrgencyTag(endAt) : null
 
   const primaryTextColor = dark ? "white100" : "black100"
   const secondaryTextColor = dark ? "black15" : "black60"
@@ -414,6 +425,8 @@ const artworkFragment = graphql`
       currentBid {
         display
       }
+      endAt
+      extendedBiddingEndAt
     }
     partner {
       name

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -12,6 +12,7 @@ import {
   AuctionWebsocketChannelInfo,
   AuctionWebsocketContextProvider,
 } from "app/utils/Websockets/auctions/AuctionSocketContext"
+import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
@@ -97,11 +98,14 @@ const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
     saleArtwork,
   } = artwork
 
-  const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
+  const { currentBiddingEndAt } = useArtworkBidding({
+    lotID: saleArtwork?.lotID,
+    lotEndAt: saleArtwork?.endAt,
+    biddingEndAt: saleArtwork?.extendedBiddingEndAt,
+  })
 
-  const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
-  const lotEndAt = saleArtwork?.endAt
-  const endAt = extendedBiddingEndAt ?? lotEndAt ?? sale?.endAt
+  const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
+  const endAt = currentBiddingEndAt ?? sale?.endAt
   const urgencyTag = sale?.isAuction && !sale?.isClosed ? getUrgencyTag(endAt) : null
 
   const primaryTextColor = dark ? "white100" : "black100"
@@ -460,6 +464,7 @@ const artworkRailCardInnerFragment = graphql`
       currentBid {
         display
       }
+      lotID
       endAt
       extendedBiddingEndAt
     }

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -1,12 +1,17 @@
 import { Flex, HeartFillIcon, HeartIcon, Text, useColor, Touchable } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import {
-  ArtworkRailCard_artwork$data,
-  ArtworkRailCard_artwork$key,
-} from "__generated__/ArtworkRailCard_artwork.graphql"
+  ArtworkRailCardInner_artwork$data,
+  ArtworkRailCardInner_artwork$key,
+} from "__generated__/ArtworkRailCardInner_artwork.graphql"
+import { ArtworkRailCard_artwork$key } from "__generated__/ArtworkRailCard_artwork.graphql"
 import { saleMessageOrBidInfo as defaultSaleMessageOrBidInfo } from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidth"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import {
+  AuctionWebsocketChannelInfo,
+  AuctionWebsocketContextProvider,
+} from "app/utils/Websockets/auctions/AuctionSocketContext"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
@@ -51,7 +56,11 @@ export interface ArtworkRailCardProps {
   trackingContextScreenOwnerType?: Schema.OwnerEntityTypes
 }
 
-export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
+interface ArtworkRailCardInnerProps extends Omit<ArtworkRailCardProps, "artwork"> {
+  artwork: ArtworkRailCardInner_artwork$key
+}
+
+const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
   hideArtistName = false,
   showPartnerName = false,
   dark = false,
@@ -72,7 +81,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
 
   const { trackEvent } = useTracking()
   const fontScale = PixelRatio.getFontScale()
-  const artwork = useFragment(artworkFragment, restProps.artwork)
+  const artwork = useFragment(artworkRailCardInnerFragment, restProps.artwork)
 
   const {
     artistNames,
@@ -285,8 +294,24 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   )
 }
 
+export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = (props) => {
+  const artwork = useFragment(artworkRailCardFragment, props.artwork)
+
+  const websocketEnabled = !!artwork.sale?.extendedBiddingIntervalMinutes
+  const socketChannelInfo: AuctionWebsocketChannelInfo = {
+    channel: "SalesChannel",
+    sale_id: artwork.sale?.internalID,
+  }
+
+  return (
+    <AuctionWebsocketContextProvider channelInfo={socketChannelInfo} enabled={websocketEnabled}>
+      <ArtworkRailCardInner {...props} artwork={artwork} />
+    </AuctionWebsocketContextProvider>
+  )
+}
+
 export interface ArtworkRailCardImageProps {
-  image: ArtworkRailCard_artwork$data["image"]
+  image: ArtworkRailCardInner_artwork$data["image"]
   size: ArtworkCardSize
   urgencyTag?: string | null
   containerWidth?: number | null
@@ -394,8 +419,18 @@ const RecentlySoldCardSection: React.FC<
   )
 }
 
-const artworkFragment = graphql`
+const artworkRailCardFragment = graphql`
   fragment ArtworkRailCard_artwork on Artwork @argumentDefinitions(width: { type: "Int" }) {
+    sale {
+      internalID
+      extendedBiddingIntervalMinutes
+    }
+    ...ArtworkRailCardInner_artwork @arguments(width: $width)
+  }
+`
+
+const artworkRailCardInnerFragment = graphql`
+  fragment ArtworkRailCardInner_artwork on Artwork @argumentDefinitions(width: { type: "Int" }) {
     id
     slug
     internalID

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -12,7 +12,6 @@ import {
   AuctionWebsocketChannelInfo,
   AuctionWebsocketContextProvider,
 } from "app/utils/Websockets/auctions/AuctionSocketContext"
-import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
@@ -98,14 +97,11 @@ const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
     saleArtwork,
   } = artwork
 
-  const { currentBiddingEndAt } = useArtworkBidding({
-    lotID: saleArtwork?.lotID,
-    lotEndAt: saleArtwork?.endAt,
-    biddingEndAt: saleArtwork?.extendedBiddingEndAt,
-  })
-
   const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
-  const endAt = currentBiddingEndAt ?? sale?.endAt
+
+  const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
+  const lotEndAt = saleArtwork?.endAt
+  const endAt = extendedBiddingEndAt ?? lotEndAt ?? sale?.endAt
   const urgencyTag = sale?.isAuction && !sale?.isClosed ? getUrgencyTag(endAt) : null
 
   const primaryTextColor = dark ? "white100" : "black100"
@@ -464,7 +460,6 @@ const artworkRailCardInnerFragment = graphql`
       currentBid {
         display
       }
-      lotID
       endAt
       extendedBiddingEndAt
     }

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -1,17 +1,12 @@
 import { Flex, HeartFillIcon, HeartIcon, Text, useColor, Touchable } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import {
-  ArtworkRailCardInner_artwork$data,
-  ArtworkRailCardInner_artwork$key,
-} from "__generated__/ArtworkRailCardInner_artwork.graphql"
-import { ArtworkRailCard_artwork$key } from "__generated__/ArtworkRailCard_artwork.graphql"
+  ArtworkRailCard_artwork$data,
+  ArtworkRailCard_artwork$key,
+} from "__generated__/ArtworkRailCard_artwork.graphql"
 import { saleMessageOrBidInfo as defaultSaleMessageOrBidInfo } from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidth"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
-import {
-  AuctionWebsocketChannelInfo,
-  AuctionWebsocketContextProvider,
-} from "app/utils/Websockets/auctions/AuctionSocketContext"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { Schema } from "app/utils/track"
@@ -56,11 +51,7 @@ export interface ArtworkRailCardProps {
   trackingContextScreenOwnerType?: Schema.OwnerEntityTypes
 }
 
-interface ArtworkRailCardInnerProps extends Omit<ArtworkRailCardProps, "artwork"> {
-  artwork: ArtworkRailCardInner_artwork$key
-}
-
-const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
+export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   hideArtistName = false,
   showPartnerName = false,
   dark = false,
@@ -81,7 +72,7 @@ const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
 
   const { trackEvent } = useTracking()
   const fontScale = PixelRatio.getFontScale()
-  const artwork = useFragment(artworkRailCardInnerFragment, restProps.artwork)
+  const artwork = useFragment(artworkFragment, restProps.artwork)
 
   const {
     artistNames,
@@ -294,24 +285,8 @@ const ArtworkRailCardInner: React.FC<ArtworkRailCardInnerProps> = ({
   )
 }
 
-export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = (props) => {
-  const artwork = useFragment(artworkRailCardFragment, props.artwork)
-
-  const websocketEnabled = !!artwork.sale?.extendedBiddingIntervalMinutes
-  const socketChannelInfo: AuctionWebsocketChannelInfo = {
-    channel: "SalesChannel",
-    sale_id: artwork.sale?.internalID,
-  }
-
-  return (
-    <AuctionWebsocketContextProvider channelInfo={socketChannelInfo} enabled={websocketEnabled}>
-      <ArtworkRailCardInner {...props} artwork={artwork} />
-    </AuctionWebsocketContextProvider>
-  )
-}
-
 export interface ArtworkRailCardImageProps {
-  image: ArtworkRailCardInner_artwork$data["image"]
+  image: ArtworkRailCard_artwork$data["image"]
   size: ArtworkCardSize
   urgencyTag?: string | null
   containerWidth?: number | null
@@ -419,18 +394,8 @@ const RecentlySoldCardSection: React.FC<
   )
 }
 
-const artworkRailCardFragment = graphql`
+const artworkFragment = graphql`
   fragment ArtworkRailCard_artwork on Artwork @argumentDefinitions(width: { type: "Int" }) {
-    sale {
-      internalID
-      extendedBiddingIntervalMinutes
-    }
-    ...ArtworkRailCardInner_artwork @arguments(width: $width)
-  }
-`
-
-const artworkRailCardInnerFragment = graphql`
-  fragment ArtworkRailCardInner_artwork on Artwork @argumentDefinitions(width: { type: "Int" }) {
     id
     slug
     internalID


### PR DESCRIPTION
This PR resolves [FX-4728] <!-- eg [PROJECT-XXXX] -->

Slack thread: [link](https://artsy.slack.com/archives/C03N12SR0RK/p1680797397951269)

### Description
Sometimes the incorrect auction countdown time is displayed for artworks on home feed. This is due to the fact that we use the “wrong” endAt [value](https://github.com/artsy/eigen/blob/77d0dbd98b1f3f212ff57d9064edfda4c006bdb4/src/app/Components/ArtworkRail/ArtworkRailCard.tsx#L84) when popcorn bidding is enabled for the auction.

### Demo
#### Auction with enabled popcorn bidding
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/231813938-4ee9ded3-b4f1-40cb-944c-07b13a00e881.mp4" />  | <video src="https://user-images.githubusercontent.com/3513494/231814008-4277024c-acb9-48e5-a632-d468cf4cface.mp4" />  | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- ix inconsistency in auction countdown for artworks on home feed - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4728]: https://artsyproduct.atlassian.net/browse/FX-4728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ