### PR TITLE
fix: My Collection artwork about tab spacing

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkAbout.tsx
@@ -25,7 +25,7 @@ export function MyCollectionArtworkAbout(props: MyCollectionArtworkAboutProps) {
 
   const Wrapper = props.renderWithoutScrollView ? Flex : Tabs.ScrollView
   return (
-    <Wrapper style={{ paddingHorizontal: space(2) }}>
+    <Wrapper style={!!props.renderWithoutScrollView && { paddingHorizontal: space(2) }}>
       <Flex mt={props.renderWithoutScrollView ? 1 : 2} mb={4}>
         <MyCollectionArtworkAboutWork artwork={artwork} marketPriceInsights={marketPriceInsights} />
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR updates the spacing in the about tab inside the My Collection artwork details screen

| | Before | After |
|--|---|---|
| with insights tab | ![image](https://github.com/artsy/eigen/assets/20655703/2ce8868c-d6dd-4608-816b-41ad90b176cb) | ![image](https://github.com/artsy/eigen/assets/20655703/8bd664e9-471f-437f-9851-199266c2f3c3) | 
| without insights tab | ![image](https://github.com/artsy/eigen/assets/20655703/86917738-033d-440b-9012-c95f17ce4333) | ![image](https://github.com/artsy/eigen/assets/20655703/681c74e1-cead-4082-92b1-bf0dcca4a544) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update about tab spacing insight MyC artwork screen - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
