### PR TITLE
fix: Remove Latest Activity rail header font boldness

### DIFF
--- a/src/app/Components/SectionTitle.tsx
+++ b/src/app/Components/SectionTitle.tsx
@@ -15,7 +15,6 @@ const Wrapper: React.FC<{ onPress?(): any }> = ({ onPress, children }) => {
 }
 
 export const SectionTitle: React.FC<{
-  fontWeight?: string
   title: React.ReactNode
   titleVariant?: TextProps["variant"]
   subtitle?: React.ReactNode
@@ -24,7 +23,6 @@ export const SectionTitle: React.FC<{
   mb?: SpacingUnit
   capitalized?: boolean
 }> = ({
-  fontWeight,
   title,
   titleVariant = "sm-display",
   subtitle,
@@ -50,7 +48,6 @@ export const SectionTitle: React.FC<{
             ellipsizeMode="tail"
             numberOfLines={1}
             testID="title"
-            fontWeight={fontWeight}
           >
             {typeof title === "string" ? titleText : title}
           </Text>

--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -51,7 +51,7 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
   return (
     <Flex pt={2}>
       <Flex px={2}>
-        <SectionTitle fontWeight="bold" title={title} onPress={handleHeaderPress} />
+        <SectionTitle title={title} onPress={handleHeaderPress} />
       </Flex>
 
       <FlatList


### PR DESCRIPTION
This PR resolves [ONYX-446] <!-- eg [PROJECT-XXXX] -->

### Description

Remove Latest Activity rail header font boldness.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-446]: https://artsyproduct.atlassian.net/browse/ONYX-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ