### PR TITLE
fix: return query name in Sentry

### DIFF
--- a/src/app/system/relay/middlewares/principalFieldErrorHandlerMiddleware.ts
+++ b/src/app/system/relay/middlewares/principalFieldErrorHandlerMiddleware.ts
@@ -19,12 +19,12 @@ export const principalFieldErrorHandlerMiddleware = async (
 
   // query did not have a principal field, but experienced an error, we report it to sentry and volley
   if (!requestHasPrincipalField && !!res?.errors?.length) {
-    trackError(req.operation.operationKind, req.operation.operationKind, "default")
-    captureMessage(`${req.operation.operationKind} failed: ${req.operation.operationKind}`, "log")
+    trackError(req.operation.name, req.operation.operationKind, "default")
+    captureMessage(`${req.operation.operationKind} failed: ${req.operation.name}`, "log")
   }
 
   if (principalFieldWasInvolvedInError) {
-    trackError(req.operation.operationKind, req.operation.operationKind, "principalField")
+    trackError(req.operation.name, req.operation.operationKind, "principalField")
     return throwError(req, res)
   } else {
     return res


### PR DESCRIPTION
### Description

Return query name in Sentry errors. This comes after I missed to return the name in Sentry.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix wrong query name returned - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
