### PR TITLE
fix: remove all implicit returns in reanimated hooks

### DIFF
--- a/src/app/Components/AnimatableHeader/AnimatableHeaderLargeTitle.tsx
+++ b/src/app/Components/AnimatableHeader/AnimatableHeaderLargeTitle.tsx
@@ -7,12 +7,11 @@ export const AnimatableHeaderLargeTitle = () => {
   const { scrollOffsetY, largeTitleVerticalOffset, setLargeTitleHeight, largeTitleEndEdge, title } =
     useAnimatableHeaderContext()
 
-  const disappearAnim = useAnimatedStyle(
-    () => ({
+  const disappearAnim = useAnimatedStyle(() => {
+    return {
       opacity: interpolate(scrollOffsetY.value, [0, largeTitleEndEdge], [1, 0], Extrapolate.CLAMP),
-    }),
-    [largeTitleEndEdge]
-  )
+    }
+  }, [largeTitleEndEdge])
 
   return (
     <Animated.View

--- a/src/app/Components/AnimatableHeader/AnimatableHeaderShadow.tsx
+++ b/src/app/Components/AnimatableHeader/AnimatableHeaderShadow.tsx
@@ -9,20 +9,22 @@ export const AnimatableHeaderShadow = () => {
   const { scrollOffsetY, headerHeight } = useAnimatableHeaderContext()
   const color = useColor()
 
-  const shadowAnim = useAnimatedStyle(() => ({
-    shadowOpacity: interpolate(
-      scrollOffsetY.value,
-      [0, SHADOW_SCROLL_OFFSET],
-      [0, 0.1],
-      Extrapolate.CLAMP
-    ),
-    elevation: interpolate(
-      scrollOffsetY.value,
-      [0, SHADOW_SCROLL_OFFSET],
-      [0, 3],
-      Extrapolate.CLAMP
-    ),
-  }))
+  const shadowAnim = useAnimatedStyle(() => {
+    return {
+      shadowOpacity: interpolate(
+        scrollOffsetY.value,
+        [0, SHADOW_SCROLL_OFFSET],
+        [0, 0.1],
+        Extrapolate.CLAMP
+      ),
+      elevation: interpolate(
+        scrollOffsetY.value,
+        [0, SHADOW_SCROLL_OFFSET],
+        [0, 3],
+        Extrapolate.CLAMP
+      ),
+    }
+  })
 
   return (
     <Box

--- a/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetBackdrop.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkListsBottomSheetBackdrop.tsx
@@ -12,9 +12,11 @@ export const ArtworkListsBottomSheetBackdrop = ({
   const color = useColor()
 
   // animated variables
-  const containerAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(animatedIndex.value, [-1, 0], [0, MAX_OPACITY], Extrapolate.CLAMP),
-  }))
+  const containerAnimatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: interpolate(animatedIndex.value, [-1, 0], [0, MAX_OPACITY], Extrapolate.CLAMP),
+    }
+  })
 
   // styles
   const containerStyle = useMemo(

--- a/src/app/Components/SearchInput.tsx
+++ b/src/app/Components/SearchInput.tsx
@@ -26,14 +26,13 @@ export const SearchInput = forwardRef<InputRef, SearchInputProps>(
     const [cancelButtonShown, setCancelButtonShown] = useState(false)
     const width = useWindowDimensions().width - space(mx) * 2
 
-    const shrinkAnim = useAnimatedStyle(
-      () => ({
+    const shrinkAnim = useAnimatedStyle(() => {
+      return {
         width: withTiming(width - (cancelButtonShown ? cancelWidth : 0), {
           duration: CANCEL_BUTTON_DURATION,
         }),
-      }),
-      [cancelButtonShown, cancelWidth]
-    )
+      }
+    }, [cancelButtonShown, cancelWidth])
 
     const inputRef = useRef<InputRef>(null)
     useImperativeHandle(ref, () => inputRef.current!)

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -7,18 +7,18 @@ import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/Artwor
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
 import { HeaderButton } from "app/Components/HeaderButton"
 import { SearchImageHeaderButton } from "app/Components/SearchImageHeaderButton"
+import { NavigationalTabs, TabsType } from "app/Components/Tabs"
 import { goBack } from "app/system/navigation/navigate"
 import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { useScreenDimensions } from "app/utils/hooks"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
-import { NavigationalTabs, TabsType } from "app/Components/Tabs"
 import React, { useCallback, useRef, useState } from "react"
 import { FlatList, View } from "react-native"
 import Animated, { runOnJS, useAnimatedScrollHandler } from "react-native-reanimated"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import { useTracking } from "react-tracking"
-import { useScreenDimensions } from "app/utils/hooks"
 import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
 import { FairCollectionsFragmentContainer } from "./Components/FairCollections"
 import { FairEditorialFragmentContainer } from "./Components/FairEditorial"
@@ -172,7 +172,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
 
   const scrollHandler = useAnimatedScrollHandler((event) => {
     const hideButtons = event.contentOffset.y > HEADER_SCROLL_THRESHOLD
-    runOnJS(setShouldHideButtons)(hideButtons)
+    return runOnJS(setShouldHideButtons)(hideButtons)
   })
 
   return (
@@ -274,7 +274,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
         <ChevronIcon direction="left" width={BACK_ICON_SIZE} height={BACK_ICON_SIZE} />
       </HeaderButton>
       <SearchImageHeaderButton
-        isImageSearchButtonVisible={shouldShowImageSearchButton && !shouldHideButtons}
+        isImageSearchButtonVisible={!!shouldShowImageSearchButton && !shouldHideButtons}
         owner={{
           type: OwnerType.fair,
           id: fair.internalID,

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingWelcome.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingWelcome.tsx
@@ -59,12 +59,24 @@ const OnboardingWelcome = () => {
   const screenHeight = "100%"
 
   const fadeOutAnimationsArr = [
-    useAnimatedStyle(() => ({ opacity: opacity.value - 1 })),
-    useAnimatedStyle(() => ({ opacity: opacity.value - 2 })),
-    useAnimatedStyle(() => ({ opacity: opacity.value - 3 })),
-    useAnimatedStyle(() => ({ opacity: opacity.value - 4 })),
-    useAnimatedStyle(() => ({ opacity: opacity.value - 5 })),
-    useAnimatedStyle(() => ({ opacity: opacity.value - 6 })),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 1 }
+    }),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 2 }
+    }),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 3 }
+    }),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 4 }
+    }),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 5 }
+    }),
+    useAnimatedStyle(() => {
+      return { opacity: opacity.value - 6 }
+    }),
   ]
 
   useEffect(() => {

--- a/src/app/Scenes/Onboarding/OnboardingWelcome.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingWelcome.tsx
@@ -33,16 +33,18 @@ export const OnboardingWelcome: React.FC<OnboardingWelcomeProps> = ({ navigation
 
   // text and logo appearance
   const opacity = useSharedValue(0)
-  const appearAnim = useAnimatedStyle(() => ({ opacity: opacity.value }))
+  const appearAnim = useAnimatedStyle(() => {
+    return { opacity: opacity.value }
+  })
   useEffect(() => {
     opacity.value = withDelay(100, withTiming(1))
   }, [])
 
   // background sliding
   const translateX = useSharedValue(0)
-  const slideAnim = useAnimatedStyle(() => ({
-    transform: [{ translateX: translateX.value }],
-  }))
+  const slideAnim = useAnimatedStyle(() => {
+    return { transform: [{ translateX: translateX.value }] }
+  })
   useEffect(() => {
     // We want to animate the background only when the device width is smaller than the scaled image width
     const imgScale = imgProps.height / screenHeight

--- a/src/app/utils/animations/useSkeletonAnimation.tsx
+++ b/src/app/utils/animations/useSkeletonAnimation.tsx
@@ -26,11 +26,13 @@ export function useSkeletonAnimation({
     }
   }, [])
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: enableSkeletonAnimation
-      ? interpolate(shared.value, [0, 1], [targetOpacityValue, 1])
-      : 1,
-  }))
+  const animatedStyle = useAnimatedStyle(() => {
+    return {
+      opacity: enableSkeletonAnimation
+        ? interpolate(shared.value, [0, 1], [targetOpacityValue, 1])
+        : 1,
+    }
+  })
 
   return animatedStyle
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

We believe that implicit returns are not playing well with babel resulting in our js functions in hooks not being converted to "worklets" which causes crashes when reanimated tries to run them on the wrong thread.

This converts all our reanimated hooks to have explicit returns.

https://artsy.slack.com/archives/C02NAJ2CGLW/p1683148878257549

props @gkartalis @damassi for sleuthing

# Follow-up:
- There is a function useCode() from reanimated used throughout our code that still has implicit returns, if we keep seeing issues maybe this needs updating as well

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Hopefully fix reanimated crashes - Brian, Chris, George 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
