### PR TITLE
fix(ProgressiveOnboarding): adjust the logic to display the first Popover of saved Artwork

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -35,7 +35,7 @@ import {
   tracks as artworkActionTracks,
 } from "app/utils/track/ArtworkActions"
 import React, { useRef, useState } from "react"
-import { Platform, View } from "react-native"
+import { View } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { LotCloseInfo } from "./LotCloseInfo"
@@ -375,7 +375,7 @@ const ArtworkHeartIcon: React.FC<{ isSaved: boolean | null; index?: number }> = 
   if (isSaved) {
     return <HeartFillIcon {...iconProps} testID="filled-heart-icon" fill="blue100" />
   }
-  if (index === 0 && Platform.OS === "ios") {
+  if (index === 0) {
     // We only try to show the save onboard Popover in the 1st element
     return (
       <ProgressiveOnboardingSaveArtwork>

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
@@ -1,7 +1,6 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { GlobalStore } from "app/store/GlobalStore"
-import { Platform } from "react-native"
 
 type ProgressiveOnboardingFindSavedArtworkProps = {
   tab: BottomTabType
@@ -21,7 +20,7 @@ export const ProgressiveOnboardingFindSavedArtwork: React.FC<
   const isFindSavedArtworkDisplayable =
     !isDismissed("find-saved-artwork").status && !!profileTabProps?.savedArtwork
 
-  if (tab !== "profile" || isFirstSession || Platform.OS === "android") {
+  if (tab !== "profile" || isFirstSession) {
     return <>{children}</>
   }
 

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -16,36 +16,39 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
 
   const savedArtworks = data?.me.counts.savedArtworks
   const isDismissed = _isDismissed("save-artwork").status
-  const isDisplayable = !isDismissed && savedArtworks === 0
+  const isDisplayable = !isDismissed && savedArtworks === 0 && isInView
 
   const handleDismiss = () => {
     setIsVisible(false)
     dismiss("save-artwork")
   }
 
-  if (!isDisplayable) {
-    if (isInView) {
-      return <>{children}</>
-    }
-
-    return <ElementInView onVisible={() => setIsInView(true)}>{children}</ElementInView>
+  // all conditions met we show the popover
+  if (isDisplayable) {
+    return (
+      <Popover
+        visible={isVisible}
+        onDismiss={handleDismiss}
+        onPressOutside={handleDismiss}
+        title={
+          <Text weight="medium" color="white100">
+            Like what you see?
+          </Text>
+        }
+        content={<Text color="white100">Hit the heart to save an artwork.</Text>}
+      >
+        <Flex>{children}</Flex>
+      </Popover>
+    )
   }
 
-  return (
-    <Popover
-      visible={isVisible}
-      onDismiss={handleDismiss}
-      onPressOutside={handleDismiss}
-      title={
-        <Text weight="medium" color="white100">
-          Like what you see?
-        </Text>
-      }
-      content={<Text color="white100">Hit the heart to save an artwork.</Text>}
-    >
-      <Flex>{children}</Flex>
-    </Popover>
-  )
+  // if the artwork element is shown but no conditions met displays only the children
+  if (isInView) {
+    return <>{children}</>
+  }
+
+  // no conditions met and children is not visible in the screen yet
+  return <ElementInView onVisible={() => setIsInView(true)}>{children}</ElementInView>
 }
 
 const query = graphql`


### PR DESCRIPTION
### Description

Fix a weird behavior once you enter a screen with an ArtworkGridItem at the bottom and try to show the Popover even when the respective element anchoring it is not on the screen yet. On Android that was breaking and becoming unresponsive.

Added back to Android since got back to work with the fix(a04e87ab9fdaa3980f5e43dc95dca532d37fc31c)

iOS

https://github.com/artsy/eigen/assets/15792853/e0832062-3062-4376-b695-888c6197a9aa

Android

https://github.com/artsy/eigen/assets/15792853/52f71a3f-cde2-4ff7-842c-024ecc782fa3


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix the first progressive onboarding alert on the Artwork screen - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
