### PR TITLE
fix: move flag out of session state so it stays between sessions

### DIFF
--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -13,6 +13,7 @@ import { useWebViewCallback } from "app/utils/useWebViewEvent"
 import { debounce } from "lodash"
 import { parse as parseQueryString } from "query-string"
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
+import { Platform } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import Share from "react-native-share"
 import WebView, { WebViewProps } from "react-native-webview"
@@ -96,7 +97,11 @@ export const ArtsyWebViewPage = ({
   }
 
   return (
-    <Flex flex={1} pt={isPresentedModally ? 0 : `${saInsets.top}px`} backgroundColor="white">
+    <Flex
+      flex={1}
+      pt={isPresentedModally && Platform.OS !== "android" ? 0 : `${saInsets.top}px`}
+      backgroundColor="white"
+    >
       <ArtsyKeyboardAvoidingView>
         <FancyModalHeader
           useXButton={isPresentedModally && !canGoBack}

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -8,7 +8,7 @@ export const HomeContainer = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
   const onboardingState = GlobalStore.useAppState((state) => state.auth.onboardingState)
   const hasRequestedPermissionsThisSession = GlobalStore.useAppState(
-    (state) => state.auth.sessionState.requestedPushPermissionsThisSession
+    (state) => state.auth.requestedPushPermissionsThisSession
   )
 
   const shouldShowArtQuiz = useFeatureFlag("ARShowArtQuizApp")
@@ -27,7 +27,7 @@ export const HomeContainer = () => {
     (!onboardingState || onboardingState === "complete" || onboardingState === "none")
   ) {
     requestPushNotificationsPermission()
-    GlobalStore.actions.auth.setSessionState({ requestedPushPermissionsThisSession: true })
+    GlobalStore.actions.auth.setState({ requestedPushPermissionsThisSession: true })
   }
 
   return <HomeQueryRenderer />

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -408,6 +408,8 @@ export const getAuthModel = (): AuthModel => ({
         userID: user.id,
         userEmail: email,
         onboardingState: onboardingState ?? "complete",
+        // Make sure we try to get push permission and new tokens on new sessions
+        requestedPushPermissionsThisSession: false,
       })
 
       if (oauthProvider === "email") {
@@ -428,9 +430,6 @@ export const getAuthModel = (): AuthModel => ({
       }
 
       postEventToProviders(tracks.loggedIn(oauthProvider))
-
-      // Make sure we try to get push permission and new tokens on new sessions
-      GlobalStore.actions.auth.setState({ requestedPushPermissionsThisSession: false })
 
       onSignIn?.()
 

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -178,7 +178,6 @@ export interface AuthPromiseRejectType {
 type SessionState = {
   isLoading: boolean
   isUserIdentified: boolean
-  requestedPushPermissionsThisSession: boolean
 }
 
 export interface AuthModel {
@@ -195,6 +194,7 @@ export interface AuthModel {
   previousSessionUserID: string | null
 
   userHasArtsyEmail: Computed<this, boolean, GlobalStoreModel>
+  requestedPushPermissionsThisSession: boolean
 
   // Actions
   setState: Action<this, Partial<StateMapper<this>>>
@@ -265,7 +265,6 @@ export const getAuthModel = (): AuthModel => ({
   sessionState: {
     isLoading: false,
     isUserIdentified: false,
-    requestedPushPermissionsThisSession: false,
   },
   userID: null,
   userAccessToken: null,
@@ -277,6 +276,7 @@ export const getAuthModel = (): AuthModel => ({
   userEmail: null,
   previousSessionUserID: null,
   userHasArtsyEmail: computed((state) => isArtsyEmail(state.userEmail ?? "")),
+  requestedPushPermissionsThisSession: false,
 
   setState: action((state, payload) => Object.assign(state, payload)),
   setSessionState: action((state, payload) => {
@@ -430,7 +430,7 @@ export const getAuthModel = (): AuthModel => ({
       postEventToProviders(tracks.loggedIn(oauthProvider))
 
       // Make sure we try to get push permission and new tokens on new sessions
-      GlobalStore.actions.auth.setSessionState({ requestedPushPermissionsThisSession: false })
+      GlobalStore.actions.auth.setState({ requestedPushPermissionsThisSession: false })
 
       onSignIn?.()
 

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -832,3 +832,21 @@ describe("App version Versions.AddOnboardingArtQuizStateToAuthModel", () => {
     expect(migratedState.auth.onboardingArtQuizState).toEqual("none")
   })
 })
+
+describe("App version Versions.AddPushPromptStateToAuthModel", () => {
+  const migrationToTest = Versions.AddPushPromptStateToAuthModel
+
+  it("adds hasRequestedPushPermissions to the auth model", () => {
+    const previousState = migrate({
+      state: { version: 0 },
+      toVersion: migrationToTest - 1,
+    })
+
+    const migratedState = migrate({
+      state: previousState,
+      toVersion: migrationToTest,
+    }) as any
+
+    expect(migratedState.auth.hasRequestedPushPermissions).toEqual(false)
+  })
+})

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -836,7 +836,7 @@ describe("App version Versions.AddOnboardingArtQuizStateToAuthModel", () => {
 describe("App version Versions.AddPushPromptStateToAuthModel", () => {
   const migrationToTest = Versions.AddPushPromptStateToAuthModel
 
-  it("adds hasRequestedPushPermissions to the auth model", () => {
+  it("adds requestedPushPermissionsThisSession to the auth model", () => {
     const previousState = migrate({
       state: { version: 0 },
       toVersion: migrationToTest - 1,
@@ -847,6 +847,6 @@ describe("App version Versions.AddPushPromptStateToAuthModel", () => {
       toVersion: migrationToTest,
     }) as any
 
-    expect(migratedState.auth.hasRequestedPushPermissions).toEqual(false)
+    expect(migratedState.auth.requestedPushPermissionsThisSession).toEqual(false)
   })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -46,9 +46,10 @@ export const Versions = {
   MoveEnvironmentToDevicePrefsAndRenameAdminToLocal: 34,
   AddCategoryToSubmissionArtworkDetails: 35,
   AddOnboardingArtQuizStateToAuthModel: 36,
+  AddPushPromptStateToAuthModel: 37,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddOnboardingArtQuizStateToAuthModel
+export const CURRENT_APP_VERSION = Versions.AddPushPromptStateToAuthModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -270,6 +271,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.AddOnboardingArtQuizStateToAuthModel]: (state) => {
     state.auth.onboardingArtQuizState = "none"
+  },
+  [Versions.AddPushPromptStateToAuthModel]: (state) => {
+    state.auth.requestedPushPermissionsThisSession = false
   },
 }
 

--- a/src/app/utils/PushNotification.ts
+++ b/src/app/utils/PushNotification.ts
@@ -1,8 +1,12 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import { getCurrentEmissionState, GlobalStore } from "app/store/GlobalStore"
+import {
+  getCurrentEmissionState,
+  GlobalStore,
+  unsafe__getEnvironment,
+  unsafe_getUserAccessToken,
+} from "app/store/GlobalStore"
 import { PendingPushNotification } from "app/store/PendingPushNotificationModel"
-import { unsafe__getEnvironment, unsafe_getUserAccessToken } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { Alert, Linking, Platform } from "react-native"
 import DeviceInfo from "react-native-device-info"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Good spot @damassi this can't be in session state if we want it to persist and prevent showing dialog if user kills the app.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Fix the push settings dialog showing up for real - Brian 

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
