### PR TITLE
chore: simplify S3 paths for shared configuration

### DIFF
--- a/scripts/setup/setup-env-for-artsy
+++ b/scripts/setup/setup-env-for-artsy
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 
-aws s3 cp s3://artsy-citadel/eigen/.env.eigen .env.shared
+aws s3 cp s3://artsy-citadel/eigen/.env.shared ./
 
 cp metaflags.example.json metaflags.json
 

--- a/scripts/setup/setup-env-for-ci
+++ b/scripts/setup/setup-env-for-ci
@@ -2,8 +2,8 @@
 set -euxo pipefail
 
 
-aws s3 cp s3://artsy-citadel/eigen/.env.eigen .env.shared
-aws s3 cp s3://artsy-citadel/eigen/.env.eigen .env
+aws s3 cp s3://artsy-citadel/eigen/.env.shared .env.shared
+aws s3 cp s3://artsy-citadel/eigen/.env.shared .env
 aws s3 cp s3://artsy-citadel/eigen/.env.releases .env.releases
 
 cp metaflags.example.json metaflags.json

--- a/scripts/setup/update-env-for-artsy
+++ b/scripts/setup/update-env-for-artsy
@@ -6,7 +6,7 @@ read -p "Are you sure you want to update the env vars in S3? " -n 1 -r
 
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-  aws s3 cp .env.shared s3://artsy-citadel/eigen/.env.eigen
+  aws s3 cp .env.shared s3://artsy-citadel/eigen/
 
   RED='\033[0;31m'
   RST='\033[0m'

--- a/scripts/utils/doctor.js
+++ b/scripts/utils/doctor.js
@@ -43,7 +43,7 @@ const r = (text) => chalk.bold.red(text)
 
 const checkEnvVariablesAreUpToDate = () => {
   exec("touch .env.temp")
-  exec("aws s3 cp s3://artsy-citadel/eigen/.env.eigen .env.temp")
+  exec("aws s3 cp s3://artsy-citadel/eigen/.env.shared .env.temp")
 
   const updatedEnv = fs.readFileSync("./.env.temp", "utf8").toString()
   let localEnv = ""


### PR DESCRIPTION
For the reasons described in https://github.com/artsy/README/pull/530, I think it's simpler and more extensible to name our shared config file the same way in S3 as it's ultimately named locally. This PR attempts to update the few scripts with the new location.

I've already copied the file to its new location, and can follow up to remove the old version a little while after this is merged:

```
aws s3 cp s3://artsy-citadel/eigen/.env.eigen s3://artsy-citadel/eigen/.env.shared
```

<details><summary>Changelog updates</summary>

#nochangelog

</details>
