### PR TITLE
fix: pass GCC_PREPROCESSOR_DEFINITIONS flag to skip flipper on test ios job

### DIFF
--- a/scripts/test-ios
+++ b/scripts/test-ios
@@ -4,6 +4,6 @@ set -euxo pipefail
 
 source ./scripts/source-for-bash-env
 
-xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Debug test -sdk iphonesimulator -destination platform="$DEVICE_HOST_PLAT",OS="$DEVICE_HOST_OS",name="$DEVICE_HOST_NAME" -derivedDataPath "$DERIVED_DATA_PATH" |
+xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -configuration Debug test -sdk iphonesimulator -destination platform="$DEVICE_HOST_PLAT",OS="$DEVICE_HOST_OS",name="$DEVICE_HOST_NAME" -derivedDataPath "$DERIVED_DATA_PATH" GCC_PREPROCESSOR_DEFINITIONS='$(inherited) CI_DISABLE_FLIPPER=1' |
 	tee ./xcode_test_raw.log |
 	bundle exec xcpretty -c --test --report junit --output ./test-results.xml


### PR DESCRIPTION

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Follow up from https://github.com/artsy/eigen/pull/9133

Fix broken tests due to missing flipper, adding a flag as we did [here](https://github.com/artsy/eigen/pull/9133/files#diff-ba93086cec5cca28644b617308de2b9ecf41ad09a97efeeb320bc63b1b3f05ffR8) to avoid from happening again

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
#nochangelog