### PR TITLE
fix(lotsByFollowedArtists): make rail more defensive

### DIFF
--- a/src/app/Components/LotsByArtistsYouFollowRail/LotsByFollowedArtistsRail.tsx
+++ b/src/app/Components/LotsByArtistsYouFollowRail/LotsByFollowedArtistsRail.tsx
@@ -35,9 +35,9 @@ export const LotsByFollowedArtistsRail: React.FC<Props> = ({
 
   const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
 
-  const hasArtworks = artworks?.length
+  const hasSaleArtworks = artworks?.some((artwork) => artwork?.saleArtwork)
 
-  if (!hasArtworks) {
+  if (!hasSaleArtworks) {
     return null
   }
 
@@ -82,19 +82,25 @@ export const LotsByFollowedArtistsRail: React.FC<Props> = ({
         data={artworks}
         initialNumToRender={isTablet ? 10 : 5}
         windowSize={3}
-        renderItem={({ item: artwork }) => (
-          <SaleArtworkTileRailCardContainer
-            onPress={() => {
-              navigateToPageableRoute(artwork.href!)
-            }}
-            saleArtwork={artwork.saleArtwork!}
-            useSquareAspectRatio
-            useCustomSaleMessage
-            contextScreenOwnerType={OwnerType.sale}
-            cardSize={cardSize}
-            refreshRail={doRefresh}
-          />
-        )}
+        renderItem={({ item: artwork }) => {
+          if (!artwork?.saleArtwork) {
+            return null
+          }
+
+          return (
+            <SaleArtworkTileRailCardContainer
+              onPress={() => {
+                navigateToPageableRoute(artwork.href!)
+              }}
+              saleArtwork={artwork.saleArtwork!}
+              useSquareAspectRatio
+              useCustomSaleMessage
+              contextScreenOwnerType={OwnerType.sale}
+              cardSize={cardSize}
+              refreshRail={doRefresh}
+            />
+          )
+        }}
         keyExtractor={(item) => item.id}
         onScroll={isCloseToEdge(fetchNextPage)}
       />

--- a/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
+++ b/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tsx
@@ -48,9 +48,9 @@ export const SaleArtworkTileRailCard: React.FC<SaleArtworkTileRailCardProps> = (
     useFeatureFlag("AREnableNewAuctionsRailCard") && cardSize === "large"
   const color = useColor()
   const tracking = useTracking()
-  const artwork = saleArtwork.artwork!
-  const extendedBiddingEndAt = saleArtwork.extendedBiddingEndAt
-  const lotEndAt = saleArtwork.endAt
+  const artwork = saleArtwork?.artwork!
+  const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
+  const lotEndAt = saleArtwork?.endAt
   const endAt = extendedBiddingEndAt ?? lotEndAt ?? saleArtwork.sale?.endAt ?? ""
   const startAt = saleArtwork.sale?.liveStartAt ?? saleArtwork.sale?.startAt ?? ""
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Some people reported not being able to load the app and getting unable to load, while testing with @cavvia's account found the issue to be on the `lotsByFollowedArtistsRail` on Home screen.

The issue is that on the rail we render saleArtworks but the `lotsByFollowedArtistsConnection` wasn't defensive.

<img width="400" src="https://github.com/artsy/eigen/assets/21178754/52dbfd4a-95f6-4449-8cd0-7193fc5ba497" />

As you can see above, it returns data but saleArtworks are null for all.

In this PR we hide the whole rail if the hasSaleArtworks is false and also adds some additional checks on the RailCard component.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix(lotsByFollowedArtists): make rail more defensive - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
