### PR TITLE
fix: text style incosistency on accepting bid terms

### DIFF
--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -567,9 +567,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 disabled={isLoading}
                 flex={undefined}
               >
-                <Text color="black60">
+                <Text color="black60" variant="xs">
                   I agree to{" "}
                   <LinkText
+                    variant="xs"
                     onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}
                   >
                     {partnerName(sale!)} Conditions of Sale
@@ -582,6 +583,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 <Text variant="xs" mt={2} color="black60">
                   I agree to{" "}
                   <LinkText
+                    variant="xs"
                     onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}
                   >
                     {partnerName(sale!)} Conditions of Sale


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes some font size inconsistencies on the accept terms of bid screen. We found it during the Mobile QA meeting (card [here](https://www.notion.so/artsy/Text-link-for-agreeing-to-terms-of-auctions-bigger-than-it-is-supposed-to-be-when-bidding-8b5fb9c3dccd4e8e91a727a8a97e5dc0?pvs=4))

#### Screenshots

|Before|After|
|---|---|
|![before1](https://github.com/artsy/eigen/assets/21178754/db89c91d-a6c0-4ca5-978f-4fbc3e426075)|![after1](https://github.com/artsy/eigen/assets/21178754/b56dd7df-fc31-43f6-adfe-dfa2dc581441)| 
|![before2](https://github.com/artsy/eigen/assets/21178754/c33b9fc3-6f07-41fe-a32b-b535a1606388)|![after2](https://github.com/artsy/eigen/assets/21178754/7a196b0e-53b0-4c77-b36e-8c9a24f0d786)| 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fixed text style incosistency on accepting bid terms - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
