### PR TITLE
chore: Fix CreateSavedSearchAlert tests after enabling feature flag

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -122,11 +122,15 @@ describe("CreateSavedSearchModal", () => {
       ),
     })
 
-    renderWithRelay()
+    const { mockResolveLastOperation } = renderWithRelay()
 
     await waitFor(() => {
-      expect(screen.getByText("Save Alert")).toBeOnTheScreen()
+      mockResolveLastOperation({
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
     })
+
+    expect(screen.getByText("Save Alert")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Save Alert"))
     await flushPromiseQueue()

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -115,7 +115,9 @@ describe("CreateSavedSearchAlert", () => {
     const { getByText } = renderWithWrappers(<TestRenderer />)
 
     await waitFor(() => {
-      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
     })
 
     expect(getByText("Bid")).toBeTruthy()
@@ -127,7 +129,9 @@ describe("CreateSavedSearchAlert", () => {
     const { getByTestId } = renderWithWrappers(<TestRenderer onClosePress={onClosePressMock} />)
 
     await waitFor(() => {
-      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
     })
     fireEvent.press(getByTestId("fancy-modal-header-left-button"))
 
@@ -143,6 +147,7 @@ describe("CreateSavedSearchAlert", () => {
     )
 
     await waitFor(() => {
+      resolveMostRecentRelayOperation(mockEnvironment)
       resolveMostRecentRelayOperation(mockEnvironment)
     })
 
@@ -176,6 +181,8 @@ describe("CreateSavedSearchAlert", () => {
       renderWithWrappers(<TestRenderer />)
 
       await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment, {})
+
         resolveMostRecentRelayOperation(mockEnvironment, {
           Viewer: () => ({
             notificationPreferences: [

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -147,7 +147,9 @@ describe("CreateSavedSearchAlert", () => {
     )
 
     await waitFor(() => {
-      resolveMostRecentRelayOperation(mockEnvironment)
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
       resolveMostRecentRelayOperation(mockEnvironment)
     })
 
@@ -181,8 +183,9 @@ describe("CreateSavedSearchAlert", () => {
       renderWithWrappers(<TestRenderer />)
 
       await waitFor(() => {
-        resolveMostRecentRelayOperation(mockEnvironment, {})
-
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          PreviewSavedSearch: () => ({ displayName: "Banana" }),
+        })
         resolveMostRecentRelayOperation(mockEnvironment, {
           Viewer: () => ({
             notificationPreferences: [

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -77,7 +77,11 @@ describe("SavedSearchAlertForm", () => {
     it("correctly renders default placeholder for input name", () => {
       const { getByTestId } = renderWithWrappers(<TestRenderer />)
 
-      expect(getByTestId("alert-input-name").props.placeholder).toEqual("artistName")
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        PreviewSavedSearch: () => ({ displayName: "Banana" }),
+      })
+
+      expect(getByTestId("alert-input-name").props.placeholder).toEqual("Banana")
     })
 
     it("calls onComplete when mutation is completed", async () => {
@@ -85,6 +89,12 @@ describe("SavedSearchAlertForm", () => {
       const { getByTestId } = renderWithWrappers(
         <TestRenderer onComplete={onCompleteMock} savedSearchAlertId="savedSearchAlertId" />
       )
+
+      await waitFor(() => {
+        resolveMostRecentRelayOperation(mockEnvironment, {
+          PreviewSavedSearch: () => ({ displayName: "Banana" }),
+        })
+      })
 
       fireEvent.changeText(getByTestId("alert-input-name"), "something new")
       fireEvent.press(getByTestId("save-alert-button"))
@@ -207,6 +217,12 @@ describe("SavedSearchAlertForm", () => {
           <TestRenderer savedSearchAlertId="savedSearchAlertId" />
         )
 
+        await waitFor(() => {
+          resolveMostRecentRelayOperation(mockEnvironment, {
+            PreviewSavedSearch: () => ({ displayName: "Banana" }),
+          })
+        })
+
         fireEvent.press(getByTestId("delete-alert-button"))
         fireEvent.press(getByTestId("dialog-primary-action-button"))
 
@@ -221,6 +237,12 @@ describe("SavedSearchAlertForm", () => {
         const { getByTestId } = renderWithWrappers(
           <TestRenderer savedSearchAlertId="savedSearchAlertId" />
         )
+
+        await waitFor(() => {
+          resolveMostRecentRelayOperation(mockEnvironment, {
+            PreviewSavedSearch: () => ({ displayName: "Banana" }),
+          })
+        })
 
         fireEvent.changeText(getByTestId("alert-input-name"), "something new")
         fireEvent.press(getByTestId("save-alert-button"))


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the `CreateSavedSearchAlert` tests. The tests failed upon enabling [this](flag.https://github.com/artsy/echo/pull/519) feature 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
