### PR TITLE
feat: prevent backward navigation when clicking a link in a webview (EMI-1395)

### DIFF
--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -5,6 +5,7 @@ import { goBack, navigate } from "app/system/navigation/navigate"
 import { appJson } from "app/utils/jsonFiles"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import mockFetch from "jest-fetch-mock"
+import { debounce } from "lodash"
 import { stringify } from "query-string"
 import Share from "react-native-share"
 import WebView, { WebViewProps } from "react-native-webview"
@@ -49,6 +50,11 @@ jest.mock("react-native-webview", () => {
   }
 })
 
+jest.mock("lodash", () => ({
+  ...jest.requireActual("lodash"),
+  debounce: jest.fn(),
+}))
+
 const mockOnNavigationStateChange: WebViewNavigation = {
   navigationType: "click",
   url: "https://gooooogle.com",
@@ -67,7 +73,10 @@ describe("ArtsyWebView", () => {
 })
 
 describe("ArtsyWebViewPage", () => {
-  beforeEach(() => jest.clearAllMocks())
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(debounce as jest.Mock).mockImplementation((func) => func)
+  })
 
   const render = (props: Partial<React.ComponentProps<typeof ArtsyWebViewPage>> = {}) =>
     renderWithWrappers(<ArtsyWebViewPage url="https://staging.artsy.net/hello" {...props} />)

--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -256,7 +256,7 @@ describe("ArtsyWebViewPage", () => {
     })
 
     describe("the inner WebView's goBack method", () => {
-      it("is called when the URL matches a ReactWebView, ModalWebView, or VanityURLEntity route", () => {
+      it("is called when the URL matches a route that is not loaded in a web view", () => {
         const tree = render()
 
         webViewProps(tree).onNavigationStateChange?.({

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -190,9 +190,12 @@ export const ArtsyWebView = forwardRef<
     const uri = url.startsWith("/") ? webURL + url : url
 
     // Debounce calls just in case multiple stopLoading calls are made in a row
-    const stopLoading = debounce(() => {
+    const stopLoading = debounce((goBack = true) => {
       innerRef.current?.stopLoading()
-      innerRef.current?.goBack()
+
+      if (goBack) {
+        innerRef.current?.goBack()
+      }
     }, 500)
 
     const onNavigationStateChange = (evt: WebViewNavigation) => {
@@ -222,7 +225,7 @@ export const ArtsyWebView = forwardRef<
         innerRef.current!.shareTitleUrl = targetURL
         return
       } else {
-        stopLoading()
+        stopLoading(result.type === "external_url" ? false : true)
       }
 
       // In case of a webview presented modally, if the targetURL is a tab View,

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -224,7 +224,7 @@ export const ArtsyWebView = forwardRef<
         innerRef.current!.shareTitleUrl = targetURL
         return
       } else {
-        const needToGoBack = result.type === "external_url" ? false : true
+        const needToGoBack = result.type !== "external_url"
         stopLoading(needToGoBack)
       }
 


### PR DESCRIPTION
This PR resolves [EMI-1395]

### Description

When users tap on external links (such as help center articles) in the checkout flow, and then return to the checkout flow by tapping the back button, they are navigated to the previous step of the checkout flow. This is a poor user experience.

This PR addresses that by ensuring that the WebView's backward navigation event (`goBack`) isn't called for taps on external links.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

#### iOS user-facing changes

- Opening help center links during checkout won't return users to the previous step

</details>


[EMI-1395]: https://artsyproduct.atlassian.net/browse/EMI-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ