### PR TITLE
chore: deprecate legacy test utils in eigen

### DIFF
--- a/src/app/utils/tests/rejectMostRecentRelayOperation.ts
+++ b/src/app/utils/tests/rejectMostRecentRelayOperation.ts
@@ -2,6 +2,11 @@ import { act } from "@testing-library/react-native"
 import { OperationDescriptor } from "relay-runtime"
 import { createMockEnvironment } from "relay-test-utils"
 
+/**
+ * @deprecated
+ * Please use `setupTestWrapper` and destrucure
+ * const { mockRejectLastOperation } = renderWithRelay() instead
+ */
 export function rejectMostRecentRelayOperation(
   mockEnvironment: ReturnType<typeof createMockEnvironment>,
   error: Error | ((operation: OperationDescriptor) => Error)

--- a/src/app/utils/tests/renderWithLayout.tsx
+++ b/src/app/utils/tests/renderWithLayout.tsx
@@ -1,6 +1,10 @@
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 
 /** Renders a React Component with specified layout using onLayout callback */
+
+/**
+ * @deprecated
+ */
 export const renderWithLayout = (component: any, layout: { width?: number; height?: number }) => {
   // create the component with renderer
   component = renderWithWrappersLEGACY(component)

--- a/src/app/utils/tests/resolveMostRecentRelayOperation.ts
+++ b/src/app/utils/tests/resolveMostRecentRelayOperation.ts
@@ -48,6 +48,11 @@ export const DefaultMockResolvers: MockResolvers = {
   String: (ctx) => goodMockResolver(ctx),
 }
 
+/**
+ * @deprecated
+ * Please use `setupTestWrapper` and destrucure
+ * const { mockResolveLastOperation } = renderWithRelay() instead
+ */
 export function resolveMostRecentRelayOperation(
   mockEnvironment: ReturnType<typeof createMockEnvironment>,
   mockResolvers?: MockResolvers


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Deprecating some legacy test helpers to prevent people from using them:

- resolveMostRecentRelayOperation
- rejectMostRecentRelayOperation
- renderWithLayout

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- deprecate legacy test utils in eigen - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
