### PR TITLE
fix: Save artist details correctly when creating an artwork

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -17,6 +17,7 @@ import { ArtworkFormValues } from "app/Scenes/MyCollection/State/MyCollectionArt
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { GlobalStore } from "app/store/GlobalStore"
 import { dismissModal, goBack, popToRoot } from "app/system/navigation/navigate"
+import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { refreshMyCollection, refreshMyCollectionInsights } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
@@ -65,6 +66,8 @@ export type MyCollectionArtworkFormProps =
 const navContainerRef = { current: null as NavigationContainerRef<any> | null }
 
 export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (props) => {
+  const enableShowError = useDevToggle("DTShowErrorInLoadFailureView")
+
   const enableCollectedArtists = useFeatureFlag("AREnableMyCollectionCollectedArtists")
   const { trackEvent } = useTracking()
   const { formValues, dirtyFormCheckValues } = GlobalStore.useAppState(
@@ -131,10 +134,10 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
       } else {
         goBack()
       }
-    } catch (e) {
-      console.error("Artwork could not be saved", e)
+    } catch (error: any) {
+      console.error("Artwork could not be saved", error)
       setLoading(false)
-      Alert.alert("Artwork could not be saved")
+      Alert.alert("Artwork could not be saved", enableShowError ? error?.message : undefined)
     }
   }
 

--- a/src/app/Scenes/MyCollection/mutations/createArtist.ts
+++ b/src/app/Scenes/MyCollection/mutations/createArtist.ts
@@ -5,7 +5,9 @@ import {
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { commitMutation, graphql } from "relay-runtime"
 
-export const createArtist = (input: CreateArtistMutationInput) => {
+export const createArtist = (
+  input: CreateArtistMutationInput
+): Promise<createArtistMutation["response"]> => {
   return new Promise((resolve, reject) => {
     commitMutation(getRelayEnvironment(), {
       mutation: graphql`
@@ -15,6 +17,7 @@ export const createArtist = (input: CreateArtistMutationInput) => {
               __typename
               ... on CreateArtistSuccess {
                 artist {
+                  internalID
                   displayName
                 }
               }
@@ -37,7 +40,7 @@ export const createArtist = (input: CreateArtistMutationInput) => {
         if (errors?.length || responseError?.__typename === "CreateArtistFailure") {
           reject(errors || responseError)
         } else {
-          resolve(response)
+          resolve(response as createArtistMutation["response"])
         }
       },
       onError: reject,


### PR DESCRIPTION
This PR resolves [ONYX-188] <!-- eg [PROJECT-XXXX] -->

### Description

**The Problem:**

When a user creates a new personal artist in the "Create Artwork" flow (creating both the artwork and the artist), the details of the artist (birthday, deathday and nationality) do not get saved correctly. This is because the `createArtworkMutation` only accepts a display name for a new personal artist ([Schema](https://github.com/artsy/eigen/blob/main/data/schema.graphql#L12578)).

**The Solution:**

I have decided to use the `createArtistMutation` instead of adding the missing parameters to the `createArtworkMutation` in Metaphysics to decouple the creation of artworks and artists. 

This way, we won't have to maintain two mutations when making adjustments to the artist form and both endpoints are independent of each other. 

I'm happy to hear your feedback on this decision.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Save artist details correctly when creating an artwork - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-188]: https://artsyproduct.atlassian.net/browse/ONYX-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ