### PR TITLE
fix: Preload Shows for You rail

### DIFF
--- a/src/app/Scenes/Home/Components/ShowsRail.tsx
+++ b/src/app/Scenes/Home/Components/ShowsRail.tsx
@@ -176,7 +176,7 @@ export const usePreloadShowsRail = (disableLocation: boolean) => {
     if (!isLoading) {
       return
     }
-    console.log("ShowsRailQuery", "prefetching")
+
     prefetchQuery(ShowsQuery, getQueryVariables(location, disableLocation))
   }, [isLoading])
 }

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -43,7 +43,7 @@ import { MeetYourNewAdvisorRail } from "app/Scenes/Home/Components/MeetYourNewAd
 import { NewWorksForYouRail } from "app/Scenes/Home/Components/NewWorksForYouRail"
 import { OldCollectionsRailFragmentContainer } from "app/Scenes/Home/Components/OldCollectionsRail"
 import { SalesRailFragmentContainer } from "app/Scenes/Home/Components/SalesRail"
-import { ShowsRailContainer } from "app/Scenes/Home/Components/ShowsRail"
+import { ShowsRailContainer, usePreloadShowsRail } from "app/Scenes/Home/Components/ShowsRail"
 import { RailScrollRef } from "app/Scenes/Home/Components/types"
 import {
   DEFAULT_RECS_MODEL_VERSION,
@@ -176,6 +176,8 @@ const Home = memo((props: HomeProps) => {
   const enableRailViewsTrackingExperiment = useExperimentVariant(
     "CX-impressions-tracking-home-rail-views"
   )
+
+  usePreloadShowsRail(enableShowsForYouLocation)
 
   // Make sure to include enough modules in the above-the-fold query to cover the whole screen!.
   const { modules, allModulesKeys } = useHomeModules(props)

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -177,6 +177,7 @@ const Home = memo((props: HomeProps) => {
     "CX-impressions-tracking-home-rail-views"
   )
 
+  // Preloading the Shows for You rail to avoid loading it when the user scrolls. This is needed because it has it's own query renderer.
   usePreloadShowsRail(enableShowsForYouLocation)
 
   // Make sure to include enough modules in the above-the-fold query to cover the whole screen!.

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -45,7 +45,7 @@ async function isRateLimited() {
   return remainingRequests < 0
 }
 
-const prefetchQuery = async (query: GraphQLTaggedNode, variables?: Variables) => {
+export const prefetchQuery = async (query: GraphQLTaggedNode, variables?: Variables) => {
   const environment = getRelayEnvironment()
   const operation = createOperationDescriptor(getRequest(query), variables ?? {})
 


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

The "Shows for You" rail uses its own query renderer to avoid increasing the loading time for the entire home screen. This is because the rail accesses the device's location before fetching data.

This leads to the situation where the rail only starts fetching the data when the user's scroll position is close to the rail. As a result, the user sees a loading state for a few seconds before the data is loaded.

To avoid this loading state, I added a function to pre-fetch all the data needed for the rail (device location and GraphQL data).

I'm happy to hear any ideas on how to solve the issue in a better way. 🙏

**Without preloading 😢 :**

https://github.com/artsy/eigen/assets/4691889/30706633-c6e1-42fe-86aa-264217c844fe

**With preloading 🥳:**

https://github.com/artsy/eigen/assets/4691889/4a1b110b-8587-4060-bef8-83e094f266c3


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Avoid "Shows for You" home screen rail loading skeleton - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
