### PR TITLE
chore: make my c auction results query optional

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Insights/AuctionResultsForArtistsYouCollect.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/AuctionResultsForArtistsYouCollect.tsx
@@ -100,7 +100,7 @@ const auctionResultsForArtistsYouCollectFragment = graphql`
 
 const AuctionResultsForArtistsYouCollectScreenQuery = graphql`
   query AuctionResultsForArtistsYouCollectQuery($count: Int, $after: String) {
-    me {
+    me @optionalField {
       ...AuctionResultsForArtistsYouCollect_me @arguments(count: $count, after: $after)
     }
   }


### PR DESCRIPTION
### Description

@egdbear this PR makes the auction results query optional to avoid breaking my collection tab because of timeouts there

In the long term we would like to support lazy loading with the sticky tabs and only triggering this query when we land on the insights tab
#nochangelog