### PR TITLE
fix: Move submit button inside KeyboardAwareScrollView in MyC form

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -40,7 +40,7 @@ import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
 import { isEmpty } from "lodash"
 import React, { useCallback, useEffect, useState } from "react"
-import { Alert, Image, ScrollView, TouchableOpacity } from "react-native"
+import { Alert, Image, Platform, ScrollView, TouchableOpacity } from "react-native"
 import { useTracking } from "react-tracking"
 
 const SHOW_FORM_VALIDATION_ERRORS_IN_DEV = false
@@ -412,19 +412,20 @@ export const MyCollectionArtworkFormMain: React.FC<
             </ScreenMargin>
           )}
         </ScrollView>
+
+        <Flex p={2} pb={Platform.OS === "android" ? 2 : 0}>
+          <Button
+            disabled={!formik.isValid || !isFormDirty()}
+            block
+            onPress={formik.handleSubmit}
+            testID="CompleteButton"
+            haptic
+            mb={`${bottom}px`}
+          >
+            {mode === "edit" ? "Save changes" : "Complete"}
+          </Button>
+        </Flex>
       </ArtsyKeyboardAvoidingView>
-      <Flex p={2}>
-        <Button
-          disabled={!formik.isValid || !isFormDirty()}
-          block
-          onPress={formik.handleSubmit}
-          testID="CompleteButton"
-          haptic
-          mb={`${bottom}px`}
-        >
-          {mode === "edit" ? "Save changes" : "Complete"}
-        </Button>
-      </Flex>
     </>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR moves the submit button inside My Collection artwork from to be above the keyboard when the keyboard is visible


### Screenshots
| | Before | After |
|---|---|---|
| Android | <img width="435" alt="image" src="https://github.com/artsy/eigen/assets/20655703/c5d9f1e8-84f6-45e2-82a1-cd3924a79ce8"> | <img width="436" alt="image" src="https://github.com/artsy/eigen/assets/20655703/022a50e9-124c-4670-b595-5c3436409a47"> |
| iOS | <img width="438" alt="image" src="https://github.com/artsy/eigen/assets/20655703/e23d2236-7511-4312-8abd-16ce18363657"> | <img width="438" alt="image" src="https://github.com/artsy/eigen/assets/20655703/c67324a9-70d7-4eb7-9d7d-654a72b037c1"> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Move submit button inside KeyboardAwareScrollView inside MyC artwork form - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
