### PR TITLE
feat(CX-3805): update add button behavior in my collection

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionStickyHeader.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionStickyHeader.tsx
@@ -92,12 +92,37 @@ export const MainStickyHeader: React.FC<{ hasArtworks: boolean }> = ({ hasArtwor
   const closeIconRef = useRef(null)
 
   const selectedTab = MyCollectionTabsStore.useStoreState((state) => state.selectedTab)
+
   const setSelectedTab = MyCollectionTabsStore.useStoreActions((actions) => actions.setSelectedTab)
   const setViewKind = MyCollectionTabsStore.useStoreActions((actions) => actions.setViewKind)
 
   const showAddToMyCollectionBottomSheet = debounce(() => {
     setViewKind({ viewKind: "Add" })
   }, 100)
+
+  const handlePlusButtonPress = () => {
+    switch (selectedTab) {
+      case "Artists":
+        navigate("my-collection/collected-artists/new")
+        break
+      case "Artworks":
+        navigate("my-collection/artworks/new", {
+          passProps: {
+            mode: "add",
+            source: Tab.collection,
+            onSuccess: () => {
+              // hide the bottom sheet
+              setViewKind({ viewKind: null })
+              popToRoot()
+            },
+          },
+        })
+        break
+      default:
+        showAddToMyCollectionBottomSheet()
+        break
+    }
+  }
 
   const { width } = useMeasure({ ref: closeIconRef })
 
@@ -132,7 +157,7 @@ export const MainStickyHeader: React.FC<{ hasArtworks: boolean }> = ({ hasArtwor
         {/* Seach and Add */}
         <Flex justifyContent="center" alignItems="center" flexDirection="row">
           <Touchable
-            onPress={showAddToMyCollectionBottomSheet}
+            onPress={handlePlusButtonPress}
             haptic
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >

--- a/src/app/Scenes/MyCollection/Components/MyCollectionStickyHeader.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionStickyHeader.tsx
@@ -100,7 +100,7 @@ export const MainStickyHeader: React.FC<{ hasArtworks: boolean }> = ({ hasArtwor
     setViewKind({ viewKind: "Add" })
   }, 100)
 
-  const handlePlusButtonPress = () => {
+  const handleCreateButtonPress = () => {
     switch (selectedTab) {
       case "Artists":
         navigate("my-collection/collected-artists/new")
@@ -157,7 +157,7 @@ export const MainStickyHeader: React.FC<{ hasArtworks: boolean }> = ({ hasArtwor
         {/* Seach and Add */}
         <Flex justifyContent="center" alignItems="center" flexDirection="row">
           <Touchable
-            onPress={handlePlusButtonPress}
+            onPress={handleCreateButtonPress}
             haptic
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates the  Add button behavior in my collection to behave differently depending on where it was opened. The new behavior is as follows:
- If the screen was opened from the artists view -> Open **Add artist you collect** flow
- If the screen was opened from the artworks view -> Open **Add artwork to your collection** flow
- If the screen was opened from the default my collection view -> Open the **Default bottom sheet drawer** flow

https://github.com/artsy/eigen/assets/11945712/a0af02d3-f1d7-443e-a5f2-ee1a6eb15ebf



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update add button behavior in my collection - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
