### PR TITLE
fix: Home screen refetch indicator logic

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -77,16 +77,7 @@ import {
 } from "app/utils/track/ArtworkActions"
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
 import { times } from "lodash"
-import React, {
-  RefObject,
-  createRef,
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import React, { RefObject, createRef, memo, useCallback, useEffect, useRef, useState } from "react"
 import {
   Alert,
   ListRenderItem,
@@ -394,28 +385,27 @@ const Home = memo((props: HomeProps) => {
 const useHandleRefresh = (relay: RelayRefetchProp, modules: any[]) => {
   const scrollRefs = useRef<Array<RefObject<RailScrollRef>>>(modules.map((_) => createRef()))
   const [isRefreshing, setIsRefreshing] = useState(false)
-  return useMemo(() => {
-    const scrollRailsToTop = () => scrollRefs.current.forEach((r) => r.current?.scrollToTop())
 
-    const handleRefresh = async () => {
-      setIsRefreshing(true)
+  const scrollRailsToTop = () => scrollRefs.current.forEach((r) => r.current?.scrollToTop())
 
-      relay.refetch(
-        { heroImageVersion: isPad() ? "WIDE" : "NARROW" },
-        {},
-        (error) => {
-          if (error) {
-            console.error("Home.tsx - Error refreshing ForYou rails:", error.message)
-          }
-          setIsRefreshing(false)
-          scrollRailsToTop()
-        },
-        { force: true }
-      )
-    }
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
 
-    return { scrollRefs, isRefreshing, handleRefresh }
-  }, [modules.join(""), relay])
+    relay.refetch(
+      { heroImageVersion: isPad() ? "WIDE" : "NARROW" },
+      {},
+      (error) => {
+        if (error) {
+          console.error("Home.tsx - Error refreshing ForYou rails:", error.message)
+        }
+        setIsRefreshing(false)
+        scrollRailsToTop()
+      },
+      { force: true }
+    )
+  }
+
+  return { scrollRefs, isRefreshing, handleRefresh }
 }
 
 export const HomeFragmentContainer = memo(


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

This PR addresses the logic of the Home screen refetch indicator. Previously, the `isRefetching` state was never set to `true` in the `Home` component. By removing the `useMemo` hook, `isRefetching` is now updated correctly and functions as intended.

I believe this change does not impact performance, which was likely the initial reason for using `useMemo`. Within the `useMemo`, there were only two function declarations and no computationally heavy code (code within the function is not executed when the function is declared).


**Before:**

https://github.com/artsy/eigen/assets/4691889/8a5fbf24-9943-48a6-b195-534ae699c10d



**Now:**

https://github.com/artsy/eigen/assets/4691889/067314d6-2678-42b6-83e6-126700dba888


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix Home screen refetch indicator logic - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
