### PR TITLE
feat: remove lists from release for 8.14.0

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tests.tsx
@@ -137,21 +137,46 @@ describe("ArtworkActions", () => {
   })
 
   describe("Save button", () => {
-    it("should trigger save mutation when user presses save button", () => {
-      const { env } = renderWithRelay({
-        Artwork: () => ({
-          ...artworkActionsArtwork,
-          isSaved: false,
-        }),
+    // TODO: remove skip when lists feature flag is readyForRelease: true
+    describe.skip("whith lists feature flag enabled", () => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkLists: true })
+      it("should trigger save mutation when user presses save button", () => {
+        const { env } = renderWithRelay({
+          Artwork: () => ({
+            ...artworkActionsArtwork,
+            isSaved: false,
+          }),
+        })
+
+        expect(screen.getByLabelText("Save artwork")).toBeTruthy()
+
+        fireEvent.press(screen.getByLabelText("Save artwork"))
+
+        expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
+          "useSaveArtworkMutation"
+        )
       })
+    })
 
-      expect(screen.getByLabelText("Save artwork")).toBeTruthy()
+    describe("whith lists feature flag disabled", () => {
+      it("should trigger save mutation when user presses save button", () => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkLists: false })
 
-      fireEvent.press(screen.getByLabelText("Save artwork"))
+        const { env } = renderWithRelay({
+          Artwork: () => ({
+            ...artworkActionsArtwork,
+            isSaved: false,
+          }),
+        })
 
-      expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
-        "useSaveArtworkMutation"
-      )
+        expect(screen.getByLabelText("Save artwork")).toBeTruthy()
+
+        fireEvent.press(screen.getByLabelText("Save artwork"))
+
+        expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
+          "useLegacySaveArtworkMutation"
+        )
+      })
     })
 
     it("should track save event when user saves and artwork successfully", () => {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -231,10 +231,9 @@ export const features: { [key: string]: FeatureDescriptor } = {
     showInDevMenu: true,
   },
   AREnableArtworkLists: {
-    readyForRelease: true,
+    readyForRelease: false,
     description: "Enable Artwork Lists",
     showInDevMenu: true,
-    echoFlagKey: "AREnableArtworkLists",
   },
   AREnableNewAuctionsRailCard: {
     description: "Enable New Auctions Home Rail Card",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

⚠️ this is a PR to reduce the future work to us and @artsy/fx-devs (not clear exactly on what the status is for the lists right now so opened it to have it ready in case we want to remove this release)

Disable `AREnableArtworkLists` from `8.14.0` in order to not to have to refresh the feature flag.

Refreshing the feature flag means that if this release goes live like this we will need to open two follow-up PRs:
- eigen to introduce a new ff for the feature
- echo to introduce a new ff for the feature to toggle remotely



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog