### PR TITLE
feat(FX-4762): Support CTA in Toast

### DIFF
--- a/src/app/Components/ArtworkLists/useArtworkListsToast.ts
+++ b/src/app/Components/ArtworkLists/useArtworkListsToast.ts
@@ -30,6 +30,7 @@ export const useArtworkListToast = () => {
 
     toast.show(message, DEFAULT_TOAST_PLACEMENT, {
       backgroundColor: "green100",
+      cta: "View List",
       onPress: () => {
         navigate(`/artwork-list/${artworkList.internalID}`)
       },
@@ -41,6 +42,7 @@ export const useArtworkListToast = () => {
 
     toast.show(message, DEFAULT_TOAST_PLACEMENT, {
       backgroundColor: "green100",
+      cta: "View Saves",
       onPress: () => {
         navigate(`/artwork-lists`)
       },

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -1,11 +1,10 @@
-import { Flex, useColor, Text } from "@artsy/palette-mobile"
+import { Flex, useColor, Text, Touchable } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { GlobalStore } from "app/store/GlobalStore"
-import { Touchable } from "@artsy/palette-mobile"
+import { useScreenDimensions } from "app/utils/hooks"
 import { useEffect, useState } from "react"
 import { Animated } from "react-native"
 import useTimeoutFn from "react-use/lib/useTimeoutFn"
-import { useScreenDimensions } from "app/utils/hooks"
 import { ToastDetails, ToastDuration } from "./types"
 
 const AnimatedFlex = Animated.createAnimatedComponent(Flex)
@@ -30,6 +29,7 @@ export const ToastComponent = ({
   Icon,
   backgroundColor = "black100",
   duration = "short",
+  cta,
 }: ToastDetails) => {
   const toastDuration = TOAST_DURATION_MAP[duration]
   const color = useColor()
@@ -97,9 +97,18 @@ export const ToastComponent = ({
   const innerTopBottom = (
     <Flex flex={1} flexDirection="row" alignItems="center" mx={2}>
       {Icon !== undefined ? <Icon fill="white100" width={25} height={25} mr={1} /> : null}
-      <Text variant="xs" color="white100">
-        {message}
-      </Text>
+
+      <Flex flex={1}>
+        <Text variant="xs" color="white100">
+          {message}
+        </Text>
+      </Flex>
+
+      {!!cta && (
+        <Text variant="sm" color="white100" underline>
+          {cta}
+        </Text>
+      )}
     </Flex>
   )
 

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -105,7 +105,7 @@ export const ToastComponent = ({
       </Flex>
 
       {!!cta && (
-        <Text variant="sm" color="white100" underline>
+        <Text variant="xs" color="white100" underline>
           {cta}
         </Text>
       )}

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -137,7 +137,6 @@ export const ToastComponent = ({
       backgroundColor={color(backgroundColor)}
       opacity={opacityAnim.interpolate({ inputRange: [0, 1], outputRange: [0, 1] })}
       overflow="hidden"
-      paddingRight={2}
       zIndex={999}
     >
       {onPress !== undefined ? (

--- a/src/app/Components/Toast/types.ts
+++ b/src/app/Components/Toast/types.ts
@@ -16,6 +16,7 @@ export interface ToastDetails {
 
   placement: ToastPlacement
   message: string
+  cta?: string
 
   onPress?: (helpers: ToastOnPressHelpers) => void
   Icon?: React.FC<IconProps>
@@ -23,4 +24,7 @@ export interface ToastDetails {
   duration?: ToastDuration
 }
 
-export type ToastOptions = Pick<ToastDetails, "onPress" | "Icon" | "backgroundColor" | "duration">
+export type ToastOptions = Pick<
+  ToastDetails,
+  "onPress" | "Icon" | "backgroundColor" | "duration" | "cta"
+>

--- a/src/app/Components/Toast/types.ts
+++ b/src/app/Components/Toast/types.ts
@@ -16,6 +16,8 @@ export interface ToastDetails {
 
   placement: ToastPlacement
   message: string
+
+  /* Display CTA for toasts with top or bottom placement */
   cta?: string
 
   onPress?: (helpers: ToastOnPressHelpers) => void


### PR DESCRIPTION
This PR resolves [FX-4762] <!-- eg [PROJECT-XXXX] -->

### ToDo
- [x] Clarify `paddingRight` with Carlos
- [x] Clarify display of CTAs for middle placed toasts

### Acceptance Criteria
* Add the ability to pass the CTA for the Toast component
* The whole toast should remain clickable, **not** just CTA

### Demo
| Before | After |
| ------------- | ------------- |
| ![before-1](https://user-images.githubusercontent.com/3513494/236295036-84be3ba7-b336-4fda-b72a-d061457ca1e4.png) | ![after-1-xs](https://user-images.githubusercontent.com/3513494/236299883-cf5fe96d-0606-441c-a6db-1720321072c5.png) | 
| ![before-2](https://user-images.githubusercontent.com/3513494/236295107-a0dcfdc0-f37f-40a8-aabe-b090f3149cfe.png) | ![after-2-xs](https://user-images.githubusercontent.com/3513494/236299777-02c31e9f-4114-4620-bc83-8b0bcdb4c965.png) |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Support CTA in Toast - dimatretyak

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4762]: https://artsyproduct.atlassian.net/browse/FX-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ