### PR TITLE
feat: ignore/dispose prev save artwork to artwork list mutation

### DIFF
--- a/src/app/utils/mutations/useLegacySaveArtwork.ts
+++ b/src/app/utils/mutations/useLegacySaveArtwork.ts
@@ -7,7 +7,7 @@ interface LegacySaveArtworkOptions {
   internalID: string
   isSaved: boolean | null
   onCompleted?: (isSaved: boolean) => void
-  onError?: () => void
+  onError?: (error: Error) => void
 }
 
 export const useLegacySaveArtwork = ({
@@ -40,9 +40,7 @@ export const useLegacySaveArtwork = ({
         refreshOnArtworkSave()
         onCompleted?.(nextSavedState)
       },
-      onError: () => {
-        onError?.()
-      },
+      onError,
     })
   }
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- ignore/dispose prev save artwork to artwork list mutation - dimatretyak

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
