### PR TITLE
fix(DIA-168): onboarding quiz crash

### DIFF
--- a/src/app/Components/FancySwiper/FancySwiper.tsx
+++ b/src/app/Components/FancySwiper/FancySwiper.tsx
@@ -8,17 +8,11 @@ export const OFFSET_X = 100
 
 interface FancySwiperProps {
   cards: Card[]
-  activeIndex: number
-  onSwipeRight: (index: number) => void
-  onSwipeLeft: (index: number) => void
+  onSwipeRight: () => void
+  onSwipeLeft: () => void
 }
 
-export const FancySwiper = ({
-  cards,
-  activeIndex,
-  onSwipeRight,
-  onSwipeLeft,
-}: FancySwiperProps) => {
+export const FancySwiper = ({ cards, onSwipeRight, onSwipeLeft }: FancySwiperProps) => {
   const remainingCards = cards.reverse()
   const swiper = useRef<Animated.ValueXY>(new Animated.ValueXY()).current
 
@@ -28,12 +22,12 @@ export const FancySwiper = ({
       swiper.setValue({ x: 0, y: 0 })
 
       if (swipeDirection === "right") {
-        onSwipeRight(activeIndex)
+        onSwipeRight()
       } else {
-        onSwipeLeft(activeIndex)
+        onSwipeLeft()
       }
     },
-    [remainingCards, activeIndex, swiper]
+    [remainingCards, swiper]
   )
 
   const panResponder = PanResponder.create({

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -46,17 +46,17 @@ const ArtQuizArtworksScreen = () => {
 
   const handleSwipe = (swipeDirection: "left" | "right") => {
     handleNext(swipeDirection === "right" ? "Like" : "Dislike", activeCardIndex)
-    setActiveCardIndex(activeCardIndex + 1)
+
+    // No need to swipe through the last card, just navigate to the results screen
+    if (activeCardIndex + 1 < artworks.length) {
+      setActiveCardIndex(activeCardIndex + 1)
+    }
   }
 
   const handleNext = (action: "Like" | "Dislike", activeIndex: number) => {
     popoverMessage.hide()
 
     const currentArtwork = artworks[activeIndex]
-
-    if (!currentArtwork) {
-      return
-    }
 
     if (action === "Like") {
       submitSave({

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -10,6 +10,7 @@ import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { isEmpty } from "lodash"
 import { Suspense, useEffect, useState } from "react"
 import { Image } from "react-native"
 
@@ -57,6 +58,10 @@ const ArtQuizArtworksScreen = () => {
     popoverMessage.hide()
 
     const currentArtwork = artworks[activeIndex]
+
+    if (isEmpty(currentArtwork)) {
+      return
+    }
 
     if (action === "Like") {
       submitSave({

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -21,6 +21,7 @@ const ArtQuizArtworksScreen = () => {
   const { width } = useScreenDimensions()
   const space = useSpace()
   const artworks = extractNodes(queryResult.me?.quiz.quizArtworkConnection)
+
   const lastInteractedArtworkIndex = queryResult.me?.quiz.quizArtworkConnection?.edges?.findIndex(
     (edge) => edge?.interactedAt === null
   )
@@ -44,14 +45,18 @@ const ArtQuizArtworksScreen = () => {
   }, [])
 
   const handleSwipe = (swipeDirection: "left" | "right", activeIndex: number) => {
-    setActiveCardIndex(activeIndex + 1)
     handleNext(swipeDirection === "right" ? "Like" : "Dislike", activeIndex)
+    setActiveCardIndex(activeIndex + 1)
   }
 
   const handleNext = (action: "Like" | "Dislike", activeIndex: number) => {
     popoverMessage.hide()
 
     const currentArtwork = artworks[activeIndex]
+
+    if (!currentArtwork) {
+      return
+    }
 
     if (action === "Like") {
       submitSave({
@@ -176,9 +181,8 @@ const ArtQuizArtworksScreen = () => {
       <Screen.Body>
         <FancySwiper
           cards={artworkCards}
-          activeIndex={activeCardIndex}
-          onSwipeRight={(index) => handleSwipe("right", index)}
-          onSwipeLeft={(index) => handleSwipe("left", index)}
+          onSwipeRight={() => handleSwipe("right", activeCardIndex)}
+          onSwipeLeft={() => handleSwipe("left", activeCardIndex)}
         />
       </Screen.Body>
     </Screen>

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -44,9 +44,9 @@ const ArtQuizArtworksScreen = () => {
     }
   }, [])
 
-  const handleSwipe = (swipeDirection: "left" | "right", activeIndex: number) => {
-    handleNext(swipeDirection === "right" ? "Like" : "Dislike", activeIndex)
-    setActiveCardIndex(activeIndex + 1)
+  const handleSwipe = (swipeDirection: "left" | "right") => {
+    handleNext(swipeDirection === "right" ? "Like" : "Dislike", activeCardIndex)
+    setActiveCardIndex(activeCardIndex + 1)
   }
 
   const handleNext = (action: "Like" | "Dislike", activeIndex: number) => {
@@ -181,8 +181,8 @@ const ArtQuizArtworksScreen = () => {
       <Screen.Body>
         <FancySwiper
           cards={artworkCards}
-          onSwipeRight={() => handleSwipe("right", activeCardIndex)}
-          onSwipeLeft={() => handleSwipe("left", activeCardIndex)}
+          onSwipeRight={() => handleSwipe("right")}
+          onSwipeLeft={() => handleSwipe("left")}
         />
       </Screen.Body>
     </Screen>


### PR DESCRIPTION
This PR resolves [DIA-168] <!-- eg [PROJECT-XXXX] -->

### Description
This PR resolves a race condition that resolved in a crash if you move through the art quiz fast. The solution here is to decouple the swiper from the handler in order to avoid relying on a state value for the active index that might be outdated. I also moved the API logic to happen before the state logic. 

**Note:** I believe the logic can be improved even further here buy having the `activeIndex` getting incremented only after a successful mutation and creating a queue of mutations. It's alright though as it is right now and it should be good enough in its current state.

**Before** 

https://github.com/artsy/eigen/assets/11945712/35e360e5-cb68-4f64-a4c5-879141059c30


**After**

https://github.com/artsy/eigen/assets/11945712/6178ad9b-eb6b-4f32-83af-3316a4368b58



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix onboarding quiz crash - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-168]: https://artsyproduct.atlassian.net/browse/DIA-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ