### PR TITLE
fix: reverse artist is checked value

### DIFF
--- a/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistPreview.tsx
@@ -86,7 +86,7 @@ export const MyCollectionBottomSheetModalArtistPreview: React.FC<
 
           <Flex flexDirection="row" alignItems="flex-start">
             <Checkbox
-              checked={isPrivate}
+              checked={!isPrivate}
               accessibilityState={{ checked: isPrivate }}
               onPress={() => {
                 setIsPrivate(!isPrivate)


### PR DESCRIPTION
### Description

This PR resolves: [ONYX-181]

This PR fixes an issue where the copy is not matching the displayed text for my collection artist. The logic should be: if an artist is private, do not tick the box.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-181]: https://artsyproduct.atlassian.net/browse/ONYX-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ