### PR TITLE
Revert "fix: Preload Shows for You rail"

### DIFF
--- a/src/app/Scenes/Home/Components/ShowsRail.tsx
+++ b/src/app/Scenes/Home/Components/ShowsRail.tsx
@@ -8,9 +8,8 @@ import { extractNodes } from "app/utils/extractNodes"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { Location, useLocation } from "app/utils/hooks/useLocation"
 import { PlaceholderBox, RandomWidthPlaceholderText } from "app/utils/placeholders"
-import { prefetchQuery } from "app/utils/queryPrefetching"
 import { times } from "lodash"
-import { Suspense, memo, useEffect } from "react"
+import { Suspense, memo } from "react"
 import { FlatList } from "react-native"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -27,7 +26,9 @@ const NUMBER_OF_SHOWS = 10
 export const ShowsRail: React.FC<ShowsRailProps> = memo(({ disableLocation, location, title }) => {
   const tracking = useTracking()
 
-  const queryVariables = getQueryVariables(location, disableLocation)
+  const queryVariables = location
+    ? { near: location }
+    : { includeShowsNearIpBasedLocation: !disableLocation && !location }
 
   const queryData = useLazyLoadQuery<ShowsRailQuery>(ShowsQuery, queryVariables)
 
@@ -165,25 +166,4 @@ const ShowsRailPlaceholder: React.FC = () => {
       </Flex>
     </Flex>
   )
-}
-
-const getQueryVariables = (location: Location | null | undefined, disableLocation: boolean) => {
-  return location
-    ? { near: location }
-    : { includeShowsNearIpBasedLocation: !disableLocation && !location }
-}
-
-export const usePreloadShowsRail = (disableLocation: boolean) => {
-  const { location, isLoading } = useLocation({
-    disabled: disableLocation,
-    skipPermissionRequests: true,
-  })
-
-  useEffect(() => {
-    if (!isLoading) {
-      return
-    }
-
-    prefetchQuery(ShowsQuery, getQueryVariables(location, disableLocation))
-  }, [isLoading])
 }

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -43,7 +43,7 @@ import { MeetYourNewAdvisorRail } from "app/Scenes/Home/Components/MeetYourNewAd
 import { NewWorksForYouRail } from "app/Scenes/Home/Components/NewWorksForYouRail"
 import { OldCollectionsRailFragmentContainer } from "app/Scenes/Home/Components/OldCollectionsRail"
 import { SalesRailFragmentContainer } from "app/Scenes/Home/Components/SalesRail"
-import { ShowsRailContainer, usePreloadShowsRail } from "app/Scenes/Home/Components/ShowsRail"
+import { ShowsRailContainer } from "app/Scenes/Home/Components/ShowsRail"
 import { RailScrollRef } from "app/Scenes/Home/Components/types"
 import {
   DEFAULT_RECS_MODEL_VERSION,
@@ -176,9 +176,6 @@ const Home = memo((props: HomeProps) => {
   const enableRailViewsTrackingExperiment = useExperimentVariant(
     "CX-impressions-tracking-home-rail-views"
   )
-
-  // Preloading the Shows for You rail to avoid loading it when the user scrolls. This is needed because it has it's own query renderer.
-  usePreloadShowsRail(enableShowsForYouLocation)
 
   // Make sure to include enough modules in the above-the-fold query to cover the whole screen!.
   const { modules, allModulesKeys } = useHomeModules(props)

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -45,7 +45,7 @@ async function isRateLimited() {
   return remainingRequests < 0
 }
 
-export const prefetchQuery = async (query: GraphQLTaggedNode, variables?: Variables) => {
+const prefetchQuery = async (query: GraphQLTaggedNode, variables?: Variables) => {
   const environment = getRelayEnvironment()
   const operation = createOperationDescriptor(getRequest(query), variables ?? {})
 


### PR DESCRIPTION
Reverts artsy/eigen#9064

---

To prevent exceeding the API limit for IP-based geo lookup, we should disable the prefetching for now.