### PR TITLE
fix(artwork lists): update handling of create/edit mutation error

### DIFF
--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListForm.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListForm.tsx
@@ -70,18 +70,21 @@ export const CreateNewArtworkListForm: FC<FlexProps> = (props) => {
       },
       onCompleted: (data) => {
         const response = data.createCollection?.responseOrError
-        const artworkList = response?.collection!
-        const result: ArtworkListEntity = {
-          name: artworkList.name,
-          internalID: artworkList.internalID,
+
+        if (response?.__typename === "CreateCollectionSuccess") {
+          const artworkList = response?.collection!
+          const result: ArtworkListEntity = {
+            name: artworkList.name,
+            internalID: artworkList.internalID,
+          }
+
+          setRecentlyAddedArtworkList(result)
+          preselectRecentlyAddedArtworkList(result)
+          closeCurrentView()
+          trackAnalyticEvent(artworkList.internalID)
+
+          helpers.setSubmitting(false)
         }
-
-        setRecentlyAddedArtworkList(result)
-        preselectRecentlyAddedArtworkList(result)
-        closeCurrentView()
-        trackAnalyticEvent(artworkList.internalID)
-
-        helpers.setSubmitting(false)
       },
       onError: (error) => {
         helpers.setFieldError("name", error.message)

--- a/src/app/Scenes/ArtworkList/views/EditArtworkListView/useEditArtworkList.ts
+++ b/src/app/Scenes/ArtworkList/views/EditArtworkListView/useEditArtworkList.ts
@@ -14,24 +14,25 @@ export const useEditArtworkList = (): Response => {
       onCompleted: (data, errors) => {
         const response = data.updateCollection?.responseOrError
 
-        if (response?.__typename !== "UpdateCollectionFailure") {
-          return config.onCompleted?.(data, errors)
-        }
+        if (response?.__typename === "UpdateCollectionFailure") {
+          // use generic error message by default
+          let errorMessage = "Something went wrong."
 
-        // use generic error message by default
-        let errorMessage = "Something went wrong."
+          const nameErrorMessage = response?.mutationError?.fieldErrors?.find(
+            (e) => e?.name === "name"
+          )
 
-        // if there is a specific error message for the name field, use that instead
-        const nameErrorMessage = response?.mutationError?.fieldErrors?.find(
-          (e) => e?.name === "name"
-        )
-        if (nameErrorMessage) {
-          errorMessage = nameErrorMessage.message
-        }
+          // if there is a specific error message for the name field, use that instead
+          if (nameErrorMessage) {
+            errorMessage = nameErrorMessage.message
+          }
 
-        if (errorMessage) {
-          const error = new Error(errorMessage)
-          config.onError?.(error)
+          if (errorMessage) {
+            const error = new Error(errorMessage)
+            config.onError?.(error)
+          }
+        } else {
+          config.onCompleted?.(data, errors)
         }
       },
     })


### PR DESCRIPTION

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes a regression introduced in [#8868][] for which we would default to a generic error message, even if a successful mutation response came back from Metaphysics.

[#8868]: https://github.com/artsy/eigen/pull/8868

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update handling of create/edit mutation error - gkartalis dblandin nickskalkin

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
