### PR TITLE
fix(NX-3507): use the right backgroundColor for counterOffer banner

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Composer.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Composer.tests.tsx
@@ -1,9 +1,9 @@
 import { Flex } from "@artsy/palette-mobile"
 import { waitFor } from "@testing-library/react-native"
 import { ComposerTestsQuery } from "__generated__/ComposerTestsQuery.graphql"
+import { Button } from "app/Components/Button"
 import { extractText } from "app/utils/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { Button } from "app/Components/Button"
 import { TextInput, TouchableWithoutFeedback } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
@@ -176,7 +176,7 @@ describe("inquiry offer", () => {
       expect(cta).not.toBeDefined()
     })
 
-    it("renders a copper offer CTA if there is a pending offer from the seller", () => {
+    it("renders a orange offer CTA if there is a pending offer from the seller", () => {
       const tree = getWrapper({
         Conversation: () => ({
           items: [
@@ -214,7 +214,7 @@ describe("inquiry offer", () => {
       expect(cta).toBeDefined()
       expect(cta.children.length).toBe(1)
       expect(extractText(cta)).toContain("Counteroffer Received")
-      expect(cta.findAllByType(Flex)[0].props).toEqual(expect.objectContaining({ bg: "copper100" }))
+      expect(cta.findAllByType(Flex)[0].props).toEqual(expect.objectContaining({ bg: "orange150" }))
     })
 
     it("renders a green cta if the seller has approved the buyer's offer", () => {

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
@@ -149,7 +149,7 @@ describe("ConversationCTA", () => {
         },
       })
       expectReviewOfferButton(wrapper, {
-        bg: "copper100",
+        bg: "orange150",
         strings: ["Offer Received"],
         Icon: AlertCircleFillIcon,
       })

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tests.tsx
@@ -191,7 +191,7 @@ describe("ConversationCTA", () => {
       })
 
       expectReviewOfferButton(wrapper, {
-        bg: "copper100",
+        bg: "orange150",
         strings: ["Counteroffer Received", "Confirm Total"],
         Icon: AlertCircleFillIcon,
       })
@@ -219,7 +219,7 @@ describe("ConversationCTA", () => {
       })
 
       expectReviewOfferButton(wrapper, {
-        bg: "copper100",
+        bg: "orange150",
         strings: ["Offer Accepted", "Confirm total"],
         Icon: AlertCircleFillIcon,
       })

--- a/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OrderUpdate.tsx
@@ -43,7 +43,7 @@ export const OrderUpdate: React.FC<OrderUpdateProps> = ({ event, conversationId 
         }
       }
     } else if (offer.fromParticipant === "SELLER") {
-      color = "copper100"
+      color = "orange150"
       Icon = AlertCircleFillIcon
       if (offer.offerAmountChanged) {
         message = `You received ${isCounter ? "a counteroffer" : "an offer"} for ${

--- a/src/app/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -73,7 +73,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({
     }
     case "OFFER_RECEIVED": {
       ctaAttributes = {
-        backgroundColor: "copper100",
+        backgroundColor: "orange150",
         message: `${offerType} Received`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,

--- a/src/app/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ReviewOfferButton.tsx
@@ -95,7 +95,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({
     }
     case "OFFER_ACCEPTED_CONFIRM_NEEDED": {
       ctaAttributes = {
-        backgroundColor: "copper100",
+        backgroundColor: "orange150",
         message: `Offer Accepted - Confirm total`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,
@@ -106,7 +106,7 @@ export const ReviewOfferButton: React.FC<ReviewOfferButtonProps> = ({
     }
     case "OFFER_RECEIVED_CONFIRM_NEEDED": {
       ctaAttributes = {
-        backgroundColor: "copper100",
+        backgroundColor: "orange150",
         message: `Counteroffer Received - Confirm Total`,
         subMessage: `The offer expires in ${expiresIn}`,
         Icon: AlertCircleFillIcon,


### PR DESCRIPTION
This PR resolves [NX-3507]

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Fixes the background color of the offer CTA inside a conversation. Also, minor fixes where other areas were using the non-existing color `copper`, changed all to `orange150`.

Before

https://user-images.githubusercontent.com/15792853/231761750-a4f0c1d6-f109-4c89-b1c3-9e1fd5202d30.mov

After

![Screenshot 2023-04-13 at 14 38 40](https://user-images.githubusercontent.com/15792853/231761686-420e52b9-14d4-4c9c-b1fa-e1a5b328d55b.png)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: use the orange150 color for the offer CTA inside a conversation - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[NX-3507]: https://artsyproduct.atlassian.net/browse/NX-3507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ