### PR TITLE
fix: Prevent Popover from rendering on Android

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -35,7 +35,7 @@ import {
   tracks as artworkActionTracks,
 } from "app/utils/track/ArtworkActions"
 import React, { useRef, useState } from "react"
-import { View } from "react-native"
+import { Platform, View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { LotCloseInfo } from "./LotCloseInfo"
@@ -375,7 +375,7 @@ const ArtworkHeartIcon: React.FC<{ isSaved: boolean | null; index?: number }> = 
   if (isSaved) {
     return <HeartFillIcon {...iconProps} testID="filled-heart-icon" fill="blue100" />
   }
-  if (index === 0) {
+  if (index === 0 && Platform.OS === "ios") {
     // We only try to show the save onboard Popover in the 1st element
     return (
       <ProgressiveOnboardingSaveArtwork>

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
@@ -1,6 +1,7 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { GlobalStore } from "app/store/GlobalStore"
+import { Platform } from "react-native"
 
 type ProgressiveOnboardingFindSavedArtworkProps = {
   tab: BottomTabType
@@ -20,7 +21,7 @@ export const ProgressiveOnboardingFindSavedArtwork: React.FC<
   const isFindSavedArtworkDisplayable =
     !isDismissed("find-saved-artwork").status && !!profileTabProps?.savedArtwork
 
-  if (tab !== "profile" || isFirstSession) {
+  if (tab !== "profile" || isFirstSession || Platform.OS === "android") {
     return <>{children}</>
   }
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR prevents the Popover from being rendered on Android due to it blocking interaction in Artwork screen on first open when the user has no saved artworks



### Videos on Android
| Before | After |
|---|---|
| <video src="https://github.com/artsy/eigen/assets/20655703/60877861-cf89-415f-a1c6-6e6212ad3a2b" />  | <video src="https://github.com/artsy/eigen/assets/20655703/19dc984c-fbcd-479d-9f67-6806f3973288" />  |	


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Prevent Popover from rendering on Android - mrsltun

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
