### PR TITLE
fix: my collection empty states paddings

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
@@ -13,7 +13,7 @@ export const MyCollectionZeroState: React.FC = () => {
   const image = require("images/my-collection-empty-state.webp")
 
   return (
-    <Tabs.ScrollView>
+    <Tabs.ScrollView contentContainerStyle={{ flexGrow: 1 }}>
       <Box mt={4}>
         <ZeroState
           bigTitle="Know Your Collection Better"

--- a/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
@@ -1,5 +1,5 @@
 import { ActionType, AddCollectedArtwork, ContextModule, OwnerType } from "@artsy/cohesion"
-import { useSpace, Flex, LockIcon, Button, Text, Tabs } from "@artsy/palette-mobile"
+import { useSpace, Flex, LockIcon, Button, Text, Tabs, Box } from "@artsy/palette-mobile"
 import { ZeroState } from "app/Components/States/ZeroState"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { navigate, popToRoot } from "app/system/navigation/navigate"
@@ -13,51 +13,49 @@ export const MyCollectionZeroState: React.FC = () => {
   const image = require("images/my-collection-empty-state.webp")
 
   return (
-    <Tabs.ScrollView
-      contentContainerStyle={{
-        paddingTop: space(4),
-      }}
-    >
-      <ZeroState
-        bigTitle="Know Your Collection Better"
-        subtitle="Manage your collection online and get free market insights."
-        image={
-          <Image
-            source={image}
-            resizeMode="contain"
-            style={{
-              alignSelf: "center",
-              marginVertical: space(2),
-            }}
-          />
-        }
-        callToAction={
-          <>
-            <Button
-              testID="add-artwork-button-zero-state"
-              onPress={() => {
-                trackEvent(tracks.addCollectedArtwork())
-                navigate("my-collection/artworks/new", {
-                  passProps: {
-                    mode: "add",
-                    source: Tab.collection,
-                    onSuccess: popToRoot,
-                  },
-                })
+    <Tabs.ScrollView>
+      <Box mt={4}>
+        <ZeroState
+          bigTitle="Know Your Collection Better"
+          subtitle="Manage your collection online and get free market insights."
+          image={
+            <Image
+              source={image}
+              resizeMode="contain"
+              style={{
+                alignSelf: "center",
+                marginVertical: space(2),
               }}
-              block
-            >
-              Upload Artwork
-            </Button>
-            <Flex flexDirection="row" justifyContent="center" alignItems="center" py={1}>
-              <LockIcon fill="black60" />
-              <Text color="black60" pl={0.5} variant="xs">
-                My Collection is not shared with sellers.
-              </Text>
-            </Flex>
-          </>
-        }
-      />
+            />
+          }
+          callToAction={
+            <>
+              <Button
+                testID="add-artwork-button-zero-state"
+                onPress={() => {
+                  trackEvent(tracks.addCollectedArtwork())
+                  navigate("my-collection/artworks/new", {
+                    passProps: {
+                      mode: "add",
+                      source: Tab.collection,
+                      onSuccess: popToRoot,
+                    },
+                  })
+                }}
+                block
+              >
+                Upload Artwork
+              </Button>
+              <Flex flexDirection="row" justifyContent="center" alignItems="center" py={1}>
+                <LockIcon fill="black60" />
+                <Text color="black60" pl={0.5} variant="xs">
+                  My Collection is not shared with sellers.
+                </Text>
+              </Flex>
+            </>
+          }
+        />
+      </Box>
     </Tabs.ScrollView>
   )
 }

--- a/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsightsEmptyState.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsightsEmptyState.tsx
@@ -1,4 +1,4 @@
-import { useSpace, Button, Tabs } from "@artsy/palette-mobile"
+import { useSpace, Button, Tabs, Box } from "@artsy/palette-mobile"
 import { ZeroState } from "app/Components/States/ZeroState"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { navigate, popToRoot } from "app/system/navigation/navigate"
@@ -8,36 +8,34 @@ export const MyCollectionInsightsEmptyState = () => {
   const space = useSpace()
 
   return (
-    <Tabs.ScrollView
-      contentContainerStyle={{
-        paddingTop: space(4),
-      }}
-    >
-      <ZeroState
-        bigTitle="Gain Deeper Knowledge of your Collection"
-        subtitle="Get free market insights about the artists you collect."
-        image={
-          <Image
-            source={require("images/my-collection-insights-empty-state-median.webp")}
-            resizeMode="contain"
-            style={{ alignSelf: "center", marginVertical: space(2) }}
-          />
-        }
-        callToAction={
-          <>
-            <Button
-              block
-              onPress={() => {
-                navigate("my-collection/artworks/new", {
-                  passProps: { mode: "add", source: Tab.insights, onSuccess: popToRoot },
-                })
-              }}
-            >
-              Upload Artwork
-            </Button>
-          </>
-        }
-      />
+    <Tabs.ScrollView>
+      <Box mt={4}>
+        <ZeroState
+          bigTitle="Gain Deeper Knowledge of your Collection"
+          subtitle="Get free market insights about the artists you collect."
+          image={
+            <Image
+              source={require("images/my-collection-insights-empty-state-median.webp")}
+              resizeMode="contain"
+              style={{ alignSelf: "center", marginVertical: space(2) }}
+            />
+          }
+          callToAction={
+            <>
+              <Button
+                block
+                onPress={() => {
+                  navigate("my-collection/artworks/new", {
+                    passProps: { mode: "add", source: Tab.insights, onSuccess: popToRoot },
+                  })
+                }}
+              >
+                Upload Artwork
+              </Button>
+            </>
+          }
+        />
+      </Box>
     </Tabs.ScrollView>
   )
 }

--- a/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsightsEmptyState.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/MyCollectionInsightsEmptyState.tsx
@@ -8,7 +8,7 @@ export const MyCollectionInsightsEmptyState = () => {
   const space = useSpace()
 
   return (
-    <Tabs.ScrollView>
+    <Tabs.ScrollView contentContainerStyle={{ flexGrow: 1 }}>
       <Box mt={4}>
         <ZeroState
           bigTitle="Gain Deeper Knowledge of your Collection"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

MyCollection empty states were not properly aligned on android, this PR fixes that.

#### Screenshots
##### Android
|Before|After|
|---|---|
|<img width="387" alt="Screenshot 2023-06-26 at 10 13 02" src="https://github.com/artsy/eigen/assets/21178754/9f0d50fc-fb25-4809-b6fe-7cc87d80937f">|<img width="385" alt="Screenshot 2023-06-26 at 10 28 04" src="https://github.com/artsy/eigen/assets/21178754/99e99ecb-a4cc-4daa-a745-73564d89ddda">|
|<img width="385" alt="Screenshot 2023-06-26 at 10 13 11" src="https://github.com/artsy/eigen/assets/21178754/6af43dde-cd48-4682-9161-e3cbe0916d0d">|<img width="379" alt="Screenshot 2023-06-26 at 10 28 11" src="https://github.com/artsy/eigen/assets/21178754/191200f6-562a-4f1c-a3da-23d1eab302cf">|

##### iOS
|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 14 Pro - 2023-06-26 at 10 27 20](https://github.com/artsy/eigen/assets/21178754/b99c451c-56c8-4e09-9023-88ca63bde465)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-26 at 10 27 20](https://github.com/artsy/eigen/assets/21178754/b99c451c-56c8-4e09-9023-88ca63bde465)|
|![Simulator Screenshot - iPhone 14 Pro - 2023-06-26 at 10 27 18](https://github.com/artsy/eigen/assets/21178754/b7122e01-2e95-44b3-a6e9-1b6d27f18778)|![Simulator Screenshot - iPhone 14 Pro - 2023-06-26 at 10 27 18](https://github.com/artsy/eigen/assets/21178754/b7122e01-2e95-44b3-a6e9-1b6d27f18778)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- my collection empty states paddings adjustments - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
