### PR TITLE
feat: enable react/jsx-no-leaked-render eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,6 +119,7 @@ module.exports = {
     "react/no-unescaped-entities": OFF,
     "react/react-in-jsx-scope": OFF,
     "react/prop-types": OFF,
+    "react/jsx-no-leaked-render": [ERR, { validStrategies: ["coerce"] }],
     "react-native/no-inline-styles": OFF,
     "react-hooks/exhaustive-deps": OFF, // we don't care about this rule, since it's often wrong. it's helpful, but often wrong.
   },


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

When we were using eslint we had the `jsxSafeConditionalsRule` custom rule for preventing of doing stuff that can crash the app like:

```tsx
const whatever = "test"

// ....random code in between......

whatever && <Text>{whatever}</Text>
```

and encouraged something like that (adding doublequotes):

```tsx
const whatever = "test"

// ....random code in between......
!!whatever && <Text>{whatever}</Text>
```

This PR enables the use of `react/jsx-no-leaked-render` rule which pretty much does the same! 

You can read more about this rule [here](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)

#### Demo Video:


https://user-images.githubusercontent.com/21178754/236007635-5d8f4b4b-ac12-4c25-b1f8-a0c4869f035b.mov



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
#nochangelog