### PR TITLE
refactor(DO_NOT_MERGE-Android perf issues): fair to use masonry grid

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -69,7 +69,7 @@ import { CitySavedListQueryRenderer } from "./Scenes/City/CitySavedList"
 import { CitySectionListQueryRenderer } from "./Scenes/City/CitySectionList"
 import { CollectionQueryRenderer } from "./Scenes/Collection/Collection"
 import { CollectionFullFeaturedArtistListQueryRenderer } from "./Scenes/Collection/Components/FullFeaturedArtistList"
-import { FairQueryRenderer } from "./Scenes/Fair/Fair"
+import { FairScreen } from "./Scenes/Fair/Fair"
 import { FairAllFollowedArtistsQueryRenderer } from "./Scenes/Fair/FairAllFollowedArtists"
 import { FairArticlesQueryRenderer } from "./Scenes/Fair/FairArticles"
 import { FairMoreInfoQueryRenderer } from "./Scenes/Fair/FairMoreInfo"
@@ -456,7 +456,7 @@ export const modules = defineModules({
     hidesBackButton: true,
     hidesBottomTabs: true,
   }),
-  Fair: reactModule(FairQueryRenderer, { fullBleed: true, hidesBackButton: true }),
+  Fair: reactModule(FairScreen, { fullBleed: true, hidesBackButton: true }),
   FairMoreInfo: reactModule(FairMoreInfoQueryRenderer),
   FairArticles: reactModule(FairArticlesQueryRenderer),
   FairAllFollowedArtists: reactModule(FairAllFollowedArtistsQueryRenderer),

--- a/src/app/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/app/Components/ArtworkFilter/useArtworkFilters.ts
@@ -22,12 +22,12 @@ interface UseArtworkFiltersOptions {
   onRefetch?: (error?: Error | null) => void
   refetchRef?: MutableRefObject<() => void>
   // this property is used to pass a refetch function from a parent component that uses relay hooks
-  hookRefetch?: RefetchFnDynamic<OperationType, any>
+  relayPaginationHookRefetch?: RefetchFnDynamic<OperationType, any>
 }
 
 export const useArtworkFilters = ({
   relay,
-  hookRefetch,
+  relayPaginationHookRefetch,
   aggregations,
   pageSize = PAGE_SIZE,
   componentPath,
@@ -72,8 +72,8 @@ export const useArtworkFilters = ({
       )
     }
 
-    if (hookRefetch) {
-      hookRefetch(
+    if (relayPaginationHookRefetch) {
+      relayPaginationHookRefetch(
         refetchVariables ?? {
           input: prepareFilterArtworksParamsForInput(
             filterArtworksParams(appliedFilters, filterType)

--- a/src/app/Components/ArtworkFilter/useArtworkFilters.ts
+++ b/src/app/Components/ArtworkFilter/useArtworkFilters.ts
@@ -1,6 +1,7 @@
 import { PAGE_SIZE } from "app/Components/constants"
 import { MutableRefObject, useEffect, useMemo } from "react"
-import { RelayPaginationProp, Variables } from "react-relay"
+import { RefetchFnDynamic, RelayPaginationProp, Variables } from "react-relay"
+import { OperationType } from "relay-runtime"
 import {
   aggregationForFilter,
   filterArtworksParams,
@@ -20,10 +21,13 @@ interface UseArtworkFiltersOptions {
   onApply?: () => void
   onRefetch?: (error?: Error | null) => void
   refetchRef?: MutableRefObject<() => void>
+  // this property is used to pass a refetch function from a parent component that uses relay hooks
+  hookRefetch?: RefetchFnDynamic<OperationType, any>
 }
 
 export const useArtworkFilters = ({
   relay,
+  hookRefetch,
   aggregations,
   pageSize = PAGE_SIZE,
   componentPath,
@@ -65,6 +69,17 @@ export const useArtworkFilters = ({
           }
         },
         refetchVariables ?? { input: prepareFilterArtworksParamsForInput(filterParams) }
+      )
+    }
+
+    if (hookRefetch) {
+      hookRefetch(
+        refetchVariables ?? {
+          input: prepareFilterArtworksParamsForInput(
+            filterArtworksParams(appliedFilters, filterType)
+          ),
+          pageSize,
+        }
       )
     }
   }

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -77,6 +77,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
 
   return (
     <MasonryFlashList
+      accessibilityLabel="Artworks Grid"
       keyboardShouldPersistTaps="handled"
       contentContainerStyle={{ paddingHorizontal: space(2), paddingBottom: space(6) }}
       data={artworks}

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -47,6 +47,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   refreshControl,
   ListEmptyComponent,
   ListHeaderComponent,
+  ListFooterComponent,
   hasMore,
   loadMore,
   isLoading,
@@ -91,7 +92,11 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
       refreshControl={refreshControl}
       renderItem={renderItem}
       ListFooterComponent={
-        <MasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+        !!ListFooterComponent ? (
+          ListFooterComponent
+        ) : (
+          <MasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+        )
       }
     />
   )

--- a/src/app/Components/constants.ts
+++ b/src/app/Components/constants.ts
@@ -1,6 +1,6 @@
 export const PAGE_SIZE = 10
-export const FAIR2_ARTWORKS_PAGE_SIZE = 30
-export const FAIR2_EXHIBITORS_PAGE_SIZE = 30
+export const FAIR_ARTWORKS_PAGE_SIZE = 30
+export const FAIR_EXHIBITORS_PAGE_SIZE = 30
 export const ARTIST_SERIES_PAGE_SIZE = 30
 export const SHOW2_ARTWORKS_PAGE_SIZE = 30
 export const SAVED_SERCHES_PAGE_SIZE = 20

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -10,7 +10,7 @@ import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilter
 import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
-import { FAIR2_ARTWORKS_PAGE_SIZE, PAGE_SIZE } from "app/Components/constants"
+import { FAIR_ARTWORKS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { Schema } from "app/utils/track"
 import { useEffect } from "react"
@@ -60,14 +60,11 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   )
 
   useArtworkFilters({
-    // TODO: relay pt 2 figure out a way to make this work without relay prop
-    // Do we need a new hook or can we customize the existing one to support
-    // usage along with relay hooks?
     relay,
-    hookRefetch: refetch,
+    relayPaginationHookRefetch: refetch,
     aggregations: dispatchAggregations,
     componentPath: "Fair/FairArtworks",
-    pageSize: FAIR2_ARTWORKS_PAGE_SIZE,
+    pageSize: FAIR_ARTWORKS_PAGE_SIZE,
   })
 
   useEffect(() => {
@@ -100,14 +97,14 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
       return
     }
 
-    loadNext(20)
+    loadNext(FAIR_ARTWORKS_PAGE_SIZE)
   }
 
   return (
     <Flex flex={1} minHeight={2}>
       <MasonryInfiniteScrollArtworkGrid
         artworks={artworks}
-        pageSize={PAGE_SIZE}
+        pageSize={FAIR_ARTWORKS_PAGE_SIZE}
         contextScreenOwnerType={OwnerType.fair}
         contextScreenOwnerId={data.internalID}
         contextScreenOwnerSlug={data.slug}

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -18,7 +18,7 @@ import { RelayPaginationProp, graphql, usePaginationFragment } from "react-relay
 import { useTracking } from "react-tracking"
 
 interface FairArtworksProps {
-  fair: FairArtworks_fair$key
+  fair?: FairArtworks_fair$key
   relay?: RelayPaginationProp
   initiallyAppliedFilter?: FilterArray
   aggregations?: aggregationsType

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -14,12 +14,12 @@ import { FAIR2_ARTWORKS_PAGE_SIZE, PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { Schema } from "app/utils/track"
 import { useEffect } from "react"
-import { graphql, usePaginationFragment } from "react-relay"
+import { RelayPaginationProp, graphql, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface FairArtworksProps {
   fair: FairArtworks_fair$key | null
-  // relay: RelayPaginationProp
+  relay?: RelayPaginationProp
   initiallyAppliedFilter?: FilterArray
   aggregations?: aggregationsType
   followedArtistCount?: number | null | undefined
@@ -27,13 +27,12 @@ interface FairArtworksProps {
 
 export const FairArtworks: React.FC<FairArtworksProps> = ({
   fair,
-  // TODO: relay pt 1 figure out a way to make this work without relay prop
-  // relay,
+  relay,
   initiallyAppliedFilter,
   aggregations,
   followedArtistCount,
 }) => {
-  const { data, hasNext, loadNext, isLoadingNext } = usePaginationFragment(
+  const { data, hasNext, loadNext, isLoadingNext, refetch } = usePaginationFragment(
     FairArtworksFragment,
     fair
   )
@@ -64,7 +63,8 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
     // TODO: relay pt 2 figure out a way to make this work without relay prop
     // Do we need a new hook or can we customize the existing one to support
     // usage along with relay hooks?
-    // relay,
+    relay,
+    hookRefetch: refetch,
     aggregations: dispatchAggregations,
     componentPath: "Fair/FairArtworks",
     pageSize: FAIR2_ARTWORKS_PAGE_SIZE,

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -1,6 +1,6 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Flex } from "@artsy/palette-mobile"
-import { FairArtworks_fair$data } from "__generated__/FairArtworks_fair.graphql"
+import { Button, Flex } from "@artsy/palette-mobile"
+import { FairArtworks_fair$key } from "__generated__/FairArtworks_fair.graphql"
 import {
   aggregationsType,
   aggregationsWithFollowedArtists,
@@ -14,12 +14,12 @@ import { FAIR2_ARTWORKS_PAGE_SIZE, PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { Schema } from "app/utils/track"
 import { useEffect } from "react"
-import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
+import { graphql, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface FairArtworksProps {
-  fair: FairArtworks_fair$data
-  relay: RelayPaginationProp
+  fair: FairArtworks_fair$key | null
+  // relay: RelayPaginationProp
   initiallyAppliedFilter?: FilterArray
   aggregations?: aggregationsType
   followedArtistCount?: number | null | undefined
@@ -27,15 +27,20 @@ interface FairArtworksProps {
 
 export const FairArtworks: React.FC<FairArtworksProps> = ({
   fair,
-  relay,
+  // TODO: relay pt 1 figure out a way to make this work without relay prop
+  // relay,
   initiallyAppliedFilter,
   aggregations,
   followedArtistCount,
 }) => {
+  const { data, hasNext, loadNext, isLoadingNext } = usePaginationFragment(
+    FairArtworksFragment,
+    fair
+  )
+
   const tracking = useTracking()
 
-
-  const artworks = extractNodes(fair.fairArtworks)
+  const artworks = extractNodes(data?.fairArtworks)
   const artworksTotal = artworks?.length ?? 0
 
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions(
@@ -47,8 +52,8 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   const counts = ArtworksFiltersStore.useStoreState((state) => state.counts)
 
   const dispatchFollowedArtistCount =
-    (followedArtistCount || fair?.fairArtworks?.counts?.followedArtists) ?? 0
-  const artworkAggregations = ((aggregations || fair?.fairArtworks?.aggregations) ??
+    (followedArtistCount || data?.fairArtworks?.counts?.followedArtists) ?? 0
+  const artworkAggregations = ((aggregations || data?.fairArtworks?.aggregations) ??
     []) as aggregationsType
   const dispatchAggregations = aggregationsWithFollowedArtists(
     dispatchFollowedArtistCount,
@@ -56,7 +61,10 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   )
 
   useArtworkFilters({
-    relay,
+    // TODO: relay pt 2 figure out a way to make this work without relay prop
+    // Do we need a new hook or can we customize the existing one to support
+    // usage along with relay hooks?
+    // relay,
     aggregations: dispatchAggregations,
     componentPath: "Fair/FairArtworks",
     pageSize: FAIR2_ARTWORKS_PAGE_SIZE,
@@ -72,6 +80,10 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
     setFiltersCountAction({ ...counts, total: artworksTotal })
   }, [artworksTotal])
 
+  if (!data) {
+    return null
+  }
+
   const trackClear = (id: string, slug: string) => {
     tracking.trackEvent({
       action_name: "clearFilters",
@@ -83,116 +95,100 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
     })
   }
 
+  const handleLoadMore = () => {
+    if (!hasNext || isLoadingNext) {
+      return
+    }
+
+    loadNext(20)
+  }
+
   return (
     <Flex flex={1} minHeight={2}>
       <MasonryInfiniteScrollArtworkGrid
         artworks={artworks}
         pageSize={PAGE_SIZE}
         contextScreenOwnerType={OwnerType.fair}
-        contextScreenOwnerId={fair.internalID}
-        contextScreenOwnerSlug={fair.slug}
+        contextScreenOwnerId={data.internalID}
+        contextScreenOwnerSlug={data.slug}
         ListEmptyComponent={
           <FilteredArtworkGridZeroState
-            id={fair.internalID}
-            slug={fair.slug}
+            id={data.internalID}
+            slug={data.slug}
             trackClear={trackClear}
           />
         }
-        hasMore={relay.hasMore()}
-        loadMore={() => relay.loadMore(PAGE_SIZE)}
-        isLoading={relay.isLoading()}
+        hasMore={false}
+        ListFooterComponent={
+          !!hasNext ? (
+            <Button
+              mt={6}
+              mb={4}
+              variant="fillGray"
+              size="large"
+              block
+              onPress={handleLoadMore}
+              loading={isLoadingNext}
+            >
+              Show more
+            </Button>
+          ) : null
+        }
       />
     </Flex>
   )
 }
 
-export const FairArtworksFragmentContainer = createPaginationContainer(
-  FairArtworks,
-  {
-    fair: graphql`
-      fragment FairArtworks_fair on Fair
-      @argumentDefinitions(
-        count: { type: "Int", defaultValue: 30 }
-        cursor: { type: "String" }
-        input: { type: "FilterArtworksInput" }
-      ) {
-        slug
-        internalID
-        fairArtworks: filterArtworksConnection(
-          first: $count
-          after: $cursor
-          aggregations: [
-            ARTIST
-            ARTIST_NATIONALITY
-            COLOR
-            DIMENSION_RANGE
-            FOLLOWED_ARTISTS
-            LOCATION_CITY
-            MAJOR_PERIOD
-            MATERIALS_TERMS
-            MEDIUM
-            PARTNER
-            PRICE_RANGE
-          ]
-          input: $input
-        ) @connection(key: "Fair_fairArtworks") {
-          aggregations {
-            slice
-            counts {
-              count
-              name
-              value
-            }
-          }
-          edges {
-            node {
-              id
-              slug
-              image(includeAll: false) {
-                aspectRatio
-              }
-              ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
-            }
-          }
-          counts {
-            total
-            followedArtists
-          }
+export const FairArtworksFragment = graphql`
+  fragment FairArtworks_fair on Fair
+  @refetchable(queryName: "FairArtworksQuery")
+  @argumentDefinitions(
+    count: { type: "Int", defaultValue: 30 }
+    cursor: { type: "String" }
+    input: { type: "FilterArtworksInput" }
+  ) {
+    slug
+    internalID
+    fairArtworks: filterArtworksConnection(
+      first: $count
+      after: $cursor
+      aggregations: [
+        ARTIST
+        ARTIST_NATIONALITY
+        COLOR
+        DIMENSION_RANGE
+        FOLLOWED_ARTISTS
+        LOCATION_CITY
+        MAJOR_PERIOD
+        MATERIALS_TERMS
+        MEDIUM
+        PARTNER
+        PRICE_RANGE
+      ]
+      input: $input
+    ) @connection(key: "Fair_fairArtworks") {
+      aggregations {
+        slice
+        counts {
+          count
+          name
+          value
         }
       }
-    `,
-  },
-  {
-    getConnectionFromProps(props) {
-      return props?.fair.fairArtworks
-    },
-    getFragmentVariables(previousVariables, count) {
-      // Relay is unable to infer this for this component, I'm not sure why.
-      return {
-        ...previousVariables,
-        count,
-      }
-    },
-    getVariables(props, { count, cursor }, fragmentVariables) {
-      return {
-        input: fragmentVariables.input,
-        props,
-        count,
-        cursor,
-        id: props.fair.slug,
-      }
-    },
-    query: graphql`
-      query FairArtworksInfiniteScrollGridQuery(
-        $id: String!
-        $count: Int!
-        $cursor: String
-        $input: FilterArtworksInput
-      ) {
-        fair(id: $id) {
-          ...FairArtworks_fair @arguments(count: $count, cursor: $cursor, input: $input)
+      edges {
+        node {
+          id
+          slug
+          image(includeAll: false) {
+            aspectRatio
+          }
+          ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
       }
-    `,
+      counts {
+        total
+        followedArtists
+      }
+    }
   }
-)
+`

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -18,7 +18,7 @@ import { RelayPaginationProp, graphql, usePaginationFragment } from "react-relay
 import { useTracking } from "react-tracking"
 
 interface FairArtworksProps {
-  fair: FairArtworks_fair$key | null
+  fair: FairArtworks_fair$key
   relay?: RelayPaginationProp
   initiallyAppliedFilter?: FilterArray
   aggregations?: aggregationsType
@@ -39,7 +39,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
 
   const tracking = useTracking()
 
-  const artworks = extractNodes(data?.fairArtworks)
+  const artworks = extractNodes(data?.fairArtworks) ?? []
   const artworksTotal = artworks?.length ?? 0
 
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions(

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -1,7 +1,7 @@
 import { Flex, Box } from "@artsy/palette-mobile"
 import { FairExhibitors_fair$data } from "__generated__/FairExhibitors_fair.graphql"
 import Spinner from "app/Components/Spinner"
-import { FAIR2_EXHIBITORS_PAGE_SIZE } from "app/Components/constants"
+import { FAIR_EXHIBITORS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import React, { useState } from "react"
 import { FlatList } from "react-native"
@@ -24,7 +24,7 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
     }
 
     setIsLoading(true)
-    relay.loadMore(FAIR2_EXHIBITORS_PAGE_SIZE, (err) => {
+    relay.loadMore(FAIR_EXHIBITORS_PAGE_SIZE, (err) => {
       setIsLoading(false)
 
       if (err) {

--- a/src/app/Scenes/Fair/Fair.tests.tsx
+++ b/src/app/Scenes/Fair/Fair.tests.tsx
@@ -1,65 +1,34 @@
-import { FairTestsQuery } from "__generated__/FairTestsQuery.graphql"
+import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
 import { NavigationalTabs, Tab } from "app/Components/LegacyTabs"
-import { extractText } from "app/utils/tests/extractText"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
-import { useTracking } from "react-tracking"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { FairCollectionsFragmentContainer } from "./Components/FairCollections"
 import { FairEditorialFragmentContainer } from "./Components/FairEditorial"
 import { FairExhibitorsFragmentContainer } from "./Components/FairExhibitors"
 import { FairFollowedArtistsRailFragmentContainer } from "./Components/FairFollowedArtistsRail"
 import { FairHeaderFragmentContainer } from "./Components/FairHeader"
-import { Fair, FairFragmentContainer } from "./Fair"
+import { FairScreen } from "./Fair"
 
 describe("Fair", () => {
-  const trackEvent = useTracking().trackEvent
-  let env: ReturnType<typeof createMockEnvironment>
-
-  beforeEach(() => {
-    env = createMockEnvironment()
+  const { renderWithRelay } = setupTestWrapper({
+    Component: () => <FairScreen fairID="art-basel-hong-kong-2020" />,
   })
 
-  const TestRenderer = () => (
-    <QueryRenderer<FairTestsQuery>
-      environment={env}
-      query={graphql`
-        query FairTestsQuery($fairID: String!) @relay_test_operation {
-          fair(id: $fairID) {
-            ...Fair_fair
-          }
-        }
-      `}
-      variables={{ fairID: "art-basel-hong-kong-2020" }}
-      render={({ props, error }) => {
-        if (props?.fair) {
-          return <FairFragmentContainer fair={props.fair} />
-        } else if (error) {
-          console.log(error)
-        }
-      }}
-    />
-  )
-
-  const getWrapper = (mockResolvers = {}) => {
-    const tree = renderWithWrappersLEGACY(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation((operation) =>
-        MockPayloadGenerator.generate(operation, mockResolvers)
-      )
+  it("renders without throwing an error", async () => {
+    renderWithRelay({
+      Fair: () => ({
+        isActive: true,
+        name: "Art Basel Hong Kong 2020",
+      }),
     })
-    return tree
-  }
 
-  it("renders without throwing an error", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.root.findAllByType(Fair)).toHaveLength(1)
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.queryByText("Art Basel Hong Kong 2020")).toBeOnTheScreen()
   })
 
-  it("renders the necessary components when fair is active", () => {
-    const wrapper = getWrapper({
+  it("renders the necessary components when fair is active", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: true,
         counts: {
@@ -69,33 +38,37 @@ describe("Fair", () => {
       }),
     })
 
-    expect(wrapper.root.findAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairCollectionsFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(NavigationalTabs)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairExhibitorsFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(1)
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairCollectionsFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(NavigationalTabs)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairExhibitorsFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(1)
   })
 
-  it("renders fewer components when fair is inactive", () => {
-    const wrapper = getWrapper({
+  it("renders fewer components when fair is inactive", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: false,
       }),
     })
 
-    expect(wrapper.root.findAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
-    expect(extractText(wrapper.root)).toMatch("This fair is currently unavailable.")
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
 
-    expect(wrapper.root.findAllByType(FairCollectionsFragmentContainer)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(NavigationalTabs)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(FairExhibitorsFragmentContainer)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
+    expect(screen.queryByText("This fair is currently unavailable.")).toBeOnTheScreen()
+
+    expect(screen.UNSAFE_queryAllByType(FairCollectionsFragmentContainer)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(NavigationalTabs)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(FairExhibitorsFragmentContainer)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(0)
   })
 
-  it("does not render components when there is no data for them", () => {
-    const wrapper = getWrapper({
+  it("does not render components when there is no data for them", async () => {
+    renderWithRelay({
       Fair: () => ({
         articles: {
           edges: [],
@@ -107,16 +80,18 @@ describe("Fair", () => {
         },
       }),
     })
-    expect(wrapper.root.findAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairEditorialFragmentContainer)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(FairCollectionsFragmentContainer)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(NavigationalTabs)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(FairExhibitorsFragmentContainer)).toHaveLength(0)
-    expect(wrapper.root.findAllByType(FairArtworksFragmentContainer)).toHaveLength(0)
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(FairHeaderFragmentContainer)).toHaveLength(1)
+    expect(screen.UNSAFE_queryAllByType(FairEditorialFragmentContainer)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(FairCollectionsFragmentContainer)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(NavigationalTabs)).toHaveLength(0)
+    expect(screen.UNSAFE_queryAllByType(FairExhibitorsFragmentContainer)).toHaveLength(0)
   })
 
-  it("renders the collections component if there are collections", () => {
-    const wrapper = getWrapper({
+  it("renders the collections component if there are collections", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: true,
         marketingCollections: [
@@ -126,11 +101,14 @@ describe("Fair", () => {
         ],
       }),
     })
-    expect(wrapper.root.findAllByType(FairCollectionsFragmentContainer)).toHaveLength(1)
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(FairCollectionsFragmentContainer)).toHaveLength(1)
   })
 
-  it("renders the editorial component if there are articles", () => {
-    const wrapper = getWrapper({
+  it("renders the editorial component if there are articles", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: true,
         articles: {
@@ -145,22 +123,14 @@ describe("Fair", () => {
         },
       }),
     })
-    expect(wrapper.root.findAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(FairEditorialFragmentContainer)).toHaveLength(1)
   })
 
-  it("renders the artists you follow rail if there are any artworks", () => {
-    let wrapper = getWrapper({
-      Fair: () => ({
-        isActive: true,
-        filterArtworksConnection: {
-          edges: [],
-        },
-      }),
-    })
-
-    expect(wrapper.root.findAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(0)
-
-    wrapper = getWrapper({
+  it("renders the artists you follow rail if there are any artworks", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: true,
         followedArtistArtworks: {
@@ -176,11 +146,13 @@ describe("Fair", () => {
       }),
     })
 
-    expect(wrapper.root.findAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(1)
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(FairFollowedArtistsRailFragmentContainer)).toHaveLength(1)
   })
 
-  it("renders the artworks/exhibitors component and tabs if there are artworks and exhibitors", () => {
-    const wrapper = getWrapper({
+  it("renders the artworks/exhibitors tabs if there are artworks and exhibitors", async () => {
+    renderWithRelay({
       Fair: () => ({
         isActive: true,
         counts: {
@@ -189,14 +161,18 @@ describe("Fair", () => {
         },
       }),
     })
-    expect(wrapper.root.findAllByType(Tab)).toHaveLength(2)
-    expect(wrapper.root.findAllByType(FairExhibitorsFragmentContainer)).toHaveLength(1)
-    expect(wrapper.root.findAllByType(FairArtworksFragmentContainer)).toHaveLength(0)
+
+    await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+    expect(screen.UNSAFE_queryAllByType(Tab)).toHaveLength(2)
+
+    expect(screen.queryByText("Artworks")).toBeOnTheScreen()
+    expect(screen.queryByText("Exhibitors")).toBeOnTheScreen()
   })
 
-  describe("tracks taps navigating between the artworks tab and exhibitors tab", () => {
-    it("When Using Palette V3", () => {
-      const wrapper = getWrapper({
+  describe("tracks", () => {
+    it("taps navigating between the artworks tab and exhibitors tab", async () => {
+      renderWithRelay({
         Fair: () => ({
           isActive: true,
           slug: "art-basel-hong-kong-2020",
@@ -207,12 +183,12 @@ describe("Fair", () => {
           },
         }),
       })
-      const tabs = wrapper.root.findAllByType(Tab)
-      const exhibitorsTab = tabs[0]
-      const artworksTab = tabs[1]
 
-      act(() => artworksTab.props.onPress())
-      expect(trackEvent).toHaveBeenCalledWith({
+      await waitForElementToBeRemoved(() => screen.getByTestId("FairPlaceholder"))
+
+      fireEvent.press(screen.getByText("Artworks"))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
         action: "tappedNavigationTab",
         context_module: "exhibitorsTab",
         context_screen_owner_type: "fair",
@@ -221,8 +197,8 @@ describe("Fair", () => {
         subject: "Artworks",
       })
 
-      act(() => exhibitorsTab.props.onPress())
-      expect(trackEvent).toHaveBeenCalledWith({
+      fireEvent.press(screen.getByText("Exhibitors"))
+      expect(mockTrackEvent).toHaveBeenCalledWith({
         action: "tappedNavigationTab",
         context_module: "artworksTab",
         context_screen_owner_type: "fair",

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -216,7 +216,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
                   return null
                 }
 
-                if (tabToShow.label === "Exhibitors" && hasExhibitors) {
+                if (tabToShow.label === "Exhibitors") {
                   return <FairExhibitorsFragmentContainer fair={fair} />
                 }
 

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -184,6 +184,15 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
               }
               case "fairTabsAndFilter": {
                 const tabToShow = tabs ? tabs[activeTab] : null
+                // remove artwork tab if there are no artworks to show and exhibitors tab if there are no exhibitors to show
+                const filteredTabs = tabs?.filter((tab) => {
+                  if (tab.label === "Artworks") {
+                    return hasArtworks
+                  } else {
+                    return hasExhibitors
+                  }
+                })
+
                 return (
                   <Box pt={`${safeAreaInsets.top}px`} backgroundColor="white">
                     <NavigationalTabs
@@ -192,7 +201,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
                         setActiveTab(index)
                       }}
                       activeTab={activeTab}
-                      tabs={tabs}
+                      tabs={filteredTabs}
                     />
                     {tabToShow?.label === "Artworks" && (
                       <HeaderArtworksFilter onPress={openFilterArtworksModal} />
@@ -207,13 +216,13 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
                   return null
                 }
 
-                if (tabToShow.label === "Exhibitors") {
+                if (tabToShow.label === "Exhibitors" && hasExhibitors) {
                   return <FairExhibitorsFragmentContainer fair={fair} />
                 }
 
                 if (tabToShow.label === "Artworks") {
                   return (
-                    <Box px={2}>
+                    <>
                       <FairArtworksFragmentContainer fair={fair} />
                       <ArtworkFilterNavigator
                         visible={isFilterArtworksModalVisible}
@@ -223,7 +232,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
                         exitModal={handleFilterArtworksModal}
                         closeModal={closeFilterArtworksModal}
                       />
-                    </Box>
+                    </>
                   )
                 }
               }

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -273,8 +273,6 @@ export const FairFragment = graphql`
     ...FairEmptyState_fair
     ...FairEditorial_fair
     ...FairCollections_fair
-    # TODO: do we need this 👇?
-    ...FairArtworks_fair @arguments(input: { sort: "-decayed_merch" })
     ...FairExhibitors_fair
     ...FairFollowedArtistsRail_fair
   }

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tests.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tests.tsx
@@ -1,76 +1,74 @@
-// import { FairAllFollowedArtistsTestsQuery } from "__generated__/FairAllFollowedArtistsTestsQuery.graphql"
-// import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-// import { graphql, QueryRenderer } from "react-relay"
-// import { act } from "react-test-renderer"
-// import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-// import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
-// import {
-//   FairAllFollowedArtists,
-//   FairAllFollowedArtistsFragmentContainer,
-// } from "./FairAllFollowedArtists"
+import { FairAllFollowedArtistsTestsQuery } from "__generated__/FairAllFollowedArtistsTestsQuery.graphql"
+import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { graphql, QueryRenderer } from "react-relay"
+import { act } from "react-test-renderer"
+import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+import { FairArtworks } from "./Components/FairArtworks"
+import {
+  FairAllFollowedArtists,
+  FairAllFollowedArtistsFragmentContainer,
+} from "./FairAllFollowedArtists"
 
-// describe("FairAllFollowedArtists", () => {
-//   let env: ReturnType<typeof createMockEnvironment>
+describe("FairAllFollowedArtists", () => {
+  let env: ReturnType<typeof createMockEnvironment>
 
-//   beforeEach(() => {
-//     env = createMockEnvironment()
-//   })
+  beforeEach(() => {
+    env = createMockEnvironment()
+  })
 
-//   const TestRenderer = () => (
-//     <QueryRenderer<FairAllFollowedArtistsTestsQuery>
-//       environment={env}
-//       query={graphql`
-//         query FairAllFollowedArtistsTestsQuery($fairID: String!) @relay_test_operation {
-//           fair(id: $fairID) {
-//             ...FairAllFollowedArtists_fair
-//           }
-//           fairForFilters: fair(id: $fairID) {
-//             ...FairAllFollowedArtists_fairForFilters
-//           }
-//         }
-//       `}
-//       variables={{ fairID: "art-basel-hong-kong-2019" }}
-//       render={({ props, error }) => {
-//         if (props?.fair && props?.fairForFilters) {
-//           return (
-//             <FairAllFollowedArtistsFragmentContainer
-//               fair={props.fair}
-//               fairForFilters={props.fairForFilters}
-//             />
-//           )
-//         } else if (error) {
-//           console.log(error)
-//         }
-//       }}
-//     />
-//   )
+  const TestRenderer = () => (
+    <QueryRenderer<FairAllFollowedArtistsTestsQuery>
+      environment={env}
+      query={graphql`
+        query FairAllFollowedArtistsTestsQuery($fairID: String!) @relay_test_operation {
+          fair(id: $fairID) {
+            ...FairAllFollowedArtists_fair
+          }
+          fairForFilters: fair(id: $fairID) {
+            ...FairAllFollowedArtists_fairForFilters
+          }
+        }
+      `}
+      variables={{ fairID: "art-basel-hong-kong-2019" }}
+      render={({ props, error }) => {
+        if (props?.fair && props?.fairForFilters) {
+          return (
+            <FairAllFollowedArtistsFragmentContainer
+              fair={props.fair}
+              fairForFilters={props.fairForFilters}
+            />
+          )
+        } else if (error) {
+          console.log(error)
+        }
+      }}
+    />
+  )
 
-//   const getWrapper = (mockResolvers = {}) => {
-//     const tree = renderWithWrappersLEGACY(<TestRenderer />)
-//     act(() => {
-//       env.mock.resolveMostRecentOperation((operation) =>
-//         MockPayloadGenerator.generate(operation, mockResolvers)
-//       )
-//     })
-//     return tree
-//   }
+  const getWrapper = (mockResolvers = {}) => {
+    const tree = renderWithWrappersLEGACY(<TestRenderer />)
+    act(() => {
+      env.mock.resolveMostRecentOperation((operation) =>
+        MockPayloadGenerator.generate(operation, mockResolvers)
+      )
+    })
+    return tree
+  }
 
-//   it("renders without throwing an error", () => {
-//     const wrapper = getWrapper()
-//     expect(wrapper.root.findAllByType(FairAllFollowedArtists)).toHaveLength(1)
-//   })
+  it("renders without throwing an error", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(FairAllFollowedArtists)).toHaveLength(1)
+  })
 
-//   it("renders a grid of artworks in the fair filtered by artists the user follows", () => {
-//     const wrapper = getWrapper()
-//     expect(wrapper.root.findAllByType(FairArtworksFragmentContainer)).toHaveLength(1)
-//     expect(
-//       wrapper.root.findAllByType(FairArtworksFragmentContainer)[0].props.initiallyAppliedFilter
-//     ).toStrictEqual([
-//       {
-//         displayText: "All Artists I Follow",
-//         paramName: "includeArtworksByFollowedArtists",
-//         paramValue: true,
-//       },
-//     ])
-//   })
-// })
+  it("renders a grid of artworks in the fair filtered by artists the user follows", () => {
+    const wrapper = getWrapper()
+    expect(wrapper.root.findAllByType(FairArtworks)).toHaveLength(1)
+    expect(wrapper.root.findAllByType(FairArtworks)[0].props.initiallyAppliedFilter).toStrictEqual([
+      {
+        displayText: "All Artists I Follow",
+        paramName: "includeArtworksByFollowedArtists",
+        paramValue: true,
+      },
+    ])
+  })
+})

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tests.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tests.tsx
@@ -1,76 +1,76 @@
-import { FairAllFollowedArtistsTestsQuery } from "__generated__/FairAllFollowedArtistsTestsQuery.graphql"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { graphql, QueryRenderer } from "react-relay"
-import { act } from "react-test-renderer"
-import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
-import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
-import {
-  FairAllFollowedArtists,
-  FairAllFollowedArtistsFragmentContainer,
-} from "./FairAllFollowedArtists"
+// import { FairAllFollowedArtistsTestsQuery } from "__generated__/FairAllFollowedArtistsTestsQuery.graphql"
+// import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+// import { graphql, QueryRenderer } from "react-relay"
+// import { act } from "react-test-renderer"
+// import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+// import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
+// import {
+//   FairAllFollowedArtists,
+//   FairAllFollowedArtistsFragmentContainer,
+// } from "./FairAllFollowedArtists"
 
-describe("FairAllFollowedArtists", () => {
-  let env: ReturnType<typeof createMockEnvironment>
+// describe("FairAllFollowedArtists", () => {
+//   let env: ReturnType<typeof createMockEnvironment>
 
-  beforeEach(() => {
-    env = createMockEnvironment()
-  })
+//   beforeEach(() => {
+//     env = createMockEnvironment()
+//   })
 
-  const TestRenderer = () => (
-    <QueryRenderer<FairAllFollowedArtistsTestsQuery>
-      environment={env}
-      query={graphql`
-        query FairAllFollowedArtistsTestsQuery($fairID: String!) @relay_test_operation {
-          fair(id: $fairID) {
-            ...FairAllFollowedArtists_fair
-          }
-          fairForFilters: fair(id: $fairID) {
-            ...FairAllFollowedArtists_fairForFilters
-          }
-        }
-      `}
-      variables={{ fairID: "art-basel-hong-kong-2019" }}
-      render={({ props, error }) => {
-        if (props?.fair && props?.fairForFilters) {
-          return (
-            <FairAllFollowedArtistsFragmentContainer
-              fair={props.fair}
-              fairForFilters={props.fairForFilters}
-            />
-          )
-        } else if (error) {
-          console.log(error)
-        }
-      }}
-    />
-  )
+//   const TestRenderer = () => (
+//     <QueryRenderer<FairAllFollowedArtistsTestsQuery>
+//       environment={env}
+//       query={graphql`
+//         query FairAllFollowedArtistsTestsQuery($fairID: String!) @relay_test_operation {
+//           fair(id: $fairID) {
+//             ...FairAllFollowedArtists_fair
+//           }
+//           fairForFilters: fair(id: $fairID) {
+//             ...FairAllFollowedArtists_fairForFilters
+//           }
+//         }
+//       `}
+//       variables={{ fairID: "art-basel-hong-kong-2019" }}
+//       render={({ props, error }) => {
+//         if (props?.fair && props?.fairForFilters) {
+//           return (
+//             <FairAllFollowedArtistsFragmentContainer
+//               fair={props.fair}
+//               fairForFilters={props.fairForFilters}
+//             />
+//           )
+//         } else if (error) {
+//           console.log(error)
+//         }
+//       }}
+//     />
+//   )
 
-  const getWrapper = (mockResolvers = {}) => {
-    const tree = renderWithWrappersLEGACY(<TestRenderer />)
-    act(() => {
-      env.mock.resolveMostRecentOperation((operation) =>
-        MockPayloadGenerator.generate(operation, mockResolvers)
-      )
-    })
-    return tree
-  }
+//   const getWrapper = (mockResolvers = {}) => {
+//     const tree = renderWithWrappersLEGACY(<TestRenderer />)
+//     act(() => {
+//       env.mock.resolveMostRecentOperation((operation) =>
+//         MockPayloadGenerator.generate(operation, mockResolvers)
+//       )
+//     })
+//     return tree
+//   }
 
-  it("renders without throwing an error", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.root.findAllByType(FairAllFollowedArtists)).toHaveLength(1)
-  })
+//   it("renders without throwing an error", () => {
+//     const wrapper = getWrapper()
+//     expect(wrapper.root.findAllByType(FairAllFollowedArtists)).toHaveLength(1)
+//   })
 
-  it("renders a grid of artworks in the fair filtered by artists the user follows", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.root.findAllByType(FairArtworksFragmentContainer)).toHaveLength(1)
-    expect(
-      wrapper.root.findAllByType(FairArtworksFragmentContainer)[0].props.initiallyAppliedFilter
-    ).toStrictEqual([
-      {
-        displayText: "All Artists I Follow",
-        paramName: "includeArtworksByFollowedArtists",
-        paramValue: true,
-      },
-    ])
-  })
-})
+//   it("renders a grid of artworks in the fair filtered by artists the user follows", () => {
+//     const wrapper = getWrapper()
+//     expect(wrapper.root.findAllByType(FairArtworksFragmentContainer)).toHaveLength(1)
+//     expect(
+//       wrapper.root.findAllByType(FairArtworksFragmentContainer)[0].props.initiallyAppliedFilter
+//     ).toStrictEqual([
+//       {
+//         displayText: "All Artists I Follow",
+//         paramName: "includeArtworksByFollowedArtists",
+//         paramValue: true,
+//       },
+//     ])
+//   })
+// })

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -20,7 +20,7 @@ import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import React, { useState } from "react"
 import { ScrollView } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
-import { FairArtworksFragmentContainer } from "./Components/FairArtworks"
+import { FairArtworks } from "./Components/FairArtworks"
 
 interface FairAllFollowedArtistsProps {
   fair: FairAllFollowedArtists_fair$data
@@ -53,7 +53,7 @@ export const FairAllFollowedArtists: React.FC<FairAllFollowedArtistsProps> = ({
         <Separator />
         <Spacer y={2} />
         <Box px="15px">
-          <FairArtworksFragmentContainer
+          <FairArtworks
             fair={fair}
             initiallyAppliedFilter={initialFilter}
             aggregations={fairForFilters.filterArtworksConnection?.aggregations as Aggregations}

--- a/src/app/Scenes/Fair/FairArtworks.tests.tsx
+++ b/src/app/Scenes/Fair/FairArtworks.tests.tsx
@@ -1,64 +1,37 @@
 import { screen } from "@testing-library/react-native"
 import { FairArtworksTestsQuery } from "__generated__/FairArtworksTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { FairArtworksFragmentContainer } from "app/Scenes/Fair/Components/FairArtworks"
-import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { graphql, QueryRenderer } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
+import { FairArtworks } from "app/Scenes/Fair/Components/FairArtworks"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
 
 describe("FairArtworks", () => {
-  let mockEnvironment: ReturnType<typeof createMockEnvironment>
-
-  const TestRenderer = () => (
-    <QueryRenderer<FairArtworksTestsQuery>
-      query={query}
-      environment={mockEnvironment}
-      variables={{
-        fairID: "art-basel-hong-kong-2020",
-      }}
-      render={({ props, error }) => {
-        if (error) {
-          console.log(error)
-          return null
+  const { renderWithRelay } = setupTestWrapper<FairArtworksTestsQuery>({
+    Component: ({ fair }) => (
+      <ArtworkFiltersStoreProvider>
+        <FairArtworks fair={fair} />
+      </ArtworkFiltersStoreProvider>
+    ),
+    query: graphql`
+      query FairArtworksTestsQuery($fairID: String!) @relay_test_operation {
+        fair(id: $fairID) {
+          ...FairArtworks_fair @arguments(input: { sort: "-decayed_merch" })
         }
-
-        if (!props?.fair) {
-          return null
-        }
-
-        return (
-          <ArtworkFiltersStoreProvider>
-            <FairArtworksFragmentContainer fair={props.fair} />
-          </ArtworkFiltersStoreProvider>
-        )
-      }}
-    />
-  )
-
-  beforeEach(() => {
-    mockEnvironment = getMockRelayEnvironment()
+      }
+    `,
   })
 
   it("renders a grid of artworks", async () => {
-    renderWithWrappers(<TestRenderer />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
+    renderWithRelay({
       Fair: () => fair,
     })
-
-    await flushPromiseQueue()
 
     expect(screen.queryByText("Artwork Title")).toBeTruthy()
     expect(screen.queryByLabelText("Artworks Grid")).toBeTruthy()
   })
 
   it("renders empty view if there are no artworks", async () => {
-    renderWithWrappers(<TestRenderer />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
+    renderWithRelay({
       Fair: () => ({
         fairArtworks: {
           edges: [],
@@ -69,19 +42,9 @@ describe("FairArtworks", () => {
       }),
     })
 
-    await flushPromiseQueue()
-
     expect(screen.queryByText(/No results found/)).toBeTruthy()
   })
 })
-
-const query = graphql`
-  query FairArtworksTestsQuery($fairID: String!) @relay_test_operation {
-    fair(id: $fairID) {
-      ...FairArtworks_fair
-    }
-  }
-`
 
 const artwork = {
   slug: "artwork-slug",

--- a/src/app/Scenes/Fair/FairArtworks.tests.tsx
+++ b/src/app/Scenes/Fair/FairArtworks.tests.tsx
@@ -9,7 +9,7 @@ describe("FairArtworks", () => {
   const { renderWithRelay } = setupTestWrapper<FairArtworksTestsQuery>({
     Component: ({ fair }) => (
       <ArtworkFiltersStoreProvider>
-        <FairArtworks fair={fair} />
+        <FairArtworks fair={fair!} />
       </ArtworkFiltersStoreProvider>
     ),
     query: graphql`

--- a/src/app/Scenes/Fair/FairArtworks.tests.tsx
+++ b/src/app/Scenes/Fair/FairArtworks.tests.tsx
@@ -1,7 +1,6 @@
 import { screen } from "@testing-library/react-native"
 import { FairArtworksTestsQuery } from "__generated__/FairArtworksTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { FairArtworksFragmentContainer } from "app/Scenes/Fair/Components/FairArtworks"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -52,18 +51,8 @@ describe("FairArtworks", () => {
 
     await flushPromiseQueue()
 
-    expect(screen.getByText("Artwork Title")).toBeTruthy()
-  })
-
-  it("requests artworks in batches of 30", () => {
-    renderWithWrappers(<TestRenderer />)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Fair: () => fair,
-    })
-
-    const artworksGridContainer = screen.UNSAFE_getByType(InfiniteScrollArtworksGridContainer)
-    expect(artworksGridContainer.props).toMatchObject({ pageSize: 30 })
+    expect(screen.queryByText("Artwork Title")).toBeTruthy()
+    expect(screen.queryByLabelText("Artworks Grid")).toBeTruthy()
   })
 
   it("renders empty view if there are no artworks", async () => {
@@ -82,7 +71,7 @@ describe("FairArtworks", () => {
 
     await flushPromiseQueue()
 
-    expect(screen.getByText(/No results found/)).toBeTruthy()
+    expect(screen.queryByText(/No results found/)).toBeTruthy()
   })
 })
 

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tests.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from "@artsy/palette-mobile"
-import { Fair, FairFragmentContainer, FairPlaceholder } from "app/Scenes/Fair/Fair"
+import { FairPlaceholder, FairScreen } from "app/Scenes/Fair/Fair"
 import { PartnerContainer, PartnerSkeleton } from "app/Scenes/Partner/Partner"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { __renderWithPlaceholderTestUtils__ } from "app/utils/renderWithPlaceholder"
@@ -39,7 +39,7 @@ describe("VanityURLEntity", () => {
     expect(UNSAFE_getAllByType(VanityURLPossibleRedirect)).toHaveLength(1)
   })
 
-  it("renders a fairQueryRenderer when given a fair id", () => {
+  it("renders Fair screen when given a fair id", () => {
     const tree = renderWithWrappersLEGACY(
       <TestRenderer entity="fair" slugType="fairID" slug="some-fair" />
     )
@@ -47,7 +47,7 @@ describe("VanityURLEntity", () => {
     act(() => {
       env.mock.resolveMostRecentOperation((operation) => MockPayloadGenerator.generate(operation))
     })
-    const fairComponent = tree.root.findByType(Fair)
+    const fairComponent = tree.root.findByType(FairScreen)
     expect(fairComponent).toBeDefined()
   })
 
@@ -121,7 +121,7 @@ describe("VanityURLEntity", () => {
           })
         )
       })
-      const fairComponent = tree.root.findByType(FairFragmentContainer)
+      const fairComponent = tree.root.findByType(FairScreen)
       expect(fairComponent).toBeDefined()
     })
 

--- a/src/app/Scenes/VanityURL/VanityURLEntity.tsx
+++ b/src/app/Scenes/VanityURL/VanityURLEntity.tsx
@@ -1,7 +1,7 @@
 import { Flex, Spinner } from "@artsy/palette-mobile"
 import { VanityURLEntityQuery } from "__generated__/VanityURLEntityQuery.graphql"
 import { VanityURLEntity_fairOrPartner$data } from "__generated__/VanityURLEntity_fairOrPartner.graphql"
-import { FairFragmentContainer, FairPlaceholder, FairQueryRenderer } from "app/Scenes/Fair/Fair"
+import { FairPlaceholder, FairScreen } from "app/Scenes/Fair/Fair"
 import { PartnerContainer, PartnerSkeleton } from "app/Scenes/Partner/Partner"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -20,7 +20,7 @@ const VanityURLEntity: React.FC<EntityProps> = ({ fairOrPartner, originalSlug })
   const isPartner = fairOrPartner.__typename === "Partner" || "id" in fairOrPartner
 
   if (isFair) {
-    return <FairFragmentContainer fair={fairOrPartner} />
+    return <FairScreen fairID={fairOrPartner.slug} />
   } else if (isPartner) {
     return <PartnerContainer partner={fairOrPartner} />
   } else {
@@ -52,7 +52,7 @@ interface RendererProps {
 
 export const VanityURLEntityRenderer: React.FC<RendererProps> = ({ entity, slugType, slug }) => {
   if (slugType === "fairID") {
-    return <FairQueryRenderer fairID={slug} />
+    return <FairScreen fairID={slug} />
   } else if (!entity && !slugType) {
     return <VanityURLPossibleRedirect slug={slug} />
   } else {


### PR DESCRIPTION
This PR resolves [PHIRE-287] & [PHIRE-342]<!-- eg [PROJECT-XXXX] -->

### Description

Refactors Fair screen to use hooks and FairArtworks to use Masonry flash list.

This solves the top two sentry issues in both platforms:

[iOS sentry stacktrace](https://artsynet.sentry.io/issues/4267639014/events/570ee5fd0a1d4bd68bd066d407cd6061/)
[Android sentry stacktrace
](https://artsynet.sentry.io/issues/4375898883/events/0b1e4ed2332d4f98ac4d98b6154d0f5b/)

If the android stops being there for this surface it means that this resolved this issue, otherwise we would need to refactor the way that we render the sections in the Fair screen.

Not much changed in the design / implementation.

The only UI visible change is that the `refetch` now triggers the FairPlaceholder but we're gonna test it on Mobile QA and with Sapphire (cc @brainbicycle) to see if it is acceptable
.
### Testing on an emulator

Previously what was happening was that when you were visiting on Android the fair screen the app was crashing after 1 or two refetches of artworks with pressing the show more button.

Same for iOS due to memory leaks of the previous masonry implementation.

If you connect flipper to the emulator / simulator there is the `Crash Reporter` Tab on the Left and when your app crashes -> next time you reopen it it populates the `Crash Reporter` tab with the information you need about the crash.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- refactor fair to use new masonry grid - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-287]: https://artsyproduct.atlassian.net/browse/PHIRE-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PHIRE-342]: https://artsyproduct.atlassian.net/browse/PHIRE-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ