### PR TITLE
fix(images): use new default resize behavior to avoid overfetching

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.144.0",
-    "@artsy/palette-mobile": "13.0.7",
+    "@artsy/palette-mobile": "13.0.8",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@gorhom/bottom-sheet": "4.4.5",

--- a/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
+++ b/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
@@ -38,7 +38,7 @@ const HeroUnit: React.FC<HeroUnitProps> = ({ item }) => {
   return (
     <Touchable key={item.internalID} onPress={handlePress}>
       <Flex bg="black100" flexDirection="row" height={CARD_HEIGHT} width={screenWidth}>
-        <Image height={CARD_HEIGHT} src={imageSrc} width={cardImageWidth} performResize={false} />
+        <Image height={CARD_HEIGHT} src={imageSrc} width={cardImageWidth} />
         <Box p={2} width={screenWidth - cardImageWidth}>
           <Text color="white100" mb={1} numberOfLines={2} variant="lg-display">
             {item.title}

--- a/src/app/system/devTools/DevMenu/DevMenu.tsx
+++ b/src/app/system/devTools/DevMenu/DevMenu.tsx
@@ -46,6 +46,7 @@ import {
 } from "react-native"
 import Config from "react-native-config"
 import DeviceInfo from "react-native-device-info"
+import FastImage from "react-native-fast-image"
 import Keychain from "react-native-keychain"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
@@ -238,6 +239,13 @@ export const DevMenu = ({ onClose = () => goBack() }: { onClose(): void }) => {
             title="Clear Relay Cache"
             onPress={() => {
               RelayCache.clearAll()
+            }}
+          />
+          <DevMenuButtonItem
+            title="Clear FastImage Cache"
+            onPress={() => {
+              FastImage.clearMemoryCache()
+              FastImage.clearDiskCache()
             }}
           />
           <DevMenuButtonItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@13.0.7":
-  version "13.0.7"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.0.7.tgz#2b8e73faac0cfa43784d93c458ac45b6134ffe52"
-  integrity sha512-J0KwUPHZWTf/nGMR0u6XZrMCCRWO4NJ0QfZWaCBlniNKTdwq8AMxR0O+Gwp/kLGRF05z1n/zVISIgpPtn8pvwA==
+"@artsy/palette-mobile@13.0.8":
+  version "13.0.8"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.0.8.tgz#a5bed4563cc04a3f76ec18280bff219671a6c5ba"
+  integrity sha512-0WwG/xByx/78EuV3tUQfh61ogQ9wBwZTtfzNOFVCYGAZpZS4FwctJ7kT2xohTUNrPjAxdgC+smOLokwYEXS4Gg==
   dependencies:
     "@artsy/palette-tokens" "^5.0.0"
     "@shopify/flash-list" "^1.5.0"


### PR DESCRIPTION
This PR resolves [ONYX-358]

Co-authored-by: @gkartalis 

### Description

Addresses [the overfetching of image data in the `HeroUnitsRail`](https://artsy.slack.com/archives/C05EEBNEF71/p1694628881863159?thread_ts=1694436720.499889&cid=C05EEBNEF71).

Prior to the change in https://github.com/artsy/palette-mobile/pull/149 the palette-mobile `Image` component was rendering images that were too low-res

In order to avoid that we added `performResize=false` to the `<Image />` tag here

That had the opposite and unintended effect of pulling down un-sized images that were multiple megabytes in size — 12mb instead of what should have been a couple hundred kb.

Fixed now — we only found one actual usage of the new `Image` component, so that's the only one updated here.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI. 
  - [x] see https://github.com/artsy/palette-mobile/pull/149
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Dev changes

- Fixes image overfetching issue on home feed

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-358]: https://artsyproduct.atlassian.net/browse/ONYX-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ