### PR TITLE
feat(PRO-159): add initiator ID to self-initiated IDV requests

### DIFF
--- a/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
@@ -94,10 +94,12 @@ export const MyProfileEditForm: React.FC<MyProfileEditFormProps> = ({ onSuccess 
     showVerificationBanner: showVerificationBannerForEmail,
     handleVerification: handleEmailVerification,
   } = useHandleEmailVerification()
+
+  const initiatorID = me?.internalID ?? ""
   const {
     showVerificationBanner: showVerificationBannerForID,
     handleVerification: handleIDVerification,
-  } = useHandleIDVerification()
+  } = useHandleIDVerification(initiatorID)
 
   const localImage = useLocalImageStorage("profile", undefined, undefined, refreshKey)
 
@@ -364,6 +366,7 @@ const meFragment = graphql`
     profession
     otherRelevantPositions
     bio
+    internalID
     location {
       display
       city

--- a/src/app/Scenes/MyProfile/__tests__/MyProfileEditForm.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfileEditForm.tests.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-native"
 import { fireEvent } from "@testing-library/react-native"
 import { MyProfileEditFormTestsQuery } from "__generated__/MyProfileEditFormTestsQuery.graphql"
 import { MyProfileEditForm } from "app/Scenes/MyProfile/MyProfileEditForm"
@@ -14,6 +15,10 @@ jest.mock("@react-navigation/native", () => {
     }),
   }
 })
+
+jest.mock("@sentry/react-native", () => ({
+  captureException: jest.fn(),
+}))
 
 describe("MyProfileEditForm", () => {
   const { renderWithRelay } = setupTestWrapper<MyProfileEditFormTestsQuery>({
@@ -32,37 +37,37 @@ describe("MyProfileEditForm", () => {
     `,
   })
 
-  describe("collector profile edit form", () => {
-    it("shows the profile verification section", () => {
-      const { getByTestId } = renderWithRelay()
-      expect(getByTestId("profile-verifications")).toBeDefined()
+  it("shows the profile verification section", () => {
+    const { getByTestId } = renderWithRelay()
+    expect(getByTestId("profile-verifications")).toBeDefined()
+  })
+
+  describe("Email Verification", () => {
+    describe("when the email is verified in Gravity", () => {
+      it("is shown as verified", async () => {
+        const { getByText } = renderWithRelay({
+          Me: () => ({
+            canRequestEmailConfirmation: false,
+            isEmailConfirmed: true,
+          }),
+        })
+        expect(getByText("Email Address Verified")).toBeTruthy()
+      })
     })
 
-    describe("Email Verification", () => {
-      describe("When the email is confirmed in Gravity", () => {
-        it("is shown as verified when it's verified in gravity", async () => {
-          const { getByText } = renderWithRelay({
-            Me: () => ({
-              canRequestEmailConfirmation: false,
-              isEmailConfirmed: true,
-            }),
-          })
-          expect(getByText("Email Address Verified")).toBeTruthy()
+    describe("when the email is not verified in Gravity", () => {
+      it("is shown as non verified", () => {
+        const { getByText } = renderWithRelay({
+          Me: () => ({
+            canRequestEmailConfirmation: true,
+            isEmailConfirmed: false,
+          }),
         })
+        expect(getByText("Verify Your Email")).toBeTruthy()
       })
 
-      describe("When the email is not verified in Gravity", () => {
-        it("is shown as non verified when it's not verified in gravity", () => {
-          const { getByText } = renderWithRelay({
-            Me: () => ({
-              canRequestEmailConfirmation: true,
-              isEmailConfirmed: false,
-            }),
-          })
-          expect(getByText("Verify Your Email")).toBeTruthy()
-        })
-
-        it("Triggers the email verification when they user presses on Verify Your Email when canRequestEmailConfirmation is set to true", async () => {
+      describe("when canRequestEmailConfirmation is set to true", () => {
+        it("triggers the email verification when the user presses on Verify Your Email", async () => {
           const { getByTestId, env } = renderWithRelay({
             Me: () => ({
               canRequestEmailConfirmation: true,
@@ -90,8 +95,10 @@ describe("MyProfileEditForm", () => {
 
           expect(getByTestId("verification-confirmation-banner")).toBeTruthy()
         })
+      })
 
-        it("Triggers the email verification when they user presses on Verify Your Email when canRequestEmailConfirmation is set to false", async () => {
+      describe("when canRequestEmailConfirmation is set to false", () => {
+        it("does not allow the user to request email verification", async () => {
           const { getByTestId } = renderWithRelay({
             Me: () => ({
               canRequestEmailConfirmation: false,
@@ -109,42 +116,161 @@ describe("MyProfileEditForm", () => {
         })
       })
     })
+  })
 
-    describe("ID Verification", () => {
-      it("is shown as verified when it's verified in gravity", () => {
-        const { getByText } = renderWithRelay({
-          Me: () => ({
-            isIdentityVerified: true,
-          }),
-        })
-        expect(getByText("ID Verified")).toBeTruthy()
+  describe("ID Verification", () => {
+    it("is shown as verified when it's verified in gravity", () => {
+      const { getByText } = renderWithRelay({
+        Me: () => ({
+          isIdentityVerified: true,
+        }),
       })
-      it("is shown as non verified when it's not verified in gravity", () => {
-        const { getByText } = renderWithRelay({
-          Me: () => ({
-            isIdentityVerified: false,
-          }),
-        })
-        expect(getByText("Verify Your ID")).toBeTruthy()
+      expect(getByText("ID Verified")).toBeTruthy()
+    })
+    it("is shown as non verified when it's not verified in gravity", () => {
+      const { getByText } = renderWithRelay({
+        Me: () => ({
+          isIdentityVerified: false,
+        }),
       })
+      expect(getByText("Verify Your ID")).toBeTruthy()
     })
 
-    describe("Complete your profile banner", () => {
-      it("shows when the user has empty fields in their profile", () => {
-        const { getByText } = renderWithRelay({
-          Me: () => ({ collectorProfile: { isProfileComplete: false } }),
-        })
+    describe("requesting IDV", () => {
+      describe("with successful IDV request", () => {
+        it("displays confirmation banner ", async () => {
+          const { getByText, env } = renderWithRelay({
+            Me: () => ({
+              isIdentityVerified: false,
+            }),
+          })
+          const VerifyIdentityButton = getByText("Verify Your ID")
+          expect(VerifyIdentityButton).toBeTruthy()
 
-        expect(getByText("Complete your profile and make a great impression")).toBeTruthy()
+          fireEvent(VerifyIdentityButton, "onPress")
+
+          env.mock.resolveMostRecentOperation({
+            data: {
+              sendIdentityVerificationEmail: {
+                confirmationOrError: {
+                  __typename: "IdentityVerificationEmailMutationSuccessType",
+                  identityVerification: {
+                    state: "pending",
+                  },
+                },
+              },
+            },
+            errors: [],
+          })
+
+          await flushPromiseQueue()
+
+          expect(getByText("ID verification link sent to", { exact: false })).toBeTruthy()
+        })
       })
 
-      it("does not show when the user has completed their profile", () => {
-        const { queryByText } = renderWithRelay({
-          Me: () => ({ collectorProfile: { isProfileComplete: true } }),
-        })
+      describe("with IDV request that returns structured error", () => {
+        // This isn't _good_ behavior, but it is what is currently happening
+        it("fails silently", async () => {
+          const { getByText, env } = renderWithRelay({
+            Me: () => ({
+              isIdentityVerified: false,
+            }),
+          })
+          const VerifyIdentityButton = getByText("Verify Your ID")
+          expect(VerifyIdentityButton).toBeTruthy()
 
-        expect(queryByText("Complete your profile and make a great impression")).toBeFalsy()
+          fireEvent(VerifyIdentityButton, "onPress")
+
+          env.mock.resolveMostRecentOperation({
+            data: {
+              sendIdentityVerificationEmail: {
+                confirmationOrError: {
+                  __typename: "IdentityVerificationEmailMutationFailureType",
+                  mutationError: {
+                    error: null,
+                    message: "name required to create verification for a non-artsy user",
+                  },
+                },
+              },
+            },
+            errors: [],
+          })
+
+          await flushPromiseQueue()
+
+          expect(() => getByText("ID verification link sent to", { exact: false })).toThrow()
+          expect(Sentry.captureException).not.toHaveBeenCalled()
+        })
       })
+
+      describe("with IDV request that errors", () => {
+        it("logs exception", async () => {
+          const relayResponse = {
+            errors: [
+              {
+                message:
+                  'String cannot represent value: { detail: { base: [Array] }, message: "Only one source type (sale, order, user/admin id) is allowed.", type: "param_error" }',
+                locations: [
+                  {
+                    line: 16,
+                    column: 19,
+                  },
+                ],
+                // @ts-ignore
+                path: [
+                  "sendIdentityVerificationEmail",
+                  "confirmationOrError",
+                  "mutationError",
+                  "message",
+                ],
+              },
+            ],
+            data: {
+              sendIdentityVerificationEmail: {
+                confirmationOrError: {
+                  __typename: "IdentityVerificationEmailMutationFailureType",
+                  mutationError: null,
+                },
+              },
+            },
+          }
+          const { getByText, env } = renderWithRelay({
+            Me: () => ({
+              isIdentityVerified: false,
+            }),
+          })
+          const VerifyIdentityButton = getByText("Verify Your ID")
+          expect(VerifyIdentityButton).toBeTruthy()
+
+          fireEvent(VerifyIdentityButton, "onPress")
+
+          env.mock.resolveMostRecentOperation(relayResponse)
+
+          await flushPromiseQueue()
+
+          expect(() => getByText("ID verification link sent to", { exact: false })).toThrow()
+          expect(Sentry.captureException).toHaveBeenCalledWith(relayResponse.errors)
+        })
+      })
+    })
+  })
+
+  describe("Complete your profile banner", () => {
+    it("shows when the user has empty fields in their profile", () => {
+      const { getByText } = renderWithRelay({
+        Me: () => ({ collectorProfile: { isProfileComplete: false } }),
+      })
+
+      expect(getByText("Complete your profile and make a great impression")).toBeTruthy()
+    })
+
+    it("does not show when the user has completed their profile", () => {
+      const { queryByText } = renderWithRelay({
+        Me: () => ({ collectorProfile: { isProfileComplete: true } }),
+      })
+
+      expect(queryByText("Complete your profile and make a great impression")).toBeFalsy()
     })
   })
 })

--- a/src/app/Scenes/MyProfile/useHandleVerification.tsx
+++ b/src/app/Scenes/MyProfile/useHandleVerification.tsx
@@ -4,36 +4,19 @@ import { verifyEmail } from "app/utils/verifyEmail"
 import { verifyID } from "app/utils/verifyID"
 import { useCallback, useState } from "react"
 
-type verificationType = "ID" | "Email"
-
-const IDVerificationBlockingStates = ["passed", "failed", "watchlist_hit"]
+const VERIFICATION_BANNER_TIMEOUT = 6000
+const ID_VERIFICATION_BLOCKING_STATES = ["passed", "failed", "watchlist_hit"]
 
 export const useHandleEmailVerification = () => {
-  return useHandleVerification("Email")
-}
-
-export const useHandleIDVerification = () => {
-  return useHandleVerification("ID")
-}
-
-const VERIFICATION_BANNER_TIMEOUT = 6000
-
-const useHandleVerification = (type: verificationType) => {
   const [showVerificationBanner, setShowVerificationBanner] = useState(false)
 
   const handleVerification = useCallback(async () => {
     try {
-      const response = await verify(type)
+      await verifyEmail(getRelayEnvironment())
 
-      // if response as state from ID verification
-      const IDVerificationState = !(response && IDVerificationBlockingStates.includes(response))
-
-      if (type === "Email" || IDVerificationState) {
-        setShowVerificationBanner(true)
-      }
+      setShowVerificationBanner(true)
     } catch (error) {
       captureException(error)
-      setShowVerificationBanner(false)
     } finally {
       // Allow the user some time to read the message
       setTimeout(() => {
@@ -45,16 +28,31 @@ const useHandleVerification = (type: verificationType) => {
   return { showVerificationBanner, handleVerification }
 }
 
-const verify = async (type: verificationType) => {
-  if (type === "Email") {
-    const { sendConfirmationEmail } = await verifyEmail(getRelayEnvironment())
+export const useHandleIDVerification = () => {
+  const [showVerificationBanner, setShowVerificationBanner] = useState(false)
 
-    const confirmationOrError = sendConfirmationEmail?.confirmationOrError
-    return confirmationOrError?.unconfirmedEmail
-  } else {
-    const { sendIdentityVerificationEmail } = await verifyID({})
+  const handleVerification = useCallback(async () => {
+    try {
+      const response = await verifyID({})
+      const verificationState =
+        response.sendIdentityVerificationEmail?.confirmationOrError?.identityVerification?.state
 
-    const confirmationOrError = sendIdentityVerificationEmail?.confirmationOrError
-    return confirmationOrError?.identityVerification?.state
-  }
+      const IdvHasValidState =
+        typeof verificationState === "string" &&
+        !ID_VERIFICATION_BLOCKING_STATES.includes(verificationState)
+
+      if (IdvHasValidState) {
+        setShowVerificationBanner(true)
+      }
+    } catch (error) {
+      captureException(error)
+    } finally {
+      // Allow the user some time to read the message
+      setTimeout(() => {
+        setShowVerificationBanner(false)
+      }, VERIFICATION_BANNER_TIMEOUT)
+    }
+  }, [])
+
+  return { showVerificationBanner, handleVerification }
 }

--- a/src/app/Scenes/MyProfile/useHandleVerification.tsx
+++ b/src/app/Scenes/MyProfile/useHandleVerification.tsx
@@ -28,12 +28,12 @@ export const useHandleEmailVerification = () => {
   return { showVerificationBanner, handleVerification }
 }
 
-export const useHandleIDVerification = () => {
+export const useHandleIDVerification = (initiatorID: string) => {
   const [showVerificationBanner, setShowVerificationBanner] = useState(false)
 
   const handleVerification = useCallback(async () => {
     try {
-      const response = await verifyID({})
+      const response = await verifyID({ initiatorID: initiatorID })
       const verificationState =
         response.sendIdentityVerificationEmail?.confirmationOrError?.identityVerification?.state
 

--- a/src/app/Scenes/MyProfile/useHandleVerification.tsx
+++ b/src/app/Scenes/MyProfile/useHandleVerification.tsx
@@ -52,9 +52,9 @@ const verify = async (type: verificationType) => {
     const confirmationOrError = sendConfirmationEmail?.confirmationOrError
     return confirmationOrError?.unconfirmedEmail
   } else {
-    const { sendIdentityVerificationEmail } = await verifyID(getRelayEnvironment())
+    const { sendIdentityVerificationEmail } = await verifyID({})
 
     const confirmationOrError = sendIdentityVerificationEmail?.confirmationOrError
-    return confirmationOrError?.identityVerificationEmail?.state
+    return confirmationOrError?.identityVerification?.state
   }
 }

--- a/src/app/utils/verifyID.ts
+++ b/src/app/utils/verifyID.ts
@@ -1,9 +1,13 @@
-import { verifyIDMutation } from "__generated__/verifyIDMutation.graphql"
-import { commitMutation, Environment, graphql } from "react-relay"
+import {
+  SendIdentityVerificationEmailMutationInput,
+  verifyIDMutation,
+} from "__generated__/verifyIDMutation.graphql"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { commitMutation, graphql } from "react-relay"
 
-export const verifyID = async (relayEnvironment: Environment) => {
+export const verifyID = async (input: SendIdentityVerificationEmailMutationInput) => {
   return new Promise<verifyIDMutation["response"]>((done, reject) => {
-    commitMutation<verifyIDMutation>(relayEnvironment, {
+    commitMutation<verifyIDMutation>(getRelayEnvironment(), {
       onCompleted: (data, errors) => (errors && errors.length ? reject(errors) : done(data)),
       onError: (error) => reject(error),
       mutation: graphql`
@@ -11,7 +15,7 @@ export const verifyID = async (relayEnvironment: Environment) => {
           sendIdentityVerificationEmail(input: $input) {
             confirmationOrError {
               ... on IdentityVerificationEmailMutationSuccessType {
-                identityVerificationEmail {
+                identityVerification {
                   internalID
                   state
                   userID
@@ -27,7 +31,7 @@ export const verifyID = async (relayEnvironment: Environment) => {
           }
         }
       `,
-      variables: { input: {} },
+      variables: { input: { ...input } },
     })
   })
 }


### PR DESCRIPTION
This PR resolves [PRO-159] 

### Description

Companion to https://github.com/artsy/gravity/pull/16451. We want to store the ID of the user who initiated an IDV request.

I didn't test this one personally since it's a small change and I haven't run Eigen in a while, so figured I'd get some help rather than fighting with sims for a day. @gkartalis thanks for volunteering to help with that! LMK if you either a) have changed your mind and want me to do it, or b) want to do it together 🙂 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Dev changes

- add initiator ID to self-initiated IDV requests

<!-- end_changelog_updates -->

</details>

[PRO-159]: https://artsyproduct.atlassian.net/browse/PRO-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ