### PR TITLE
chore(My Collection): remove grid/list view option for artworks

### DIFF
--- a/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
+++ b/src/app/Scenes/MyCollection/utils/localArtworkSortAndFilter.ts
@@ -7,7 +7,6 @@ import {
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { FilterConfigTypes, FilterDisplayConfig } from "app/Components/ArtworkFilter/types"
 import { MyCollectionArtworkEdge } from "app/Scenes/MyCollection/MyCollection"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { normalizeText } from "app/utils/normalizeText"
 import { compact, filter, orderBy, uniqBy } from "lodash"
 import { DateTime } from "luxon"
@@ -17,7 +16,6 @@ export const useLocalArtworkFilter = (artworksList?: any[] | null) => {
   const setFilterType = ArtworksFiltersStore.useStoreActions((s) => s.setFilterTypeAction)
   const setSortOptions = ArtworksFiltersStore.useStoreActions((s) => s.setSortOptions)
   const setFilterOptions = ArtworksFiltersStore.useStoreActions((s) => s.setFilterOptions)
-  const enableCollectedArtists = useFeatureFlag("AREnableMyCollectionCollectedArtists")
 
   const initLocalArtworkFilter = (artworks: any[]) => {
     setFilterType("local")
@@ -113,12 +111,6 @@ export const useLocalArtworkFilter = (artworksList?: any[] | null) => {
     ])
     setFilterOptions(
       compact([
-        enableCollectedArtists && {
-          configType: FilterConfigTypes.FilterScreenViewOptions,
-          displayText: "View As",
-          filterType: "viewAs",
-          ScreenComponent: "FilterOptionsScreen",
-        },
         {
           configType: FilterConfigTypes.FilterScreenCheckboxItem,
           displayText: "Show Only Submitted Artworks",


### PR DESCRIPTION
### Description

The toggle allowing a user to select between Grid and List views within the My Collection surface is currently placed within the Sort/Filter panel.

Using the toggle doesn't interact with the filter state however, instead utilizing a global user preference which alters the displayed artworks (not visible in the same screen) right away. This can be confusing because every other control in the panel affects the enabled/disabled state of the "Show results" primary action button.

For now, we're going to remove this feature until we can find a better placement for it.

### Screenshots

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2023-08-04 at 17 09 44](https://github.com/artsy/eigen/assets/123595/37539a74-f167-44d3-b11f-3db43e517b7b) | ![Simulator Screenshot - iPhone 14 Pro - 2023-08-04 at 17 11 44](https://github.com/artsy/eigen/assets/123595/2db5d61d-fca5-40c7-8813-dc1d65db04b6) | 


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
