### PR TITLE
fix: featured representation horizontal padding

### DIFF
--- a/src/app/Components/Artist/ArtistHeader.tsx
+++ b/src/app/Components/Artist/ArtistHeader.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Touchable,
   useScreenDimensions,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { useScreenScrollContext } from "@artsy/palette-mobile/dist/elements/Screen/ScreenScrollContext"
 import { ArtistHeader_artist$data } from "__generated__/ArtistHeader_artist.graphql"
@@ -46,6 +47,7 @@ export const useArtistHeaderImageDimensions = () => {
 }
 
 export const ArtistHeader: React.FC<Props> = ({ artist, me, onLayoutChange }) => {
+  const space = useSpace()
   const { width, height, aspectRatio } = useArtistHeaderImageDimensions()
   const { updateScrollYOffset } = useScreenScrollContext()
   const showArtistsAlertsSetFeatureFlag = useFeatureFlag("ARShowArtistsAlertsSet")
@@ -121,8 +123,8 @@ export const ArtistHeader: React.FC<Props> = ({ artist, me, onLayoutChange }) =>
       </Box>
 
       {!!hasVerifiedRepresentatives && (
-        <Flex pointerEvents="box-none" px={2}>
-          <Flex pointerEvents="none">
+        <Flex pointerEvents="box-none">
+          <Flex pointerEvents="none" px={2}>
             <Text pt={2} pb={1} variant="sm" color="black60">
               Featured representation
             </Text>
@@ -141,6 +143,9 @@ export const ArtistHeader: React.FC<Props> = ({ artist, me, onLayoutChange }) =>
               </Pill>
             )}
             ItemSeparatorComponent={() => <Spacer x={1} />}
+            contentContainerStyle={{
+              paddingHorizontal: space(2),
+            }}
           />
           <Spacer y={2} />
         </Flex>


### PR DESCRIPTION
[future-friday]

### Description
This PR brings a small fix to the artist-featured representation rail where it gets cropped when you scroll it.

### Before

https://github.com/artsy/eigen/assets/11945712/cc83091e-5d69-48e7-b793-07d9e10509e9

___
### After

https://github.com/artsy/eigen/assets/11945712/dfc51bb5-d697-4e61-bebe-ffdea5d303eb


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
