### PR TITLE
fix: disable tab scroll on Profile screen

### DIFF
--- a/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks.tsx
@@ -60,6 +60,12 @@ export const MyProfileHeaderMyCollectionAndSavedWorks: React.FC<Props> = ({ init
                 setVisualClueAsSeen("MyCollectionInsights")
               }
             }}
+            // FYI: We're disabling horizontal scroll between Profile tabs as it
+            // conflicts with the horizontal scroll of the Artists rail within
+            // the My Collection tab.
+            pagerProps={{
+              scrollEnabled: false,
+            }}
           >
             <Tabs.Tab name={Tab.collection} label={Tab.collection}>
               <Tabs.Lazy>


### PR DESCRIPTION
### Description

Disable horizontal scroll between Profile tabs as it conflicts with the horizontal scroll of the Artists rail within the My Collection tab.

This PR resolves [ONYX-233](https://artsyproduct.atlassian.net/browse/ONYX-233)

cc/ @MounirDhahri @olerichter00 

| Before | After |
|--------|--------|
| <video src="https://github.com/artsy/eigen/assets/123595/9c05ac6a-c4ec-4903-b7a0-0707099e107b" /> | <video src="https://github.com/artsy/eigen/assets/123595/9d3caa92-ce0f-42a7-b797-880a7ea5d567" /> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: disable scroll between Profile screen tabs to avoid conflict with My Collection artists rail - devon

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-233]: https://artsyproduct.atlassian.net/browse/ONYX-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ