### PR TITLE
refactor: use screen component to get rid of extra margins on iOS

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -451,7 +451,10 @@ export const modules = defineModules({
   Feature: reactModule(FeatureQueryRenderer, { fullBleed: true }),
   FullArtistSeriesList: reactModule(ArtistSeriesFullArtistSeriesListQueryRenderer),
   FullFeaturedArtistList: reactModule(CollectionFullFeaturedArtistListQueryRenderer),
-  GalleriesForYou: reactModule(GalleriesForYouScreen),
+  GalleriesForYou: reactModule(GalleriesForYouScreen, {
+    fullBleed: true,
+    hidesBackButton: true,
+  }),
   Gene: reactModule(GeneQueryRenderer, {
     fullBleed: true,
     hidesBackButton: true,

--- a/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
+++ b/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
@@ -1,11 +1,12 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Flex, Spacer, Text, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
+import { Flex, Screen, Spacer, Text, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { GalleriesForYouScreenQuery } from "__generated__/GalleriesForYouScreenQuery.graphql"
 import { GalleriesForYouScreen_partnersConnection$key } from "__generated__/GalleriesForYouScreen_partnersConnection.graphql"
 import {
   MAX_PARTNER_LIST_ITEM_WIDTH,
   PartnerListItem,
 } from "app/Scenes/GalleriesForYou/Components/PartnerListItem"
+import { goBack } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { isPad } from "app/utils/hardware"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
@@ -14,10 +15,9 @@ import { PlaceholderBox, ProvidePlaceholderContext } from "app/utils/placeholder
 import { useRefreshControl } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
-import { useStickyScrollHeader } from "app/utils/useStickyScrollHeader"
 import { times } from "lodash"
 import { Suspense, useEffect, useState } from "react"
-import { ActivityIndicator, Animated } from "react-native"
+import { ActivityIndicator } from "react-native"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
 interface GalleriesForYouProps {
@@ -47,16 +47,6 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
 
   const partners = extractNodes(data.partnersConnection)
 
-  const { headerElement, scrollProps } = useStickyScrollHeader({
-    header: (
-      <Flex flex={1} pl={6} pr={4} pt={0.5}>
-        <Text variant="sm" numberOfLines={1} style={{ flexShrink: 1 }}>
-          Galleries For You
-        </Text>
-      </Flex>
-    ),
-  })
-
   // Refetch in case the user doesn't follow artists and there are no results
   // This will show results even in case the user doesn't follow any artists
   const [hasRefetched, setHasRefetched] = useState(false)
@@ -80,39 +70,39 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
     <ProvideScreenTrackingWithCohesionSchema
       info={screen({ context_screen_owner_type: OwnerType.galleriesForYou })}
     >
-      <Flex mb={2}>
-        {!!visualizeLocation && (
-          <Text ml={6} color="red">
-            Location: {location ? JSON.stringify(location) : "Using IP-based location"}
-          </Text>
-        )}
-
-        <Animated.FlatList
-          data={partners}
-          ListHeaderComponent={<GalleriesForYouHeader />}
-          refreshControl={RefreshControl}
-          onEndReached={() => loadNext(GalleriesForYouQueryVariables.count)}
-          renderItem={({ item }) => {
-            return <PartnerListItem partner={item} userLocation={userLocation} />
-          }}
-          keyExtractor={(item) => item.internalID}
-          ItemSeparatorComponent={() => <Spacer y={4} />}
-          ListFooterComponent={() => (
-            <Flex
-              alignItems="center"
-              justifyContent="center"
-              p={4}
-              pb={6}
-              style={{ opacity: isLoadingNext && hasNext ? 1 : 0 }}
-            >
-              <ActivityIndicator />
-            </Flex>
+      <Screen>
+        <Screen.AnimatedHeader title="Galeries For You" onBack={goBack} />
+        <Screen.Body fullwidth>
+          {!!visualizeLocation && (
+            <Text ml={6} color="red">
+              Location: {location ? JSON.stringify(location) : "Using IP-based location"}
+            </Text>
           )}
-          {...scrollProps}
-        />
 
-        {headerElement}
-      </Flex>
+          <Screen.FlatList
+            data={partners}
+            ListHeaderComponent={<GalleriesForYouHeader />}
+            refreshControl={RefreshControl}
+            onEndReached={() => loadNext(GalleriesForYouQueryVariables.count)}
+            renderItem={({ item }) => {
+              return <PartnerListItem partner={item} userLocation={userLocation} />
+            }}
+            keyExtractor={(item) => item.internalID}
+            ItemSeparatorComponent={() => <Spacer y={4} />}
+            ListFooterComponent={() => (
+              <Flex
+                alignItems="center"
+                justifyContent="center"
+                p={4}
+                pb={6}
+                style={{ opacity: isLoadingNext && hasNext ? 1 : 0 }}
+              >
+                <ActivityIndicator />
+              </Flex>
+            )}
+          />
+        </Screen.Body>
+      </Screen>
     </ProvideScreenTrackingWithCohesionSchema>
   )
 }
@@ -196,7 +186,7 @@ const GalleriesForYouQuery = graphql`
 
 const GalleriesForYouHeader: React.FC = () => {
   return (
-    <Flex mx={2} mb={4} mt={6}>
+    <Flex mx={2} mb={4}>
       <Text variant="lg-display" mb={0.5}>
         Galleries For You
       </Text>
@@ -215,29 +205,33 @@ const GalleriesForYouPlaceholder: React.FC = () => {
 
   return (
     <ProvidePlaceholderContext>
-      <Flex testID="PlaceholderGrid">
-        <GalleriesForYouHeader />
+      <Screen testID="PlaceholderGrid">
+        <Screen.Header onBack={goBack} />
+        <Screen.Body fullwidth>
+          <GalleriesForYouHeader />
 
-        <Flex px={2} mx="auto">
-          {times(5).map((i) => {
-            return (
-              <Flex mb={4} key={i}>
-                <PlaceholderBox width={width} height={width / 1.33} />
-                <Spacer y={1} />
-                <PlaceholderBox width={width} height={60} />
-              </Flex>
-            )
-          })}
-        </Flex>
-      </Flex>
+          <Flex px={2} mx="auto">
+            {times(5).map((i) => {
+              return (
+                <Flex mb={4} key={i}>
+                  <PlaceholderBox width={width} height={width / 1.33} />
+                  <Spacer y={1} />
+                  <PlaceholderBox width={width} height={60} />
+                </Flex>
+              )
+            })}
+          </Flex>
+        </Screen.Body>
+      </Screen>
     </ProvidePlaceholderContext>
   )
 }
 
 const NoGalleries: React.FC = () => (
-  <Flex>
+  <Screen>
+    <Screen.Header onBack={goBack} />
     <GalleriesForYouHeader />
 
     <Text mx={2}>Sorry, we couldn’t find any results for you.</Text>
-  </Flex>
+  </Screen>
 )

--- a/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
+++ b/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
@@ -62,10 +62,6 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
     setHasRefetched(true)
   }, [partners])
 
-  if (!partners.length) {
-    return <NoGalleries />
-  }
-
   return (
     <ProvideScreenTrackingWithCohesionSchema
       info={screen({ context_screen_owner_type: OwnerType.galleriesForYou })}
@@ -100,6 +96,7 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
                 <ActivityIndicator />
               </Flex>
             )}
+            ListEmptyComponent={() => <NoGalleries />}
           />
         </Screen.Body>
       </Screen>
@@ -227,11 +224,4 @@ const GalleriesForYouPlaceholder: React.FC = () => {
   )
 }
 
-const NoGalleries: React.FC = () => (
-  <Screen>
-    <Screen.Header onBack={goBack} />
-    <GalleriesForYouHeader />
-
-    <Text mx={2}>Sorry, we couldn’t find any results for you.</Text>
-  </Screen>
-)
+const NoGalleries: React.FC = () => <Text mx={2}>Sorry, we couldn’t find any results for you.</Text>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Refactors the Galleries For You screen to use the `<Screen />` component and to use the animated headers for consistency.

Also uses the ListEmptyComponent for the empty state.

Margin that we wanted to get rid of:
<img width="300" src="https://github.com/artsy/eigen/assets/21178754/c0d1dc64-c6bd-4c84-ae39-98f57eec947a" />

### Screenshots





#### Android

|Placeholder|Screen video|empty state|
|---|---|---|
|<img width="363" alt="Screenshot 2023-08-09 at 09 55 46" src="https://github.com/artsy/eigen/assets/21178754/0cf0fb12-02ee-4166-b470-4eb45255788b">|<video src="https://github.com/artsy/eigen/assets/21178754/d4476e9a-8be9-48cd-bddd-f67d77decc6a" width="300" />|<img width="362" alt="Screenshot 2023-08-09 at 09 55 08" src="https://github.com/artsy/eigen/assets/21178754/39ed6cda-924c-4903-8be7-781e95506e6c">|

#### iOS

|Placeholder|Screen video|empty state|
|---|---|---|
|![Simulator Screenshot - iPhone 14 - 2023-08-09 at 09 57 48](https://github.com/artsy/eigen/assets/21178754/336121d5-2f99-4389-b145-8cfecacbcd9b)|<video src="https://github.com/artsy/eigen/assets/21178754/0d31e23d-40af-4916-9f19-f47b8f70d7cc" width="300" />|![Simulator Screenshot - iPhone 14 - 2023-08-09 at 09 58 18](https://github.com/artsy/eigen/assets/21178754/ebbfeabc-db6e-4cd1-b498-87e2dca722dd)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- refactor: use screen component galleries for you - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
