### PR TITLE
fix: Fix showing the Collected Artists onboarding modal when the FF is turned off

### DIFF
--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -162,7 +162,7 @@ const MyCollection: React.FC<{
   if (artworks.length === 0 && hasCollectedArtists) {
     return (
       <Tabs.ScrollView>
-        <MyCollectionCollectedArtistsOnboardingModal />
+        {!!enableCollectedArtists && <MyCollectionCollectedArtistsOnboardingModal />}
         <MyCollectionCollectedArtists me={me} />
         {selectedTab === null && (
           <>
@@ -190,7 +190,7 @@ const MyCollection: React.FC<{
           hasArtworks={artworks.length > 0}
         />
       </Tabs.SubTabBar>
-      <MyCollectionCollectedArtistsOnboardingModal />
+      {!!enableCollectedArtists && <MyCollectionCollectedArtistsOnboardingModal />}
 
       <ArtworkFilterNavigator
         visible={isFilterModalVisible}

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -159,10 +159,10 @@ const MyCollection: React.FC<{
   }
 
   // User has no artworks but has manually added collected artists
-  if (artworks.length === 0 && hasCollectedArtists) {
+  if (artworks.length === 0 && hasCollectedArtists && enableCollectedArtists) {
     return (
       <Tabs.ScrollView>
-        {!!enableCollectedArtists && <MyCollectionCollectedArtistsOnboardingModal />}
+        <MyCollectionCollectedArtistsOnboardingModal />
         <MyCollectionCollectedArtists me={me} />
         {selectedTab === null && (
           <>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue that shows the Artist Collected Onboarding modal when the feature flag is turned off
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

| | Before | After |
|--|---|---|
| Android | <video src="https://github.com/artsy/eigen/assets/20655703/22464a62-1278-4cdd-9a03-03659d1a8127" /> | <video src="https://github.com/artsy/eigen/assets/20655703/6546463c-e186-4209-b3b8-b17580ef440e" /> |
| iOS | <video src="https://github.com/artsy/eigen/assets/20655703/92292e07-39ce-4572-8623-ac9e98435c81" /> | <video src="https://github.com/artsy/eigen/assets/20655703/de531799-b9b8-43c6-8fa4-00dce7a47d1f" /> |























### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Disable Collected Artist onboarding modal if the feature flag is off - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
