### PR TITLE
fix(ONYX-225): show showAddToMyCollectionBottomSheet on the MyC empty state

### DIFF
--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -65,7 +65,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
       <Text variant="sm-display" mb={1}>
         Please try again
       </Text>
-      {isStaging && <Box mb={1} border={2} width={200} borderColor="devpurple" />}
+      {!!isStaging && <Box mb={1} border={2} width={200} borderColor="devpurple" />}
       <Touchable
         onPress={debounce(() => {
           if (!isAnimating) {

--- a/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionZeroState.tsx
@@ -2,9 +2,11 @@ import { ActionType, AddCollectedArtwork, ContextModule, OwnerType } from "@arts
 import { useSpace, Flex, LockIcon, Button, Text, Tabs, Box } from "@artsy/palette-mobile"
 import { ZeroState } from "app/Components/States/ZeroState"
 import { ModalCarousel } from "app/Scenes/Home/Components/ModalCarouselComponents/ModalCarousel"
+import { MyCollectionTabsStore } from "app/Scenes/MyCollection/State/MyCollectionTabsStore"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { navigate } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { debounce } from "lodash"
 import { useState } from "react"
 import { Image } from "react-native"
 import { useTracking } from "react-tracking"
@@ -16,7 +18,13 @@ export const MyCollectionZeroState: React.FC = () => {
 
   const [isMyCollectionModalVisible, setIsMyCollectionModalVisible] = useState(false)
 
+  const setViewKind = MyCollectionTabsStore.useStoreActions((actions) => actions.setViewKind)
+
   const image = require("images/my-collection-empty-state.webp")
+
+  const showAddToMyCollectionBottomSheet = debounce(() => {
+    setViewKind({ viewKind: "Add" })
+  }, 100)
 
   return (
     <Tabs.ScrollView contentContainerStyle={{ flexGrow: 1 }}>
@@ -45,11 +53,7 @@ export const MyCollectionZeroState: React.FC = () => {
                   testID="add-artwork-button-zero-state"
                   onPress={() => {
                     trackEvent(tracks.addCollectedArtwork())
-                    navigate("my-collection/artworks/new", {
-                      passProps: {
-                        source: Tab.collection,
-                      },
-                    })
+                    showAddToMyCollectionBottomSheet()
                   }}
                   block
                 >


### PR DESCRIPTION
This PR resolves [ONYX-225] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Show showAddToMyCollectionBottomSheet (modal with Add Artist and Add Artwork buttons) on the MyC empty state instead of navigating to Add Artist screen
Slack thread: https://artsy.slack.com/archives/C05EQL4R5N0/p1691572134461639

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- show modal with Add Artist and Add Artwork buttons on the MyC empty state -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-225]: https://artsyproduct.atlassian.net/browse/ONYX-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ