### PR TITLE
fix: do not show artwork lists prompt during the onboarding

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -28,6 +28,7 @@ import { PageableRouteProps } from "app/system/navigation/useNavigateToPageableR
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { RandomNumberGenerator } from "app/utils/placeholders"
 import {
   ArtworkActionTrackingProps,
@@ -43,59 +44,60 @@ const SAVE_ICON_SIZE = 22
 
 export interface ArtworkProps extends Partial<PageableRouteProps>, ArtworkActionTrackingProps {
   artwork: ArtworkGridItem_artwork$data
-  /** Overrides onPress and prevents the default behaviour. */
-  onPress?: (artworkID: string) => void
-  trackingFlow?: string
-  /** Pass Tap to override generic ing, used for home tracking in rails */
-  trackTap?: (artworkSlug: string, index?: number) => void
-  itemIndex?: number
-
-  /** Hide urgency tags (3 Days left, 1 hour left) */
-  hideUrgencyTags?: boolean
+  /** styles for each field: allows for customization of each field */
+  artistNamesTextStyle?: TextProps
+  disableArtworksListPrompt?: boolean
+  /** Hide sale info */
+  height?: number
   /** Hide partner name */
   hidePartner?: boolean
-  /** Hide sale info */
   hideSaleInfo?: boolean
   hideSaveIcon?: boolean
-  height?: number
+  /** Hide urgency tags (3 Days left, 1 hour left) */
+  hideUrgencyTags?: boolean
+  /** Pass Tap to override generic ing, used for home tracking in rails */
+  itemIndex?: number
+  lotLabelTextStyle?: TextProps
+  /** Overrides onPress and prevents the default behaviour. */
+  onPress?: (artworkID: string) => void
+  partnerNameTextStyle?: TextProps
+  saleInfoTextStyle?: TextProps
   /** Show the lot number (Lot 213) */
   showLotLabel?: boolean
-  /** styles for each field: allows for customization of each field */
-  urgencyTagTextStyle?: TextProps
-  lotLabelTextStyle?: TextProps
-  artistNamesTextStyle?: TextProps
   titleTextStyle?: TextProps
-  saleInfoTextStyle?: TextProps
-  partnerNameTextStyle?: TextProps
+  trackTap?: (artworkSlug: string, index?: number) => void
+  trackingFlow?: string
   /** allows for artwork to be added to recent searches */
   updateRecentSearchesOnTap?: boolean
+  urgencyTagTextStyle?: TextProps
 }
 
 export const Artwork: React.FC<ArtworkProps> = ({
+  artistNamesTextStyle,
   artwork,
-  onPress,
-  navigateToPageableRoute,
-  trackTap,
-  itemIndex,
-  height,
   contextModule,
+  contextScreen,
   contextScreenOwnerId,
   contextScreenOwnerSlug,
   contextScreenOwnerType,
   contextScreenQuery,
-  contextScreen,
-  hideUrgencyTags = false,
+  disableArtworksListPrompt = false,
+  height,
   hidePartner = false,
   hideSaleInfo = false,
   hideSaveIcon = false,
-  showLotLabel = false,
-  urgencyTagTextStyle,
+  hideUrgencyTags = false,
+  itemIndex,
   lotLabelTextStyle,
-  artistNamesTextStyle,
-  titleTextStyle,
-  saleInfoTextStyle,
+  navigateToPageableRoute,
+  onPress,
   partnerNameTextStyle,
+  saleInfoTextStyle,
+  showLotLabel = false,
+  titleTextStyle,
+  trackTap,
   updateRecentSearchesOnTap = false,
+  urgencyTagTextStyle,
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
@@ -159,6 +161,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
   const { isSaved, saveArtworkToLists } = useSaveArtworkToArtworkLists({
     artworkFragmentRef: artwork,
+    onCompleted: onArtworkSavedOrUnSaved,
+  })
+
+  const handleArtworkSave = useSaveArtwork({
+    id: artwork.id,
+    internalID: artwork.internalID,
+    isSaved: artwork.isSaved,
     onCompleted: onArtworkSavedOrUnSaved,
   })
 
@@ -342,7 +351,11 @@ export const Artwork: React.FC<ArtworkProps> = ({
               </Flex>
               {!!eableArtworkGridSaveIcon && !hideSaveIcon && (
                 <Flex>
-                  <Touchable haptic onPress={saveArtworkToLists} testID="save-artwork-icon">
+                  <Touchable
+                    haptic
+                    onPress={disableArtworksListPrompt ? handleArtworkSave : saveArtworkToLists}
+                    testID="save-artwork-icon"
+                  >
                     {isSaved ? (
                       <HeartFillIcon
                         testID="filled-heart-icon"
@@ -460,6 +473,7 @@ export default createFragmentContainer(Artwork, {
       isBiddable
       isInquireable
       isOfferable
+      isSaved
       artistNames
       href
       sale {

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -45,6 +45,9 @@ import Artwork, { ArtworkProps } from "./ArtworkGridItem"
  */
 
 export interface Props extends ArtworkActionTrackingProps {
+  /** Do not show add to artworks list prompt */
+  disableArtworksListPrompt?: boolean
+
   /** The direction for the grid, currently only 'column' is supported . */
   sectionDirection?: string
 
@@ -161,38 +164,39 @@ export const DEFAULT_SECTION_MARGIN = 20
 export const DEFAULT_ITEM_MARGIN = 20
 
 const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
+  autoFetch = true,
+  connection,
+  contextScreen,
+  contextScreenOwnerId,
+  contextScreenOwnerSlug,
+  contextScreenOwnerType,
+  contextScreenQuery,
+  disableArtworksListPrompt = false,
+  FooterComponent,
+  hasMore,
+  HeaderComponent,
+  hidePartner = false,
+  hideSaveIcon = false,
+  hideUrgencyTags,
+  isLoading,
+  isMyCollection = false,
+  itemComponentProps,
+  itemMargin = DEFAULT_ITEM_MARGIN,
+  loadMore,
+  localSortAndFilterArtworks,
+  onScroll,
+  pageSize = PAGE_SIZE,
+  refreshControl,
+  scrollEventThrottle,
   sectionCount = Dimensions.get("window").width > 700 ? 3 : 2,
   sectionMargin = DEFAULT_SECTION_MARGIN,
-  itemMargin = DEFAULT_ITEM_MARGIN,
   shouldAddPadding = false,
-  autoFetch = true,
-  pageSize = PAGE_SIZE,
-  hidePartner = false,
-  isMyCollection = false,
-  useParentAwareScrollView = Platform.OS === "android",
   showLoadingSpinner = false,
-  hideSaveIcon = false,
-  updateRecentSearchesOnTap = false,
-  itemComponentProps,
-  width,
-  hasMore,
-  isLoading,
-  loadMore,
-  connection,
-  localSortAndFilterArtworks,
-  HeaderComponent,
-  FooterComponent,
-  stickyHeaderIndices,
-  onScroll,
-  scrollEventThrottle,
   showLotLabel,
-  hideUrgencyTags,
-  contextScreen,
-  contextScreenQuery,
-  contextScreenOwnerSlug,
-  contextScreenOwnerId,
-  contextScreenOwnerType,
-  refreshControl,
+  stickyHeaderIndices,
+  updateRecentSearchesOnTap = false,
+  useParentAwareScrollView = Platform.OS === "android",
+  width,
 }) => {
   const artworks = extractNodes(connection)
 
@@ -303,6 +307,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
           ? {}
           : {
               hideSaveIcon,
+              disableArtworksListPrompt,
             }
         const ItemComponent = isMyCollection
           ? MyCollectionArtworkGridItemFragmentContainer

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
@@ -53,6 +53,7 @@ const OnboardingMarketingCollection: React.FC<OnboardingMarketingCollectionProps
           hasMore={() => false}
           connection={marketingCollection?.artworks}
           shouldAddPadding
+          disableArtworksListPrompt
         />
         <Flex p={2} backgroundColor="white">
           <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>


### PR DESCRIPTION
This PR resolves [ONYX-262] <!-- eg [PROJECT-XXXX] -->

### Description

This PR hides **Add to artworks list** prompt during the onboarding.
**Bonus:** alphabetically order some props (sorry for the big diff)

https://github.com/artsy/eigen/assets/11945712/001db72a-7048-4594-ab49-6f3353b5f05c



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- do not show artwork lists prompt during onboarding - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-262]: https://artsyproduct.atlassian.net/browse/ONYX-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ