### PR TITLE
chore: check-code ci job uses danger-github-oss context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,6 +413,7 @@ jobs:
       - run:
           name: Release app version
           command: ./scripts/release-ios-app-branch
+
 workflows:
   version: 2
   nightly:
@@ -470,6 +471,7 @@ workflows:
                 - play_store_submission
 
       - check-code:
+          context: danger-github-oss
           filters:
             branches:
               ignore:
@@ -485,6 +487,7 @@ workflows:
               ignore:
                 - app_store_submission
                 - play_store_submission
+
       - horizon/block:
           context: horizon
           project_id: 37


### PR DESCRIPTION
This PR resolves [PHIRE-82](https://artsyproduct.atlassian.net/browse/PHIRE-82) <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This switches the CI `check-code` job to read _danger github token_ from CircleCI contexts. By my understanding, that is the only job that requires this var.

### PR Checklist

~- [ ] I have tested my changes on **iOS** and **Android**.~
~- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.~
~- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.~
~- [ ] I have added **tests**, or my changes don't require any.~
~- [ ] I added an **[app state migration]**, or my changes do not require one.~
~- [ ] I have added a **changelog entry** below, or my changes do not require one.~
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any

### To the reviewers 👀

~- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.~

### To the Assignee 👀 

❗ Migration: ❗
- [ ] unset [`DANGER_GITHUB_API_TOKEN` CircleCI project environment variable](https://app.circleci.com/settings/project/github/artsy/eigen/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fartsy%2Feigen) before merging

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-82]: https://artsyproduct.atlassian.net/browse/PHIRE-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ