### PR TITLE
chore: make artist list item clickable

### DIFF
--- a/src/app/Components/ArtistListItem.tsx
+++ b/src/app/Components/ArtistListItem.tsx
@@ -14,16 +14,17 @@ import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironme
 
 interface Props {
   artist: ArtistListItem_artist$data
-  relay: RelayProp
   Component?: any
-  contextModule?: string
-  withFeedback?: boolean
   containerStyle?: StyleProp<ViewStyle>
+  contextModule?: string
   disableNavigation?: boolean
   onFollowFinish?: () => void
-  uploadsCount?: number | null
+  onPress?: () => void
+  relay: RelayProp
   RightButton?: JSX.Element
   showFollowButton?: boolean
+  uploadsCount?: number | null
+  withFeedback?: boolean
 }
 
 export const formatTombstoneText = (
@@ -47,16 +48,17 @@ export const formatTombstoneText = (
 }
 
 const ArtistListItem: React.FC<Props> = ({
-  withFeedback = false,
-  containerStyle = {},
-  disableNavigation,
-  relay,
   artist,
-  onFollowFinish,
+  containerStyle = {},
   contextModule,
-  uploadsCount,
+  disableNavigation,
+  onFollowFinish,
+  onPress,
+  relay,
   RightButton,
   showFollowButton = true,
+  uploadsCount,
+  withFeedback = false,
 }) => {
   const { is_followed, initials, image, href, name, nationality, birthday, deathday } = artist
   const imageURl = image && image.url
@@ -118,6 +120,11 @@ const ArtistListItem: React.FC<Props> = ({
         <Touchable
           noFeedback={!withFeedback}
           onPress={() => {
+            if (onPress) {
+              onPress()
+              return
+            }
+
             if (href && !disableNavigation) {
               handleTap(href)
             }

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistItem.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistItem.tsx
@@ -1,4 +1,4 @@
-import { MoreIcon, Touchable } from "@artsy/palette-mobile"
+import { MoreIcon, Touchable, useSpace } from "@artsy/palette-mobile"
 import { MyCollectionCollectedArtistItem_artist$key } from "__generated__/MyCollectionCollectedArtistItem_artist.graphql"
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
@@ -18,6 +18,7 @@ export const MyCollectionCollectedArtistItem: React.FC<ArtistItem> = ({
 }) => {
   const setViewKind = MyCollectionTabsStore.useStoreActions((state) => state.setViewKind)
   const artistData = useFragment<MyCollectionCollectedArtistItem_artist$key>(artistFragment, artist)
+  const space = useSpace()
 
   const showArtistPreview = () => {
     setViewKind({
@@ -40,6 +41,8 @@ export const MyCollectionCollectedArtistItem: React.FC<ArtistItem> = ({
       artist={artistData}
       uploadsCount={artworksCount}
       showFollowButton={false}
+      withFeedback
+      containerStyle={{ paddingHorizontal: space(2) }}
       RightButton={RightButton}
       onPress={showArtistPreview}
     />

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistItem.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistItem.tsx
@@ -19,17 +19,17 @@ export const MyCollectionCollectedArtistItem: React.FC<ArtistItem> = ({
   const setViewKind = MyCollectionTabsStore.useStoreActions((state) => state.setViewKind)
   const artistData = useFragment<MyCollectionCollectedArtistItem_artist$key>(artistFragment, artist)
 
+  const showArtistPreview = () => {
+    setViewKind({
+      viewKind: "Artist",
+      id: artistData.internalID,
+      artworksCount: artworksCount,
+    })
+  }
+
   const RightButton = useMemo(() => {
     return (
-      <Touchable
-        onPress={() => {
-          setViewKind({
-            viewKind: "Artist",
-            id: artistData.internalID,
-            artworksCount: artworksCount,
-          })
-        }}
-      >
+      <Touchable onPress={showArtistPreview}>
         <MoreIcon height={18} width={18} />
       </Touchable>
     )
@@ -41,6 +41,7 @@ export const MyCollectionCollectedArtistItem: React.FC<ArtistItem> = ({
       uploadsCount={artworksCount}
       showFollowButton={false}
       RightButton={RightButton}
+      onPress={showArtistPreview}
     />
   )
 }

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
@@ -57,7 +57,7 @@ export const MyCollectionCollectedArtistsRail: React.FC<MyCollectionCollectedArt
   if (!collectedArtists) return <></>
 
   return (
-    <Flex mx={-2}>
+    <Flex>
       <Animated.FlatList
         horizontal
         showsHorizontalScrollIndicator={false}

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsView.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsView.tsx
@@ -78,9 +78,9 @@ export const MyCollectionCollectedArtistsView: React.FC<MyCollectionCollectedArt
         return (
           <MyCollectionCollectedArtistItem
             artworksCount={item.artworksCount}
-            // Castiing this type as ts was not able to infer it
+            // casting this type because typescript was not able to infer it correctly
             artist={item.artist!}
-            // Castiing this type as ts was not able to infer it
+            // casting this type because typescript was not able to infer it correctly
             key={item.artist!.internalID}
             compact
           />
@@ -89,11 +89,11 @@ export const MyCollectionCollectedArtistsView: React.FC<MyCollectionCollectedArt
       onEndReached={handleLoadMore}
       ListFooterComponent={!!hasNext ? <LoadingIndicator /> : <Spacer y={2} />}
       ListHeaderComponent={() => (
-        <Flex alignItems="flex-end">
+        <Flex alignItems="flex-end" px={2}>
           <ViewAsIcons onViewOptionChange={onViewOptionChange} viewOption={viewOption} />
         </Flex>
       )}
-      style={{ paddingTop: space(2) }}
+      style={{ paddingVertical: space(2) }}
       ItemSeparatorComponent={() => <Spacer y={2} />}
       refreshControl={
         !__TEST__ ? (

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -170,6 +170,7 @@ const MyCollection: React.FC<{
       innerRef={innerFlatListRef}
       keyboardDismissMode="on-drag"
       keyboardShouldPersistTaps="handled"
+      paddingHorizontal={0}
     >
       <ArtworkFilterNavigator
         visible={isFilterModalVisible}
@@ -324,7 +325,7 @@ export const MyCollectionPlaceholder: React.FC = () => {
           {/* icon, name, time joined */}
           <Flex flexDirection="row">
             <PlaceholderBox width={50} height={50} borderRadius={50} />
-            <Flex flex={1} justifyContent="center" ml={2}>
+            <Flex flex={1} justifyContent="center" ml={2} mt={2}>
               <PlaceholderText width={80} height={25} />
               <PlaceholderText width={100} height={15} />
             </Flex>

--- a/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
+++ b/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
@@ -86,7 +86,7 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({
   }
 
   return (
-    <Flex minHeight={minHeight}>
+    <Flex minHeight={minHeight} px={2}>
       <Flex mb={1}>
         {!!showSearchBar && (
           <MyCollectionSearchBar


### PR DESCRIPTION
### Description

This PR addresses the following QA bugs reported by Pierluca:
- Show the artist preview modal instead of navigating to the user press
- Adds underlay color to artwork rows for better UX


https://github.com/artsy/eigen/assets/11945712/989e016c-f167-4ef3-aa69-0b086c96ebaa


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochanges

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
