### PR TITLE
fix(tabs): ensure back actions are present

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.130.0",
-    "@artsy/palette-mobile": "11.0.32",
+    "@artsy/palette-mobile": "11.0.33",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@formatjs/intl-datetimeformat": "6.8.0",

--- a/src/app/Scenes/Activity/Activity.tsx
+++ b/src/app/Scenes/Activity/Activity.tsx
@@ -4,6 +4,7 @@ import { Tabs } from "@artsy/palette-mobile"
 import { ActivityQuery } from "__generated__/ActivityQuery.graphql"
 
 import { useMarkNotificationsAsSeen } from "app/Scenes/Activity/hooks/useMarkNotificationsAsSeen"
+import { goBack } from "app/system/navigation/navigate"
 import { Suspense } from "react"
 import { OnTabChangeCallback } from "react-native-collapsible-tab-view"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -51,7 +52,11 @@ export const Activity = () => {
   }
 
   return (
-    <Tabs.TabsWithHeader title="Activity" onTabChange={handleTabPress}>
+    <Tabs.TabsWithHeader
+      title="Activity"
+      onTabChange={handleTabPress}
+      headerProps={{ onBack: goBack }}
+    >
       <Tabs.Tab name="All" label="All">
         <Tabs.Lazy>
           <ActivityContainer type="all" />

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -1,4 +1,5 @@
 import { Tabs } from "@artsy/palette-mobile"
+import { goBack } from "app/system/navigation/navigate"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 
 import { IndexChangeEventData } from "react-native-collapsible-tab-view/lib/typescript/src/types"
@@ -58,7 +59,11 @@ export const Favorites: React.FC = () => {
         context_screen_owner_type: null,
       }}
     >
-      <Tabs.TabsWithHeader title="Follows" onTabChange={fireTabSelectionAnalytics}>
+      <Tabs.TabsWithHeader
+        title="Follows"
+        onTabChange={fireTabSelectionAnalytics}
+        headerProps={{ onBack: goBack }}
+      >
         <Tabs.Tab name={Tab.artists.name} label={Tab.artists.label}>
           <Tabs.Lazy>
             <FavoriteArtistsQueryRenderer />

--- a/src/app/Scenes/Gene/Gene.tsx
+++ b/src/app/Scenes/Gene/Gene.tsx
@@ -5,6 +5,7 @@ import About from "app/Components/Gene/About"
 import { GeneArtworksPaginationContainer } from "app/Components/Gene/GeneArtworks"
 import { GenePlaceholder } from "app/Components/Gene/GenePlaceholder"
 import Header from "app/Components/Gene/Header"
+import { goBack } from "app/system/navigation/navigate"
 
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -55,6 +56,7 @@ export const Gene: React.FC<GeneProps> = (props) => {
             <Header gene={gene} shortForm={false} />
           </Flex>
         )}
+        headerProps={{ onBack: goBack }}
       >
         <Tabs.Tab name="Works" label="Works">
           <Tabs.Lazy>

--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -4,6 +4,7 @@ import { PartnerQuery } from "__generated__/PartnerQuery.graphql"
 import { Partner_partner$data } from "__generated__/Partner_partner.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { HeaderTabsGridPlaceholder } from "app/Components/HeaderTabGridPlaceholder"
+import { goBack } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -41,6 +42,7 @@ const Partner: React.FC<PartnerProps> = (props) => {
           title={partner.name!}
           initialTabName={initialTab}
           BelowTitleHeaderComponent={() => <PartnerHeader partner={partner} />}
+          headerProps={{ onBack: goBack }}
         >
           <Tabs.Tab name="Overview" label="Overview">
             <Tabs.ScrollView>
@@ -61,7 +63,11 @@ const Partner: React.FC<PartnerProps> = (props) => {
         context_screen_owner_type: Schema.OwnerEntityTypes.Partner,
       }}
     >
-      <Tabs.TabsWithHeader title={partner.name!} initialTabName={initialTab}>
+      <Tabs.TabsWithHeader
+        title={partner.name!}
+        initialTabName={initialTab}
+        headerProps={{ onBack: goBack }}
+      >
         <Tabs.Tab name="Overview" label="Overview">
           <Tabs.Lazy>
             <PartnerOverview partner={partner} />

--- a/src/app/Scenes/Tag/Tag.tsx
+++ b/src/app/Scenes/Tag/Tag.tsx
@@ -1,6 +1,7 @@
 import { Tabs } from "@artsy/palette-mobile"
 import { TagQuery, TagQuery$data } from "__generated__/TagQuery.graphql"
 import { TagPlaceholder } from "app/Scenes/Tag/TagPlaceholder"
+import { goBack } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -30,7 +31,7 @@ export const Tag: React.FC<TagProps> = (props) => {
         context_screen_owner_slug: tag?.slug,
       }}
     >
-      <Tabs.TabsWithHeader title={tag?.name!}>
+      <Tabs.TabsWithHeader title={tag?.name!} headerProps={{ onBack: goBack }}>
         <Tabs.Tab name="Artworks" label="Artworks">
           <TagArtworksPaginationContainer tag={tag!} />
         </Tabs.Tab>

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@11.0.32":
-  version "11.0.32"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.32.tgz#163ab0812fae27d4c675879a23b8a7f24e59433f"
-  integrity sha512-8nw0pyXCKnpwxF9/RiNTpeovqmbMjm+PANzYgHChfX2N7bRaww2gf7t4N9B2o+oN9p6yjOcESNI2dOhPwNqw7Q==
+"@artsy/palette-mobile@11.0.33":
+  version "11.0.33"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.33.tgz#a239634beb7373eb36c705007a7ab453fb174c71"
+  integrity sha512-uz2wy88YGOEJYu3k5MZCm1FnwD8vRcQKGxPfMWmSGPXXba/WhCIl3Tp8uUhFSeKyHcyyFPlHk6jeSPx8jqwvoQ==
   dependencies:
     "@artsy/palette-tokens" "^4.0.1"
     "@styled-system/core" "^5.1.2"


### PR DESCRIPTION
Related: 
- https://github.com/artsy/palette-mobile/pull/107

### Description

Bumps palette with the latest, which centers content. Also fixes some missing back actions when we rolled in the animated headers. 

cc @artsy/mobile-platform 

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

