### PR TITLE
fix: Encountered two children with the same key home warning

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -377,7 +377,7 @@ const Home = memo((props: HomeProps) => {
         ListHeaderComponent={<HomeHeader />}
         ListFooterComponent={() => <Flex mb={4}>{!!loading && <BelowTheFoldPlaceholder />}</Flex>}
         ItemSeparatorComponent={ModuleSeparator}
-        keyExtractor={(_item) => _item.title}
+        keyExtractor={(_item) => _item.key}
       />
       {!!props.meAbove && <EmailConfirmationBannerFragmentContainer me={props.meAbove} />}
     </View>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the `Encountered two children with the same key,` warning that we were getting in the home screen.

The reason that this was happening was that inside useHomeModules we had two elements with matching title [here](https://github.com/artsy/eigen/blob/b85b154859bbdee6c6330b6955667a31b8e07dd0/src/app/Scenes/Home/useHomeModules.ts#L88) and [here](https://github.com/artsy/eigen/blob/b85b154859bbdee6c6330b6955667a31b8e07dd0/src/app/Scenes/Home/useHomeModules.ts#L35).

This PR fixes this issue by replacing the title with the key in the keyExtractor in the flatlist.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- warning about same key in the home flatlist - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
