### PR TITLE
lib(palette): bump to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.124.0",
-    "@artsy/palette-mobile": "11.0.14",
+    "@artsy/palette-mobile": "11.0.15",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@gorhom/bottom-sheet": "4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -229,10 +229,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@11.0.14":
-  version "11.0.14"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.14.tgz#0d8ae712c1308a73a772ee7588a3750f3fa1aa85"
-  integrity sha512-9npvjb3ysAm8JTUDo/D+VQr4iEejbeQrTNiJPIwHZ+9jjWCb5wzPfhNxdjRc8MkiZtu6GYrgE4aY4p22a7XCjA==
+"@artsy/palette-mobile@11.0.15":
+  version "11.0.15"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.15.tgz#ddd8883e85b1653e040ec6f9be9fb6d6dc5be594"
+  integrity sha512-UcGYs3M/KsZrHrEL+dhw5QV1zeiX4qo/Ko7RLF7fvN5RfdB/cmZmyIKAwWf79sd++2CIUvmqiympQfxBLJa4DQ==
   dependencies:
     "@artsy/palette-tokens" "^4.0.1"
     "@styled-system/core" "^5.1.2"


### PR DESCRIPTION
Related: 
- https://github.com/artsy/palette-mobile/pull/88

### Description

Noticed that the button was triggering a crash when _not_ in debugging mode, and it (seemed) to point at the button. Updating here. 

cc @artsy/mobile-platform 

