### PR TITLE
fix(CX-3782): hide profile visual clue indicator after navigating to insights tab

### DIFF
--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
@@ -12,7 +12,7 @@ import {
 import { MyProfileHeaderQueryRenderer } from "app/Scenes/MyProfile/MyProfileHeader"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { useVisualClue } from "app/utils/hooks/useVisualClue"
+import { setVisualClueAsSeen, useVisualClue } from "app/utils/hooks/useVisualClue"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { useMemo } from "react"
@@ -38,7 +38,7 @@ export const MyProfileHeaderMyCollectionAndSavedWorks: React.FC<Props> = ({ init
 
   // Check if there's new content
   const indicators = []
-  if (showVisualClue("AddedArtworkWithInsightsVisualClueDot")) {
+  if (showVisualClue("MyCollectionInsights")) {
     indicators.push({
       tabName: Tab.insights,
       Component: () => {
@@ -55,6 +55,11 @@ export const MyProfileHeaderMyCollectionAndSavedWorks: React.FC<Props> = ({ init
             initialTabName={initialTab}
             renderHeader={() => <MyProfileHeaderQueryRenderer />}
             indicators={indicators}
+            onTabPress={(tabName) => {
+              if (tabName === Tab.insights) {
+                setVisualClueAsSeen("MyCollectionInsights")
+              }
+            }}
           >
             <Tabs.Tab name={Tab.collection} label={Tab.collection}>
               <Tabs.Lazy>


### PR DESCRIPTION
This PR resolves [CX-3782] <!-- eg [PROJECT-XXXX] -->

### Description

This PR hides the indicator after navigating to insights tab. We were showing the wrong indicator and not removing it 😄

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- hide profile visual clue indicator after navigating to insights tab - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3782]: https://artsyproduct.atlassian.net/browse/CX-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ