### PR TITLE
fix: Prevent Shows for You rail to reload when scrolling

### DIFF
--- a/src/app/Scenes/Home/Components/ShowsRail.tsx
+++ b/src/app/Scenes/Home/Components/ShowsRail.tsx
@@ -9,7 +9,7 @@ import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { Location, useLocation } from "app/utils/hooks/useLocation"
 import { PlaceholderBox, RandomWidthPlaceholderText } from "app/utils/placeholders"
 import { times } from "lodash"
-import { Suspense } from "react"
+import { Suspense, memo } from "react"
 import { FlatList } from "react-native"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -23,7 +23,7 @@ interface ShowsRailProps {
 // Because we never show more than 2 shows per gallery we need to overfetch, filter out, and then limit the number of shows.
 const NUMBER_OF_SHOWS = 10
 
-export const ShowsRail: React.FC<ShowsRailProps> = ({ disableLocation, location, title }) => {
+export const ShowsRail: React.FC<ShowsRailProps> = memo(({ disableLocation, location, title }) => {
   const tracking = useTracking()
 
   const queryVariables = location
@@ -72,7 +72,7 @@ export const ShowsRail: React.FC<ShowsRailProps> = ({ disableLocation, location,
       </Flex>
     </Flex>
   )
-}
+})
 
 const ShowsQuery = graphql`
   query ShowsRailQuery($near: Near, $includeShowsNearIpBasedLocation: Boolean) {


### PR DESCRIPTION
This PR resolves [CX-3740] <!-- eg [PROJECT-XXXX] -->

### Description

Prevent Shows for You rail to reload when scrolling.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[CX-3740]: https://artsyproduct.atlassian.net/browse/CX-3740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ