### PR TITLE
fix: Filter out notifications without images in Latest Activity rail

### DIFF
--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -82,7 +82,8 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 const notificationsConnectionFragment = graphql`
   fragment ActivityRail_notificationsConnection on Viewer
   @argumentDefinitions(count: { type: "Int", defaultValue: 6 }) {
-    notificationsConnection(first: $count) {
+    # Filtering out notifications without associated artworks to avoid displaying notifications without image
+    notificationsConnection(first: $count, notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED]) {
       edges {
         node {
           internalID

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -521,7 +521,7 @@ export const HomeFragmentContainer = memo(
       notificationsConnection: graphql`
         fragment Home_notificationsConnection on Viewer {
           ...ActivityRail_notificationsConnection @arguments(count: 6)
-          notificationsConnection(first: 6) {
+          notificationsConnection(first: 6, notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED]) {
             edges {
               node {
                 internalID


### PR DESCRIPTION
This PR resolves [ONYX-465] <!-- eg [PROJECT-XXXX] -->

### Description

We have decided to filter out all notifications without associated artworks for now to avoid showing items without images in the rail until we fix the backend to support an artworks connection or find other ways to display images.



**Notification Types to include:**

`[ARTWORK_ALERT, ARTWORK_PUBLISHED]`


**Follow-Up:**

- Remove the filtering once Metaphysics exposes an `artworkConnection` for all notification types
- Consider a default image for edge cases where notifications don't have artworks with images associated (e.g. Editorial notifications)

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Filter out notifications without images in Latest Activity rail - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-465]: https://artsyproduct.atlassian.net/browse/ONYX-465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ