### PR TITLE
fix: don't let the bidders call get cached

### DIFF
--- a/ios/Artsy/Networking/ARRouter.m
+++ b/ios/Artsy/Networking/ARRouter.m
@@ -580,8 +580,9 @@ static NSString *hostFromString(NSString *string)
     if (saleID) {
         params = @{ @"sale_id" : saleID };
     }
-
-    return [self requestWithMethod:@"GET" path:ARMyBiddersURL parameters:params];
+    NSMutableURLRequest *req = [self requestWithMethod:@"GET" path:ARMyBiddersURL parameters:params];
+    req.cachePolicy = NSURLRequestReloadIgnoringCacheData;
+    return req;
 }
 
 + (NSURLRequest *)requestForSaleID:(NSString *)saleID


### PR DESCRIPTION
This PR resolves [MOPLAT-660] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Have a very strong suspicion this is the root of our issues with registered bidders seeing registration closed. Getting `304 Not Changed` responses from the service without this setting which will result in the cached values used, if the cache is bad the button will be in a bad state. Will try to reproduce the bug with this in mind tomorrow. In the meantime I don't think there is harm in merging this. 

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-  fix registered bidders sometimes seeing registration closed - Brian 

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-660]: https://artsyproduct.atlassian.net/browse/MOPLAT-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ