### PR TITLE
fix(onyx-134): fixes broken redirects to partners

### DIFF
--- a/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
@@ -146,6 +146,7 @@ const PartnerCardArtwork: PartnerCard_artwork$data = {
     name: "Test Gallery",
     slug: "12345",
     id: "12345",
+    href: "12345",
     initials: "TG",
     profile: {
       id: "12345",

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tsx
@@ -15,7 +15,7 @@ interface PartnerCardProps {
 }
 
 export const PartnerCard: React.FC<PartnerCardProps> = ({ artwork, shouldShowQuestions }) => {
-  const handleTap = (slug: string) => navigateToPartner(slug)
+  const handleTap = (href: string) => navigateToPartner(href)
 
   const partner = artwork.partner!
 
@@ -47,7 +47,7 @@ export const PartnerCard: React.FC<PartnerCardProps> = ({ artwork, shouldShowQue
           <Spacer y={1} />
         </>
       )}
-      <TouchableWithoutFeedback onPress={() => handleTap(partner.slug!)}>
+      <TouchableWithoutFeedback onPress={() => handleTap(partner.href!)}>
         <EntityHeader
           name={partner.name!}
           meta={locationNames || undefined}
@@ -76,6 +76,7 @@ export const PartnerCardFragmentContainer = createFragmentContainer(PartnerCard,
         name
         slug
         id
+        href
         initials
         profile {
           id

--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
@@ -191,7 +191,7 @@ export const AutosuggestSearchResult: React.FC<{
  */
 function navigateToResult(result: AutosuggestResult, artistTab: ArtistTabs = "Artworks") {
   if (result.displayType === "Gallery" || result.displayType === "Institution") {
-    navigateToPartner(result.slug!)
+    navigateToPartner(result.href!)
   } else if (result.displayType === "Fair") {
     navigateToEntity(result.href!, EntityType.Fair, SlugType.ProfileID)
   } else if (result.__typename === "Artist") {

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tsx
@@ -20,16 +20,11 @@ const VanityURLEntity: React.FC<EntityProps> = ({ fairOrPartner, originalSlug })
   // https://github.com/facebook/relay/commit/ed53bb095ddd494092819884cb4f46df94b45b79#diff-4e3d961b12253787bd61506608bc366be34ab276c09690de7df17203de7581e8
   const isFair = fairOrPartner.__typename === "Fair" || "slug" in fairOrPartner
   const isPartner = fairOrPartner.__typename === "Partner" || "id" in fairOrPartner
-  const { safeAreaInsets } = useScreenDimensions()
 
   if (isFair) {
     return <FairFragmentContainer fair={fairOrPartner} />
   } else if (isPartner) {
-    return (
-      <View style={{ flex: 1, paddingTop: safeAreaInsets.top ?? 0 }}>
-        <PartnerContainer partner={fairOrPartner} />
-      </View>
-    )
+    return <PartnerContainer partner={fairOrPartner} />
   } else {
     return <VanityURLPossibleRedirect slug={originalSlug} />
   }

--- a/src/app/system/navigation/navigate.tests.tsx
+++ b/src/app/system/navigation/navigate.tests.tsx
@@ -2,7 +2,7 @@ import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { GlobalStore } from "app/store/GlobalStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { Linking } from "react-native"
-import { getPartnerSlug, navigate } from "./navigate"
+import { navigate } from "./navigate"
 
 function args(mock: jest.Mock) {
   return mock.mock.calls[mock.mock.calls.length - 1]
@@ -307,17 +307,5 @@ describe(navigate, () => {
       await navigate("/artist/andy-warhol")
       expect(LegacyNativeModules.ARScreenPresenterModule.pushView).toHaveBeenCalledTimes(3)
     })
-  })
-})
-
-describe("getPartnerSlug", () => {
-  it('should not modify the slug if "partner/" is not present', () => {
-    const slug = "partner/my-partner"
-    expect(getPartnerSlug(slug)).toBe("partner/my-partner")
-  })
-
-  it('should remove "partner/" if it exists in the slug', () => {
-    const slug = "my-partner"
-    expect(getPartnerSlug(slug)).toBe(`partner/${slug}`)
   })
 })

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -220,19 +220,7 @@ export enum SlugType {
   FairID = "fairID",
 }
 
-const partnerRegex = /partner\//
-
-export function getPartnerSlug(slug: string) {
-  if (partnerRegex.test(slug)) {
-    return slug
-  }
-
-  return `partner/${slug}`
-}
-
-export function navigateToPartner(slug: string) {
-  const href = getPartnerSlug(slug)
-
+export function navigateToPartner(href: string) {
   navigate(href, {
     passProps: { entity: EntityType.Partner, slugType: SlugType.ProfileID },
   })


### PR DESCRIPTION
This PR resolves [ONYX-134]

### Description

When searching for some partners, like British museum, for example, redirect is broken. This happens because we redirect user to a `partner/<profile_slug>` route, which might not exist, since <**profile**_slug> and <**partner**_slug> might be different.

For instance, British museum's profile slug is `britishmuseum` (this slug is returned from search as `href` or `slug` fields). We redirect user to the `partner/britishmuseum` page, but there is no such **partner** with such slug, the correct one is `british-museum`.

[Related PR.](https://github.com/artsy/eigen/pull/8791)

| Before | After |
|---|---|
| https://github.com/artsy/eigen/assets/3934579/875f74ca-ca7b-4189-847c-0dc777169810 | https://github.com/artsy/eigen/assets/3934579/929f5275-6f50-4c78-9164-c32187e93828 |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixes broken redirects from search for some partners - Nikita

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
