### PR TITLE
refactor: error boundary screens

### DIFF
--- a/src/app/Components/NotFoundFailureView.tsx
+++ b/src/app/Components/NotFoundFailureView.tsx
@@ -1,5 +1,4 @@
-import { Flex, Text, Button } from "@artsy/palette-mobile"
-import { BackButton } from "app/system/navigation/BackButton"
+import { Flex, Text, Button, Screen } from "@artsy/palette-mobile"
 import { goBack } from "app/system/navigation/navigate"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 
@@ -20,27 +19,29 @@ export const NotFoundFailureView: React.FC<NotFoundFailureViewProps> = ({
   const showErrorMessage = __DEV__ || isDevToggleEnabled
 
   return (
-    <>
-      <BackButton onPress={() => goBack()} style={{ top: 10 }} />
+    <Screen>
+      <Screen.Body fullwidth>
+        <Screen.Header onBack={goBack} />
 
-      <Flex flex={1} m={4} justifyContent="center" alignItems="center">
-        <Text variant="lg-display" mb={1} textAlign="center">
-          {title ?? "Not Found"}
-        </Text>
-        <Text variant="lg-display" color="black60" mb={4} textAlign="center">
-          {text ?? "Sorry, the resource you were looking for doesn’t exist."}
-        </Text>
+        <Flex flex={1} m={4} justifyContent="center" alignItems="center">
+          <Text variant="lg-display" mb={1} textAlign="center">
+            {title ?? "Not Found"}
+          </Text>
+          <Text variant="lg-display" color="black60" mb={4} textAlign="center">
+            {text ?? "Sorry, the resource you were looking for doesn’t exist."}
+          </Text>
 
-        <Button variant="outline" block onPress={() => goBack()}>
-          {backButtonText ?? "Back"}
-        </Button>
+          <Button variant="outline" block onPress={() => goBack()}>
+            {backButtonText ?? "Back"}
+          </Button>
 
-        {!!showErrorMessage && (
-          <Flex my={2}>
-            <Text>Error: {error?.message}</Text>
-          </Flex>
-        )}
-      </Flex>
-    </>
+          {!!showErrorMessage && (
+            <Flex my={2}>
+              <Text>Error: {error?.message}</Text>
+            </Flex>
+          )}
+        </Flex>
+      </Screen.Body>
+    </Screen>
   )
 }

--- a/src/app/Components/RetryErrorBoundary.tests.tsx
+++ b/src/app/Components/RetryErrorBoundary.tests.tsx
@@ -1,8 +1,5 @@
-import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import "react-native"
-
-import { LoadFailureView } from "./LoadFailureView"
-import { RetryErrorBoundary, RetryErrorBoundaryLegacy } from "./RetryErrorBoundary"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { RetryErrorBoundary } from "./RetryErrorBoundary"
 
 const consoleError = console.error
 beforeEach(() => {
@@ -49,43 +46,6 @@ describe("RetryErrorBoundary", () => {
 
       expect(getByText("Not Found")).toBeDefined()
     })
-  })
-})
-describe("RetryErrorBoundaryLegacy", () => {
-  it("Renders the fallback view when the rendered component crashes", () => {
-    const tree = renderWithWrappersLEGACY(
-      <RetryErrorBoundaryLegacy render={() => <CrashingComponent shouldCrash />} />
-    )
-    expect(tree.root.findAllByType(LoadFailureView)).toHaveLength(1)
-  })
-
-  it("passes false for isRetry to render prop on first pass", () => {
-    let receivedIsRetry = true
-    renderWithWrappersLEGACY(
-      <RetryErrorBoundaryLegacy
-        render={({ isRetry }) => {
-          receivedIsRetry = isRetry
-          return <CrashingComponent shouldCrash />
-        }}
-      />
-    )
-    expect(receivedIsRetry).toBeFalsy()
-  })
-
-  it("passes true for isRetry to render prop on retry", () => {
-    let receivedIsRetry = false
-    const tree = renderWithWrappersLEGACY(
-      <RetryErrorBoundaryLegacy
-        render={({ isRetry }) => {
-          receivedIsRetry = isRetry
-          // Only crash on the first attempt, succeed on the retry.
-          return <CrashingComponent shouldCrash={isRetry ? false : true} />
-        }}
-      />
-    )
-    // Simulate user pressing retry button
-    tree.root.findAllByType(LoadFailureView)[0].props.onRetry()
-    expect(receivedIsRetry).toBeTruthy()
   })
 })
 

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -1,48 +1,6 @@
-import { captureMessage } from "@sentry/react-native"
 import React, { Component } from "react"
 import { LoadFailureView } from "./LoadFailureView"
 import { NotFoundFailureView } from "./NotFoundFailureView"
-
-enum ErrorState {
-  Okay,
-  Error,
-  Retry,
-}
-
-interface Props {
-  render: (props: { isRetry: boolean }) => React.ReactNode
-}
-
-interface State {
-  errorState: ErrorState
-}
-
-/// Catches any errors and shows a failure screen. The user can tap a button to retry the render, which is indicated to
-/// the render prop with a parameter value of `true`.
-export class RetryErrorBoundaryLegacy extends Component<Props, State> {
-  // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-  static getDerivedStateFromError(error) {
-    console.error(error)
-    captureMessage(error.stack)
-    return { errorState: ErrorState.Error }
-  }
-
-  state = {
-    errorState: ErrorState.Okay,
-  }
-
-  render() {
-    const { render } = this.props
-    const containers = {
-      [ErrorState.Okay]: () => render({ isRetry: false }),
-      [ErrorState.Error]: () => (
-        <LoadFailureView onRetry={() => this.setState({ errorState: ErrorState.Retry })} />
-      ),
-      [ErrorState.Retry]: () => render({ isRetry: true }),
-    }
-    return containers[this.state.errorState]()
-  }
-}
 
 // Taken from https://relay.dev/docs/guided-tour/rendering/error-states/#when-using-uselazyloadquery
 interface RetryErrorBoundaryProps {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -10,7 +10,6 @@ import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsCo
 import { AuctionTimerState, currentTimerState } from "app/Components/Bidding/Components/Timer"
 import { usePageableScreensContext } from "app/Components/PageableScreensView/PageableScreensContext"
 import { PageableScreensView } from "app/Components/PageableScreensView/PageableScreensView"
-import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { ArtworkScreenHeader } from "app/Scenes/Artwork/Components/ArtworkScreenHeader"
 import { OfferSubmittedModal } from "app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal"
@@ -619,46 +618,38 @@ export const ArtworkQueryRenderer: React.FC<ArtworkPageableScreenProps> = ({
   ...others
 }) => {
   return (
-    <>
-      <RetryErrorBoundaryLegacy
-        render={() => {
+    <AboveTheFoldQueryRenderer<ArtworkAboveTheFoldQuery, ArtworkBelowTheFoldQuery>
+      environment={environment || getRelayEnvironment()}
+      above={{
+        query: ArtworkScreenQuery,
+        variables: { artworkID },
+      }}
+      below={{
+        query: graphql`
+          query ArtworkBelowTheFoldQuery($artworkID: String!) {
+            artwork(id: $artworkID) {
+              ...Artwork_artworkBelowTheFold
+            }
+          }
+        `,
+        variables: { artworkID },
+      }}
+      render={{
+        renderPlaceholder: () => <AboveTheFoldPlaceholder artworkID={artworkID} />,
+        renderComponent: ({ above, below }) => {
           return (
-            <AboveTheFoldQueryRenderer<ArtworkAboveTheFoldQuery, ArtworkBelowTheFoldQuery>
-              environment={environment || getRelayEnvironment()}
-              above={{
-                query: ArtworkScreenQuery,
-                variables: { artworkID },
-              }}
-              below={{
-                query: graphql`
-                  query ArtworkBelowTheFoldQuery($artworkID: String!) {
-                    artwork(id: $artworkID) {
-                      ...Artwork_artworkBelowTheFold
-                    }
-                  }
-                `,
-                variables: { artworkID },
-              }}
-              render={{
-                renderPlaceholder: () => <AboveTheFoldPlaceholder artworkID={artworkID} />,
-                renderComponent: ({ above, below }) => {
-                  return (
-                    <ArtworkContainer
-                      {...others}
-                      artworkAboveTheFold={above.artwork}
-                      artworkBelowTheFold={below?.artwork ?? null}
-                      me={above.me}
-                    />
-                  )
-                },
-              }}
-              fetchPolicy="store-and-network"
-              cacheConfig={{ force: true }}
+            <ArtworkContainer
+              {...others}
+              artworkAboveTheFold={above.artwork}
+              artworkBelowTheFold={below?.artwork ?? null}
+              me={above.me}
             />
           )
-        }}
-      />
-    </>
+        },
+      }}
+      fetchPolicy="store-and-network"
+      cacheConfig={{ force: true }}
+    />
   )
 }
 
@@ -694,7 +685,7 @@ export const ArtworkPageableScreen: React.FC<ArtworkPageableScreenProps> = (prop
 
   return (
     <>
-      {artworkProps?.artworkAboveTheFold && (
+      {!!artworkProps?.artworkAboveTheFold && (
         <ArtworkScreenHeader artwork={artworkProps.artworkAboveTheFold} />
       )}
       {/*

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -4,7 +4,6 @@ import { PartnerQuery } from "__generated__/PartnerQuery.graphql"
 import { Partner_partner$data } from "__generated__/Partner_partner.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
-import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import { TabsWithHeader } from "app/Components/Tabs/TabsWithHeader"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -128,34 +127,24 @@ export const PartnerQueryRenderer: React.FC<{
   }
 
   return (
-    <RetryErrorBoundaryLegacy
-      render={({ isRetry }) => {
-        return (
-          <QueryRenderer<PartnerQuery>
-            environment={getRelayEnvironment()}
-            query={graphql`
-              query PartnerQuery($partnerID: String!, $displayArtistsSection: Boolean!) {
-                partner(id: $partnerID) {
-                  ...Partner_partner @arguments(displayArtistsSection: $displayArtistsSection)
-                }
-              }
-            `}
-            variables={{
-              partnerID,
-              displayArtistsSection: data?.partner?.displayArtistsSection ?? true,
-            }}
-            cacheConfig={{
-              // Bypass Relay cache on retries.
-              ...(isRetry && { force: true }),
-            }}
-            render={renderWithPlaceholder({
-              Container: PartnerContainer,
-              initialProps: others,
-              renderPlaceholder: () => <HeaderTabsGridPlaceholder />,
-            })}
-          />
-        )
+    <QueryRenderer<PartnerQuery>
+      environment={getRelayEnvironment()}
+      query={graphql`
+        query PartnerQuery($partnerID: String!, $displayArtistsSection: Boolean!) {
+          partner(id: $partnerID) {
+            ...Partner_partner @arguments(displayArtistsSection: $displayArtistsSection)
+          }
+        }
+      `}
+      variables={{
+        partnerID,
+        displayArtistsSection: data?.partner?.displayArtistsSection ?? true,
       }}
+      render={renderWithPlaceholder({
+        Container: PartnerContainer,
+        initialProps: others,
+        renderPlaceholder: () => <HeaderTabsGridPlaceholder />,
+      })}
     />
   )
 }

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -14,7 +14,6 @@ import {
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { DEFAULT_NEW_SALE_ARTWORK_SORT } from "app/Components/ArtworkFilter/Filters/SortOptions"
 import { LoadFailureView } from "app/Components/LoadFailureView"
-import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import Spinner from "app/Components/Spinner"
 import { CascadingEndTimesBanner } from "app/Scenes/Artwork/Components/CascadingEndTimesBanner"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
@@ -471,56 +470,48 @@ export const SaleQueryRenderer: React.FC<{
   }, [])
 
   return (
-    <RetryErrorBoundaryLegacy
-      render={() => {
-        return (
-          <AboveTheFoldQueryRenderer<SaleAboveTheFoldQuery, SaleBelowTheFoldQuery>
-            environment={environment || getRelayEnvironment()}
-            above={{
-              query: SaleScreenQuery,
-              variables: { saleID, saleSlug: saleID },
-            }}
-            below={
-              enableArtworksConnection
-                ? {
-                    query: SaleScreenBelowNewQuery,
-                    variables: {
-                      saleID,
-                      // @ts-ignore
-                      input: {
-                        sort: DEFAULT_NEW_SALE_ARTWORK_SORT.paramValue,
-                        priceRange: "",
-                      },
-                    },
-                  }
-                : {
-                    query: SaleScreenBelowQuery,
-                    variables: { saleID },
-                  }
-            }
-            render={({ props, error }) => {
-              if (error) {
-                if (__DEV__) {
-                  console.error(error)
-                } else {
-                  captureMessage(error.stack!)
-                }
-                return <LoadFailureView />
-              }
-              if (!props?.above.me || !props.above.sale) {
-                return <SalePlaceholder />
-              }
-              return (
-                <SaleContainer sale={props.above.sale} me={props.above.me} below={props.below} />
-              )
-            }}
-            cacheConfig={{
-              force: true,
-            }}
-            fetchPolicy="store-and-network"
-          />
-        )
+    <AboveTheFoldQueryRenderer<SaleAboveTheFoldQuery, SaleBelowTheFoldQuery>
+      environment={environment || getRelayEnvironment()}
+      above={{
+        query: SaleScreenQuery,
+        variables: { saleID, saleSlug: saleID },
       }}
+      below={
+        enableArtworksConnection
+          ? {
+              query: SaleScreenBelowNewQuery,
+              variables: {
+                saleID,
+                // @ts-ignore
+                input: {
+                  sort: DEFAULT_NEW_SALE_ARTWORK_SORT.paramValue,
+                  priceRange: "",
+                },
+              },
+            }
+          : {
+              query: SaleScreenBelowQuery,
+              variables: { saleID },
+            }
+      }
+      render={({ props, error }) => {
+        if (error) {
+          if (__DEV__) {
+            console.error(error)
+          } else {
+            captureMessage(error.stack!)
+          }
+          return <LoadFailureView />
+        }
+        if (!props?.above.me || !props.above.sale) {
+          return <SalePlaceholder />
+        }
+        return <SaleContainer sale={props.above.sale} me={props.above.me} below={props.below} />
+      }}
+      cacheConfig={{
+        force: true,
+      }}
+      fetchPolicy="store-and-network"
     />
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

As we were working on sticky tab stuff we realized that some of the error boundary screens weren't working properly and due to the changes we did (fullBleed: true) it broke a bit the design of this page.

This PR fixes that and readjusts the screens to be always correcly aligned utilizing the `<Screen />` palette component.

As a **bonus** I also removed all the references of the `RetryErrorBoundaryLegacy` which was used in some places (and it was **overriding** the new error boundary that we already have in place in the providers of the app.

Nothing changes behavior wise since they both used under the hood the same view 🤷‍♂️.

⚠️ I didn't touch the Override that we do in **MyCollection** since it is due to using specific error messages related with the errors in this screen 🌟


#### Screenshots:

##### Partner

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 15 03 00](https://github.com/artsy/eigen/assets/21178754/2ad37101-87a0-497b-9c1b-01cfd84b4a89)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 14 59 41](https://github.com/artsy/eigen/assets/21178754/9a9df791-3ab5-4d48-a3bb-92e200c71c07)| 

##### Artwork

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 15 03 11](https://github.com/artsy/eigen/assets/21178754/65c9faab-80e9-46a1-a3a8-a051e25a091c)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 15 06 41](https://github.com/artsy/eigen/assets/21178754/aee722d1-830f-4652-a626-10398a4e39f4)| 

##### Sale

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 15 02 43](https://github.com/artsy/eigen/assets/21178754/14b27f17-ae6c-466d-a64f-48aef606b6c5)|![Simulator Screenshot - iPhone 14 Pro - 2023-05-25 at 15 02 43](https://github.com/artsy/eigen/assets/21178754/14b27f17-ae6c-466d-a64f-48aef606b6c5)| 

weird that on sale we get unable to load vs the error screen 🤷‍♂️

### Follow ups:

We might need to find a better way to handle the artwork page, since due to [hiding the bottom tab bar](https://github.com/artsy/eigen/blob/main/src/app/AppRegistry.tsx#L356) the Screen component is not adjusted correctly and it has the `bottomTabBar` height as padding top for some reason 🤔 but it was broken before and this PR is already an improvement (see artwork before and after screenshots)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- error boundary screens - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
