### PR TITLE
fix: only check for collected artists feature flag if ff is enabled

### DIFF
--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -159,8 +159,11 @@ const MyCollection: React.FC<{
   }, [artworks])
 
   // User has no artworks and no collected artists
-  if (artworks.length === 0 && !hasCollectedArtists) {
-    return <MyCollectionZeroState />
+  if (artworks.length === 0) {
+    // Only check for collected artists count if collected artists feature flag is enabled
+    if (!enableCollectedArtists || !hasCollectedArtists) {
+      return <MyCollectionZeroState />
+    }
   }
 
   // User has no artworks but has manually added collected artists


### PR DESCRIPTION
### Description

I am adding this check in case we roll back enabled collected artists after releasing it and having artists and no arworks in my collection.

I noticed this design "bug" on my personal accounts after disabling the feature flag while having collected artists in my collection.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
