### PR TITLE
fix(flaky test): give all the live auction snapshots a tolerance

### DIFF
--- a/ios/ArtsyTests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
+++ b/ios/ArtsyTests/View_Controller_Tests/Live_Auction/LiveAuctionLotViewControllerTests.swift
@@ -71,40 +71,40 @@ class LiveAuctionLotViewControllerTests: QuickSpec {
             it("looks good for upcoming lots") {
                 auctionViewModel.distance = 1
                 lotViewModel.lotStateSignal.update(.upcomingLot(isHighestBidder: false))
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("looks good for upcoming lots that the user is winning") {
                 auctionViewModel.distance = 1
                 lotViewModel.lotStateSignal.update(.upcomingLot(isHighestBidder: true))
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("doesnt show a live auction call to action when auction is closed") {
                 lotViewModel.lotStateSignal.update(.closedLot(wasPassed: false))
                 auctionViewModel.saleAvailabilitySignal.update(.closed)
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("looks good when its lot becomes the current lot") {
                 lotViewModel.lotStateSignal.update(.liveLot)
                 auctionViewModel.currentLotSignal.update(lotViewModel)
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("looks good for lots with a met reserve") {
                 lotViewModel.reserveStatusSignal.update(.reserveMet)
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("looks good for lots with a (not yet met) reserve") {
                 lotViewModel.reserveStatusSignal.update(.reserveNotMet)
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("looks good for out-of-order lots") {
                 auctionViewModel.distance = -1
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
 
             it("handles updates to number of bids") {
@@ -114,7 +114,7 @@ class LiveAuctionLotViewControllerTests: QuickSpec {
                 lotViewModel.numberOfBids = 2
                 lotViewModel.numberOfBidsSignal.update(2)
 
-                expect(subject) == snapshot()
+                expect(subject).to(haveValidSnapshot(tolerance: 0.3))
             }
         }
     }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Gives all the snapshot tests a tolerance for live auction view controller. If they continue to fail we can remove. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix flaky test part 2 - Brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
