### PR TITLE
fix: use the same relay env between Home screen and `useMutation`

### DIFF
--- a/src/app/Components/Artist/ArtistHeader.tsx
+++ b/src/app/Components/Artist/ArtistHeader.tsx
@@ -3,7 +3,6 @@ import { ArtistHeaderFollowArtistMutation } from "__generated__/ArtistHeaderFoll
 import { ArtistHeader_artist$data } from "__generated__/ArtistHeader_artist.graphql"
 import { FollowButton } from "app/Components/Button/FollowButton"
 import { formatLargeNumberOfItems } from "app/utils/formatLargeNumberOfItems"
-import { refreshOnArtistFollow } from "app/utils/refreshHelpers"
 import { Schema } from "app/utils/track"
 import { useState } from "react"
 import { commitMutation, createFragmentContainer, graphql, RelayProp } from "react-relay"
@@ -87,7 +86,6 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
   }
 
   const successfulFollowChange = () => {
-    refreshOnArtistFollow()
     trackEvent({
       action_name: artist.isFollowed
         ? Schema.ActionNames.ArtistUnfollow

--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -5,7 +5,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { SaveArtworkOptions, useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { graphql, useFragment } from "react-relay"
 
-interface Options extends Pick<SaveArtworkOptions, "onCompleted" | "onError" | "contextScreen"> {
+interface Options extends Pick<SaveArtworkOptions, "onCompleted" | "onError"> {
   artworkFragmentRef: useSaveArtworkToArtworkLists_artwork$key
 }
 

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -171,7 +171,6 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
     internalID,
     isSaved,
     onCompleted: onArtworkSavedOrUnSaved,
-    contextScreen: trackingContextScreenOwnerType,
   })
 
   const displayForRecentlySoldArtwork =
@@ -397,7 +396,7 @@ const RecentlySoldCardSection: React.FC<
         <Text variant="lg-display" numberOfLines={1}>
           {priceRealizedDisplay}
         </Text>
-        {performanceDisplay && (
+        {!!performanceDisplay && (
           <Text variant="lg-display" color="green" numberOfLines={1}>
             {`+${performanceDisplay}`}
           </Text>

--- a/src/app/Scenes/Home/Home.tests.tsx
+++ b/src/app/Scenes/Home/Home.tests.tsx
@@ -1,9 +1,8 @@
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
-import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { act } from "react-test-renderer"
 import { GraphQLSingularResponse } from "relay-runtime"
-import { createMockEnvironment } from "relay-test-utils"
 import { HomeQueryRenderer } from "./Home"
 
 jest.mock("app/Components/Home/ArtistRails/ArtistRail", () => ({
@@ -19,11 +18,11 @@ jest.mock("app/Scenes/Home/Components/SalesRail", () => ({
   SalesRailFragmentContainer: jest.fn(() => null),
 }))
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe(HomeQueryRenderer, () => {
   const getWrapper = async () => {
-    const tree = renderWithHookWrappersTL(<HomeQueryRenderer />, mockEnvironment)
+    const tree = renderWithWrappers(<HomeQueryRenderer environment={mockEnvironment} />)
 
     mockMostRecentOperation("HomeAboveTheFoldQuery", {
       errors: [],

--- a/src/app/Scenes/Home/Home.tests.tsx
+++ b/src/app/Scenes/Home/Home.tests.tsx
@@ -1,8 +1,8 @@
+import { defaultEnvironment } from "app/system/relay/createEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { act } from "react-test-renderer"
 import { GraphQLSingularResponse } from "relay-runtime"
-import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { createMockEnvironment } from "relay-test-utils"
 import { HomeQueryRenderer } from "./Home"
 
@@ -19,29 +19,11 @@ jest.mock("app/Scenes/Home/Components/SalesRail", () => ({
   SalesRailFragmentContainer: jest.fn(() => null),
 }))
 
+const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+
 describe(HomeQueryRenderer, () => {
-  let mockEnvironment: ReturnType<typeof createMockEnvironment>
-
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
-
-  const mockMostRecentOperation = (
-    name: string,
-    result: GraphQLSingularResponse = { errors: [] }
-  ) => {
-    expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(name)
-
-    act(() => {
-      mockEnvironment.mock.resolveMostRecentOperation(result)
-    })
-  }
-
   const getWrapper = async () => {
-    const tree = renderWithHookWrappersTL(
-      <HomeQueryRenderer environment={mockEnvironment as unknown as RelayModernEnvironment} />,
-      mockEnvironment
-    )
+    const tree = renderWithHookWrappersTL(<HomeQueryRenderer />, mockEnvironment)
 
     mockMostRecentOperation("HomeAboveTheFoldQuery", {
       errors: [],
@@ -76,9 +58,20 @@ describe(HomeQueryRenderer, () => {
     expect(getByTestId("home-flat-list")).toBeTruthy()
   })
 
-  // it("renders an email confirmation banner", async () => {
-  //   const { getByText } = await getWrapper()
+  it("renders an email confirmation banner", async () => {
+    const { getByText } = await getWrapper()
 
-  //   expect(getByText("Tap here to verify your email address")).toBeTruthy()
-  // })
+    expect(getByText("Tap here to verify your email address")).toBeTruthy()
+  })
 })
+
+const mockMostRecentOperation = (
+  name: string,
+  result: GraphQLSingularResponse = { errors: [] }
+) => {
+  expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(name)
+
+  act(() => {
+    mockEnvironment.mock.resolveMostRecentOperation(result)
+  })
+}

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -93,7 +93,6 @@ import {
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
 import { useTracking } from "react-tracking"
-import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useContentCards } from "./Components/ContentCards"
 import HomeAnalytics from "./homeAnalytics"
 import { useHomeModules } from "./useHomeModules"
@@ -690,11 +689,7 @@ const messages = {
   },
 }
 
-interface HomeQRProps {
-  environment?: RelayModernEnvironment
-}
-
-export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
+export const HomeQueryRenderer: React.FC = () => {
   const { flash_message } = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.tabProps.home ?? {}
   ) as {
@@ -737,7 +732,7 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
 
   return (
     <AboveTheFoldQueryRenderer<HomeAboveTheFoldQuery, HomeBelowTheFoldQuery>
-      environment={environment || getRelayEnvironment()}
+      environment={getRelayEnvironment()}
       above={{
         query: graphql`
           query HomeAboveTheFoldQuery($version: String!) {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -50,7 +50,7 @@ import {
 import { search2QueryDefaultVariables } from "app/Scenes/Search/Search2"
 import { ViewingRoomsHomeMainRail } from "app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
 import { maybeReportExperimentVariant } from "app/utils/experiments/reporter"
@@ -741,7 +741,7 @@ export const HomeQueryRenderer: React.FC = () => {
 
   return (
     <AboveTheFoldQueryRenderer<HomeAboveTheFoldQuery, HomeBelowTheFoldQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       above={{
         query: graphql`
           query HomeAboveTheFoldQuery($version: String!) {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -93,6 +93,8 @@ import {
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
 import { useTracking } from "react-tracking"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
+import { RelayMockEnvironment } from "relay-test-utils/lib/RelayModernMockEnvironment"
 import { useContentCards } from "./Components/ContentCards"
 import HomeAnalytics from "./homeAnalytics"
 import { useHomeModules } from "./useHomeModules"
@@ -689,7 +691,11 @@ const messages = {
   },
 }
 
-export const HomeQueryRenderer: React.FC = () => {
+interface HomeQRProps {
+  environment?: RelayModernEnvironment | RelayMockEnvironment
+}
+
+export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
   const { flash_message } = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.tabProps.home ?? {}
   ) as {
@@ -732,7 +738,7 @@ export const HomeQueryRenderer: React.FC = () => {
 
   return (
     <AboveTheFoldQueryRenderer<HomeAboveTheFoldQuery, HomeBelowTheFoldQuery>
-      environment={getRelayEnvironment()}
+      environment={environment || getRelayEnvironment()}
       above={{
         query: graphql`
           query HomeAboveTheFoldQuery($version: String!) {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -93,6 +93,7 @@ import {
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 
 import { useTracking } from "react-tracking"
+import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useContentCards } from "./Components/ContentCards"
 import HomeAnalytics from "./homeAnalytics"
 import { useHomeModules } from "./useHomeModules"
@@ -689,7 +690,11 @@ const messages = {
   },
 }
 
-export const HomeQueryRenderer: React.FC = () => {
+interface HomeQRProps {
+  environment?: RelayModernEnvironment
+}
+
+export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
   const { flash_message } = GlobalStore.useAppState(
     (state) => state.bottomTabs.sessionState.tabProps.home ?? {}
   ) as {
@@ -732,7 +737,7 @@ export const HomeQueryRenderer: React.FC = () => {
 
   return (
     <AboveTheFoldQueryRenderer<HomeAboveTheFoldQuery, HomeBelowTheFoldQuery>
-      environment={getRelayEnvironment()}
+      environment={environment || getRelayEnvironment()}
       above={{
         query: graphql`
           query HomeAboveTheFoldQuery($version: String!) {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -64,7 +64,6 @@ import {
   useMemoizedRandom,
 } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
-import { RefreshEvents, HOME_SCREEN_REFRESH_KEY } from "app/utils/refreshHelpers"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import {
   ArtworkActionTrackingProps,
@@ -199,14 +198,6 @@ const Home = memo((props: HomeProps) => {
   ).current
 
   const { isRefreshing, handleRefresh, scrollRefs } = useHandleRefresh(relay, modules)
-
-  useEffect(() => {
-    RefreshEvents.addListener(HOME_SCREEN_REFRESH_KEY, handleRefresh)
-
-    return () => {
-      RefreshEvents.removeListener(HOME_SCREEN_REFRESH_KEY, handleRefresh)
-    }
-  }, [])
 
   const renderItem: ListRenderItem<HomeModule> | null | undefined = useCallback(
     ({ item, index }: { item: HomeModule; index: number }) => {

--- a/src/app/utils/mutations/useSaveArtwork.ts
+++ b/src/app/utils/mutations/useSaveArtwork.ts
@@ -1,6 +1,4 @@
-import { ScreenOwnerType } from "@artsy/cohesion"
 import { refreshOnArtworkSave } from "app/utils/refreshHelpers"
-import { Schema } from "app/utils/track"
 import { useMutation } from "react-relay"
 import { graphql } from "relay-runtime"
 
@@ -10,7 +8,6 @@ export interface SaveArtworkOptions {
   isSaved: boolean | null
   onCompleted?: (isSaved: boolean) => void
   onError?: () => void
-  contextScreen?: Schema.OwnerEntityTypes | ScreenOwnerType
 }
 
 export const useSaveArtwork = ({
@@ -19,7 +16,6 @@ export const useSaveArtwork = ({
   isSaved,
   onCompleted,
   onError,
-  contextScreen,
 }: SaveArtworkOptions) => {
   const [commit] = useMutation(SaveArtworkMutation)
   const nextSavedState = !isSaved
@@ -41,7 +37,7 @@ export const useSaveArtwork = ({
         },
       },
       onCompleted: () => {
-        refreshOnArtworkSave(contextScreen)
+        refreshOnArtworkSave()
         onCompleted?.(nextSavedState)
       },
       onError: () => {

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -1,7 +1,5 @@
 import EventEmitter from "events"
 import { PAGE_SIZE } from "app/Components/constants"
-import { SaveArtworkOptions } from "app/utils/mutations/useSaveArtwork"
-import { Schema } from "app/utils/track"
 import { useState } from "react"
 import { RefreshControl } from "react-native"
 
@@ -11,23 +9,9 @@ RefreshEvents.setMaxListeners(20)
 export const FAVORITE_ARTWORKS_REFRESH_KEY = "refreshFavoriteArtworks"
 export const MY_COLLECTION_REFRESH_KEY = "refreshMyCollection"
 export const MY_COLLECTION_INSIGHTS_REFRESH_KEY = "refreshMyCollectionInsights"
-export const HOME_SCREEN_REFRESH_KEY = "refreshHomeScreen"
 
-export const refreshOnArtworkSave = (contextScreen: SaveArtworkOptions["contextScreen"]) => {
+export const refreshOnArtworkSave = () => {
   refreshFavoriteArtworks()
-
-  refreshHomeScreen(contextScreen)
-}
-
-export const refreshOnArtistFollow = (contextScreen?: Schema.OwnerEntityTypes) => {
-  refreshHomeScreen(contextScreen)
-}
-
-export const refreshHomeScreen = (contextScreen: SaveArtworkOptions["contextScreen"]) => {
-  // Only refresh home screen if we are not on the home screen
-  if (contextScreen === Schema.OwnerEntityTypes.Home) return
-
-  RefreshEvents.emit(HOME_SCREEN_REFRESH_KEY)
 }
 
 export const refreshMyCollection = () => {


### PR DESCRIPTION
This PR resolves [CX-3586] <!-- eg [PROJECT-XXXX] -->

Related PR: https://github.com/artsy/eigen/pull/8442

### Description
The problem in the [CX-3586](https://artsyproduct.atlassian.net/browse/CX-3586) task was that we used different relay env on the Home screen and `useMutation` (this hook uses env, which is passed [here](https://github.com/artsy/eigen/blob/8676b5afc7fee7e0d681fd14bfb5c978290ff116/src/app/Providers.tsx#L78)).

We have already faced such a problem [here](https://github.com/artsy/eigen/pull/8219) and [here](https://github.com/artsy/eigen/pull/8391) + some [related PR](https://github.com/artsy/eigen/pull/8393) from George

### Demo
#### Artists
| Android | iOS |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/236521664-a3a2a846-71da-43bf-9df6-bf64a4caf2da.mp4" />  | <video src="https://user-images.githubusercontent.com/3513494/236518444-faf93abe-03c6-40e9-bfd5-bc7f114e9f66.mp4" />  | 

#### Artworks
| Android | iOS |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/3513494/236521705-48349e74-bcd6-4841-b1e4-7be5d22618a1.mp4" /> | <video src="https://user-images.githubusercontent.com/3513494/236518522-33b705ff-e8d0-42b9-a763-91ac81b617b3.mp4" /> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use the same relay env between Home screen and `useMutation` - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3586]: https://artsyproduct.atlassian.net/browse/CX-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-3586]: https://artsyproduct.atlassian.net/browse/CX-3586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ