### PR TITLE
feat(onyx-113): Do not dispatch new artwork lists behavior when tapping 'Watch lot' on artwork screen

### DIFF
--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -9,11 +9,13 @@ import { graphql, useFragment } from "react-relay"
 
 interface Options extends Pick<SaveArtworkOptions, "onCompleted" | "onError"> {
   artworkFragmentRef: useSaveArtworkToArtworkLists_artwork$key
+  saveToDefaultCollectionOnly?: boolean
 }
 
 export const useSaveArtworkToArtworkLists = (options: Options) => {
   const { artworkFragmentRef, onCompleted, ...restOptions } = options
-  const isArtworkListsEnabled = useFeatureFlag("AREnableArtworkLists")
+  const isArtworkListsFFEnabled = useFeatureFlag("AREnableArtworkLists")
+  const isArtworkListsEnabled = !options.saveToDefaultCollectionOnly && isArtworkListsFFEnabled
   const { onSave, dispatch } = useArtworkListsContext()
   const { artworkListID, removedArtworkIDs } = useArtworkListContext()
   const artwork = useFragment(ArtworkFragment, artworkFragmentRef)

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -12,11 +12,12 @@ import { ArtworkActions_artwork$data } from "__generated__/ArtworkActions_artwor
 import { ArtworkHeader_artwork$data } from "__generated__/ArtworkHeader_artwork.graphql"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { ArtworkSaveButton } from "app/Scenes/Artwork/Components/ArtworkSaveButton"
+import { isOpenOrUpcomingSale } from "app/Scenes/Artwork/utils/isOpenOrUpcomingSale"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { cm2in } from "app/utils/conversions"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
-import { isEmpty, take } from "lodash"
+import { take } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -53,7 +54,7 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOn
   const space = useSpace()
 
   const enableInstantVIR = useFeatureFlag("AREnableInstantViewInRoom")
-  const isOpenSale = (!isEmpty(sale) && sale?.isAuction && !sale?.isClosed) ?? false
+  const openOrUpcomingSale = isOpenOrUpcomingSale(sale)
 
   const openViewInRoom = () => {
     const heightIn = cm2in(heightCm!)
@@ -78,7 +79,7 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOn
   return (
     <Flex justifyContent="center" flexDirection="row" width="100%">
       <Join separator={<Spacer x={2} />}>
-        <ArtworkSaveButton artwork={artwork} saveToDefaultCollectionOnly={isOpenSale} />
+        <ArtworkSaveButton artwork={artwork} saveToDefaultCollectionOnly={openOrUpcomingSale} />
         {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
           <Touchable
             hitSlop={{

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -16,7 +16,7 @@ import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { cm2in } from "app/utils/conversions"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
-import { take } from "lodash"
+import { isEmpty, take } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import styled from "styled-components/native"
@@ -48,11 +48,12 @@ export const shareContent = (
 }
 
 export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOnPress }) => {
-  const { image, id, slug, heightCm, widthCm, isHangable } = artwork
+  const { image, id, slug, heightCm, widthCm, isHangable, sale } = artwork
   const { trackEvent } = useTracking()
   const space = useSpace()
 
   const enableInstantVIR = useFeatureFlag("AREnableInstantViewInRoom")
+  const isOpenSale = (!isEmpty(sale) && sale?.isAuction && !sale?.isClosed) ?? false
 
   const openViewInRoom = () => {
     const heightIn = cm2in(heightCm!)
@@ -77,7 +78,7 @@ export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOn
   return (
     <Flex justifyContent="center" flexDirection="row" width="100%">
       <Join separator={<Spacer x={2} />}>
-        <ArtworkSaveButton artwork={artwork} />
+        <ArtworkSaveButton artwork={artwork} saveToDefaultCollectionOnly={isOpenSale} />
         {!!(LegacyNativeModules.ARCocoaConstantsModule.AREnabled && isHangable) && (
           <Touchable
             hitSlop={{
@@ -130,6 +131,10 @@ export const ArtworkActionsFragmentContainer = createFragmentContainer(ArtworkAc
       }
       widthCm
       heightCm
+      sale {
+        isAuction
+        isClosed
+      }
     }
   `,
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -20,6 +20,7 @@ import { useTracking } from "react-tracking"
 
 interface ArtworkSaveButtonProps {
   artwork: ArtworkSaveButton_artwork$key
+  saveToDefaultCollectionOnly?: boolean
 }
 
 interface IconProps {
@@ -62,7 +63,10 @@ const getA11yLabel = (isSaved: boolean, isOpenSale: boolean) => {
   return "Save artwork"
 }
 
-export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork }) => {
+export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
+  artwork,
+  saveToDefaultCollectionOnly = false,
+}) => {
   const space = useSpace()
   const { trackEvent } = useTracking()
   const artworkData = useFragment(ArtworkSaveButtonFragment, artwork)
@@ -77,6 +81,7 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({ artwork })
         context_module: Schema.ContextModules.ArtworkActions,
       })
     },
+    saveToDefaultCollectionOnly,
   })
   const { sale } = artworkData
 

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -12,8 +12,8 @@ import {
 } from "@artsy/palette-mobile"
 import { ArtworkSaveButton_artwork$key } from "__generated__/ArtworkSaveButton_artwork.graphql"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { isOpenOrUpcomingSale } from "app/Scenes/Artwork/utils/isOpenOrUpcomingSale"
 import { Schema } from "app/utils/track"
-import { isEmpty } from "lodash"
 import { StyleSheet } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -43,16 +43,16 @@ const SaveButtonIcon: React.FC<IconProps> = ({ isSaved }) => {
   return <HeartIcon accessibilityLabel="Save icon" />
 }
 
-const getSaveButtonText = (isSaved: boolean, isOpenSale: boolean) => {
-  if (isOpenSale) {
+const getSaveButtonText = (isSaved: boolean, openOrUpcomingSale: boolean) => {
+  if (openOrUpcomingSale) {
     return "Watch lot"
   }
 
   return isSaved ? "Saved" : "Save"
 }
 
-const getA11yLabel = (isSaved: boolean, isOpenSale: boolean) => {
-  if (isOpenSale) {
+const getA11yLabel = (isSaved: boolean, openOrUpcomingSale: boolean) => {
+  if (openOrUpcomingSale) {
     return "Watch lot"
   }
 
@@ -84,11 +84,10 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
     saveToDefaultCollectionOnly,
   })
   const { sale } = artworkData
+  const openOrUpcomingSale = isOpenOrUpcomingSale(sale)
 
-  const isOpenSale = !isEmpty(sale) && sale?.isAuction && !sale?.isClosed
-
-  const a11yLabel = getA11yLabel(!!isSaved, !!isOpenSale)
-  const buttonCopy = getSaveButtonText(!!isSaved, !!isOpenSale)
+  const a11yLabel = getA11yLabel(!!isSaved, !!openOrUpcomingSale)
+  const buttonCopy = getSaveButtonText(!!isSaved, !!openOrUpcomingSale)
 
   return (
     <Touchable
@@ -103,7 +102,11 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
       onPress={saveArtworkToLists}
     >
       <Flex flexDirection="row" justifyContent="flex-start" alignItems="center">
-        {isOpenSale ? <WatchLotIcon isSaved={!!isSaved} /> : <SaveButtonIcon isSaved={!!isSaved} />}
+        {openOrUpcomingSale ? (
+          <WatchLotIcon isSaved={!!isSaved} />
+        ) : (
+          <SaveButtonIcon isSaved={!!isSaved} />
+        )}
         <Spacer x={0.5} />
 
         <Box position="relative">
@@ -112,7 +115,7 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
           {/* Hidden from screen readers */}
           {!__TEST__ && (
             <Text variant="sm" color="transparent" accessibilityElementsHidden>
-              {isOpenSale ? "Watch lot" : "Saved"}
+              {openOrUpcomingSale ? "Watch lot" : "Saved"}
             </Text>
           )}
           <Box {...StyleSheet.absoluteFillObject}>

--- a/src/app/Scenes/Artwork/utils/isOpenOrUpcomingSale.ts
+++ b/src/app/Scenes/Artwork/utils/isOpenOrUpcomingSale.ts
@@ -1,0 +1,10 @@
+import { isEmpty } from "lodash"
+
+interface SaleProps {
+  isAuction: boolean | null
+  isClosed: boolean | null
+}
+
+export const isOpenOrUpcomingSale = (sale: SaleProps | null) => {
+  return Boolean(!isEmpty(sale) && sale?.isAuction && !sale?.isClosed)
+}


### PR DESCRIPTION
This PR resolves [ONYX-113] 

### Description

Do not dispatch new artwork lists behavior when tapping 'Watch lot' on artwork screen

https://github.com/artsy/eigen/assets/3934579/6d4a6468-90e1-4138-bede-07997007b81f

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Do not display artwork lists bottom sheet component when tapping 'Watch lot' on artwork screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-113]: https://artsyproduct.atlassian.net/browse/ONYX-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ