### PR TITLE
fix(ONYX-167): navigate to my collection after deleting artwork

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -32,7 +32,7 @@ import { MyCollectionArtworkStore } from "app/Scenes/MyCollection/Screens/Artwor
 import { myCollectionDeleteArtwork } from "app/Scenes/MyCollection/mutations/myCollectionDeleteArtwork"
 import { Currency } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "app/store/GlobalStore"
-import { goBack, popToRoot } from "app/system/navigation/navigate"
+import { dismissModal, goBack, popToRoot } from "app/system/navigation/navigate"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { artworkMediumCategories } from "app/utils/artworkMediumCategories"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -200,6 +200,7 @@ export const MyCollectionArtworkFormMain: React.FC<
           await myCollectionDeleteArtwork(artwork.internalID)
         }
         refreshMyCollection()
+        dismissModal()
         popToRoot()
       } catch (e) {
         if (__DEV__) {


### PR DESCRIPTION
This PR resolves [ONYX-167] <!-- eg [PROJECT-XXXX] -->

### Description

Navigate to my collection after deleting artwork


https://github.com/artsy/eigen/assets/11945712/408ffdce-0a64-48d8-9a6b-5504b8aa2143


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochanges


#8133 Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-167]: https://artsyproduct.atlassian.net/browse/ONYX-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ