### PR TITLE
feat(alerts): add confirmation modal with matching artworks

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -1,17 +1,60 @@
 import { OwnerType } from "@artsy/cohesion"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import {
   SavedSearchEntity,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { CreateSavedSearchAlert } from "app/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
-import { SavedSearchAlertMutationResult } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import {
+  CreateSavedSearchAlertNavigationStack,
+  SavedSearchAlertMutationResult,
+} from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import {
+  SavedSearchStoreProvider,
+  savedSearchModel,
+} from "app/Scenes/SavedSearchAlert/SavedSearchStore"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import {
   CreateSavedSearchModal,
   CreateSavedSearchModalProps,
   tracks,
 } from "./CreateSavedSearchModal"
+
+jest.mock("../../../Scenes/SavedSearchAlert/queries/getSavedSearchIdByCriteria", () => ({
+  getSavedSearchIdByCriteria: () => Promise.resolve(null),
+}))
+
+jest.mock("../../../Scenes/SavedSearchAlert/mutations/createSavedSearchAlert", () => ({
+  createSavedSearchAlert: () =>
+    Promise.resolve({
+      createSavedSearch: { savedSearchOrErrors: { internalID: "new-alert-4242" } },
+    }),
+}))
+
+const mockNavigate = jest.fn()
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native")
+  return {
+    ...actualNav,
+    useNavigation: () => {
+      return {
+        navigate: mockNavigate,
+        addListener: jest.fn(),
+      }
+    },
+    useRoute: () => {
+      const params: CreateSavedSearchAlertNavigationStack["ConfirmationScreen"] = {
+        searchCriteriaID: "foo-bar-42",
+        closeModal: jest.fn(),
+      }
+
+      return { params }
+    },
+  }
+})
 
 const savedSearchEntity: SavedSearchEntity = {
   placeholder: "Placeholder",
@@ -39,6 +82,19 @@ const mockedMutationResult: SavedSearchAlertMutationResult = {
   id: "savedSearchAlertId",
 }
 
+const TestWrapper: React.FC = ({ children }) => (
+  <SavedSearchStoreProvider
+    runtimeModel={{
+      ...savedSearchModel,
+      attributes,
+      aggregations: [],
+      entity: savedSearchEntity,
+    }}
+  >
+    {children}
+  </SavedSearchStoreProvider>
+)
+
 describe("CreateSavedSearchModal", () => {
   const TestRenderer = (props?: Partial<CreateSavedSearchModalProps>) => {
     return <CreateSavedSearchModal {...defaultProps} {...props} />
@@ -56,5 +112,28 @@ describe("CreateSavedSearchModal", () => {
     expect(mockTrackEvent).toHaveBeenCalledWith(
       tracks.toggleSavedSearch(true, OwnerType.artist, "ownerId", "ownerSlug", "savedSearchAlertId")
     )
+  })
+
+  it("navigates to the confirmation screen", async () => {
+    const { renderWithRelay } = setupTestWrapper({
+      Component: () => (
+        <TestWrapper>
+          <CreateSavedSearchModal {...defaultProps} />,
+        </TestWrapper>
+      ),
+    })
+
+    renderWithRelay()
+
+    await waitFor(() => {
+      expect(screen.getByText("Save Alert")).toBeOnTheScreen()
+    })
+
+    fireEvent.press(screen.getByText("Save Alert"))
+    await flushPromiseQueue()
+
+    expect(mockNavigate).toHaveBeenCalledWith("ConfirmationScreen", {
+      searchCriteriaID: "new-alert-4242",
+    })
   })
 })

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -1,13 +1,10 @@
 import { OwnerType } from "@artsy/cohesion"
-import { fireEvent } from "@testing-library/react-native"
 import {
   SavedSearchEntity,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { CreateSavedSearchAlert } from "app/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
 import { SavedSearchAlertMutationResult } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
-import { navigate } from "app/system/navigation/navigate"
-import { delay } from "app/utils/delay"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import {
@@ -49,34 +46,6 @@ describe("CreateSavedSearchModal", () => {
 
   it("renders without throwing an error", () => {
     renderWithWrappers(<TestRenderer />)
-  })
-
-  it("should navigate to the saved search alerts list when popover is pressed", async () => {
-    const { getByText, UNSAFE_root } = renderWithWrappers(<TestRenderer />)
-
-    UNSAFE_root.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult)
-
-    fireEvent.press(getByText("Your alert has been created."))
-
-    expect(navigate).toHaveBeenCalledWith("/my-profile/settings", {
-      popToRootTabView: true,
-      showInTabName: "profile",
-    })
-  })
-
-  it("should call navigate twice", async () => {
-    const { UNSAFE_root, getByText } = renderWithWrappers(<TestRenderer />)
-
-    UNSAFE_root.findByType(CreateSavedSearchAlert).props.params.onComplete(mockedMutationResult)
-    fireEvent.press(getByText("Your alert has been created."))
-
-    await delay(200)
-
-    expect(navigate).toHaveBeenCalledWith("/my-profile/settings", {
-      popToRootTabView: true,
-      showInTabName: "profile",
-    })
-    expect(navigate).toHaveBeenCalledWith("/my-profile/saved-search-alerts")
   })
 
   it("tracks clicks when the create alert button is pressed", async () => {

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -10,13 +10,11 @@ import {
   SavedSearchEntity,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { CreateSavedSearchAlert } from "app/Scenes/SavedSearchAlert/CreateSavedSearchAlert"
 import {
   CreateSavedSearchAlertParams,
   SavedSearchAlertMutationResult,
 } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
-import { navigate, NavigateOptions } from "app/system/navigation/navigate"
 import { useEffect } from "react"
 import { useTracking } from "react-tracking"
 
@@ -32,7 +30,6 @@ export interface CreateSavedSearchModalProps {
 export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (props) => {
   const { visible, entity, attributes, aggregations, closeModal, onComplete } = props
   const tracking = useTracking()
-  const popover = usePopoverMessage()
 
   useEffect(() => {
     if (visible) {
@@ -48,33 +45,17 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
 
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
     const { owner } = entity
-
     tracking.trackEvent(tracks.toggleSavedSearch(true, owner.type, owner.id, owner.slug, result.id))
-    closeModal()
-    onComplete?.()
-
-    popover.show({
-      title: "Your alert has been created.",
-      message: "Edit your alerts in your profile, in Settings.",
-      onPress: async () => {
-        const options: NavigateOptions = {
-          popToRootTabView: true,
-          showInTabName: "profile",
-        }
-
-        await navigate("/my-profile/settings", options)
-        setTimeout(() => {
-          navigate("/my-profile/saved-search-alerts")
-        }, 100)
-      },
-    })
   }
 
   const params: CreateSavedSearchAlertParams = {
     aggregations,
     attributes,
     entity,
-    onClosePress: closeModal,
+    onClosePress: () => {
+      onComplete?.() // close the filter modal stack (if coming from artist artwork grid)
+      closeModal() // close the alert modal stack
+    },
     onComplete: handleComplete,
   }
 

--- a/src/app/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/app/Components/ArtworkGrids/GenericGrid.tsx
@@ -227,7 +227,7 @@ const styles = StyleSheet.create<Styles>({
   },
 })
 
-const injectHooks = (Component: typeof GenericArtworksGrid) => (props: Props) => {
+const injectHooks = (Component: typeof GenericArtworksGrid) => (props: Props & PropsForArtwork) => {
   const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: props.artworks })
   return <Component {...props} navigateToPageableRoute={navigateToPageableRoute} />
 }

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -60,6 +60,9 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
               <Stack.Screen
                 name="ConfirmationScreen"
                 component={ConfirmationScreen}
+                options={{
+                  gestureEnabled: false,
+                }}
                 initialParams={{
                   closeModal: params.onClosePress,
                 }}

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -9,6 +9,7 @@ import {
 } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { CreateSavedSearchAlertContentQueryRenderer } from "app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer"
 import { AlertPriceRangeScreenQueryRenderer } from "app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen"
+import { ConfirmationScreen } from "app/Scenes/SavedSearchAlert/screens/ConfirmationScreen"
 import {
   CreateSavedSearchAlertNavigationStack,
   CreateSavedSearchAlertProps,
@@ -54,6 +55,13 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                 options={{
                   // Avoid PanResponser conflicts between the slider and the slide back gesture
                   gestureEnabled: false,
+                }}
+              />
+              <Stack.Screen
+                name="ConfirmationScreen"
+                component={ConfirmationScreen}
+                initialParams={{
+                  closeModal: params.onClosePress,
                 }}
               />
             </Stack.Navigator>

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -1,5 +1,6 @@
 import { ActionType, DeletedSavedSearch, EditedSavedSearch, OwnerType } from "@artsy/cohesion"
 import { Dialog, quoteLeft, quoteRight, useTheme } from "@artsy/palette-mobile"
+import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { FormikProvider, useFormik } from "formik"
@@ -9,6 +10,7 @@ import { useTracking } from "react-tracking"
 import { useFirstMountState } from "react-use/lib/useFirstMountState"
 import { Form } from "./Components/Form"
 import {
+  CreateSavedSearchAlertNavigationStack,
   SavedSearchAlertFormValues,
   SavedSearchAlertMutationResult,
   SavedSearchPill,
@@ -62,6 +64,9 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const [shouldShowEmailSubscriptionWarning, setShouldShowEmailSubscriptionWarning] = useState(
     !userAllowsEmails
   )
+  const navigation =
+    useNavigation<NavigationProp<CreateSavedSearchAlertNavigationStack, "CreateSavedSearchAlert">>()
+
   const formik = useFormik<SavedSearchAlertFormValues>({
     initialValues,
     enableReinitialize: true,
@@ -163,6 +168,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         id: response.createSavedSearch?.savedSearchOrErrors.internalID!,
       }
 
+      navigation.navigate("ConfirmationScreen", { searchCriteriaID: result.id })
       onComplete?.(result)
     } catch (error) {
       console.error(error)

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -35,6 +35,7 @@ export type CreateSavedSearchAlertNavigationStack = {
   CreateSavedSearchAlert: CreateSavedSearchAlertParams
   AlertPriceRange: undefined
   EmailPreferences: undefined
+  ConfirmationScreen: ConfirmationScreenParams
 }
 
 export interface EditSavedSearchAlertParams {
@@ -53,10 +54,16 @@ export type EditSavedSearchAlertNavigationStack = {
   EditSavedSearchAlertContent: EditSavedSearchAlertParams
   AlertPriceRange: undefined
   EmailPreferences: undefined
+  ConfirmationScreen: ConfirmationScreenParams
 }
 
 export interface SavedSearchPill {
   label: string
   value: string | boolean | number
   paramName: SearchCriteria
+}
+
+export interface ConfirmationScreenParams {
+  searchCriteriaID: string
+  closeModal?: () => void
 }

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -78,13 +78,15 @@ describe(ConfirmationScreen, () => {
   })
 
   describe("CTAs", () => {
-    it("renders manage-alerts button always", () => {
+    it("renders manage-alerts button always", async () => {
       renderWithRelay()
 
       const manageButton = screen.queryByText("Manage your alerts")
       expect(manageButton).toBeOnTheScreen()
 
       fireEvent.press(manageButton!)
+      await flushPromiseQueue()
+
       expect(navigate).toHaveBeenCalledWith("/my-profile/saved-search-alerts")
     })
 
@@ -98,6 +100,8 @@ describe(ConfirmationScreen, () => {
       expect(seeAllButton).toBeOnTheScreen()
 
       fireEvent.press(seeAllButton!)
+      await flushPromiseQueue()
+
       expect(navigate).toHaveBeenCalledWith("/artist/david-hockney", {
         passProps: { searchCriteriaID: "foo-bar-42" },
       })

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -1,0 +1,162 @@
+import { OwnerType } from "@artsy/cohesion"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
+import {
+  SavedSearchEntity,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
+import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import {
+  SavedSearchStoreProvider,
+  savedSearchModel,
+} from "app/Scenes/SavedSearchAlert/SavedSearchStore"
+import { navigate } from "app/system/navigation/navigate"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { ConfirmationScreen, NUMBER_OF_ARTWORKS_TO_SHOW } from "./ConfirmationScreen"
+
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native")
+  return {
+    ...actualNav,
+    useNavigation: () => {
+      return {
+        navigate: jest.fn(),
+      }
+    },
+    useRoute: () => {
+      const params: CreateSavedSearchAlertNavigationStack["ConfirmationScreen"] = {
+        searchCriteriaID: "foo-bar-42",
+        closeModal: jest.fn(),
+      }
+
+      return { params }
+    },
+  }
+})
+
+const TestWrapper: React.FC = ({ children }) => (
+  <SavedSearchStoreProvider
+    runtimeModel={{
+      ...savedSearchModel,
+      attributes,
+      aggregations,
+      entity,
+    }}
+  >
+    {children}
+  </SavedSearchStoreProvider>
+)
+
+describe(ConfirmationScreen, () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: () => (
+      <TestWrapper>
+        <ConfirmationScreen />
+      </TestWrapper>
+    ),
+  })
+
+  it("displays the newly created alert criteria", () => {
+    renderWithRelay()
+
+    expect(screen.queryByText("Your alert has been saved")).toBeOnTheScreen()
+    expect(screen.queryByText("David Hockney")).toBeOnTheScreen()
+    expect(screen.queryByText("Unique")).toBeOnTheScreen()
+    expect(screen.queryByText("Painting")).toBeOnTheScreen()
+  })
+
+  it("displays the matching artworks", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => artworksConnection,
+    })
+    await flushPromiseQueue()
+
+    expect(screen.getByText("Untitled #1")).toBeOnTheScreen()
+    expect(screen.getByText("Untitled #2")).toBeOnTheScreen()
+  })
+
+  describe("CTAs", () => {
+    it("renders manage-alerts button always", () => {
+      renderWithRelay()
+
+      const manageButton = screen.queryByText("Manage your alerts")
+      expect(manageButton).toBeOnTheScreen()
+
+      fireEvent.press(manageButton!)
+      expect(navigate).toHaveBeenCalledWith("/my-profile/saved-search-alerts")
+    })
+
+    it("renders see-all button if there are more works to show", async () => {
+      renderWithRelay({
+        FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW + 1 } }),
+      })
+      await flushPromiseQueue()
+
+      const seeAllButton = screen.queryByText("See all matching works")
+      expect(seeAllButton).toBeOnTheScreen()
+
+      fireEvent.press(seeAllButton!)
+      expect(navigate).toHaveBeenCalledWith("/artist/david-hockney", {
+        passProps: { searchCriteriaID: "foo-bar-42" },
+      })
+    })
+
+    it("does not render see-all button if there are no more works to show", async () => {
+      renderWithRelay({
+        FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW - 1 } }),
+      })
+      await flushPromiseQueue()
+
+      expect(screen.queryByText("See all matching works")).not.toBeOnTheScreen()
+    })
+  })
+})
+
+/* mock data */
+
+const artworksConnection = {
+  counts: {
+    total: 2,
+  },
+  edges: [
+    {
+      node: {
+        title: "Untitled #1",
+      },
+    },
+    {
+      node: {
+        title: "Untitled #2",
+      },
+    },
+  ],
+}
+
+const attributes: SearchCriteriaAttributes = {
+  artistIDs: ["david-hockney"],
+  attributionClass: ["unique"],
+  additionalGeneIDs: ["painting"],
+}
+
+const aggregations: Aggregations = [
+  {
+    slice: "MEDIUM",
+    counts: [{ name: "Painting", value: "painting", count: 42 }],
+  },
+]
+
+const entity: SavedSearchEntity = {
+  placeholder: "Placeholder title for alert",
+  artists: [
+    {
+      id: "david-hockney",
+      name: "David Hockney",
+    },
+  ],
+  owner: {
+    id: "some-artwork",
+    slug: "some-artwork",
+    type: OwnerType.artwork,
+  },
+}

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -67,6 +67,46 @@ describe(ConfirmationScreen, () => {
     expect(screen.queryByText("Painting")).toBeOnTheScreen()
   })
 
+  it("displays the correct message when there are many matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW + 1 } }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
+
+    expect(
+      screen.queryByText(
+        "11 works currently on Artsy match your criteria. See our top picks for you:"
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it("displays the correct message when there are few matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW - 1 } }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
+
+    expect(
+      screen.queryByText(
+        "You might like these 9 works currently on Artsy that match your criteria:"
+      )
+    ).toBeOnTheScreen()
+  })
+
+  it("displays the correct message when there are no matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({ counts: { total: 0 } }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
+
+    expect(
+      screen.queryByText("There aren't any works available that meet the criteria at this time.")
+    ).toBeOnTheScreen()
+  })
+
   it("displays the matching artworks", async () => {
     renderWithRelay({
       FilterArtworksConnection: () => artworksConnection,

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
 import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import {
   SavedSearchEntity,
@@ -71,7 +71,7 @@ describe(ConfirmationScreen, () => {
     renderWithRelay({
       FilterArtworksConnection: () => artworksConnection,
     })
-    await flushPromiseQueue()
+    await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
 
     expect(screen.getByText("Untitled #1")).toBeOnTheScreen()
     expect(screen.getByText("Untitled #2")).toBeOnTheScreen()
@@ -94,7 +94,7 @@ describe(ConfirmationScreen, () => {
       renderWithRelay({
         FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW + 1 } }),
       })
-      await flushPromiseQueue()
+      await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
 
       const seeAllButton = screen.queryByText("See all matching works")
       expect(seeAllButton).toBeOnTheScreen()
@@ -111,7 +111,7 @@ describe(ConfirmationScreen, () => {
       renderWithRelay({
         FilterArtworksConnection: () => ({ counts: { total: NUMBER_OF_ARTWORKS_TO_SHOW - 1 } }),
       })
-      await flushPromiseQueue()
+      await waitForElementToBeRemoved(() => screen.getByTestId("MatchingArtworksPlaceholder"))
 
       expect(screen.queryByText("See all matching works")).not.toBeOnTheScreen()
     })

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -22,6 +22,7 @@ jest.mock("@react-navigation/native", () => {
     useNavigation: () => {
       return {
         navigate: jest.fn(),
+        addListener: jest.fn(),
       }
     },
     useRoute: () => {

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -100,7 +100,7 @@ const MatchingArtworksPlaceholder: React.FC = () => {
   const screen = useScreenDimensions()
   const { space } = useTheme()
   return (
-    <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
+    <Box testID="MatchingArtworksPlaceholder" borderTopWidth={1} borderTopColor="black30" pt={1}>
       <PlaceholderRaggedText numLines={2} textHeight={20} />
       <Spacer y={2} />
       <GenericGridPlaceholder width={screen.width - space(4)} />

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -157,7 +157,6 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
       <GenericGrid
         width={screen.width - space(2)}
         artworks={artworks}
-        // @ts-expect-error TODO: fix type error maybe introduced in 298c1fd
         onPress={(slug: string) => {
           closeModal?.()
           // TODO: tracking and history?

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -154,7 +154,16 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
 
       <Spacer y={2} />
 
-      <GenericGrid width={screen.width - space(2)} artworks={artworks} />
+      <GenericGrid
+        width={screen.width - space(2)}
+        artworks={artworks}
+        // @ts-expect-error TODO: fix type error maybe introduced in 298c1fd
+        onPress={(slug: string) => {
+          closeModal?.()
+          // TODO: tracking and history?
+          navigate(`artwork/${slug}`)
+        }}
+      />
 
       <Spacer y={4} />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -13,6 +13,7 @@ import { useSavedSearchPills } from "app/Scenes/SavedSearchAlert/useSavedSearchP
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
+import { PlaceholderRaggedText } from "app/utils/placeholders"
 import { Suspense } from "react"
 import { ScrollView } from "react-native"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -76,10 +77,8 @@ export const ConfirmationScreen: React.FC<Props> = (props) => {
 }
 
 const MatchingArtworksContainer: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
-  const screen = useScreenDimensions()
-
   return (
-    <Suspense fallback={<GenericGridPlaceholder width={screen.width - 40} />}>
+    <Suspense fallback={<MatchingArtworksPlaceholder />}>
       <MatchingArtworks closeModal={closeModal} />
     </Suspense>
   )
@@ -100,7 +99,20 @@ const matchingArtworksQuery = graphql`
   }
 `
 
+const MatchingArtworksPlaceholder: React.FC = () => {
+  const screen = useScreenDimensions()
+  const { space } = useTheme()
+  return (
+    <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
+      <PlaceholderRaggedText numLines={2} textHeight={20} />
+      <Spacer y={2} />
+      <GenericGridPlaceholder width={screen.width - space(4)} />
+    </Box>
+  )
+}
+
 const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
+  const screen = useScreenDimensions()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
   const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
@@ -125,7 +137,10 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
 
       <Spacer y={2} />
 
-      <GenericGrid artworks={artworks} />
+      <GenericGrid
+        width={screen.width} // important to include this
+        artworks={artworks}
+      />
 
       <Spacer y={4} />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -19,7 +19,7 @@ import { ScrollView } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
-const NUMBER_OF_ARTWORKS_TO_SHOW = 10
+export const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
 export const ConfirmationScreen: React.FC = () => {
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -17,6 +17,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
+import { pluralize } from "app/utils/pluralize"
 import { useEffect } from "react"
 import { ScrollView } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -171,7 +172,8 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
   return (
     <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
       <Text variant="sm" color="black60">
-        You might like these {total} works currently on Artsy that match your criteria
+        You might like {pluralize("this", total, "these")} {total} {pluralize("work", total)}{" "}
+        currently on Artsy that match your criteria
       </Text>
 
       <Spacer y={2} />

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -118,7 +118,11 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
   const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
-    input: attributes as FilterArtworksInput,
+    input: {
+      ...attributes,
+      forSale: true,
+      sort: "-published_at",
+    } as FilterArtworksInput,
   })
 
   const artworks = extractNodes(data.artworksConnection)

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -177,11 +177,20 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
     )
   }
 
+  const numWorks = `${total} ${pluralize("work", total)}`
+
+  const message = !!areMoreMatchesAvailable
+    ? `${numWorks} currently on Artsy match your criteria. See our top picks for you:`
+    : `You might like ${pluralize(
+        "this",
+        total,
+        "these"
+      )} ${numWorks} currently on Artsy that match your criteria:`
+
   return (
     <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
       <Text variant="sm" color="black60">
-        You might like {pluralize("this", total, "these")} {total} {pluralize("work", total)}{" "}
-        currently on Artsy that match your criteria
+        {message}
       </Text>
 
       <Spacer y={2} />

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,4 +1,5 @@
 import { Box, Button, Flex, Join, Spacer, Text } from "@artsy/palette-mobile"
+import { RouteProp, useRoute } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import {
   ConfirmationScreenMatchingArtworksQuery,
@@ -113,6 +114,7 @@ const MatchingArtworksPlaceholder: React.FC = () => {
 
 const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
   const screen = useScreenDimensions()
+  const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
   const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
@@ -122,11 +124,15 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
   const artworks = extractNodes(data.artworksConnection)
   const total = data?.artworksConnection?.counts?.total // TODO: handle zero state
 
-  const areMoreMatchesAvailable = total > 10 && !!attributes.artistIDs?.[0] // TODO: constant
+  const areMoreMatchesAvailable = total > 10 && attributes?.artistIDs?.length === 1 // TODO: constant
 
   const handleSeeAllMatchingWorks = () => {
     closeModal?.()
-    navigate(`/artist/${attributes.artistIDs?.[0]}`) // TODO: filter attributes
+    navigate(`/artist/${attributes.artistIDs?.[0]}`, {
+      passProps: {
+        searchCriteriaID: route.params.searchCriteriaID,
+      },
+    })
   }
 
   return (

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile"
-import { RouteProp, useRoute } from "@react-navigation/native"
+import { NavigationProp, RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import {
   ConfirmationScreenMatchingArtworksQuery,
   FilterArtworksInput,
@@ -15,7 +15,7 @@ import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToP
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
 import { ScrollView } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -23,11 +23,20 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 export const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
 export const ConfirmationScreen: React.FC = () => {
+  const navigation =
+    useNavigation<NavigationProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const { closeModal } = route.params
   const { bottom: bottomInset } = useSafeAreaInsets()
   const pills = useSavedSearchPills()
   const { space } = useTheme()
+
+  useEffect(() => {
+    const backListener = navigation.addListener("beforeRemove", (e) => {
+      e.preventDefault()
+    })
+    return backListener
+  }, [])
 
   const handleLeftButtonPress = () => {
     closeModal?.()

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -44,7 +44,9 @@ export const ConfirmationScreen: React.FC = () => {
 
   const handleManageAlerts = () => {
     closeModal?.()
-    navigate("/my-profile/saved-search-alerts")
+    requestAnimationFrame(() => {
+      navigate("/my-profile/saved-search-alerts")
+    })
   }
 
   return (
@@ -153,10 +155,12 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
 
   const handleSeeAllMatchingWorks = () => {
     closeModal?.()
-    navigate(`/artist/${attributes.artistIDs?.[0]}`, {
-      passProps: {
-        searchCriteriaID: route.params.searchCriteriaID,
-      },
+    requestAnimationFrame(() => {
+      navigate(`/artist/${attributes.artistIDs?.[0]}`, {
+        passProps: {
+          searchCriteriaID: route.params.searchCriteriaID,
+        },
+      })
     })
   }
 
@@ -174,7 +178,9 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
         onPress={(slug: string) => {
           closeModal?.()
           // TODO: tracking and history?
-          navigateToPageableRoute?.(`artwork/${slug}`)
+          requestAnimationFrame(() => {
+            navigateToPageableRoute?.(`artwork/${slug}`)
+          })
         }}
       />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Join, Spacer, Text } from "@artsy/palette-mobile"
+import { Box, Button, Flex, Join, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import { RouteProp, useRoute } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import {
@@ -17,6 +17,7 @@ import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
 import { Suspense } from "react"
 import { ScrollView } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
 type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">
@@ -24,7 +25,9 @@ type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "Confirmati
 export const ConfirmationScreen: React.FC<Props> = (props) => {
   const { route } = props
   const { closeModal } = route.params
+  const { bottom: bottomInset } = useSafeAreaInsets()
   const pills = useSavedSearchPills()
+  const { space } = useTheme()
 
   const handleLeftButtonPress = () => {
     closeModal?.()
@@ -38,12 +41,19 @@ export const ConfirmationScreen: React.FC<Props> = (props) => {
   return (
     <Box flex={1}>
       <FancyModalHeader hideBottomDivider useXButton onLeftButtonPress={handleLeftButtonPress} />
-      <Box px={2}>
-        <Text variant="lg">Your alert has been saved</Text>
+      <Box flex={1}>
+        <Text variant="lg" px={2}>
+          Your alert has been saved
+        </Text>
 
         <Spacer y={1} />
 
-        <ScrollView>
+        <ScrollView
+          contentContainerStyle={{
+            paddingBottom: bottomInset,
+            paddingHorizontal: space(2),
+          }}
+        >
           <Text variant="sm" color="black60">
             We’ll let you know when matching works are added to Artsy.
           </Text>
@@ -69,8 +79,6 @@ export const ConfirmationScreen: React.FC<Props> = (props) => {
           <Button onPress={handleManageAlerts} block variant="outline">
             Manage your alerts
           </Button>
-
-          <Spacer y={12} />
         </ScrollView>
       </Box>
     </Box>
@@ -114,6 +122,7 @@ const MatchingArtworksPlaceholder: React.FC = () => {
 
 const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
   const screen = useScreenDimensions()
+  const { space } = useTheme()
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
@@ -147,10 +156,7 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
 
       <Spacer y={2} />
 
-      <GenericGrid
-        width={screen.width} // important to include this
-        artworks={artworks}
-      />
+      <GenericGrid width={screen.width - space(2)} artworks={artworks} />
 
       <Spacer y={4} />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -191,7 +191,7 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
         artworks={artworks}
         onPress={(slug: string) => {
           closeModal?.()
-          // TODO: tracking and history?
+          // TODO: tracking
           requestAnimationFrame(() => {
             navigateToPageableRoute?.(`artwork/${slug}`)
           })

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -11,6 +11,7 @@ import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAle
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSavedSearchPills } from "app/Scenes/SavedSearchAlert/useSavedSearchPills"
 import { navigate } from "app/system/navigation/navigate"
+import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToPageableRoute"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
@@ -98,6 +99,7 @@ const matchingArtworksQuery = graphql`
       }
       edges {
         node {
+          slug
           ...GenericGrid_artworks
         }
       }
@@ -135,6 +137,8 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
   const artworks = extractNodes(data.artworksConnection)
   const total = data?.artworksConnection?.counts?.total // TODO: handle zero state
 
+  const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
+
   const areMoreMatchesAvailable =
     total > NUMBER_OF_ARTWORKS_TO_SHOW && attributes?.artistIDs?.length === 1
 
@@ -161,7 +165,7 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
         onPress={(slug: string) => {
           closeModal?.()
           // TODO: tracking and history?
-          navigate(`artwork/${slug}`)
+          navigateToPageableRoute?.(`artwork/${slug}`)
         }}
       />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile
 import { NavigationProp, RouteProp, useNavigation, useRoute } from "@react-navigation/native"
 import {
   ConfirmationScreenMatchingArtworksQuery,
+  ConfirmationScreenMatchingArtworksQuery$data,
   FilterArtworksInput,
 } from "__generated__/ConfirmationScreenMatchingArtworksQuery.graphql"
 import GenericGrid, { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
@@ -14,8 +15,9 @@ import { navigate } from "app/system/navigation/navigate"
 import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToPageableRoute"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks/useScreenDimensions"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { PlaceholderRaggedText } from "app/utils/placeholders"
-import { Suspense, useEffect } from "react"
+import { useEffect } from "react"
 import { ScrollView } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -94,13 +96,34 @@ export const ConfirmationScreen: React.FC = () => {
   )
 }
 
-const MatchingArtworksContainer: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
+const MatchingArtworksPlaceholder: React.FC = () => {
+  const screen = useScreenDimensions()
+  const { space } = useTheme()
   return (
-    <Suspense fallback={<MatchingArtworksPlaceholder />}>
-      <MatchingArtworks closeModal={closeModal} />
-    </Suspense>
+    <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
+      <PlaceholderRaggedText numLines={2} textHeight={20} />
+      <Spacer y={2} />
+      <GenericGridPlaceholder width={screen.width - space(4)} />
+    </Box>
   )
 }
+
+const MatchingArtworksContainer: React.FC<{ closeModal?: () => void }> = withSuspense(
+  ({ closeModal }) => {
+    const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
+    const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
+      first: NUMBER_OF_ARTWORKS_TO_SHOW,
+      input: {
+        ...attributes,
+        forSale: true,
+        sort: "-published_at",
+      } as FilterArtworksInput,
+    })
+
+    return <MatchingArtworks artworksConnection={data.artworksConnection} closeModal={closeModal} />
+  },
+  MatchingArtworksPlaceholder
+)
 
 const matchingArtworksQuery = graphql`
   query ConfirmationScreenMatchingArtworksQuery($input: FilterArtworksInput, $first: Int) {
@@ -117,37 +140,18 @@ const matchingArtworksQuery = graphql`
     }
   }
 `
-
-const MatchingArtworksPlaceholder: React.FC = () => {
-  const screen = useScreenDimensions()
-  const { space } = useTheme()
-  return (
-    <Box borderTopWidth={1} borderTopColor="black30" pt={1}>
-      <PlaceholderRaggedText numLines={2} textHeight={20} />
-      <Spacer y={2} />
-      <GenericGridPlaceholder width={screen.width - space(4)} />
-    </Box>
-  )
+interface MatchingArtworksProps {
+  artworksConnection: ConfirmationScreenMatchingArtworksQuery$data["artworksConnection"]
+  closeModal?: () => void
 }
 
-const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal }) => {
+const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection, closeModal }) => {
   const screen = useScreenDimensions()
   const { space } = useTheme()
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
+  const artworks = extractNodes(artworksConnection)
+  const total = artworksConnection?.counts?.total // TODO: handle zero state
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
-
-  const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
-    first: NUMBER_OF_ARTWORKS_TO_SHOW,
-    input: {
-      ...attributes,
-      forSale: true,
-      sort: "-published_at",
-    } as FilterArtworksInput,
-  })
-
-  const artworks = extractNodes(data.artworksConnection)
-  const total = data?.artworksConnection?.counts?.total // TODO: handle zero state
-
   const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
 
   const areMoreMatchesAvailable =

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Join, Spacer, Text, useTheme } from "@artsy/palette-mobile"
+import { Box, Button, Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import { RouteProp, useRoute } from "@react-navigation/native"
 import { StackScreenProps } from "@react-navigation/stack"
 import {
@@ -61,18 +61,16 @@ export const ConfirmationScreen: React.FC<Props> = (props) => {
           <Spacer y={2} />
 
           <Flex flexDirection="row" flexWrap="wrap">
-            <Join separator={<Spacer x={1} />}>
-              {pills.map((pill) => {
-                return (
-                  <Pill key={`param-${pill.paramName}-value-${pill.value}`} block>
-                    {pill.label}
-                  </Pill>
-                )
-              })}
-            </Join>
+            {pills.map((pill) => {
+              return (
+                <Pill key={`param-${pill.paramName}-value-${pill.value}`} block mr={1} mb={1}>
+                  {pill.label}
+                </Pill>
+              )
+            })}
           </Flex>
 
-          <Spacer y={2} />
+          <Spacer y={1} />
 
           <MatchingArtworksContainer closeModal={closeModal} />
 

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -20,6 +20,8 @@ import { ScrollView } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
+const NUMBER_OF_ARTWORKS_TO_SHOW = 10
+
 type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">
 
 export const ConfirmationScreen: React.FC<Props> = (props) => {
@@ -92,8 +94,8 @@ const MatchingArtworksContainer: React.FC<{ closeModal?: () => void }> = ({ clos
 }
 
 const matchingArtworksQuery = graphql`
-  query ConfirmationScreenMatchingArtworksQuery($input: FilterArtworksInput) {
-    artworksConnection(first: 20, input: $input) {
+  query ConfirmationScreenMatchingArtworksQuery($input: FilterArtworksInput, $first: Int) {
+    artworksConnection(first: $first, input: $input) {
       counts {
         total
       }
@@ -125,6 +127,7 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
   const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
+    first: NUMBER_OF_ARTWORKS_TO_SHOW,
     input: {
       ...attributes,
       forSale: true,
@@ -135,7 +138,8 @@ const MatchingArtworks: React.FC<{ closeModal?: () => void }> = ({ closeModal })
   const artworks = extractNodes(data.artworksConnection)
   const total = data?.artworksConnection?.counts?.total // TODO: handle zero state
 
-  const areMoreMatchesAvailable = total > 10 && attributes?.artistIDs?.length === 1 // TODO: constant
+  const areMoreMatchesAvailable =
+    total > NUMBER_OF_ARTWORKS_TO_SHOW && attributes?.artistIDs?.length === 1
 
   const handleSeeAllMatchingWorks = () => {
     closeModal?.()

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,13 +1,17 @@
-import { Box, Button, Spacer, Text } from "@artsy/palette-mobile"
+import { Box, Flex, Join, Spacer, Text } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { Pill } from "app/Components/Pill"
 import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import { useSavedSearchPills } from "app/Scenes/SavedSearchAlert/useSavedSearchPills"
+import { ScrollView } from "react-native"
 
 type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">
 
 export const ConfirmationScreen: React.FC<Props> = (props) => {
   const { route } = props
   const { closeModal } = route.params
+  const pills = useSavedSearchPills()
 
   const handleLeftButtonPress = () => {
     closeModal?.()
@@ -17,9 +21,35 @@ export const ConfirmationScreen: React.FC<Props> = (props) => {
     <Box>
       <FancyModalHeader hideBottomDivider useXButton onLeftButtonPress={handleLeftButtonPress} />
       <Box px={2}>
-        <Text variant="lg">Confirmation Screen TKTK</Text>
-        <Spacer y={2} />
-        <Button onPress={closeModal}>Dismiss</Button>
+        <Text variant="lg">Your alert has been saved</Text>
+
+        <Spacer y={1} />
+
+        <ScrollView>
+          <Text variant="sm" color="black60">
+            We’ll let you know when matching works are added to Artsy.
+          </Text>
+
+          <Spacer y={2} />
+
+          <Flex flexDirection="row" flexWrap="wrap">
+            <Join separator={<Spacer x={1} />}>
+              {pills.map((pill) => {
+                return (
+                  <Pill key={`param-${pill.paramName}-value-${pill.value}`} block>
+                    {pill.label}
+                  </Pill>
+                )
+              })}
+            </Join>
+          </Flex>
+
+          <Spacer y={2} />
+
+          <Text pb={1000} backgroundColor="black10">
+            Artworks TKTK
+          </Text>
+        </ScrollView>
       </Box>
     </Box>
   )

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import { RouteProp, useRoute } from "@react-navigation/native"
-import { StackScreenProps } from "@react-navigation/stack"
 import {
   ConfirmationScreenMatchingArtworksQuery,
   FilterArtworksInput,
@@ -22,10 +21,8 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 
 const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
-type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">
-
-export const ConfirmationScreen: React.FC<Props> = (props) => {
-  const { route } = props
+export const ConfirmationScreen: React.FC = () => {
+  const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const { closeModal } = route.params
   const { bottom: bottomInset } = useSafeAreaInsets()
   const pills = useSavedSearchPills()

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -1,0 +1,26 @@
+import { Box, Button, Spacer, Text } from "@artsy/palette-mobile"
+import { StackScreenProps } from "@react-navigation/stack"
+import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+
+type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">
+
+export const ConfirmationScreen: React.FC<Props> = (props) => {
+  const { route } = props
+  const { closeModal } = route.params
+
+  const handleLeftButtonPress = () => {
+    closeModal?.()
+  }
+
+  return (
+    <Box>
+      <FancyModalHeader hideBottomDivider useXButton onLeftButtonPress={handleLeftButtonPress} />
+      <Box px={2}>
+        <Text variant="lg">Confirmation Screen TKTK</Text>
+        <Spacer y={2} />
+        <Button onPress={closeModal}>Dismiss</Button>
+      </Box>
+    </Box>
+  )
+}

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -151,7 +151,7 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
   const { space } = useTheme()
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const artworks = extractNodes(artworksConnection)
-  const total = artworksConnection?.counts?.total // TODO: handle zero state
+  const total = artworksConnection?.counts?.total
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
   const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
 
@@ -167,6 +167,14 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
         },
       })
     })
+  }
+
+  if (total === 0) {
+    return (
+      <Text mb={2} p={2} bg="black10" color="black60">
+        There aren't any works available that meet the criteria at this time.
+      </Text>
+    )
   }
 
   return (


### PR DESCRIPTION
This PR resolves [FX-4805] <!-- eg [PROJECT-XXXX] -->

### Description

Counterpart to https://github.com/artsy/force/pull/12543

Adds a richer confirmation experience when creating an alert — a preview of currently matching artworks, plus CTAs to view all, or manage alerts:

Props to @gkartalis and @mzikherman for pairing 🙏🏽 

<img height=600 src="https://github.com/artsy/eigen/assets/140521/85995313-c327-42f3-a973-85f4ea7bfe32" />

<details>
<summary>TODO</summary>

- [x] Confirm this screen is wired up correctly for all journeys (artwork vs artist & create vs ~edit~)
  - As on web, this is only wired up for the creation flow, not the editing flow
- [x] Confirm callbacks (for exiting modal etc) are passed around correctly for all journeys
- [x] What's up with long press context menu??
  - Confirmed working from grid long-press and rail long-press
- [x] Implement the confirmation screen
  - [x] Refactor to use Relay hooks
  - [x] Skeleton placeholders
  - [x] Refactor to use `SavedSearchStore`, to avoid prop drilling and extra querying
  - [x] Restrict to for-sale works
  - [x] Match web experience for scroll behavior
  - [x] CTAs to view all & manage alerts
  - [x] Handle zero state (no matches)
    - Still some work to do here, in order to:
      - have a sensible zero state when there are no matches
      - have a sensible "one state" when there is only one match, redundantly displaying the work or grid you started from
      - align copy and design with web for zero-state and one-state
- [x] Specs
</details>


## Beta builds

> **Note**
>
> **Please feel free to test out these beta builds on your device**

Android: `8.17.0-1674645367 `

iOS: `8.17.0-2023.07.12.21 `

## Screencaps

### Android

|From an artwork|From an artist|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/140521/3f1fb91e-3c19-4829-998c-f9d6117e99d8" />|<video src="https://github.com/artsy/eigen/assets/140521/29ece8e1-63d5-417c-929a-22288281b5ca" />

### iOS

|From an artwork|From an artist|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/140521/9f9e5331-e440-4f48-a5d3-232dca519364" />|<video src="https://github.com/artsy/eigen/assets/140521/194426b0-6aa9-43eb-8967-7627078fb6a5" />

<!--video src="https://github.com/artsy/eigen/assets/140521/ca58f583-c1df-4ec2-84d9-44dc0a5bcb85" /-->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
  - See the TODO collapsible section above for some follow-ups related to zero states and consistency with web
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Enhances the process of creating alerts, by showing examples of artwork inventory matched by the new alert

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[FX-4805]: https://artsyproduct.atlassian.net/browse/FX-4805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ