### PR TITLE
fix: add extra padding to create alert artist footer

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -1,16 +1,16 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import {
-  useSpace,
-  useScreenDimensions,
-  Flex,
-  Tabs,
-  Text,
+  BellIcon,
   Box,
   Button,
-  Spacer,
-  BellIcon,
-  Spinner,
+  Flex,
   Message,
+  Spacer,
+  Spinner,
+  Tabs,
+  Text,
+  useScreenDimensions,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { ArtistArtworks_artist$data } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtistArtworksFilterHeader } from "app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader"
@@ -35,8 +35,7 @@ import {
 } from "app/utils/masonryHelpers"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useEffect, useMemo } from "react"
-import { Dimensions } from "react-native"
-import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { RelayPaginationProp, createPaginationContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface ArtworksGridProps extends InfiniteScrollGridProps {
@@ -186,12 +185,11 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
       return (
         <Message
           title="Get notified when works you're looking for are added."
-          containerStyle={{ width: Dimensions.get("window").width, left: -space(2), mt: 2 }}
+          containerStyle={{ my: 2 }}
           IconComponent={() => {
             return <CreateAlertButton />
           }}
           iconPosition="right"
-          showCloseButton
         />
       )
     }


### PR DESCRIPTION
### Description

This PR adds some extra padding to the create alert artist footer. It also removes the X button that is no longer part of the designs.
![Group 1 (9)](https://github.com/artsy/eigen/assets/11945712/642b0caa-c87b-449a-8c69-71cb919263af)




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.


#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
