### PR TITLE
chore: update copy on create alert artist artworks footer

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -213,7 +213,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     if (showCreateAlertAtEndOfList && !relay.hasMore()) {
       return (
         <Message
-          title="Get notified when works you're looking for are added."
+          title="Get notified when new works are added."
           containerStyle={{ my: 2 }}
           IconComponent={() => {
             return <CreateAlertButton />


### PR DESCRIPTION
### Description

This PR comes as a follow-up on a discussion with Barney to shorten the cope for the create alert. This is in order to avoid an issue where the text comes across 3 lines if the screen is too small. 
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog 
Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
