### PR TITLE
refactor: update empty state for artwork lists

### DIFF
--- a/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tests.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tests.tsx
@@ -40,19 +40,18 @@ describe("ArtworkListEmptyState", () => {
         artworkList: {
           default: true,
         },
-
-        savedArtworksArtworkList: {
-          artworksCount: 0,
-        },
       }),
     })
     await flushPromiseQueue()
 
-    expect(getByText("Keep track of artworks you love")).toBeTruthy()
-    expect(getByText("Select the heart on an artwork to save it or add it to a list.")).toBeTruthy()
+    const title = "Keep track of artworks you love"
+    const description = "Select the heart on an artwork to save it or add it to a list."
+
+    expect(getByText(title)).toBeTruthy()
+    expect(getByText(description)).toBeTruthy()
   })
 
-  it("should render correct texts for non-default artwork list when user has saved artworks", async () => {
+  it("should render correct texts for non-default artwork list", async () => {
     const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
@@ -60,41 +59,15 @@ describe("ArtworkListEmptyState", () => {
         artworkList: {
           default: false,
         },
-
-        savedArtworksArtworkList: {
-          artworksCount: 2,
-        },
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(getByText("Start curating your list of works")).toBeTruthy()
-    expect(
-      getByText("Add works from Saved Artworks or add new artworks as you browse.")
-    ).toBeTruthy()
-  })
-
-  it("should render correct texts for non-default artwork list when user doesn't have any saved artworks", async () => {
-    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Me: () => ({
-        artworkList: {
-          default: false,
-          artworks: {
-            edges: [],
-          },
-        },
-
-        savedArtworksArtworkList: {
-          artworksCount: 0,
-        },
       }),
     })
 
     await flushPromiseQueue()
 
-    expect(getByText("Keep track of artworks you love")).toBeTruthy()
-    expect(getByText("Select the heart on an artwork to save it or add it to a list.")).toBeTruthy()
+    const title = "Start curating your list of works"
+    const description = "Add works from Saved Artworks or add new artworks as you browse."
+
+    expect(getByText(title)).toBeTruthy()
+    expect(getByText(description)).toBeTruthy()
   })
 })

--- a/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tsx
@@ -13,9 +13,8 @@ interface ArtworkListEmptyStateProps {
 export const ArtworkListEmptyState = ({ me, title }: ArtworkListEmptyStateProps) => {
   const fragmentData = useFragment(artworkListEmptyStateFragment, me)
 
-  const savedArtworksCount = fragmentData.savedArtworksArtworkList?.artworksCount ?? 0
   const isDefaultArtworkList = fragmentData.artworkList?.default ?? false
-  const text = getText(isDefaultArtworkList, savedArtworksCount)
+  const text = getText(isDefaultArtworkList)
 
   return (
     <Flex mb={1}>
@@ -45,15 +44,11 @@ const artworkListEmptyStateFragment = graphql`
     artworkList: collection(id: $listID) {
       default
     }
-
-    savedArtworksArtworkList: collection(id: "saved-artwork") {
-      artworksCount(onlyVisible: true)
-    }
   }
 `
 
-const getText = (isDefaultArtworkList: boolean, savedArtworksCount: number) => {
-  if (isDefaultArtworkList || savedArtworksCount === 0) {
+const getText = (isDefaultArtworkList: boolean) => {
+  if (isDefaultArtworkList) {
     return {
       title: "Keep track of artworks you love",
       description: "Select the heart on an artwork to save it or add it to a list.",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
Small updates for empty artwork lists state

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
