### PR TITLE
refactor: prevent image requests with falsy height / width

### DIFF
--- a/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
+++ b/src/app/Components/OpaqueImageView/OpaqueImageView.tsx
@@ -110,14 +110,19 @@ export default class OpaqueImageView extends React.Component<Props, State> {
   imageURL() {
     const { imageURL, useRawURL } = this.props
 
+    if (!this.state.height || !this.state.width) {
+      return null
+    }
+
     if (imageURL) {
       if (useRawURL) {
         return imageURL
       }
+
       return createGeminiUrl({
         imageURL,
-        width: this.state.width!,
-        height: this.state.height!,
+        width: this.state.width,
+        height: this.state.height,
         // Either scale or crop, based on if an aspect ratio is available.
         resizeMode: this.state.aspectRatio ? "fit" : "fill",
       })

--- a/src/app/Components/OpaqueImageView2/OpaqueImageView2.tsx
+++ b/src/app/Components/OpaqueImageView2/OpaqueImageView2.tsx
@@ -87,23 +87,7 @@ export const OpaqueImageView: React.FC<Props> = ({ aspectRatio, ...props }) => {
   const [fIHeight, setFIHeight] = useState(0)
   const [fIWidth, setFIWidth] = useState(0)
   const style = StyleSheet.flatten(props.style) ?? {}
-  if (__DEV__) {
-    if (
-      !(
-        (style.width && style.height) ||
-        (props.width && props.height) ||
-        (aspectRatio && (style.height || props.height)) ||
-        (aspectRatio && (style.width || props.width))
-      )
-    ) {
-      console.error(
-        "[OpaqueImageView2] Either an aspect ratio or specific dimensions or flex should be specified."
-      )
-      return <View style={{ height: 100, width: 100, backgroundColor: "red" }} />
-    }
-  }
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const getActualDimensions = useCallback(() => {
     if (props.height && props.width) {
       return [props.width, props.height]
@@ -128,12 +112,27 @@ export const OpaqueImageView: React.FC<Props> = ({ aspectRatio, ...props }) => {
     return [layoutWidth, layoutHeight]
   }, [props.height, props.width, style.width, style.height, aspectRatio, layoutHeight, layoutWidth])
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     const [fWidth, fHeight] = getActualDimensions()
     setFIHeight(fHeight)
     setFIWidth(fWidth)
   }, [getActualDimensions])
+
+  if (__DEV__) {
+    if (
+      !(
+        (style.width && style.height) ||
+        (props.width && props.height) ||
+        (aspectRatio && (style.height || props.height)) ||
+        (aspectRatio && (style.width || props.width))
+      )
+    ) {
+      console.error(
+        "[OpaqueImageView2] Either an aspect ratio or specific dimensions or flex should be specified."
+      )
+      return <View style={{ height: 100, width: 100, backgroundColor: "red" }} />
+    }
+  }
 
   if (React.Children.count(props.children) > 0) {
     console.error("Please don't add children to a OpaqueImageView. Doesn't work on android.")
@@ -143,10 +142,15 @@ export const OpaqueImageView: React.FC<Props> = ({ aspectRatio, ...props }) => {
   const getImageURL = () => {
     const { imageURL, useRawURL } = props
 
+    if (!layoutHeight || !layoutWidth) {
+      return
+    }
+
     if (imageURL) {
       if (useRawURL) {
         return imageURL
       }
+
       return createGeminiUrl({
         imageURL,
         width: layoutWidth,


### PR DESCRIPTION
This PR resolves [PHIRE-311] <!-- eg [PROJECT-XXXX] -->

### Description

Continuation of an effort to reduce the `400` requests from geminy due to falsy height and width that we started with @anandaroop.

Early exit to prevent making requests to Gemini with falsy widths and heights.

The component is smart enough to actually do the request when it should (when it has the dimensions)

Also fixes some rules of hooks issues.

|Before|After|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/21178754/3e59bba6-6c44-4ac2-8cdd-1a0e1124359c" height="500" />|<video src="https://github.com/artsy/eigen/assets/21178754/b055e0fd-7d6b-4b42-bb46-27a15beac701" height="500" />|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- prevent image requests with falsy height / width - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-311]: https://artsyproduct.atlassian.net/browse/PHIRE-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ