### PR TITLE
fix: do not show onboarding modal unless tab is active

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -28,6 +28,7 @@ export interface BottomTabsModel {
   setUnseenNotificationsCount: Action<BottomTabsModel, number>
   fetchNotificationsInfo: Thunk<BottomTabsModel>
   setTabProps: Action<BottomTabsModel, { tab: BottomTabType; props: object | undefined }>
+  setSelectedTab: Action<BottomTabsModel, BottomTabType>
   hasUnseenNotifications: Computed<this, boolean>
 }
 
@@ -129,6 +130,9 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
   }),
   setTabProps: action((state, { tab, props }) => {
     state.sessionState.tabProps[tab] = props
+  }),
+  setSelectedTab: action((state, payload) => {
+    state.sessionState.selectedTab = payload
   }),
   hasUnseenNotifications: computed((state) => state.sessionState.unseenCounts.notifications > 0),
 })

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
@@ -1,8 +1,7 @@
 import { Button, Flex, Text } from "@artsy/palette-mobile"
-import { useIsFocused } from "@react-navigation/native"
-import { GlobalStore } from "app/store/GlobalStore"
 import { VisualCluesConstMap } from "app/store/config/visualClues"
 import { navigate } from "app/system/navigation/navigate"
+import { useIsFocusedInTab } from "app/utils/hooks/useIsFocusedInTab"
 import { setVisualClueAsSeen, useVisualClue } from "app/utils/hooks/useVisualClue"
 import React, { useEffect, useState } from "react"
 import { Image, Modal } from "react-native"
@@ -11,8 +10,7 @@ import { SafeAreaView } from "react-native-safe-area-context"
 export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
   const { showVisualClue } = useVisualClue()
   const [showModal, setShowModal] = useState(false)
-  const isFocused = useIsFocused()
-  const activeTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
+  const isFocused = useIsFocusedInTab("profile")
 
   const showMyCollectionCollectedArtistsOnboarding = !!showVisualClue(
     "MyCollectionArtistsCollectedOnboarding"
@@ -21,7 +19,7 @@ export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
   useEffect(() => {
     // Only show the modal after a delay to avoid hiding my collection content immediately
     const showModalTimeout = setTimeout(() => {
-      if (activeTab === "profile" || isFocused) {
+      if (isFocused) {
         setShowModal(true)
       }
     }, 1000)
@@ -29,7 +27,7 @@ export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
     return () => {
       clearTimeout(showModalTimeout)
     }
-  }, [activeTab, isFocused])
+  }, [isFocused])
 
   if (!showMyCollectionCollectedArtistsOnboarding || !showModal) {
     return null

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
@@ -1,4 +1,6 @@
 import { Button, Flex, Text } from "@artsy/palette-mobile"
+import { useIsFocused } from "@react-navigation/native"
+import { GlobalStore } from "app/store/GlobalStore"
 import { VisualCluesConstMap } from "app/store/config/visualClues"
 import { navigate } from "app/system/navigation/navigate"
 import { setVisualClueAsSeen, useVisualClue } from "app/utils/hooks/useVisualClue"
@@ -9,6 +11,8 @@ import { SafeAreaView } from "react-native-safe-area-context"
 export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
   const { showVisualClue } = useVisualClue()
   const [showModal, setShowModal] = useState(false)
+  const isFocused = useIsFocused()
+  const activeTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
 
   const showMyCollectionCollectedArtistsOnboarding = !!showVisualClue(
     "MyCollectionArtistsCollectedOnboarding"
@@ -17,7 +21,9 @@ export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
   useEffect(() => {
     // Only show the modal after a delay to avoid hiding my collection content immediately
     const showModalTimeout = setTimeout(() => {
-      setShowModal(true)
+      if (activeTab === "profile" || isFocused) {
+        setShowModal(true)
+      }
     }, 1000)
 
     return () => {

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsOnboardingModal.tsx
@@ -29,7 +29,7 @@ export const MyCollectionCollectedArtistsOnboardingModal: React.FC<{}> = () => {
     return () => {
       clearTimeout(showModalTimeout)
     }
-  }, [])
+  }, [activeTab, isFocused])
 
   if (!showMyCollectionCollectedArtistsOnboarding || !showModal) {
     return null

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -152,6 +152,7 @@ export function switchTab(tab: BottomTabType, props?: object) {
   if (props) {
     GlobalStore.actions.bottomTabs.setTabProps({ tab, props })
   }
+  GlobalStore.actions.bottomTabs.setSelectedTab(tab)
   LegacyNativeModules.ARScreenPresenterModule.switchTab(tab)
   saveDevNavigationStateSelectedTab(tab)
 }

--- a/src/app/utils/hooks/useIsFocusedInTab.ts
+++ b/src/app/utils/hooks/useIsFocusedInTab.ts
@@ -1,0 +1,10 @@
+import { useIsFocused } from "@react-navigation/native"
+import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
+import { GlobalStore } from "app/store/GlobalStore"
+
+export const useIsFocusedInTab = (tab: BottomTabType) => {
+  const isFocused = useIsFocused()
+  const activeTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
+
+  return isFocused && activeTab === tab
+}


### PR DESCRIPTION
This PR resolves [this issue](https://artsy.slack.com/archives/C05EQL4R5N0/p1692019426486269) <!-- eg [PROJECT-XXXX] -->

### Description

When the user moves from Home to My Collection and back to Home quickly, the first time modal (Share artists you collect) shows up, and after clicking the button the app becomes unresponsive, until the user kills the app.

Suggested approach: only show the modal if the user did move to a different screen.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- do not show onboarding modal unless tab is active - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
