### PR TITLE
fix(FX-4814): fixes wrong create collection validation message

### DIFF
--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
@@ -117,7 +117,12 @@ describe("CreateNewArtworkListView", () => {
             responseOrError: {
               __typename: "CreateCollectionFailure",
               mutationError: {
-                message: errorMessage,
+                fieldErrors: [
+                  {
+                    name: "name",
+                    message: errorMessage,
+                  },
+                ],
               },
             },
           },

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
@@ -20,7 +20,18 @@ export const useCreateNewArtworkList = (): Response => {
       ...config,
       onCompleted: (data, errors) => {
         const response = data.createCollection?.responseOrError
-        const errorMessage = response?.mutationError?.message
+
+        // use generic error message by default
+        let errorMessage = "Something went wrong."
+
+        // if there is a specific error message for the name field, use that instead
+        const nameErrorMessage = response?.mutationError?.fieldErrors?.find(
+          (e) => e?.name === "name"
+        )
+
+        if (nameErrorMessage) {
+          errorMessage = nameErrorMessage.message
+        }
 
         if (errorMessage) {
           const error = new Error(errorMessage)
@@ -83,7 +94,10 @@ const CreateNewArtworkListMutation = graphql`
 
         ... on CreateCollectionFailure {
           mutationError {
-            message
+            fieldErrors {
+              name
+              message
+            }
           }
         }
       }


### PR DESCRIPTION
This PR resolves [FX-4814]

### Description

Fixes launch blocking bug when renaming an artwork list displays a wrong validation message.

Same [as here](https://github.com/artsy/eigen/pull/8866).

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4814]: https://artsyproduct.atlassian.net/browse/FX-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ