### PR TITLE
fix: Update artist auction results initial filters logic

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tsx
@@ -115,15 +115,12 @@ const ArtistInsightsAuctionResults: React.FC<Props> = ({
   })
 
   useEffect(() => {
-    let filters: FilterArray = []
+    setFilterTypeAction("auctionResult")
 
     if (Array.isArray(initialFilters)) {
-      filters = initialFilters
+      setInitialFilterStateAction(initialFilters)
+      applyFiltersAction()
     }
-
-    setInitialFilterStateAction(filters)
-    setFilterTypeAction("auctionResult")
-    applyFiltersAction()
   }, [])
 
   const getSortDescription = useCallback(() => {

--- a/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterHelpers.ts
@@ -3,6 +3,7 @@ import {
   entries,
   filter,
   isArray,
+  isEmpty,
   isEqual,
   isUndefined,
   pick,
@@ -563,10 +564,9 @@ export const getFilterArrayFromQueryParams = (queryParams: {
 }) => {
   return compact(
     entries(queryParams).map(([key, value]) => {
-      if (value) {
+      if (!isEmpty(value)) {
         const filterData: FilterData = {
-          // @ts-expect-error TODO: fix type error
-          displayText: FilterDisplayName[key],
+          displayText: FilterDisplayName[key as keyof typeof FilterDisplayName],
           paramName: key as FilterParamName,
           paramValue: value,
         }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR solves the issue of showing 1 applied filter in the Artist's auction results screen when in reality there are no filters applied to the auction results

The issue comes from the initial filters obtained URL query params coming from the Price Database screen

### Screenshots
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/20655703/232437034-3a6ff53f-b79f-4ad9-9e03-3a70203ef067.png) | ![image](https://user-images.githubusercontent.com/20655703/232437048-efa0bf27-7fef-44c9-b5ca-1016d14e775f.png) |

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update artist auction results initial filters logic - mrsltun

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
