### PR TITLE
lib(palette): Bump to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.130.0",
-    "@artsy/palette-mobile": "11.0.38",
+    "@artsy/palette-mobile": "11.0.39",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@formatjs/intl-datetimeformat": "6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -237,10 +237,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@11.0.38":
-  version "11.0.38"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.38.tgz#dd826c354165ceaffed370d968aa2a409d7389c3"
-  integrity sha512-437WwCCq2PKFSw30AiYzgX3c8WzufhNIPlbHAASp7hM5xnHZyMZlkI0aKq132l8Qt6LL00mrnl3Vr6nsBuwnIQ==
+"@artsy/palette-mobile@11.0.39":
+  version "11.0.39"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-11.0.39.tgz#a98603857d75abef485e1688350b2b148c11cc2a"
+  integrity sha512-aOBoWLrWl2FH4aKi6kQddQHCMoaupsQmeHX2QtrRzV/VCVg26vm7IHmUYV5BjHKHMVMV0BP3h05twGO3l6vNoA==
   dependencies:
     "@artsy/palette-tokens" "^4.0.1"
     "@styled-system/core" "^5.1.2"


### PR DESCRIPTION


### Description

This fixes the tabs indicator overlap. 

<img width="214" alt="Screenshot 2023-06-08 at 12 53 36 PM" src="https://github.com/artsy/eigen/assets/236943/b7449772-bc41-4166-af14-f511ad8588a4">

cc @artsy/mobile-platform 
