### PR TITLE
feat(sticky-tabs-2): sticky animated header

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -338,7 +338,7 @@
         "filename": "src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx",
         "hashed_secret": "93b7de46c3a1b8545624f0e125cd7919da42d787",
         "is_verified": false,
-        "line_number": 100
+        "line_number": 86
       }
     ],
     "src/app/Scenes/Partner/Components/PartnerShows.tests.tsx": [
@@ -1035,5 +1035,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-10T18:41:45Z"
+  "generated_at": "2023-05-24T16:47:28Z"
 }

--- a/src/app/Components/Artist/ArtistAbout/ArtistAbout.tests.tsx
+++ b/src/app/Components/Artist/ArtistAbout/ArtistAbout.tests.tsx
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react-native"
 import { ArtistAboutTestsQuery } from "__generated__/ArtistAboutTestsQuery.graphql"
 import Biography from "app/Components/Artist/Biography"
-import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { ModalStack } from "app/system/navigation/ModalStack"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -12,14 +11,7 @@ describe("ArtistAbout", () => {
   const { renderWithRelay } = setupTestWrapper<ArtistAboutTestsQuery>({
     Component: ({ artist }) => (
       <ModalStack>
-        <StickyTabPage
-          tabs={[
-            {
-              title: "test",
-              content: <ArtistAboutContainer artist={artist!} />,
-            },
-          ]}
-        />
+        <ArtistAboutContainer artist={artist!} />
       </ModalStack>
     ),
     query: graphql`

--- a/src/app/Components/Artist/ArtistHeader.tests.tsx
+++ b/src/app/Components/Artist/ArtistHeader.tests.tsx
@@ -17,14 +17,6 @@ describe("ArtistHeader", () => {
     variables: { artistID: "artist-id" },
   })
 
-  it("renders properly", () => {
-    renderWithRelay({
-      Artist: () => mockArtist,
-    })
-
-    expect(screen.queryByText("Marcel Duchamp")).toBeTruthy()
-  })
-
   it("displays follow button for artist", () => {
     renderWithRelay({
       Artist: () => mockArtist,
@@ -47,7 +39,6 @@ describe("ArtistHeader", () => {
 const mockArtist = {
   internalID: "some-id",
   id: "marcel-duchamp",
-  name: "Marcel Duchamp",
   nationality: "French",
   birthday: "11/17/1992",
   counts: {

--- a/src/app/Components/Artist/ArtistHeader.tsx
+++ b/src/app/Components/Artist/ArtistHeader.tsx
@@ -1,4 +1,4 @@
-import { Spacer, bullet, Flex, Box, Text } from "@artsy/palette-mobile"
+import { bullet, Flex, Box, Text } from "@artsy/palette-mobile"
 import { ArtistHeaderFollowArtistMutation } from "__generated__/ArtistHeaderFollowArtistMutation.graphql"
 import { ArtistHeader_artist$data } from "__generated__/ArtistHeader_artist.graphql"
 import { FollowButton } from "app/Components/Button/FollowButton"
@@ -119,9 +119,6 @@ export const ArtistHeader: React.FC<Props> = ({ artist, relay }) => {
 
   return (
     <Box px={2} pb={1}>
-      <Text variant="lg-display">{artist.name}</Text>
-      <Spacer y={1} />
-
       <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
         <Flex flex={1}>
           {!!bylineRequired && (

--- a/src/app/Components/Button/FollowButton.tsx
+++ b/src/app/Components/Button/FollowButton.tsx
@@ -13,7 +13,7 @@ export const FollowButton = ({ isFollowed, ...restProps }: FollowButtonProps) =>
       variant={isFollowed ? "outline" : "outlineGray"}
       size="small"
       longestText="Following"
-      icon={isFollowed && <CheckIcon fill="black60" width="16px" height="16px" />}
+      icon={!!isFollowed && <CheckIcon fill="black60" width="16px" height="16px" />}
       {...restProps}
     >
       {isFollowed ? "Following" : "Follow"}

--- a/src/app/Components/Gene/About.tests.tsx
+++ b/src/app/Components/Gene/About.tests.tsx
@@ -1,7 +1,6 @@
 // Note: test renderer must be required after react-native.
-import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import "react-native"
 
 import About from "./About"
 
@@ -42,13 +41,8 @@ it("renders without throwing a error", () => {
   }
 
   renderWithWrappersLEGACY(
-    <StickyTabPage
-      tabs={[
-        {
-          title: "test",
-          content: <About gene={gene as any} />,
-        },
-      ]}
-    />
+    <TabsWithHeader title="test">
+      <About gene={gene as any} />
+    </TabsWithHeader>
   )
 })

--- a/src/app/Components/Gene/GeneArtworks.tests.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tests.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, waitFor } from "@testing-library/react-native"
 import { GeneArtworksTestsQuery } from "__generated__/GeneArtworksTestsQuery.graphql"
-import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
@@ -26,14 +26,9 @@ describe("GeneArtworks", () => {
         render={({ props }) => {
           if (props?.gene) {
             return (
-              <StickyTabPage
-                tabs={[
-                  {
-                    title: "test",
-                    content: <GeneArtworksPaginationContainer gene={props.gene} />,
-                  },
-                ]}
-              />
+              <TabsWithHeader title="test">
+                <GeneArtworksPaginationContainer gene={props.gene} />
+              </TabsWithHeader>
             )
           }
 

--- a/src/app/Components/Gene/Header.tsx
+++ b/src/app/Components/Gene/Header.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from "@artsy/palette-mobile"
+import { Box } from "@artsy/palette-mobile"
 import { HeaderFollowGeneMutation } from "__generated__/HeaderFollowGeneMutation.graphql"
 import { Header_gene$data } from "__generated__/Header_gene.graphql"
 import { FollowButton } from "app/Components/Button/FollowButton"
@@ -21,22 +21,6 @@ const track: Track<Props, State> = _track
 @track()
 class Header extends React.Component<Props, State> {
   state = { isFollowedChanging: false }
-
-  render() {
-    const { gene } = this.props
-    const title = gene.displayName || gene.name || ""
-
-    return (
-      <>
-        <Box>
-          <Text variant="lg-display" numberOfLines={2}>
-            {title}
-          </Text>
-        </Box>
-        {this.renderFollowButton()}
-      </>
-    )
-  }
 
   @track((props) => ({
     action_name: props.gene.isFollowed
@@ -131,7 +115,7 @@ class Header extends React.Component<Props, State> {
     })
   }
 
-  renderFollowButton() {
+  render() {
     if (this.props.shortForm) {
       return null
     }
@@ -156,8 +140,6 @@ export default createFragmentContainer(Header, {
       slug
       id
       isFollowed
-      name
-      displayName
     }
   `,
 })

--- a/src/app/Components/Tabs/AnimatedTabsHeader.tsx
+++ b/src/app/Components/Tabs/AnimatedTabsHeader.tsx
@@ -11,7 +11,7 @@ import {
 import { useNavigation } from "@react-navigation/native"
 import { TabsContext } from "app/Components/Tabs/TabsContext"
 import { isTablet } from "react-native-device-info"
-import Animated, { Easing, FadeInLeft, FadeOut } from "react-native-reanimated"
+import Animated, { Easing, FadeOut, FadeInDown } from "react-native-reanimated"
 
 export interface HeaderProps {
   animated?: boolean
@@ -42,8 +42,6 @@ export const Header: React.FC<HeaderProps> = ({
   title,
 }) => {
   const navigation = useNavigation()
-  // TODO: Remove this once we figure out if we need it or not
-  const isSelectModeActive = false
 
   const Left = () => {
     if (hideLeftElements) {
@@ -71,10 +69,6 @@ export const Header: React.FC<HeaderProps> = ({
   }
 
   const Center = () => {
-    if (isSelectModeActive) {
-      return null
-    }
-
     if (!animated) {
       return (
         <Flex width={isTablet() ? "100%" : "70%"} flex={1}>
@@ -92,13 +86,13 @@ export const Header: React.FC<HeaderProps> = ({
     return (
       <>
         <Animated.View
-          entering={FadeInLeft.duration(400).easing(Easing.out(Easing.exp))}
+          entering={FadeInDown.duration(400).easing(Easing.out(Easing.exp))}
           exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
           style={{
             flex: 1,
           }}
         >
-          <Flex width={isTablet() ? "100%" : "70%"}>
+          <Flex alignItems="center">
             <Text variant="md" numberOfLines={1}>
               {title}
             </Text>

--- a/src/app/Components/Tabs/AnimatedTabsHeader.tsx
+++ b/src/app/Components/Tabs/AnimatedTabsHeader.tsx
@@ -1,0 +1,140 @@
+import {
+  ArrowLeftIcon,
+  DEFAULT_HIT_SLOP,
+  NAVBAR_HEIGHT,
+  ZINDEX,
+  Flex,
+  Spacer,
+  Text,
+  Touchable,
+} from "@artsy/palette-mobile"
+import { useNavigation } from "@react-navigation/native"
+import { TabsContext } from "app/Components/Tabs/TabsContext"
+import { isTablet } from "react-native-device-info"
+import Animated, { Easing, FadeInLeft, FadeOut } from "react-native-reanimated"
+
+export interface HeaderProps {
+  animated?: boolean
+  hideLeftElements?: boolean
+  hideRightElements?: boolean
+  leftElements?: React.ReactNode
+  onBack?: () => void
+  rightElements?: React.ReactNode
+  scrollY?: number
+  title?: string
+  titleShown?: boolean
+}
+
+export const AnimatedTabsHeader: React.FC<HeaderProps> = (props) => {
+  const scrollY = TabsContext.useStoreState((state) => state.currentScrollY)
+
+  return <Header scrollY={scrollY} animated={true} {...props} />
+}
+
+export const Header: React.FC<HeaderProps> = ({
+  animated = false,
+  scrollY = 0,
+  hideLeftElements,
+  hideRightElements,
+  leftElements,
+  onBack,
+  rightElements,
+  title,
+}) => {
+  const navigation = useNavigation()
+  // TODO: Remove this once we figure out if we need it or not
+  const isSelectModeActive = false
+
+  const Left = () => {
+    if (hideLeftElements) {
+      return null
+    }
+
+    return (
+      <>
+        {leftElements ? (
+          <>{leftElements}</>
+        ) : (
+          // If no left elements passed, show back button
+          <Touchable
+            onPress={onBack ?? navigation.goBack}
+            underlayColor="transparent"
+            hitSlop={DEFAULT_HIT_SLOP}
+          >
+            <ArrowLeftIcon fill="onBackgroundHigh" top="2px" />
+          </Touchable>
+        )}
+
+        <Spacer x={1} />
+      </>
+    )
+  }
+
+  const Center = () => {
+    if (isSelectModeActive) {
+      return null
+    }
+
+    if (!animated) {
+      return (
+        <Flex width={isTablet() ? "100%" : "70%"} flex={1}>
+          <Text variant="md" numberOfLines={1}>
+            {title}
+          </Text>
+        </Flex>
+      )
+    }
+
+    if (scrollY < NAVBAR_HEIGHT) {
+      return <Flex flex={1} flexDirection="row" />
+    }
+
+    return (
+      <>
+        <Animated.View
+          entering={FadeInLeft.duration(400).easing(Easing.out(Easing.exp))}
+          exiting={FadeOut.duration(400).easing(Easing.out(Easing.exp))}
+          style={{
+            flex: 1,
+          }}
+        >
+          <Flex width={isTablet() ? "100%" : "70%"}>
+            <Text variant="md" numberOfLines={1}>
+              {title}
+            </Text>
+          </Flex>
+        </Animated.View>
+      </>
+    )
+  }
+
+  const Right = () => {
+    if (hideRightElements) {
+      return null
+    }
+
+    return (
+      <>
+        <Spacer x={1} />
+
+        {rightElements}
+      </>
+    )
+  }
+
+  return (
+    <Flex
+      height={NAVBAR_HEIGHT}
+      flexDirection="row"
+      px={2}
+      py={1}
+      zIndex={ZINDEX.header}
+      backgroundColor="background"
+      alignItems="center"
+    >
+      <Left />
+      <Center />
+      <Right />
+    </Flex>
+  )
+}

--- a/src/app/Components/Tabs/TabFlatList.tsx
+++ b/src/app/Components/Tabs/TabFlatList.tsx
@@ -1,8 +1,10 @@
 import { useSpace } from "@artsy/palette-mobile"
+import { useListenForTabContentScroll } from "app/Components/Tabs/useListenForTabContentScroll"
 import { FlatListProps } from "react-native"
 import { Tabs } from "react-native-collapsible-tab-view"
 
 export function TabFlatList<T>(props: FlatListProps<T>) {
+  useListenForTabContentScroll()
   const space = useSpace()
 
   const contentContainerStyle = (props.contentContainerStyle ?? {}) as object

--- a/src/app/Components/Tabs/TabScrollView.tsx
+++ b/src/app/Components/Tabs/TabScrollView.tsx
@@ -1,8 +1,10 @@
 import { useSpace } from "@artsy/palette-mobile"
+import { useListenForTabContentScroll } from "app/Components/Tabs/useListenForTabContentScroll"
 import { ScrollViewProps } from "react-native"
 import { Tabs } from "react-native-collapsible-tab-view"
 
 export const TabScrollView: React.FC<ScrollViewProps> = (props) => {
+  useListenForTabContentScroll()
   const space = useSpace()
 
   const contentContainerStyle = (props.contentContainerStyle ?? {}) as object

--- a/src/app/Components/Tabs/TabsContext.tsx
+++ b/src/app/Components/Tabs/TabsContext.tsx
@@ -1,0 +1,14 @@
+import { Action, action, createContextStore } from "easy-peasy"
+
+interface TabsContextStore {
+  currentScrollY: number
+  updateCurrentScrollY: Action<this, number>
+}
+
+export const TabsContext = createContextStore<TabsContextStore>({
+  currentScrollY: 0,
+
+  updateCurrentScrollY: action((state, currentScrollY) => {
+    state.currentScrollY = currentScrollY
+  }),
+})

--- a/src/app/Components/Tabs/TabsWithHeader.tsx
+++ b/src/app/Components/Tabs/TabsWithHeader.tsx
@@ -1,7 +1,6 @@
 import { Flex, Text, Screen } from "@artsy/palette-mobile"
 import { AnimatedTabsHeader, HeaderProps } from "app/Components/Tabs/AnimatedTabsHeader"
 import { TabsContainer } from "app/Components/Tabs/TabsContainer"
-import { TabsContext } from "app/Components/Tabs/TabsContext"
 import { CollapsibleProps } from "react-native-collapsible-tab-view"
 
 interface TabsWithHeaderProps {
@@ -20,32 +19,30 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
   title,
 }) => {
   return (
-    <TabsContext.Provider>
-      <Screen>
-        <AnimatedTabsHeader title={title} {...headerProps} />
-        <Screen.Body fullwidth>
-          <TabsContainer
-            renderHeader={() => {
-              if (!showLargeHeaderText || !title) {
-                return null
-              }
+    <Screen>
+      <AnimatedTabsHeader title={title} {...headerProps} />
+      <Screen.Body fullwidth>
+        <TabsContainer
+          renderHeader={() => {
+            if (!showLargeHeaderText || !title) {
+              return null
+            }
 
-              return (
-                <>
-                  <Flex my={1} pl={2} justifyContent="center" alignSelf="flex-start">
-                    <Text variant="lg-display" numberOfLines={2}>
-                      {title}
-                    </Text>
-                  </Flex>
-                  {!!HeaderComponent && <HeaderComponent />}
-                </>
-              )
-            }}
-          >
-            {children}
-          </TabsContainer>
-        </Screen.Body>
-      </Screen>
-    </TabsContext.Provider>
+            return (
+              <>
+                <Flex my={1} pl={2} justifyContent="center" alignSelf="flex-start">
+                  <Text variant="lg-display" numberOfLines={2}>
+                    {title}
+                  </Text>
+                </Flex>
+                {!!HeaderComponent && <HeaderComponent />}
+              </>
+            )
+          }}
+        >
+          {children}
+        </TabsContainer>
+      </Screen.Body>
+    </Screen>
   )
 }

--- a/src/app/Components/Tabs/TabsWithHeader.tsx
+++ b/src/app/Components/Tabs/TabsWithHeader.tsx
@@ -1,0 +1,51 @@
+import { Flex, Text, Screen } from "@artsy/palette-mobile"
+import { AnimatedTabsHeader, HeaderProps } from "app/Components/Tabs/AnimatedTabsHeader"
+import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsContext } from "app/Components/Tabs/TabsContext"
+import { CollapsibleProps } from "react-native-collapsible-tab-view"
+
+interface TabsWithHeaderProps {
+  title: string
+  HeaderComponent?: () => JSX.Element
+  headerProps?: HeaderProps
+  showLargeHeaderText?: boolean
+  children: CollapsibleProps["children"]
+}
+
+export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
+  children,
+  HeaderComponent,
+  headerProps = {},
+  showLargeHeaderText = true,
+  title,
+}) => {
+  return (
+    <TabsContext.Provider>
+      <Screen>
+        <AnimatedTabsHeader title={title} {...headerProps} />
+        <Screen.Body fullwidth>
+          <TabsContainer
+            renderHeader={() => {
+              if (!showLargeHeaderText || !title) {
+                return null
+              }
+
+              return (
+                <>
+                  <Flex my={1} pl={2} justifyContent="center" alignSelf="flex-start">
+                    <Text variant="lg-display" numberOfLines={2}>
+                      {title}
+                    </Text>
+                  </Flex>
+                  {!!HeaderComponent && <HeaderComponent />}
+                </>
+              )
+            }}
+          >
+            {children}
+          </TabsContainer>
+        </Screen.Body>
+      </Screen>
+    </TabsContext.Provider>
+  )
+}

--- a/src/app/Components/Tabs/TabsWithHeader.tsx
+++ b/src/app/Components/Tabs/TabsWithHeader.tsx
@@ -5,7 +5,7 @@ import { CollapsibleProps } from "react-native-collapsible-tab-view"
 
 interface TabsWithHeaderProps extends TabsContainerProps {
   title: string
-  HeaderComponent?: () => JSX.Element
+  BelowTitleHeaderComponent?: () => JSX.Element
   headerProps?: HeaderProps
   showLargeHeaderText?: boolean
   children: CollapsibleProps["children"]
@@ -13,7 +13,7 @@ interface TabsWithHeaderProps extends TabsContainerProps {
 
 export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
   children,
-  HeaderComponent,
+  BelowTitleHeaderComponent,
   headerProps = {},
   showLargeHeaderText = true,
   title,
@@ -37,7 +37,7 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
                     {title}
                   </Text>
                 </Flex>
-                {!!HeaderComponent && <HeaderComponent />}
+                {!!BelowTitleHeaderComponent && <BelowTitleHeaderComponent />}
               </>
             )
           }}

--- a/src/app/Components/Tabs/TabsWithHeader.tsx
+++ b/src/app/Components/Tabs/TabsWithHeader.tsx
@@ -1,9 +1,9 @@
 import { Flex, Text, Screen } from "@artsy/palette-mobile"
 import { AnimatedTabsHeader, HeaderProps } from "app/Components/Tabs/AnimatedTabsHeader"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsContainer, TabsContainerProps } from "app/Components/Tabs/TabsContainer"
 import { CollapsibleProps } from "react-native-collapsible-tab-view"
 
-interface TabsWithHeaderProps {
+interface TabsWithHeaderProps extends TabsContainerProps {
   title: string
   HeaderComponent?: () => JSX.Element
   headerProps?: HeaderProps
@@ -17,12 +17,14 @@ export const TabsWithHeader: React.FC<TabsWithHeaderProps> = ({
   headerProps = {},
   showLargeHeaderText = true,
   title,
+  ...rest
 }) => {
   return (
     <Screen>
       <AnimatedTabsHeader title={title} {...headerProps} />
       <Screen.Body fullwidth>
         <TabsContainer
+          {...rest}
           renderHeader={() => {
             if (!showLargeHeaderText || !title) {
               return null

--- a/src/app/Components/Tabs/useListenForTabContentScroll.tsx
+++ b/src/app/Components/Tabs/useListenForTabContentScroll.tsx
@@ -1,0 +1,64 @@
+import { NAVBAR_HEIGHT } from "@artsy/palette-mobile"
+import { TabsContext } from "app/Components/Tabs/TabsContext"
+
+import { useEffect, useState } from "react"
+import { useCurrentTabScrollY } from "react-native-collapsible-tab-view"
+import { runOnJS, SharedValue, useAnimatedReaction, useSharedValue } from "react-native-reanimated"
+
+export const useListenForTabContentScroll = () => {
+  const scrollY = useAnimatedTabsHeaderScrolling(useCurrentTabScrollY())
+  const updateCurrentScrollY = TabsContext.useStoreActions(
+    (actions) => actions.updateCurrentScrollY
+  )
+
+  useEffect(() => {
+    updateCurrentScrollY(scrollY)
+  }, [scrollY, updateCurrentScrollY])
+}
+
+const useAnimatedTabsHeaderScrolling = (scrollY: SharedValue<number>) => {
+  const listenForScroll = useSharedValue(true)
+  const [currScrollY, setCurrScrollY] = useState(scrollY.value)
+
+  // Needed to run on JS thread
+  const update = (y: number) => {
+    setCurrScrollY(y)
+  }
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      listenForScroll.value = false
+    }, 1000)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [listenForScroll])
+
+  useAnimatedReaction(
+    () => [scrollY.value, listenForScroll.value] as const,
+    ([animatedScrollY, isListeningForScroll], previousScroll) => {
+      const [prevScrollY] = previousScroll ?? [0, false]
+
+      // Hacky way to avoid some weird header behavior.
+      // look at HACKS.md for more info.
+      const suddenlyScrolled = Math.abs(animatedScrollY - prevScrollY) > NAVBAR_HEIGHT
+
+      if (isListeningForScroll && suddenlyScrolled) {
+        return
+      }
+
+      const prevTitleShown = prevScrollY >= NAVBAR_HEIGHT
+      const currTitleShown = animatedScrollY >= NAVBAR_HEIGHT
+
+      if (prevTitleShown === currTitleShown) {
+        return
+      }
+
+      runOnJS(update)(Math.floor(animatedScrollY))
+    },
+    [scrollY]
+  )
+
+  return currScrollY
+}

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -2,6 +2,7 @@ import { Theme, Spinner, ScreenDimensionsProvider } from "@artsy/palette-mobile"
 import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsContext"
 import { ShareSheetProvider } from "app/Components/ShareSheet/ShareSheetContext"
+import { TabsContext } from "app/Components/Tabs/TabsContext"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ProvideScreenDimensions } from "app/utils/hooks/useScreenDimensions"
@@ -62,6 +63,7 @@ export const TestProviders: React.FC<{ skipRelay?: boolean }> = ({
       ScreenDimensionsProvider,
       !skipRelay && RelayDefaultEnvProvider,
       Theme,
+      TabsContext.Provider,
       PopoverMessageProvider,
       ShareSheetProvider,
       ToastProvider,

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -35,6 +35,7 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       ScreenDimensionsProvider,
       RelayDefaultEnvProvider,
       ThemeWithDarkModeSupport, // uses: GlobalStoreProvider
+      TabsContext.Provider,
       RetryErrorBoundary,
       SuspenseProvider,
       ActionSheetProvider,

--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -1,10 +1,8 @@
 import { ActionType } from "@artsy/cohesion"
 import { ClickedActivityPanelTab } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
-import { Screen } from "@artsy/palette-mobile"
 import { ActivityQuery } from "__generated__/ActivityQuery.graphql"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { useMarkNotificationsAsSeen } from "app/Scenes/Activity/hooks/useMarkNotificationsAsSeen"
-import { goBack } from "app/system/navigation/navigate"
 import { Suspense } from "react"
 import { OnTabChangeCallback, Tabs } from "react-native-collapsible-tab-view"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -52,29 +50,18 @@ export const Activity = () => {
   }
 
   return (
-    <Screen>
-      <Screen.Body fullwidth>
-        <TabsContainer
-          onTabChange={handleTabPress}
-          renderHeader={() => {
-            return (
-              <Screen.Header
-                title="Activity"
-                titleProps={{ alignItems: "center" }}
-                onBack={goBack}
-              />
-            )
-          }}
-        >
-          <Tabs.Tab name="All" label="All">
-            <ActivityContainer type="all" />
-          </Tabs.Tab>
-          <Tabs.Tab name="Alerts" label="Alerts">
-            <ActivityContainer type="alerts" />
-          </Tabs.Tab>
-        </TabsContainer>
-      </Screen.Body>
-    </Screen>
+    <TabsWithHeader title="Activity" onTabChange={handleTabPress}>
+      <Tabs.Tab name="All" label="All">
+        <Tabs.Lazy>
+          <ActivityContainer type="all" />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+      <Tabs.Tab name="Alerts" label="Alerts">
+        <Tabs.Lazy>
+          <ActivityContainer type="alerts" />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+    </TabsWithHeader>
   )
 }
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizArtist.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizArtist.tsx
@@ -5,12 +5,12 @@ import {
   ArtQuizArtist_artist$key,
 } from "__generated__/ArtQuizArtist_artist.graphql"
 import { SmallArtworkRail } from "app/Components/ArtworkRail/SmallArtworkRail"
+import { FollowButton } from "app/Components/Button/FollowButton"
 import { ReadMore } from "app/Components/ReadMore"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { debounce } from "lodash"
-import { FollowButton } from "app/Components/Button/FollowButton"
 import { TouchableOpacity } from "react-native"
 import { graphql, useFragment, useMutation } from "react-relay"
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
@@ -1,6 +1,6 @@
-import { Flex, Screen } from "@artsy/palette-mobile"
+import { Flex } from "@artsy/palette-mobile"
 import { ArtQuizResultsEmptyTabsQuery } from "__generated__/ArtQuizResultsEmptyTabsQuery.graphql"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { ArtQuizResultsTabsHeader } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader"
 import { ArtQuizTrendingArtists } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingArtists"
 import { ArtQuizTrendingCollections } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollections"
@@ -15,35 +15,29 @@ export const ArtQuizResultsEmptyTabs = () => {
   )
 
   return (
-    <Screen>
-      <Screen.Body fullwidth>
-        <Screen.Header onBack={() => navigate("/")} />
-        <TabsContainer
-          lazy
-          renderHeader={() => {
-            return (
-              <Flex mb={1}>
-                <ArtQuizResultsTabsHeader
-                  title="Explore Your Quiz Results"
-                  subtitle="There are almost 2 million artworks on Artsy—keep exploring to find something you love."
-                />
-              </Flex>
-            )
-          }}
-        >
-          <Tabs.Tab name="trendingCollections" label="Trending Collections">
-            <Tabs.Lazy>
-              <ArtQuizTrendingCollections viewer={queryResult.viewer} />
-            </Tabs.Lazy>
-          </Tabs.Tab>
-          <Tabs.Tab name="trendingArtists" label="Trending Artists">
-            <Tabs.Lazy>
-              <ArtQuizTrendingArtists viewer={queryResult.viewer} />
-            </Tabs.Lazy>
-          </Tabs.Tab>
-        </TabsContainer>
-      </Screen.Body>
-    </Screen>
+    <TabsWithHeader
+      title="Explore Your Quiz Results"
+      lazy
+      headerProps={{
+        onBack: () => navigate("/"),
+      }}
+      BelowTitleHeaderComponent={() => (
+        <Flex mb={1}>
+          <ArtQuizResultsTabsHeader subtitle="There are almost 2 million artworks on Artsy—keep exploring to find something you love." />
+        </Flex>
+      )}
+    >
+      <Tabs.Tab name="trendingCollections" label="Trending Collections">
+        <Tabs.Lazy>
+          <ArtQuizTrendingCollections viewer={queryResult.viewer} />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+      <Tabs.Tab name="trendingArtists" label="Trending Artists">
+        <Tabs.Lazy>
+          <ArtQuizTrendingArtists viewer={queryResult.viewer} />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+    </TabsWithHeader>
   )
 }
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsEmptyTabs.tsx
@@ -32,10 +32,14 @@ export const ArtQuizResultsEmptyTabs = () => {
           }}
         >
           <Tabs.Tab name="trendingCollections" label="Trending Collections">
-            <ArtQuizTrendingCollections viewer={queryResult.viewer} />
+            <Tabs.Lazy>
+              <ArtQuizTrendingCollections viewer={queryResult.viewer} />
+            </Tabs.Lazy>
           </Tabs.Tab>
           <Tabs.Tab name="trendingArtists" label="Trending Artists">
-            <ArtQuizTrendingArtists viewer={queryResult.viewer} />
+            <Tabs.Lazy>
+              <ArtQuizTrendingArtists viewer={queryResult.viewer} />
+            </Tabs.Lazy>
           </Tabs.Tab>
         </TabsContainer>
       </Screen.Body>

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabs.tsx
@@ -1,7 +1,7 @@
-import { Flex, Screen } from "@artsy/palette-mobile"
+import { Flex } from "@artsy/palette-mobile"
 import { ArtQuizResultsQuery$data } from "__generated__/ArtQuizResultsQuery.graphql"
 import { ArtQuizResultsTabs_me$key } from "__generated__/ArtQuizResultsTabs_me.graphql"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { ArtQuizExploreArtists } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizExploreArtists"
 import { ArtQuizExploreArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizExploreArtworks"
 import { ArtQuizLikedArtworks } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizLikedArtworks"
@@ -20,52 +20,59 @@ enum Tab {
 export const ArtQuizResultsTabs = ({ me }: { me: ArtQuizResultsQuery$data["me"] }) => {
   const queryResult = useFragment<ArtQuizResultsTabs_me$key>(artQuizResultsTabsFragment, me)?.quiz
 
-  const [activeTab, setActiveTab] = useState<string>(Tab.worksYouLiked)
+  const [activeTab, setActiveTab] = useState<string>("worksYouLiked")
 
   const savedArtworks = queryResult?.savedArtworks!
   const recommendedArtworks = queryResult?.recommendedArtworks!
+  const title =
+    activeTab !== "worksYouLiked" ? "Explore Art We Think You'll Love" : "Explore Your Quiz Results"
 
   return (
-    <Screen>
-      <Screen.Body fullwidth>
-        <Screen.Header onBack={() => navigate("/")} />
-        <TabsContainer
-          tabScrollEnabled
-          // TODO: Figure out why this doesn't work
-          onTabChange={(tab) => {
-            console.log(tab)
-            setActiveTab(tab.tabName)
-          }}
-          renderHeader={() => {
-            return (
-              <Flex mb={1}>
-                {activeTab === "worksYouLiked" ? (
-                  <ArtQuizResultsTabsHeader
-                    title="Explore Art We Think You'll Love"
-                    subtitle="We think you’ll enjoy these recommendations based on your likes. Keep saving and following to continue tailoring Artsy to you."
-                  />
-                ) : (
-                  <ArtQuizResultsTabsHeader
-                    title="Explore Your Quiz Results"
-                    subtitle="We think you’ll enjoy these recommendations based on your likes. To tailor Artsy to your art tastes, follow artists and save works you love."
-                  />
-                )}
-              </Flex>
-            )
-          }}
-        >
-          <Tabs.Tab name="worksYouLiked" label={Tab.worksYouLiked}>
-            <ArtQuizLikedArtworks savedArtworks={savedArtworks} />
-          </Tabs.Tab>
-          <Tabs.Tab name="worksForYou" label={Tab.worksForYou}>
-            <ArtQuizExploreArtworks recommendedArtworks={recommendedArtworks} />
-          </Tabs.Tab>
-          <Tabs.Tab name="artistsForYou" label={Tab.artistsForYou}>
-            <ArtQuizExploreArtists savedArtworks={savedArtworks} />
-          </Tabs.Tab>
-        </TabsContainer>
-      </Screen.Body>
-    </Screen>
+    <TabsWithHeader
+      title={title}
+      tabScrollEnabled
+      lazy
+      headerProps={{
+        onBack: () => navigate("/"),
+      }}
+      onTabPress={(tabName) => {
+        setActiveTab(tabName)
+      }}
+      onTabChange={({ tabName }) => {
+        setActiveTab(tabName)
+      }}
+      BelowTitleHeaderComponent={() => {
+        if (activeTab === "worksYouLiked") {
+          return (
+            <Flex mb={1}>
+              <ArtQuizResultsTabsHeader subtitle="We think you’ll enjoy these recommendations based on your likes. Keep saving and following to continue tailoring Artsy to you." />
+            </Flex>
+          )
+        }
+
+        return (
+          <Flex mb={1}>
+            <ArtQuizResultsTabsHeader subtitle="We think you’ll enjoy these recommendations based on your likes. To tailor Artsy to your art tastes, follow artists and save works you love." />
+          </Flex>
+        )
+      }}
+    >
+      <Tabs.Tab name="worksYouLiked" label={Tab.worksYouLiked}>
+        <Tabs.Lazy>
+          <ArtQuizLikedArtworks savedArtworks={savedArtworks} />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+      <Tabs.Tab name="worksForYou" label={Tab.worksForYou}>
+        <Tabs.Lazy>
+          <ArtQuizExploreArtworks recommendedArtworks={recommendedArtworks} />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+      <Tabs.Tab name="artistsForYou" label={Tab.artistsForYou}>
+        <Tabs.Lazy>
+          <ArtQuizExploreArtists savedArtworks={savedArtworks} />
+        </Tabs.Lazy>
+      </Tabs.Tab>
+    </TabsWithHeader>
   )
 }
 

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizResultsTabsHeader.tsx
@@ -5,11 +5,10 @@ import { unsafe_getUserEmail } from "app/store/GlobalStore"
 import { graphql, useMutation } from "react-relay"
 
 interface ArtQuizResultsTabsHeaderProps {
-  title: string
   subtitle: string
 }
 
-export const ArtQuizResultsTabsHeader = ({ title, subtitle }: ArtQuizResultsTabsHeaderProps) => {
+export const ArtQuizResultsTabsHeader = ({ subtitle }: ArtQuizResultsTabsHeaderProps) => {
   const currentUserEmail = unsafe_getUserEmail()
   const [submitMutation, isLoading] = useMutation<ArtQuizResultsTabsHeaderTriggerCampaignMutation>(
     TriggerCampaignButtonMutation
@@ -33,7 +32,6 @@ export const ArtQuizResultsTabsHeader = ({ title, subtitle }: ArtQuizResultsTabs
 
   return (
     <Flex px={2}>
-      <Text variant="lg">{title}</Text>
       <Text variant="sm" color="black60">
         {subtitle}
       </Text>

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollection.tsx
@@ -25,7 +25,7 @@ export const ArtQuizTrendingCollection = ({
 
   return (
     <Flex pt={2}>
-      <Flex px={2}>
+      <Flex>
         <Text variant="md">{collection?.title}</Text>
         <ReadMore
           content={collection?.descriptionMarkdown!}

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollections.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResultsTabs/ArtQuizTrendingCollections.tsx
@@ -16,8 +16,6 @@ export const ArtQuizTrendingCollections: React.FC<ArtQuizTrendingCollectionsProp
     viewer
   )
 
-  console.log(viewerData)
-
   return (
     <TabFlatList
       data={viewerData?.marketingCollections!}

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -110,7 +110,9 @@ export const Artist: React.FC<ArtistProps> = (props) => {
             ),
             onBack: goBack,
           }}
-          HeaderComponent={() => <ArtistHeaderFragmentContainer artist={artistAboveTheFold!} />}
+          BelowTitleHeaderComponent={() => (
+            <ArtistHeaderFragmentContainer artist={artistAboveTheFold!} />
+          )}
         >
           {displayAboutSection ? (
             <Tabs.Tab name="Overview" label="Overview">

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -33,7 +33,7 @@ import { Tabs } from "react-native-collapsible-tab-view"
 import { graphql } from "react-relay"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
-// const INITIAL_TAB = "Artworks"
+const INITIAL_TAB = "Artworks"
 
 interface ArtistProps {
   artistAboveTheFold: NonNullable<ArtistAboveTheFoldQuery["response"]["artist"]>
@@ -49,7 +49,7 @@ export const Artist: React.FC<ArtistProps> = (props) => {
   const {
     artistAboveTheFold,
     artistBelowTheFold,
-    // initialTab = INITIAL_TAB,
+    initialTab = INITIAL_TAB,
     searchCriteria,
     fetchCriteriaError,
     predefinedFilters,
@@ -98,7 +98,7 @@ export const Artist: React.FC<ArtistProps> = (props) => {
     >
       <ArtworkFiltersStoreProvider>
         <TabsWithHeader
-          // TODO: implement initial tab?
+          initialTabName={initialTab}
           title={artistAboveTheFold.name!}
           headerProps={{
             rightElements: (

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -1,4 +1,4 @@
-import { Screen, ShareIcon } from "@artsy/palette-mobile"
+import { ShareIcon } from "@artsy/palette-mobile"
 import {
   ArtistAboveTheFoldQuery,
   FilterArtworksInput,
@@ -21,7 +21,7 @@ import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSear
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { SearchCriteriaQueryRenderer } from "app/Scenes/Artist/SearchCriteria"
 import { goBack } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -33,7 +33,7 @@ import { Tabs } from "react-native-collapsible-tab-view"
 import { graphql } from "react-relay"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 
-const INITIAL_TAB = "Artworks"
+// const INITIAL_TAB = "Artworks"
 
 interface ArtistProps {
   artistAboveTheFold: NonNullable<ArtistAboveTheFoldQuery["response"]["artist"]>
@@ -49,7 +49,7 @@ export const Artist: React.FC<ArtistProps> = (props) => {
   const {
     artistAboveTheFold,
     artistBelowTheFold,
-    initialTab = INITIAL_TAB,
+    // initialTab = INITIAL_TAB,
     searchCriteria,
     fetchCriteriaError,
     predefinedFilters,
@@ -97,67 +97,62 @@ export const Artist: React.FC<ArtistProps> = (props) => {
       }}
     >
       <ArtworkFiltersStoreProvider>
-        <Screen>
-          <Screen.Body fullwidth>
-            <Screen.Header
-              onBack={goBack}
-              rightElements={
+        <TabsWithHeader
+          // TODO: implement initial tab?
+          title={artistAboveTheFold.name!}
+          headerProps={{
+            rightElements: (
+              <>
+                <TouchableOpacity onPress={handleSharePress}>
+                  <ShareIcon width={23} height={23} />
+                </TouchableOpacity>
+              </>
+            ),
+            onBack: goBack,
+          }}
+          HeaderComponent={() => <ArtistHeaderFragmentContainer artist={artistAboveTheFold!} />}
+        >
+          {displayAboutSection ? (
+            <Tabs.Tab name="Overview" label="Overview">
+              <Tabs.Lazy>
                 <>
-                  <TouchableOpacity onPress={handleSharePress}>
-                    <ShareIcon width={23} height={23} />
-                  </TouchableOpacity>
+                  {artistBelowTheFold ? (
+                    <ArtistAboutContainer artist={artistBelowTheFold} />
+                  ) : (
+                    <LoadingPage />
+                  )}
                 </>
-              }
-            />
-            <TabsContainer
-              initialTabName={initialTab}
-              renderHeader={() => {
-                return <ArtistHeaderFragmentContainer artist={artistAboveTheFold!} />
-              }}
-            >
-              {displayAboutSection ? (
-                <Tabs.Tab name="Overview" label="Overview">
-                  <Tabs.Lazy>
-                    <>
-                      {artistBelowTheFold ? (
-                        <ArtistAboutContainer artist={artistBelowTheFold} />
-                      ) : (
-                        <LoadingPage />
-                      )}
-                    </>
-                  </Tabs.Lazy>
-                </Tabs.Tab>
-              ) : null}
+              </Tabs.Lazy>
+            </Tabs.Tab>
+          ) : null}
 
-              <Tabs.Tab name="Artworks" label="Artworks">
-                <Tabs.Lazy>
-                  <ArtistArtworks
-                    artist={artistAboveTheFold}
-                    searchCriteria={searchCriteria}
-                    predefinedFilters={predefinedFilters}
-                  />
-                </Tabs.Lazy>
-              </Tabs.Tab>
+          <Tabs.Tab name="Artworks" label="Artworks">
+            <Tabs.Lazy>
+              <ArtistArtworks
+                artist={artistAboveTheFold}
+                searchCriteria={searchCriteria}
+                predefinedFilters={predefinedFilters}
+              />
+            </Tabs.Lazy>
+          </Tabs.Tab>
 
-              {artistAboveTheFold?.statuses?.auctionLots ? (
-                <Tabs.Tab name="Insights" label="Insights">
-                  <Tabs.Lazy>
-                    <>
-                      {artistBelowTheFold ? (
-                        <ArtistInsightsFragmentContainer
-                          artist={artistBelowTheFold}
-                          initialFilters={auctionResultsInitialFilters}
-                        />
-                      ) : (
-                        <LoadingPage />
-                      )}
-                    </>
-                  </Tabs.Lazy>
-                </Tabs.Tab>
-              ) : null}
-            </TabsContainer>
-          </Screen.Body>
-        </Screen>
+          {artistAboveTheFold?.statuses?.auctionLots ? (
+            <Tabs.Tab name="Insights" label="Insights">
+              <Tabs.Lazy>
+                <>
+                  {artistBelowTheFold ? (
+                    <ArtistInsightsFragmentContainer
+                      artist={artistBelowTheFold}
+                      initialFilters={auctionResultsInitialFilters}
+                    />
+                  ) : (
+                    <LoadingPage />
+                  )}
+                </>
+              </Tabs.Lazy>
+            </Tabs.Tab>
+          ) : null}
+        </TabsWithHeader>
       </ArtworkFiltersStoreProvider>
     </ProvideScreenTracking>
   )

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -29,7 +29,6 @@ const Tab = {
 export const Favorites: React.FC = () => {
   const tracking = useTracking()
 
-  // @ts-ignore TODO: add onChangeTab event prop to TabsWithHeader!
   const fireTabSelectionAnalytics = (selectedTab: IndexChangeEventData) => {
     let eventDetails
 
@@ -59,7 +58,7 @@ export const Favorites: React.FC = () => {
         context_screen_owner_type: null,
       }}
     >
-      <TabsWithHeader title="Follows">
+      <TabsWithHeader title="Follows" onTabChange={fireTabSelectionAnalytics}>
         <Tabs.Tab name={Tab.artists.name} label={Tab.artists.label}>
           <Tabs.Lazy>
             <FavoriteArtistsQueryRenderer />

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -1,6 +1,4 @@
-import { Flex, Screen, Text } from "@artsy/palette-mobile"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
-import { goBack } from "app/system/navigation/navigate"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { Tabs } from "react-native-collapsible-tab-view"
 import { IndexChangeEventData } from "react-native-collapsible-tab-view/lib/typescript/src/types"
@@ -31,6 +29,7 @@ const Tab = {
 export const Favorites: React.FC = () => {
   const tracking = useTracking()
 
+  // @ts-ignore TODO: add onChangeTab event prop to TabsWithHeader!
   const fireTabSelectionAnalytics = (selectedTab: IndexChangeEventData) => {
     let eventDetails
 
@@ -60,39 +59,23 @@ export const Favorites: React.FC = () => {
         context_screen_owner_type: null,
       }}
     >
-      <Screen>
-        <Screen.Body fullwidth>
-          <Screen.Header onBack={goBack} />
-          <TabsContainer
-            onTabChange={fireTabSelectionAnalytics}
-            renderHeader={() => {
-              return (
-                <Flex>
-                  <Text variant="lg-display" m={2}>
-                    Follows
-                  </Text>
-                </Flex>
-              )
-            }}
-          >
-            <Tabs.Tab name={Tab.artists.name} label={Tab.artists.label}>
-              <Tabs.Lazy>
-                <FavoriteArtistsQueryRenderer />
-              </Tabs.Lazy>
-            </Tabs.Tab>
-            <Tabs.Tab name={Tab.shows.name} label={Tab.shows.label}>
-              <Tabs.Lazy>
-                <FavoriteShowsQueryRenderer />
-              </Tabs.Lazy>
-            </Tabs.Tab>
-            <Tabs.Tab name={Tab.categories.name} label={Tab.categories.label}>
-              <Tabs.Lazy>
-                <FavoriteCategoriesQueryRenderer />
-              </Tabs.Lazy>
-            </Tabs.Tab>
-          </TabsContainer>
-        </Screen.Body>
-      </Screen>
+      <TabsWithHeader title="Follows">
+        <Tabs.Tab name={Tab.artists.name} label={Tab.artists.label}>
+          <Tabs.Lazy>
+            <FavoriteArtistsQueryRenderer />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+        <Tabs.Tab name={Tab.shows.name} label={Tab.shows.label}>
+          <Tabs.Lazy>
+            <FavoriteShowsQueryRenderer />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+        <Tabs.Tab name={Tab.categories.name} label={Tab.categories.label}>
+          <Tabs.Lazy>
+            <FavoriteCategoriesQueryRenderer />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+      </TabsWithHeader>
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/Gene/Gene.tests.tsx
+++ b/src/app/Scenes/Gene/Gene.tests.tsx
@@ -4,7 +4,6 @@ import { GeneTestsQuery } from "__generated__/GeneTestsQuery.graphql"
 import { ArtworkFilterOptionsScreen } from "app/Components/ArtworkFilter"
 import About from "app/Components/Gene/About"
 import { GeneArtworks } from "app/Components/Gene/GeneArtworks"
-import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
@@ -23,6 +22,8 @@ describe("Gene", () => {
           query GeneTestsQuery($geneID: String!, $input: FilterArtworksInput)
           @relay_test_operation {
             gene(id: $geneID) {
+              displayName
+              name
               slug
               ...Header_gene
               ...About_gene
@@ -34,16 +35,7 @@ describe("Gene", () => {
           if (!props?.gene) {
             return null
           }
-          return (
-            <StickyTabPage
-              tabs={[
-                {
-                  title: "test",
-                  content: <Gene geneID={geneID} gene={props.gene} />,
-                },
-              ]}
-            />
-          )
+          return <Gene geneID={geneID} gene={props.gene!} />
         }}
         variables={{
           geneID,

--- a/src/app/Scenes/Gene/Gene.tsx
+++ b/src/app/Scenes/Gene/Gene.tsx
@@ -42,7 +42,7 @@ export const Gene: React.FC<GeneProps> = (props) => {
     >
       <TabsWithHeader
         title={title}
-        HeaderComponent={() => (
+        BelowTitleHeaderComponent={() => (
           <Flex
             px={commonPadding}
             {...(isPad

--- a/src/app/Scenes/Gene/Gene.tsx
+++ b/src/app/Scenes/Gene/Gene.tsx
@@ -1,21 +1,20 @@
-import { Screen } from "@artsy/palette-mobile"
+import { Flex } from "@artsy/palette-mobile"
 import { FilterArtworksInput, GeneQuery } from "__generated__/GeneQuery.graphql"
 import { getParamsForInputByFilterType } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import About from "app/Components/Gene/About"
 import { GeneArtworksPaginationContainer } from "app/Components/Gene/GeneArtworks"
 import { GenePlaceholder } from "app/Components/Gene/GenePlaceholder"
 import Header from "app/Components/Gene/Header"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
-import { goBack } from "app/system/navigation/navigate"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
-import { Dimensions, StyleSheet, View, ViewStyle } from "react-native"
+import { Dimensions } from "react-native"
 import { Tabs } from "react-native-collapsible-tab-view"
 import { graphql, QueryRenderer } from "react-relay"
 
 const isPad = Dimensions.get("window").width > 700
-const commonPadding = isPad ? 40 : 20
+const commonPadding = isPad ? 4 : 2
 
 interface GeneProps {
   geneID: string
@@ -30,6 +29,7 @@ interface GeneQueryRendererProps {
 
 export const Gene: React.FC<GeneProps> = (props) => {
   const { gene, geneID } = props
+  const title = gene.displayName || gene.name || ""
 
   return (
     <ProvideScreenTracking
@@ -40,29 +40,33 @@ export const Gene: React.FC<GeneProps> = (props) => {
         context_screen_owner_slug: gene.slug,
       }}
     >
-      <Screen>
-        <Screen.Header onBack={goBack} />
-        <TabsContainer
-          lazy
-          renderHeader={() => (
-            <View style={styles.header}>
-              <Header gene={gene} shortForm={false} />
-            </View>
-          )}
-          // TODO: add renderBelowTabBar artwork filters
-        >
-          <Tabs.Tab name="Works" label="Works">
-            <Tabs.Lazy>
-              <GeneArtworksPaginationContainer gene={gene} />
-            </Tabs.Lazy>
-          </Tabs.Tab>
-          <Tabs.Tab name="About" label="About">
-            <Tabs.Lazy>
-              <About gene={gene} />
-            </Tabs.Lazy>
-          </Tabs.Tab>
-        </TabsContainer>
-      </Screen>
+      <TabsWithHeader
+        title={title}
+        HeaderComponent={() => (
+          <Flex
+            px={commonPadding}
+            {...(isPad
+              ? {
+                  width: 330,
+                  alignSelf: "center",
+                }
+              : {})}
+          >
+            <Header gene={gene} shortForm={false} />
+          </Flex>
+        )}
+      >
+        <Tabs.Tab name="Works" label="Works">
+          <Tabs.Lazy>
+            <GeneArtworksPaginationContainer gene={gene} />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+        <Tabs.Tab name="About" label="About">
+          <Tabs.Lazy>
+            <About gene={gene} />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+      </TabsWithHeader>
     </ProvideScreenTracking>
   )
 }
@@ -83,6 +87,8 @@ export const GeneQueryRenderer: React.FC<GeneQueryRendererProps> = (props) => {
       query={graphql`
         query GeneQuery($geneID: String!, $input: FilterArtworksInput) {
           gene(id: $geneID) {
+            displayName
+            name
             slug
             ...Header_gene
             ...About_gene
@@ -102,25 +108,3 @@ export const GeneQueryRenderer: React.FC<GeneQueryRendererProps> = (props) => {
     />
   )
 }
-
-interface Styles {
-  container: ViewStyle
-  header: ViewStyle
-}
-
-const styles = StyleSheet.create<Styles>({
-  container: {
-    flex: 1,
-  },
-  header: {
-    paddingLeft: commonPadding,
-    paddingRight: commonPadding,
-    marginBottom: 10,
-    ...(isPad
-      ? {
-          width: 330,
-          alignSelf: "center",
-        }
-      : {}),
-  },
-})

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tests.tsx
@@ -44,20 +44,6 @@ describe("PartnerHeader", () => {
     expect(extractText(tree.root)).toContain("1.2K works")
   })
 
-  it("renders the partner name", async () => {
-    const tree = renderWithWrappersLEGACY(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation({
-        errors: [],
-        data: {
-          partner: PartnerHeaderFixture,
-        },
-      })
-    })
-
-    expect(extractText(tree.root)).toContain("Gagosian")
-  })
-
   it("renders the follow button", async () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer />)
     act(() => {

--- a/src/app/Scenes/Partner/Components/PartnerHeader.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerHeader.tsx
@@ -23,9 +23,6 @@ const PartnerHeader: React.FC<{
   return (
     <>
       <Box px={2} pb={1}>
-        <Text variant="lg-display" mb={1}>
-          {partner.name}
-        </Text>
         <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
           <Stack spacing={0.5}>
             {!!eligibleArtworks && (
@@ -49,7 +46,6 @@ const PartnerHeader: React.FC<{
 export const PartnerHeaderContainer = createFragmentContainer(PartnerHeader, {
   partner: graphql`
     fragment PartnerHeader_partner on Partner {
-      name
       profile {
         # Only fetch something so we can see if the profile exists.
         name

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -1,12 +1,11 @@
-import { Screen, Separator } from "@artsy/palette-mobile"
+import { Separator } from "@artsy/palette-mobile"
 import { PartnerInitialQuery } from "__generated__/PartnerInitialQuery.graphql"
 import { PartnerQuery } from "__generated__/PartnerQuery.graphql"
 import { Partner_partner$data } from "__generated__/Partner_partner.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
-import { goBack } from "app/system/navigation/navigate"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -27,6 +26,7 @@ interface PartnerProps {
 }
 
 const Partner: React.FC<PartnerProps> = (props) => {
+  // @ts-ignore TODO: add initial tab prop to TabsWithHeader
   const { partner, initialTab } = props
   const { partnerType, displayFullPartnerPage } = partner
 
@@ -56,34 +56,25 @@ const Partner: React.FC<PartnerProps> = (props) => {
         context_screen_owner_type: Schema.OwnerEntityTypes.Partner,
       }}
     >
-      <Screen>
-        <Screen.Body fullwidth>
-          <Screen.Header onBack={goBack} />
-          <TabsContainer
-            lazy
-            initialTabName={initialTab}
-            renderHeader={() => <PartnerHeader partner={partner} />}
-          >
-            <Tabs.Tab name="Overview" label="Overview">
-              <Tabs.Lazy>
-                <PartnerOverview partner={partner} />
-              </Tabs.Lazy>
-            </Tabs.Tab>
-            <Tabs.Tab name="Artworks" label="Artworks">
-              <Tabs.Lazy>
-                <ArtworkFiltersStoreProvider>
-                  <PartnerArtwork partner={partner} />
-                </ArtworkFiltersStoreProvider>
-              </Tabs.Lazy>
-            </Tabs.Tab>
-            <Tabs.Tab name="Shows" label="Shows">
-              <Tabs.Lazy>
-                <PartnerShows partner={partner} />
-              </Tabs.Lazy>
-            </Tabs.Tab>
-          </TabsContainer>
-        </Screen.Body>
-      </Screen>
+      <TabsWithHeader title={partner.name!}>
+        <Tabs.Tab name="Overview" label="Overview">
+          <Tabs.Lazy>
+            <PartnerOverview partner={partner} />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+        <Tabs.Tab name="Artworks" label="Artworks">
+          <Tabs.Lazy>
+            <ArtworkFiltersStoreProvider>
+              <PartnerArtwork partner={partner} />
+            </ArtworkFiltersStoreProvider>
+          </Tabs.Lazy>
+        </Tabs.Tab>
+        <Tabs.Tab name="Shows" label="Shows">
+          <Tabs.Lazy>
+            <PartnerShows partner={partner} />
+          </Tabs.Lazy>
+        </Tabs.Tab>
+      </TabsWithHeader>
     </ProvideScreenTracking>
   )
 }
@@ -95,6 +86,7 @@ export const PartnerContainer = createRefetchContainer(
       fragment Partner_partner on Partner
       @argumentDefinitions(displayArtistsSection: { type: "Boolean", defaultValue: true }) {
         id
+        name
         internalID
         slug
         partnerType

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -26,7 +26,6 @@ interface PartnerProps {
 }
 
 const Partner: React.FC<PartnerProps> = (props) => {
-  // @ts-ignore TODO: add initial tab prop to TabsWithHeader
   const { partner, initialTab } = props
   const { partnerType, displayFullPartnerPage } = partner
 
@@ -56,7 +55,7 @@ const Partner: React.FC<PartnerProps> = (props) => {
         context_screen_owner_type: Schema.OwnerEntityTypes.Partner,
       }}
     >
-      <TabsWithHeader title={partner.name!}>
+      <TabsWithHeader title={partner.name!} initialTabName={initialTab}>
         <Tabs.Tab name="Overview" label="Overview">
           <Tabs.Lazy>
             <PartnerOverview partner={partner} />

--- a/src/app/Scenes/Tag/Tag.tsx
+++ b/src/app/Scenes/Tag/Tag.tsx
@@ -1,7 +1,6 @@
-import { Screen } from "@artsy/palette-mobile"
 import { TagQuery, TagQuery$data } from "__generated__/TagQuery.graphql"
-import { TabsContainer } from "app/Components/Tabs/TabsContainer"
-import { goBack } from "app/system/navigation/navigate"
+import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
+import { TagPlaceholder } from "app/Scenes/Tag/TagPlaceholder"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -9,7 +8,6 @@ import { Tabs } from "react-native-collapsible-tab-view"
 import { graphql, QueryRenderer } from "react-relay"
 import About from "./About"
 import { TagArtworksPaginationContainer } from "./TagArtworks"
-import { TagPlaceholder } from "./TagPlaceholder"
 
 interface TagProps {
   tagID?: string
@@ -32,30 +30,16 @@ export const Tag: React.FC<TagProps> = (props) => {
         context_screen_owner_slug: tag?.slug,
       }}
     >
-      <Screen>
-        <Screen.Body fullwidth>
-          <TabsContainer
-            renderHeader={() => {
-              return (
-                <Screen.Header
-                  title={tag?.name!}
-                  titleProps={{ alignItems: "flex-start" }}
-                  onBack={goBack}
-                />
-              )
-            }}
-          >
-            <Tabs.Tab name="Artworks" label="Artworks">
-              <TagArtworksPaginationContainer tag={tag!} />
-            </Tabs.Tab>
-            {!!tag?.description ? (
-              <Tabs.Tab name="About" label="About">
-                <About tag={tag} />
-              </Tabs.Tab>
-            ) : null}
-          </TabsContainer>
-        </Screen.Body>
-      </Screen>
+      <TabsWithHeader title={tag?.name!}>
+        <Tabs.Tab name="Artworks" label="Artworks">
+          <TagArtworksPaginationContainer tag={tag!} />
+        </Tabs.Tab>
+        {!!tag?.description ? (
+          <Tabs.Tab name="About" label="About">
+            <About tag={tag} />
+          </Tabs.Tab>
+        ) : null}
+      </TabsWithHeader>
     </ProvideScreenTracking>
   )
 }

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -3,14 +3,12 @@ import { TagArtworks_tag$data } from "__generated__/TagArtworks_tag.graphql"
 import { ArtworkFilterNavigator } from "app/Components/ArtworkFilter"
 import { FilterModalMode } from "app/Components/ArtworkFilter/ArtworkFilterOptionsScreen"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import {
-  useArtworkFilters,
-  useSelectedFiltersCount,
-} from "app/Components/ArtworkFilter/useArtworkFilters"
-import { ArtworksFilterHeader } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
+import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { SubTabBar } from "app/Components/Tabs/SubTabBar"
 import { TabScrollView } from "app/Components/Tabs/TabScrollView"
+import { TagArtworksFilterHeader } from "app/Scenes/Tag/TagArtworksFilterHeader"
 import { Schema } from "app/utils/track"
 import React, { useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -29,7 +27,6 @@ export const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay, openFilter
   const tracking = useTracking()
   const artworksTotal = tag.artworks?.counts?.total ?? 0
   const initialArtworksTotal = useRef(artworksTotal)
-  const selectedFiltersCount = useSelectedFiltersCount()
 
   const trackClear = () => {
     tracking.trackEvent(tracks.clearFilters(tag.id, tag.slug))
@@ -59,13 +56,9 @@ export const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay, openFilter
 
   return (
     <>
-      {/* TODO: find a better way than neg margin to align the sort and filter */}
-      <Box mx={-2}>
-        <ArtworksFilterHeader
-          selectedFiltersCount={selectedFiltersCount}
-          onFilterPress={openFilterModal}
-        />
-      </Box>
+      <SubTabBar>
+        <TagArtworksFilterHeader openFilterArtworksModal={openFilterModal} />
+      </SubTabBar>
       <Spacer y={1} />
       <Text variant="sm-display" color="black60" mb={2}>
         Showing {artworksTotal} works

--- a/src/app/Scenes/Tag/TagArtworksFilterHeader.tsx
+++ b/src/app/Scenes/Tag/TagArtworksFilterHeader.tsx
@@ -1,0 +1,22 @@
+import { Box } from "@artsy/palette-mobile"
+import { useSelectedFiltersCount } from "app/Components/ArtworkFilter/useArtworkFilters"
+import { ArtworksFilterHeader } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
+
+interface TagArtworksFilterProps {
+  openFilterArtworksModal: (mode: "sortAndFilter") => void
+}
+
+export const TagArtworksFilterHeader: React.FC<TagArtworksFilterProps> = ({
+  openFilterArtworksModal,
+}) => {
+  const appliedFiltersCount = useSelectedFiltersCount()
+
+  return (
+    <Box backgroundColor="white100">
+      <ArtworksFilterHeader
+        onFilterPress={() => openFilterArtworksModal("sortAndFilter")}
+        selectedFiltersCount={appliedFiltersCount}
+      />
+    </Box>
+  )
+}


### PR DESCRIPTION
This PR resolves [MOPLAT-779] <!-- eg [PROJECT-XXXX] -->

### Description

- Copied over some useful components from energy for the animated header on tabs.
- Adjusted animation of header
- Extended the interface of `TabsWithHeader` to take as props useful props for `TabContainer` like `onTabChanged` and `initialTab`
- Sticky animated header in the following screens:
  - [x] Tag.tsx :white_check_mark:
  - [x] Partner.tsx :white_check_mark:
  - [x] Favorites :white_check_mark:
  - [x] Artist :white_check_mark:
  - [x] Gene :white_check_mark:
  - [x] Activity.tsx :white_check_mark:
  - [x] ArtQuizResultsPage :white_check_mark:
  - [ ] MyCollection (also not addressed since we don't have a header there and no back button either 🤷)


#### Video demos

##### Partner
https://github.com/artsy/eigen/assets/21178754/898c3bb3-9547-43aa-8b15-09b9bbe01a6f

##### Tag
https://github.com/artsy/eigen/assets/21178754/7f3041aa-2713-4c0e-a2b1-8919523dc042

##### Artist
https://github.com/artsy/eigen/assets/21178754/b0f8a4dc-2575-4222-8293-9607595fd824

##### Gene
https://github.com/artsy/eigen/assets/21178754/9f87e5c1-1e8d-4f56-bdb5-9bab200f039a

##### Follows / "favorites"
https://github.com/artsy/eigen/assets/21178754/4d788259-78bc-4112-9927-13d53be624bd

##### Activity

https://github.com/artsy/eigen/assets/21178754/6dee568e-e83b-4a17-8761-9bab81b15ebb

##### Art-quiz

user **liked** artworks

https://github.com/artsy/eigen/assets/21178754/973eedb0-b982-4444-b03b-7934da8526aa

user **didnt** like artworks

https://github.com/artsy/eigen/assets/21178754/69364480-d08e-473c-9771-f6fe3682ab94


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- sticky animated header on most screens that use sticky tabs - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPLAT-779]: https://artsyproduct.atlassian.net/browse/MOPLAT-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ