### PR TITLE
fix(alerts): don't include current artwork in suggested inventory

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tests.tsx
@@ -37,6 +37,15 @@ describe("CreateArtworkAlertModal", () => {
     const { UNSAFE_getByType } = renderWithRelay()
     expect(UNSAFE_getByType(CreateSavedSearchModal)).toBeTruthy()
   })
+
+  it("passes current artwork id to modal", () => {
+    const { UNSAFE_getByProps } = renderWithRelay({
+      Artwork: () => ({
+        internalID: "set-alert-from-me",
+      }),
+    })
+    expect(UNSAFE_getByProps({ currentArtworkID: "set-alert-from-me" })).toBeTruthy()
+  })
 })
 
 describe("computeArtworkAlertProps", () => {

--- a/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal.tsx
@@ -68,6 +68,7 @@ export const CreateArtworkAlertModal: React.FC<CreateArtworkAlertModalProps> = (
       aggregations={artworkAlert.aggregations!}
       closeModal={onClose}
       contextModule={contextModule}
+      currentArtworkID={data.internalID}
     />
   )
 }

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -26,10 +26,20 @@ export interface CreateSavedSearchModalProps {
   closeModal: () => void
   onComplete?: () => void
   contextModule?: ContextModule
+  currentArtworkID?: string
 }
 
 export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (props) => {
-  const { visible, entity, attributes, aggregations, closeModal, onComplete, contextModule } = props
+  const {
+    visible,
+    entity,
+    attributes,
+    aggregations,
+    closeModal,
+    onComplete,
+    contextModule,
+    currentArtworkID,
+  } = props
   const tracking = useTracking()
 
   useEffect(() => {
@@ -54,6 +64,7 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
     aggregations,
     attributes,
     entity,
+    currentArtworkID,
     onClosePress: () => {
       onComplete?.() // close the filter modal stack (if coming from artist artwork grid)
       closeModal() // close the alert modal stack

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -20,7 +20,7 @@ const Stack = createStackNavigator<CreateSavedSearchAlertNavigationStack>()
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
   const { visible, params } = props
-  const { attributes, aggregations, entity } = params
+  const { attributes, aggregations, entity, currentArtworkID } = params
 
   return (
     <SavedSearchStoreProvider
@@ -29,6 +29,7 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
         attributes: attributes as SearchCriteriaAttributes,
         aggregations,
         entity,
+        currentArtworkID,
       }}
     >
       <NavigationContainer independent>

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -20,6 +20,7 @@ export interface CreateSavedSearchAlertParams {
   aggregations: Aggregations
   attributes: SearchCriteriaAttributes
   entity: SavedSearchEntity
+  currentArtworkID?: string
   onClosePress: () => void
   onComplete: (response: SavedSearchAlertMutationResult) => void
 }

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -12,6 +12,8 @@ interface SavedSearchModel {
   aggregations: Aggregations
   entity: SavedSearchEntity
   dirty: boolean
+  /** Artwork ID, if the current saved search alert is being set from an artwork */
+  currentArtworkID?: string
 
   setValueToAttributesByKeyAction: Action<
     this,
@@ -41,6 +43,7 @@ export const savedSearchModel: SavedSearchModel = {
       slug: "",
     },
   },
+  currentArtworkID: undefined,
 
   setValueToAttributesByKeyAction: action((state, payload) => {
     if (payload.key === "priceRange") {

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -117,12 +117,14 @@ const MatchingArtworksPlaceholder: React.FC = () => {
 const MatchingArtworksContainer: React.FC<{ closeModal?: () => void }> = withSuspense(
   ({ closeModal }) => {
     const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
+    const currentArtworkID = SavedSearchStore.useStoreState((state) => state.currentArtworkID)
     const data = useLazyLoadQuery<ConfirmationScreenMatchingArtworksQuery>(matchingArtworksQuery, {
       first: NUMBER_OF_ARTWORKS_TO_SHOW,
       input: {
         ...attributes,
         forSale: true,
         sort: "-published_at",
+        excludeArtworkIDs: currentArtworkID ? [currentArtworkID] : undefined,
       } as FilterArtworksInput,
     })
 


### PR DESCRIPTION
This PR resolves [ONYX-397]

Counterpart of https://github.com/artsy/force/pull/12973

### Description

Copied from the Force PR^

> When saving an alert, we use the alert's criteria to display potentially matching inventory.
> 
> If the alert is being saved from an _artwork_, we don't want to redundantly show that very artwork again as part of that inventory — a problem that is especially apparent when the alert criteria only match a handful of works.
> 
> This change therefore allows the current artwork to be passed in the `excludeArtworkIDs` param that is already supported by the `artworksConnection` field.


|If setting an alert from this work…|Before|After|
|---|---|---|
|<img width="790" alt="orign" src="https://github.com/artsy/eigen/assets/140521/35e92e44-2a09-4750-9a4e-75099bc2c601">|<img width="790" alt="b4" src="https://github.com/artsy/eigen/assets/140521/5af63f75-0f99-4bee-a88b-70f516406009">|<img width="790" alt="a4" src="https://github.com/artsy/eigen/assets/140521/e62be602-bf0d-4fbd-9ff1-e412ba48a6f1">|





### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Don't redundantly suggest an artwork, when setting an alert from that artwork.

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-397]: https://artsyproduct.atlassian.net/browse/ONYX-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ