### PR TITLE
fix(DIA-310): empty state logic on Artist about tab

### DIFF
--- a/src/app/Components/Artist/ArtistAbout/ArtistAbout.tests.tsx
+++ b/src/app/Components/Artist/ArtistAbout/ArtistAbout.tests.tsx
@@ -24,6 +24,25 @@ describe("ArtistAbout", () => {
     variables: { artistID: "artist-id" },
   })
 
+  it("renders the empty state", () => {
+    renderWithRelay({
+      Artist: () => ({
+        hasArtistSeriesConnection: { totalCount: 0 },
+        counts: { articles: 0, relatedArtists: 0 },
+        insights: [],
+      }),
+      ArtistBlurb: () => ({
+        text: null,
+      }),
+      ShowConnection: () => ({ totalCount: 0 }),
+      GeneConnection: () => ({ edges: [] }),
+    })
+
+    expect(
+      screen.getByText(/We'll update this page when more information is available/)
+    ).toBeOnTheScreen()
+  })
+
   describe("Biography", () => {
     it("is shown when the artist has metadata", () => {
       renderWithRelay({
@@ -69,7 +88,9 @@ describe("ArtistAbout", () => {
 
     it("does not render when there are no articles", () => {
       renderWithRelay({
-        ArticleConnection: () => ({ edges: null }),
+        Artist: () => ({
+          counts: { articles: 0 },
+        }),
       })
 
       expect(screen.queryByText(/Artsy Editorial Featuring/)).not.toBeOnTheScreen()

--- a/src/app/Components/Artist/ArtistAbout/ArtistAbout.tsx
+++ b/src/app/Components/Artist/ArtistAbout/ArtistAbout.tsx
@@ -21,16 +21,21 @@ export const ArtistAbout: React.FC<Props> = ({ artist }) => {
   const relatedArtists = extractNodes(artist.related?.artistsConnection)
   const relatedGenes = extractNodes(artist.related?.genes)
 
-  const isDisplayable =
-    artist.hasMetadata || !!articles.length || !!relatedArtists.length || !!relatedGenes.length
-
   const hasInsights = artist.hasArtistInsights.length > 0
   const hasArtistSeries = artist.hasArtistSeriesConnection?.totalCount ?? 0 > 0
   const hasShows = artist.hasArtistShows?.totalCount ?? 0 > 0
   const hasBiography = !!artist.hasBiographyBlurb?.text
-  const hasArticles = articles.length > 0
-  const hasRelatedArtists = relatedArtists.length > 0
+  const hasArticles = artist.counts?.articles ?? 0 > 0
+  const hasRelatedArtists = artist.counts?.relatedArtists ?? 0 > 0
   const hasRelatedGenes = relatedGenes.length > 0
+
+  const isDisplayable =
+    hasArtistSeries ||
+    hasInsights ||
+    hasBiography ||
+    hasArticles ||
+    hasRelatedArtists ||
+    hasRelatedGenes
 
   return (
     <Tabs.ScrollView contentContainerStyle={{ paddingHorizontal: 0 }}>
@@ -79,7 +84,6 @@ export const ArtistAboutContainer = createFragmentContainer(ArtistAbout, {
       hasBiographyBlurb: biographyBlurb(format: PLAIN, partnerBio: false) {
         text
       }
-      hasMetadata
       internalID
       hasArtistInsights: insights {
         entities
@@ -94,6 +98,10 @@ export const ArtistAboutContainer = createFragmentContainer(ArtistAbout, {
       ...ArtistAboutShows_artist
       ...ArtistCareerHighlights_artist
       ...RelatedArtistsRailCell_artist
+      counts {
+        articles
+        relatedArtists
+      }
       related {
         artistsConnection(first: 12) {
           edges {


### PR DESCRIPTION
This PR resolves [DIA-310] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the logic of when or not to display the empty state. It's very similar to Force's implementation.

Before

<img width="320" src="https://github.com/artsy/eigen/assets/15792853/3d1906ca-71f5-481e-b722-4a3487884ac5" />

After

<img width="320" src="https://github.com/artsy/eigen/assets/15792853/234c9821-5151-4fcf-ad26-f22073c097d3" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: show correctly the empty state on Artists' about tab - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-310]: https://artsyproduct.atlassian.net/browse/DIA-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ