### PR TITLE
fix: artwork lists loading indicator

### DIFF
--- a/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
+++ b/src/app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@artsy/palette-mobile"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
 import { ArtworkListsBottomSheetSectionTitle } from "app/Components/ArtworkLists/components/ArtworkListsBottomSheetSectionTitle"
 import { AutomountedBottomSheetModal } from "app/Components/ArtworkLists/components/AutomountedBottomSheetModal"
@@ -23,7 +24,11 @@ export const SelectArtworkListsForArtworkView = () => {
       </ArtworkListsBottomSheetSectionTitle>
 
       <SelectArtworkListsForArtworkHeader />
-      <SelectArtworkListsForArtwork />
+
+      <Flex flex={1} overflow="hidden">
+        <SelectArtworkListsForArtwork />
+      </Flex>
+
       <SelectArtworkListsForArtworkFooter />
     </AutomountedBottomSheetModal>
   )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
The Artwork lists loading indicator took up all the space and for this reason the footer component was not displayed. This PR fixes it

### Demo
| Before | After |
| ------------- | ------------- |
| ![before](https://github.com/artsy/eigen/assets/3513494/114ca93e-8856-4ec7-b9f7-9099de11717c) | ![after](https://github.com/artsy/eigen/assets/3513494/df6284fd-561d-4b0f-b253-8f6be83b4aab) | 
| ![before](https://github.com/artsy/eigen/assets/3513494/74759fef-e2ea-4ca7-bacf-c7c45d08874e) | ![after](https://github.com/artsy/eigen/assets/3513494/25d91987-370b-4c10-9646-21f81bbb853f) |

### Video
https://github.com/artsy/eigen/assets/3513494/9d9a0310-3eaf-4778-b934-020264f87020

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix artwork lists loading indicator - dimatetyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
