### PR TITLE
fix: hide context menu on android

### DIFF
--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -134,6 +134,10 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     onPressToCall?.()
   }
 
+  if (!shouldDisplayContextMenu) {
+    return <>{children}</>
+  }
+
   return (
     <ContextMenu
       actions={contextActions}


### PR DESCRIPTION
This PR resolves [MOPLAT-619] <!-- eg [PROJECT-XXXX] -->

### Description

Hides the long press feature on android.

Turns out the disabled prop on ContextMenu is working only on iOS so I did an early return if it is android return only the children, otherwise wrap with the ContextMenu

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

[MOPLAT-619]: https://artsyproduct.atlassian.net/browse/MOPLAT-619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ