### PR TITLE
docs: add section about setting up after long time [skip ci]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 ## Getting Started
 
 - [Getting Started](getting_started.md)
+- [I have eigen installed but haven't run it in a while](setting_up_eigen_after_long_time.md)
 - [Troubleshooting](troubleshooting.md)
 
 ## Meandering Around

--- a/docs/setting_up_eigen_after_long_time.md
+++ b/docs/setting_up_eigen_after_long_time.md
@@ -1,0 +1,37 @@
+# Setting up eigen after a long time of not using it
+
+## Setup
+
+```sh
+yarn setup:artsy # this is `yarn setup:oss` if you're not working at Artsy
+yarn install:all
+yarn relay
+```
+
+### In case of Pod errors:
+
+You might encounter some Pod errors, i.e.:
+
+```sh
+[!] Unable to find the `FlipperKit` repo. Please update the CocoaPods cache by running `pod repo update`.
+```
+
+in that case, you can try to run the following commands:
+
+```sh
+cd ios && bundle exec pod repo update && bundle exec pod install
+```
+
+This will update the stale pods on your local environment.
+
+## Running on iOS
+
+You can open xcode with `yarn open-xcode`, clean the project with <kbd>⌘ cmd</kbd> + <kbd>⇧ shift</kbd> + <kbd>K</kbd>
+
+and then press the play button to run the app.
+
+## Running on Android
+
+```sh
+yarn android
+```


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Updating the docs for setting up eigen after a long time, happy to hear peoples thoughts on it

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog