### PR TITLE
chore(ONYX-463): save recent price ranges only after saving alert

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPriceRange.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPriceRange.tsx
@@ -7,7 +7,6 @@ import { PriceRange } from "app/Components/PriceRange/types"
 import { getBarsFromAggregations } from "app/Components/PriceRange/utils"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSearchCriteriaAttributes } from "app/Scenes/SavedSearchAlert/helpers"
-import { GlobalStore } from "app/store/GlobalStore"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { useEffect, useState } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -38,7 +37,6 @@ const SavedSearchFilterPriceRange: React.FC<SavedSearchFilterPriceRangeProps> = 
         key: SearchCriteria.priceRange,
         value: filterPriceRange,
       })
-      GlobalStore.actions.recentPriceRanges.addNewPriceRange(filterPriceRange)
     },
     200,
     [filterPriceRange]

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -1,11 +1,16 @@
 import { ActionType, DeletedSavedSearch, EditedSavedSearch, OwnerType } from "@artsy/cohesion"
 import { Dialog, quoteLeft, quoteRight, useTheme } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
-import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
+import {
+  SearchCriteria,
+  SearchCriteriaAttributes,
+} from "app/Components/ArtworkFilter/SavedSearch/types"
+import { GlobalStore } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { refreshSavedAlerts } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
-import React, { useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { Alert, ScrollView, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { useFirstMountState } from "react-use/lib/useFirstMountState"
@@ -21,6 +26,7 @@ import {
   checkOrRequestPushPermissions,
   clearDefaultAttributes,
   showWarningMessageForDuplicateAlert,
+  useSearchCriteriaAttributes,
 } from "./helpers"
 import { createSavedSearchAlert } from "./mutations/createSavedSearchAlert"
 import { deleteSavedSearchMutation } from "./mutations/deleteSavedSearchAlert"
@@ -50,6 +56,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
     onDeleteComplete,
     ...other
   } = props
+  const enableAlertsFilters = useFeatureFlag("AREnableAlertsFilters")
+
   const isUpdateForm = !!savedSearchAlertId
   const isFirstRender = useFirstMountState()
   const pills = useSavedSearchPills()
@@ -58,6 +66,9 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.removeValueFromAttributesByKeyAction
   )
+
+  const selectedRriceRange = useSearchCriteriaAttributes(SearchCriteria.priceRange) as string
+
   const tracking = useTracking()
   const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
@@ -118,6 +129,11 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
         }
 
         await submitHandler(userAlertSettings, clearedAttributes)
+
+        // If the user set a price range, we would like to save it in the store to prompt it the next time
+        if (enableAlertsFilters && selectedRriceRange) {
+          GlobalStore.actions.recentPriceRanges.addNewPriceRange(selectedRriceRange)
+        }
       } catch (error) {
         console.error(error)
       }

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -13,7 +13,7 @@ import {
   PushAuthorizationStatus,
 } from "app/utils/PushNotification"
 import useAppState from "app/utils/useAppState"
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { createRefetchContainer, graphql, QueryRenderer, RelayRefetchProp } from "react-relay"
 
 interface CreateSavedSearchAlertContentProps {


### PR DESCRIPTION
This PR resolves [ONYX-463] <!-- eg [PROJECT-XXXX] -->

### Description

Save recent price ranges only after saving alert


https://github.com/artsy/eigen/assets/11945712/caa6e6a2-ac79-49ae-9795-4b39153a266d



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- save recent price ranges only after saving alert - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-463]: https://artsyproduct.atlassian.net/browse/ONYX-463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ