### PR TITLE
build(ci): preboot simulators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
             - v18-pods-{{ checksum ".manifests/cocoapods" }}
       - run:
           name: Install Pods
-          command: cd ios; bundle exec pod check --ignore-dev-pods || bundle exec pod install; cd ..;
+          command: cd ios; bundle exec pod check --ignore-dev-pods || bundle exec pod install; cd ..;xr
       - save_cache:
           key: v18-pods-{{ checksum ".manifests/cocoapods" }}
           paths:
@@ -391,6 +391,9 @@ jobs:
       - install-cocoapods
       - build-app-ios
       - macos/install-rosetta
+      - macos/preboot-simulator:
+          device: "iPhone 14 Pro"
+          version: "16.4"
       - run:
           name: Run tests if native code has changed
           command: ls xcode_test_raw.log || ./scripts/ci-test-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ commands:
             - v18-pods-{{ checksum ".manifests/cocoapods" }}
       - run:
           name: Install Pods
-          command: cd ios; bundle exec pod check --ignore-dev-pods || bundle exec pod install; cd ..;xr
+          command: cd ios; bundle exec pod check --ignore-dev-pods || bundle exec pod install; cd ..;
       - save_cache:
           key: v18-pods-{{ checksum ".manifests/cocoapods" }}
           paths:


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Try prebooting simulators using macOS orb to see if that speeds up tests.

Going to merge this as is, one possible optimization to follow-up on, we probably only want to do the test prep in the case where native code changed. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Preboot iOS simulators when running tests - Brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
