### PR TITLE
fix(DIA-195): does not submit if the forgot form is not dirty yet

### DIFF
--- a/src/app/Scenes/Onboarding/ForgotPassword.tests.tsx
+++ b/src/app/Scenes/Onboarding/ForgotPassword.tests.tsx
@@ -1,7 +1,6 @@
-import { Input } from "app/Components/Input"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { mockNavigate } from "app/utils/tests/navigationMocks"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { act } from "react-test-renderer"
+import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { ForgotPasswordForm } from "./ForgotPassword"
 
 const navigationPropsMock = {
@@ -38,22 +37,32 @@ describe("ForgotPassword", () => {
     )
   }
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("renders reset button disabled initially", () => {
-    const tree = renderWithWrappersLEGACY(<TestProvider />)
-    const resetButton = tree.root.findByProps({ testID: "resetButton" })
-    expect(resetButton.props.disabled).toEqual(true)
+    renderWithHookWrappersTL(<TestProvider />)
+
+    expect(screen.getByTestId("resetButton").props.accessibilityState.disabled).toEqual(true)
   })
 
   it("validates form on blur", () => {
-    const tree = renderWithWrappersLEGACY(<TestProvider />)
+    renderWithHookWrappersTL(<TestProvider />)
 
-    const emailInput = tree.root.findByType(Input)
+    const emailInput = screen.getByTestId("email-address")
 
-    act(() => {
-      emailInput.props.onChangeText("example@mail.com")
-      emailInput.props.onBlur()
-    })
+    fireEvent.changeText(emailInput, "example@mail.com")
+    fireEvent(emailInput, "blur")
 
     expect(mockValidateForm).toHaveBeenCalled()
+  })
+
+  it("does not submit when onSubmitEditing if the form is not dirty", () => {
+    renderWithHookWrappersTL(<TestProvider />)
+
+    fireEvent(screen.getByTestId("email-address"), "submitEditing")
+
+    expect(mockValidateForm).not.toHaveBeenCalled()
   })
 })

--- a/src/app/Scenes/Onboarding/ForgotPassword.tsx
+++ b/src/app/Scenes/Onboarding/ForgotPassword.tsx
@@ -60,7 +60,11 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
                 onChangeText={(text) => {
                   handleChange("email")(text.trim())
                 }}
-                onSubmitEditing={handleSubmit}
+                onSubmitEditing={() => {
+                  if (dirty) {
+                    handleSubmit()
+                  }
+                }}
                 onBlur={() => {
                   validateForm()
                 }}
@@ -72,6 +76,7 @@ export const ForgotPasswordForm: React.FC<ForgotPasswordFormProps> = ({
                 spellCheck={false}
                 autoCorrect={false}
                 textContentType="emailAddress"
+                testID="email-address"
               />
             )}
           </Flex>


### PR DESCRIPTION
This PR resolves [DIA-195] <!-- eg [PROJECT-XXXX] -->

### Description

Simple bug fix, on the Forgot Password screen, if we submit via keyboard without inputting anything the form submits. This PR doesn't allow submitting the Form if it's not dirty yet.

Bonus: small test refactor off deprecated methods

Before:

https://github.com/artsy/eigen/assets/15792853/87530c11-4145-4fc8-9261-1f8da03371f9

After:

https://github.com/artsy/eigen/assets/15792853/a7f71788-f119-49d0-a9d7-4b5bac033241


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: forgot password screen does not submit with the keyboard without data being input - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
