### PR TITLE
fix: description identifiers

### DIFF
--- a/eslint-rules/no-uselazyloadquery-inside-suspense.js
+++ b/eslint-rules/no-uselazyloadquery-inside-suspense.js
@@ -14,7 +14,7 @@ module.exports = createRule({
     hasSuggestions: true,
     docs: {
       description:
-        "When we use `useLazyLoadQuery` inside a component that has `<Suspense />` in react-native it causes a crash, this rule is for preventing that"
+        "When we use useLazyLoadQuery inside a component that has <Suspense /> in react-native it causes a crash, this rule is for preventing that",
       recommended: "error",
     },
     messages: {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

description identifiers error fix,

after merging the custom rule I merged a change via github suggestions in the description which breaks the rule with:

```bash
$ eslint --cache --cache-location '.cache/eslint/' --ext .ts,.tsx --fix /Users/georgekartalis/Artsy/eigen/src/app/Components/LocationAutocomplete.tsx

Oops! Something went wrong! :(

ESLint: 8.32.0

/Users/georgekartalis/Artsy/eigen/node_modules/eslint-plugin-artsy/no-uselazyloadquery-inside-suspense.js:18
      recommended: "error",
      ^^^^^^^^^^^

SyntaxError: Unexpected identifier
    at compileFunction (<anonymous>)
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1084:15)
    at Module._compile (node:internal/modules/cjs/loader:1119:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1209:10)
    at Module.load (node:internal/modules/cjs/loader:1033:32)
    at Function.Module._load (node:internal/modules/cjs/loader:868:12)
    at Module.require (node:internal/modules/cjs/loader:1057:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/georgekartalis/Artsy/eigen/node_modules/eslint-plugin-artsy/index.js:3:44)
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
