### PR TITLE
fix: inbox empty state

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -147,7 +147,7 @@ export const Conversations: React.FC<Props> = (props) => {
         onEndReachedThreshold={0.2}
         contentContainerStyle={{
           flexGrow: 1,
-          justifyContent: !conversations.length ? "center" : "flex-start",
+          justifyContent: "flex-start",
         }}
         ListEmptyComponent={<NoMessages />}
       />


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Fixes the layout of inbox empty state.

Before:
![inbox-before](https://github.com/artsy/eigen/assets/49686530/bd901407-0cc9-45c6-b3ea-5542c86be36c)

After:
![inbox after](https://github.com/artsy/eigen/assets/49686530/8ab78bd8-6dbf-48f0-83f8-1924928d1493)


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix inbox empty state - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
