### PR TITLE
fix: Update generate Changelog script

### DIFF
--- a/scripts/changelog/generateChangelog.ts
+++ b/scripts/changelog/generateChangelog.ts
@@ -95,8 +95,8 @@ async function getChangelogFromPrs(prs: PullsGetResponse[]) {
   const prsWithoutChangelog: PullsGetResponse[] = []
   const prsWithNoChangelog: PullsGetResponse[] = []
   for (const pr of prs) {
-    // pr body without comments
-    const prBody = pr.body.replace(/<!--.*?-->/g, "")
+    // pr body without comments except <!-- end_changelog_updates --> (used in parseSectionPositions)
+    const prBody = pr.body.replace(/<!--((?!end_changelog).)*-->/g, "")
     let prHasChangelog = false
     for (const section of SECTIONS) {
       const positions = parseSectionPositions(section, prBody)
@@ -110,7 +110,9 @@ async function getChangelogFromPrs(prs: PullsGetResponse[]) {
       }
     }
     if (!prHasChangelog) {
-      prBody.includes("#nochangelog") ? prsWithNoChangelog.push(pr) : prsWithoutChangelog.push(pr)
+      prBody.toLocaleLowerCase().includes("#nochangelog")
+        ? prsWithNoChangelog.push(pr)
+        : prsWithoutChangelog.push(pr)
     }
   }
   return { changelog, prsWithoutChangelog, prsWithNoChangelog }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the generate changelog script:
- Updates stripping the comments from the PR body to keep `<!-- end_changelog_updates -->` 
- Updates the check on nochangelog in the pr body to accept NoChangelog & noChangelog

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update generate changelog script - mrsltun

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
