### PR TITLE
refactor: always use the same relay env

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -297,14 +297,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 596
+        "line_number": 595
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 684
+        "line_number": 683
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1035,5 +1035,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-25T09:38:38Z"
+  "generated_at": "2023-05-26T12:58:22Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -297,14 +297,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 595
+        "line_number": 599
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 683
+        "line_number": 687
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1035,5 +1035,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-26T12:58:22Z"
+  "generated_at": "2023-05-26T18:47:03Z"
 }

--- a/src/app/Components/ArtistAutosuggest/ArtistAutosuggest.tests.tsx
+++ b/src/app/Components/ArtistAutosuggest/ArtistAutosuggest.tests.tsx
@@ -1,11 +1,10 @@
 import { fireEvent } from "@testing-library/react-native"
 import { ArtworkDetails } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetails"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe("ArtworkDetailsForm", () => {
   const TestRenderer = () => (

--- a/src/app/Components/ArtistAutosuggest/ArtistAutosuggestResults.tsx
+++ b/src/app/Components/ArtistAutosuggest/ArtistAutosuggestResults.tsx
@@ -11,7 +11,7 @@ import { captureMessage } from "@sentry/react-native"
 import { ArtistAutosuggestResultsQuery } from "__generated__/ArtistAutosuggestResultsQuery.graphql"
 import { ArtistAutosuggestResults_results$data } from "__generated__/ArtistAutosuggestResults_results.graphql"
 import { ErrorView } from "app/Components/ErrorView/ErrorView"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import {
   ProvidePlaceholderContext,
   PlaceholderBox,
@@ -242,7 +242,7 @@ export const ArtistAutosuggestResults: React.FC<{
               @arguments(query: $query, count: $count, entities: $entities)
           }
         `}
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
       />
     )
   },

--- a/src/app/Components/Bidding/Context/TimeOffsetProvider.tests.tsx
+++ b/src/app/Components/Bidding/Context/TimeOffsetProvider.tests.tsx
@@ -1,11 +1,10 @@
 import { Text } from "@artsy/palette-mobile"
 import { waitFor } from "@testing-library/react-native"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import PropTypes from "prop-types"
 import React from "react"
-import { createMockEnvironment } from "relay-test-utils"
 import { TimeOffsetProvider } from "./TimeOffsetProvider"
 
 const SECONDS = 1000
@@ -23,7 +22,7 @@ class TestConsumer extends React.Component {
 }
 
 describe("TimeOffsetProvider", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
 
   const TestWrapper = () => {
     return (

--- a/src/app/Components/Bidding/Context/TimeOffsetProvider.tests.tsx
+++ b/src/app/Components/Bidding/Context/TimeOffsetProvider.tests.tsx
@@ -5,6 +5,7 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import PropTypes from "prop-types"
 import React from "react"
+import { createMockEnvironment } from "relay-test-utils"
 import { TimeOffsetProvider } from "./TimeOffsetProvider"
 
 const SECONDS = 1000
@@ -22,7 +23,7 @@ class TestConsumer extends React.Component {
 }
 
 describe("TimeOffsetProvider", () => {
-  const mockEnvironment = getMockRelayEnvironment()
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
   const TestWrapper = () => {
     return (
@@ -33,7 +34,7 @@ describe("TimeOffsetProvider", () => {
   }
 
   beforeEach(() => {
-    mockEnvironment.mockClear()
+    mockEnvironment = getMockRelayEnvironment()
     Date.now = jest.fn(() => DATE_NOW)
   })
 

--- a/src/app/Components/Bidding/Context/TimeOffsetProvider.tsx
+++ b/src/app/Components/Bidding/Context/TimeOffsetProvider.tsx
@@ -1,5 +1,5 @@
 import { TimeOffsetProviderQuery } from "__generated__/TimeOffsetProviderQuery.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import PropTypes from "prop-types"
 import React from "react"
 import { fetchQuery, graphql } from "relay-runtime"
@@ -10,7 +10,7 @@ const getLocalTimestampInMilliSeconds = () => {
 
 const fetchSystemTime = () =>
   fetchQuery<TimeOffsetProviderQuery>(
-    defaultEnvironment,
+    getRelayEnvironment(),
     graphql`
       query TimeOffsetProviderQuery {
         system {

--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -13,7 +13,7 @@ import { Modal } from "app/Components/Modal"
 import Spinner from "app/Components/Spinner"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import NavigatorIOS, {
   NavigatorIOSPushArgs,
 } from "app/utils/__legacy_do_not_use__navigator-ios-shim"
@@ -109,7 +109,7 @@ describe("ConfirmBid", () => {
     const component = mountConfirmBidComponent(initialProps)
 
     expect(component.root.findAllByType(Spinner).length).toEqual(1)
-    ;(defaultEnvironment as any).mock.resolveMostRecentOperation(() => ({
+    getMockRelayEnvironment().mock.resolveMostRecentOperation(() => ({
       data: {
         node: {
           __typename: "SaleArtwork",

--- a/src/app/Components/Bidding/Screens/ConfirmBid/BidderPositionQuery.ts
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/BidderPositionQuery.ts
@@ -1,10 +1,10 @@
 import { BidderPositionQuery } from "__generated__/BidderPositionQuery.graphql"
-import { defaultEnvironment as environment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { fetchQuery, graphql } from "relay-runtime"
 
 export const bidderPositionQuery = (bidderPositionID: string) => {
   return fetchQuery<BidderPositionQuery>(
-    environment,
+    getRelayEnvironment(),
     graphql`
       query BidderPositionQuery($bidderPositionID: String!) {
         me {

--- a/src/app/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/PriceSummary.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Text } from "@artsy/palette-mobile"
 import { PriceSummaryQuery } from "__generated__/PriceSummaryQuery.graphql"
 import { PriceSummary_calculatedCost$data } from "__generated__/PriceSummary_calculatedCost.graphql"
 import { Bid } from "app/Components/Bidding/types"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
@@ -69,7 +69,7 @@ interface PriceSummaryProps extends Partial<PriceSummaryQuery["variables"]> {
 
 export const PriceSummary = ({ saleArtworkId, bid }: PriceSummaryProps) => (
   <QueryRenderer<PriceSummaryQuery>
-    environment={defaultEnvironment}
+    environment={getRelayEnvironment()}
     query={graphql`
       query PriceSummaryQuery($saleArtworkId: ID!, $bidAmountMinor: Int!) {
         node(id: $saleArtworkId) {

--- a/src/app/Components/Bidding/Screens/Registration.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tsx
@@ -16,7 +16,7 @@ import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { dismissModal, navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import { bidderNeedsIdentityVerification } from "app/utils/auction/bidderNeedsIdentityVerification"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -518,7 +518,7 @@ export const RegistrationQueryRenderer: React.FC<{ saleID: string; navigator: Na
         Register to bid
       </FancyModalHeader>
       <QueryRenderer<RegistrationQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query RegistrationQuery($saleID: String!) {
             sale(id: $saleID) {

--- a/src/app/Components/Containers/Inbox.tsx
+++ b/src/app/Components/Containers/Inbox.tsx
@@ -5,7 +5,7 @@ import { Inbox_me$data } from "__generated__/Inbox_me.graphql"
 import { ConversationsContainer } from "app/Scenes/Inbox/Components/Conversations/Conversations"
 import { MyBidsContainer } from "app/Scenes/MyBids/MyBids"
 import { listenToNativeEvents } from "app/store/NativeModel"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { track } from "app/utils/track"
@@ -141,7 +141,7 @@ export class Inbox extends React.Component<Props, State> {
           testID="tabWrapper-bids"
         >
           <MyBidsContainer
-            isActiveTab={this.props.isVisible && this.state.activeTab === Tab.bids}
+            isActiveTab={!!this.props.isVisible && this.state.activeTab === Tab.bids}
             me={this.props.me}
           />
         </TabWrapper>
@@ -155,7 +155,7 @@ export class Inbox extends React.Component<Props, State> {
         >
           <ConversationsContainer
             me={this.props.me}
-            isActiveTab={this.props.isVisible && this.state.activeTab === Tab.inquiries}
+            isActiveTab={!!this.props.isVisible && this.state.activeTab === Tab.inquiries}
           />
         </TabWrapper>
       </ScrollableTabView>
@@ -203,7 +203,7 @@ export const InboxScreenQuery = graphql`
 export const InboxQueryRenderer: React.FC<{ isVisible: boolean }> = (props) => {
   return (
     <QueryRenderer<InboxQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={InboxScreenQuery}
       variables={{}}
       render={(...args) =>

--- a/src/app/Components/Containers/Inquiry.tsx
+++ b/src/app/Components/Containers/Inquiry.tsx
@@ -4,10 +4,9 @@ import { InquiryQuery } from "__generated__/InquiryQuery.graphql"
 import { Inquiry_artwork$data } from "__generated__/Inquiry_artwork.graphql"
 import ArtworkPreview from "app/Scenes/Inbox/Components/Conversations/Preview/ArtworkPreview"
 import { MetadataText, SmallHeadline } from "app/Scenes/Inbox/Components/Typography"
-import { getCurrentEmissionState } from "app/store/GlobalStore"
-import { unsafe__getEnvironment } from "app/store/GlobalStore"
+import { getCurrentEmissionState, unsafe__getEnvironment } from "app/store/GlobalStore"
 import { dismissModal } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { Schema, Track, track as _track } from "app/utils/track"
@@ -280,7 +279,7 @@ export const InquiryFragmentContainer = createFragmentContainer(Inquiry, {
 export const InquiryQueryRenderer: React.FC<{ artworkID: string }> = ({ artworkID }) => {
   return (
     <QueryRenderer<InquiryQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query InquiryQuery($artworkID: String!) {
           artwork(id: $artworkID) {

--- a/src/app/Components/Containers/WorksForYou.tsx
+++ b/src/app/Components/Containers/WorksForYou.tsx
@@ -8,7 +8,7 @@ import { ZeroState } from "app/Components/States/ZeroState"
 import Notification from "app/Components/WorksForYou/Notification"
 import { PAGE_SIZE } from "app/Components/constants"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { track } from "app/utils/track"
@@ -195,7 +195,7 @@ export const WorksForYouScreenQuery = graphql`
 export const WorksForYouQueryRenderer: React.FC = () => {
   return (
     <QueryRenderer<WorksForYouQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={WorksForYouScreenQuery}
       variables={{}}
       render={renderWithLoadProgress(WorksForYouContainer)}

--- a/src/app/Components/Home/ArtistRails/RecommendedArtistsRail.tsx
+++ b/src/app/Components/Home/ArtistRails/RecommendedArtistsRail.tsx
@@ -8,7 +8,7 @@ import { SectionTitle } from "app/Components/SectionTitle"
 import { defaultArtistVariables } from "app/Scenes/Artist/Artist"
 import { RailScrollProps } from "app/Scenes/Home/Components/types"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import React, { memo, useImperativeHandle, useRef, useState } from "react"
 import { FlatList, ViewProps } from "react-native"
@@ -182,7 +182,7 @@ export const tracks = {
 
 const followOrUnfollowArtist = (followArtist: ArtistCard_artist$data) => {
   return new Promise<void>((resolve, reject) => {
-    commitMutation<RecommendedArtistsRailFollowMutation>(defaultEnvironment, {
+    commitMutation<RecommendedArtistsRailFollowMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation RecommendedArtistsRailFollowMutation($input: FollowArtistInput!) {
           followArtist(input: $input) {

--- a/src/app/Components/PhotoRow/PhotoRow.tests.tsx
+++ b/src/app/Components/PhotoRow/PhotoRow.tests.tsx
@@ -1,12 +1,11 @@
 import { fireEvent } from "@testing-library/react-native"
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
 import { PhotoRow } from "./PhotoRow"
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 const mockHandlePhotoDelete = jest.fn()
 
 describe("PhotoRow", () => {

--- a/src/app/Scenes/Artist/SearchCriteria.tsx
+++ b/src/app/Scenes/Artist/SearchCriteria.tsx
@@ -1,6 +1,6 @@
 import { SearchCriteriaQuery } from "__generated__/SearchCriteriaQuery.graphql"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { isNull } from "lodash"
 import { graphql, QueryRenderer } from "react-relay"
@@ -19,7 +19,7 @@ export interface SearchCriteriaQueryRendererProps {
 }
 
 export const SearchCriteriaQueryRenderer: React.FC<SearchCriteriaQueryRendererProps> = (props) => {
-  const { render, searchCriteriaId, environment = defaultEnvironment } = props
+  const { render, searchCriteriaId, environment = getRelayEnvironment() } = props
   const { renderComponent, renderPlaceholder } = render
 
   if (searchCriteriaId) {

--- a/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -14,7 +14,7 @@ import { ArtistSeriesArtworksFragmentContainer } from "app/Scenes/ArtistSeries/A
 import { ArtistSeriesHeaderFragmentContainer } from "app/Scenes/ArtistSeries/ArtistSeriesHeader"
 import { ArtistSeriesMetaFragmentContainer } from "app/Scenes/ArtistSeries/ArtistSeriesMeta"
 import { ArtistSeriesMoreSeriesFragmentContainer } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -180,7 +180,7 @@ export const ArtistSeriesQueryRenderer: React.FC<{ artistSeriesID: string }> = (
   return (
     <ArtworkFiltersStoreProvider>
       <QueryRenderer<ArtistSeriesQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query ArtistSeriesQuery($artistSeriesID: ID!) {
             artistSeries(id: $artistSeriesID) {

--- a/src/app/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList.tsx
@@ -3,7 +3,7 @@ import { Flex, Box, Text } from "@artsy/palette-mobile"
 import { ArtistSeriesFullArtistSeriesListQuery } from "__generated__/ArtistSeriesFullArtistSeriesListQuery.graphql"
 import { ArtistSeriesFullArtistSeriesList_artist$data } from "__generated__/ArtistSeriesFullArtistSeriesList_artist.graphql"
 import { ArtistSeriesListItem } from "app/Scenes/ArtistSeries/ArtistSeriesListItem"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTracking } from "app/utils/track"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
@@ -78,7 +78,7 @@ export const ArtistSeriesFullArtistSeriesListQueryRenderer: React.FC<{ artistID:
 }) => {
   return (
     <QueryRenderer<ArtistSeriesFullArtistSeriesListQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ArtistSeriesFullArtistSeriesListQuery($artistID: String!) {
           artist(id: $artistID) {

--- a/src/app/Scenes/ArtistShows/ArtistShows2.tsx
+++ b/src/app/Scenes/ArtistShows/ArtistShows2.tsx
@@ -3,7 +3,7 @@ import { ArtistShows2Query } from "__generated__/ArtistShows2Query.graphql"
 import { ArtistShows2_artist$data } from "__generated__/ArtistShows2_artist.graphql"
 import { ArtistShowFragmentContainer } from "app/Components/Artist/ArtistShows/ArtistShow"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { PlaceholderBox } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -150,7 +150,7 @@ export const ArtistShows2QueryRenderer: React.FC<{ artistID: string }> = ({ arti
   return (
     <QueryRenderer<ArtistShows2Query>
       cacheConfig={{ force: true }}
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ArtistShows2Query($artistID: String!) {
           artist(id: $artistID) {

--- a/src/app/Scenes/Artwork/Components/RequestConditionReport.tsx
+++ b/src/app/Scenes/Artwork/Components/RequestConditionReport.tsx
@@ -4,7 +4,7 @@ import { RequestConditionReportQuery } from "__generated__/RequestConditionRepor
 import { RequestConditionReport_artwork$data } from "__generated__/RequestConditionReport_artwork.graphql"
 import { RequestConditionReport_me$data } from "__generated__/RequestConditionReport_me.graphql"
 import { Modal } from "app/Components/Modal"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Schema, track } from "app/utils/track"
 import { Component } from "react"
 import { View } from "react-native"
@@ -154,7 +154,7 @@ export const RequestConditionReportQueryRenderer: React.FC<{
 }> = ({ artworkID }) => {
   return (
     <QueryRenderer<RequestConditionReportQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       variables={{ artworkID }}
       query={graphql`
         query RequestConditionReportQuery($artworkID: String!) {

--- a/src/app/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
+++ b/src/app/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ.tsx
@@ -2,7 +2,7 @@ import { Spacer, Box, Text, Separator, Join, Button } from "@artsy/palette-mobil
 import { ArtworkAttributionClassFAQQuery } from "__generated__/ArtworkAttributionClassFAQQuery.graphql"
 import { ArtworkAttributionClassFAQ_artworkAttributionClasses$data } from "__generated__/ArtworkAttributionClassFAQ_artworkAttributionClasses.graphql"
 import { goBack } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useScreenDimensions } from "app/utils/hooks"
 import { useAndroidGoBack } from "app/utils/hooks/useBackHandler"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -78,7 +78,7 @@ export const ARTWORK_ATTRIBUTION_CLASS_FAQ_QUERY = graphql`
 export const ArtworkAttributionClassFAQQueryRenderer: React.FC = (props) => {
   return (
     <QueryRenderer<ArtworkAttributionClassFAQQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={ARTWORK_ATTRIBUTION_CLASS_FAQ_QUERY}
       variables={{}}
       render={renderWithLoadProgress(ArtworkAttributionClassFAQContainer, props)}

--- a/src/app/Scenes/ArtworkMedium/ArtworkMedium.tsx
+++ b/src/app/Scenes/ArtworkMedium/ArtworkMedium.tsx
@@ -2,7 +2,7 @@ import { Spacer, Box, Text, Separator, Join, Button } from "@artsy/palette-mobil
 import { ArtworkMediumQuery } from "__generated__/ArtworkMediumQuery.graphql"
 import { ArtworkMedium_artwork$data } from "__generated__/ArtworkMedium_artwork.graphql"
 import { goBack } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useScreenDimensions } from "app/utils/hooks"
 import { useAndroidGoBack } from "app/utils/hooks/useBackHandler"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -71,7 +71,7 @@ export const ArtworkMediumQueryRenderer: React.FC<{
 }> = (props) => {
   return (
     <QueryRenderer<ArtworkMediumQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={ARTWORK_MEDIUM_QUERY}
       variables={{ id: props.artworkID }}
       render={renderWithLoadProgress(ArtworkMediumFragmentContainer, props)}

--- a/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tests.tsx
+++ b/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tests.tsx
@@ -1,13 +1,14 @@
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { createMockEnvironment } from "relay-test-utils"
 import { AuctionBuyersPremiumQueryRenderer } from "./AuctionBuyersPremium"
 
 describe("AuctionBuyersPremium", () => {
-  const mockEnvironment = getMockRelayEnvironment()
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
   beforeEach(() => {
-    mockEnvironment.mockClear()
+    mockEnvironment = getMockRelayEnvironment()
   })
 
   const TestRenderer = () => {

--- a/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tests.tsx
+++ b/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tests.tsx
@@ -1,11 +1,10 @@
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
 import { AuctionBuyersPremiumQueryRenderer } from "./AuctionBuyersPremium"
 
 describe("AuctionBuyersPremium", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
 
   beforeEach(() => {
     mockEnvironment.mockClear()

--- a/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tsx
+++ b/src/app/Scenes/AuctionBuyersPremium/AuctionBuyersPremium.tsx
@@ -3,7 +3,7 @@ import { AuctionBuyersPremiumQuery } from "__generated__/AuctionBuyersPremiumQue
 import { AuctionBuyersPremium_sale$data } from "__generated__/AuctionBuyersPremium_sale.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { goBack } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderRaggedText, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { compact } from "lodash"
@@ -123,7 +123,7 @@ export const AuctionBuyersPremiumQueryRenderer: FC<AuctionBuyersPremiumQueryRend
 }) => {
   return (
     <QueryRenderer<AuctionBuyersPremiumQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       variables={{ saleID }}
       query={graphql`
         query AuctionBuyersPremiumQuery($saleID: String!) {

--- a/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
@@ -5,7 +5,7 @@ import { AuctionResultsScreenWrapper_me$data } from "__generated__/AuctionResult
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { AuctionResultsList, LoadingSkeleton } from "app/Components/AuctionResultsList"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
@@ -201,7 +201,7 @@ export const AuctionResultsScreenScreenWrapperQueryQueryRenderer: React.FC<{
       : AuctionResultsSorts.DATE_DESC
   return (
     <QueryRenderer<AuctionResultsScreenWrapperContainerQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={AuctionResultsScreenWrapperQuery}
       variables={{
         state,

--- a/src/app/Scenes/BottomTabs/BottomTabsNavigator.tests.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsNavigator.tests.tsx
@@ -1,6 +1,7 @@
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { ModalStack } from "app/system/navigation/ModalStack"
 import { NavStack } from "app/system/navigation/NavStack"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
 import { act } from "react-test-renderer"
@@ -14,7 +15,7 @@ describe(BottomTabsNavigator, () => {
 
   beforeEach(() => {
     require("app/system/relay/createEnvironment").reset()
-    mockEnvironment = require("app/system/relay/createEnvironment").defaultEnvironment
+    mockEnvironment = getMockRelayEnvironment()
   })
 
   it("shows the current tab content", async () => {

--- a/src/app/Scenes/City/CityFairList.tsx
+++ b/src/app/Scenes/City/CityFairList.tsx
@@ -3,7 +3,7 @@ import { CityFairListQuery } from "__generated__/CityFairListQuery.graphql"
 import { CityFairList_city$data } from "__generated__/CityFairList_city.graphql"
 import Spinner from "app/Components/Spinner"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { Schema, screenTrack } from "app/utils/track"
@@ -170,7 +170,7 @@ interface CityFairListProps {
 export const CityFairListQueryRenderer: React.FC<CityFairListProps> = ({ citySlug }) => {
   return (
     <QueryRenderer<CityFairListQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query CityFairListQuery($citySlug: String!) {
           city(slug: $citySlug) {

--- a/src/app/Scenes/City/CitySavedList.tsx
+++ b/src/app/Scenes/City/CitySavedList.tsx
@@ -2,7 +2,7 @@ import { CitySavedListQuery } from "__generated__/CitySavedListQuery.graphql"
 import { CitySavedList_city$data } from "__generated__/CitySavedList_city.graphql"
 import { CitySavedList_me$data } from "__generated__/CitySavedList_me.graphql"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -160,7 +160,7 @@ interface CitySavedListProps {
 export const CitySavedListQueryRenderer: React.FC<CitySavedListProps> = ({ citySlug }) => {
   return (
     <QueryRenderer<CitySavedListQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query CitySavedListQuery($citySlug: String!) {
           me {

--- a/src/app/Scenes/City/CitySectionList.tsx
+++ b/src/app/Scenes/City/CitySectionList.tsx
@@ -7,7 +7,7 @@ import {
 import { CitySectionList_city$data } from "__generated__/CitySectionList_city.graphql"
 import { PAGE_SIZE } from "app/Components/constants"
 import { BucketKey } from "app/Scenes/Map/bucketCityResults"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -251,7 +251,7 @@ export const CitySectionListQueryRenderer: React.FC<CitySectionListProps> = ({
 
   return (
     <QueryRenderer<CitySectionListQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query CitySectionListQuery(
           $citySlug: String!

--- a/src/app/Scenes/Collection/Components/FullFeaturedArtistList.tsx
+++ b/src/app/Scenes/Collection/Components/FullFeaturedArtistList.tsx
@@ -3,7 +3,7 @@ import { FullFeaturedArtistListQuery } from "__generated__/FullFeaturedArtistLis
 import { FullFeaturedArtistList_collection$data } from "__generated__/FullFeaturedArtistList_collection.graphql"
 import { ArtistListItemContainer as ArtistListItem } from "app/Components/ArtistListItem"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import React from "react"
 import { FlatList, ViewProps } from "react-native"
@@ -82,7 +82,7 @@ export const CollectionFullFeaturedArtistListQueryRenderer: React.FC<{ collectio
   collectionID,
 }) => (
   <QueryRenderer<FullFeaturedArtistListQuery>
-    environment={defaultEnvironment}
+    environment={getRelayEnvironment()}
     query={graphql`
       query FullFeaturedArtistListQuery($collectionID: String!) {
         collection: marketingCollection(slug: $collectionID) {

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -9,7 +9,7 @@ import { HeaderButton } from "app/Components/HeaderButton"
 import { SearchImageHeaderButton } from "app/Components/SearchImageHeaderButton"
 import { NavigationalTabs, TabsType } from "app/Components/Tabs"
 import { goBack } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useScreenDimensions } from "app/utils/hooks"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -326,7 +326,7 @@ export const FairFragmentContainer = createFragmentContainer(Fair, {
 export const FairQueryRenderer: React.FC<FairQueryRendererProps> = ({ fairID }) => {
   return (
     <QueryRenderer<FairQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FairQuery($fairID: String!) {
           fair(id: $fairID) @principalField {

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -13,7 +13,7 @@ import {
   FilterParamName,
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import React, { useState } from "react"
@@ -128,7 +128,7 @@ export const FairAllFollowedArtistsFragmentContainer = createFragmentContainer(
 export const FairAllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> = ({ fairID }) => {
   return (
     <QueryRenderer<FairAllFollowedArtistsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FairAllFollowedArtistsQuery($fairID: String!) {
           fair(id: $fairID) @principalField {

--- a/src/app/Scenes/Fair/FairArticles.tsx
+++ b/src/app/Scenes/Fair/FairArticles.tsx
@@ -12,7 +12,7 @@ import { FairArticlesQuery } from "__generated__/FairArticlesQuery.graphql"
 import { FairArticles_fair$data } from "__generated__/FairArticles_fair.graphql"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useEnvironment } from "app/utils/hooks/useEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { compact } from "lodash"
@@ -210,7 +210,7 @@ export const FairArticlesPaginationContainer = createPaginationContainer(
 export const FairArticlesQueryRenderer: React.FC<FairArticlesQueryRendererProps> = ({ fairID }) => {
   return (
     <QueryRenderer<FairArticlesQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={FAIR2_ARTICLES_QUERY}
       variables={{ id: fairID, first: FAIR2_ARTICLES_PAGE_SIZE }}
       render={renderWithLoadProgress(FairArticlesPaginationContainer)}

--- a/src/app/Scenes/Fair/FairMoreInfo.tsx
+++ b/src/app/Scenes/Fair/FairMoreInfo.tsx
@@ -4,7 +4,7 @@ import { FairMoreInfo_fair$data } from "__generated__/FairMoreInfo_fair.graphql"
 import { LocationMapContainer } from "app/Components/LocationMap/LocationMap"
 import { Markdown } from "app/Components/Markdown"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { defaultRules } from "app/utils/renderMarkdown"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -159,7 +159,7 @@ export const FairMoreInfoFragmentContainer = createFragmentContainer(FairMoreInf
 export const FairMoreInfoQueryRenderer: React.FC<FairMoreInfoQueryRendererProps> = ({ fairID }) => {
   return (
     <QueryRenderer<FairMoreInfoQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FairMoreInfoQuery($fairID: String!) {
           fair(id: $fairID) @principalField {

--- a/src/app/Scenes/Favorites/FavoriteArtists.tsx
+++ b/src/app/Scenes/Favorites/FavoriteArtists.tsx
@@ -8,7 +8,7 @@ import { StickTabPageRefreshControl } from "app/Components/StickyTabPage/StickTa
 import { StickyTabPageFlatList } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import React from "react"
@@ -160,7 +160,7 @@ const FavoriteArtistsContainer = createPaginationContainer(
 export const FavoriteArtistsQueryRenderer = () => {
   return (
     <QueryRenderer<FavoriteArtistsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FavoriteArtistsQuery {
           me {

--- a/src/app/Scenes/Favorites/FavoriteArtworks.tsx
+++ b/src/app/Scenes/Favorites/FavoriteArtworks.tsx
@@ -8,7 +8,7 @@ import { StickTabPageRefreshControl } from "app/Components/StickyTabPage/StickTa
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "app/Components/constants"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
 import { FAVORITE_ARTWORKS_REFRESH_KEY, RefreshEvents } from "app/utils/refreshHelpers"
@@ -188,7 +188,7 @@ export const FavoriteArtworksQueryRenderer = () => {
   const screen = useScreenDimensions()
   return (
     <QueryRenderer<FavoriteArtworksQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={FavoriteArtworksScreenQuery}
       variables={{
         count: 10,

--- a/src/app/Scenes/Favorites/FavoriteCategories.tsx
+++ b/src/app/Scenes/Favorites/FavoriteCategories.tsx
@@ -9,7 +9,7 @@ import { StickTabPageRefreshControl } from "app/Components/StickyTabPage/StickTa
 import { StickyTabPageFlatList } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 
@@ -161,7 +161,7 @@ const FavoriteCategoriesContainer = createPaginationContainer(
 export const FavoriteCategoriesQueryRenderer = () => {
   return (
     <QueryRenderer<FavoriteCategoriesQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FavoriteCategoriesQuery {
           me {

--- a/src/app/Scenes/Favorites/FavoriteShows.tsx
+++ b/src/app/Scenes/Favorites/FavoriteShows.tsx
@@ -9,7 +9,7 @@ import { StickTabPageRefreshControl } from "app/Components/StickyTabPage/StickTa
 import { StickyTabPageFlatList } from "app/Components/StickyTabPage/StickyTabPageFlatList"
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { PAGE_SIZE } from "app/Components/constants"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { Component } from "react"
@@ -157,7 +157,7 @@ const FavoriteShowsContainer = createPaginationContainer(
 export const FavoriteShowsQueryRenderer = () => {
   return (
     <QueryRenderer<FavoriteShowsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FavoriteShowsQuery {
           me {

--- a/src/app/Scenes/Feature/Feature.tests.tsx
+++ b/src/app/Scenes/Feature/Feature.tests.tsx
@@ -1,12 +1,16 @@
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractText } from "app/utils/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 import { FeatureQueryRenderer } from "./Feature"
 
-const mockRelayEnvironment = getMockRelayEnvironment()
-
 describe(FeatureQueryRenderer, () => {
+  let mockRelayEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockRelayEnvironment = getMockRelayEnvironment()
+  })
+
   it("renders without failing", () => {
     const tree = renderWithWrappersLEGACY(<FeatureQueryRenderer slug="anything" />)
 

--- a/src/app/Scenes/Feature/Feature.tests.tsx
+++ b/src/app/Scenes/Feature/Feature.tests.tsx
@@ -1,14 +1,10 @@
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractText } from "app/utils/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator } from "relay-test-utils"
 import { FeatureQueryRenderer } from "./Feature"
 
-let mockRelayEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
-beforeEach(() => {
-  mockRelayEnvironment = require("app/system/relay/createEnvironment").defaultEnvironment =
-    createMockEnvironment()
-})
+const mockRelayEnvironment = getMockRelayEnvironment()
 
 describe(FeatureQueryRenderer, () => {
   it("renders without failing", () => {

--- a/src/app/Scenes/Feature/Feature.tsx
+++ b/src/app/Scenes/Feature/Feature.tsx
@@ -4,14 +4,14 @@ import { Feature_feature$data } from "__generated__/Feature_feature.graphql"
 import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import GenericGrid from "app/Components/ArtworkGrids/GenericGrid"
 import { Stack } from "app/Components/Stack"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { isPad } from "app/utils/hardware"
+import { useScreenDimensions } from "app/utils/hooks"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { chunk, flattenDeep } from "lodash"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { useScreenDimensions } from "app/utils/hooks"
 import { FeatureFeaturedLinkFragmentContainer } from "./components/FeatureFeaturedLink"
 import {
   FeatureHeaderFragmentContainer,
@@ -221,7 +221,7 @@ const FeatureFragmentContainer = createFragmentContainer(FeatureApp, {
 export const FeatureQueryRenderer: React.FC<{ slug: string }> = ({ slug }) => {
   return (
     <QueryRenderer<FeatureQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query FeatureQuery($slug: ID!) {
           feature(id: $slug) {

--- a/src/app/Scenes/Gene/Gene.tsx
+++ b/src/app/Scenes/Gene/Gene.tsx
@@ -5,7 +5,7 @@ import { GeneArtworksPaginationContainer } from "app/Components/Gene/GeneArtwork
 import { GenePlaceholder } from "app/Components/Gene/GenePlaceholder"
 import Header from "app/Components/Gene/Header"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { Dimensions, StyleSheet, View, ViewStyle } from "react-native"
@@ -78,7 +78,7 @@ export const GeneQueryRenderer: React.FC<GeneQueryRendererProps> = (props) => {
 
   return (
     <QueryRenderer<GeneQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query GeneQuery($geneID: String!, $input: FilterArtworksInput) {
           gene(id: $geneID) {

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react-native"
 import { InquiryPurchaseButtonTestsQuery } from "__generated__/InquiryPurchaseButtonTestsQuery.graphql"
 import { navigate } from "app/system/navigation/navigate"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { Alert } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
@@ -55,8 +56,7 @@ const getWrapper = (mockResolvers = {}) => {
 
 describe("InquiryPurchaseButton", () => {
   beforeEach(() => {
-    require("app/system/relay/createEnvironment").reset()
-    environment = require("app/system/relay/createEnvironment").defaultEnvironment
+    environment = getMockRelayEnvironment()
   })
 
   it("navigates to the order webview when button is tapped", () => {

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
@@ -2,7 +2,7 @@ import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { InquiryPurchaseButtonOrderMutation } from "__generated__/InquiryPurchaseButtonOrderMutation.graphql"
 import { InquiryPurchaseButton_artwork$data } from "__generated__/InquiryPurchaseButton_artwork.graphql"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import React, { useState } from "react"
 import { Alert } from "react-native"
 import { commitMutation, createFragmentContainer, graphql } from "react-relay"
@@ -58,7 +58,7 @@ export const InquiryPurchaseButton: React.FC<InquiryPurchaseButtonProps> = ({
     }
 
     setIsCommittingMutation(true)
-    commitMutation<InquiryPurchaseButtonOrderMutation>(defaultEnvironment, {
+    commitMutation<InquiryPurchaseButtonOrderMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation InquiryPurchaseButtonOrderMutation(
           $input: CommerceCreateInquiryOrderWithArtworkInput!

--- a/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -5,7 +5,7 @@ import { MakeOfferModal_artwork$data } from "__generated__/MakeOfferModal_artwor
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails } from "app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails"
 import { dismissModal } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import React, { useState } from "react"
@@ -112,7 +112,7 @@ export const MakeOfferModalQueryRenderer: React.FC<{
       }}
     >
       <QueryRenderer<MakeOfferModalQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query MakeOfferModalQuery($artworkID: String!) {
             artwork(id: $artworkID) {

--- a/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OpenInquiryModalButton.tests.tsx
@@ -2,12 +2,11 @@ import { fireEvent } from "@testing-library/react-native"
 import { OpenInquiryModalButtonTestQuery } from "__generated__/OpenInquiryModalButtonTestQuery.graphql"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import relay, { QueryRenderer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment } from "relay-test-utils"
 import { OpenInquiryModalButtonFragmentContainer } from "./OpenInquiryModalButton"
 
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -28,7 +27,7 @@ const tappedPurchaseEvent = {
 }
 
 describe("OpenInquiryModalButtonTestQueryRenderer", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
   const TestRenderer = () => (
     <QueryRenderer<OpenInquiryModalButtonTestQuery>
       environment={mockEnvironment}

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
@@ -5,7 +5,7 @@ import { PurchaseModal_artwork$data } from "__generated__/PurchaseModal_artwork.
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails } from "app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails"
 import { dismissModal } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import React, { useState } from "react"
@@ -112,7 +112,7 @@ export const PurchaseModalQueryRenderer: React.FC<{
       }}
     >
       <QueryRenderer<PurchaseModalQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query PurchaseModalQuery($artworkID: String!) {
             artwork(id: $artworkID) {

--- a/src/app/Scenes/Inbox/Components/Conversations/UpdateConversation.ts
+++ b/src/app/Scenes/Inbox/Components/Conversations/UpdateConversation.ts
@@ -1,5 +1,5 @@
 import { UpdateConversationMutation } from "__generated__/UpdateConversationMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "react-relay"
 import { MutationConfig } from "relay-runtime"
 
@@ -14,7 +14,7 @@ export function updateConversation(
   onCompleted: MutationConfig<any>["onCompleted"],
   onError: MutationConfig<any>["onError"]
 ) {
-  return commitMutation<UpdateConversationMutation>(defaultEnvironment, {
+  return commitMutation<UpdateConversationMutation>(getRelayEnvironment(), {
     updater: (store) => {
       store!.get(conversation.id)!.setValue(false, "unread")
     },

--- a/src/app/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/app/Scenes/Inbox/Screens/Conversation.tsx
@@ -1,4 +1,4 @@
-import { InfoCircleIcon, Flex, Text } from "@artsy/palette-mobile"
+import { InfoCircleIcon, Flex, Text, Touchable } from "@artsy/palette-mobile"
 import NetInfo from "@react-native-community/netinfo"
 import { ConversationQuery } from "__generated__/ConversationQuery.graphql"
 import { Conversation_me$data } from "__generated__/Conversation_me.graphql"
@@ -10,11 +10,10 @@ import { updateConversation } from "app/Scenes/Inbox/Components/Conversations/Up
 import { ShadowSeparator } from "app/Scenes/Inbox/Components/ShadowSeparator"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigationEvents } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { Schema, Track, track as _track } from "app/utils/track"
-import { Touchable } from "@artsy/palette-mobile"
 import React from "react"
 import { View } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
@@ -278,7 +277,7 @@ export const ConversationQueryRenderer: React.FC<{
   const { conversationID, navigator } = props
   return (
     <QueryRenderer<ConversationQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ConversationQuery($conversationID: String!) {
           me {

--- a/src/app/Scenes/Inbox/Screens/ConversationDetails.tsx
+++ b/src/app/Scenes/Inbox/Screens/ConversationDetails.tsx
@@ -9,7 +9,7 @@ import { AttachmentListFragmentContainer } from "app/Scenes/Inbox/Components/Con
 import { SellerReplyEstimateFragmentContainer } from "app/Scenes/Inbox/Components/Conversations/SellerReplyEstimate"
 import { ShippingFragmentContainer } from "app/Scenes/Inbox/Components/Conversations/Shipping"
 import { Support } from "app/Scenes/Inbox/Components/Conversations/Support"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ScrollView } from "react-native"
@@ -92,7 +92,7 @@ export const ConversationDetailsQueryRenderer: React.FC<{
 }> = ({ conversationID }) => {
   return (
     <QueryRenderer<ConversationDetailsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ConversationDetailsQuery($conversationID: String!) {
           me {

--- a/src/app/Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow.tsx
+++ b/src/app/Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow.tsx
@@ -3,7 +3,7 @@ import { LotsByArtistsYouFollowQuery } from "__generated__/LotsByArtistsYouFollo
 import { LotsByArtistsYouFollow_me$data } from "__generated__/LotsByArtistsYouFollow_me.graphql"
 import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderGrid, ProvidePlaceholderContext } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
@@ -78,7 +78,7 @@ export const LotsByArtistsYouFollowFragmentContainer = createPaginationContainer
 export const LotsByArtistsYouFollowQueryRenderer: React.FC = () => {
   return (
     <QueryRenderer<LotsByArtistsYouFollowQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={LotsByArtistsYouFollowScreenQuery}
       variables={lotsByArtistsYouFollowDefaultVariables()}
       render={renderWithPlaceholder({

--- a/src/app/Scenes/Map/MapRenderer.tsx
+++ b/src/app/Scenes/Map/MapRenderer.tsx
@@ -1,9 +1,9 @@
 import { useTheme } from "@artsy/palette-mobile"
 import { MapRendererQuery } from "__generated__/MapRendererQuery.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { SafeAreaInsets } from "app/utils/hooks"
 import { View } from "react-native"
 import { graphql, QueryRenderer } from "react-relay"
-import { SafeAreaInsets } from "app/utils/hooks"
 import { GlobalMapContainer as GlobalMap } from "./GlobalMap"
 
 // Are you seeing "cannot read .fairs of null"? You might need to set your simulator location.
@@ -24,7 +24,7 @@ export const MapRenderer: React.FC<{
 
   return (
     <QueryRenderer<MapRendererQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         # Don't rename this query without also updating the generate-cities-cache.js script.
         query MapRendererQuery($citySlug: String!, $maxInt: Int!) {

--- a/src/app/Scenes/MyAccount/MyAccount.tsx
+++ b/src/app/Scenes/MyAccount/MyAccount.tsx
@@ -5,7 +5,7 @@ import { MenuItem } from "app/Components/MenuItem"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useAppleLink } from "app/utils/LinkedAccounts/apple"
 import { useFacebookLink } from "app/utils/LinkedAccounts/facebook"
 import { useGoogleLink } from "app/utils/LinkedAccounts/google"
@@ -233,7 +233,7 @@ export const MyAccountContainer = createFragmentContainer(MyAccount, {
 export const MyAccountQueryRenderer: React.FC<{}> = () => {
   return (
     <QueryRenderer<MyAccountQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyAccountQuery {
           me {

--- a/src/app/Scenes/MyAccount/MyAccountDeleteAccount.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountDeleteAccount.tsx
@@ -5,7 +5,7 @@ import { MyAccountDeleteAccount_me$data } from "__generated__/MyAccountDeleteAcc
 import { DeleteAccountInput } from "__generated__/deleteUserAccountMutation.graphql"
 import { Input } from "app/Components/Input"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import React, { useState } from "react"
@@ -149,7 +149,7 @@ export const MyAccountDeleteAccountFragmentContainer = createFragmentContainer(
 export const MyAccountDeleteAccountQueryRenderer: React.FC = () => {
   return (
     <QueryRenderer<MyAccountDeleteAccountQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyAccountDeleteAccountQuery {
           me {

--- a/src/app/Scenes/MyAccount/MyAccountEditEmail.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditEmail.tsx
@@ -2,7 +2,7 @@ import { MyAccountEditEmailQuery } from "__generated__/MyAccountEditEmailQuery.g
 import { MyAccountEditEmail_me$data } from "__generated__/MyAccountEditEmail_me.graphql"
 import { Input } from "app/Components/Input"
 import { useToast } from "app/Components/Toast/toastHook"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import React, { useEffect, useRef, useState } from "react"
@@ -91,7 +91,7 @@ export const MyAccountEditEmailContainer = createFragmentContainer(MyAccountEdit
 export const MyAccountEditEmailQueryRenderer: React.FC<{}> = () => {
   return (
     <QueryRenderer<MyAccountEditEmailQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyAccountEditEmailQuery {
           me {

--- a/src/app/Scenes/MyAccount/MyAccountEditPhone.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPhone.tsx
@@ -1,7 +1,7 @@
 import { MyAccountEditPhoneQuery } from "__generated__/MyAccountEditPhoneQuery.graphql"
 import { MyAccountEditPhone_me$data } from "__generated__/MyAccountEditPhone_me.graphql"
 import { PhoneInput } from "app/Components/Input/PhoneInput/PhoneInput"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import React, { useEffect, useState } from "react"
@@ -73,7 +73,7 @@ const MyAccountEditPhoneContainer = createFragmentContainer(MyAccountEditPhone, 
 export const MyAccountEditPhoneQueryRenderer: React.FC<{}> = () => {
   return (
     <QueryRenderer<MyAccountEditPhoneQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyAccountEditPhoneQuery {
           me {

--- a/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
@@ -1,9 +1,9 @@
 import { MyAccountEditPriceRangeQuery } from "__generated__/MyAccountEditPriceRangeQuery.graphql"
 import { MyAccountEditPriceRange_me$data } from "__generated__/MyAccountEditPriceRange_me.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { Select, SelectOption } from "app/Components/Select"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import { Select, SelectOption } from "app/Components/Select"
 import React, { useEffect, useState } from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 import {
@@ -79,7 +79,7 @@ export const MyAccountEditPriceRangeContainer = createFragmentContainer(MyAccoun
 export const MyAccountEditPriceRangeQueryRenderer: React.FC<{}> = () => {
   return (
     <QueryRenderer<MyAccountEditPriceRangeQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyAccountEditPriceRangeQuery {
           me {

--- a/src/app/Scenes/MyAccount/deleteUserAccount.ts
+++ b/src/app/Scenes/MyAccount/deleteUserAccount.ts
@@ -2,13 +2,13 @@ import {
   DeleteAccountInput,
   deleteUserAccountMutation,
 } from "__generated__/deleteUserAccountMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Environment } from "react-relay"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const deleteUserAccount = async (
   input: DeleteAccountInput = {},
-  environment: Environment = defaultEnvironment
+  environment: Environment = getRelayEnvironment()
 ): Promise<deleteUserAccountMutation["response"]> => {
   return new Promise<deleteUserAccountMutation["response"]>((resolve, reject) =>
     commitMutation<deleteUserAccountMutation>(environment, {

--- a/src/app/Scenes/MyAccount/updateMyUserProfile.ts
+++ b/src/app/Scenes/MyAccount/updateMyUserProfile.ts
@@ -2,12 +2,12 @@ import {
   UpdateMyProfileInput,
   updateMyUserProfileMutation,
 } from "__generated__/updateMyUserProfileMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, Environment, graphql } from "react-relay"
 
 export const updateMyUserProfile = async (
   input: UpdateMyProfileInput = {},
-  environment: Environment = defaultEnvironment
+  environment: Environment = getRelayEnvironment()
 ) => {
   await new Promise((resolve, reject) =>
     commitMutation<updateMyUserProfileMutation>(environment, {

--- a/src/app/Scenes/MyBids/MyBids.tsx
+++ b/src/app/Scenes/MyBids/MyBids.tsx
@@ -2,15 +2,14 @@ import { OwnerType } from "@artsy/cohesion"
 import { Spacer, Flex, Text, Separator, Join } from "@artsy/palette-mobile"
 import { MyBidsQuery } from "__generated__/MyBidsQuery.graphql"
 import { MyBids_me$data } from "__generated__/MyBids_me.graphql"
-
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useScreenDimensions } from "app/utils/hooks"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { useEffect, useState } from "react"
 import { RefreshControl, ScrollView } from "react-native"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
-import { useScreenDimensions } from "app/utils/hooks"
 import { MyBidsPlaceholder, SaleCardFragmentContainer } from "./Components"
 import { LotStatusListItemContainer } from "./Components/LotStatusListItem"
 import { NoBids } from "./Components/NoBids"
@@ -225,7 +224,7 @@ export const MyBidsContainer = createRefetchContainer(
 
 export const MyBidsQueryRenderer: React.FC = () => (
   <QueryRenderer<MyBidsQuery>
-    environment={defaultEnvironment}
+    environment={getRelayEnvironment()}
     query={graphql`
       query MyBidsQuery {
         me {

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -19,7 +19,7 @@ import { MyCollectionZeroState } from "app/Scenes/MyCollection/Components/MyColl
 import { MyCollectionZeroStateArtworks } from "app/Scenes/MyCollection/Components/MyCollectionZeroStateArtworks"
 import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -295,7 +295,7 @@ export const MyCollectionQueryRenderer: React.FC = () => {
     >
       <ArtworkFiltersStoreProvider>
         <QueryRenderer<MyCollectionQuery>
-          environment={defaultEnvironment}
+          environment={getRelayEnvironment()}
           query={MyCollectionScreenQuery}
           variables={{}}
           cacheConfig={{ force: true }}

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateScreen.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/RequestForPriceEstimateScreen.tsx
@@ -4,12 +4,12 @@ import { RequestForPriceEstimateScreenMutation } from "__generated__/RequestForP
 import { Toast } from "app/Components/Toast/Toast"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { ArtsyKeyboardAvoidingViewContext } from "app/utils/ArtsyKeyboardAvoidingView"
 import { FormikProvider, useFormik } from "formik"
 import { Environment } from "react-relay"
 import { useTracking } from "react-tracking"
 import { commitMutation, graphql } from "relay-runtime"
-import { ArtsyKeyboardAvoidingViewContext } from "app/utils/ArtsyKeyboardAvoidingView"
 import * as Yup from "yup"
 import { RequestForPriceEstimateForm } from "./RequestForPriceEstimateForm"
 
@@ -125,7 +125,7 @@ export const RequestForPriceEstimateScreen: React.FC<RequestForPriceEstimateScre
           backgroundColor: "red100",
         })
       }
-      requestForPriceEstimateMutation(defaultEnvironment, onCompleted, onError, input)
+      requestForPriceEstimateMutation(getRelayEnvironment(), onCompleted, onError, input)
     },
     validationSchema: ValidationSchema,
   })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -1,11 +1,10 @@
 import { fireEvent } from "@testing-library/react-native"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
 import { MyCollectionArtworkScreen } from "./MyCollectionArtwork"
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe("My Collection Artwork", () => {
   it("show new artwork screen ", () => {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
@@ -5,7 +5,7 @@ import { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
 import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { FadeIn } from "app/Components/FadeIn"
 import { LoadFailureView } from "app/Components/LoadFailureView"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useScreenDimensions } from "app/utils/hooks"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { trim } from "lodash"
@@ -131,7 +131,7 @@ export const ArtworkAutosuggestResultsQueryRenderer: React.FC<{
 }> = ({ keyword, artistSlug, onPress, onSkipPress, setShowSkipAheadToAddArtworkLink }) => {
   return (
     <QueryRenderer<ArtworkAutosuggestResultsContainerQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ArtworkAutosuggestResultsContainerQuery(
           $count: Int!

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -15,6 +15,7 @@ import * as LocalImageStore from "app/utils/LocalImageStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { Image } from "react-native-image-crop-picker"
+import { createMockEnvironment } from "relay-test-utils"
 import {
   MyCollectionArtworkForm,
   MyCollectionArtworkFormProps,
@@ -31,9 +32,14 @@ jest.mock("app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/uploadFileT
 const getConvectionGeminiKeyMock = getConvectionGeminiKey as jest.Mock<any>
 const getGeminiCredentialsForEnvironmentMock = getGeminiCredentialsForEnvironment as jest.Mock<any>
 const uploadFileToS3Mock = uploadFileToS3 as jest.Mock<any>
-const mockEnvironment = getMockRelayEnvironment()
 
 describe("MyCollectionArtworkForm", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
+
   describe("Editing an artwork", () => {
     it("renders the main form", async () => {
       const { getByText, getByTestId } = renderWithHookWrappersTL(
@@ -62,7 +68,6 @@ describe("MyCollectionArtworkForm", () => {
 
   describe("Adding a new artwork", () => {
     afterEach(() => {
-      mockEnvironment.mockClear()
       jest.clearAllMocks()
     })
 
@@ -507,7 +512,6 @@ describe("MyCollectionArtworkForm", () => {
 
   describe("loading screens", () => {
     afterEach(() => {
-      mockEnvironment.mockClear()
       jest.clearAllMocks()
     })
 

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -10,12 +10,11 @@ import {
   uploadFileToS3,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/uploadFileToS3"
 import { GlobalStore, __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import * as LocalImageStore from "app/utils/LocalImageStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { Image } from "react-native-image-crop-picker"
-import { createMockEnvironment } from "relay-test-utils"
 import {
   MyCollectionArtworkForm,
   MyCollectionArtworkFormProps,
@@ -32,7 +31,7 @@ jest.mock("app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/uploadFileT
 const getConvectionGeminiKeyMock = getConvectionGeminiKey as jest.Mock<any>
 const getGeminiCredentialsForEnvironmentMock = getGeminiCredentialsForEnvironment as jest.Mock<any>
 const uploadFileToS3Mock = uploadFileToS3 as jest.Mock<any>
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe("MyCollectionArtworkForm", () => {
   describe("Editing an artwork", () => {

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
@@ -10,7 +10,7 @@ import { ArtworkAutosuggest } from "app/Scenes/MyCollection/Screens/ArtworkForm/
 import { useArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm"
 import { ArtworkFormScreen } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { omit, pickBy } from "lodash"
 import React, { useEffect, useState } from "react"
 import { ScrollView } from "react-native"
@@ -126,7 +126,7 @@ const fetchArtwork = async (
   artworkID: string
 ): Promise<MyCollectionArtworkFormArtworkQuery["response"]["artwork"] | undefined> => {
   const result = await fetchQuery<MyCollectionArtworkFormArtworkQuery>(
-    defaultEnvironment,
+    getRelayEnvironment(),
     graphql`
       query MyCollectionArtworkFormArtworkQuery($artworkID: String!) {
         artwork(id: $artworkID) {

--- a/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsights.tsx
@@ -5,7 +5,7 @@ import { StickyTabPageFlatListContext } from "app/Components/StickyTabPage/Stick
 import { StickyTabPageScrollView } from "app/Components/StickyTabPage/StickyTabPageScrollView"
 import { MyCollectionArtworkUploadMessages } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkUploadMessages"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { setVisualClueAsSeen, useVisualClue } from "app/utils/hooks/useVisualClue"
 import {
@@ -62,7 +62,7 @@ export const MyCollectionInsights: React.FC<{}> = ({}) => {
 
     setIsRefreshing(true)
 
-    fetchQuery(defaultEnvironment, MyCollectionInsightsScreenQuery, {}).subscribe({
+    fetchQuery(getRelayEnvironment(), MyCollectionInsightsScreenQuery, {}).subscribe({
       complete: () => {
         setIsRefreshing(false)
       },

--- a/src/app/Scenes/MyCollection/mutations/deleteArtworkImage.ts
+++ b/src/app/Scenes/MyCollection/mutations/deleteArtworkImage.ts
@@ -1,10 +1,10 @@
 import { deleteArtworkImageMutation } from "__generated__/deleteArtworkImageMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "react-relay"
 
 export function deleteArtworkImage(artworkID: string, imageID: string) {
   return new Promise<deleteArtworkImageMutation["response"]>((resolve, reject) => {
-    commitMutation<deleteArtworkImageMutation>(defaultEnvironment, {
+    commitMutation<deleteArtworkImageMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation deleteArtworkImageMutation($input: DeleteArtworkImageInput!) {
           deleteArtworkImage(input: $input) {

--- a/src/app/Scenes/MyCollection/mutations/myCollectionCreateArtwork.ts
+++ b/src/app/Scenes/MyCollection/mutations/myCollectionCreateArtwork.ts
@@ -1,12 +1,12 @@
 import { myCollectionCreateArtworkMutation } from "__generated__/myCollectionCreateArtworkMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "react-relay"
 
 export function myCollectionCreateArtwork(
   input: myCollectionCreateArtworkMutation["variables"]["input"]
 ) {
   return new Promise<myCollectionCreateArtworkMutation["response"]>((resolve, reject) => {
-    commitMutation<myCollectionCreateArtworkMutation>(defaultEnvironment, {
+    commitMutation<myCollectionCreateArtworkMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation myCollectionCreateArtworkMutation($input: MyCollectionCreateArtworkInput!) {
           myCollectionCreateArtwork(input: $input) {

--- a/src/app/Scenes/MyCollection/mutations/myCollectionDeleteArtwork.ts
+++ b/src/app/Scenes/MyCollection/mutations/myCollectionDeleteArtwork.ts
@@ -1,10 +1,10 @@
 import { myCollectionDeleteArtworkMutation } from "__generated__/myCollectionDeleteArtworkMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "react-relay"
 
 export function myCollectionDeleteArtwork(artworkId: string) {
   return new Promise<myCollectionDeleteArtworkMutation["response"]>((resolve, reject) => {
-    commitMutation<myCollectionDeleteArtworkMutation>(defaultEnvironment, {
+    commitMutation<myCollectionDeleteArtworkMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation myCollectionDeleteArtworkMutation($input: MyCollectionDeleteArtworkInput!) {
           myCollectionDeleteArtwork(input: $input) {

--- a/src/app/Scenes/MyCollection/mutations/myCollectionUpdateArtwork.ts
+++ b/src/app/Scenes/MyCollection/mutations/myCollectionUpdateArtwork.ts
@@ -1,12 +1,12 @@
 import { myCollectionUpdateArtworkMutation } from "__generated__/myCollectionUpdateArtworkMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "react-relay"
 
 export function myCollectionUpdateArtwork(
   input: myCollectionUpdateArtworkMutation["variables"]["input"]
 ) {
   return new Promise<myCollectionUpdateArtworkMutation["response"]>((resolve, reject) => {
-    commitMutation<myCollectionUpdateArtworkMutation>(defaultEnvironment, {
+    commitMutation<myCollectionUpdateArtworkMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation myCollectionUpdateArtworkMutation($input: MyCollectionUpdateArtworkInput!) {
           myCollectionUpdateArtwork(input: $input) {

--- a/src/app/Scenes/MyProfile/LoggedInUserInfo.tests.tsx
+++ b/src/app/Scenes/MyProfile/LoggedInUserInfo.tests.tsx
@@ -5,11 +5,16 @@ import { extractText } from "app/utils/tests/extractText"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
 import { UserProfileQueryRenderer } from "./LoggedInUserInfo"
 
-const env = getMockRelayEnvironment()
-
 describe(UserProfileQueryRenderer, () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = getMockRelayEnvironment()
+  })
+
   it("spins until the operation resolves", () => {
     const tree = renderWithWrappersLEGACY(<UserProfileQueryRenderer />)
     expect(tree.root.findAllByType(Spinner)).toHaveLength(1)

--- a/src/app/Scenes/MyProfile/LoggedInUserInfo.tests.tsx
+++ b/src/app/Scenes/MyProfile/LoggedInUserInfo.tests.tsx
@@ -1,14 +1,13 @@
 import { Text } from "@artsy/palette-mobile"
 import Spinner from "app/Components/Spinner"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractText } from "app/utils/tests/extractText"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { act } from "react-test-renderer"
-import { createMockEnvironment } from "relay-test-utils"
 import { UserProfileQueryRenderer } from "./LoggedInUserInfo"
 
-const env = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const env = getMockRelayEnvironment()
 
 describe(UserProfileQueryRenderer, () => {
   it("spins until the operation resolves", () => {

--- a/src/app/Scenes/MyProfile/LoggedInUserInfo.tsx
+++ b/src/app/Scenes/MyProfile/LoggedInUserInfo.tsx
@@ -2,7 +2,7 @@ import { Box, Text } from "@artsy/palette-mobile"
 import { LoggedInUserInfoQuery } from "__generated__/LoggedInUserInfoQuery.graphql"
 import { LoggedInUserInfo_me$data } from "__generated__/LoggedInUserInfo_me.graphql"
 import Spinner from "app/Components/Spinner"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import React from "react"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
@@ -29,7 +29,7 @@ const UserProfileFragmentContainer = createFragmentContainer(UserProfile, {
 
 export const UserProfileQueryRenderer: React.FC = () => (
   <QueryRenderer<LoggedInUserInfoQuery>
-    environment={defaultEnvironment}
+    environment={getRelayEnvironment()}
     query={graphql`
       query LoggedInUserInfoQuery {
         me {

--- a/src/app/Scenes/MyProfile/MyProfilePayment.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePayment.tsx
@@ -6,7 +6,7 @@ import { CreditCardDetailsContainer } from "app/Components/CreditCardDetails"
 import { MenuItem } from "app/Components/MenuItem"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -230,7 +230,7 @@ const MyProfilePaymentContainer = createPaginationContainer(
 export const MyProfilePaymentQueryRenderer: React.FC<{}> = ({}) => {
   return (
     <QueryRenderer<MyProfilePaymentQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyProfilePaymentQuery($count: Int!) {
           me {

--- a/src/app/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
@@ -4,7 +4,7 @@ import { Input, InputTitle } from "app/Components/Input"
 import { Select } from "app/Components/Select/SelectV2"
 import { Stack } from "app/Components/Stack"
 import { MyAccountFieldEditScreen } from "app/Scenes/MyAccount/Components/MyAccountFieldEditScreen"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Action, action, computed, Computed, useLocalStore } from "easy-peasy"
 import React, { useEffect, useRef } from "react"
 import { LiteCreditCardInput } from "react-native-credit-card-input"
@@ -226,7 +226,7 @@ export const MyProfilePaymentNewCreditCard: React.FC<{}> = ({}) => {
 const saveCreditCard = (token: string) => {
   return new Promise<MyProfilePaymentNewCreditCardSaveCardMutation["response"]>(
     (resolve, reject) => {
-      commitMutation<MyProfilePaymentNewCreditCardSaveCardMutation>(defaultEnvironment, {
+      commitMutation<MyProfilePaymentNewCreditCardSaveCardMutation>(getRelayEnvironment(), {
         mutation: graphql`
           mutation MyProfilePaymentNewCreditCardSaveCardMutation($input: CreditCardInput!) {
             createCreditCard(input: $input) {

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tests.tsx
@@ -7,14 +7,13 @@ import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotif
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { Platform, Switch } from "react-native"
 import { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
 import {
   AllowPushNotificationsBanner,
   MyProfilePushNotifications,
   MyProfilePushNotificationsQueryRenderer,
   OpenSettingsBanner,
 } from "./MyProfilePushNotifications"
-
-const env = getMockRelayEnvironment()
 
 describe(SwitchMenu, () => {
   it("title is set to black100 when enabled", () => {
@@ -47,6 +46,12 @@ describe(SwitchMenu, () => {
 })
 
 describe(MyProfilePushNotificationsQueryRenderer, () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    env = getMockRelayEnvironment()
+  })
+
   it("Loads until the operation resolves", () => {
     const tree = renderWithWrappersLEGACY(<MyProfilePushNotificationsQueryRenderer />)
     expect(tree.root.findAllByType(MyProfilePushNotifications)).toHaveLength(1)

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tests.tsx
@@ -1,13 +1,12 @@
 import { Text } from "@artsy/palette-mobile"
 import { SwitchMenu } from "app/Components/SwitchMenu"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { Platform, Switch } from "react-native"
 import { act } from "react-test-renderer"
-import { createMockEnvironment } from "relay-test-utils"
 import {
   AllowPushNotificationsBanner,
   MyProfilePushNotifications,
@@ -15,7 +14,7 @@ import {
   OpenSettingsBanner,
 } from "./MyProfilePushNotifications"
 
-const env = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const env = getMockRelayEnvironment()
 
 describe(SwitchMenu, () => {
   it("title is set to black100 when enabled", () => {

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -5,7 +5,7 @@ import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { SwitchMenu } from "app/Components/SwitchMenu"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { updateMyUserProfile } from "app/Scenes/MyAccount/updateMyUserProfile"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import {
   getNotificationPermissionsStatus,
   PushAuthorizationStatus,
@@ -329,7 +329,7 @@ const MyProfilePushNotificationsContainer = createRefetchContainer(
 export const MyProfilePushNotificationsQueryRenderer: React.FC<{}> = ({}) => {
   return (
     <QueryRenderer<MyProfilePushNotificationsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query MyProfilePushNotificationsQuery {
           me {

--- a/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
+++ b/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
@@ -4,7 +4,7 @@ import { NewWorksForYouQuery } from "__generated__/NewWorksForYouQuery.graphql"
 import { NewWorksForYou_viewer$data } from "__generated__/NewWorksForYou_viewer.graphql"
 import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
 import { maybeReportExperimentVariant } from "app/utils/experiments/reporter"
 import { PlaceholderGrid, ProvidePlaceholderContext } from "app/utils/placeholders"
@@ -177,7 +177,7 @@ export const NewWorksForYouQueryRenderer: React.FC<NewWorksForYouQueryRendererPr
 
   return (
     <QueryRenderer<NewWorksForYouQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={NewWorksForYouScreenQuery}
       variables={{
         version,

--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetails.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, Text, Separator } from "@artsy/palette-mobile"
 import { OrderDetailsQuery } from "__generated__/OrderDetailsQuery.graphql"
 import { OrderDetails_order$data } from "__generated__/OrderDetails_order.graphql"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -237,7 +237,7 @@ export const OrderDetailsContainer = createFragmentContainer(OrderDetails, {
 export const OrderDetailsQueryRender: React.FC<{ orderID: string }> = ({ orderID: orderID }) => {
   return (
     <QueryRenderer<OrderDetailsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query OrderDetailsQuery($orderID: ID!) {
           order: commerceOrder(id: $orderID) @optionalField {

--- a/src/app/Scenes/OrderHistory/OrderHistory.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistory.tsx
@@ -2,7 +2,7 @@ import { Flex, Box, useTheme, Text, Separator } from "@artsy/palette-mobile"
 import { OrderHistoryQuery } from "__generated__/OrderHistoryQuery.graphql"
 import { OrderHistory_me$data } from "__generated__/OrderHistory_me.graphql"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { PlaceholderBox, PlaceholderButton, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -164,7 +164,7 @@ export const OrderHistoryContainer = createPaginationContainer(
 export const OrderHistoryQueryRender: React.FC<{}> = ({}) => {
   return (
     <QueryRenderer<OrderHistoryQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query OrderHistoryQuery($count: Int!) {
           me @optionalField {

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -6,7 +6,7 @@ import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/Artwor
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { RetryErrorBoundaryLegacy } from "app/Components/RetryErrorBoundary"
 import { StickyTabPage } from "app/Components/StickyTabPage/StickyTabPage"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { Schema, screenTrack } from "app/utils/track"
 import { useClientQuery } from "app/utils/useClientQuery"
@@ -106,7 +106,7 @@ export const PartnerQueryRenderer: React.FC<{
   isVisible: boolean
 }> = ({ partnerID, ...others }) => {
   const { loading, data } = useClientQuery<PartnerInitialQuery>({
-    environment: defaultEnvironment,
+    environment: getRelayEnvironment(),
     query: graphql`
       query PartnerInitialQuery($partnerID: String!) {
         partner(id: $partnerID) {
@@ -126,7 +126,7 @@ export const PartnerQueryRenderer: React.FC<{
       render={({ isRetry }) => {
         return (
           <QueryRenderer<PartnerQuery>
-            environment={defaultEnvironment}
+            environment={getRelayEnvironment()}
             query={graphql`
               query PartnerQuery($partnerID: String!, $displayArtistsSection: Boolean!) {
                 partner(id: $partnerID) {

--- a/src/app/Scenes/Partner/Screens/PartnerLocations.tsx
+++ b/src/app/Scenes/Partner/Screens/PartnerLocations.tsx
@@ -2,7 +2,7 @@ import { Spacer, Box, Text } from "@artsy/palette-mobile"
 import { PartnerLocationsQuery } from "__generated__/PartnerLocationsQuery.graphql"
 import { PartnerLocations_partner$data } from "__generated__/PartnerLocations_partner.graphql"
 import { PartnerMapContainer as PartnerMap } from "app/Scenes/Partner/Components/PartnerMap"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { isCloseToBottom } from "app/utils/isCloseToBottom"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -100,7 +100,7 @@ export const PartnerLocationsContainer = createPaginationContainer(
 export const PartnerLocationsQueryRenderer: React.FC<{ partnerID: string }> = ({ partnerID }) => {
   return (
     <QueryRenderer<PartnerLocationsQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query PartnerLocationsQuery($partnerID: String!) {
           partner(id: $partnerID) {

--- a/src/app/Scenes/PriceDatabase/PriceDatabase.tests.tsx
+++ b/src/app/Scenes/PriceDatabase/PriceDatabase.tests.tsx
@@ -5,11 +5,16 @@ import { navigate } from "app/system/navigation/navigate"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithHookWrappersTL, renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { createMockEnvironment } from "relay-test-utils"
 import { PriceDatabase } from "./PriceDatabase"
 
-const mockEnvironment = getMockRelayEnvironment()
-
 describe(PriceDatabase, () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
+
   it("renders the price database", () => {
     const { getByText } = renderWithHookWrappersTL(<PriceDatabase />, mockEnvironment)
 

--- a/src/app/Scenes/PriceDatabase/PriceDatabase.tests.tsx
+++ b/src/app/Scenes/PriceDatabase/PriceDatabase.tests.tsx
@@ -2,13 +2,12 @@ import { act, fireEvent } from "@testing-library/react-native"
 import { ArtistAutosuggestResultsPaginationQuery } from "__generated__/ArtistAutosuggestResultsPaginationQuery.graphql"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithHookWrappersTL, renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { createMockEnvironment } from "relay-test-utils"
 import { PriceDatabase } from "./PriceDatabase"
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe(PriceDatabase, () => {
   it("renders the price database", () => {

--- a/src/app/Scenes/SaleInfo/SaleInfo.tsx
+++ b/src/app/Scenes/SaleInfo/SaleInfo.tsx
@@ -8,7 +8,7 @@ import { MenuItem } from "app/Components/MenuItem"
 import { RegisterToBidButtonContainer } from "app/Scenes/Sale/Components/RegisterToBidButton"
 import { saleStatus } from "app/Scenes/Sale/helpers"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderText, PlaceholderBox } from "app/utils/placeholders"
 import { defaultRules } from "app/utils/renderMarkdown"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -251,7 +251,7 @@ export const SaleInfoContainer = createFragmentContainer(SaleInfo, {
 export const SaleInfoQueryRenderer: React.FC<{ saleID: string }> = ({ saleID: saleID }) => {
   return (
     <QueryRenderer<SaleInfoQueryRendererQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query SaleInfoQueryRendererQuery($saleID: String!) {
           sale(id: $saleID) {

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -13,6 +13,7 @@ import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { createMockEnvironment } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 import { CreateSavedSearchAlert } from "./CreateSavedSearchAlert"
 import { CreateSavedSearchAlertParams } from "./SavedSearchAlertModel"
@@ -66,11 +67,11 @@ const defaultParams: CreateSavedSearchAlertParams = {
 }
 
 describe("CreateSavedSearchAlert", () => {
-  const mockEnvironment = getMockRelayEnvironment()
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
   beforeEach(() => {
-    mockEnvironment.mockClear()
+    mockEnvironment = getMockRelayEnvironment()
     notificationPermissions.mockClear()
   })
 

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -7,13 +7,12 @@ import {
   getArtworkFiltersModel,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { SavedSearchEntity } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 import { CreateSavedSearchAlert } from "./CreateSavedSearchAlert"
 import { CreateSavedSearchAlertParams } from "./SavedSearchAlertModel"
@@ -67,7 +66,7 @@ const defaultParams: CreateSavedSearchAlertParams = {
 }
 
 describe("CreateSavedSearchAlert", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
   beforeEach(() => {

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -6,14 +6,15 @@ import { extractText } from "app/utils/tests/extractText"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { createMockEnvironment } from "relay-test-utils"
 import { EditSavedSearchAlertQueryRenderer } from "./EditSavedSearchAlert"
 
 describe("EditSavedSearchAlert", () => {
-  const mockEnvironment = getMockRelayEnvironment()
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
   beforeEach(() => {
-    mockEnvironment.mockClear()
+    mockEnvironment = getMockRelayEnvironment()
     notificationPermissions.mockImplementationOnce((cb) =>
       cb(null, PushAuthorizationStatus.Authorized)
     )

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -1,16 +1,15 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { goBack } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { extractText } from "app/utils/tests/extractText"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
 import { EditSavedSearchAlertQueryRenderer } from "./EditSavedSearchAlert"
 
 describe("EditSavedSearchAlert", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
   beforeEach(() => {

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -12,7 +12,7 @@ import {
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { goBack, GoBackProps, navigationEvents } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -173,7 +173,7 @@ export const EditSavedSearchAlertQueryRenderer: React.FC<EditSavedSearchAlertBas
       render={renderWithPlaceholder({
         render: (relayProps: SavedSearchAlertQuery["response"]) => (
           <QueryRenderer<EditSavedSearchAlertQuery>
-            environment={defaultEnvironment}
+            environment={getRelayEnvironment()}
             query={graphql`
               query EditSavedSearchAlertQuery($artistIDs: [String]) {
                 viewer {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
@@ -1,5 +1,5 @@
 import { SavedSearchAlertQuery } from "__generated__/SavedSearchAlertQuery.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { graphql, QueryRenderer } from "react-relay"
 
 interface SearchCriteriaAlertBaseProps {
@@ -16,7 +16,7 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
 
   return (
     <QueryRenderer<SavedSearchAlertQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query SavedSearchAlertQuery($savedSearchAlertId: ID!) {
           me {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -13,94 +13,287 @@ import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotif
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import { Alert } from "react-native"
+import { createMockEnvironment } from "relay-test-utils"
 import { SavedSearchAlertForm, SavedSearchAlertFormProps, tracks } from "./SavedSearchAlertForm"
 import { SavedSearchStoreProvider, savedSearchModel } from "./SavedSearchStore"
 
-const spyAlert = jest.spyOn(Alert, "alert")
-const mockEnvironment = getMockRelayEnvironment()
-const notificationPermissions = mockFetchNotificationPermissions(false)
+describe("SavedSearchAlertForm", () => {
+  const spyAlert = jest.spyOn(Alert, "alert")
+  const notificationPermissions = mockFetchNotificationPermissions(false)
 
-const withoutDuplicateAlert = async () => {
-  await waitFor(() => {
-    const mutation = mockEnvironment.mock.getMostRecentOperation()
-    expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
-  })
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
-  // No duplicate alert
-  resolveMostRecentRelayOperation(mockEnvironment, {
-    Me: () => ({
-      savedSearch: null,
-    }),
-  })
-}
-
-const TestRenderer = (props: Partial<SavedSearchAlertFormProps>) => {
-  return (
-    <SavedSearchStoreProvider
-      runtimeModel={{
-        ...savedSearchModel,
-        attributes: attributes as SearchCriteriaAttributes,
-        aggregations,
-        entity: savedSearchEntity,
-      }}
-    >
-      <SavedSearchAlertForm {...baseProps} {...props} />
-    </SavedSearchStoreProvider>
-  )
-}
-
-describe("Saved search alert form", () => {
   beforeEach(() => {
-    spyAlert.mockClear()
-    mockEnvironment.mockClear()
-    notificationPermissions.mockImplementationOnce((cb) =>
-      cb(null, PushAuthorizationStatus.Authorized)
-    )
+    mockEnvironment = getMockRelayEnvironment()
   })
 
-  it("renders without throwing an error", () => {
-    renderWithWrappers(<TestRenderer />)
-  })
-
-  it("correctly renders default placeholder for input name", () => {
-    const { getByTestId } = renderWithWrappers(<TestRenderer />)
-
-    expect(getByTestId("alert-input-name").props.placeholder).toEqual("Placeholder")
-  })
-
-  it("calls onComplete when mutation is completed", async () => {
-    const onCompleteMock = jest.fn()
-    const { getByTestId } = renderWithWrappers(
-      <TestRenderer onComplete={onCompleteMock} savedSearchAlertId="savedSearchAlertId" />
-    )
-
-    fireEvent.changeText(getByTestId("alert-input-name"), "something new")
-    fireEvent.press(getByTestId("save-alert-button"))
-
+  const withoutDuplicateAlert = async () => {
     await waitFor(() => {
-      resolveMostRecentRelayOperation(mockEnvironment)
+      const mutation = mockEnvironment.mock.getMostRecentOperation()
+      expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
     })
 
-    expect(onCompleteMock).toHaveBeenCalled()
-  })
+    // No duplicate alert
+    resolveMostRecentRelayOperation(mockEnvironment, {
+      Me: () => ({
+        savedSearch: null,
+      }),
+    })
+  }
 
-  describe("Create flow", () => {
-    it("calls create mutation when `Save Alert` buttin is pressed", async () => {
+  const TestRenderer = (props: Partial<SavedSearchAlertFormProps>) => {
+    return (
+      <SavedSearchStoreProvider
+        runtimeModel={{
+          ...savedSearchModel,
+          attributes: attributes as SearchCriteriaAttributes,
+          aggregations,
+          entity: savedSearchEntity,
+        }}
+      >
+        <SavedSearchAlertForm {...baseProps} {...props} />
+      </SavedSearchStoreProvider>
+    )
+  }
+
+  describe("Saved search alert form", () => {
+    beforeEach(() => {
+      spyAlert.mockClear()
+      mockEnvironment.mockClear()
+      notificationPermissions.mockImplementationOnce((cb) =>
+        cb(null, PushAuthorizationStatus.Authorized)
+      )
+    })
+
+    it("renders without throwing an error", () => {
+      renderWithWrappers(<TestRenderer />)
+    })
+
+    it("correctly renders default placeholder for input name", () => {
       const { getByTestId } = renderWithWrappers(<TestRenderer />)
 
+      expect(getByTestId("alert-input-name").props.placeholder).toEqual("Placeholder")
+    })
+
+    it("calls onComplete when mutation is completed", async () => {
+      const onCompleteMock = jest.fn()
+      const { getByTestId } = renderWithWrappers(
+        <TestRenderer onComplete={onCompleteMock} savedSearchAlertId="savedSearchAlertId" />
+      )
+
       fireEvent.changeText(getByTestId("alert-input-name"), "something new")
+      fireEvent.press(getByTestId("save-alert-button"))
+
+      await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment)
+      })
+
+      expect(onCompleteMock).toHaveBeenCalled()
+    })
+
+    describe("Create flow", () => {
+      it("calls create mutation when `Save Alert` buttin is pressed", async () => {
+        const { getByTestId } = renderWithWrappers(<TestRenderer />)
+
+        fireEvent.changeText(getByTestId("alert-input-name"), "something new")
+        fireEvent.press(getByTestId("save-alert-button"))
+
+        await withoutDuplicateAlert()
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+
+          expect(mutation.request.node.operation.name).toBe("createSavedSearchAlertMutation")
+          expect(mutation.request.variables).toEqual({
+            input: {
+              attributes: createMutationAttributes,
+              userAlertSettings: {
+                name: "something new",
+                email: true,
+                push: true,
+              },
+            },
+          })
+        })
+      })
+
+      it("should auto populate alert name for the create mutation", async () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer initialValues={{ ...baseProps.initialValues, name: "" }} />
+        )
+
+        fireEvent.press(getByTestId("save-alert-button"))
+
+        await withoutDuplicateAlert()
+        await waitFor(() => {
+          expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
+            input: {
+              attributes,
+              userAlertSettings: {
+                name: "Placeholder",
+              },
+            },
+          })
+        })
+      })
+    })
+
+    describe("Update flow", () => {
+      it("should show a warning message if a user has disabled `Custom Alerts`", async () => {
+        const { getByText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" userAllowsEmails={false} />
+        )
+
+        expect(getByText("Change your email preferences")).toBeTruthy()
+        expect(
+          getByText("To receive Email Alerts, please update your email preferences.")
+        ).toBeTruthy()
+      })
+
+      it("should auto populate alert name for edit mutation", async () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            initialValues={{ ...baseProps.initialValues, name: "update value" }}
+          />
+        )
+
+        fireEvent.changeText(getByTestId("alert-input-name"), "")
+        fireEvent.press(getByTestId("save-alert-button"))
+
+        await waitFor(() => {
+          expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
+            input: {
+              userAlertSettings: {
+                name: `Placeholder`,
+              },
+            },
+          })
+        })
+      })
+
+      it("calls update mutation when `Save Alert` button is pressed", async () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        fireEvent.changeText(getByTestId("alert-input-name"), "something new")
+        fireEvent.press(getByTestId("save-alert-button"))
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+
+          expect(mutation.request.node.operation.name).toBe("updateSavedSearchAlertMutation")
+          expect(mutation.request.variables).toEqual({
+            input: {
+              attributes,
+              searchCriteriaID: "savedSearchAlertId",
+              userAlertSettings: {
+                name: "something new",
+                email: true,
+                push: true,
+              },
+            },
+          })
+        })
+      })
+
+      it("tracks analytics event when `Delete Alert` button is pressed", async () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        fireEvent.press(getByTestId("delete-alert-button"))
+        fireEvent.press(getByTestId("dialog-primary-action-button"))
+
+        await waitFor(() => {
+          resolveMostRecentRelayOperation(mockEnvironment)
+        })
+
+        expect(mockTrackEvent).toHaveBeenCalledWith(tracks.deletedSavedSearch("savedSearchAlertId"))
+      })
+
+      it("tracks analytics event when `Save Alert` button is pressed", async () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        fireEvent.changeText(getByTestId("alert-input-name"), "something new")
+        fireEvent.press(getByTestId("save-alert-button"))
+
+        await waitFor(() => {
+          resolveMostRecentRelayOperation(mockEnvironment)
+        })
+
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          tracks.editedSavedSearch(
+            "savedSearchAlertId",
+            { name: "name", email: true, push: true },
+            { name: "something new", email: true, push: true }
+          )
+        )
+      })
+
+      it("should render `Delete Alert` button", () => {
+        const { getAllByTestId } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        expect(getAllByTestId("delete-alert-button")).toHaveLength(1)
+      })
+
+      it("calls delete mutation when the delete alert button is pressed", async () => {
+        const onDeletePressMock = jest.fn()
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            onDeleteComplete={onDeletePressMock}
+          />
+        )
+
+        fireEvent.press(getByTestId("delete-alert-button"))
+        fireEvent.press(getByTestId("dialog-primary-action-button"))
+
+        expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(
+          "deleteSavedSearchAlertMutation"
+        )
+
+        await waitFor(() => {
+          resolveMostRecentRelayOperation(mockEnvironment)
+        })
+
+        expect(onDeletePressMock).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("Notification toggles", () => {
+    beforeEach(() => {
+      spyAlert.mockClear()
+      notificationPermissions.mockImplementationOnce((cb) => {
+        cb(null, PushAuthorizationStatus.Authorized)
+      })
+    })
+
+    it("toggles should be displayed", async () => {
+      const { queryByText } = renderWithWrappers(<TestRenderer />)
+
+      expect(queryByText("Email Alerts")).toBeTruthy()
+      expect(queryByText("Mobile Alerts")).toBeTruthy()
+    })
+
+    it("state of toggles should be passed in mutation", async () => {
+      const { getByTestId } = renderWithWrappers(<TestRenderer />)
+
       fireEvent.press(getByTestId("save-alert-button"))
 
       await withoutDuplicateAlert()
       await waitFor(() => {
         const mutation = mockEnvironment.mock.getMostRecentOperation()
-
-        expect(mutation.request.node.operation.name).toBe("createSavedSearchAlertMutation")
         expect(mutation.request.variables).toEqual({
           input: {
             attributes: createMutationAttributes,
             userAlertSettings: {
-              name: "something new",
+              name: "name",
               email: true,
               push: true,
             },
@@ -109,80 +302,21 @@ describe("Saved search alert form", () => {
       })
     })
 
-    it("should auto populate alert name for the create mutation", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer initialValues={{ ...baseProps.initialValues, name: "" }} />
-      )
+    it("state of email toggle should be passed to mutation", async () => {
+      const { getByTestId, getByLabelText } = renderWithWrappers(<TestRenderer />)
 
+      fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
       fireEvent.press(getByTestId("save-alert-button"))
 
       await withoutDuplicateAlert()
       await waitFor(() => {
-        expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
-          input: {
-            attributes,
-            userAlertSettings: {
-              name: "Placeholder",
-            },
-          },
-        })
-      })
-    })
-  })
-
-  describe("Update flow", () => {
-    it("should show a warning message if a user has disabled `Custom Alerts`", async () => {
-      const { getByText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" userAllowsEmails={false} />
-      )
-
-      expect(getByText("Change your email preferences")).toBeTruthy()
-      expect(
-        getByText("To receive Email Alerts, please update your email preferences.")
-      ).toBeTruthy()
-    })
-
-    it("should auto populate alert name for edit mutation", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer
-          savedSearchAlertId="savedSearchAlertId"
-          initialValues={{ ...baseProps.initialValues, name: "update value" }}
-        />
-      )
-
-      fireEvent.changeText(getByTestId("alert-input-name"), "")
-      fireEvent.press(getByTestId("save-alert-button"))
-
-      await waitFor(() => {
-        expect(mockEnvironment.mock.getMostRecentOperation().request.variables).toMatchObject({
-          input: {
-            userAlertSettings: {
-              name: `Placeholder`,
-            },
-          },
-        })
-      })
-    })
-
-    it("calls update mutation when `Save Alert` button is pressed", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      fireEvent.changeText(getByTestId("alert-input-name"), "something new")
-      fireEvent.press(getByTestId("save-alert-button"))
-
-      await waitFor(() => {
         const mutation = mockEnvironment.mock.getMostRecentOperation()
-
-        expect(mutation.request.node.operation.name).toBe("updateSavedSearchAlertMutation")
         expect(mutation.request.variables).toEqual({
           input: {
-            attributes,
-            searchCriteriaID: "savedSearchAlertId",
+            attributes: createMutationAttributes,
             userAlertSettings: {
-              name: "something new",
-              email: true,
+              name: "name",
+              email: false,
               push: true,
             },
           },
@@ -190,594 +324,470 @@ describe("Saved search alert form", () => {
       })
     })
 
-    it("tracks analytics event when `Delete Alert` button is pressed", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      fireEvent.press(getByTestId("delete-alert-button"))
-      fireEvent.press(getByTestId("dialog-primary-action-button"))
-
-      await waitFor(() => {
-        resolveMostRecentRelayOperation(mockEnvironment)
-      })
-
-      expect(mockTrackEvent).toHaveBeenCalledWith(tracks.deletedSavedSearch("savedSearchAlertId"))
-    })
-
-    it("tracks analytics event when `Save Alert` button is pressed", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      fireEvent.changeText(getByTestId("alert-input-name"), "something new")
-      fireEvent.press(getByTestId("save-alert-button"))
-
-      await waitFor(() => {
-        resolveMostRecentRelayOperation(mockEnvironment)
-      })
-
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        tracks.editedSavedSearch(
-          "savedSearchAlertId",
-          { name: "name", email: true, push: true },
-          { name: "something new", email: true, push: true }
-        )
-      )
-    })
-
-    it("should render `Delete Alert` button", () => {
-      const { getAllByTestId } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      expect(getAllByTestId("delete-alert-button")).toHaveLength(1)
-    })
-
-    it("calls delete mutation when the delete alert button is pressed", async () => {
-      const onDeletePressMock = jest.fn()
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer
-          savedSearchAlertId="savedSearchAlertId"
-          onDeleteComplete={onDeletePressMock}
-        />
-      )
-
-      fireEvent.press(getByTestId("delete-alert-button"))
-      fireEvent.press(getByTestId("dialog-primary-action-button"))
-
-      expect(mockEnvironment.mock.getMostRecentOperation().request.node.operation.name).toBe(
-        "deleteSavedSearchAlertMutation"
-      )
-
-      await waitFor(() => {
-        resolveMostRecentRelayOperation(mockEnvironment)
-      })
-
-      expect(onDeletePressMock).toHaveBeenCalled()
-    })
-  })
-})
-
-describe("Notification toggles", () => {
-  beforeEach(() => {
-    spyAlert.mockClear()
-    notificationPermissions.mockImplementationOnce((cb) => {
-      cb(null, PushAuthorizationStatus.Authorized)
-    })
-  })
-
-  it("toggles should be displayed", async () => {
-    const { queryByText } = renderWithWrappers(<TestRenderer />)
-
-    expect(queryByText("Email Alerts")).toBeTruthy()
-    expect(queryByText("Mobile Alerts")).toBeTruthy()
-  })
-
-  it("state of toggles should be passed in mutation", async () => {
-    const { getByTestId } = renderWithWrappers(<TestRenderer />)
-
-    fireEvent.press(getByTestId("save-alert-button"))
-
-    await withoutDuplicateAlert()
-    await waitFor(() => {
-      const mutation = mockEnvironment.mock.getMostRecentOperation()
-      expect(mutation.request.variables).toEqual({
-        input: {
-          attributes: createMutationAttributes,
-          userAlertSettings: {
-            name: "name",
-            email: true,
-            push: true,
-          },
-        },
-      })
-    })
-  })
-
-  it("state of email toggle should be passed to mutation", async () => {
-    const { getByTestId, getByLabelText } = renderWithWrappers(<TestRenderer />)
-
-    fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
-    fireEvent.press(getByTestId("save-alert-button"))
-
-    await withoutDuplicateAlert()
-    await waitFor(() => {
-      const mutation = mockEnvironment.mock.getMostRecentOperation()
-      expect(mutation.request.variables).toEqual({
-        input: {
-          attributes: createMutationAttributes,
-          userAlertSettings: {
-            name: "name",
-            email: false,
-            push: true,
-          },
-        },
-      })
-    })
-  })
-
-  it("state of push toggle should be passed to mutation", async () => {
-    const { getByTestId, getByLabelText } = renderWithWrappers(<TestRenderer />)
-
-    fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", false)
-    fireEvent.press(getByTestId("save-alert-button"))
-
-    await withoutDuplicateAlert()
-    await waitFor(() => {
-      const mutation = mockEnvironment.mock.getMostRecentOperation()
-      expect(mutation.request.variables).toEqual({
-        input: {
-          attributes: createMutationAttributes,
-          userAlertSettings: {
-            name: "name",
-            email: true,
-            push: false,
-          },
-        },
-      })
-    })
-  })
-
-  it("push toggle keeps in the same state when push permissions are denied", async () => {
-    notificationPermissions.mockReset()
-    notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Denied))
-
-    const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
-      <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
-    )
-
-    await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).toBeCalled()
-    expect(queryAllByA11yState({ selected: true })).toHaveLength(0)
-  })
-
-  it("push toggle keeps in the same state when push permissions are not not determined", async () => {
-    notificationPermissions.mockReset()
-    notificationPermissions.mockImplementation((cb) =>
-      cb(null, PushAuthorizationStatus.NotDetermined)
-    )
-
-    const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
-      <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
-    )
-
-    await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).toBeCalled()
-    expect(queryAllByA11yState({ selected: true })).toHaveLength(0)
-  })
-
-  it("push toggle turns on when push permissions are enabled", async () => {
-    const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
-      <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
-    )
-
-    await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).not.toBeCalled()
-    expect(queryAllByA11yState({ selected: true })).toHaveLength(1)
-  })
-})
-
-describe("Allow to send emails modal", () => {
-  beforeEach(() => {
-    spyAlert.mockClear()
-  })
-
-  it("should display modal when the user enables email toggle", async () => {
-    const { getByLabelText } = renderWithWrappers(
-      <TestRenderer
-        initialValues={{ ...baseProps.initialValues, push: false, email: false }}
-        userAllowsEmails={false}
-      />
-    )
-
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).toBeCalled()
-  })
-
-  it("should display modal only once", async () => {
-    // @ts-ignore
-    spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Accept" button
-
-    const { getByLabelText } = renderWithWrappers(
-      <TestRenderer
-        initialValues={{ ...baseProps.initialValues, push: false, email: false }}
-        userAllowsEmails={false}
-      />
-    )
-
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).toBeCalledTimes(1)
-  })
-
-  it("should not display modal if email toggle off and then back on", async () => {
-    const { getByLabelText } = renderWithWrappers(<TestRenderer userAllowsEmails={false} />)
-
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-
-    expect(spyAlert).toBeCalledTimes(0)
-  })
-
-  it('should call update mutation if the user is tapped "Accept" button', async () => {
-    // @ts-ignore
-    spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Accept" button
-
-    const { getByLabelText, getByTestId } = renderWithWrappers(
-      <TestRenderer
-        initialValues={{ ...baseProps.initialValues, push: false, email: false }}
-        userAllowsEmails={false}
-      />
-    )
-
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-    await fireEvent.press(getByTestId("save-alert-button"))
-
-    await waitFor(() => {
-      const mutation = mockEnvironment.mock.getMostRecentOperation()
-      expect(mutation.request.node.operation.name).toEqual("updateNotificationPreferencesMutation")
-      expect(mutation.request.variables).toEqual({
-        input: { subscriptionGroups: [{ name: "custom_alerts", status: "SUBSCRIBED" }] },
-      })
-    })
-  })
-
-  it("should not call update email frequency mutation if the user previously opted out of emails and toggle was on by default", async () => {
-    const { getByTestId } = renderWithWrappers(
-      <TestRenderer
-        savedSearchAlertId="savedSearchAlertId"
-        initialValues={{ ...baseProps.initialValues, email: true }}
-        userAllowsEmails={false}
-      />
-    )
-
-    await fireEvent.changeText(getByTestId("alert-input-name"), "updated name")
-    await fireEvent.press(getByTestId("save-alert-button"))
-
-    await waitFor(() => {
-      const mutation = mockEnvironment.mock.getMostRecentOperation()
-      expect(mutation.request.node.operation.name).toEqual("updateSavedSearchAlertMutation")
-    })
-  })
-})
-
-describe("Pills", () => {
-  it("should correctly render pills", () => {
-    const { getByText } = renderWithWrappers(<TestRenderer />)
-
-    expect(getByText("artistName")).toBeTruthy()
-    expect(getByText("Limited Edition")).toBeTruthy()
-    expect(getByText("Tate Ward Auctions")).toBeTruthy()
-    expect(getByText("New York, NY, USA")).toBeTruthy()
-    expect(getByText("Photography")).toBeTruthy()
-    expect(getByText("Prints")).toBeTruthy()
-  })
-
-  it("should have removable filter pills", () => {
-    const { getByText } = renderWithWrappers(<TestRenderer />)
-    // artist pill should appear and not be removable
-    expect(getByText("artistName")).toBeTruthy()
-    expect(getByText("artistName")).not.toHaveProp("onPress")
-
-    fireEvent.press(getByText("Prints"))
-    fireEvent.press(getByText("Photography"))
-
-    waitForElementToBeRemoved(() => getByText("Prints"))
-    waitForElementToBeRemoved(() => getByText("Photography"))
-  })
-})
-
-describe("Save alert button", () => {
-  describe("Create flow", () => {
-    it("should be enabled by default", () => {
-      const { getByTestId } = renderWithWrappers(<TestRenderer />)
-
-      expect(getByTestId("save-alert-button")).not.toBeDisabled()
-    })
-
-    it("should be enabled if selected at least one of toggles", () => {
-      const { getByTestId, getByLabelText } = renderWithWrappers(
-        <TestRenderer
-          initialValues={{ ...baseProps.initialValues, name: "name", push: false, email: false }}
-        />
-      )
-
-      fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-
-      expect(getByTestId("save-alert-button")).not.toBeDisabled()
-    })
-
-    it("should be disabled if none of toggles have been selected", () => {
+    it("state of push toggle should be passed to mutation", async () => {
       const { getByTestId, getByLabelText } = renderWithWrappers(<TestRenderer />)
 
       fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", false)
-      fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+      fireEvent.press(getByTestId("save-alert-button"))
 
-      expect(getByTestId("save-alert-button")).toBeDisabled()
+      await withoutDuplicateAlert()
+      await waitFor(() => {
+        const mutation = mockEnvironment.mock.getMostRecentOperation()
+        expect(mutation.request.variables).toEqual({
+          input: {
+            attributes: createMutationAttributes,
+            userAlertSettings: {
+              name: "name",
+              email: true,
+              push: false,
+            },
+          },
+        })
+      })
+    })
+
+    it("push toggle keeps in the same state when push permissions are denied", async () => {
+      notificationPermissions.mockReset()
+      notificationPermissions.mockImplementation((cb) => cb(null, PushAuthorizationStatus.Denied))
+
+      const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
+        <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
+      )
+
+      await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
+
+      expect(spyAlert).toBeCalled()
+      expect(queryAllByA11yState({ selected: true })).toHaveLength(0)
+    })
+
+    it("push toggle keeps in the same state when push permissions are not not determined", async () => {
+      notificationPermissions.mockReset()
+      notificationPermissions.mockImplementation((cb) =>
+        cb(null, PushAuthorizationStatus.NotDetermined)
+      )
+
+      const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
+        <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
+      )
+
+      await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
+
+      expect(spyAlert).toBeCalled()
+      expect(queryAllByA11yState({ selected: true })).toHaveLength(0)
+    })
+
+    it("push toggle turns on when push permissions are enabled", async () => {
+      const { getByLabelText, queryAllByA11yState } = renderWithWrappers(
+        <TestRenderer initialValues={{ ...baseProps.initialValues, push: false, email: false }} />
+      )
+
+      await fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", true)
+
+      expect(spyAlert).not.toBeCalled()
+      expect(queryAllByA11yState({ selected: true })).toHaveLength(1)
     })
   })
 
-  describe("Update flow", () => {
-    it("should be disabled by default", () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      expect(getByTestId("save-alert-button")).toBeDisabled()
+  describe("Allow to send emails modal", () => {
+    beforeEach(() => {
+      spyAlert.mockClear()
     })
 
-    it("should be disabled if no changes have been made by the user", () => {
-      const { getByTestId } = renderWithWrappers(
+    it("should display modal when the user enables email toggle", async () => {
+      const { getByLabelText } = renderWithWrappers(
         <TestRenderer
-          savedSearchAlertId="savedSearchAlertId"
-          initialValues={{ ...baseProps.initialValues, name: "name" }}
+          initialValues={{ ...baseProps.initialValues, push: false, email: false }}
+          userAllowsEmails={false}
         />
       )
 
-      expect(getByTestId("save-alert-button")).toBeDisabled()
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+
+      expect(spyAlert).toBeCalled()
     })
 
-    it("should be disabled if none of toggles have been selected", () => {
-      const { getByTestId, getByLabelText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+    it("should display modal only once", async () => {
+      // @ts-ignore
+      spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Accept" button
+
+      const { getByLabelText } = renderWithWrappers(
+        <TestRenderer
+          initialValues={{ ...baseProps.initialValues, push: false, email: false }}
+          userAllowsEmails={false}
+        />
       )
 
-      fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", false)
-      fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
 
-      expect(getByTestId("save-alert-button")).toBeDisabled()
+      expect(spyAlert).toBeCalledTimes(1)
     })
 
-    it("should be enabled if alert doesn't have name", () => {
+    it("should not display modal if email toggle off and then back on", async () => {
+      const { getByLabelText } = renderWithWrappers(<TestRenderer userAllowsEmails={false} />)
+
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+
+      expect(spyAlert).toBeCalledTimes(0)
+    })
+
+    it('should call update mutation if the user is tapped "Accept" button', async () => {
+      // @ts-ignore
+      spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "Accept" button
+
+      const { getByLabelText, getByTestId } = renderWithWrappers(
+        <TestRenderer
+          initialValues={{ ...baseProps.initialValues, push: false, email: false }}
+          userAllowsEmails={false}
+        />
+      )
+
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+      await fireEvent.press(getByTestId("save-alert-button"))
+
+      await waitFor(() => {
+        const mutation = mockEnvironment.mock.getMostRecentOperation()
+        expect(mutation.request.node.operation.name).toEqual(
+          "updateNotificationPreferencesMutation"
+        )
+        expect(mutation.request.variables).toEqual({
+          input: { subscriptionGroups: [{ name: "custom_alerts", status: "SUBSCRIBED" }] },
+        })
+      })
+    })
+
+    it("should not call update email frequency mutation if the user previously opted out of emails and toggle was on by default", async () => {
       const { getByTestId } = renderWithWrappers(
         <TestRenderer
           savedSearchAlertId="savedSearchAlertId"
-          initialValues={{ ...baseProps.initialValues, name: "" }}
+          initialValues={{ ...baseProps.initialValues, email: true }}
+          userAllowsEmails={false}
         />
       )
 
-      expect(getByTestId("save-alert-button")).not.toBeDisabled()
-    })
+      await fireEvent.changeText(getByTestId("alert-input-name"), "updated name")
+      await fireEvent.press(getByTestId("save-alert-button"))
 
-    it("should be enabled if changes have been made by the user", () => {
-      const { getByTestId } = renderWithWrappers(
-        <TestRenderer
-          savedSearchAlertId="savedSearchAlertId"
-          initialValues={{ ...baseProps.initialValues, name: "name" }}
-        />
-      )
-
-      fireEvent.changeText(getByTestId("alert-input-name"), "updated name")
-
-      expect(getByTestId("save-alert-button")).not.toBeDisabled()
-    })
-
-    it("should be enabled if filters are changed", () => {
-      const { getByText, getAllByText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
-
-      expect(getAllByText("Save Alert")[0]).toBeDisabled()
-      fireEvent.press(getByText("Limited Edition"))
-      expect(getAllByText("Save Alert")[0]).not.toBeDisabled()
-    })
-
-    it("should be enabled if selected at least one of toggles", () => {
-      const { getByTestId, getByLabelText } = renderWithWrappers(
-        <TestRenderer
-          savedSearchAlertId="savedSearchAlertId"
-          initialValues={{ ...baseProps.initialValues, name: "name", push: false, email: false }}
-        />
-      )
-
-      fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
-
-      expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      await waitFor(() => {
+        const mutation = mockEnvironment.mock.getMostRecentOperation()
+        expect(mutation.request.node.operation.name).toEqual("updateSavedSearchAlertMutation")
+      })
     })
   })
-})
 
-describe("Email preferences", () => {
-  it("should display email `Update email preferences` link only when email toggle is enabled", async () => {
-    const { queryByText, getByLabelText } = renderWithWrappers(<TestRenderer />)
+  describe("Pills", () => {
+    it("should correctly render pills", () => {
+      const { getByText } = renderWithWrappers(<TestRenderer />)
 
-    expect(queryByText("Update email preferences")).toBeTruthy()
-    await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
-    expect(queryByText("Update email preferences")).toBeFalsy()
+      expect(getByText("artistName")).toBeTruthy()
+      expect(getByText("Limited Edition")).toBeTruthy()
+      expect(getByText("Tate Ward Auctions")).toBeTruthy()
+      expect(getByText("New York, NY, USA")).toBeTruthy()
+      expect(getByText("Photography")).toBeTruthy()
+      expect(getByText("Prints")).toBeTruthy()
+    })
+
+    it("should have removable filter pills", () => {
+      const { getByText } = renderWithWrappers(<TestRenderer />)
+      // artist pill should appear and not be removable
+      expect(getByText("artistName")).toBeTruthy()
+      expect(getByText("artistName")).not.toHaveProp("onPress")
+
+      fireEvent.press(getByText("Prints"))
+      fireEvent.press(getByText("Photography"))
+
+      waitForElementToBeRemoved(() => getByText("Prints"))
+      waitForElementToBeRemoved(() => getByText("Photography"))
+    })
   })
 
-  it("should call navigate handler when `Update email preferences` link is pressed", async () => {
-    const { getByText } = renderWithWrappers(<TestRenderer />)
+  describe("Save alert button", () => {
+    describe("Create flow", () => {
+      it("should be enabled by default", () => {
+        const { getByTestId } = renderWithWrappers(<TestRenderer />)
 
-    fireEvent.press(getByText("Update email preferences"))
+        expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      })
 
-    expect(navigate).toBeCalledWith("/unsubscribe", {
-      passProps: {
-        backProps: {
-          previousScreen: "Unsubscribe",
+      it("should be enabled if selected at least one of toggles", () => {
+        const { getByTestId, getByLabelText } = renderWithWrappers(
+          <TestRenderer
+            initialValues={{ ...baseProps.initialValues, name: "name", push: false, email: false }}
+          />
+        )
+
+        fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+
+        expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      })
+
+      it("should be disabled if none of toggles have been selected", () => {
+        const { getByTestId, getByLabelText } = renderWithWrappers(<TestRenderer />)
+
+        fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", false)
+        fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+
+        expect(getByTestId("save-alert-button")).toBeDisabled()
+      })
+    })
+
+    describe("Update flow", () => {
+      it("should be disabled by default", () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        expect(getByTestId("save-alert-button")).toBeDisabled()
+      })
+
+      it("should be disabled if no changes have been made by the user", () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            initialValues={{ ...baseProps.initialValues, name: "name" }}
+          />
+        )
+
+        expect(getByTestId("save-alert-button")).toBeDisabled()
+      })
+
+      it("should be disabled if none of toggles have been selected", () => {
+        const { getByTestId, getByLabelText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        fireEvent(getByLabelText("Mobile Alerts Toggler"), "valueChange", false)
+        fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+
+        expect(getByTestId("save-alert-button")).toBeDisabled()
+      })
+
+      it("should be enabled if alert doesn't have name", () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            initialValues={{ ...baseProps.initialValues, name: "" }}
+          />
+        )
+
+        expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      })
+
+      it("should be enabled if changes have been made by the user", () => {
+        const { getByTestId } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            initialValues={{ ...baseProps.initialValues, name: "name" }}
+          />
+        )
+
+        fireEvent.changeText(getByTestId("alert-input-name"), "updated name")
+
+        expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      })
+
+      it("should be enabled if filters are changed", () => {
+        const { getByText, getAllByText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        expect(getAllByText("Save Alert")[0]).toBeDisabled()
+        fireEvent.press(getByText("Limited Edition"))
+        expect(getAllByText("Save Alert")[0]).not.toBeDisabled()
+      })
+
+      it("should be enabled if selected at least one of toggles", () => {
+        const { getByTestId, getByLabelText } = renderWithWrappers(
+          <TestRenderer
+            savedSearchAlertId="savedSearchAlertId"
+            initialValues={{ ...baseProps.initialValues, name: "name", push: false, email: false }}
+          />
+        )
+
+        fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", true)
+
+        expect(getByTestId("save-alert-button")).not.toBeDisabled()
+      })
+    })
+  })
+
+  describe("Email preferences", () => {
+    it("should display email `Update email preferences` link only when email toggle is enabled", async () => {
+      const { queryByText, getByLabelText } = renderWithWrappers(<TestRenderer />)
+
+      expect(queryByText("Update email preferences")).toBeTruthy()
+      await fireEvent(getByLabelText("Email Alerts Toggler"), "valueChange", false)
+      expect(queryByText("Update email preferences")).toBeFalsy()
+    })
+
+    it("should call navigate handler when `Update email preferences` link is pressed", async () => {
+      const { getByText } = renderWithWrappers(<TestRenderer />)
+
+      fireEvent.press(getByText("Update email preferences"))
+
+      expect(navigate).toBeCalledWith("/unsubscribe", {
+        passProps: {
+          backProps: {
+            previousScreen: "Unsubscribe",
+          },
         },
-      },
-    })
-  })
-
-  it("should call custom handler when it is passed", async () => {
-    const onUpdateEmailPreferencesMock = jest.fn()
-    const { getByText } = renderWithWrappers(
-      <TestRenderer onUpdateEmailPreferencesPress={onUpdateEmailPreferencesMock} />
-    )
-
-    fireEvent.press(getByText("Update email preferences"))
-
-    expect(onUpdateEmailPreferencesMock).toBeCalled()
-  })
-})
-
-describe("Checking for a duplicate alert", () => {
-  beforeEach(() => {
-    spyAlert.mockClear()
-    mockEnvironment.mockClear()
-  })
-
-  describe("Create flow", () => {
-    it("should call create mutation without a warning message", async () => {
-      const { getAllByText } = renderWithWrappers(<TestRenderer />)
-
-      fireEvent.press(getAllByText("Save Alert")[0])
-
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
-      })
-
-      // No duplicate alert
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Me: () => ({
-          savedSearch: null,
-        }),
-      })
-
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("createSavedSearchAlertMutation")
       })
     })
 
-    it("should display a warning message if there is a duplicate", async () => {
-      const { getAllByText } = renderWithWrappers(<TestRenderer />)
-
-      fireEvent.press(getAllByText("Save Alert")[0])
-
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
-      })
-
-      resolveMostRecentRelayOperation(mockEnvironment)
-
-      await waitFor(() => expect(spyAlert.mock.calls[0][0]).toBe("Duplicate Alert"))
-    })
-
-    it('should call create mutation when "Replace" button is pressed', async () => {
-      // @ts-ignore
-      spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
-
-      const { getAllByText } = renderWithWrappers(<TestRenderer />)
-
-      fireEvent.press(getAllByText("Save Alert")[0])
-
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
-      })
-
-      resolveMostRecentRelayOperation(mockEnvironment)
-
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("createSavedSearchAlertMutation")
-      })
-    })
-  })
-
-  describe("Update flow", () => {
-    it("should call update mutation without a warning message", async () => {
-      const { getAllByText, getByText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+    it("should call custom handler when it is passed", async () => {
+      const onUpdateEmailPreferencesMock = jest.fn()
+      const { getByText } = renderWithWrappers(
+        <TestRenderer onUpdateEmailPreferencesPress={onUpdateEmailPreferencesMock} />
       )
 
-      fireEvent.press(getByText("Prints"))
-      fireEvent.press(getAllByText("Save Alert")[0])
+      fireEvent.press(getByText("Update email preferences"))
 
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+      expect(onUpdateEmailPreferencesMock).toBeCalled()
+    })
+  })
+
+  describe("Checking for a duplicate alert", () => {
+    beforeEach(() => {
+      spyAlert.mockClear()
+      mockEnvironment.mockClear()
+    })
+
+    describe("Create flow", () => {
+      it("should call create mutation without a warning message", async () => {
+        const { getAllByText } = renderWithWrappers(<TestRenderer />)
+
+        fireEvent.press(getAllByText("Save Alert")[0])
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
+
+        // No duplicate alert
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Me: () => ({
+            savedSearch: null,
+          }),
+        })
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("createSavedSearchAlertMutation")
+        })
       })
 
-      // No duplicate alert
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Me: () => ({
-          savedSearch: null,
-        }),
+      it("should display a warning message if there is a duplicate", async () => {
+        const { getAllByText } = renderWithWrappers(<TestRenderer />)
+
+        fireEvent.press(getAllByText("Save Alert")[0])
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
+
+        resolveMostRecentRelayOperation(mockEnvironment)
+
+        await waitFor(() => expect(spyAlert.mock.calls[0][0]).toBe("Duplicate Alert"))
       })
 
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("updateSavedSearchAlertMutation")
+      it('should call create mutation when "Replace" button is pressed', async () => {
+        // @ts-ignore
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
+
+        const { getAllByText } = renderWithWrappers(<TestRenderer />)
+
+        fireEvent.press(getAllByText("Save Alert")[0])
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
+
+        resolveMostRecentRelayOperation(mockEnvironment)
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("createSavedSearchAlertMutation")
+        })
       })
     })
 
-    it("should display a warning message if there is a duplicate and user is able to view duplicate alert", async () => {
-      // @ts-ignore
-      spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "View Duplicate" button
+    describe("Update flow", () => {
+      it("should call update mutation without a warning message", async () => {
+        const { getAllByText, getByText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
 
-      const { getAllByText, getByText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
+        fireEvent.press(getByText("Prints"))
+        fireEvent.press(getAllByText("Save Alert")[0])
 
-      fireEvent.press(getByText("Prints"))
-      fireEvent.press(getAllByText("Save Alert")[0])
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
 
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        // No duplicate alert
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Me: () => ({
+            savedSearch: null,
+          }),
+        })
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("updateSavedSearchAlertMutation")
+        })
       })
 
-      resolveMostRecentRelayOperation(mockEnvironment)
+      it("should display a warning message if there is a duplicate and user is able to view duplicate alert", async () => {
+        // @ts-ignore
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[1].onPress()) // Click "View Duplicate" button
 
-      await waitFor(() => expect(spyAlert.mock.calls[0][0]).toBe("Duplicate Alert"))
+        const { getAllByText, getByText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
 
-      expect(navigate).toBeCalledWith("/my-profile/saved-search-alerts/internalID-1")
-    })
+        fireEvent.press(getByText("Prints"))
+        fireEvent.press(getAllByText("Save Alert")[0])
 
-    it('should call update mutation when "Replace" button is pressed', async () => {
-      // @ts-ignore
-      spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
 
-      const { getAllByText, getByText } = renderWithWrappers(
-        <TestRenderer savedSearchAlertId="savedSearchAlertId" />
-      )
+        resolveMostRecentRelayOperation(mockEnvironment)
 
-      fireEvent.press(getByText("Prints"))
-      fireEvent.press(getAllByText("Save Alert")[0])
+        await waitFor(() => expect(spyAlert.mock.calls[0][0]).toBe("Duplicate Alert"))
 
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        expect(navigate).toBeCalledWith("/my-profile/saved-search-alerts/internalID-1")
       })
 
-      resolveMostRecentRelayOperation(mockEnvironment)
+      it('should call update mutation when "Replace" button is pressed', async () => {
+        // @ts-ignore
+        spyAlert.mockImplementation((_title, _message, buttons) => buttons[0].onPress()) // Click "Replace" button
 
-      await waitFor(() => {
-        const mutation = mockEnvironment.mock.getMostRecentOperation()
-        expect(mutation.fragment.node.name).toBe("updateSavedSearchAlertMutation")
+        const { getAllByText, getByText } = renderWithWrappers(
+          <TestRenderer savedSearchAlertId="savedSearchAlertId" />
+        )
+
+        fireEvent.press(getByText("Prints"))
+        fireEvent.press(getAllByText("Save Alert")[0])
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("getSavedSearchIdByCriteriaQuery")
+        })
+
+        resolveMostRecentRelayOperation(mockEnvironment)
+
+        await waitFor(() => {
+          const mutation = mockEnvironment.mock.getMostRecentOperation()
+          expect(mutation.fragment.node.name).toBe("updateSavedSearchAlertMutation")
+        })
       })
     })
   })

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -6,19 +6,18 @@ import {
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import { Alert } from "react-native"
-import { createMockEnvironment } from "relay-test-utils"
 import { SavedSearchAlertForm, SavedSearchAlertFormProps, tracks } from "./SavedSearchAlertForm"
 import { SavedSearchStoreProvider, savedSearchModel } from "./SavedSearchStore"
 
 const spyAlert = jest.spyOn(Alert, "alert")
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 const notificationPermissions = mockFetchNotificationPermissions(false)
 
 const withoutDuplicateAlert = async () => {

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -10,7 +10,7 @@ import {
   CreateSavedSearchAlertNavigationStack,
   SavedSearchAlertMutationResult,
 } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import {
   getNotificationPermissionsStatus,
   PushAuthorizationStatus,
@@ -129,7 +129,7 @@ export const CreateSavedSearchAlertContentQueryRenderer: React.FC<
 > = (props) => {
   return (
     <QueryRenderer<CreateSavedSearchContentContainerQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query CreateSavedSearchContentContainerQuery {
           viewer {

--- a/src/app/Scenes/SavedSearchAlert/mutations/createSavedSearchAlert.ts
+++ b/src/app/Scenes/SavedSearchAlert/mutations/createSavedSearchAlert.ts
@@ -1,7 +1,7 @@
 import { createSavedSearchAlertMutation } from "__generated__/createSavedSearchAlertMutation.graphql"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { SavedSearchAlertFormValues } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const createSavedSearchAlert = (
@@ -9,7 +9,7 @@ export const createSavedSearchAlert = (
   attributes: SearchCriteriaAttributes
 ): Promise<createSavedSearchAlertMutation["response"]> => {
   return new Promise((resolve, reject) => {
-    commitMutation<createSavedSearchAlertMutation>(defaultEnvironment, {
+    commitMutation<createSavedSearchAlertMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation createSavedSearchAlertMutation($input: CreateSavedSearchInput!) {
           createSavedSearch(input: $input) {

--- a/src/app/Scenes/SavedSearchAlert/mutations/deleteSavedSearchAlert.ts
+++ b/src/app/Scenes/SavedSearchAlert/mutations/deleteSavedSearchAlert.ts
@@ -1,10 +1,10 @@
 import { deleteSavedSearchAlertMutation } from "__generated__/deleteSavedSearchAlertMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const deleteSavedSearchMutation = (savedSearchAlertId: string) => {
   return new Promise((resolve, reject) => {
-    commitMutation<deleteSavedSearchAlertMutation>(defaultEnvironment, {
+    commitMutation<deleteSavedSearchAlertMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation deleteSavedSearchAlertMutation($input: DisableSavedSearchInput!) {
           disableSavedSearch(input: $input) {

--- a/src/app/Scenes/SavedSearchAlert/mutations/updateNotificationPreferences.ts
+++ b/src/app/Scenes/SavedSearchAlert/mutations/updateNotificationPreferences.ts
@@ -2,7 +2,7 @@ import {
   NotificationPreferenceInput,
   updateNotificationPreferencesMutation,
 } from "__generated__/updateNotificationPreferencesMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const updateNotificationPreferences = (
@@ -13,7 +13,7 @@ export const updateNotificationPreferences = (
   }
 
   return new Promise((resolve, reject) => {
-    commitMutation<updateNotificationPreferencesMutation>(defaultEnvironment, {
+    commitMutation<updateNotificationPreferencesMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation updateNotificationPreferencesMutation(
           $input: updateNotificationPreferencesMutationInput!

--- a/src/app/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/app/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -1,7 +1,7 @@
 import { updateSavedSearchAlertMutation } from "__generated__/updateSavedSearchAlertMutation.graphql"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { SavedSearchAlertFormValues } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const updateSavedSearchAlert = (
@@ -16,7 +16,7 @@ export const updateSavedSearchAlert = (
   }
 
   return new Promise((resolve, reject) => {
-    commitMutation<updateSavedSearchAlertMutation>(defaultEnvironment, {
+    commitMutation<updateSavedSearchAlertMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation updateSavedSearchAlertMutation($input: UpdateSavedSearchInput!) {
           updateSavedSearch(input: $input) {

--- a/src/app/Scenes/SavedSearchAlert/queries/getSavedSearchIdByCriteria.ts
+++ b/src/app/Scenes/SavedSearchAlert/queries/getSavedSearchIdByCriteria.ts
@@ -1,6 +1,6 @@
 import { getSavedSearchIdByCriteriaQuery } from "__generated__/getSavedSearchIdByCriteriaQuery.graphql"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { fetchQuery, graphql } from "relay-runtime"
 
 export const getSavedSearchIdByCriteria = async (criteria: SearchCriteriaAttributes) => {
@@ -15,7 +15,7 @@ export const getSavedSearchIdByCriteria = async (criteria: SearchCriteriaAttribu
   `
 
   const request = fetchQuery<getSavedSearchIdByCriteriaQuery>(
-    defaultEnvironment,
+    getRelayEnvironment(),
     query,
     { criteria },
     {

--- a/src/app/Scenes/SavedSearchAlertsList/SavedSearchAlertsList.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/SavedSearchAlertsList.tsx
@@ -1,6 +1,6 @@
 import { SavedSearchAlertsListQuery } from "__generated__/SavedSearchAlertsListQuery.graphql"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { graphql, QueryRenderer } from "react-relay"
 import { SavedSearchAlertsListPlaceholder } from "./Components/SavedSearchAlertsListPlaceholder"
@@ -10,7 +10,7 @@ import { SortButton } from "./Components/SortButton"
 export const SavedSearchAlertsListQueryRenderer: React.FC = () => {
   return (
     <QueryRenderer<SavedSearchAlertsListQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query SavedSearchAlertsListQuery {
           me {

--- a/src/app/Scenes/Search/AutosuggestResults.tests.tsx
+++ b/src/app/Scenes/Search/AutosuggestResults.tests.tsx
@@ -9,6 +9,7 @@ import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecent
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { FlatList } from "react-native"
 import { act } from "react-test-renderer"
+import { createMockEnvironment } from "relay-test-utils"
 import { AutosuggestResults } from "./AutosuggestResults"
 import { SearchContext } from "./SearchContext"
 import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
@@ -127,7 +128,6 @@ jest.mock("./RecentSearches", () => {
 
 const notifyRecentSearchMock = require("./RecentSearches").useRecentSearches().notifyRecentSearch
 
-const env = getMockRelayEnvironment()
 const consoleErrorMock = jest.fn()
 const whiteListErrors = [
   "Warning: An update to %s inside a test was not wrapped in act(...).",
@@ -148,8 +148,10 @@ console.error = (...args: any[]) => {
 }
 
 describe("AutosuggestResults", () => {
+  let env: ReturnType<typeof createMockEnvironment>
+
   beforeEach(() => {
-    env.mockClear()
+    env = getMockRelayEnvironment()
     consoleErrorMock.mockClear()
     notifyRecentSearchMock.mockClear()
     inputBlurMock.mockClear()

--- a/src/app/Scenes/Search/AutosuggestResults.tests.tsx
+++ b/src/app/Scenes/Search/AutosuggestResults.tests.tsx
@@ -2,14 +2,13 @@ import { AutosuggestResultsPaginationQuery$rawResponse } from "__generated__/Aut
 import { AutosuggestResultsQuery$rawResponse } from "__generated__/AutosuggestResultsQuery.graphql"
 import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import Spinner from "app/Components/Spinner"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { CatchErrors } from "app/utils/CatchErrors"
 import { extractText } from "app/utils/tests/extractText"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { FlatList } from "react-native"
 import { act } from "react-test-renderer"
-import { createMockEnvironment } from "relay-test-utils"
 import { AutosuggestResults } from "./AutosuggestResults"
 import { SearchContext } from "./SearchContext"
 import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
@@ -128,7 +127,7 @@ jest.mock("./RecentSearches", () => {
 
 const notifyRecentSearchMock = require("./RecentSearches").useRecentSearches().notifyRecentSearch
 
-const env = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const env = getMockRelayEnvironment()
 const consoleErrorMock = jest.fn()
 const whiteListErrors = [
   "Warning: An update to %s inside a test was not wrapped in act(...).",

--- a/src/app/Scenes/Search/AutosuggestResults.tsx
+++ b/src/app/Scenes/Search/AutosuggestResults.tsx
@@ -6,7 +6,7 @@ import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import Spinner from "app/Components/Spinner"
 import { SearchContext } from "app/Scenes/Search/SearchContext"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { isPad } from "app/utils/hardware"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
@@ -371,7 +371,7 @@ export const AutosuggestResults: React.FC<{
               @arguments(query: $query, count: $count, entities: $entities)
           }
         `}
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
       />
     )
   },

--- a/src/app/Scenes/Search/Search.tests.tsx
+++ b/src/app/Scenes/Search/Search.tests.tsx
@@ -1,12 +1,13 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { Pill } from "app/Components/Pill"
 import { RecentSearch } from "app/Scenes/Search/SearchModel"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { isPad } from "app/utils/hardware"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { Pill } from "app/Components/Pill"
 import { RelayEnvironmentProvider } from "react-relay"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 import { SearchScreen } from "./Search"
@@ -52,9 +53,8 @@ describe("Search Screen", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
   beforeEach(() => {
-    require("app/system/relay/createEnvironment").reset()
     ;(isPad as jest.Mock).mockReset()
-    mockEnvironment = require("app/system/relay/createEnvironment").defaultEnvironment
+    mockEnvironment = getMockRelayEnvironment()
   })
 
   const TestRenderer = () => {

--- a/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
@@ -1,15 +1,14 @@
 import { fireEvent } from "@testing-library/react-native"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { __renderWithPlaceholderTestUtils__ } from "app/utils/renderWithPlaceholder"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
 import { SearchArtworksQueryRenderer } from "./SearchArtworksContainer"
 
 describe("SearchArtworks", () => {
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
 
   const TestRenderer = () => {
     return <SearchArtworksQueryRenderer keyword="keyword" />

--- a/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
@@ -5,18 +5,19 @@ import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { createMockEnvironment } from "relay-test-utils"
 import { SearchArtworksQueryRenderer } from "./SearchArtworksContainer"
 
 describe("SearchArtworks", () => {
-  const mockEnvironment = getMockRelayEnvironment()
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
 
   const TestRenderer = () => {
     return <SearchArtworksQueryRenderer keyword="keyword" />
   }
-
-  beforeEach(() => {
-    mockEnvironment.mockClear()
-  })
 
   it("should render without throwing an error", () => {
     const { getByText } = renderWithWrappers(<TestRenderer />)

--- a/src/app/Scenes/Search/SearchArtworksContainer.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tsx
@@ -1,7 +1,7 @@
 import { SearchArtworksContainerQuery } from "__generated__/SearchArtworksContainerQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { LoadFailureView } from "app/Components/LoadFailureView"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { graphql, QueryRenderer } from "react-relay"
 import { SearchArtworksGridPaginationContainer } from "./SearchArtworksGrid"
@@ -11,7 +11,7 @@ export const SearchArtworksQueryRenderer: React.FC<{ keyword: string }> = ({ key
   return (
     <ArtworkFiltersStoreProvider>
       <QueryRenderer<SearchArtworksContainerQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query SearchArtworksContainerQuery($count: Int!, $cursor: String, $keyword: String) {
             viewer {

--- a/src/app/Scenes/Search/UserPrefsModel.tsx
+++ b/src/app/Scenes/Search/UserPrefsModel.tsx
@@ -1,7 +1,7 @@
 import { UserPrefsModelQuery } from "__generated__/UserPrefsModelQuery.graphql"
 import { GlobalStore } from "app/store/GlobalStore"
 import { GlobalStoreModel } from "app/store/GlobalStoreModel"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Action, action, thunk, Thunk, thunkOn, ThunkOn } from "easy-peasy"
 import { getCurrencies } from "react-native-localize"
 import { fetchQuery, graphql } from "relay-runtime"
@@ -98,7 +98,7 @@ export const getUserPrefsModel = (): UserPrefsModel => ({
 
 const fetchMe = async () => {
   const result = await fetchQuery<UserPrefsModelQuery>(
-    defaultEnvironment,
+    getRelayEnvironment(),
     graphql`
       query UserPrefsModelQuery {
         me {

--- a/src/app/Scenes/SellWithArtsy/ConsignmentInquiry/ConsignmentInquiryScreen.tsx
+++ b/src/app/Scenes/SellWithArtsy/ConsignmentInquiry/ConsignmentInquiryScreen.tsx
@@ -5,7 +5,7 @@ import { AbandonFlowModal } from "app/Components/AbandonFlowModal"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { useToast } from "app/Components/Toast/toastHook"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { FormikProvider, useFormik } from "formik"
 import { useState } from "react"
@@ -124,7 +124,7 @@ export const ConsignmentInquiryScreen: React.FC<InquiryScreenProps> = ({
         })
       }
 
-      createConsignmentInquiry(defaultEnvironment, onCompleted, onError, input)
+      createConsignmentInquiry(getRelayEnvironment(), onCompleted, onError, input)
     },
     validationSchema: ValidationSchema,
   })

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetails.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetails.tests.tsx
@@ -7,12 +7,11 @@ import {
   updateConsignSubmission,
 } from "app/Scenes/SellWithArtsy/mutations"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment } from "relay-test-utils"
 import { ArtworkDetails } from "./ArtworkDetails"
 import { createOrUpdateSubmission } from "./utils/createOrUpdateSubmission"
 import { mockFormValues } from "./utils/testUtils"
@@ -27,7 +26,7 @@ jest.mock("../../mutations/updateConsignSubmissionMutation", () => ({
 
 const createConsignSubmissionMock = createConsignSubmission as jest.Mock
 const updateConsignSubmissionMock = updateConsignSubmission as jest.Mock
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe("ArtworkDetails", () => {
   const TestRenderer = ({ isLastStep = false }: { isLastStep?: boolean }) => (

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
@@ -3,11 +3,11 @@ import { fireEvent } from "@testing-library/react-native"
 import { STEPS, SubmitSWAArtworkFlow } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { updateConsignSubmission } from "app/Scenes/SellWithArtsy/mutations"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils/"
+import { MockPayloadGenerator } from "relay-test-utils/"
 import { ContactInformationQueryRenderer } from "./ContactInformation"
 
 jest.mock("../../mutations/updateConsignSubmissionMutation", () => ({
@@ -20,7 +20,7 @@ describe("ContactInformationForm", () => {
   afterEach(() => {
     GlobalStore.actions.artworkSubmission.submission.resetSessionState()
   })
-  const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+  const mockEnvironment = getMockRelayEnvironment()
   const handlePressTest = jest.fn()
   const TestRenderer = ({ isLastStep = true }: { isLastStep?: boolean }) => (
     <ContactInformationQueryRenderer handlePress={handlePressTest} isLastStep={isLastStep} />

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tests.tsx
@@ -7,7 +7,7 @@ import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
-import { MockPayloadGenerator } from "relay-test-utils/"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils/"
 import { ContactInformationQueryRenderer } from "./ContactInformation"
 
 jest.mock("../../mutations/updateConsignSubmissionMutation", () => ({
@@ -20,7 +20,12 @@ describe("ContactInformationForm", () => {
   afterEach(() => {
     GlobalStore.actions.artworkSubmission.submission.resetSessionState()
   })
-  const mockEnvironment = getMockRelayEnvironment()
+
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
+
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const handlePressTest = jest.fn()
   const TestRenderer = ({ isLastStep = true }: { isLastStep?: boolean }) => (
     <ContactInformationQueryRenderer handlePress={handlePressTest} isLastStep={isLastStep} />

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ContactInformation/ContactInformation.tsx
@@ -4,7 +4,7 @@ import { ContactInformation_me$data } from "__generated__/ContactInformation_me.
 import { CTAButton } from "app/Components/Button/CTAButton"
 import { Input } from "app/Components/Input"
 import { PhoneInput } from "app/Components/Input/PhoneInput/PhoneInput"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { Formik } from "formik"
 import { noop } from "lodash"
 import React, { useState } from "react"
@@ -107,7 +107,7 @@ export const ContactInformationQueryRenderer: React.FC<{
 }> = ({ handlePress, isLastStep }) => {
   return (
     <QueryRenderer<ContactInformationQueryRendererQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ContactInformationQueryRendererQuery {
           me {

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
@@ -5,11 +5,11 @@ import {
   updateConsignSubmission,
 } from "app/Scenes/SellWithArtsy/mutations"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator } from "relay-test-utils"
 import { STEPS, SubmitArtwork, SubmitSWAArtworkFlow } from "./SubmitArtwork"
 
 jest.mock("../mutations/updateConsignSubmissionMutation", () => ({
@@ -50,9 +50,7 @@ describe(SubmitArtwork, () => {
   })
 
   describe("Submission Flow", () => {
-    const mockEnvironment = defaultEnvironment as unknown as ReturnType<
-      typeof createMockEnvironment
-    >
+    const mockEnvironment = getMockRelayEnvironment()
 
     afterEach(() => {
       GlobalStore.actions.artworkSubmission.submission.resetSessionState()
@@ -203,9 +201,7 @@ describe(SubmitArtwork, () => {
   })
 
   describe("Submission VisualClues", () => {
-    const mockEnvironment = defaultEnvironment as unknown as ReturnType<
-      typeof createMockEnvironment
-    >
+    const mockEnvironment = getMockRelayEnvironment()
 
     let addClueSpy = jest
       .spyOn(GlobalStore.actions.visualClue, "addClue")

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tests.tsx
@@ -9,7 +9,7 @@ import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useTracking } from "react-tracking"
-import { MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 import { STEPS, SubmitArtwork, SubmitSWAArtworkFlow } from "./SubmitArtwork"
 
 jest.mock("../mutations/updateConsignSubmissionMutation", () => ({
@@ -24,6 +24,12 @@ const updateConsignSubmissionMock = updateConsignSubmission as jest.Mock
 const createConsignSubmissionMock = createConsignSubmission as jest.Mock
 
 describe(SubmitArtwork, () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
+
   describe("Steps CTA Buttons", () => {
     it('Displays "Save & Continue" if Accordion Step is not the last and "Submit Artwork" if last', () => {
       const { queryByText: queryByText1 } = renderWithWrappers(
@@ -50,8 +56,6 @@ describe(SubmitArtwork, () => {
   })
 
   describe("Submission Flow", () => {
-    const mockEnvironment = getMockRelayEnvironment()
-
     afterEach(() => {
       GlobalStore.actions.artworkSubmission.submission.resetSessionState()
     })
@@ -201,8 +205,6 @@ describe(SubmitArtwork, () => {
   })
 
   describe("Submission VisualClues", () => {
-    const mockEnvironment = getMockRelayEnvironment()
-
     let addClueSpy = jest
       .spyOn(GlobalStore.actions.visualClue, "addClue")
       .mockImplementation(() => null)

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tests.tsx
@@ -6,19 +6,21 @@ import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
 import { useTracking } from "react-tracking"
-import { MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 import { UploadPhotos } from "./UploadPhotos"
 
-const mockEnvironment = getMockRelayEnvironment()
-
 describe("UploadPhotos", () => {
+  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+
   const TestRenderer = ({ isLastStep = false }: { isLastStep?: boolean }) => (
     <RelayEnvironmentProvider environment={mockEnvironment}>
       <UploadPhotos handlePress={jest.fn()} isLastStep={isLastStep} />
     </RelayEnvironmentProvider>
   )
 
-  beforeEach(() => mockEnvironment.mockClear())
+  beforeEach(() => {
+    mockEnvironment = getMockRelayEnvironment()
+  })
 
   it("renders correct explanation for upload photos form", () => {
     const { getByText } = renderWithWrappers(<TestRenderer />)

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tests.tsx
@@ -1,15 +1,15 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { STEPS, SubmitSWAArtworkFlow } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { RelayEnvironmentProvider } from "react-relay"
 import { useTracking } from "react-tracking"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { MockPayloadGenerator } from "relay-test-utils"
 import { UploadPhotos } from "./UploadPhotos"
 
-const mockEnvironment = defaultEnvironment as ReturnType<typeof createMockEnvironment>
+const mockEnvironment = getMockRelayEnvironment()
 
 describe("UploadPhotos", () => {
   const TestRenderer = ({ isLastStep = false }: { isLastStep?: boolean }) => (

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/addAssetToConsignment.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/addAssetToConsignment.ts
@@ -2,12 +2,12 @@ import {
   addAssetToConsignmentMutation,
   AddAssetToConsignmentSubmissionInput,
 } from "__generated__/addAssetToConsignmentMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const addAssetToConsignment = (input: AddAssetToConsignmentSubmissionInput) => {
   return new Promise<addAssetToConsignmentMutation["response"]>((resolve, reject) => {
-    commitMutation<addAssetToConsignmentMutation>(defaultEnvironment, {
+    commitMutation<addAssetToConsignmentMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation addAssetToConsignmentMutation($input: AddAssetToConsignmentSubmissionInput!) {
           addAssetToConsignmentSubmission(input: $input) {

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/createGeminiAssetWithS3Credentials.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/createGeminiAssetWithS3Credentials.ts
@@ -2,12 +2,12 @@ import {
   createGeminiAssetWithS3CredentialsMutation,
   CreateGeminiEntryForAssetInput,
 } from "__generated__/createGeminiAssetWithS3CredentialsMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const createGeminiAssetWithS3Credentials = (input: CreateGeminiEntryForAssetInput) => {
   return new Promise<string>((resolve, reject) => {
-    commitMutation<createGeminiAssetWithS3CredentialsMutation>(defaultEnvironment, {
+    commitMutation<createGeminiAssetWithS3CredentialsMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation createGeminiAssetWithS3CredentialsMutation(
           $input: CreateGeminiEntryForAssetInput!

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/getConvectionGeminiKey.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/getConvectionGeminiKey.ts
@@ -1,10 +1,10 @@
 import { getConvectionGeminiKeyQuery } from "__generated__/getConvectionGeminiKeyQuery.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { fetchQuery, graphql } from "relay-runtime"
 
 export const getConvectionGeminiKey = () =>
   fetchQuery<getConvectionGeminiKeyQuery>(
-    defaultEnvironment,
+    getRelayEnvironment(),
     graphql`
       query getConvectionGeminiKeyQuery {
         system {

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/getGeminiCredentialsForEnvironment.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/gemini/getGeminiCredentialsForEnvironment.ts
@@ -2,7 +2,7 @@ import {
   getGeminiCredentialsForEnvironmentMutation,
   RequestCredentialsForAssetUploadInput,
 } from "__generated__/getGeminiCredentialsForEnvironmentMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export type AssetCredentials =
@@ -13,7 +13,7 @@ export const getGeminiCredentialsForEnvironment = (
   input: RequestCredentialsForAssetUploadInput
 ) => {
   return new Promise<AssetCredentials>((resolve, reject) => {
-    commitMutation<getGeminiCredentialsForEnvironmentMutation>(defaultEnvironment, {
+    commitMutation<getGeminiCredentialsForEnvironmentMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation getGeminiCredentialsForEnvironmentMutation(
           $input: RequestCredentialsForAssetUploadInput!

--- a/src/app/Scenes/SellWithArtsy/mutations/createConsignSubmissionMutation.ts
+++ b/src/app/Scenes/SellWithArtsy/mutations/createConsignSubmissionMutation.ts
@@ -3,12 +3,12 @@ import {
   CreateSubmissionMutationInput,
 } from "__generated__/createConsignSubmissionMutation.graphql"
 import { getCurrentEmissionState } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const createConsignSubmission = (input: CreateSubmissionMutationInput) => {
   return new Promise<string>((resolve, reject) => {
-    commitMutation<createConsignSubmissionMutation>(defaultEnvironment, {
+    commitMutation<createConsignSubmissionMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation createConsignSubmissionMutation($input: CreateSubmissionMutationInput!) {
           createConsignmentSubmission(input: $input) {

--- a/src/app/Scenes/SellWithArtsy/mutations/removeAssetFromConsignmentSubmissionMutation.ts
+++ b/src/app/Scenes/SellWithArtsy/mutations/removeAssetFromConsignmentSubmissionMutation.ts
@@ -2,12 +2,12 @@ import {
   RemoveAssetFromConsignmentSubmissionInput,
   removeAssetFromConsignmentSubmissionMutation,
 } from "__generated__/removeAssetFromConsignmentSubmissionMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const removeAssetFromSubmission = (input: RemoveAssetFromConsignmentSubmissionInput) => {
   return new Promise<string>((resolve, reject) => {
-    commitMutation<removeAssetFromConsignmentSubmissionMutation>(defaultEnvironment, {
+    commitMutation<removeAssetFromConsignmentSubmissionMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation removeAssetFromConsignmentSubmissionMutation(
           $input: RemoveAssetFromConsignmentSubmissionInput!

--- a/src/app/Scenes/SellWithArtsy/mutations/updateConsignSubmissionMutation.ts
+++ b/src/app/Scenes/SellWithArtsy/mutations/updateConsignSubmissionMutation.ts
@@ -2,12 +2,12 @@ import {
   updateConsignSubmissionMutation,
   UpdateSubmissionMutationInput,
 } from "__generated__/updateConsignSubmissionMutation.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
 export const updateConsignSubmission = (input: UpdateSubmissionMutationInput) => {
   return new Promise<string>((resolve, reject) => {
-    commitMutation<updateConsignSubmissionMutation>(defaultEnvironment, {
+    commitMutation<updateConsignSubmissionMutation>(getRelayEnvironment(), {
       mutation: graphql`
         mutation updateConsignSubmissionMutation($input: UpdateSubmissionMutationInput!) {
           updateConsignmentSubmission(input: $input) {

--- a/src/app/Scenes/Show/Screens/ShowMoreInfo.tsx
+++ b/src/app/Scenes/Show/Screens/ShowMoreInfo.tsx
@@ -5,7 +5,7 @@ import { PartnerEntityHeaderFragmentContainer as PartnerEntityHeader } from "app
 import { ReadMore } from "app/Components/ReadMore"
 import { ShowHoursFragmentContainer as ShowHours } from "app/Scenes/Show/Components/ShowHours"
 import { ShowLocationFragmentContainer as ShowLocation } from "app/Scenes/Show/Components/ShowLocation"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { FlatList } from "react-native"
@@ -216,7 +216,7 @@ export const ShowMoreInfoFragmentContainer = createFragmentContainer(ShowMoreInf
 export const ShowMoreInfoQueryRenderer: React.FC<{ showID: string }> = ({ showID }) => {
   return (
     <QueryRenderer<ShowMoreInfoQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ShowMoreInfoQuery($id: String!) {
           show(id: $id) {

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -5,7 +5,8 @@ import { Show_show$data } from "__generated__/Show_show.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
 import { SearchImageHeaderButton } from "app/Components/SearchImageHeaderButton"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useScreenDimensions } from "app/utils/hooks"
 import { PlaceholderBox, PlaceholderGrid, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -14,7 +15,6 @@ import React, { useRef, useState } from "react"
 import { Animated } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { useScreenDimensions } from "app/utils/hooks"
 import { ShowArtworksWithNavigation as ShowArtworks } from "./Components/ShowArtworks"
 import { ShowArtworksEmptyStateFragmentContainer } from "./Components/ShowArtworksEmptyState"
 import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
@@ -166,7 +166,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
 export const ShowQueryRenderer: React.FC<ShowQueryRendererProps> = ({ showID }) => {
   return (
     <QueryRenderer<ShowQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ShowQuery($showID: String!) {
           show(id: $showID) @principalField {

--- a/src/app/Scenes/Tag/Tag.tsx
+++ b/src/app/Scenes/Tag/Tag.tsx
@@ -5,7 +5,7 @@ import About from "app/Components/Tag/About"
 import { TagArtworksPaginationContainer } from "app/Components/Tag/TagArtworks"
 import { TagPlaceholder } from "app/Components/Tag/TagPlaceholder"
 import Header from "app/Scenes/Tag/TagHeader"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { View } from "react-native"
@@ -88,7 +88,7 @@ export const TagQueryRenderer: React.FC<TagQueryRendererProps> = (props) => {
 
   return (
     <QueryRenderer<TagQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query TagQuery($tagID: String!, $input: FilterArtworksInput) {
           tag(id: $tagID) {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
@@ -2,6 +2,7 @@ import { Spinner } from "@artsy/palette-mobile"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { Fair, FairFragmentContainer, FairPlaceholder } from "app/Scenes/Fair/Fair"
 import { PartnerContainer } from "app/Scenes/Partner/Partner"
+import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { __renderWithPlaceholderTestUtils__ } from "app/utils/renderWithPlaceholder"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { act } from "react-test-renderer"
@@ -25,8 +26,7 @@ describe("VanityURLEntity", () => {
   let env: ReturnType<typeof createMockEnvironment>
 
   beforeEach(() => {
-    require("app/system/relay/createEnvironment").reset()
-    env = require("app/system/relay/createEnvironment").defaultEnvironment
+    env = getMockRelayEnvironment()
   })
 
   it("renders a VanityURLPossibleRedirect when 404", () => {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tsx
@@ -4,7 +4,7 @@ import { VanityURLEntity_fairOrPartner$data } from "__generated__/VanityURLEntit
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
 import { FairFragmentContainer, FairPlaceholder, FairQueryRenderer } from "app/Scenes/Fair/Fair"
 import { PartnerContainer } from "app/Scenes/Partner/Partner"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useScreenDimensions } from "app/utils/hooks"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { View } from "react-native"
@@ -67,7 +67,7 @@ export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugT
   } else {
     return (
       <QueryRenderer<VanityURLEntityQuery>
-        environment={defaultEnvironment}
+        environment={getRelayEnvironment()}
         query={graphql`
           query VanityURLEntityQuery($id: String!) {
             vanityURLEntity(id: $id) {

--- a/src/app/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
+++ b/src/app/Scenes/ViewingRoom/ViewingRoomArtworks.tsx
@@ -5,7 +5,7 @@ import ImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { ReadMore } from "app/Components/ReadMore"
 import { navigate } from "app/system/navigation/navigate"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -217,7 +217,7 @@ export const ViewingRoomArtworksQueryRenderer: React.FC<{ viewing_room_id: strin
 }) => {
   return (
     <QueryRenderer<ViewingRoomArtworksQueryRendererQuery>
-      environment={defaultEnvironment}
+      environment={getRelayEnvironment()}
       query={graphql`
         query ViewingRoomArtworksQueryRendererQuery($viewingRoomID: ID!) {
           viewingRoom(id: $viewingRoomID) {

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -1,7 +1,7 @@
 import { modules } from "app/AppRegistry"
 import { matchRoute } from "app/routes"
 import { GlobalStore } from "app/store/GlobalStore"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { RateLimiter } from "limiter"
 import { useEffect } from "react"
@@ -46,7 +46,7 @@ async function isRateLimited() {
 }
 
 const prefetchQuery = async (query: GraphQLTaggedNode, variables?: Variables) => {
-  const environment = defaultEnvironment
+  const environment = getRelayEnvironment()
   const operation = createOperationDescriptor(getRequest(query), variables ?? {})
 
   try {

--- a/src/app/utils/relayHelpers.ts
+++ b/src/app/utils/relayHelpers.ts
@@ -1,4 +1,4 @@
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useReducer } from "react"
 import { Record } from "relay-runtime/lib/store/RelayStoreTypes"
 
@@ -17,7 +17,7 @@ export type ExtractNodeType<T> = T extends { edges: any }
   ? NonNullable<NonNullable<NonNullable<NonNullable<T>["edges"]>[number]>["node"]>
   : never
 
-const getStore = () => defaultEnvironment.getStore()
+const getStore = () => getRelayEnvironment().getStore()
 
 /**
  * Find a relay  from the Relay store by providing a key value pair

--- a/src/app/utils/tests/renderWithWrappers.tsx
+++ b/src/app/utils/tests/renderWithWrappers.tsx
@@ -1,6 +1,6 @@
 import { render, RenderOptions } from "@testing-library/react-native"
 import { TestProviders } from "app/Providers"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { track } from "app/utils/track"
 import { Component, Suspense } from "react"
 import { Environment, RelayEnvironmentProvider } from "react-relay"
@@ -78,7 +78,7 @@ export const renderWithWrappers = (component: ReactElement, wrapperProps?: Wrapp
 
 export const renderWithHookWrappersTL = (
   component: ReactElement,
-  environment: Environment = defaultEnvironment
+  environment: Environment = getRelayEnvironment()
 ) => {
   const jsx = (
     <RelayEnvironmentProvider environment={environment}>

--- a/src/app/utils/useImageSearch.ts
+++ b/src/app/utils/useImageSearch.ts
@@ -1,5 +1,5 @@
 import { useImageSearchQuery } from "__generated__/useImageSearchQuery.graphql"
-import { defaultEnvironment } from "app/system/relay/createEnvironment"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ReactNativeFile } from "extract-files"
 import { useState } from "react"
 import { Platform } from "react-native"
@@ -66,7 +66,7 @@ export const useImageSearch = () => {
       })
 
       const response = await fetchQuery<useImageSearchQuery>(
-        defaultEnvironment,
+        getRelayEnvironment(),
         graphql`
           query useImageSearchQuery($file: Upload!) {
             reverseImageSearch(image: $file) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

Related PRs: https://github.com/artsy/eigen/pull/8636, https://github.com/artsy/eigen/pull/8219, https://github.com/artsy/eigen/pull/8391, https://github.com/artsy/eigen/pull/8393

### Description
We are again faced ([1](https://www.notion.so/artsy/If-I-tap-into-an-artwork-from-a-grid-save-and-then-navigate-back-to-the-grid-the-artwork-does-not-2a134e7567d145a1a405daa6eed825de), [2](https://www.notion.so/artsy/After-adding-an-artwork-to-a-custom-list-if-I-tap-on-the-artwork-s-save-icon-again-it-removes-the--0914a56c1daa4d2ca08d972f2925585f), [3](https://www.notion.so/artsy/If-I-remove-an-artwork-from-all-lists-including-Saved-Artworks-the-heart-icon-remains-filled-in--6cbd4350ad38435886971ccfa6a23628)) with the problem that the data in the relay store is **not** updated correctly due to the fact that **different** relay env are used

### Demo
| Before | After |
| ------------- | ------------- |
| <video src="https://github.com/artsy/eigen/assets/3513494/9dec7b77-15c4-4a33-8965-5e2cb021a987" /> | <video src="https://github.com/artsy/eigen/assets/3513494/fe7e551b-b64a-4a3e-b191-2cea5c760931" />  | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- always use the same relay env - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
