### PR TITLE
fix: Make Alert form Save CTA sticky

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -454,6 +454,7 @@ export const modules = defineModules({
   DevMenu: reactModule(DevMenu, { fullBleed: true, hidesBottomTabs: true, hidesBackButton: true }),
   EditSavedSearchAlert: reactModule(EditSavedSearchAlertQueryRenderer, {
     hidesBackButton: true,
+    hidesBottomTabs: true,
   }),
   Fair: reactModule(FairQueryRenderer, { fullBleed: true, hidesBackButton: true }),
   FairMoreInfo: reactModule(FairMoreInfoQueryRenderer),

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -46,9 +46,9 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
     if (visible) {
       const event = tracks.tappedCreateAlert({
         contextModule: contextModule,
-        ownerId: entity?.owner.id!,
-        ownerType: entity?.owner.type!,
-        ownerSlug: entity?.owner.slug!,
+        ownerId: entity?.owner.id,
+        ownerType: entity?.owner.type,
+        ownerSlug: entity?.owner.slug,
       })
 
       tracking.trackEvent(event)
@@ -57,6 +57,11 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
 
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
     const { owner } = entity
+
+    if (!result.id) {
+      return
+    }
+
     tracking.trackEvent(tracks.toggleSavedSearch(true, owner.type, owner.id, owner.slug, result.id))
   }
 

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -224,11 +224,13 @@ export const MyCollectionArtworkFormMain: React.FC<
   }
 
   const deleteArtwork = async (shouldDeleteArtist?: boolean) => {
-    trackEvent(tracks.deleteCollectedArtwork(artwork!.internalID, artwork!.slug))
+    if (!artwork) return
+
+    trackEvent(tracks.deleteCollectedArtwork(artwork.internalID, artwork?.slug))
     try {
       // TODO: Fix this separetely
       if (!__TEST__) {
-        await myCollectionDeleteArtwork(artwork!.internalID)
+        await myCollectionDeleteArtwork(artwork.internalID)
       }
 
       if (shouldDeleteArtist && formikValues.artistSearchResult?.internalID) {

--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import {
   ArrowRightIcon,
+  ArtsyKeyboardAvoidingView,
   Box,
   Button,
   Flex,
@@ -9,6 +10,8 @@ import {
   Spacer,
   Text,
   Touchable,
+  useScreenDimensions,
+  useTheme,
 } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { SearchCriteria } from "app/Components/ArtworkFilter/SavedSearch/types"
@@ -25,10 +28,12 @@ import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { navigate } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
+import { Platform, ScrollView, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { SavedSearchAlertSwitch } from "./SavedSearchAlertSwitch"
 
 interface FormProps {
+  contentContainerStyle?: StyleProp<ViewStyle>
   pills: SavedSearchPill[]
   savedSearchAlertId?: string
   isLoading?: boolean
@@ -43,6 +48,7 @@ interface FormProps {
 }
 
 export const Form: React.FC<FormProps> = ({
+  contentContainerStyle,
   pills,
   savedSearchAlertId,
   isLoading,
@@ -60,6 +66,8 @@ export const Form: React.FC<FormProps> = ({
   const enableDetailsInput = useFeatureFlag("AREnableAlertDetailsInput")
 
   const tracking = useTracking()
+  const { space } = useTheme()
+  const { bottom } = useScreenDimensions().safeAreaInsets
 
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
   const { isSubmitting, values, errors, dirty, handleBlur, handleChange } =
@@ -109,150 +117,164 @@ export const Form: React.FC<FormProps> = ({
   const isArtistPill = (pill: SavedSearchPill) => pill.paramName === SearchCriteria.artistID
 
   return (
-    <Box>
-      {!isEditMode && (
-        <InfoButton
-          titleElement={
-            <Text variant="lg-display" mb={1} mr={0.5}>
-              Create Alert
-            </Text>
-          }
-          trackEvent={() => {
-            tracking.trackEvent(tracks.tappedCreateAlertHeaderButton())
-          }}
-          maxModalHeight={300}
-          modalTitle="Create Alert"
-          modalContent={
-            <Flex py={1}>
-              <Text>
-                On the hunt for a particular work? Create an alert and we’ll let you know when
-                matching works are added to Artsy.
+    <ArtsyKeyboardAvoidingView>
+      <ScrollView
+        keyboardDismissMode="on-drag"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
+      >
+        {!isEditMode && (
+          <InfoButton
+            titleElement={
+              <Text variant="lg-display" mb={1} mr={0.5}>
+                Create Alert
               </Text>
-            </Flex>
-          }
-        />
-      )}
-
-      <Join separator={<Spacer y={2} />}>
-        <Box>
-          <SavedSearchNameInputQueryRenderer attributes={attributes} />
-
-          <Box mt={2}>
-            <InputTitle>Filters</InputTitle>
-            <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
-              {pills.map((pill, index) => (
-                <Pill
-                  testID="alert-pill"
-                  m={0.5}
-                  variant="filter"
-                  disabled={isArtistPill(pill)}
-                  key={`filter-label-${index}`}
-                  onPress={() => onRemovePill(pill)}
-                >
-                  {pill.label}
-                </Pill>
-              ))}
-            </Flex>
-          </Box>
-        </Box>
-
-        {!!enableAlertsFilters ? (
-          <Flex mt={2}>
-            <MenuItem
-              title="Add Filters"
-              description={
-                enableAlertsFiltersSizeFiltering
-                  ? "Including Price Range, Rarity, Medium, Size, Color"
-                  : "Including Price Range, Rarity, Medium, Color"
-              }
-              onPress={() => {
-                navigation.navigate("SavedSearchFilterScreen")
-              }}
-              px={0}
-            />
-          </Flex>
-        ) : null}
-
-        {/* Price range is part of the new filters screen, no need to show it here anymore */}
-        {!enableAlertsFilters && (
-          <Flex my={1}>
-            <Touchable
-              accessibilityLabel="Set price range"
-              accessibilityRole="button"
-              onPress={() => navigation.navigate("AlertPriceRange")}
-            >
-              <Flex flexDirection="row" alignItems="center" py={1}>
-                <Flex flex={1}>
-                  <Text variant="sm-display">Set price range you are interested in</Text>
-                </Flex>
-                <Flex alignSelf="center" mt={0.5}>
-                  <ArrowRightIcon />
-                </Flex>
+            }
+            trackEvent={() => {
+              tracking.trackEvent(tracks.tappedCreateAlertHeaderButton())
+            }}
+            maxModalHeight={300}
+            modalTitle="Create Alert"
+            modalContent={
+              <Flex py={1}>
+                <Text>
+                  On the hunt for a particular work? Create an alert and we’ll let you know when
+                  matching works are added to Artsy.
+                </Text>
               </Flex>
-            </Touchable>
-          </Flex>
+            }
+          />
         )}
 
-        {!!enableDetailsInput && (
-          <Flex>
-            <Text>Tell us more about what you’re looking for</Text>
-            <Spacer y={1} />
-            <Input
-              placeholder="For example, a specific request such as ‘figurative painting’ or ‘David Hockney iPad drawings.’"
-              value={values.details}
-              onChangeText={handleChange("details")}
-              onBlur={handleBlur("details")}
-              error={errors.details}
-              multiline
-              maxLength={700}
-              testID="alert-input-details"
-            />
-          </Flex>
-        )}
+        <Join separator={<Spacer y={2} />}>
+          <Box>
+            <SavedSearchNameInputQueryRenderer attributes={attributes} />
 
-        <Box>
-          <SavedSearchAlertSwitch
-            label="Push Notifications"
-            onChange={onTogglePushNotification}
-            active={values.push}
-          />
-
-          <Spacer y={1} />
-
-          <SavedSearchAlertSwitch
-            label="Email"
-            onChange={onToggleEmailNotification}
-            active={values.email}
-          />
-
-          {!!shouldShowEmailWarning && (
-            <Box backgroundColor="orange10" my={1} p={2}>
-              <Text variant="xs" color="orange150">
-                Change your email preferences
-              </Text>
-              <Text variant="xs" mt={0.5}>
-                To receive alerts via email, please update your email preferences.
-              </Text>
+            <Box mt={2}>
+              <InputTitle>Filters</InputTitle>
+              <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
+                {pills.map((pill, index) => (
+                  <Pill
+                    testID="alert-pill"
+                    m={0.5}
+                    variant="filter"
+                    disabled={isArtistPill(pill)}
+                    key={`filter-label-${index}`}
+                    onPress={() => onRemovePill(pill)}
+                  >
+                    {pill.label}
+                  </Pill>
+                ))}
+              </Flex>
             </Box>
+          </Box>
+
+          {!!enableAlertsFilters ? (
+            <Flex mt={2}>
+              <MenuItem
+                title="Add Filters"
+                description={
+                  enableAlertsFiltersSizeFiltering
+                    ? "Including Price Range, Rarity, Medium, Size, Color"
+                    : "Including Price Range, Rarity, Medium, Color"
+                }
+                onPress={() => {
+                  navigation.navigate("SavedSearchFilterScreen")
+                }}
+                px={0}
+              />
+            </Flex>
+          ) : null}
+
+          {/* Price range is part of the new filters screen, no need to show it here anymore */}
+          {!enableAlertsFilters && (
+            <Flex my={1}>
+              <Touchable
+                accessibilityLabel="Set price range"
+                accessibilityRole="button"
+                onPress={() => navigation.navigate("AlertPriceRange")}
+              >
+                <Flex flexDirection="row" alignItems="center" py={1}>
+                  <Flex flex={1}>
+                    <Text variant="sm-display">Set price range you are interested in</Text>
+                  </Flex>
+                  <Flex alignSelf="center" mt={0.5}>
+                    <ArrowRightIcon />
+                  </Flex>
+                </Flex>
+              </Touchable>
+            </Flex>
           )}
 
-          {!!values.email && (
-            <Text
-              onPress={handleUpdateEmailPreferencesPress}
-              variant="xs"
-              color="black60"
-              style={{ textDecorationLine: "underline" }}
-              mt={1}
-            >
-              Update email preferences
-            </Text>
+          {!!enableDetailsInput && (
+            <Flex>
+              <Text>Tell us more about what you’re looking for</Text>
+              <Spacer y={1} />
+              <Input
+                placeholder="For example, a specific request such as ‘figurative painting’ or ‘David Hockney iPad drawings.’"
+                value={values.details}
+                onChangeText={handleChange("details")}
+                onBlur={handleBlur("details")}
+                error={errors.details}
+                multiline
+                maxLength={700}
+                testID="alert-input-details"
+              />
+            </Flex>
           )}
-        </Box>
-      </Join>
 
-      <Spacer y={2} />
+          <Box>
+            <SavedSearchAlertSwitch
+              label="Push Notifications"
+              onChange={onTogglePushNotification}
+              active={values.push}
+            />
 
-      <Box mt={6}>
+            <Spacer y={1} />
+
+            <SavedSearchAlertSwitch
+              label="Email"
+              onChange={onToggleEmailNotification}
+              active={values.email}
+            />
+
+            {!!shouldShowEmailWarning && (
+              <Box backgroundColor="orange10" my={1} p={2}>
+                <Text variant="xs" color="orange150">
+                  Change your email preferences
+                </Text>
+                <Text variant="xs" mt={0.5}>
+                  To receive alerts via email, please update your email preferences.
+                </Text>
+              </Box>
+            )}
+            <Spacer y={4} />
+            <Spacer y={4} />
+
+            {!!values.email && (
+              <Text
+                onPress={handleUpdateEmailPreferencesPress}
+                variant="xs"
+                color="black60"
+                style={{ textDecorationLine: "underline" }}
+                mt={1}
+              >
+                Update email preferences
+              </Text>
+            )}
+          </Box>
+        </Join>
+
+        <Spacer y={2} />
+      </ScrollView>
+
+      <Flex
+        p={2}
+        mb={`${bottom}px`}
+        pb={Platform.OS === "android" ? 2 : 0}
+        borderTopWidth={1}
+        borderTopColor="black10"
+      >
         <Button
           testID="save-alert-button"
           disabled={isSaveAlertButtonDisabled}
@@ -263,6 +285,7 @@ export const Form: React.FC<FormProps> = ({
         >
           {isEditMode ? "Save Alert" : "Create Alert"}
         </Button>
+
         {!!isEditMode && (
           <>
             <Spacer y={2} />
@@ -277,13 +300,14 @@ export const Form: React.FC<FormProps> = ({
             </Button>
           </>
         )}
+
         {!isEditMode && (
-          <Text variant="sm" color="black60" textAlign="center" my={2}>
+          <Text variant="sm" color="black60" textAlign="center" mt={2}>
             Access all your saved alerts in your profile.
           </Text>
         )}
-      </Box>
-    </Box>
+      </Flex>
+    </ArtsyKeyboardAvoidingView>
   )
 }
 

--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -300,7 +300,7 @@ export const Form: React.FC<FormProps> = ({
         )}
 
         {!isEditMode && (
-          <Text variant="sm" color="black60" textAlign="center" mt={2}>
+          <Text variant="xs" color="black60" textAlign="center" mt={2}>
             Access all your saved alerts in your profile.
           </Text>
         )}

--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -248,8 +248,6 @@ export const Form: React.FC<FormProps> = ({
                 </Text>
               </Box>
             )}
-            <Spacer y={4} />
-            <Spacer y={4} />
 
             {!!values.email && (
               <Text

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -1,5 +1,5 @@
 import { ActionType, DeletedSavedSearch, EditedSavedSearch, OwnerType } from "@artsy/cohesion"
-import { Dialog, quoteLeft, quoteRight, useTheme } from "@artsy/palette-mobile"
+import { Dialog, quoteLeft, quoteRight } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import {
   SearchCriteria,
@@ -11,7 +11,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { refreshSavedAlerts } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
 import { useEffect, useState } from "react"
-import { Alert, ScrollView, StyleProp, ViewStyle } from "react-native"
+import { Alert, StyleProp, ViewStyle } from "react-native"
 import { useTracking } from "react-tracking"
 import { useFirstMountState } from "react-use/lib/useFirstMountState"
 import { Form } from "./Components/Form"
@@ -70,7 +70,6 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   const selectedRriceRange = useSearchCriteriaAttributes(SearchCriteria.priceRange) as string
 
   const tracking = useTracking()
-  const { space } = useTheme()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
   const [shouldShowEmailSubscriptionWarning, setShouldShowEmailSubscriptionWarning] = useState(
     !userAllowsEmails
@@ -145,21 +144,25 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
     userAlertSettings: SavedSearchAlertFormValues,
     alertAttributes: SearchCriteriaAttributes
   ) => {
+    if (!savedSearchAlertId) return
+
     try {
       formik.setSubmitting(true)
 
       const response = await updateSavedSearchAlert(
-        savedSearchAlertId!,
+        savedSearchAlertId,
         userAlertSettings,
         alertAttributes
       )
+
       tracking.trackEvent(
-        tracks.editedSavedSearch(savedSearchAlertId!, initialValues, userAlertSettings)
+        tracks.editedSavedSearch(savedSearchAlertId, initialValues, userAlertSettings)
       )
 
       const result: SavedSearchAlertMutationResult = {
-        id: response.updateSavedSearch?.savedSearchOrErrors.internalID!,
+        id: response.updateSavedSearch?.savedSearchOrErrors.internalID,
       }
+
       onComplete?.(result)
     } catch (error) {
       console.error(error)
@@ -176,7 +179,7 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
       formik.setSubmitting(true)
       const response = await createSavedSearchAlert(userAlertSettings, alertAttributes)
       const result: SavedSearchAlertMutationResult = {
-        id: response.createSavedSearch?.savedSearchOrErrors.internalID!,
+        id: response.createSavedSearch?.savedSearchOrErrors.internalID,
       }
 
       navigation.navigate("ConfirmationScreen", { searchCriteriaID: result.id })
@@ -236,9 +239,11 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
   }
 
   const onDelete = async () => {
+    if (!savedSearchAlertId) return
+
     try {
-      await deleteSavedSearchMutation(savedSearchAlertId!)
-      tracking.trackEvent(tracks.deletedSavedSearch(savedSearchAlertId!))
+      await deleteSavedSearchMutation(savedSearchAlertId)
+      tracking.trackEvent(tracks.deletedSavedSearch(savedSearchAlertId))
       onDeleteComplete?.()
     } catch (error) {
       console.error(error)
@@ -260,44 +265,39 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   return (
     <FormikProvider value={formik}>
-      <ScrollView
-        keyboardDismissMode="on-drag"
-        keyboardShouldPersistTaps="handled"
-        contentContainerStyle={[{ padding: space(2) }, contentContainerStyle]}
-      >
-        <Form
-          pills={pills}
-          savedSearchAlertId={savedSearchAlertId}
-          hasChangedFilters={hasChangedFilters}
-          onDeletePress={handleDeletePress}
-          onSubmitPress={formik.handleSubmit}
-          onTogglePushNotification={handleTogglePushNotification}
-          onToggleEmailNotification={handleToggleEmailNotification}
-          onRemovePill={handleRemovePill}
-          shouldShowEmailWarning={shouldShowEmailWarning}
-          {...other}
+      <Form
+        contentContainerStyle={contentContainerStyle}
+        pills={pills}
+        savedSearchAlertId={savedSearchAlertId}
+        hasChangedFilters={hasChangedFilters}
+        onDeletePress={handleDeletePress}
+        onSubmitPress={formik.handleSubmit}
+        onTogglePushNotification={handleTogglePushNotification}
+        onToggleEmailNotification={handleToggleEmailNotification}
+        onRemovePill={handleRemovePill}
+        shouldShowEmailWarning={shouldShowEmailWarning}
+        {...other}
+      />
+      {!!savedSearchAlertId && (
+        <Dialog
+          isVisible={visibleDeleteDialog}
+          title="Delete Alert"
+          detail="You will no longer receive notifications for artworks matching the criteria in this alert."
+          primaryCta={{
+            text: "Delete",
+            onPress: () => {
+              onDelete()
+              setVisibleDeleteDialog(false)
+            },
+          }}
+          secondaryCta={{
+            text: "Keep Alert",
+            onPress: () => {
+              setVisibleDeleteDialog(false)
+            },
+          }}
         />
-        {!!savedSearchAlertId && (
-          <Dialog
-            isVisible={visibleDeleteDialog}
-            title="Delete Alert"
-            detail="You will no longer receive notifications for artworks matching the criteria in this alert."
-            primaryCta={{
-              text: "Delete",
-              onPress: () => {
-                onDelete()
-                setVisibleDeleteDialog(false)
-              },
-            }}
-            secondaryCta={{
-              text: "Keep Alert",
-              onPress: () => {
-                setVisibleDeleteDialog(false)
-              },
-            }}
-          />
-        )}
-      </ScrollView>
+      )}
     </FormikProvider>
   )
 }

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -13,7 +13,7 @@ export interface SavedSearchAlertFormValues {
 }
 
 export interface SavedSearchAlertMutationResult {
-  id: string
+  id?: string
 }
 
 // Navigation
@@ -69,6 +69,6 @@ export interface SavedSearchPill {
 }
 
 export interface ConfirmationScreenParams {
-  searchCriteriaID: string
+  searchCriteriaID?: string
   closeModal?: () => void
 }


### PR DESCRIPTION
This PR resolves [ONYX-502] <!-- eg [PROJECT-XXXX] -->

### Description

This PR makes the Alert form's "Save" (and "Delete) CTAs sticky and removes the bottom navigation for the "Create Alert" flow and the "Edit Alert" screen ([Slack Discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1699547193794289)).

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Plus - 2023-11-09 at 17 15 16](https://github.com/artsy/eigen/assets/4691889/b003208f-f64a-4819-9dc1-2bd58b12c070) | ![Simulator Screenshot - iPhone 15 Plus - 2023-11-09 at 17 10 13](https://github.com/artsy/eigen/assets/4691889/dc32dc6e-6f8d-4864-9d58-6524b403407e)|
| --- | --- |
|![Simulator Screenshot - iPhone 15 Plus - 2023-11-09 at 17 14 54](https://github.com/artsy/eigen/assets/4691889/72f974f0-e4f1-4c9a-bd8f-5b9b91e0f581) |![Simulator Screenshot - iPhone 15 Plus - 2023-11-09 at 17 10 51](https://github.com/artsy/eigen/assets/4691889/211926fa-5b18-442c-b764-9d4c2ec4043d) |





### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Make Alert form "Save" CTA sticky (Create and Edit form) - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-502]: https://artsyproduct.atlassian.net/browse/ONYX-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ