### PR TITLE
fix(articles): fetch the larger image urls, remove default param

### DIFF
--- a/src/app/Scenes/Article/Components/ArticleHero.tsx
+++ b/src/app/Scenes/Article/Components/ArticleHero.tsx
@@ -60,7 +60,7 @@ const ArticleHeroFragment = graphql`
       ... on ArticleFeatureSection {
         image {
           aspectRatio
-          url
+          url(version: ["main", "normalized", "larger", "large"])
         }
       }
     }

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
@@ -28,7 +28,7 @@ export const ArticleSectionImageCollectionImage: React.FC<
       width={width}
       height={height}
       aspectRatio={aspectRatio}
-      geminiResizeMode="fill"
+      performResize={false}
     />
   )
 }
@@ -38,7 +38,7 @@ const ArticleSectionImageCollectionImageQuery = graphql`
     ... on ArticleImageSection {
       id
       image {
-        url
+        url(version: ["main", "normalized", "larger", "large"])
         width
         height
       }
@@ -46,7 +46,7 @@ const ArticleSectionImageCollectionImageQuery = graphql`
     ... on Artwork {
       id
       image {
-        url
+        url(version: ["main", "normalized", "larger", "large"])
         width
         height
       }
@@ -54,7 +54,7 @@ const ArticleSectionImageCollectionImageQuery = graphql`
     ... on ArticleUnpublishedArtwork {
       id
       image {
-        url
+        url(version: ["main", "normalized", "larger", "large"])
         width
         height
       }

--- a/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
+++ b/src/app/Scenes/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx
@@ -22,15 +22,7 @@ export const ArticleSectionImageCollectionImage: React.FC<
   const height = (data.image?.height ?? width) * widthShrinkPercentage
   const aspectRatio = width / height
 
-  return (
-    <Image
-      src={data.image.url}
-      width={width}
-      height={height}
-      aspectRatio={aspectRatio}
-      performResize={false}
-    />
-  )
+  return <Image src={data.image.url} width={width} height={height} aspectRatio={aspectRatio} />
 }
 
 const ArticleSectionImageCollectionImageQuery = graphql`


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

The image quality in certain images in articles is still not great because we aren't fetching high quality image urls. We left out specifying a version parameter when fetching the url from metaphysics and this appears to be defaulting to the medium.jpg image url which is quite small. This then is the basis for the resized image from gemini so the resultant image is quite blurry. 

This fetching was just copied from force so 👀 appreciated: https://github.com/artsy/force/blob/3a1e19354d48ebad8d47439ad0925891b1c02e0b/src/Apps/Article/Components/Sections/ArticleSectionImageCollection/ArticleSectionImageCollectionImage.tsx#L66


## Follow-ups
- Also updated the articleHero image but can't find an article with one of those, needs to be tested
- Can we document the right way to fetch images? Should the version param be required in MP? feels unexpected to default to getting back a tiny image url

### Before
![botero-before](https://github.com/artsy/eigen/assets/49686530/082c54a4-91d4-411a-a4f2-b1977ada3c8d)


### After
![botero-after](https://github.com/artsy/eigen/assets/49686530/be2279ec-c800-481c-9e27-2c7be5784a1f)


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Higher quality images in articles - Brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
