### PR TITLE
fix: broken padding in create alert screen

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -148,55 +148,49 @@ export const Form: React.FC<FormProps> = ({
           />
         )}
 
-        <Join separator={<Spacer y={2} />}>
-          <Box>
-            <SavedSearchNameInputQueryRenderer attributes={attributes} />
+        <Join separator={<Spacer y={4} />}>
+          <SavedSearchNameInputQueryRenderer attributes={attributes} />
 
-            <Box mt={2}>
-              <Text variant="sm-display">Filters</Text>
-              <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
-                {pills.map((pill, index) => (
-                  <Pill
-                    testID="alert-pill"
-                    m={0.5}
-                    variant="filter"
-                    disabled={isArtistPill(pill)}
-                    key={`filter-label-${index}`}
-                    onPress={() => onRemovePill(pill)}
-                  >
-                    {pill.label}
-                  </Pill>
-                ))}
-              </Flex>
-            </Box>
+          <Box>
+            <Text variant="sm-display">Filters</Text>
+            <Flex flexDirection="row" flexWrap="wrap" mt={1} mx={-0.5}>
+              {pills.map((pill, index) => (
+                <Pill
+                  testID="alert-pill"
+                  m={0.5}
+                  variant="filter"
+                  disabled={isArtistPill(pill)}
+                  key={`filter-label-${index}`}
+                  onPress={() => onRemovePill(pill)}
+                >
+                  {pill.label}
+                </Pill>
+              ))}
+            </Flex>
           </Box>
 
           {!!enableAlertsFilters && !enableAlertsSuggestedFilters ? (
-            <Flex mt={2}>
-              <MenuItem
-                title="Add Filters"
-                description={
-                  enableAlertsFiltersSizeFiltering
-                    ? "Including Price Range, Rarity, Medium, Size, Color"
-                    : "Including Price Range, Rarity, Medium, Color"
-                }
-                onPress={() => {
-                  navigation.navigate("SavedSearchFilterScreen")
-                }}
-                px={0}
-              />
-            </Flex>
+            <MenuItem
+              title="Add Filters"
+              description={
+                enableAlertsFiltersSizeFiltering
+                  ? "Including Price Range, Rarity, Medium, Size, Color"
+                  : "Including Price Range, Rarity, Medium, Color"
+              }
+              onPress={() => {
+                navigation.navigate("SavedSearchFilterScreen")
+              }}
+              px={0}
+            />
           ) : null}
 
           {enableAlertsFilters && enableAlertsSuggestedFilters ? (
-            <Flex mt={2}>
-              <SavedSearchSuggestedFiltersQueryRenderer />
-            </Flex>
+            <SavedSearchSuggestedFiltersQueryRenderer />
           ) : null}
 
           {/* Price range is part of the new filters screen, no need to show it here anymore */}
           {!enableAlertsFilters && (
-            <Flex my={1}>
+            <Flex>
               <Touchable
                 accessibilityLabel="Set price range"
                 accessibilityRole="button"

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchSuggestedFilters.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchSuggestedFilters.tsx
@@ -83,6 +83,7 @@ export const SavedSearchSuggestedFilters: React.FC<{}> = () => {
           navigation.navigate("SavedSearchFilterScreen")
         }}
         px={0}
+        py={0}
       />
     )
   }


### PR DESCRIPTION
### Description

This PR fixes padding issues on the create alert flow <!-- eg [PROJECT-XXXX] -->


![Screenshot 2023-11-23 at 14 34 16](https://github.com/artsy/eigen/assets/11945712/199460b5-2383-492d-a982-11bade026292)
_The red background is only for the screenshot_

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochagelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
