### PR TITLE
chore(ONYX-190): dismiss keyboard after leaving add personal artist route

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tests.tsx
@@ -11,6 +11,7 @@ jest.mock("@react-navigation/native", () => {
     useNavigation: () => ({
       navigate: jest.fn(),
     }),
+    useIsFocused: () => true,
     useRoute: () => {
       const props: ArtworkFormScreen["AddMyCollectionArtist"] = {
         props: {

--- a/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
@@ -1,13 +1,13 @@
 import { ArtsyKeyboardAvoidingView, Button, Flex, Join, Spacer } from "@artsy/palette-mobile"
-import { RouteProp, useNavigation, useRoute } from "@react-navigation/native"
+import { RouteProp, useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { AbandonFlowModal } from "app/Components/AbandonFlowModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { Input } from "app/Components/Input"
 import { ArtworkFormScreen } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
 import { useFormik } from "formik"
-import React, { useRef, useState } from "react"
-import { ScrollView } from "react-native"
+import React, { useEffect, useRef, useState } from "react"
+import { Keyboard, ScrollView } from "react-native"
 import * as Yup from "yup"
 
 export interface MyCollectionCustomArtistSchema {
@@ -37,6 +37,14 @@ export const AddMyCollectionArtist: React.FC = () => {
   const nationalityInputRef = useRef<Input>(null)
   const birthYearInputRef = useRef<Input>(null)
   const deathYearInputRef = useRef<Input>(null)
+
+  const isFocused = useIsFocused()
+
+  useEffect(() => {
+    if (isFocused) {
+      Keyboard.dismiss()
+    }
+  }, [isFocused])
 
   const { handleSubmit, validateField, handleChange, dirty, isValid, values, errors } =
     useFormik<MyCollectionCustomArtistSchema>({


### PR DESCRIPTION
This PR resolves [ONYX-190] <!-- eg [PROJECT-XXXX] -->

### Description

https://github.com/artsy/eigen/assets/11945712/06e501d3-6647-4053-bf01-f4f13c075cb7


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-190]: https://artsyproduct.atlassian.net/browse/ONYX-190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ