### PR TITLE
fix: fix latest activity rail when user has viewing room published event

### DIFF
--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -33,20 +33,22 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
     navigateToActivityItem(item.targetHref)
   }
 
-  const imageURL = artworks[0].image?.preview?.src
+  const imageURL = artworks[0]?.image?.preview?.src
 
   const notificationTypeLabel = getNotificationTypeLabel(item.notificationType)
 
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
       <Flex flexDirection="row">
-        <Flex mr={1} accessibilityLabel="Activity Artwork Image">
-          <OpaqueImageView
-            imageURL={imageURL}
-            width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
-            height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
-          />
-        </Flex>
+        {!!imageURL ? (
+          <Flex mr={1} accessibilityLabel="Activity Artwork Image">
+            <OpaqueImageView
+              imageURL={imageURL}
+              width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+              height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+            />
+          </Flex>
+        ) : null}
 
         <Flex maxWidth={MAX_WIDTH} overflow="hidden">
           <Flex flexDirection="row" style={{ marginTop: -4 }}>


### PR DESCRIPTION
### Description

If user has viewing room published notification - home screen crashes. It happens because viewing room notifications always have an empty `artworksConnection`, but the code assumes that artworks always exist.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-  fix latest activity rail when user has viewing room published event - @nickskalkin 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
