### PR TITLE
feat: refresh ff AREnableLongPressArtworkCards

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -246,11 +246,10 @@ export const features: { [key: string]: FeatureDescriptor } = {
     readyForRelease: false,
     showInDevMenu: true,
   },
-  AREnableArtworkContextMenu: {
+  AREnableLongPressArtworkCards: {
     description: "Enable Context Menu on artwork cards",
-    readyForRelease: true,
+    readyForRelease: false,
     showInDevMenu: true,
-    echoFlagKey: "AREnableArtworkContextMenu",
   },
   AREnableShowsForYouLocation: {
     description: "Enable Shows For You Location",


### PR DESCRIPTION
This PR resolves [MOPLAT-819]

### Description

Deprecates `AREnableArtworkContextMenu` and refreshes it to `AREnableLongPressArtworkCards`.

Reason: 

Before the `8.14.0` release where the `AREnableArtworkContextMenu` was marked as `readyForRelease: true` got some launch blocking design feedback so we are refreshing the feature flag to prevent leaking the feature to `8.14.0` version.

Related echo PR: TODO: add echo PR


### Follow ups:

Mark `AREnableLongPressArtworkCards` as ready for release and enable it on echo when feedback is addressed (ticketed [here](https://artsyproduct.atlassian.net/browse/MOPLAT-823))


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

[MOPLAT-819]: https://artsyproduct.atlassian.net/browse/MOPLAT-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ