### PR TITLE
fix: Improve Alert Color filter responsiveness

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAdditionalGeneIDs.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAdditionalGeneIDs.tsx
@@ -14,8 +14,8 @@ export const SavedSearchFilterAdditionalGeneIDs = () => {
     SearchCriteria.additionalGeneIDs
   ) as string[]
 
-  const setValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
-    (actions) => actions.setValueToAttributesByKeyAction
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
   )
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.removeValueFromAttributesByKeyAction
@@ -34,7 +34,7 @@ export const SavedSearchFilterAdditionalGeneIDs = () => {
       })
     } else {
       const newValues = (selectedAttributes || []).concat(value)
-      setValueToAttributesByKeyAction({
+      addValueToAttributesByKeyAction({
         key: SearchCriteria.additionalGeneIDs,
         value: newValues,
       })

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPriceRange.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPriceRange.tsx
@@ -28,13 +28,13 @@ const SavedSearchFilterPriceRange: React.FC<SavedSearchFilterPriceRangeProps> = 
     storePriceRangeValue || DEFAULT_PRICE_RANGE
   )
 
-  const setValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
-    (actions) => actions.setValueToAttributesByKeyAction
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
   )
 
   useDebounce(
     () => {
-      setValueToAttributesByKeyAction({
+      addValueToAttributesByKeyAction({
         key: SearchCriteria.priceRange,
         value: filterPriceRange,
       })

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterRarity.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterRarity.tsx
@@ -10,8 +10,8 @@ export const SavedSearchFilterRarity = () => {
     SearchCriteria.attributionClass
   ) as string[]
 
-  const setValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
-    (actions) => actions.setValueToAttributesByKeyAction
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
   )
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.removeValueFromAttributesByKeyAction
@@ -30,7 +30,7 @@ export const SavedSearchFilterRarity = () => {
       })
     } else {
       const newValues = (selectedAttributes || []).concat(value)
-      setValueToAttributesByKeyAction({
+      addValueToAttributesByKeyAction({
         key: SearchCriteria.attributionClass,
         value: newValues,
       })

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterWaysToBuy.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterWaysToBuy.tsx
@@ -7,8 +7,8 @@ import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 export const SavedSearchFilterWaysToBuy = () => {
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
 
-  const setValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
-    (actions) => actions.setValueToAttributesByKeyAction
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
   )
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.removeValueFromAttributesByKeyAction
@@ -41,7 +41,7 @@ export const SavedSearchFilterWaysToBuy = () => {
                     value: false,
                   })
                 } else {
-                  setValueToAttributesByKeyAction({
+                  addValueToAttributesByKeyAction({
                     key: criterion,
                     value: true,
                   })

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -16,7 +16,8 @@ export interface SavedSearchModel {
   /** Artwork ID, if the current saved search alert is being set from an artwork */
   currentArtworkID?: string
 
-  setValueToAttributesByKeyAction: Action<
+  setAttributeAction: Action<this, { key: SearchCriteria; value: any }>
+  addValueToAttributesByKeyAction: Action<
     this,
     {
       key: SearchCriteria
@@ -47,7 +48,11 @@ export const savedSearchModel: SavedSearchModel = {
   },
   currentArtworkID: undefined,
 
-  setValueToAttributesByKeyAction: action((state, payload) => {
+  setAttributeAction: action((state, payload) => {
+    state.attributes[payload.key] = payload.value
+  }),
+
+  addValueToAttributesByKeyAction: action((state, payload) => {
     if (payload.key === "priceRange" && typeof payload.value === "string") {
       // set form dirty on price update
       if (state.attributes[payload.key] !== payload.value) {

--- a/src/app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen.tsx
@@ -37,12 +37,12 @@ export const AlertPriceRangeScreen: React.FC<AlertPriceRanceScreenProps> = ({
   const [filterPriceRange, setFilterPriceRange] = useState(
     attributes.priceRange || DEFAULT_PRICE_RANGE
   )
-  const setValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
-    (actions) => actions.setValueToAttributesByKeyAction
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
   )
 
   const handleOnButtonPress = () => {
-    setValueToAttributesByKeyAction({
+    addValueToAttributesByKeyAction({
       key: SearchCriteria.priceRange,
       value: filterPriceRange,
     })


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

This PR improves the Alert Color filter responsiveness by adding a local state for selected colors and delaying the store update which rerenders the whole screen.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
