### PR TITLE
fix(ONYX-301): padding is wrong on the follows page, collected artists rail and myc empty state

### DIFF
--- a/src/app/Scenes/Favorites/FavoriteArtists.tsx
+++ b/src/app/Scenes/Favorites/FavoriteArtists.tsx
@@ -1,4 +1,4 @@
-import { Spacer, ClassTheme, Tabs } from "@artsy/palette-mobile"
+import { Spacer, ClassTheme, Tabs, Flex } from "@artsy/palette-mobile"
 import { FavoriteArtistsQuery } from "__generated__/FavoriteArtistsQuery.graphql"
 import { FavoriteArtists_me$data } from "__generated__/FavoriteArtists_me.graphql"
 import { ArtistListItemContainer as ArtistListItem } from "app/Components/ArtistListItem"
@@ -95,8 +95,12 @@ class Artists extends React.Component<Props, State> {
             ItemSeparatorComponent={() => <Spacer y={1} />}
             ListFooterComponent={
               this.state.fetchingMoreData ? (
-                <Spinner style={{ marginTop: 20, marginBottom: 20 }} />
-              ) : null
+                <Flex my={4} flexDirection="row" justifyContent="center">
+                  <Spinner />
+                </Flex>
+              ) : (
+                <Spacer y={2} />
+              )
             }
             renderItem={({ item }) => {
               return (

--- a/src/app/Scenes/Favorites/FavoriteCategories.tsx
+++ b/src/app/Scenes/Favorites/FavoriteCategories.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Tabs } from "@artsy/palette-mobile"
+import { Flex, Spacer, Tabs } from "@artsy/palette-mobile"
 import { FavoriteCategoriesQuery } from "__generated__/FavoriteCategoriesQuery.graphql"
 import { FavoriteCategories_me$data } from "__generated__/FavoriteCategories_me.graphql"
 import { SavedItemRow } from "app/Components/Lists/SavedItemRow"
@@ -94,8 +94,12 @@ export class Categories extends React.Component<Props, State> {
         }
         ListFooterComponent={
           this.state.fetchingMoreData ? (
-            <Spinner style={{ marginTop: 20, marginBottom: 20 }} />
-          ) : null
+            <Flex my={4} flexDirection="row" justifyContent="center">
+              <Spinner />
+            </Flex>
+          ) : (
+            <Spacer y={2} />
+          )
         }
         renderItem={({ item }) => {
           return (

--- a/src/app/Scenes/Favorites/FavoriteShows.tsx
+++ b/src/app/Scenes/Favorites/FavoriteShows.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Tabs } from "@artsy/palette-mobile"
+import { Flex, Spacer, Tabs } from "@artsy/palette-mobile"
 import { FavoriteShowsQuery } from "__generated__/FavoriteShowsQuery.graphql"
 import { FavoriteShows_me$data } from "__generated__/FavoriteShows_me.graphql"
 import { ShowItemRowContainer as ShowItemRow } from "app/Components/Lists/ShowItemRow"
@@ -94,8 +94,12 @@ export class Shows extends Component<Props, State> {
         }
         ListFooterComponent={
           this.state.fetchingMoreData ? (
-            <Spinner style={{ marginTop: 20, marginBottom: 20 }} />
-          ) : null
+            <Flex my={4} flexDirection="row" justifyContent="center">
+              <Spinner />
+            </Flex>
+          ) : (
+            <Spacer y={2} />
+          )
         }
         renderItem={({ item }) => {
           return <ShowItemRow show={item} isListItem />

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
@@ -57,8 +57,6 @@ export const MyCollectionCollectedArtistsRail: React.FC<MyCollectionCollectedArt
 
   return (
     <Flex testID="my-collection-collected-artists-rail">
-      <Flex position="absolute" top={0} left={0} right={0} height={1} bg="black5"></Flex>
-
       <Animated.FlatList
         horizontal
         showsHorizontalScrollIndicator={false}
@@ -103,13 +101,13 @@ export const MyCollectionCollectedArtistsRail: React.FC<MyCollectionCollectedArt
         contentContainerStyle={{
           paddingTop: space(2),
           paddingBottom: space(4),
-          paddingHorizontal: space(2),
+          paddingLeft: space(2),
         }}
         ListFooterComponent={
-          <Flex flexDirection="row" mr={4}>
+          <Flex flexDirection="row">
             {!!isLoadingNext && (
               <Flex
-                mr={1}
+                mr={2}
                 width={ARTIST_CIRCLE_DIAMETER}
                 height={ARTIST_CIRCLE_DIAMETER}
                 alignItems="center"

--- a/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionCollectedArtistsRail.tsx
@@ -104,10 +104,10 @@ export const MyCollectionCollectedArtistsRail: React.FC<MyCollectionCollectedArt
           paddingLeft: space(2),
         }}
         ListFooterComponent={
-          <Flex flexDirection="row">
+          <Flex flexDirection="row" mr={1}>
             {!!isLoadingNext && (
               <Flex
-                mr={2}
+                mr={1}
                 width={ARTIST_CIRCLE_DIAMETER}
                 height={ARTIST_CIRCLE_DIAMETER}
                 alignItems="center"

--- a/src/app/Scenes/MyCollection/Components/MyCollectionZeroStateArtworks.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionZeroStateArtworks.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@artsy/palette-mobile"
+import { Button, Flex, Text } from "@artsy/palette-mobile"
 import { Tab } from "app/Scenes/MyProfile/MyProfileHeaderMyCollectionAndSavedWorks"
 import { navigate } from "app/system/navigation/navigate"
 import { useTracking } from "react-tracking"
@@ -13,22 +13,23 @@ export const MyCollectionZeroStateArtworks: React.FC = () => {
       <Text variant="xs" color="black60">
         Access price and market insights and build an online record of your collection.
       </Text>
-      <Button
-        testID="add-artwork-button-zero-artworks-state"
-        onPress={() => {
-          trackEvent(tracks.addCollectedArtwork())
-          navigate("my-collection/artworks/new", {
-            passProps: {
-              source: Tab.collection,
-            },
-          })
-        }}
-        variant="outline"
-        size="small"
-        mt={2}
-      >
-        Add Artworks
-      </Button>
+      <Flex mt={2} flexDirection="row" justifyContent="space-between">
+        <Button
+          testID="add-artwork-button-zero-artworks-state"
+          onPress={() => {
+            trackEvent(tracks.addCollectedArtwork())
+            navigate("my-collection/artworks/new", {
+              passProps: {
+                source: Tab.collection,
+              },
+            })
+          }}
+          variant="outline"
+          size="small"
+        >
+          Add Artworks
+        </Button>
+      </Flex>
     </>
   )
 }

--- a/src/app/Scenes/MyCollection/Components/MyCollectionZeroStateArtworks.tsx
+++ b/src/app/Scenes/MyCollection/Components/MyCollectionZeroStateArtworks.tsx
@@ -13,7 +13,7 @@ export const MyCollectionZeroStateArtworks: React.FC = () => {
       <Text variant="xs" color="black60">
         Access price and market insights and build an online record of your collection.
       </Text>
-      <Flex mt={2} flexDirection="row" justifyContent="space-between">
+      <Flex mt={2} flexDirection="row">
         <Button
           testID="add-artwork-button-zero-artworks-state"
           onPress={() => {

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -207,7 +207,7 @@ const MyCollection: React.FC<{
         <MyCollectionCollectedArtists me={me} />
         {selectedTab === null && (
           <Flex px={2}>
-            <Separator my={4} />
+            <Separator mb={4} mt={2} />
             <MyCollectionZeroStateArtworks />
           </Flex>
         )}


### PR DESCRIPTION
This PR resolves [ONYX-301] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


| Artist collected rail Before | Artist collected rail After | Artist collected rail Before | Artist collected rail After |
| --- | --- | --- | --- |
| ![12](https://github.com/artsy/eigen/assets/36167539/e3dd9447-9cd6-4326-a9f9-666e59c0490a) | ![10](https://github.com/artsy/eigen/assets/36167539/c287430b-007c-40ff-91ba-e1a5f2387a23) | ![13](https://github.com/artsy/eigen/assets/36167539/6d2187c7-efde-4af5-8655-c3e3a12278a3) | ![11](https://github.com/artsy/eigen/assets/36167539/0aae15e6-e342-4b11-8e99-85113dee7dc9) |


| My Collection Empty State Before | My Collection Empty State After | 
| --- | --- |
| ![10](https://github.com/artsy/eigen/assets/36167539/7297891f-29ca-4637-80f6-44749d6a844f) | ![14](https://github.com/artsy/eigen/assets/36167539/d8f22ded-ceeb-4d95-9849-b4b3066c52a5) |


| Follows tab Before | Follows tab After |
| --- | --- |
| ![15](https://github.com/artsy/eigen/assets/36167539/5477c3b4-118c-4f84-85ea-6bb78f907caf) | ![9](https://github.com/artsy/eigen/assets/36167539/ccfa65cc-d76e-4f1c-9b4b-77da652005a9) |
 

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix padding on the follows page, collected artists rail and myc empty state - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-301]: https://artsyproduct.atlassian.net/browse/ONYX-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ