### PR TITLE
feat: don't display contextual menu button for "Saved Artworks" list

### DIFF
--- a/src/app/Scenes/ArtworkList/ArtworkList.tests.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tests.tsx
@@ -71,10 +71,7 @@ describe("ArtworkList", () => {
         resolveMostRecentRelayOperation(mockEnvironment, {
           Me: () => ({
             ...me,
-            artworkList: {
-              ...me.artworkList,
-              default: false,
-            },
+            artworkList: customArtworkList,
           }),
         })
 
@@ -93,10 +90,9 @@ describe("ArtworkList", () => {
           Me: () => ({
             ...me,
             artworkList: {
-              ...me.artworkList,
-              default: false,
+              ...customArtworkList,
               artworks: {
-                ...me.artworkList.artworks,
+                ...customArtworkList.artworks,
                 totalCount: 0,
               },
             },
@@ -111,27 +107,38 @@ describe("ArtworkList", () => {
   })
 })
 
-const me = {
-  artworkList: {
-    internalID: "id-1",
-    name: "Saved Artworks",
-    default: true,
-    artworks: {
-      totalCount: 2,
-      edges: [
-        {
-          node: {
-            title: "Artwork Title 1",
-            internalID: "613a38d6611297000d7ccc1d",
-          },
-        },
-        {
-          node: {
-            title: "Artwork Title 2",
-            internalID: "614e4006f856a0000df1399c",
-          },
-        },
-      ],
+const artworks = {
+  totalCount: 2,
+  edges: [
+    {
+      node: {
+        title: "Artwork Title 1",
+        internalID: "613a38d6611297000d7ccc1d",
+      },
     },
-  },
+    {
+      node: {
+        title: "Artwork Title 2",
+        internalID: "614e4006f856a0000df1399c",
+      },
+    },
+  ],
+}
+
+const defaultArtworkList = {
+  internalID: "id-1",
+  name: "Saved Artworks",
+  default: true,
+  artworks,
+}
+
+const customArtworkList = {
+  internalID: "custom-artwork-list",
+  name: "Custom Artwork List",
+  default: false,
+  artworks,
+}
+
+const me = {
+  artworkList: defaultArtworkList,
 }

--- a/src/app/Scenes/ArtworkList/ArtworkList.tests.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tests.tsx
@@ -4,6 +4,8 @@ import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import { createMockEnvironment } from "relay-test-utils"
 
+const CONTEXTUAL_MENU_LABEL = "Contextual Menu Button"
+
 describe("ArtworkList", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
@@ -42,12 +44,78 @@ describe("ArtworkList", () => {
     expect(findByText("Artwork Title 1")).toBeTruthy()
     expect(findByText("Artwork Title 2")).toBeTruthy()
   })
+
+  describe("Contextual menu button", () => {
+    it("should NOT be displayed for default artwork list", async () => {
+      const { queryByLabelText } = renderWithHookWrappersTL(
+        <ArtworkList listID="some-id" />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Me: () => me,
+      })
+
+      await flushPromiseQueue()
+
+      expect(queryByLabelText(CONTEXTUAL_MENU_LABEL)).toBeNull()
+    })
+
+    describe("custom artwork list", () => {
+      it("should be displayed", async () => {
+        const { getByLabelText } = renderWithHookWrappersTL(
+          <ArtworkList listID="some-id" />,
+          mockEnvironment
+        )
+
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Me: () => ({
+            ...me,
+            artworkList: {
+              ...me.artworkList,
+              default: false,
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        expect(getByLabelText(CONTEXTUAL_MENU_LABEL)).toBeTruthy()
+      })
+
+      it("should be displayed for empty state", async () => {
+        const { getByLabelText } = renderWithHookWrappersTL(
+          <ArtworkList listID="some-id" />,
+          mockEnvironment
+        )
+
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Me: () => ({
+            ...me,
+            artworkList: {
+              ...me.artworkList,
+              default: false,
+              artworks: {
+                ...me.artworkList.artworks,
+                totalCount: 0,
+              },
+            },
+          }),
+        })
+
+        await flushPromiseQueue()
+
+        expect(getByLabelText(CONTEXTUAL_MENU_LABEL)).toBeTruthy()
+      })
+    })
+  })
 })
 
 const me = {
   artworkList: {
     internalID: "id-1",
     name: "Saved Artworks",
+    default: true,
     artworks: {
       totalCount: 2,
       edges: [

--- a/src/app/Scenes/ArtworkList/ArtworkList.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tsx
@@ -172,7 +172,7 @@ const ArtworkListPlaceholder = () => {
   const space = useSpace()
   return (
     <ProvidePlaceholderContext>
-      <ArtworkListHeader />
+      <ArtworkListHeader canRenderContextualMenuButton={true} />
 
       <Flex px={2}>
         <PlaceholderText height={20} width={200} marginVertical={space(2)} />

--- a/src/app/Scenes/ArtworkList/ArtworkList.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tsx
@@ -83,6 +83,7 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   return (
     <ArtworkListsProvider artworkListId={listID}>
       <ArtworkListHeader
+        canRenderContextualMenuButton={!artworkList.default}
         artworkListEntity={{
           title: artworkList.name,
           internalID: artworkList.internalID,
@@ -142,6 +143,7 @@ const artworkListFragment = graphql`
     artworkList: collection(id: $listID) {
       internalID
       name
+      default
 
       artworks: artworksConnection(first: $count, after: $after, sort: $sort)
         @connection(key: "ArtworkList_artworks") {

--- a/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListEmptyState.tsx
@@ -25,7 +25,10 @@ export const ArtworkListEmptyState = ({ me, refreshControl }: ArtworkListEmptySt
 
   return (
     <Flex flex={1} mb={1}>
-      <ArtworkListHeader artworkListEntity={artworkListEntity} />
+      <ArtworkListHeader
+        artworkListEntity={artworkListEntity}
+        canRenderContextualMenuButton={!artworkList.default}
+      />
 
       <ScrollView style={{ flex: 1 }} refreshControl={refreshControl}>
         <ArtworkListTitle title={artworkList.name} />

--- a/src/app/Scenes/ArtworkList/ArtworkListHeader.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListHeader.tsx
@@ -5,13 +5,15 @@ import { goBack } from "app/system/navigation/navigate"
 import { FC, useCallback, useState } from "react"
 import { HeaderMenuArtworkListEntity } from "./types"
 
-const EditHeaderButton = () => <MoreIcon fill="black100" width={24} height={24} />
-
 export interface ArtworkListHeaderProps {
   artworkListEntity?: HeaderMenuArtworkListEntity
+  canRenderContextualMenuButton?: boolean
 }
 
-export const ArtworkListHeader: FC<ArtworkListHeaderProps> = ({ artworkListEntity }) => {
+export const ArtworkListHeader: FC<ArtworkListHeaderProps> = ({
+  artworkListEntity,
+  canRenderContextualMenuButton,
+}) => {
   const [isManageViewVisible, setIsManageViewVisible] = useState(false)
 
   const openManageArtworkListView = () => {
@@ -30,7 +32,20 @@ export const ArtworkListHeader: FC<ArtworkListHeaderProps> = ({ artworkListEntit
     <>
       <FancyModalHeader
         onLeftButtonPress={goBack}
-        renderRightButton={EditHeaderButton}
+        renderRightButton={() => {
+          if (canRenderContextualMenuButton) {
+            return (
+              <MoreIcon
+                fill="black100"
+                width={24}
+                height={24}
+                accessibilityLabel="Contextual Menu Button"
+              />
+            )
+          }
+
+          return <></>
+        }}
         rightButtonDisabled={!artworkListEntity}
         onRightButtonPress={openManageArtworkListView}
         hideBottomDivider


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
don't display contextual menu button for "Saved Artworks" list (our default artwork list)

### Demo
| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/artsy/eigen/assets/3513494/3486db6b-5808-4d32-9403-08c97ab53c09" />  | <video src="https://github.com/artsy/eigen/assets/3513494/920b7047-cc8f-4b76-8ba2-ed265435a9ad" />  | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- don't display contextual menu button for "Saved Artworks" list - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
