### PR TITLE
feat: scroll back to artworks grid

### DIFF
--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
@@ -31,6 +31,7 @@ type ArtistTabs = "Insights" | "Artworks"
 
 type PassedProps = {
   initialTab: ArtistTabs
+  scrollToArtworksGrid?: boolean
 }
 
 type HandleResultPress = (passProps?: PassedProps) => void
@@ -199,13 +200,20 @@ function navigateToResult(result: AutosuggestResult, props?: PassedProps) {
   } else if (result.displayType === "Fair") {
     navigateToEntity(result.href!, EntityType.Fair, SlugType.ProfileID)
   } else if (result.__typename === "Artist") {
-    if (props?.initialTab === "Insights") {
-      navigate(`${result.href!}/auction-results`, { passProps: props })
+    switch (props?.initialTab) {
+      case "Insights":
+        navigate(`${result.href!}/auction-results`, { passProps: props })
+        break
+      case "Artworks":
+        navigate(`${result.href!}/artworks`, {
+          passProps: props,
+        })
+        break
+
+      default:
+        navigate(result.href!)
+        break
     }
-    if (props?.initialTab === "Artworks") {
-      navigate(`${result.href!}/artworks`, { passProps: props })
-    }
-    navigate(result.href!)
   } else {
     navigate(result.href!)
   }

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -140,7 +140,8 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     })),
     addRoute("/artist/:artistID/artworks", "Artist", (params) => ({
       ...params,
-      initialTab: "Insights",
+      initialTab: "Artworks",
+      scrollToArtworksGrid: true,
     })),
     addRoute("/artist/:artistID/shows", "ArtistShows"),
 


### PR DESCRIPTION
### Description
chore: scroll back to artworks grid on artworks press.

https://github.com/artsy/eigen/assets/11945712/d03a02d2-a72b-4779-b55b-a68013e813cd



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
