### PR TITLE
feat: Prefer default images in widget GRO-1756

### DIFF
--- a/ios/ArtsyWidget/Fixtures.swift
+++ b/ios/ArtsyWidget/Fixtures.swift
@@ -90,7 +90,7 @@ extension Fixtures {
     
     static var primaryArtwork: Artwork {
         let artist = Artist(name: "Alex Katz")
-        let artworkImage = ArtworkImage(geminiToken: "pd7rW3I1mXhW0vbAJDVm3Q", position: 1)
+        let artworkImage = ArtworkImage(geminiToken: "pd7rW3I1mXhW0vbAJDVm3Q", isDefault: true, position: 1)
         let image = UIImage(named: "PrimaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -105,7 +105,7 @@ extension Fixtures {
     
     static var secondaryArtwork: Artwork {
         let artist = Artist(name: "René Magritte")
-        let artworkImage = ArtworkImage(geminiToken: "qX0FwYdx5eGxF7cx8V6fkw", position: 1)
+        let artworkImage = ArtworkImage(geminiToken: "qX0FwYdx5eGxF7cx8V6fkw", isDefault: true, position: 1)
         let image = UIImage(named: "SecondaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -120,7 +120,7 @@ extension Fixtures {
     
     static var tertiaryArtwork: Artwork {
         let artist = Artist(name: "Judy Chicago")
-        let artworkImage = ArtworkImage(geminiToken: "wh7YA3qtmGFEwC611OklJQ", position: 1)
+        let artworkImage = ArtworkImage(geminiToken: "wh7YA3qtmGFEwC611OklJQ", isDefault: true, position: 1)
         let image = UIImage(named: "TertiaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,
@@ -135,7 +135,7 @@ extension Fixtures {
     
     static var quaternaryArtwork: Artwork {
         let artist = Artist(name: "Francis Picabia")
-        let artworkImage = ArtworkImage(geminiToken: "ZjpYFZIoBhhLCzQow6V7DA", position: 1)
+        let artworkImage = ArtworkImage(geminiToken: "ZjpYFZIoBhhLCzQow6V7DA", isDefault: true, position: 1)
         let image = UIImage(named: "QuaternaryArtworkImage")!
         let artwork = Artwork(
             artist: artist,

--- a/ios/ArtsyWidget/Models/Artwork.swift
+++ b/ios/ArtsyWidget/Models/Artwork.swift
@@ -14,8 +14,9 @@ struct Artwork: Codable {
     var image: UIImage?
     
     var firstImageToken: String {
+        let defaultImage = artworkImages.first(where: { $0.isDefault })
         let sortedImages = artworkImages.sorted { $0.position < $1.position }
-        let firstImage = sortedImages.first ?? ArtworkImage.fallback()
+        let firstImage = defaultImage ?? sortedImages.first ?? ArtworkImage.fallback()
         
         return firstImage.geminiToken
     }

--- a/ios/ArtsyWidget/Models/ArtworkImage.swift
+++ b/ios/ArtsyWidget/Models/ArtworkImage.swift
@@ -4,10 +4,11 @@ struct ArtworkImage: Codable {
     static func fallback() -> ArtworkImage {
         let artwork = Fixtures.primaryArtwork
         let token = artwork.artworkImages.first!.geminiToken
-        let artworkImage = ArtworkImage(geminiToken: token, position: 1)
+        let artworkImage = ArtworkImage(geminiToken: token, isDefault: true, position: 1)
         return artworkImage
     }
     
     let geminiToken: String
+    let isDefault: Bool
     let position: Int
 }


### PR DESCRIPTION
Turns out another thing we should do is prefer the image that has been marked as `is_default` so this PR just updates the logic like so:

* if there's a default image, use that
* if not then find the image with the lowest position
* if there still isn't an image then use a fallback

Note: we shouldn't even reach that third branch but it's there just in case.

https://artsyproduct.atlassian.net/browse/GRO-1756

/cc @artsy/grow-devs @isakelaris 