### PR TITLE
fix: always use fixed height for error/remaining label in create artwork list flow

### DIFF
--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListInput.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListInput.tsx
@@ -1,4 +1,4 @@
-import { InputProps } from "@artsy/palette-mobile"
+import { Box, Flex, InputProps, Text, computeBorderColor, useColor } from "@artsy/palette-mobile"
 import { BottomSheetInput } from "app/Components/BottomSheetInput"
 import { RemainingCharactersLabel } from "./RemainingCharactersLabel"
 
@@ -7,11 +7,23 @@ interface CreateNewArtworkListInputProps extends InputProps {
   maxLength: number
 }
 
-export const CreateNewArtworkListInput = (props: CreateNewArtworkListInputProps) => {
+export const CreateNewArtworkListInput = ({ error, ...rest }: CreateNewArtworkListInputProps) => {
+  const color = useColor()
+  const borderColor = color(computeBorderColor({ error: !!error }))
+
   return (
-    <>
-      <BottomSheetInput {...props} />
-      <RemainingCharactersLabel currentLength={props.value.length} maxLength={props.maxLength} />
-    </>
+    <Box>
+      <BottomSheetInput {...rest} style={{ borderColor: borderColor }} />
+
+      <Flex height={25} justifyContent="center" mt={1}>
+        {!!error ? (
+          <Text variant="xs" color="red100">
+            {error}
+          </Text>
+        ) : (
+          <RemainingCharactersLabel currentLength={rest.value.length} maxLength={rest.maxLength} />
+        )}
+      </Flex>
+    </Box>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
Fixing the issue that was discussed in [this Slack thread](https://artsy.slack.com/archives/C9SATFLUU/p1683218101980409)

### Demo
#### iOS
| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/236276403-6406f383-ba83-4993-a5de-e4679bc89a56.mp4" />  | <video src="https://user-images.githubusercontent.com/3513494/236276490-dac2e1ae-d490-446d-8f89-d9069b86a224.mp4" />  | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- always use fixed height for error/remaining label in create artwork list flow - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
