### PR TITLE
refactor(alerts): use eligibility flag from MP instead of computing locally

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
@@ -23,10 +23,10 @@ describe("CreateArtworkAlertModal", () => {
     `,
   })
 
-  it("returns null if no artists", () => {
+  it("returns null if artwork is ineligible", () => {
     const { queryByText } = renderWithRelay({
       Artwork: () => ({
-        artistsArray: [],
+        isEligibleToCreateAlert: false,
       }),
     })
 
@@ -42,6 +42,7 @@ describe("CreateArtworkAlertModal", () => {
 describe("computeArtworkAlertProps", () => {
   const artwork = {
     artistsArray: [{ name: "foo", internalID: "bar" }],
+    isEligibleToCreateAlert: true,
     attributionClass: {
       internalID: "1",
     },
@@ -56,18 +57,17 @@ describe("computeArtworkAlertProps", () => {
     },
   } as unknown as CreateArtworkAlertModal_artwork$data
 
-  it("should return default props when no artists are provided", () => {
-    const result = computeArtworkAlertProps({ ...artwork, artistsArray: [] })
+  it("should return default props when artwork is ineligible for alert", () => {
+    const result = computeArtworkAlertProps({ ...artwork, isEligibleToCreateAlert: false })
 
     expect(result).toEqual({
-      hasArtists: false,
       entity: null,
       attributes: null,
       aggregations: null,
     })
   })
 
-  it("should return correct props when artists are provided", () => {
+  it("should return correct props when artwork is eligible for alert", () => {
     const result = computeArtworkAlertProps(artwork)
 
     expect(result).toEqual({
@@ -86,7 +86,6 @@ describe("computeArtworkAlertProps", () => {
         artists: [{ id: "bar", name: "foo" }],
         owner: { type: "artwork", id: "2", slug: "test-artwork" },
       },
-      hasArtists: true,
     })
   })
 
@@ -104,7 +103,6 @@ describe("computeArtworkAlertProps", () => {
         artists: [{ id: "bar", name: "foo" }],
         owner: { type: "artwork", id: "2", slug: "test-artwork" },
       },
-      hasArtists: true,
     })
   })
 })

--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
@@ -33,6 +33,7 @@ export const CreateArtworkAlertModal: React.FC<CreateArtworkAlertModalProps> = (
         title
         internalID
         slug
+        isEligibleToCreateAlert
         artistsArray: artists {
           internalID
           name
@@ -51,11 +52,13 @@ export const CreateArtworkAlertModal: React.FC<CreateArtworkAlertModalProps> = (
     artwork
   )
 
-  const artworkAlert = computeArtworkAlertProps(data)
+  const { isEligibleToCreateAlert } = data
 
-  if (!artworkAlert.hasArtists) {
+  if (!isEligibleToCreateAlert) {
     return null
   }
+
+  const artworkAlert = computeArtworkAlertProps(data)
 
   return (
     <CreateSavedSearchModal
@@ -72,12 +75,10 @@ export const CreateArtworkAlertModal: React.FC<CreateArtworkAlertModalProps> = (
 export const computeArtworkAlertProps = (
   artwork: CreateArtworkAlertModal_artwork$data | BrowseSimilarWorks_artwork$data
 ) => {
-  const artistsArray = artwork.artistsArray ?? []
-  const hasArtists = artistsArray.length > 0
+  const { isEligibleToCreateAlert } = artwork
 
-  if (!hasArtists) {
+  if (!isEligibleToCreateAlert) {
     return {
-      hasArtists,
       entity: null,
       attributes: null,
       aggregations: null,
@@ -129,6 +130,5 @@ export const computeArtworkAlertProps = (
     entity,
     attributes,
     aggregations,
-    hasArtists,
   }
 }

--- a/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
@@ -22,16 +22,25 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
     artwork
   )
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
-  const { title, artistNames, isInAuction, sale, saleArtwork, internalID, slug } = artworkData
+  const {
+    artistNames,
+    internalID,
+    isEligibleToCreateAlert,
+    isInAuction,
+    sale,
+    saleArtwork,
+    slug,
+    title,
+  } = artworkData
   const formattedArtistNames = artistNames ? artistNames + ", " : ""
-  const hasArtists = artistNames?.length ?? 0 > 0
 
   const hasArtworksSuggestions =
     (artworkData.savedSearch?.suggestedArtworksConnection?.totalCount ?? 0) > 0
 
   const isLotClosedOrBiddingEnded =
     hasBiddingEnded(sale, saleArtwork) || isLotClosed(sale, saleArtwork)
-  const displayAuctionCreateAlertHeader = hasArtists && isInAuction && isLotClosedOrBiddingEnded
+  const displayAuctionCreateAlertHeader =
+    isEligibleToCreateAlert && isInAuction && isLotClosedOrBiddingEnded
 
   if (!displayAuctionCreateAlertHeader) {
     return null
@@ -119,6 +128,7 @@ const artworkAuctionCreateAlertHeaderFragment = graphql`
   fragment ArtworkAuctionCreateAlertHeader_artwork on Artwork {
     title
     internalID
+    isEligibleToCreateAlert
     artistNames
     isInAuction
     internalID

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -31,7 +31,7 @@ describe("ArtworkScreenHeader", () => {
   it("renders the header", () => {
     renderWithRelay({
       Artwork: () => ({
-        artists: [{ name: "test" }],
+        isEligibleToCreateAlert: true,
       }),
     })
 
@@ -51,10 +51,10 @@ describe("ArtworkScreenHeader", () => {
   })
 
   describe("Create alert button", () => {
-    it("renders the header but not the create alert button if the artwork doesn't have an associated artist", () => {
+    it("renders the header but not the create alert button if the artwork isn't eligible", () => {
       renderWithRelay({
         Artwork: () => ({
-          artists: [],
+          isEligibleToCreateAlert: false,
         }),
       })
 
@@ -67,7 +67,7 @@ describe("ArtworkScreenHeader", () => {
         Artwork: () => ({
           internalID: "internalID-1",
           slug: "slug-1",
-          artistsArray: [{ name: "some-artist-name" }],
+          isEligibleToCreateAlert: true,
         }),
       })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -19,8 +19,7 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
     artworkRef
   )
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
-  const { isForSale, sale, saleArtwork, isInAuction } = artwork
-  const hasArtists = !!artwork?.artists?.length
+  const { isForSale, sale, saleArtwork, isInAuction, isEligibleToCreateAlert } = artwork
 
   const isLotClosedOrBiddingEnded =
     hasBiddingEnded(sale, saleArtwork) || isLotClosed(sale, saleArtwork)
@@ -29,7 +28,7 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
   const displayCreateAlertHeader =
     isInAuction && isLotClosedOrBiddingEnded && enableAuctionHeaderAlertCTA
 
-  if (!!displayCreateAlertHeader || !hasArtists) {
+  if (!!displayCreateAlertHeader || !isEligibleToCreateAlert) {
     return null
   }
 
@@ -56,6 +55,7 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
 
 const ArtworkScreenHeaderCreateAlert_artwork = graphql`
   fragment ArtworkScreenHeaderCreateAlert_artwork on Artwork {
+    isEligibleToCreateAlert
     isInAuction
     ...CreateArtworkAlertModal_artwork
     artists {

--- a/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks.tsx
+++ b/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks.tsx
@@ -44,11 +44,11 @@ export interface BrowseSimilarWorksProps {
 const BrowseSimilarWorks: React.FC<{ artwork: BrowseSimilarWorks_artwork$key }> = (props) => {
   const artwork = useFragment(similarWorksFragment, props.artwork)
 
-  const artworkAlert = computeArtworkAlertProps(artwork)
-
-  if (!artworkAlert.hasArtists) {
+  if (!artwork.isEligibleToCreateAlert) {
     return null
   }
+
+  const artworkAlert = computeArtworkAlertProps(artwork)
 
   const params: BrowseSimilarWorksProps = {
     aggregations: artworkAlert.aggregations!,
@@ -79,6 +79,7 @@ const similarWorksFragment = graphql`
     title
     internalID
     slug
+    isEligibleToCreateAlert
     artistsArray: artists {
       internalID
       name


### PR DESCRIPTION
This PR resolves [ONYX-394]

Follow-up to https://github.com/artsy/metaphysics/pull/5296

Counterpart of https://github.com/artsy/force/pull/12905 and very similar!

### Description

We have conditional logic to determine whether an artwork is eligible to have an alert created from it. This logic has multiplied throughout client code paths in Force and Eigen.

This addresses that tech debt by relying on the new `isEligibleToCreateAlert` flag computed in Metaphysics, instead of computing this eligibility locally.

Mostly that means diffs along the lines of…

```diff
- const hasArtists = artwork.artists?.length > 0
- if (hasArtists) {
+ if (artwork.isEligibleToCreateAlert) {
   // render an alert cta
 }   
```


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Refactor artwork alerts to use eligibility flag from MP instead of computing locally

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-394]: https://artsyproduct.atlassian.net/browse/ONYX-394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ