### PR TITLE
fix: make alert name multiline on android

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
@@ -6,6 +6,7 @@ import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useFormikContext } from "formik"
 import { omit } from "lodash"
 import { useEffect, useState } from "react"
+import { Platform } from "react-native"
 import { QueryRenderer } from "react-relay"
 import { graphql } from "relay-runtime"
 interface SavedSearchNameInputProps {
@@ -34,6 +35,10 @@ export const SavedSearchNameInput: React.FC<SavedSearchNameInputProps> = ({ plac
       error={errors.name}
       testID="alert-input-name"
       maxLength={75}
+      // Android doesn't ellipsize long text, and instead wraps it to the next line.
+      // This makes the text look like it's cut off
+      // See: https://github.com/facebook/react-native/issues/29663
+      multiline={Platform.OS === "android"}
     />
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This CI makes the alert name input span across multiple lines in Android. This is required to make sure that text doesn't cut because of the input height. Ideally, we would ellipsize the text but this is not yet supported in RN on Android. Another solution that I tried to work on is to make to use the placeholders array that we are also using inside the search tab, but this turned out to be not possible because it assumes we know the possible placeholder strings (which is obviously not the case here)



<img width="668" alt="Screenshot 2023-09-06 at 12 33 57" src="https://github.com/artsy/eigen/assets/11945712/5c73da97-2048-466b-8fff-d3f4d1077241">


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- make alert name multiline on android - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
