### PR TITLE
fix(DIA-198): add better disabled control on login via email screen

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingLogin.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingLogin.tsx
@@ -73,6 +73,9 @@ export const OnboardingLoginWithEmailForm: React.FC<OnboardingLoginProps> = ({
     return clearTimeout(timeout)
   }, [])
 
+  // To avoid not having the form in an invalid state when one of the fields have no value yet
+  const valuesNotEmpty = !!values.email && !!values.password
+
   return (
     <Flex flex={1} backgroundColor="white" flexGrow={1} pb={1}>
       <ArtsyKeyboardAvoidingView>
@@ -115,6 +118,7 @@ export const OnboardingLoginWithEmailForm: React.FC<OnboardingLoginProps> = ({
               // enable autofill of login details from the device keychain.
               textContentType="username"
               error={errors.email}
+              testID="email-address"
             />
             <Spacer y={2} />
             <Input
@@ -134,7 +138,11 @@ export const OnboardingLoginWithEmailForm: React.FC<OnboardingLoginProps> = ({
                 }
                 handleChange("password")(text)
               }}
-              onSubmitEditing={handleSubmit}
+              onSubmitEditing={() => {
+                if (dirty && valuesNotEmpty) {
+                  handleSubmit()
+                }
+              }}
               onBlur={() => validateForm()}
               placeholder="Password"
               placeholderTextColor={color("black30")}
@@ -147,6 +155,7 @@ export const OnboardingLoginWithEmailForm: React.FC<OnboardingLoginProps> = ({
               textContentType="password"
               value={values.password}
               error={errors.password}
+              testID="password"
             />
           </Box>
           <Spacer y={4} />
@@ -166,7 +175,7 @@ export const OnboardingLoginWithEmailForm: React.FC<OnboardingLoginProps> = ({
             onPress={handleSubmit}
             block
             haptic="impactMedium"
-            disabled={!(isValid && dirty) || isSubmitting} // isSubmitting to prevent weird appearances of the errors caused by async submiting
+            disabled={!isValid || !valuesNotEmpty}
             loading={isSubmitting}
             testID="loginButton"
             variant="fillDark"


### PR DESCRIPTION
This PR resolves [DIA-198] <!-- eg [PROJECT-XXXX] -->

### Description

Related to #9531, prevents submitting the form without being correctly filled via the keyboard submit button.
Also, disable the button until the form is valid.

Bonus: refactored the deprecated use of our test suite within the tests

Before

https://github.com/artsy/eigen/assets/15792853/d01cf52d-676c-4585-88d4-46993f14a92e

After

https://github.com/artsy/eigen/assets/15792853/b2b19bc5-c5cb-456b-9a6b-a20beb43d733

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: disable the cta on the login screen until the form is in a valid state, prevent submitting when its blank - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-198]: https://artsyproduct.atlassian.net/browse/DIA-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ