### PR TITLE
feat: Use generated displayName in Saved Search form

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
@@ -83,7 +83,6 @@ describe("computeArtworkAlertProps", () => {
         additionalGeneIDs: ["test-gene"],
       },
       entity: {
-        placeholder: "foo",
         artists: [{ id: "bar", name: "foo" }],
         owner: { type: "artwork", id: "2", slug: "test-artwork" },
       },
@@ -102,7 +101,6 @@ describe("computeArtworkAlertProps", () => {
         additionalGeneIDs: [],
       },
       entity: {
-        placeholder: "foo",
         artists: [{ id: "bar", name: "foo" }],
         owner: { type: "artwork", id: "2", slug: "test-artwork" },
       },

--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
@@ -89,7 +89,6 @@ export const computeArtworkAlertProps = (artwork: CreateArtworkAlertModal_artwor
   }))
 
   const entity: SavedSearchEntity = {
-    placeholder: artists[0]?.name ?? "",
     artists: formattedArtists,
     owner: {
       type: OwnerType.artwork,

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -57,7 +57,6 @@ jest.mock("@react-navigation/native", () => {
 })
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "Placeholder",
   artists: [{ id: "artistId", name: "artistName" }],
   owner: {
     type: OwnerType.artist,

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -1,16 +1,16 @@
 import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
-import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
+import { TransitionPresets, createStackNavigator } from "@react-navigation/stack"
 import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
 import {
-  changedFiltersParams,
   FilterArray,
-  filterArtworksParams,
   FilterParamName,
   FilterParams,
-  getUnitedSelectedAndAppliedFilters,
   ParamDefaultValues,
+  changedFiltersParams,
+  filterArtworksParams,
+  getUnitedSelectedAndAppliedFilters,
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { AdditionalGeneIDsOptionsScreen } from "app/Components/ArtworkFilter/Filters/AdditionalGeneIDsOptions"
@@ -38,8 +38,8 @@ import { useEffect, useState } from "react"
 import { ViewProps } from "react-native"
 import { useTracking } from "react-tracking"
 import {
-  ArtworkFilterOptionsScreen,
   FilterModalMode as ArtworkFilterMode,
+  ArtworkFilterOptionsScreen,
 } from "./ArtworkFilterOptionsScreen"
 import { AuctionHouseOptionsScreen } from "./Filters/AuctionHouseOptions"
 import { LocationCitiesOptionsScreen } from "./Filters/LocationCitiesOptions"
@@ -107,7 +107,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   const [isCreateAlertModalVisible, setIsCreateAlertModalVisible] = useState(false)
 
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: name!,
     artists: [{ id: id!, name: name! }],
     owner: {
       type: OwnerType.artist,

--- a/src/app/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers.tests.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers.tests.ts
@@ -288,7 +288,6 @@ describe("getSearchCriteriaFromFilters", () => {
 
   it("returns fields in the saved search criteria format", () => {
     const savedSearchEntity: SavedSearchEntity = {
-      placeholder: "placeholder",
       artists: [firstArtist],
       owner,
     }
@@ -302,7 +301,6 @@ describe("getSearchCriteriaFromFilters", () => {
 
   it("returns fields in the saved search criteria format for multiple artists", () => {
     const savedSearchEntity: SavedSearchEntity = {
-      placeholder: "placeholder",
       artists: [firstArtist, secondArtist],
       owner,
     }
@@ -316,7 +314,6 @@ describe("getSearchCriteriaFromFilters", () => {
 
   it("returns single artist id", () => {
     const savedSearchEntity: SavedSearchEntity = {
-      placeholder: "placeholder",
       artists: [firstArtist],
       owner,
     }
@@ -328,7 +325,6 @@ describe("getSearchCriteriaFromFilters", () => {
 
   it("returns multiple artist ids", () => {
     const savedSearchEntity: SavedSearchEntity = {
-      placeholder: "placeholder",
       artists: [firstArtist, secondArtist],
       owner,
     }

--- a/src/app/Components/ArtworkFilter/SavedSearch/types.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/types.ts
@@ -1,4 +1,5 @@
 import { ScreenOwnerType } from "@artsy/cohesion"
+import { ArtworkSizes } from "__generated__/FormQuery.graphql"
 
 export enum SearchCriteria {
   artistID = "artistID",
@@ -35,7 +36,7 @@ export interface SearchCriteriaAttributes {
   [SearchCriteria.inquireableOnly]?: boolean | null
   [SearchCriteria.offerable]?: boolean | null
   [SearchCriteria.dimensionRange]?: string | null
-  [SearchCriteria.sizes]?: string[] | null
+  [SearchCriteria.sizes]?: ArtworkSizes[] | null
   [SearchCriteria.height]?: string | null
   [SearchCriteria.width]?: string | null
   [SearchCriteria.materialsTerms]?: string[] | null
@@ -54,7 +55,6 @@ export interface SavedSearchEntityOwner {
 }
 
 export interface SavedSearchEntity {
-  placeholder: string
   artists: SavedSearchEntityArtist[]
   owner: SavedSearchEntityOwner
 }

--- a/src/app/Components/ArtworkFilter/SavedSearch/types.ts
+++ b/src/app/Components/ArtworkFilter/SavedSearch/types.ts
@@ -1,5 +1,5 @@
 import { ScreenOwnerType } from "@artsy/cohesion"
-import { ArtworkSizes } from "__generated__/FormQuery.graphql"
+import { ArtworkSizes } from "__generated__/SavedSearchNameInputQuery.graphql"
 
 export enum SearchCriteria {
   artistID = "artistID",

--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -22,7 +22,6 @@ import {
 } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { navigate } from "app/system/navigation/navigate"
-import { useExperimentFlag } from "app/utils/experiments/hooks"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
 import { omit } from "lodash"
@@ -68,13 +67,12 @@ export const Form: React.FC<FormProps> = ({
       }
     `,
     {
-      // TODO: Check why typing don't work and dimensionRange attribute is allowed.
       attributes: omit(attributes, ["displayName", "dimensionRange"]),
     }
   )
 
-  const isFallbackToGeneratedAlertNamesEnabled = useExperimentFlag(
-    "onyx_force-fallback-to-generated-alert-names"
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "AREnableFallbackToGeneratedAlertNames"
   )
   const entity = SavedSearchStore.useStoreState((state) => state.entity)
   const { isSubmitting, values, errors, dirty, handleBlur, handleChange } =

--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -101,8 +101,6 @@ export const Form: React.FC<FormProps> = ({
     })
   }
 
-  console.log({ attributes1: attributes })
-
   const isArtistPill = (pill: SavedSearchPill) => pill.paramName === SearchCriteria.artistID
 
   return (

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
@@ -45,8 +45,6 @@ interface SavedSearchNameInputQueryRendererProps {
 export const SavedSearchNameInputQueryRenderer: React.FC<
   SavedSearchNameInputQueryRendererProps
 > = ({ attributes }) => {
-  console.log({ attributes2: attributes })
-
   return (
     <QueryRenderer<SavedSearchNameInputQuery>
       environment={getRelayEnvironment()}

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
@@ -1,0 +1,72 @@
+import { Input } from "@artsy/palette-mobile"
+import { SavedSearchNameInputQuery } from "__generated__/SavedSearchNameInputQuery.graphql"
+import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { SavedSearchAlertFormValues } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useFormikContext } from "formik"
+import { omit } from "lodash"
+import { useEffect, useState } from "react"
+import { QueryRenderer } from "react-relay"
+import { graphql } from "relay-runtime"
+interface SavedSearchNameInputProps {
+  placeholder?: string
+}
+
+export const SavedSearchNameInput: React.FC<SavedSearchNameInputProps> = ({ placeholder }) => {
+  const { values, errors, handleBlur, handleChange } =
+    useFormikContext<SavedSearchAlertFormValues>()
+
+  const [placeholderState, setPlaceholderState] = useState(placeholder)
+
+  useEffect(() => {
+    if (placeholder) {
+      setPlaceholderState(placeholder)
+    }
+  })
+
+  return (
+    <Input
+      title="Name"
+      placeholder={placeholderState}
+      value={values.name}
+      onChangeText={handleChange("name")}
+      onBlur={handleBlur("name")}
+      error={errors.name}
+      testID="alert-input-name"
+      maxLength={75}
+    />
+  )
+}
+
+interface SavedSearchNameInputQueryRendererProps {
+  attributes: SearchCriteriaAttributes
+}
+
+export const SavedSearchNameInputQueryRenderer: React.FC<
+  SavedSearchNameInputQueryRendererProps
+> = ({ attributes }) => {
+  console.log({ attributes2: attributes })
+
+  return (
+    <QueryRenderer<SavedSearchNameInputQuery>
+      environment={getRelayEnvironment()}
+      query={graphql`
+        query SavedSearchNameInputQuery($attributes: PreviewSavedSearchAttributes!) {
+          previewSavedSearch(attributes: $attributes) {
+            displayName
+          }
+        }
+      `}
+      variables={{
+        attributes: omit(attributes, ["displayName", "dimensionRange"]),
+      }}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+        }
+
+        return <SavedSearchNameInput placeholder={props?.previewSavedSearch?.displayName} />
+      }}
+    />
+  )
+}

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -109,17 +109,27 @@ describe("CreateSavedSearchAlert", () => {
   it("renders without throwing an error", async () => {
     const { getByText } = renderWithWrappers(<TestRenderer />)
 
-    resolveMostRecentRelayOperation(mockEnvironment)
+    await waitFor(() => {
+      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
+    })
 
     expect(getByText("Bid")).toBeTruthy()
     expect(getByText("Open Edition")).toBeTruthy()
   })
 
-  it("should call onClosePress handler when the close button is pressed", () => {
+  it("should call onClosePress handler when the close button is pressed", async () => {
     const onClosePressMock = jest.fn()
     const { getByTestId } = renderWithWrappers(<TestRenderer onClosePress={onClosePressMock} />)
 
-    resolveMostRecentRelayOperation(mockEnvironment)
+    await waitFor(() => {
+      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
+    })
     fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
     expect(onClosePressMock).toBeCalled()
@@ -133,7 +143,12 @@ describe("CreateSavedSearchAlert", () => {
       <TestRenderer onComplete={onCompleteMock} />
     )
 
-    resolveMostRecentRelayOperation(mockEnvironment)
+    await waitFor(() => {
+      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
+    })
 
     fireEvent.changeText(getByTestId("alert-input-name"), "something new")
     fireEvent.press(getByText("Save Alert"))
@@ -164,12 +179,17 @@ describe("CreateSavedSearchAlert", () => {
       setStatusForPushNotifications(PushAuthorizationStatus.Authorized)
       renderWithWrappers(<TestRenderer />)
 
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Viewer: () => ({
-          notificationPreferences: [
-            { status: "SUBSCRIBED", name: "custom_alerts", channel: "email" },
-          ],
-        }),
+      await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          PreviewSavedSearch: () => ({ displayName: "Banana" }),
+        })
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Viewer: () => ({
+            notificationPreferences: [
+              { status: "SUBSCRIBED", name: "custom_alerts", channel: "email" },
+            ],
+          }),
+        })
       })
 
       await flushPromiseQueue()
@@ -183,12 +203,17 @@ describe("CreateSavedSearchAlert", () => {
       setStatusForPushNotifications(PushAuthorizationStatus.Authorized)
       renderWithWrappers(<TestRenderer />)
 
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Viewer: () => ({
-          notificationPreferences: [
-            { status: "UNSUBSCRIBED", name: "custom_alerts", channel: "email" },
-          ],
-        }),
+      await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          PreviewSavedSearch: () => ({ displayName: "Banana" }),
+        })
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          Viewer: () => ({
+            notificationPreferences: [
+              { status: "UNSUBSCRIBED", name: "custom_alerts", channel: "email" },
+            ],
+          }),
+        })
       })
 
       await flushPromiseQueue()
@@ -198,9 +223,15 @@ describe("CreateSavedSearchAlert", () => {
       })
     })
 
-    it("push toggle is enabled by default when push permissions are enabled", () => {
+    it("push toggle is enabled by default when push permissions are enabled", async () => {
       setStatusForPushNotifications(PushAuthorizationStatus.Authorized)
       renderWithWrappers(<TestRenderer />)
+
+      await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          PreviewSavedSearch: () => ({ displayName: "Banana" }),
+        })
+      })
 
       expect(screen.queryByLabelText("Mobile Alerts Toggler")).toHaveProp("accessibilityState", {
         selected: true,

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -7,6 +7,7 @@ import {
   getArtworkFiltersModel,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { SavedSearchEntity } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -67,6 +68,10 @@ const defaultParams: CreateSavedSearchAlertParams = {
 }
 
 describe("CreateSavedSearchAlert", () => {
+  __globalStoreTestUtils__?.injectFeatureFlags({
+    AREnableFallbackToGeneratedAlertNames: true,
+  })
+
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
@@ -111,9 +116,6 @@ describe("CreateSavedSearchAlert", () => {
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment)
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        PreviewSavedSearch: () => ({ displayName: "Banana" }),
-      })
     })
 
     expect(getByText("Bid")).toBeTruthy()
@@ -126,9 +128,6 @@ describe("CreateSavedSearchAlert", () => {
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment)
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        PreviewSavedSearch: () => ({ displayName: "Banana" }),
-      })
     })
     fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
@@ -145,9 +144,6 @@ describe("CreateSavedSearchAlert", () => {
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment)
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        PreviewSavedSearch: () => ({ displayName: "Banana" }),
-      })
     })
 
     fireEvent.changeText(getByTestId("alert-input-name"), "something new")
@@ -181,9 +177,6 @@ describe("CreateSavedSearchAlert", () => {
 
       await waitFor(() => {
         resolveMostRecentRelayOperation(mockEnvironment, {
-          PreviewSavedSearch: () => ({ displayName: "Banana" }),
-        })
-        resolveMostRecentRelayOperation(mockEnvironment, {
           Viewer: () => ({
             notificationPreferences: [
               { status: "SUBSCRIBED", name: "custom_alerts", channel: "email" },
@@ -204,9 +197,6 @@ describe("CreateSavedSearchAlert", () => {
       renderWithWrappers(<TestRenderer />)
 
       await waitFor(() => {
-        resolveMostRecentRelayOperation(mockEnvironment, {
-          PreviewSavedSearch: () => ({ displayName: "Banana" }),
-        })
         resolveMostRecentRelayOperation(mockEnvironment, {
           Viewer: () => ({
             notificationPreferences: [

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -47,7 +47,6 @@ const initialData: ArtworkFiltersState = {
 }
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "Placeholder",
   artists: [],
   owner: {
     type: OwnerType.artist,

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
@@ -10,16 +11,13 @@ import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRece
 import { createMockEnvironment } from "relay-test-utils"
 import { EditSavedSearchAlertQueryRenderer } from "./EditSavedSearchAlert"
 
-jest.mock("app/utils/experiments/hooks", () => ({
-  useExperimentFlag: (name: string) =>
-    ["onyx_force-fallback-to-generated-alert-names"].includes(name),
-}))
-
 describe("EditSavedSearchAlert", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
   beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableFallbackToGeneratedAlertNames: true })
+
     mockEnvironment = getMockRelayEnvironment()
     notificationPermissions.mockImplementationOnce((cb) =>
       cb(null, PushAuthorizationStatus.Authorized)

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -56,9 +56,7 @@ describe("EditSavedSearchAlert", () => {
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment, {
         SearchCriteria: () => ({
-          userAlertSettings: {
-            name: "updated-name",
-          },
+          displayName: "updated-name",
         }),
       })
     })
@@ -103,8 +101,8 @@ describe("EditSavedSearchAlert", () => {
           artistIDs: ["artistID"],
           materialsTerms: ["paper"],
         },
+        displayName: "unique-name",
         userAlertSettings: {
-          name: "unique-name",
           push: true,
           email: true,
         },
@@ -118,9 +116,9 @@ describe("EditSavedSearchAlert", () => {
     resolveMostRecentRelayOperation(mockEnvironment, {
       SearchCriteria: () => ({
         ...searchCriteria,
+        name: "",
         userAlertSettings: {
           ...searchCriteria.userAlertSettings,
-          name: "",
         },
       }),
     })
@@ -254,6 +252,7 @@ const searchCriteria = {
   attributionClass: [],
   colors: [],
   dimensionRange: null,
+  name: "unique-name",
   sizes: [],
   height: null,
   inquireableOnly: null,
@@ -265,7 +264,6 @@ const searchCriteria = {
   priceRange: null,
   width: null,
   userAlertSettings: {
-    name: "unique-name",
     push: true,
     email: true,
   },

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -19,13 +19,13 @@ import {
 } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { AlertPriceRangeScreenQueryRenderer } from "app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen"
 import { EmailPreferencesScreen } from "app/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen"
-import { goBack, GoBackProps, navigationEvents } from "app/system/navigation/navigate"
+import { GoBackProps, goBack, navigationEvents } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import React, { useCallback, useEffect } from "react"
-import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
+import { QueryRenderer, RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { EditSavedSearchFormPlaceholder } from "./Components/EditSavedSearchAlertPlaceholder"
 import { SavedSearchAlertQueryRenderer } from "./SavedSearchAlert"
 import { SavedSearchStoreProvider, savedSearchModel } from "./SavedSearchStore"
@@ -63,7 +63,6 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
     name: artist.name!,
   }))
   const entity: SavedSearchEntity = {
-    placeholder: formattedArtists[0].name ?? "",
     artists: formattedArtists,
     owner: {
       type: OwnerType.savedSearch,

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
@@ -28,6 +28,7 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
               attributionClass
               colors
               dimensionRange
+              displayName
               sizes
               height
               inquireableOnly
@@ -38,8 +39,8 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
               partnerIDs
               priceRange
               userAlertSettings {
-                name
                 email
+                name
                 push
               }
               width

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -794,7 +794,6 @@ describe("SavedSearchAlertForm", () => {
 })
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "Artist Name",
   artists: [{ id: "artistID", name: "artistName" }],
   owner: {
     type: OwnerType.artist,

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -5,6 +5,7 @@ import {
   SavedSearchEntity,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
@@ -18,6 +19,10 @@ import { SavedSearchAlertForm, SavedSearchAlertFormProps, tracks } from "./Saved
 import { SavedSearchStoreProvider, savedSearchModel } from "./SavedSearchStore"
 
 describe("SavedSearchAlertForm", () => {
+  __globalStoreTestUtils__?.injectFeatureFlags({
+    AREnableFallbackToGeneratedAlertNames: true,
+  })
+
   const spyAlert = jest.spyOn(Alert, "alert")
   const notificationPermissions = mockFetchNotificationPermissions(false)
 
@@ -72,7 +77,7 @@ describe("SavedSearchAlertForm", () => {
     it("correctly renders default placeholder for input name", () => {
       const { getByTestId } = renderWithWrappers(<TestRenderer />)
 
-      expect(getByTestId("alert-input-name").props.placeholder).toEqual("Artist Name")
+      expect(getByTestId("alert-input-name").props.placeholder).toEqual("artistName")
     })
 
     it("calls onComplete when mutation is completed", async () => {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -241,7 +241,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   const shouldShowEmailWarning = !!savedSearchAlertId && !!initialValues.email && !userAllowsEmails
 
-  console.log({ attributes })
   return (
     <FormikProvider value={formik}>
       <ScrollView

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -5,7 +5,7 @@ import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSear
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { refreshSavedAlerts } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
-import React, { useEffect, useState } from "react"
+import React, { Suspense, useEffect, useState } from "react"
 import { Alert, ScrollView, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { useFirstMountState } from "react-use/lib/useFirstMountState"
@@ -242,47 +242,50 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const shouldShowEmailWarning = !!savedSearchAlertId && !!initialValues.email && !userAllowsEmails
 
   return (
-    <FormikProvider value={formik}>
-      <ScrollView
-        keyboardDismissMode="on-drag"
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
-      >
-        <Form
-          attributes={attributes}
-          pills={pills}
-          savedSearchAlertId={savedSearchAlertId}
-          hasChangedFilters={hasChangedFilters}
-          onDeletePress={handleDeletePress}
-          onSubmitPress={formik.handleSubmit}
-          onTogglePushNotification={handleTogglePushNotification}
-          onToggleEmailNotification={handleToggleEmailNotification}
-          onRemovePill={handleRemovePill}
-          shouldShowEmailWarning={shouldShowEmailWarning}
-          {...other}
-        />
-      </ScrollView>
-      {!!savedSearchAlertId && (
-        <Dialog
-          isVisible={visibleDeleteDialog}
-          title="Delete Alert"
-          detail="You will no longer receive notifications for artworks matching the criteria in this alert."
-          primaryCta={{
-            text: "Delete",
-            onPress: () => {
-              onDelete()
-              setVisibleDeleteDialog(false)
-            },
-          }}
-          secondaryCta={{
-            text: "Keep Alert",
-            onPress: () => {
-              setVisibleDeleteDialog(false)
-            },
-          }}
-        />
-      )}
-    </FormikProvider>
+    // TODO: Add fallback
+    <Suspense fallback={null}>
+      <FormikProvider value={formik}>
+        <ScrollView
+          keyboardDismissMode="on-drag"
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
+        >
+          <Form
+            attributes={attributes}
+            pills={pills}
+            savedSearchAlertId={savedSearchAlertId}
+            hasChangedFilters={hasChangedFilters}
+            onDeletePress={handleDeletePress}
+            onSubmitPress={formik.handleSubmit}
+            onTogglePushNotification={handleTogglePushNotification}
+            onToggleEmailNotification={handleToggleEmailNotification}
+            onRemovePill={handleRemovePill}
+            shouldShowEmailWarning={shouldShowEmailWarning}
+            {...other}
+          />
+        </ScrollView>
+        {!!savedSearchAlertId && (
+          <Dialog
+            isVisible={visibleDeleteDialog}
+            title="Delete Alert"
+            detail="You will no longer receive notifications for artworks matching the criteria in this alert."
+            primaryCta={{
+              text: "Delete",
+              onPress: () => {
+                onDelete()
+                setVisibleDeleteDialog(false)
+              },
+            }}
+            secondaryCta={{
+              text: "Keep Alert",
+              onPress: () => {
+                setVisibleDeleteDialog(false)
+              },
+            }}
+          />
+        )}
+      </FormikProvider>
+    </Suspense>
   )
 }
 

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -249,6 +249,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
       >
         <Form
+          attributes={attributes}
           pills={pills}
           savedSearchAlertId={savedSearchAlertId}
           hasChangedFilters={hasChangedFilters}

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -5,7 +5,7 @@ import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSear
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { refreshSavedAlerts } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
-import React, { Suspense, useEffect, useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Alert, ScrollView, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { useFirstMountState } from "react-use/lib/useFirstMountState"
@@ -241,50 +241,48 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   const shouldShowEmailWarning = !!savedSearchAlertId && !!initialValues.email && !userAllowsEmails
 
+  console.log({ attributes })
   return (
-    <Suspense fallback={null}>
-      <FormikProvider value={formik}>
-        <ScrollView
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
-        >
-          <Form
-            attributes={attributes}
-            pills={pills}
-            savedSearchAlertId={savedSearchAlertId}
-            hasChangedFilters={hasChangedFilters}
-            onDeletePress={handleDeletePress}
-            onSubmitPress={formik.handleSubmit}
-            onTogglePushNotification={handleTogglePushNotification}
-            onToggleEmailNotification={handleToggleEmailNotification}
-            onRemovePill={handleRemovePill}
-            shouldShowEmailWarning={shouldShowEmailWarning}
-            {...other}
-          />
-        </ScrollView>
-        {!!savedSearchAlertId && (
-          <Dialog
-            isVisible={visibleDeleteDialog}
-            title="Delete Alert"
-            detail="You will no longer receive notifications for artworks matching the criteria in this alert."
-            primaryCta={{
-              text: "Delete",
-              onPress: () => {
-                onDelete()
-                setVisibleDeleteDialog(false)
-              },
-            }}
-            secondaryCta={{
-              text: "Keep Alert",
-              onPress: () => {
-                setVisibleDeleteDialog(false)
-              },
-            }}
-          />
-        )}
-      </FormikProvider>
-    </Suspense>
+    <FormikProvider value={formik}>
+      <ScrollView
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
+      >
+        <Form
+          pills={pills}
+          savedSearchAlertId={savedSearchAlertId}
+          hasChangedFilters={hasChangedFilters}
+          onDeletePress={handleDeletePress}
+          onSubmitPress={formik.handleSubmit}
+          onTogglePushNotification={handleTogglePushNotification}
+          onToggleEmailNotification={handleToggleEmailNotification}
+          onRemovePill={handleRemovePill}
+          shouldShowEmailWarning={shouldShowEmailWarning}
+          {...other}
+        />
+      </ScrollView>
+      {!!savedSearchAlertId && (
+        <Dialog
+          isVisible={visibleDeleteDialog}
+          title="Delete Alert"
+          detail="You will no longer receive notifications for artworks matching the criteria in this alert."
+          primaryCta={{
+            text: "Delete",
+            onPress: () => {
+              onDelete()
+              setVisibleDeleteDialog(false)
+            },
+          }}
+          secondaryCta={{
+            text: "Keep Alert",
+            onPress: () => {
+              setVisibleDeleteDialog(false)
+            },
+          }}
+        />
+      )}
+    </FormikProvider>
   )
 }
 

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -242,7 +242,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const shouldShowEmailWarning = !!savedSearchAlertId && !!initialValues.email && !userAllowsEmails
 
   return (
-    // TODO: Add fallback
     <Suspense fallback={null}>
       <FormikProvider value={formik}>
         <ScrollView

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -40,8 +40,8 @@ export type CreateSavedSearchAlertNavigationStack = {
 
 export interface EditSavedSearchAlertParams {
   userAlertSettings?: {
-    name: string | null
     email: boolean
+    name?: string | null
     push: boolean
   }
   savedSearchAlertId?: string

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -5,7 +5,7 @@ import {
   SearchCriteria,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { action, Action, createContextStore } from "easy-peasy"
+import { Action, action, createContextStore } from "easy-peasy"
 
 interface SavedSearchModel {
   attributes: SearchCriteriaAttributes
@@ -34,7 +34,6 @@ export const savedSearchModel: SavedSearchModel = {
   aggregations: [],
   dirty: false,
   entity: {
-    placeholder: "",
     artists: [],
     owner: {
       type: OwnerType.artist,

--- a/src/app/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/app/Scenes/SavedSearchAlert/helpers.ts
@@ -4,10 +4,11 @@ import {
 } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { unsafe_getPushPromptSettings } from "app/store/GlobalStore"
 import {
-  getNotificationPermissionsStatus,
   PushAuthorizationStatus,
+  getNotificationPermissionsStatus,
 } from "app/utils/PushNotification"
 import { requestSystemPermissions } from "app/utils/requestPushNotificationsPermission"
+import { omit } from "lodash"
 import { Alert, AlertButton, Linking, Platform } from "react-native"
 
 export const requestNotificationPermissions = () => {
@@ -101,7 +102,7 @@ export const clearDefaultAttributes = (attributes: SearchCriteriaAttributes) => 
     }
   })
 
-  return clearedAttributes
+  return omit(clearedAttributes, "displayName")
 }
 
 export const showWarningMessageForDuplicateAlert = ({

--- a/src/app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen.tests.tsx
@@ -111,7 +111,6 @@ describe("AlertPriceRangeScreen", () => {
 })
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "Placeholder",
   artists: [{ id: "artistID", name: "artistName" }],
   owner: {
     type: OwnerType.artist,

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tests.tsx
@@ -192,7 +192,6 @@ const aggregations: Aggregations = [
 ]
 
 const entity: SavedSearchEntity = {
-  placeholder: "Placeholder title for alert",
   artists: [
     {
       id: "david-hockney",

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -235,9 +235,6 @@ export const SavedSearchesListPaginationContainer = createPaginationContainer(
             node {
               internalID
               displayName
-              userAlertSettings {
-                name
-              }
             }
           }
         }

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -276,7 +276,7 @@ export const features: { [key: string]: FeatureDescriptor } = {
   },
   AREnableFallbackToGeneratedAlertNames: {
     description: "Enable fallback to generated alert names",
-    readyForRelease: true,
+    readyForRelease: false,
     showInDevMenu: true,
     echoFlagKey: "AREnableFallbackToGeneratedAlertNames",
   },

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -274,6 +274,12 @@ export const features: { [key: string]: FeatureDescriptor } = {
     readyForRelease: false,
     showInDevMenu: true,
   },
+  AREnableFallbackToGeneratedAlertNames: {
+    description: "Enable fallback to generated alert names",
+    readyForRelease: true,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableFallbackToGeneratedAlertNames",
+  },
 }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
- This PR resolves [ONYX-228] <!-- eg [PROJECT-XXXX] -->

- Related Force PR: https://github.com/artsy/force/pull/12751

### Description

This PR updates the Saved Search form (edit & create) to use Metaphysic's generated display name as a placeholder.

https://github.com/artsy/eigen/assets/4691889/0aa9be37-0ba8-402a-bfb5-9b2196783bd7


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Use generated displayName in Saved Search form - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-228]: https://artsyproduct.atlassian.net/browse/ONYX-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ