### PR TITLE
feat(FX-4754): display artwork data in artwork lists bottom sheet

### DIFF
--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
@@ -30,6 +30,14 @@ describe("ArtworkListsProvider", () => {
   })
 
   describe("Select lists for artwork", () => {
+    it("should display artwork info", () => {
+      const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+
+      expect(getByText(/Banksy/)).toBeTruthy()
+      expect(getByText(/Artwork Title/)).toBeTruthy()
+      expect(getByText(/2023/)).toBeTruthy()
+    })
+
     it("should not be displayed by default", () => {
       const { queryByText } = renderWithHookWrappersTL(
         <TestRenderer artwork={undefined} />,

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
@@ -58,24 +58,6 @@ describe("ArtworkInfo", () => {
 
     expect(queryByText(/Artwork Title/)).toBeTruthy()
   })
-
-  describe("Artists", () => {
-    it("should render `Artist Unavailable` when `artistNames` value is null", () => {
-      const { queryByText } = renderWithHookWrappersTL(
-        <ArtworkInfo artwork={{ ...artworkEntity, artistNames: null }} />
-      )
-
-      expect(queryByText(/Artist Unavailable/)).toBeTruthy()
-    })
-
-    it("should render `Artist Unavailable` when `artistNames` value is empty string", () => {
-      const { queryByText } = renderWithHookWrappersTL(
-        <ArtworkInfo artwork={{ ...artworkEntity, artistNames: "" }} />
-      )
-
-      expect(queryByText(/Artist Unavailable/)).toBeTruthy()
-    })
-  })
 })
 
 const artworkEntity: ArtworkEntity = {

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
@@ -1,0 +1,88 @@
+import { ArtworkEntity } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { ArtworkInfo } from "app/Components/ArtworkLists/components/ArtworkInfo"
+import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
+
+describe("ArtworkInfo", () => {
+  it("should render artist names, artwork title and year", () => {
+    const { getByText } = renderWithHookWrappersTL(<ArtworkInfo artwork={artworkEntity} />)
+
+    expect(getByText(/Banksy/)).toBeTruthy()
+    expect(getByText(/Artwork Title/)).toBeTruthy()
+    expect(getByText(/2023/)).toBeTruthy()
+  })
+
+  it("should render artist names and artwork title", () => {
+    const { queryByText } = renderWithHookWrappersTL(
+      <ArtworkInfo artwork={{ ...artworkEntity, year: null }} />
+    )
+
+    // Not displayed
+    expect(queryByText(/2023/)).toBeFalsy()
+
+    expect(queryByText(/Banksy/)).toBeTruthy()
+    expect(queryByText(/Artwork Title/)).toBeTruthy()
+  })
+
+  it("should render artwork title and year", () => {
+    const { queryByText } = renderWithHookWrappersTL(
+      <ArtworkInfo artwork={{ ...artworkEntity, artistNames: null }} />
+    )
+
+    // Not displayed
+    expect(queryByText(/Banksy/)).toBeFalsy()
+
+    expect(queryByText(/Artwork Title/)).toBeTruthy()
+    expect(queryByText(/2023/)).toBeTruthy()
+  })
+
+  it("should render artwork title and year", () => {
+    const { queryByText } = renderWithHookWrappersTL(
+      <ArtworkInfo artwork={{ ...artworkEntity, artistNames: null }} />
+    )
+
+    // Not displayed
+    expect(queryByText(/Banksy/)).toBeFalsy()
+
+    expect(queryByText(/Artwork Title/)).toBeTruthy()
+    expect(queryByText(/2023/)).toBeTruthy()
+  })
+
+  it("should render only artwork title", () => {
+    const { queryByText } = renderWithHookWrappersTL(
+      <ArtworkInfo artwork={{ ...artworkEntity, artistNames: null, year: null }} />
+    )
+
+    // Not displayed
+    expect(queryByText(/Banksy/)).toBeFalsy()
+    expect(queryByText(/2023/)).toBeFalsy()
+
+    expect(queryByText(/Artwork Title/)).toBeTruthy()
+  })
+
+  describe("Artists", () => {
+    it("should render `Artist Unavailable` when `artistNames` value is null", () => {
+      const { queryByText } = renderWithHookWrappersTL(
+        <ArtworkInfo artwork={{ ...artworkEntity, artistNames: null }} />
+      )
+
+      expect(queryByText(/Artist Unavailable/)).toBeTruthy()
+    })
+
+    it("should render `Artist Unavailable` when `artistNames` value is empty string", () => {
+      const { queryByText } = renderWithHookWrappersTL(
+        <ArtworkInfo artwork={{ ...artworkEntity, artistNames: "" }} />
+      )
+
+      expect(queryByText(/Artist Unavailable/)).toBeTruthy()
+    })
+  })
+})
+
+const artworkEntity: ArtworkEntity = {
+  id: "artwork-id",
+  internalID: "artwork-internal-id",
+  artistNames: "Banksy",
+  title: "Artwork Title",
+  year: "2023",
+  imageURL: null,
+}

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -1,0 +1,35 @@
+import { Box, Flex, Spacer, Text } from "@artsy/palette-mobile"
+import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
+
+const ARTWORK_IMAGE_SIZE = 50
+
+export const ArtworkInfo = () => {
+  const { state } = useArtworkListsContext()
+  const artwork = state.artwork!
+
+  const getArtistNames = () => {
+    if (!artwork.artistNames) {
+      return "Artist Unavailable"
+    }
+
+    return artwork.artistNames
+  }
+
+  return (
+    <Flex flexDirection="row" alignItems="center">
+      <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
+      <Spacer x={1} />
+      <Box>
+        <Text variant="sm-display" numberOfLines={1}>
+          {getArtistNames()}
+        </Text>
+        <Text variant="sm" color="black60" numberOfLines={2}>
+          <Text variant="sm" color="black60" italic>
+            {artwork.title}
+          </Text>
+          {artwork.year && `, ${artwork.year}`}
+        </Text>
+      </Box>
+    </Flex>
+  )
+}

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -26,9 +26,11 @@ export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
       <Spacer x={1} />
 
       <Box>
-        <Text variant="sm-display" numberOfLines={1}>
-          {getArtistNames(artwork)}
-        </Text>
+        {!!artwork.artistNames && (
+          <Text variant="sm-display" numberOfLines={1}>
+            {artwork.artistNames}
+          </Text>
+        )}
 
         <Text variant="sm" color="black60" numberOfLines={2}>
           <Text variant="sm" color="black60" italic>
@@ -39,12 +41,4 @@ export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
       </Box>
     </Flex>
   )
-}
-
-const getArtistNames = (artwork: ArtworkEntity) => {
-  if (!artwork.artistNames) {
-    return "Artist Unavailable"
-  }
-
-  return artwork.artistNames
 }

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -11,6 +11,7 @@ interface ArtworkInfoProps {
 export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
   return (
     <Flex flexDirection="row" alignItems="center">
+      {/* TODO: Use reusable artwork list image component */}
       <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
       <Spacer x={1} />
       <Box>

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -13,11 +13,14 @@ export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
     <Flex flexDirection="row" alignItems="center">
       {/* TODO: Use reusable artwork list image component */}
       <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
+
       <Spacer x={1} />
+
       <Box>
         <Text variant="sm-display" numberOfLines={1}>
           {getArtistNames(artwork)}
         </Text>
+
         <Text variant="sm" color="black60" numberOfLines={2}>
           <Text variant="sm" color="black60" italic>
             {artwork.title}

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkEntity } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { FC } from "react"
 
 const ARTWORK_IMAGE_SIZE = 50
@@ -12,7 +13,15 @@ export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
   return (
     <Flex flexDirection="row" alignItems="center">
       {/* TODO: Use reusable artwork list image component */}
-      <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
+      {artwork.imageURL ? (
+        <OpaqueImageView
+          width={ARTWORK_IMAGE_SIZE}
+          height={ARTWORK_IMAGE_SIZE}
+          imageURL={artwork.imageURL}
+        />
+      ) : (
+        <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
+      )}
 
       <Spacer x={1} />
 

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -9,21 +9,13 @@ interface ArtworkInfoProps {
 }
 
 export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
-  const getArtistNames = () => {
-    if (!artwork.artistNames) {
-      return "Artist Unavailable"
-    }
-
-    return artwork.artistNames
-  }
-
   return (
     <Flex flexDirection="row" alignItems="center">
       <Box width={ARTWORK_IMAGE_SIZE} height={ARTWORK_IMAGE_SIZE} bg="black15" />
       <Spacer x={1} />
       <Box>
         <Text variant="sm-display" numberOfLines={1}>
-          {getArtistNames()}
+          {getArtistNames(artwork)}
         </Text>
         <Text variant="sm" color="black60" numberOfLines={2}>
           <Text variant="sm" color="black60" italic>
@@ -34,4 +26,12 @@ export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
       </Box>
     </Flex>
   )
+}
+
+const getArtistNames = (artwork: ArtworkEntity) => {
+  if (!artwork.artistNames) {
+    return "Artist Unavailable"
+  }
+
+  return artwork.artistNames
 }

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tsx
@@ -1,12 +1,14 @@
 import { Box, Flex, Spacer, Text } from "@artsy/palette-mobile"
-import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { ArtworkEntity } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { FC } from "react"
 
 const ARTWORK_IMAGE_SIZE = 50
 
-export const ArtworkInfo = () => {
-  const { state } = useArtworkListsContext()
-  const artwork = state.artwork!
+interface ArtworkInfoProps {
+  artwork: ArtworkEntity
+}
 
+export const ArtworkInfo: FC<ArtworkInfoProps> = ({ artwork }) => {
   const getArtistNames = () => {
     if (!artwork.artistNames) {
       return "Artist Unavailable"

--- a/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle.tsx
@@ -1,9 +1,9 @@
-import { Text } from "@artsy/palette-mobile"
+import { Text, TextProps } from "@artsy/palette-mobile"
 import { FC } from "react"
 
-export const ArtworkListsBottomSheetSectionTitle: FC = ({ children }) => {
+export const ArtworkListsBottomSheetSectionTitle: FC<TextProps> = ({ children, ...rest }) => {
   return (
-    <Text variant="sm-display" textAlign="center" mt={1}>
+    <Text variant="sm-display" textAlign="center" {...rest}>
       {children}
     </Text>
   )

--- a/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle.tsx
@@ -3,7 +3,7 @@ import { FC } from "react"
 
 export const ArtworkListsBottomSheetSectionTitle: FC = ({ children }) => {
   return (
-    <Text variant="sm-display" textAlign="center" my={1}>
+    <Text variant="sm-display" textAlign="center" mt={1}>
       {children}
     </Text>
   )

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView.tsx
@@ -48,7 +48,9 @@ export const CreateNewArtworkListView = () => {
       onDismiss={closeCurrentView}
     >
       <BottomSheetView onLayout={handleContentLayout}>
-        <ArtworkListsBottomSheetSectionTitle>Create a new list</ArtworkListsBottomSheetSectionTitle>
+        <ArtworkListsBottomSheetSectionTitle mt={1}>
+          Create a new list
+        </ArtworkListsBottomSheetSectionTitle>
 
         <Box m={2}>
           <ArtworkInfo artwork={state.artwork!} />

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView.tsx
@@ -1,6 +1,7 @@
-import { Button, Spacer } from "@artsy/palette-mobile"
+import { Box, Button, Spacer } from "@artsy/palette-mobile"
 import { BottomSheetView, useBottomSheetDynamicSnapPoints } from "@gorhom/bottom-sheet"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { ArtworkInfo } from "app/Components/ArtworkLists/components/ArtworkInfo"
 import { ArtworkListsBottomSheetSectionTitle } from "app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle"
 import { AutomountedBottomSheetModal } from "app/Components/ArtworkLists/components/AutomountedBottomSheetModal"
 import { BottomSheetInput } from "app/Components/BottomSheetInput"
@@ -8,7 +9,7 @@ import { useMemo, useState } from "react"
 
 export const CreateNewArtworkListView = () => {
   const [name, setName] = useState("")
-  const { dispatch } = useArtworkListsContext()
+  const { state, dispatch } = useArtworkListsContext()
   const initialSnapPoints = useMemo(() => ["CONTENT_HEIGHT"], [])
 
   const { animatedHandleHeight, animatedSnapPoints, animatedContentHeight, handleContentLayout } =
@@ -48,6 +49,10 @@ export const CreateNewArtworkListView = () => {
     >
       <BottomSheetView onLayout={handleContentLayout}>
         <ArtworkListsBottomSheetSectionTitle>Create a new list</ArtworkListsBottomSheetSectionTitle>
+
+        <Box m={2}>
+          <ArtworkInfo artwork={state.artwork!} />
+        </Box>
 
         <BottomSheetInput placeholder="Placeholder" value={name} onChangeText={setName} />
 

--- a/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
+++ b/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Spacer, Text } from "@artsy/palette-mobile"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
+import { ArtworkInfo } from "app/Components/ArtworkLists/components/ArtworkInfo"
 import { ArtworkListsBottomSheetSectionTitle } from "app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle"
 import { AutomountedBottomSheetModal } from "app/Components/ArtworkLists/components/AutomountedBottomSheetModal"
 import { SelectArtworkListsForArtwork } from "app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/components/SelectArtworkListsForArtwork"
@@ -28,6 +29,10 @@ export const SelectArtworkListsForArtworkView = () => {
       <ArtworkListsBottomSheetSectionTitle>
         Select lists for this artwork
       </ArtworkListsBottomSheetSectionTitle>
+
+      <Box m={2}>
+        <ArtworkInfo />
+      </Box>
 
       {!!state.recentlyAddedArtworkList && (
         <Box bg="green100">

--- a/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
+++ b/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
@@ -26,7 +26,7 @@ export const SelectArtworkListsForArtworkView = () => {
 
   return (
     <AutomountedBottomSheetModal visible={visible} snapPoints={SNAP_POINTS} onDismiss={reset}>
-      <ArtworkListsBottomSheetSectionTitle>
+      <ArtworkListsBottomSheetSectionTitle mt={1}>
         Select lists for this artwork
       </ArtworkListsBottomSheetSectionTitle>
 

--- a/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
+++ b/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
@@ -31,7 +31,7 @@ export const SelectArtworkListsForArtworkView = () => {
       </ArtworkListsBottomSheetSectionTitle>
 
       <Box m={2}>
-        <ArtworkInfo />
+        <ArtworkInfo artwork={state.artwork!} />
       </Box>
 
       {!!state.recentlyAddedArtworkList && (


### PR DESCRIPTION
This PR resolves [FX-4754] <!-- eg [PROJECT-XXXX] -->

### Demo
#### iOS
https://user-images.githubusercontent.com/3513494/234289011-c5ea4034-2491-44d4-b151-f166686a7994.mp4

#### Android
https://user-images.githubusercontent.com/3513494/234289151-6753b70e-8641-46c5-8a75-d2a7ce054197.mp4

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- display artwork data in artwork lists bottom sheet - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4754]: https://artsyproduct.atlassian.net/browse/FX-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ