### PR TITLE
feat(article): Add relay data layer and Article component stubs 

### DIFF
--- a/src/app/Scenes/Article/ArticleScreen.tsx
+++ b/src/app/Scenes/Article/ArticleScreen.tsx
@@ -1,4 +1,5 @@
-import { Text } from "@artsy/palette-mobile"
+import { ArticleScreenQuery } from "__generated__/ArticleScreenQuery.graphql"
+import { ArticleBody } from "app/Scenes/Article/Components/ArticleBody"
 import { PlaceholderGrid, ProvidePlaceholderContext } from "app/utils/placeholders"
 import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -16,17 +17,21 @@ export const ArticleScreen: React.FC<ArticleScreenProps> = (props) => {
 }
 
 const Article: React.FC<ArticleScreenProps> = () => {
-  const data = useLazyLoadQuery(ArticleScreenQuery, {
+  const data = useLazyLoadQuery<ArticleScreenQuery>(articleScreenQuery, {
     slug: "artsy-editorial-data-spotlight-artists-demand-2023",
   })
-  console.log(data)
-  return <Text>Hi Article</Text>
+
+  if (!data.article) {
+    return null
+  }
+
+  return <ArticleBody article={data.article} />
 }
 
-export const ArticleScreenQuery = graphql`
+export const articleScreenQuery = graphql`
   query ArticleScreenQuery($slug: String!) {
     article(id: $slug) {
-      internalID
+      ...ArticleBody_article
     }
   }
 `

--- a/src/app/Scenes/Article/Components/ArticleBody.tsx
+++ b/src/app/Scenes/Article/Components/ArticleBody.tsx
@@ -1,0 +1,71 @@
+import { ArticleBody_article$key } from "__generated__/ArticleBody_article.graphql"
+import { ArticleByline } from "app/Scenes/Article/Components/ArticleByline"
+import { ArticleHero } from "app/Scenes/Article/Components/ArticleHero"
+import { ArticleNewsSource } from "app/Scenes/Article/Components/ArticleNewsSource"
+import { ArticleSection } from "app/Scenes/Article/Components/ArticleSection"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleBodyProps {
+  article: ArticleBody_article$key
+}
+
+export const ArticleBody: React.FC<ArticleBodyProps> = ({ article }) => {
+  const articleData = useFragment(ArticleBodyQuery, article)
+
+  return (
+    <>
+      <ArticleHero article={articleData} />
+      <ArticleByline article={articleData} />
+      <ArticleNewsSource article={articleData} />
+
+      {articleData.sections.map((section, index) => {
+        return (
+          <>
+            <ArticleSection key={index} section={section} />
+          </>
+        )
+      })}
+    </>
+  )
+}
+
+const ArticleBodyQuery = graphql`
+  fragment ArticleBody_article on Article {
+    ...ArticleHero_article
+    ...ArticleByline_article
+    ...ArticleNewsSource_article
+    hero {
+      __typename
+    }
+    seriesArticle {
+      thumbnailTitle
+      href
+    }
+    vertical
+    byline
+    internalID
+    slug
+    layout
+    leadParagraph
+    title
+    href
+    publishedAt
+    sections {
+      ...ArticleSection_section
+    }
+    postscript
+    relatedArticles {
+      internalID
+      title
+      href
+      byline
+      thumbnailImage {
+        cropped(width: 100, height: 100) {
+          src
+          srcSet
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/ArticleByline.tsx
+++ b/src/app/Scenes/Article/Components/ArticleByline.tsx
@@ -1,0 +1,45 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleByline_article$key } from "__generated__/ArticleByline_article.graphql"
+import { Fragment } from "react"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleBylineProps {
+  article: ArticleByline_article$key
+}
+
+export const ArticleByline: React.FC<ArticleBylineProps> = ({ article }) => {
+  const data = useFragment(ArticleBylineQuery, article)
+  return (
+    <>
+      <Text>{data.byline}</Text>
+
+      {data.authors.map((author, index) => {
+        return (
+          <Fragment key={index}>
+            <Text>{author.name}</Text>
+            <Text>{author.bio}</Text>
+          </Fragment>
+        )
+      })}
+    </>
+  )
+}
+
+const ArticleBylineQuery = graphql`
+  fragment ArticleByline_article on Article {
+    byline
+    authors {
+      internalID
+      name
+      initials
+      bio
+      image {
+        cropped(width: 60, height: 60) {
+          src
+          srcSet
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/ArticleHero.tsx
+++ b/src/app/Scenes/Article/Components/ArticleHero.tsx
@@ -1,0 +1,48 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleHero_article$key } from "__generated__/ArticleHero_article.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleHeroProps {
+  article: ArticleHero_article$key
+}
+
+export const ArticleHero: React.FC<ArticleHeroProps> = ({ article }) => {
+  const data = useFragment(ArticleHeroQuery, article)
+
+  return (
+    <>
+      <Text>{data.title}</Text>
+      <Text>{data.href}</Text>
+      <Text>{data.vertical}</Text>
+      <Text>{data.byline}</Text>
+    </>
+  )
+}
+
+const ArticleHeroQuery = graphql`
+  fragment ArticleHero_article on Article {
+    title
+    href
+    vertical
+    byline
+    hero {
+      ... on ArticleFeatureSection {
+        layout
+        embed
+        media
+        image {
+          url
+          split: resized(width: 900) {
+            src
+            srcSet
+          }
+          text: cropped(width: 1600, height: 900) {
+            src
+            srcSet
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/ArticleNewsSource.tsx
+++ b/src/app/Scenes/Article/Components/ArticleNewsSource.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleNewsSource_article$key } from "__generated__/ArticleNewsSource_article.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleNewsSourceProps {
+  article: ArticleNewsSource_article$key
+}
+
+export const ArticleNewsSource: React.FC<ArticleNewsSourceProps> = ({ article }) => {
+  const data = useFragment(ArticleNewsSourceQuery, article)
+
+  if (!data.newsSource) {
+    return null
+  }
+
+  return (
+    <>
+      <Text>{data.newsSource.title}</Text>
+      <Text>{data.newsSource.url}</Text>
+    </>
+  )
+}
+
+const ArticleNewsSourceQuery = graphql`
+  fragment ArticleNewsSource_article on Article {
+    newsSource {
+      title
+      url
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/ArticleSection.tsx
+++ b/src/app/Scenes/Article/Components/ArticleSection.tsx
@@ -1,0 +1,38 @@
+import { ArticleSection_section$key } from "__generated__/ArticleSection_section.graphql"
+import { ArticleSectionEmbed } from "app/Scenes/Article/Components/Sections/ArticleSectionEmbed"
+import { ArticleSectionImageCollection } from "app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollection"
+import { ArticleSectionImageSet } from "app/Scenes/Article/Components/Sections/ArticleSectionImageSet"
+import { ArticleSectionSocialEmbed } from "app/Scenes/Article/Components/Sections/ArticleSectionSocialEmbed"
+import { ArticleSectionText } from "app/Scenes/Article/Components/Sections/ArticleSectionText"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionProps {
+  section: ArticleSection_section$key
+}
+
+export const ArticleSection: React.FC<ArticleSectionProps> = ({ section }) => {
+  const data = useFragment(ArticleSectionQuery, section)
+
+  return (
+    <>
+      <ArticleSectionText section={data} />
+      <ArticleSectionImageCollection section={data} />
+      <ArticleSectionImageSet section={data} />
+      <ArticleSectionSocialEmbed section={data} />
+      <ArticleSectionEmbed section={data} />
+    </>
+  )
+}
+
+const ArticleSectionQuery = graphql`
+  fragment ArticleSection_section on ArticleSections {
+    __typename
+    ...ArticleSectionText_section
+    ...ArticleSectionImageCollection_section
+    ...ArticleSectionImageSet_section
+    ...ArticleSectionSocialEmbed_section
+    ...ArticleSectionEmbed_section
+    # ...ArticleSectionVideo_section
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionEmbed.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionEmbed.tsx
@@ -1,0 +1,29 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionEmbed_section$key } from "__generated__/ArticleSectionEmbed_section.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionEmbedProps {
+  section: ArticleSectionEmbed_section$key
+}
+
+export const ArticleSectionEmbed: React.FC<ArticleSectionEmbedProps> = ({ section }) => {
+  const data = useFragment(ArticleSectionEmbedQuery, section)
+
+  return (
+    <>
+      <Text>{data.url}</Text>
+      <Text>{data.height}</Text>
+      <Text>{data._layout}</Text>
+    </>
+  )
+}
+
+const ArticleSectionEmbedQuery = graphql`
+  fragment ArticleSectionEmbed_section on ArticleSectionEmbed {
+    url
+    height
+    mobileHeight
+    _layout: layout
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollection.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollection.tsx
@@ -1,0 +1,43 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionImageCollection_section$key } from "__generated__/ArticleSectionImageCollection_section.graphql"
+import { ArticleSectionImageCollectionCaption } from "app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionCaption"
+import { ArticleSectionImageCollectionImage } from "app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage"
+import { Fragment } from "react"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionImageCollectionProps {
+  section: ArticleSectionImageCollection_section$key
+}
+
+export const ArticleSectionImageCollection: React.FC<ArticleSectionImageCollectionProps> = ({
+  section,
+}) => {
+  const data = useFragment(ArticleSectionImageCollectionQuery, section)
+
+  return (
+    <>
+      <Text>{data.layout}</Text>
+
+      {data.figures.map((figure, index) => {
+        return (
+          <Fragment key={index}>
+            <ArticleSectionImageCollectionImage figure={figure} />
+            <ArticleSectionImageCollectionCaption figure={figure} />
+          </Fragment>
+        )
+      })}
+    </>
+  )
+}
+
+const ArticleSectionImageCollectionQuery = graphql`
+  fragment ArticleSectionImageCollection_section on ArticleSectionImageCollection {
+    layout
+    figures {
+      __typename
+      ...ArticleSectionImageCollectionImage_figure
+      ...ArticleSectionImageCollectionCaption_figure
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionCaption.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionCaption.tsx
@@ -1,0 +1,35 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionImageCollectionCaption_figure$key } from "__generated__/ArticleSectionImageCollectionCaption_figure.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionImageCollectionCaptionProps {
+  figure: ArticleSectionImageCollectionCaption_figure$key
+}
+
+export const ArticleSectionImageCollectionCaption: React.FC<
+  ArticleSectionImageCollectionCaptionProps
+> = ({ figure }) => {
+  const data = useFragment(ArticleSectionImageCollectionCaptionQuery, figure)
+
+  return <>{data.__typename === "ArticleImageSection" && <Text>{data.caption}</Text>}</>
+}
+
+const ArticleSectionImageCollectionCaptionQuery = graphql`
+  fragment ArticleSectionImageCollectionCaption_figure on ArticleSectionImageCollectionFigure {
+    __typename
+    ... on ArticleImageSection {
+      caption
+    }
+    ... on ArticleUnpublishedArtwork {
+      title
+      date
+      artist {
+        name
+      }
+      partner {
+        name
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
@@ -1,0 +1,49 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionImageCollectionImage_figure$key } from "__generated__/ArticleSectionImageCollectionImage_figure.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionImageCollectionImageProps {
+  figure: ArticleSectionImageCollectionImage_figure$key
+}
+
+export const ArticleSectionImageCollectionImage: React.FC<
+  ArticleSectionImageCollectionImageProps
+> = ({ figure }) => {
+  const data = useFragment(ArticleSectionImageCollectionImageQuery, figure)
+
+  return (
+    <>
+      <Text>{data.image?.url}</Text>
+    </>
+  )
+}
+
+const ArticleSectionImageCollectionImageQuery = graphql`
+  fragment ArticleSectionImageCollectionImage_figure on ArticleSectionImageCollectionFigure {
+    ... on ArticleImageSection {
+      id
+      image {
+        url(version: ["normalized", "larger", "large"])
+        width
+        height
+      }
+    }
+    ... on Artwork {
+      id
+      image {
+        url(version: ["normalized", "larger", "large"])
+        width
+        height
+      }
+    }
+    ... on ArticleUnpublishedArtwork {
+      id
+      image {
+        url(version: ["normalized", "larger", "large"])
+        width
+        height
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageSet.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageSet.tsx
@@ -1,0 +1,65 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionImageSet_section$key } from "__generated__/ArticleSectionImageSet_section.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionImageSetProps {
+  section: ArticleSectionImageSet_section$key
+}
+
+export const ArticleSectionImageSet: React.FC<ArticleSectionImageSetProps> = ({ section }) => {
+  const data = useFragment(ArticleSectionImageSetQuery, section)
+
+  return (
+    <>
+      <Text>{data.title}</Text>
+    </>
+  )
+}
+
+const ArticleSectionImageSetQuery = graphql`
+  fragment ArticleSectionImageSet_section on ArticleSectionImageSet {
+    setLayout: layout
+    title
+    counts {
+      figures
+    }
+    cover {
+      __typename
+      ... on ArticleImageSection {
+        id
+        image {
+          small: cropped(width: 80, height: 80, version: ["normalized", "larger", "large"]) {
+            src
+            srcSet
+            height
+            width
+          }
+          large: resized(width: 1220, version: ["normalized", "larger", "large"]) {
+            src
+            srcSet
+            height
+            width
+          }
+        }
+      }
+      ... on Artwork {
+        id
+        image {
+          small: cropped(width: 80, height: 80, version: ["normalized", "larger", "large"]) {
+            src
+            srcSet
+            height
+            width
+          }
+          large: resized(width: 1220, version: ["normalized", "larger", "large"]) {
+            src
+            srcSet
+            height
+            width
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionSocialEmbed.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionSocialEmbed.tsx
@@ -1,0 +1,28 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionSocialEmbed_section$key } from "__generated__/ArticleSectionSocialEmbed_section.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionSocialEmbedProps {
+  section: ArticleSectionSocialEmbed_section$key
+}
+
+export const ArticleSectionSocialEmbed: React.FC<ArticleSectionSocialEmbedProps> = ({
+  section,
+}) => {
+  const data = useFragment(ArticleSectionSocialEmbedQuery, section)
+
+  return (
+    <>
+      <Text>{data.url}</Text>
+      <Text>{data.embed}</Text>
+    </>
+  )
+}
+
+const ArticleSectionSocialEmbedQuery = graphql`
+  fragment ArticleSectionSocialEmbed_section on ArticleSectionSocialEmbed {
+    url
+    embed
+  }
+`

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionText.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionText.tsx
@@ -1,0 +1,19 @@
+import { Text } from "@artsy/palette-mobile"
+import { ArticleSectionText_section$key } from "__generated__/ArticleSectionText_section.graphql"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface ArticleSectionTextProps {
+  section: ArticleSectionText_section$key
+}
+
+export const ArticleSectionText: React.FC<ArticleSectionTextProps> = ({ section }) => {
+  const data = useFragment(ArticleSectionTextQuery, section)
+  return <Text>{data.body}</Text>
+}
+
+const ArticleSectionTextQuery = graphql`
+  fragment ArticleSectionText_section on ArticleSectionText {
+    body
+  }
+`


### PR DESCRIPTION
### Description

This adds the relay article data layer and lays out all of the component stubs. 

cc @artsy/mobile-platform 