### PR TITLE
fix(home): missing Home_heroUnits spread fragment

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -126,7 +126,7 @@ export interface HomeProps extends ViewProps {
   meBelow: Home_meBelow$data | null
   relay: RelayRefetchProp
   emergingPicks: Home_emergingPicks$data | null
-  heroUnits: HomeAboveTheFoldQuery$data["heroUnits"] | null
+  heroUnits: HomeAboveTheFoldQuery$data["heroUnitsConnection"] | null
 }
 
 const Home = memo((props: HomeProps) => {
@@ -750,7 +750,8 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
             newWorksForYou: viewer @optionalField {
               ...Home_newWorksForYou
             }
-            heroUnits: heroUnitsConnection(first: 10, private: true) @optionalField {
+            heroUnitsConnection(first: 10, private: true) @optionalField {
+              ...Home_heroUnits
               ...HeroUnitsRail_heroUnitsConnection
             }
           }
@@ -802,7 +803,7 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
               meAbove={above.me}
               meBelow={below ? below.me : null}
               loading={!below}
-              heroUnits={above ? above.heroUnits : null}
+              heroUnits={above ? above.heroUnitsConnection : null}
             />
           )
         },


### PR DESCRIPTION
### Description

No data changes only fixes the error from below which was caused because we never spread the fragment `Home_heroUnits`. 
Small renaming in the query to remove the alias, I don't know why I see a lot of aliasing to match UI from GraphQL, I strongly believe we should use what comes from MP, if the naming is bad there we should go on MP and change instead of aliasing. Alias in Relay should be used to avoid conflicting fields from different fragments/queries, for example 2 fragments relying on `date` but each one using a different format `param`.

<img width="1502" alt="Screenshot 2023-07-07 at 10 43 22" src="https://github.com/artsy/eigen/assets/15792853/c66b0a2c-e6b6-4bd2-9b71-9e9e79d91d6a">


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- spread Home_heroUnits fragment in Home - araujobarret

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
