### PR TITLE
chore: Remove ARReorderSWAArtworkSubmissionFlow ff

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -18,7 +18,6 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { BackButton } from "app/system/navigation/BackButton"
 import { goBack } from "app/system/navigation/navigate"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
@@ -40,11 +39,7 @@ export enum STEPS {
   ContactInformation = "ContactInformation",
 }
 
-const DEFAULT_STEPS_IN_ORDER: STEPS[] = [
-  STEPS.ArtworkDetails,
-  STEPS.UploadPhotos,
-  STEPS.ContactInformation,
-]
+const STEPS_IN_ORDER: STEPS[] = [STEPS.ContactInformation, STEPS.ArtworkDetails, STEPS.UploadPhotos]
 
 type SubmitArtworkScreenNavigationProps = StackScreenProps<
   SubmitArtworkOverviewNavigationStack,
@@ -54,11 +49,6 @@ type SubmitArtworkScreenNavigationProps = StackScreenProps<
 export const SubmitArtworkScreen: React.FC<SubmitArtworkScreenNavigationProps> = ({
   navigation,
 }) => {
-  const enableReorderedSubmissionFlow = useFeatureFlag("ARReorderSWAArtworkSubmissionFlow")
-  const STEPS_IN_ORDER: typeof DEFAULT_STEPS_IN_ORDER = enableReorderedSubmissionFlow
-    ? [STEPS.ContactInformation, STEPS.ArtworkDetails, STEPS.UploadPhotos]
-    : DEFAULT_STEPS_IN_ORDER
-
   return <SubmitSWAArtworkFlow navigation={navigation} stepsInOrder={STEPS_IN_ORDER} />
 }
 

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -76,11 +76,6 @@ export const features: { [key: string]: FeatureDescriptor } = {
     readyForRelease: true,
     echoFlagKey: "AREnableNewRequestPriceEstimateLogic",
   },
-  ARReorderSWAArtworkSubmissionFlow: {
-    description: "Reorder SWA Artwork submission flow",
-    readyForRelease: true,
-    echoFlagKey: "ARReorderSWAArtworkSubmissionFlow",
-  },
   AREnablePanOnStaticHeader: {
     description: "Enable Scroll/Pan on StaticHeader",
     readyForRelease: false,


### PR DESCRIPTION
This PR resolves [ONYX-342] <!-- eg [PROJECT-XXXX] -->

### Description

Remove ARReorderSWAArtworkSubmissionFlow ff.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-342]: https://artsyproduct.atlassian.net/browse/ONYX-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ