### PR TITLE
fix: only request push notifications once per login session

### DIFF
--- a/ios/Artsy/App/ARAppNotificationsDelegate.m
+++ b/ios/Artsy/App/ARAppNotificationsDelegate.m
@@ -194,9 +194,9 @@
         @"action_name" : @"Cancel",
         @"context_screen"  : analyticsContext
     }];
-    [AROptions setBool:YES forOption:ARPushNotificationsAppleDialogueRejected];
 #if (TARGET_IPHONE_SIMULATOR == 0)
     ARErrorLog(@"Error registering for remote notifications: %@", error.localizedDescription);
+    [AROptions setBool:YES forOption:ARPushNotificationsAppleDialogueRejected];
 #endif
 }
 

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -7,6 +7,9 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 export const HomeContainer = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
   const onboardingState = GlobalStore.useAppState((state) => state.auth.onboardingState)
+  const hasRequestedPermissionsThisSession = GlobalStore.useAppState(
+    (state) => state.auth.sessionState.requestedPushPermissionsThisSession
+  )
 
   const shouldShowArtQuiz = useFeatureFlag("ARShowArtQuizApp")
 
@@ -19,8 +22,12 @@ export const HomeContainer = () => {
     return null
   }
 
-  if (!onboardingState || onboardingState === "complete" || onboardingState === "none") {
+  if (
+    !hasRequestedPermissionsThisSession &&
+    (!onboardingState || onboardingState === "complete" || onboardingState === "none")
+  ) {
     requestPushNotificationsPermission()
+    GlobalStore.actions.auth.setSessionState({ requestedPushPermissionsThisSession: true })
   }
 
   return <HomeQueryRenderer />

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -178,6 +178,7 @@ export interface AuthPromiseRejectType {
 type SessionState = {
   isLoading: boolean
   isUserIdentified: boolean
+  requestedPushPermissionsThisSession: boolean
 }
 
 export interface AuthModel {
@@ -264,6 +265,7 @@ export const getAuthModel = (): AuthModel => ({
   sessionState: {
     isLoading: false,
     isUserIdentified: false,
+    requestedPushPermissionsThisSession: false,
   },
   userID: null,
   userAccessToken: null,
@@ -426,6 +428,9 @@ export const getAuthModel = (): AuthModel => ({
       }
 
       postEventToProviders(tracks.loggedIn(oauthProvider))
+
+      // Make sure we try to get push permission and new tokens on new sessions
+      GlobalStore.actions.auth.setSessionState({ requestedPushPermissionsThisSession: false })
 
       onSignIn?.()
 


### PR DESCRIPTION
This PR resolves [MOPLAT-737] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds a check to make sure we only request push permissions once per login session to not spam Android users with the settings dialog when they deny push permissions. 

**Follow-ups:**
Digging into this code revealed it is fairly buggy, probably at least partially my fault but having the logic split across native side and typescript side makes it hard to follow. Going to create a ticket to bring this all over to typescript, write some tests and hopefully fix some of these bugs:
- We are not refreshing tokens when the users push status is authorized
- Login is not the relevant event for our push logic, we should be checking it any time the app is launched
- Not a bug necessarily but now that Android has a similar push permissions model we should make the logic similar

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Fix push settings dialog showing many times - Brian 

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-737]: https://artsyproduct.atlassian.net/browse/MOPLAT-737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ