### PR TITLE
fix: Fix Latest Activity rail caching issue

### DIFF
--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -16,8 +16,6 @@ interface ActivityRailProps {
   notificationsConnection: ActivityRail_notificationsConnection$key | null
 }
 
-const NUMBER_OF_ITEMS = 6
-
 export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notificationsConnection }) => {
   const { trackEvent } = useTracking()
 
@@ -25,18 +23,14 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes
-    .filter((notification) => {
-      if (isArtworksBasedNotification(notification.notificationType)) {
-        const artworksCount = notification.artworks?.totalCount ?? 0
-        return artworksCount > 0
-      }
+  const notifications = notificationsNodes.filter((notification) => {
+    if (isArtworksBasedNotification(notification.notificationType)) {
+      const artworksCount = notification.artworks?.totalCount ?? 0
+      return artworksCount > 0
+    }
 
-      return true
-    })
-    // Because `notificationsConnect` returns different items based on the `first` param,
-    // we need to fetch the exact same number of notifications as on the notifications screen and slice here until the bug is fixed.
-    .slice(0, NUMBER_OF_ITEMS)
+    return true
+  })
 
   if (notifications.length === 0) {
     return null
@@ -87,7 +81,7 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 
 const notificationsConnectionFragment = graphql`
   fragment ActivityRail_notificationsConnection on Viewer
-  @argumentDefinitions(count: { type: "Int", defaultValue: 6 }) {
+  @argumentDefinitions(count: { type: "Int" }) {
     # Filtering out notifications without associated artworks to avoid displaying notifications without image
     notificationsConnection(first: $count, notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED]) {
       edges {

--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -16,6 +16,8 @@ interface ActivityRailProps {
   notificationsConnection: ActivityRail_notificationsConnection$key | null
 }
 
+const NUMBER_OF_ITEMS = 6
+
 export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notificationsConnection }) => {
   const { trackEvent } = useTracking()
 
@@ -23,14 +25,18 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter((notification) => {
-    if (isArtworksBasedNotification(notification.notificationType)) {
-      const artworksCount = notification.artworks?.totalCount ?? 0
-      return artworksCount > 0
-    }
+  const notifications = notificationsNodes
+    .filter((notification) => {
+      if (isArtworksBasedNotification(notification.notificationType)) {
+        const artworksCount = notification.artworks?.totalCount ?? 0
+        return artworksCount > 0
+      }
 
-    return true
-  })
+      return true
+    })
+    // Because `notificationsConnect` returns different items based on the `first` param,
+    // we need to fetch the exact same number of notifications as on the notifications screen and slice here until the bug is fixed.
+    .slice(0, NUMBER_OF_ITEMS)
 
   if (notifications.length === 0) {
     return null

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -520,8 +520,11 @@ export const HomeFragmentContainer = memo(
       `,
       notificationsConnection: graphql`
         fragment Home_notificationsConnection on Viewer {
-          ...ActivityRail_notificationsConnection @arguments(count: 6)
-          notificationsConnection(first: 6, notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED]) {
+          ...ActivityRail_notificationsConnection @arguments(count: 10)
+          notificationsConnection(
+            first: 10
+            notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED]
+          ) {
             edges {
               node {
                 internalID


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

The `notificationsConnection` cache key [depends on the number of items fetched](https://github.com/artsy/gravity/blob/a7fc24ce4e6def061a2571741012d3ed20a326e6/app/api/v1/me_notifications_endpoint.rb#L27). This can lead to inconsistencies between the activity screen (fetches initially 10 items) and the Activity rail (fetches 6 items).

As a quick fix, this PR aligns increases the number of items being fetched for the Activity rail to match the number of items fetched for the screen.

**Follow-Up:**

We should look into ways to change the way the activity feed is cached to avoid the issue.

**Screenshots:**
| Screen (10 items) | Fetching 6 items 🔴  | Fetching 10 items 🟢  |
| --- | --- | --- |
|![screen](https://github.com/artsy/eigen/assets/4691889/8930f46b-7b06-4a99-bdc8-0a43e158a260) |![no good](https://github.com/artsy/eigen/assets/4691889/e27fa7ee-bd9d-4450-96fd-6bdf39195606) |![good](https://github.com/artsy/eigen/assets/4691889/9363a8a4-1e76-49b0-b0e8-736eea15ff7c) |









### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
