### PR TITLE
feat(onyx-356): single activity panel notification screen

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -8,6 +8,7 @@ import {
   WorksForYouScreenQuery,
 } from "app/Components/Containers/WorksForYou"
 import { FadeIn } from "app/Components/FadeIn"
+import { ActivityItemScreenQueryRenderer } from "app/Scenes/Activity/ActivityItemScreen"
 import { ArtQuiz } from "app/Scenes/ArtQuiz/ArtQuiz"
 import { ArtQuizResults } from "app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults"
 import { ArticleScreen } from "app/Scenes/Article/ArticleScreen"
@@ -337,6 +338,9 @@ export const modules = defineModules({
   Activity: reactModule(Activity, {
     fullBleed: true,
     hidesBackButton: true,
+  }),
+  ActivityItem: reactModule(ActivityItemScreenQueryRenderer, {
+    hidesBottomTabs: true,
   }),
   About: reactModule(About),
   AddMyCollectionArtist: reactModule(AddMyCollectionArtist, {

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -23,7 +23,7 @@ const UNREAD_INDICATOR_SIZE = 8
 const ARTWORK_IMAGE_SIZE = 55
 
 export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
-  const navigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
+  const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
   const markAsRead = useMarkNotificationAsRead()
   const tracking = useTracking()
   const item = useFragment(activityItemFragment, props.item)
@@ -39,7 +39,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
       markAsRead(item)
     }
 
-    if (navigateToASingleNotification) {
+    if (enableNavigateToASingleNotification) {
       navigate(`/activity/${item.internalID}`)
     } else {
       navigateToActivityItem(item.targetHref)

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -5,7 +5,9 @@ import { ActivityItem_item$key } from "__generated__/ActivityItem_item.graphql"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { useMarkNotificationAsRead } from "app/Scenes/Activity/mutations/useMarkNotificationAsRead"
 import { navigateToActivityItem } from "app/Scenes/Activity/utils/navigateToActivityItem"
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { TouchableOpacity } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -21,6 +23,7 @@ const UNREAD_INDICATOR_SIZE = 8
 const ARTWORK_IMAGE_SIZE = 55
 
 export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
+  const navigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
   const markAsRead = useMarkNotificationAsRead()
   const tracking = useTracking()
   const item = useFragment(activityItemFragment, props.item)
@@ -32,10 +35,14 @@ export const ActivityItem: React.FC<ActivityItemProps> = (props) => {
   const handlePress = () => {
     tracking.trackEvent(tracks.tappedNotification(item.notificationType))
 
-    navigateToActivityItem(item.targetHref)
-
     if (item.isUnread) {
       markAsRead(item)
+    }
+
+    if (navigateToASingleNotification) {
+      navigate(`/activity/${item.internalID}`)
+    } else {
+      navigateToActivityItem(item.targetHref)
     }
   }
 

--- a/src/app/Scenes/Activity/ActivityItemArtworksGrid.tsx
+++ b/src/app/Scenes/Activity/ActivityItemArtworksGrid.tsx
@@ -8,7 +8,8 @@ import { useWindowDimensions } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
 const TOTAL_HORIZONTAL_PADDING = 40
-const IMAGE_OFFSET = 10
+const IMAGES_PER_ROW = 2
+const GAP_BETWEEN_IMAGES = 1
 
 interface ActivityItemArtworksGridProps {
   notification: ActivityItemArtworksGrid_notification$key
@@ -28,53 +29,29 @@ export const ActivityItemArtworksGrid: FC<ActivityItemArtworksGridProps> = ({ no
   }
 
   const imageURLs = compact(artworkNodes.map((node) => node.image?.resized?.url ?? null))
-  const rowImageWidth = (width - (TOTAL_HORIZONTAL_PADDING + IMAGE_OFFSET)) / 2
+  const rowImageWidth = (width - TOTAL_HORIZONTAL_PADDING - 10) / IMAGES_PER_ROW
 
   return (
     <>
-      <Box>
-        <Flex flexDirection="row">
-          <ArtworkImage
-            imageURL={imageURLs[0]}
-            size={rowImageWidth}
-            artworkHref={artworkNodes[0].href!}
-          />
-          <Spacer x={`${IMAGE_OFFSET}px`} />
-
-          {artworkNodes.length > 1 && (
-            <ArtworkImage
-              imageURL={imageURLs[1]}
-              size={rowImageWidth}
-              artworkHref={artworkNodes[1].href!}
-            />
-          )}
-        </Flex>
-
-        {artworkNodes.length > 2 && (
-          <>
-            <Spacer y={`${IMAGE_OFFSET}px`} />
-
-            <Flex flexDirection="row">
+      <Flex flex={1} flexDirection="row" flexWrap="wrap">
+        {imageURLs.map((imageURL, index) => {
+          return (
+            <Box
+              key={`artwork-image-${index}`}
+              mr={index % 2 == 0 ? GAP_BETWEEN_IMAGES : 0}
+              mb={GAP_BETWEEN_IMAGES}
+            >
               <ArtworkImage
-                imageURL={imageURLs[2]}
+                imageURL={imageURL}
                 size={rowImageWidth}
-                artworkHref={artworkNodes[2].href!}
+                artworkHref={artworkNodes[index].href!}
               />
-              <Spacer x={`${IMAGE_OFFSET}px`} />
+            </Box>
+          )
+        })}
+      </Flex>
 
-              {artworkNodes.length > 3 && (
-                <ArtworkImage
-                  imageURL={imageURLs[3]}
-                  size={rowImageWidth}
-                  artworkHref={artworkNodes[3].href!}
-                />
-              )}
-            </Flex>
-          </>
-        )}
-      </Box>
-
-      <Spacer y={2} />
+      <Spacer y={1} />
     </>
   )
 }
@@ -113,31 +90,25 @@ const ArtworkImage: FC<ArtworkImageProps> = ({ imageURL, size, artworkHref, ...r
 
 export const ActivityItemArtworksGridPlaceholder: FC = () => {
   const { width } = useWindowDimensions()
-  const rowImageWidth = (width - (TOTAL_HORIZONTAL_PADDING + IMAGE_OFFSET)) / 2
+  const rowImageWidth = (width - TOTAL_HORIZONTAL_PADDING - 10) / IMAGES_PER_ROW
 
   return (
     <>
-      <Box>
-        <Flex flexDirection="row">
-          <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
-          <Spacer x={`${IMAGE_OFFSET}px`} />
+      <Flex flex={1} flexDirection="row" flexWrap="wrap">
+        {Array.from(Array(4)).map((_, index) => {
+          return (
+            <SkeletonBox
+              key={`artwork-image-placeholder-${index}`}
+              mr={index % 2 == 0 ? GAP_BETWEEN_IMAGES : 0}
+              mb={GAP_BETWEEN_IMAGES}
+              width={rowImageWidth}
+              height={rowImageWidth}
+            />
+          )
+        })}
+      </Flex>
 
-          <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
-        </Flex>
-
-        <>
-          <Spacer y={`${IMAGE_OFFSET}px`} />
-
-          <Flex flexDirection="row">
-            <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
-            <Spacer x={`${IMAGE_OFFSET}px`} />
-
-            <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
-          </Flex>
-        </>
-      </Box>
-
-      <Spacer y={2} />
+      <Spacer y={1} />
     </>
   )
 }

--- a/src/app/Scenes/Activity/ActivityItemArtworksGrid.tsx
+++ b/src/app/Scenes/Activity/ActivityItemArtworksGrid.tsx
@@ -1,0 +1,143 @@
+import { Box, Flex, FlexProps, Image, SkeletonBox, Spacer, Touchable } from "@artsy/palette-mobile"
+import { ActivityItemArtworksGrid_notification$key } from "__generated__/ActivityItemArtworksGrid_notification.graphql"
+import { navigate } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { compact } from "lodash"
+import { FC } from "react"
+import { useWindowDimensions } from "react-native"
+import { graphql, useFragment } from "react-relay"
+
+const TOTAL_HORIZONTAL_PADDING = 40
+const IMAGE_OFFSET = 10
+
+interface ActivityItemArtworksGridProps {
+  notification: ActivityItemArtworksGrid_notification$key
+}
+
+export const ActivityItemArtworksGrid: FC<ActivityItemArtworksGridProps> = ({ notification }) => {
+  const { width } = useWindowDimensions()
+
+  const data = useFragment<ActivityItemArtworksGrid_notification$key>(
+    activityItemArtworksGridFragment,
+    notification
+  )
+  const artworkNodes = extractNodes(data.artworksConnection)
+
+  if (artworkNodes.length === 0) {
+    return null
+  }
+
+  const imageURLs = compact(artworkNodes.map((node) => node.image?.resized?.url ?? null))
+  const rowImageWidth = (width - (TOTAL_HORIZONTAL_PADDING + IMAGE_OFFSET)) / 2
+
+  return (
+    <>
+      <Box>
+        <Flex flexDirection="row">
+          <ArtworkImage
+            imageURL={imageURLs[0]}
+            size={rowImageWidth}
+            artworkHref={artworkNodes[0].href!}
+          />
+          <Spacer x={`${IMAGE_OFFSET}px`} />
+
+          {artworkNodes.length > 1 && (
+            <ArtworkImage
+              imageURL={imageURLs[1]}
+              size={rowImageWidth}
+              artworkHref={artworkNodes[1].href!}
+            />
+          )}
+        </Flex>
+
+        {artworkNodes.length > 2 && (
+          <>
+            <Spacer y={`${IMAGE_OFFSET}px`} />
+
+            <Flex flexDirection="row">
+              <ArtworkImage
+                imageURL={imageURLs[2]}
+                size={rowImageWidth}
+                artworkHref={artworkNodes[2].href!}
+              />
+              <Spacer x={`${IMAGE_OFFSET}px`} />
+
+              {artworkNodes.length > 3 && (
+                <ArtworkImage
+                  imageURL={imageURLs[3]}
+                  size={rowImageWidth}
+                  artworkHref={artworkNodes[3].href!}
+                />
+              )}
+            </Flex>
+          </>
+        )}
+      </Box>
+
+      <Spacer y={2} />
+    </>
+  )
+}
+
+const activityItemArtworksGridFragment = graphql`
+  fragment ActivityItemArtworksGrid_notification on Notification {
+    artworksConnection(first: 4) {
+      edges {
+        node {
+          href
+          image {
+            resized(height: 300, width: 300, version: "normalized") {
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+`
+interface ArtworkImageProps extends FlexProps {
+  artworkHref: string
+  imageURL: string
+  size: number
+}
+
+const ArtworkImage: FC<ArtworkImageProps> = ({ imageURL, size, artworkHref, ...rest }) => {
+  return (
+    <Touchable onPress={() => navigate(artworkHref!)}>
+      <Flex {...rest}>
+        <Image src={imageURL!} width={size} height={size} />
+      </Flex>
+    </Touchable>
+  )
+}
+
+export const ActivityItemArtworksGridPlaceholder: FC = () => {
+  const { width } = useWindowDimensions()
+  const rowImageWidth = (width - (TOTAL_HORIZONTAL_PADDING + IMAGE_OFFSET)) / 2
+
+  return (
+    <>
+      <Box>
+        <Flex flexDirection="row">
+          <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
+          <Spacer x={`${IMAGE_OFFSET}px`} />
+
+          <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
+        </Flex>
+
+        <>
+          <Spacer y={`${IMAGE_OFFSET}px`} />
+
+          <Flex flexDirection="row">
+            <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
+            <Spacer x={`${IMAGE_OFFSET}px`} />
+
+            <SkeletonBox width={rowImageWidth} height={rowImageWidth} />
+          </Flex>
+        </>
+      </Box>
+
+      <Spacer y={2} />
+    </>
+  )
+}

--- a/src/app/Scenes/Activity/ActivityItemScreen.tsx
+++ b/src/app/Scenes/Activity/ActivityItemScreen.tsx
@@ -129,7 +129,6 @@ const ActivityItemQuery = graphql`
         notificationType
         publishedAt(format: "RELATIVE")
         targetHref
-
         ...ActivityItemArtworksGrid_notification
       }
     }

--- a/src/app/Scenes/Activity/ActivityItemScreen.tsx
+++ b/src/app/Scenes/Activity/ActivityItemScreen.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, SkeletonBox, Spacer, Text, useTheme } from "@artsy/palette-mobile"
+import { Box, Flex, SkeletonBox, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import {
   ActivityItemScreenQuery,
   ActivityItemScreenQuery$data,
@@ -40,9 +40,9 @@ const PlaceholderComponent: FC = () => {
         <ActivityItemArtworksGridPlaceholder />
 
         <Flex flex={1}>
-          <Button variant="outline" haptic block onPress={() => {}} disabled>
+          <Text underline textAlign="center">
             View more
-          </Button>
+          </Text>
         </Flex>
       </ScrollView>
     </Flex>
@@ -88,16 +88,15 @@ const ActivityItemScreen: FC<ActivityItemScreenProps> = ({ me }) => {
         <ActivityItemArtworksGrid notification={notification} />
 
         <Flex flex={1}>
-          <Button
-            variant="outline"
-            haptic
-            block
+          <Text
+            underline
+            textAlign="center"
             onPress={() => {
               navigateToActivityItem(notification.targetHref)
             }}
           >
             View more
-          </Button>
+          </Text>
         </Flex>
       </ScrollView>
     </Flex>

--- a/src/app/Scenes/Activity/ActivityItemScreen.tsx
+++ b/src/app/Scenes/Activity/ActivityItemScreen.tsx
@@ -1,0 +1,150 @@
+import { Box, Button, Flex, SkeletonBox, Spacer, Text, useTheme } from "@artsy/palette-mobile"
+import {
+  ActivityItemScreenQuery,
+  ActivityItemScreenQuery$data,
+} from "__generated__/ActivityItemScreenQuery.graphql"
+import {
+  ActivityItemArtworksGrid,
+  ActivityItemArtworksGridPlaceholder,
+} from "app/Scenes/Activity/ActivityItemArtworksGrid"
+import { ActivityItemTypeLabel } from "app/Scenes/Activity/ActivityItemTypeLabel"
+import { navigateToActivityItem } from "app/Scenes/Activity/utils/navigateToActivityItem"
+import { shouldDisplayNotificationTypeLabel } from "app/Scenes/Activity/utils/shouldDisplayNotificationTypeLabel"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { FC } from "react"
+import { ScrollView } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { graphql, useLazyLoadQuery } from "react-relay"
+
+interface ActivityItemScreenProps {
+  me: ActivityItemScreenQuery$data["me"]
+}
+
+const PlaceholderComponent: FC = () => {
+  const { space } = useTheme()
+  const { bottom: bottomInset } = useSafeAreaInsets()
+
+  return (
+    <Flex flex={1}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingTop: space(6),
+          paddingBottom: bottomInset,
+          paddingHorizontal: space(2),
+        }}
+      >
+        <ActivityItemPlaceholder />
+
+        <Spacer y={2} />
+
+        <ActivityItemArtworksGridPlaceholder />
+
+        <Flex flex={1}>
+          <Button variant="outline" haptic block onPress={() => {}} disabled>
+            View more
+          </Button>
+        </Flex>
+      </ScrollView>
+    </Flex>
+  )
+}
+
+const ActivityItemScreen: FC<ActivityItemScreenProps> = ({ me }) => {
+  const { space } = useTheme()
+  const { bottom: bottomInset } = useSafeAreaInsets()
+  const notification = me?.notification
+
+  if (!notification) {
+    return null
+  }
+
+  return (
+    <Flex flex={1}>
+      <ScrollView
+        contentContainerStyle={{
+          paddingTop: space(6),
+          paddingBottom: bottomInset,
+          paddingHorizontal: space(2),
+        }}
+      >
+        <Flex flexDirection="row">
+          {shouldDisplayNotificationTypeLabel(notification.notificationType) && (
+            <ActivityItemTypeLabel notificationType={notification.notificationType} />
+          )}
+
+          <Text variant="xs" color="black60">
+            {notification.publishedAt}
+          </Text>
+        </Flex>
+
+        <Text variant="sm-display" fontWeight="bold">
+          {notification.title}
+        </Text>
+
+        <Text variant="sm-display">{notification.message}</Text>
+
+        <Spacer y={2} />
+
+        <ActivityItemArtworksGrid notification={notification} />
+
+        <Flex flex={1}>
+          <Button
+            variant="outline"
+            haptic
+            block
+            onPress={() => {
+              navigateToActivityItem(notification.targetHref)
+            }}
+          >
+            View more
+          </Button>
+        </Flex>
+      </ScrollView>
+    </Flex>
+  )
+}
+
+interface ActivityItemScreenQueryRendererProps {
+  notificationID: string
+}
+
+export const ActivityItemScreenQueryRenderer: FC<ActivityItemScreenQueryRendererProps> =
+  withSuspense(({ notificationID }) => {
+    const data = useLazyLoadQuery<ActivityItemScreenQuery>(ActivityItemQuery, {
+      internalID: notificationID,
+    })
+
+    if (!data.me?.notification) {
+      return null
+    }
+
+    return <ActivityItemScreen me={data.me} />
+  }, PlaceholderComponent)
+
+const ActivityItemQuery = graphql`
+  query ActivityItemScreenQuery($internalID: String!) {
+    me {
+      notification(id: $internalID) {
+        title
+        message
+        notificationType
+        publishedAt(format: "RELATIVE")
+        targetHref
+
+        ...ActivityItemArtworksGrid_notification
+      }
+    }
+  }
+`
+
+const ActivityItemPlaceholder = () => {
+  return (
+    <Box>
+      <SkeletonBox width={30} height={20} />
+      <Spacer y={0.5} />
+      <SkeletonBox width={130} height={15} />
+      <Spacer y={0.5} />
+      <SkeletonBox width={100} height={15} />
+    </Box>
+  )
+}

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -40,7 +40,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
     }
   }
 
-  const imageURL = artworks[0].image?.preview?.src
+  const imageURL = artworks[0]?.image?.preview?.src
 
   const notificationTypeLabel = getNotificationTypeLabel(item.notificationType)
 

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -7,7 +7,9 @@ import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { useMarkNotificationAsRead } from "app/Scenes/Activity/mutations/useMarkNotificationAsRead"
 import { getNotificationTypeLabel } from "app/Scenes/Activity/utils/getNotificationTypeLabel"
 import { navigateToActivityItem } from "app/Scenes/Activity/utils/navigateToActivityItem"
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { TouchableOpacity } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
@@ -20,6 +22,7 @@ export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 55
 const MAX_WIDTH = 220
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
+  const navigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
   const markAsRead = useMarkNotificationAsRead()
 
   const item = useFragment(ActivityRailItemFragment, props.item)
@@ -30,7 +33,11 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
 
     markAsRead(item)
 
-    navigateToActivityItem(item.targetHref)
+    if (navigateToASingleNotification) {
+      navigate(`/activity/${item.internalID}`)
+    } else {
+      navigateToActivityItem(item.targetHref)
+    }
   }
 
   const imageURL = artworks[0].image?.preview?.src

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -22,7 +22,7 @@ export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 55
 const MAX_WIDTH = 220
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
-  const navigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
+  const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
   const markAsRead = useMarkNotificationAsRead()
 
   const item = useFragment(ActivityRailItemFragment, props.item)
@@ -33,7 +33,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
 
     markAsRead(item)
 
-    if (navigateToASingleNotification) {
+    if (enableNavigateToASingleNotification) {
       navigate(`/activity/${item.internalID}`)
     } else {
       navigateToActivityItem(item.targetHref)

--- a/src/app/Scenes/MyCollection/Screens/Insights/ArtistItem.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/ArtistItem.tsx
@@ -1,7 +1,6 @@
-import { NoArtworkIcon, Flex, useColor, Text } from "@artsy/palette-mobile"
+import { NoArtworkIcon, Flex, useColor, Text, Touchable } from "@artsy/palette-mobile"
 import { ArtistItem_artist$key } from "__generated__/ArtistItem_artist.graphql"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
-import { Touchable } from "@artsy/palette-mobile"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtistItemProps {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -123,6 +123,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     addRoute("/", "Home"),
     addRoute("/about", "About"),
     addRoute("/activity", "Activity"),
+    addRoute("/activity/:notificationID", "ActivityItem"),
     addRoute("/art-quiz", "ArtQuiz"),
     addRoute("/art-quiz/artworks", "ArtQuiz"),
     addRoute("/art-quiz/results", "ArtQuizResults"),


### PR DESCRIPTION
This PR resolves [ONYX-356]

### Description

- [Figma prototype](https://www.figma.com/proto/VjFsvmJ7e5geXuRGDeKRCg/Onyx---Design-Strategy-WIP?page-id=841%3A3070&type=design&node-id=1187-4428&viewport=99%2C-1064%2C0.31&t=2zHDojRSyxBIT0wv-1&scaling=scale-down&starting-point-node-id=851%3A859)

I've added a new screen for individual activity panel notifications. You can navigate to it by clicking on an activity panel item from activity panel or latest activities rail.

### Demo

https://github.com/artsy/eigen/assets/3934579/cee75832-aa92-4045-8a67-71e2ade1b4da

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
  - [ ] I will appreciate if someone tests my changes on Android simulator
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
  - [x] This is not a final version - thus no tests so far 
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- behind feature flag: new screen for individual activity panel notifications - @nickskalkin 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-356]: https://artsyproduct.atlassian.net/browse/ONYX-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ