### PR TITLE
refactor(PHIRE-218): use MasonryFlashList of full screen grids

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -80,7 +80,7 @@ import { PurchaseModalQueryRenderer } from "./Scenes/Inbox/Components/Conversati
 import { ConversationNavigator } from "./Scenes/Inbox/ConversationNavigator"
 import { ConversationDetailsQueryRenderer } from "./Scenes/Inbox/Screens/ConversationDetails"
 import {
-  LotsByArtistsYouFollowQueryRenderer,
+  LotsByArtistsYouFollowScreen,
   LotsByArtistsYouFollowScreenQuery,
 } from "./Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow"
 import { MapContainer } from "./Scenes/Map/MapContainer"
@@ -475,7 +475,7 @@ export const modules = defineModules({
     modalPresentationStyle: "fullScreen",
   }),
   LocalDiscovery: reactModule(CityGuideView, { fullBleed: true }),
-  LotsByArtistsYouFollow: reactModule(LotsByArtistsYouFollowQueryRenderer, {}, [
+  LotsByArtistsYouFollow: reactModule(LotsByArtistsYouFollowScreen, {}, [
     LotsByArtistsYouFollowScreenQuery,
   ]),
   MakeOfferModal: reactModule(MakeOfferModalQueryRenderer, {

--- a/src/app/Components/ArtworkGrids/MasonryArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryArtworkGridItem.tsx
@@ -1,0 +1,65 @@
+import { ScreenOwnerType } from "@artsy/cohesion"
+import { Flex, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
+import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
+import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToPageableRoute"
+import { NUM_COLUMNS_MASONRY } from "app/utils/masonryHelpers"
+import { FragmentRefs } from "relay-runtime"
+
+interface Artwork {
+  readonly id: string
+  readonly image: {
+    readonly aspectRatio: number
+  } | null
+  readonly slug: string
+  readonly " $fragmentSpreads": FragmentRefs<"ArtworkGridItem_artwork">
+}
+
+interface MasonryArtworkGridItemProps {
+  item: Artwork
+  index: number
+  columnIndex: number
+  contextScreenOwnerType?: ScreenOwnerType
+  contextScreen?: ScreenOwnerType
+  contextScreenOwnerId?: string
+  contextScreenOwnerSlug?: string
+  navigateToPageableRoute: ReturnType<typeof useNavigateToPageableRoute>["navigateToPageableRoute"]
+}
+
+export const MasonryArtworkGridItem: React.FC<MasonryArtworkGridItemProps> = ({
+  item,
+  index,
+  columnIndex,
+  contextScreenOwnerType,
+  contextScreenOwnerId,
+  contextScreenOwnerSlug,
+  contextScreen,
+  navigateToPageableRoute,
+  ...rest
+}) => {
+  const space = useSpace()
+  const { width } = useScreenDimensions()
+
+  const imgAspectRatio = item.image?.aspectRatio ?? 1
+  const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+  const imgHeight = imgWidth / imgAspectRatio
+
+  return (
+    <Flex
+      pl={columnIndex === 0 ? 0 : 1}
+      pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+      mt={2}
+    >
+      <ArtworkGridItem
+        {...rest}
+        itemIndex={index}
+        contextScreenOwnerType={contextScreenOwnerType}
+        contextScreenOwnerId={contextScreenOwnerId}
+        contextScreenOwnerSlug={contextScreenOwnerSlug}
+        contextScreen={contextScreen}
+        artwork={item}
+        height={imgHeight}
+        navigateToPageableRoute={navigateToPageableRoute}
+      />
+    </Flex>
+  )
+}

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -1,0 +1,88 @@
+import { ScreenOwnerType } from "@artsy/cohesion"
+import { useSpace } from "@artsy/palette-mobile"
+import { MasonryFlashList, MasonryFlashListProps } from "@shopify/flash-list"
+import { MasonryArtworkGridItem } from "app/Components/ArtworkGrids/MasonryArtworkGridItem"
+import { PAGE_SIZE } from "app/Components/constants"
+import { useNavigateToPageableRoute } from "app/system/navigation/useNavigateToPageableRoute"
+import {
+  ESTIMATED_MASONRY_ITEM_SIZE,
+  MasonryArtworkItem,
+  MasonryListFooterComponent,
+  NUM_COLUMNS_MASONRY,
+  ON_END_REACHED_THRESHOLD_MASONRY,
+  masonryRenderItemProps,
+} from "app/utils/masonryHelpers"
+import { useCallback } from "react"
+
+type MasonryFlashListOmittedProps = Omit<
+  MasonryFlashListProps<MasonryArtworkItem[]>,
+  "renderItem" | "data"
+>
+
+interface MasonryInfiniteScrollArtworkGridProps extends MasonryFlashListOmittedProps {
+  artworks: MasonryArtworkItem[]
+  pageSize?: number
+  contextScreenOwnerType?: ScreenOwnerType
+  contextScreen?: ScreenOwnerType
+  contextScreenOwnerId?: string
+  contextScreenOwnerSlug?: string
+  loadMore?: (pageSize: number) => void
+  hasMore?: boolean
+  isLoading?: boolean
+}
+
+export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArtworkGridProps> = ({
+  artworks,
+  pageSize = PAGE_SIZE,
+  contextScreenOwnerType,
+  contextScreen,
+  contextScreenOwnerId,
+  contextScreenOwnerSlug,
+  refreshControl,
+  ListEmptyComponent,
+  hasMore,
+  loadMore,
+  isLoading,
+}) => {
+  const space = useSpace()
+  const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
+  const shouldDisplaySpinner = !!artworks.length && !!isLoading && !!hasMore
+
+  const onEndReached = useCallback(() => {
+    if (!!hasMore && !!isLoading && !!loadMore) {
+      loadMore?.(pageSize)
+    }
+  }, [hasMore, isLoading])
+
+  const renderItem = ({ item, index, columnIndex }: masonryRenderItemProps) => (
+    <MasonryArtworkGridItem
+      index={index}
+      item={item}
+      columnIndex={columnIndex}
+      navigateToPageableRoute={navigateToPageableRoute}
+      contextScreenOwnerType={contextScreenOwnerType}
+      contextScreen={contextScreen}
+      contextScreenOwnerId={contextScreenOwnerId}
+      contextScreenOwnerSlug={contextScreenOwnerSlug}
+    />
+  )
+
+  return (
+    <MasonryFlashList
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={{ paddingHorizontal: space(2), paddingBottom: space(2) }}
+      data={artworks}
+      keyExtractor={(item) => item.id}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
+      numColumns={NUM_COLUMNS_MASONRY}
+      estimatedItemSize={ESTIMATED_MASONRY_ITEM_SIZE}
+      ListEmptyComponent={ListEmptyComponent}
+      refreshControl={refreshControl}
+      renderItem={renderItem}
+      ListFooterComponent={
+        <MasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+      }
+    />
+  )
+}

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -72,7 +72,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   return (
     <MasonryFlashList
       keyboardShouldPersistTaps="handled"
-      contentContainerStyle={{ paddingHorizontal: space(2), paddingBottom: space(2) }}
+      contentContainerStyle={{ paddingHorizontal: space(2), paddingBottom: space(6) }}
       data={artworks}
       keyExtractor={(item) => item.id}
       onEndReached={onEndReached}

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -31,6 +31,12 @@ interface MasonryInfiniteScrollArtworkGridProps extends MasonryFlashListOmittedP
   isLoading?: boolean
 }
 
+/**
+ * Reusable component for displaying a masonry grid of artworks with infinite scroll.
+ * Note that it is only intended to be used for full screen grids. If you want to use
+ * a masonry grid in a Tab surface, use Tabs.Masonry instead.
+ *
+ */
 export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArtworkGridProps> = ({
   artworks,
   pageSize = PAGE_SIZE,

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -40,6 +40,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   contextScreenOwnerSlug,
   refreshControl,
   ListEmptyComponent,
+  ListHeaderComponent,
   hasMore,
   loadMore,
   isLoading,
@@ -47,9 +48,10 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   const space = useSpace()
   const { navigateToPageableRoute } = useNavigateToPageableRoute({ items: artworks })
   const shouldDisplaySpinner = !!artworks.length && !!isLoading && !!hasMore
+  const shouldDisplayHeader = !!artworks.length && ListHeaderComponent !== undefined
 
   const onEndReached = useCallback(() => {
-    if (!!hasMore && !!isLoading && !!loadMore) {
+    if (!!hasMore && !isLoading && !!loadMore) {
       loadMore?.(pageSize)
     }
   }, [hasMore, isLoading])
@@ -77,6 +79,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
       onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
       numColumns={NUM_COLUMNS_MASONRY}
       estimatedItemSize={ESTIMATED_MASONRY_ITEM_SIZE}
+      ListHeaderComponent={shouldDisplayHeader ? ListHeaderComponent : null}
       ListEmptyComponent={ListEmptyComponent}
       refreshControl={refreshControl}
       renderItem={renderItem}

--- a/src/app/Scenes/ArtworkList/ArtworkListArtworksGridHeader.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListArtworksGridHeader.tsx
@@ -15,7 +15,7 @@ export const ArtworkListArtworksGridHeader: FC<ArtworkListArtworksGridHeaderProp
   onSortButtonPress,
 }) => {
   return (
-    <Flex mb={1}>
+    <Flex>
       <ArtworkListTitle title={title} />
       <Separator borderColor="black10" mt={1} />
       <Flex flexDirection="row" justifyContent="space-between" alignItems="center">

--- a/src/app/Scenes/ArtworkRecommendations/ArtworkRecommendations.tsx
+++ b/src/app/Scenes/ArtworkRecommendations/ArtworkRecommendations.tsx
@@ -3,7 +3,7 @@ import { SimpleMessage, Spacer } from "@artsy/palette-mobile"
 import { ArtworkRecommendationsQuery } from "__generated__/ArtworkRecommendationsQuery.graphql"
 import { ArtworkRecommendations_me$key } from "__generated__/ArtworkRecommendations_me.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -36,22 +36,18 @@ export const ArtworkRecommendations: React.FC = () => {
       info={screen({ context_screen_owner_type: OwnerType.artworkRecommendations })}
     >
       <PageWithSimpleHeader title={SCREEN_TITLE}>
-        {artworks.length ? (
-          <InfiniteScrollArtworksGridContainer
-            connection={data?.artworkRecommendations}
-            loadMore={(pageSize, onComplete) => loadNext(pageSize, { onComplete } as any)}
-            hasMore={() => hasNext}
-            isLoading={() => isLoadingNext}
-            pageSize={PAGE_SIZE}
-            contextScreenOwnerType={OwnerType.artworkRecommendations}
-            contextScreen={OwnerType.artworkRecommendations}
-            HeaderComponent={<Spacer y={2} />}
-            shouldAddPadding
-            refreshControl={RefreshControl}
-          />
-        ) : (
-          <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
-        )}
+        <MasonryInfiniteScrollArtworkGrid
+          artworks={artworks}
+          contextScreenOwnerType={OwnerType.artworkRecommendations}
+          contextScreen={OwnerType.artworkRecommendations}
+          ListEmptyComponent={
+            <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
+          }
+          refreshControl={RefreshControl}
+          hasMore={hasNext}
+          loadMore={() => loadNext(PAGE_SIZE)}
+          isLoading={isLoadingNext}
+        />
       </PageWithSimpleHeader>
     </ProvideScreenTrackingWithCohesionSchema>
   )
@@ -78,10 +74,14 @@ const artworkConnectionFragment = graphql`
       edges {
         cursor
         node {
-          internalID
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
+          }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-      ...InfiniteScrollArtworksGrid_connection
     }
   }
 `

--- a/src/app/Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow.tsx
+++ b/src/app/Scenes/LotsByArtistsYouFollow/LotsByArtistsYouFollow.tsx
@@ -1,30 +1,32 @@
 import { Spacer, SimpleMessage } from "@artsy/palette-mobile"
 import { LotsByArtistsYouFollowQuery } from "__generated__/LotsByArtistsYouFollowQuery.graphql"
-import { LotsByArtistsYouFollow_me$data } from "__generated__/LotsByArtistsYouFollow_me.graphql"
+import { LotsByArtistsYouFollow_me$key } from "__generated__/LotsByArtistsYouFollow_me.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { PAGE_SIZE } from "app/Components/constants"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
-import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
+import { useRefreshControl } from "app/utils/refreshHelpers"
+import { Suspense } from "react"
+import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
 const SCREEN_TITLE = "Auction Lots for You"
-interface LotsByArtistsYouFollowProps {
-  me: LotsByArtistsYouFollow_me$data
-  relay: RelayPaginationProp
-}
 
-export const LotsByArtistsYouFollow: React.FC<LotsByArtistsYouFollowProps> = ({ me, relay }) => {
-  const { hasMore, isLoading, loadMore } = relay
-  const hasNext = hasMore()
-  const loading = isLoading()
+export const LotsByArtistsYouFollow: React.FC = () => {
+  const queryData = useLazyLoadQuery<LotsByArtistsYouFollowQuery>(
+    LotsByArtistsYouFollowScreenQuery,
+    lotsByArtistsYouFollowDefaultVariables()
+  )
 
-  const artworks = extractNodes(me?.lotsByFollowedArtistsConnection)
-  // PAGINATION NOT WORKING FIX IT
-  // NO ANALYTICS
+  const { data, loadNext, hasNext, isLoadingNext, refetch } = usePaginationFragment<
+    LotsByArtistsYouFollowQuery,
+    LotsByArtistsYouFollow_me$key
+  >(artworkConnectionFragment, queryData.me)
+
+  const RefreshControl = useRefreshControl(refetch)
+  const artworks = extractNodes(data?.lotsByFollowedArtistsConnection)
+
   return (
     <PageWithSimpleHeader title={SCREEN_TITLE}>
       <MasonryInfiniteScrollArtworkGrid
@@ -33,71 +35,51 @@ export const LotsByArtistsYouFollow: React.FC<LotsByArtistsYouFollowProps> = ({ 
           <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
         }
         hasMore={hasNext}
-        loadMore={() => loadMore(PAGE_SIZE)}
-        isLoading={loading}
+        loadMore={() => loadNext(PAGE_SIZE)}
+        isLoading={isLoadingNext}
+        refreshControl={RefreshControl}
       />
     </PageWithSimpleHeader>
   )
 }
 
 export const lotsByArtistsYouFollowDefaultVariables = () => ({
-  count: 10,
+  count: PAGE_SIZE,
 })
 
 export const LotsByArtistsYouFollowScreenQuery = graphql`
-  query LotsByArtistsYouFollowQuery($count: Int!, $cursor: String) {
+  query LotsByArtistsYouFollowQuery($count: Int!, $after: String) {
     me {
-      ...LotsByArtistsYouFollow_me @arguments(count: $count, cursor: $cursor)
+      ...LotsByArtistsYouFollow_me @arguments(count: $count, after: $after)
     }
   }
 `
 
-export const LotsByArtistsYouFollowFragmentContainer = createPaginationContainer(
-  LotsByArtistsYouFollow,
-  {
-    me: graphql`
-      fragment LotsByArtistsYouFollow_me on Me
-      @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
-        lotsByFollowedArtistsConnection(
-          first: $count
-          after: $cursor
-          liveSale: true
-          isAuction: true
-        ) @connection(key: "LotsByArtistsYouFollow_lotsByFollowedArtistsConnection") {
-          edges {
-            cursor
-            node {
-              id
-              slug
-              image(includeAll: false) {
-                aspectRatio
-              }
-              ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
-            }
+const artworkConnectionFragment = graphql`
+  fragment LotsByArtistsYouFollow_me on Me
+  @refetchable(queryName: "LotsByArtistsYouFollow_meRefetch")
+  @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+    lotsByFollowedArtistsConnection(first: $count, after: $after, liveSale: true, isAuction: true)
+      @connection(key: "LotsByArtistsYouFollow_lotsByFollowedArtistsConnection") {
+      edges {
+        node {
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
           }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-    `,
-  },
-  {
-    getConnectionFromProps: ({ me }) => me && me.lotsByFollowedArtistsConnection,
-    getVariables: (_props, { count, cursor }) => ({ count, cursor }),
-    query: LotsByArtistsYouFollowScreenQuery,
+    }
   }
-)
+`
 
-export const LotsByArtistsYouFollowQueryRenderer: React.FC = () => {
+export const LotsByArtistsYouFollowScreen: React.FC = () => {
   return (
-    <QueryRenderer<LotsByArtistsYouFollowQuery>
-      environment={getRelayEnvironment()}
-      query={LotsByArtistsYouFollowScreenQuery}
-      variables={lotsByArtistsYouFollowDefaultVariables()}
-      render={renderWithPlaceholder({
-        Container: LotsByArtistsYouFollowFragmentContainer,
-        renderPlaceholder: Placeholder,
-        renderFallback: () => null,
-      })}
-    />
+    <Suspense fallback={<Placeholder />}>
+      <LotsByArtistsYouFollow />
+    </Suspense>
   )
 }
 

--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
@@ -3,7 +3,7 @@ import { Spacer, SimpleMessage } from "@artsy/palette-mobile"
 import { NewWorksFromGalleriesYouFollowQuery } from "__generated__/NewWorksFromGalleriesYouFollowQuery.graphql"
 import { NewWorksFromGalleriesYouFollow_artworksConnection$key } from "__generated__/NewWorksFromGalleriesYouFollow_artworksConnection.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -35,22 +35,18 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
       info={screen({ context_screen_owner_type: OwnerType.newWorksFromGalleriesYouFollow })}
     >
       <PageWithSimpleHeader title={SCREEN_TITLE}>
-        {artworks.length ? (
-          <InfiniteScrollArtworksGridContainer
-            connection={data?.newWorksFromGalleriesYouFollowConnection}
-            loadMore={(pageSize, onComplete) => loadNext(pageSize, { onComplete } as any)}
-            hasMore={() => hasNext}
-            isLoading={() => isLoadingNext}
-            pageSize={PAGE_SIZE}
-            contextScreenOwnerType={OwnerType.newWorksFromGalleriesYouFollow}
-            contextScreen={OwnerType.newWorksFromGalleriesYouFollow}
-            HeaderComponent={<Spacer y={2} />}
-            shouldAddPadding
-            refreshControl={RefreshControl}
-          />
-        ) : (
-          <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
-        )}
+        <MasonryInfiniteScrollArtworkGrid
+          artworks={artworks}
+          contextScreenOwnerType={OwnerType.newWorksFromGalleriesYouFollow}
+          contextScreen={OwnerType.newWorksFromGalleriesYouFollow}
+          ListEmptyComponent={
+            <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
+          }
+          refreshControl={RefreshControl}
+          hasMore={hasNext}
+          loadMore={() => loadNext(PAGE_SIZE)}
+          isLoading={isLoadingNext}
+        />
       </PageWithSimpleHeader>
     </ProvideScreenTrackingWithCohesionSchema>
   )
@@ -77,10 +73,14 @@ const artworkConnectionFragment = graphql`
       edges {
         cursor
         node {
-          internalID
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
+          }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-      ...InfiniteScrollArtworksGrid_connection
     }
   }
 `

--- a/src/app/Scenes/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/app/Scenes/RecentlyViewed/RecentlyViewed.tsx
@@ -3,7 +3,7 @@ import { Spacer, SimpleMessage } from "@artsy/palette-mobile"
 import { RecentlyViewedQuery } from "__generated__/RecentlyViewedQuery.graphql"
 import { RecentlyViewed_artworksConnection$key } from "__generated__/RecentlyViewed_artworksConnection.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -35,22 +35,18 @@ export const RecentlyViewed: React.FC = () => {
       info={screen({ context_screen_owner_type: OwnerType.recentlyViewed })}
     >
       <PageWithSimpleHeader title={SCREEN_TITLE}>
-        {artworks.length ? (
-          <InfiniteScrollArtworksGridContainer
-            connection={data?.recentlyViewedArtworksConnection}
-            loadMore={(pageSize, onComplete) => loadNext(pageSize, { onComplete } as any)}
-            hasMore={() => hasNext}
-            isLoading={() => isLoadingNext}
-            pageSize={PAGE_SIZE}
-            contextScreenOwnerType={OwnerType.recentlyViewed}
-            contextScreen={OwnerType.recentlyViewed}
-            HeaderComponent={<Spacer y={2} />}
-            shouldAddPadding
-            refreshControl={RefreshControl}
-          />
-        ) : (
-          <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
-        )}
+        <MasonryInfiniteScrollArtworkGrid
+          artworks={artworks}
+          contextScreenOwnerType={OwnerType.recentlyViewed}
+          contextScreen={OwnerType.recentlyViewed}
+          ListEmptyComponent={
+            <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
+          }
+          refreshControl={RefreshControl}
+          hasMore={hasNext}
+          loadMore={(pageSize) => loadNext(pageSize)}
+          isLoading={isLoadingNext}
+        />
       </PageWithSimpleHeader>
     </ProvideScreenTrackingWithCohesionSchema>
   )
@@ -77,10 +73,14 @@ const artworkConnectionFragment = graphql`
       edges {
         cursor
         node {
-          internalID
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
+          }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-      ...InfiniteScrollArtworksGrid_connection
     }
   }
 `

--- a/src/app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed.tsx
+++ b/src/app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed.tsx
@@ -3,7 +3,7 @@ import { Spacer, SimpleMessage } from "@artsy/palette-mobile"
 import { SimilarToRecentlyViewedQuery } from "__generated__/SimilarToRecentlyViewedQuery.graphql"
 import { SimilarToRecentlyViewed_artworksConnection$key } from "__generated__/SimilarToRecentlyViewed_artworksConnection.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -35,22 +35,18 @@ export const SimilarToRecentlyViewed: React.FC = () => {
       info={screen({ context_screen_owner_type: OwnerType.similarToRecentlyViewed })}
     >
       <PageWithSimpleHeader title={SCREEN_TITLE}>
-        {artworks.length ? (
-          <InfiniteScrollArtworksGridContainer
-            connection={data?.similarToRecentlyViewedConnection}
-            loadMore={(pageSize, onComplete) => loadNext(pageSize, { onComplete } as any)}
-            hasMore={() => hasNext}
-            isLoading={() => isLoadingNext}
-            pageSize={PAGE_SIZE}
-            contextScreenOwnerType={OwnerType.similarToRecentlyViewed}
-            contextScreen={OwnerType.similarToRecentlyViewed}
-            HeaderComponent={<Spacer y={2} />}
-            shouldAddPadding
-            refreshControl={RefreshControl}
-          />
-        ) : (
-          <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
-        )}
+        <MasonryInfiniteScrollArtworkGrid
+          artworks={artworks}
+          contextScreenOwnerType={OwnerType.similarToRecentlyViewed}
+          contextScreen={OwnerType.similarToRecentlyViewed}
+          ListEmptyComponent={
+            <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
+          }
+          refreshControl={RefreshControl}
+          hasMore={hasNext}
+          loadMore={(pageSize) => loadNext(pageSize)}
+          isLoading={isLoadingNext}
+        />
       </PageWithSimpleHeader>
     </ProvideScreenTrackingWithCohesionSchema>
   )
@@ -77,10 +73,14 @@ const artworkConnectionFragment = graphql`
       edges {
         cursor
         node {
-          internalID
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
+          }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-      ...InfiniteScrollArtworksGrid_connection
     }
   }
 `

--- a/src/app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed.tsx
+++ b/src/app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed.tsx
@@ -71,7 +71,6 @@ const artworkConnectionFragment = graphql`
     similarToRecentlyViewedConnection(first: $count, after: $after)
       @connection(key: "SimilarToRecentlyViewed_similarToRecentlyViewedConnection") {
       edges {
-        cursor
         node {
           id
           slug

--- a/src/app/utils/masonryHelpers/index.ts
+++ b/src/app/utils/masonryHelpers/index.ts
@@ -1,8 +1,0 @@
-import { isTablet } from "react-native-device-info"
-
-// https://shopify.github.io/flash-list/docs/fundamentals/performant-components#estimateditemsize
-export const ESTIMATED_MASONRY_ITEM_SIZE = 272
-
-export const NUM_COLUMNS_MASONRY = isTablet() ? 3 : 2
-
-export const ON_END_REACHED_THRESHOLD_MASONRY = 0.3

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -1,4 +1,5 @@
-import { Flex, Spinner } from "@artsy/palette-mobile"
+import { Flex } from "@artsy/palette-mobile"
+import { ActivityIndicator, Platform } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { FragmentRefs } from "relay-runtime"
 
@@ -32,7 +33,9 @@ export const MasonryListFooterComponent: React.FC<MasonryListFooterComponentProp
   shouldDisplaySpinner,
 }) =>
   shouldDisplaySpinner ? (
-    <Flex my={4} flexDirection="row" justifyContent="center">
-      <Spinner />
+    <Flex width="100%" position="absolute">
+      <Flex mt={2}>
+        <ActivityIndicator color={Platform.OS === "android" ? "black" : undefined} />
+      </Flex>
     </Flex>
   ) : null

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -1,0 +1,38 @@
+import { Flex, Spinner } from "@artsy/palette-mobile"
+import { isTablet } from "react-native-device-info"
+import { FragmentRefs } from "relay-runtime"
+
+// https://shopify.github.io/flash-list/docs/fundamentals/performant-components#estimateditemsize
+export const ESTIMATED_MASONRY_ITEM_SIZE = 272
+
+export const NUM_COLUMNS_MASONRY = isTablet() ? 3 : 2
+
+export const ON_END_REACHED_THRESHOLD_MASONRY = 0.3
+
+export interface masonryRenderItemProps {
+  item: MasonryArtworkItem
+  index: number
+  columnIndex: number
+}
+
+export interface MasonryArtworkItem {
+  readonly id: string
+  readonly image: {
+    readonly aspectRatio: number
+  } | null
+  readonly slug: string
+  readonly " $fragmentSpreads": FragmentRefs<"ArtworkGridItem_artwork">
+}
+
+interface MasonryListFooterComponentProps {
+  shouldDisplaySpinner: boolean
+}
+
+export const MasonryListFooterComponent: React.FC<MasonryListFooterComponentProps> = ({
+  shouldDisplaySpinner,
+}) =>
+  shouldDisplaySpinner ? (
+    <Flex my={4} flexDirection="row" justifyContent="center">
+      <Spinner />
+    </Flex>
+  ) : null


### PR DESCRIPTION
This PR resolves [PHIRE-218] <!-- eg [PROJECT-XXXX] -->

### Description

> [!IMPORTANT]
> Nothing changed UI wise! 

Replacing the following surfaces with the new MasonryFlashList. 
Created also a reusable component for FullScreen Masonry grids (there is another one for the tabs).

Refactored surfaces:
- [x] ArtworkList.tsx
- [x] ArtworkRecommendations.tsx
- [x] NewWorksForYou.tsx
- [x] NewWorksFromGalleriesYouFollow.tsx
- [x] SimilarToRecentlyViewed.tsx  
- [x] RecentlyViewed.tsx
- [x] LotsByArtistsYouFollow.tsx

> [!NOTE]
> There was also a **bonus** refactor on the `LotsByArtistsYouFollow.tsx` surface that refactored the queryRenderer to use relay hooks instead ⭐️


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- refactor full screen artworkgrid surfaces to use new masonry - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-218]: https://artsyproduct.atlassian.net/browse/PHIRE-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ