### PR TITLE
fix: artist page insights hidden behind sticky tab

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Tabs } from "@artsy/palette-mobile"
+import { Tabs, useSpace } from "@artsy/palette-mobile"
 import { ArtistInsights_artist$data } from "__generated__/ArtistInsights_artist.graphql"
 import { ARTIST_HEADER_HEIGHT } from "app/Components/Artist/ArtistHeader"
 import { ArtistInsightsEmpty } from "app/Components/Artist/ArtistInsights/ArtistsInsightsEmpty"
@@ -31,7 +31,7 @@ const FILTER_BUTTON_OFFSET = 50
 
 export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
   const { artist, relay, initialFilters } = props
-
+  const space = useSpace()
   const tracking = useTracking()
 
   const [isFilterButtonVisible, setIsFilterButtonVisible] = useState(false)
@@ -80,7 +80,10 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
   return (
     <ArtworkFiltersStoreProvider>
       <Tabs.ScrollView
-        contentContainerStyle={{ paddingTop: 20, paddingBottom: 60, paddingHorizontal: 20 }}
+        contentContainerStyle={{
+          marginTop: space(2),
+          marginHorizontal: space(2),
+        }}
         onScrollEndDrag={onScrollEndDrag}
       >
         <MarketStatsQueryRenderer

--- a/src/app/Components/Artist/ArtistInsights/ArtistInsights.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsights.tsx
@@ -83,6 +83,7 @@ export const ArtistInsights: React.FC<ArtistInsightsProps> = (props) => {
         contentContainerStyle={{
           marginTop: space(2),
           marginHorizontal: space(2),
+          paddingBottom: space(4),
         }}
         onScrollEndDrag={onScrollEndDrag}
       >


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Solves https://www.notion.so/Android-Artist-Auction-Results-content-is-hidden-behind-the-tabs-25c838b4c3174afc8c127f5edebd0005 launch blocking bug

Android

|Before|After|
|---|---|
|<img width="361" alt="Screenshot 2023-07-10 at 13 13 13" src="https://github.com/artsy/eigen/assets/21178754/549d238b-e12d-45f7-b97e-e09909aa4dea">|<img width="362" alt="Screenshot 2023-07-10 at 13 50 27" src="https://github.com/artsy/eigen/assets/21178754/a0a44347-63ea-4cb2-b4c3-3f3c202d6aa5">|
|<img width="363" alt="Screenshot 2023-07-10 at 13 16 04" src="https://github.com/artsy/eigen/assets/21178754/d5bab0ed-6c4f-4137-b74d-eb5a2f584b5d">|<img width="362" alt="Screenshot 2023-07-10 at 13 50 37" src="https://github.com/artsy/eigen/assets/21178754/c89119a0-1025-40f7-a9b1-cdba34e41470">
|
|<img width="361" alt="Screenshot 2023-07-10 at 13 14 18" src="https://github.com/artsy/eigen/assets/21178754/b53ac46e-f57f-4575-b90f-9f567b439595">|<img width="364" alt="Screenshot 2023-07-10 at 11 22 03" src="https://github.com/artsy/eigen/assets/21178754/583b4e27-4080-4b3a-99dd-67c830f3ab70">|
|<img width="363" alt="Screenshot 2023-07-10 at 13 14 54" src="https://github.com/artsy/eigen/assets/21178754/93baaaa4-360f-47e4-8a16-5bbe790662d9">|<img width="363" alt="Screenshot 2023-07-10 at 11 21 49" src="https://github.com/artsy/eigen/assets/21178754/63ee89b7-054a-4fb6-a715-515f369ed930">|

iOS

https://github.com/artsy/eigen/assets/21178754/6de0d9a2-5747-4257-8923-82d91f666559

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
