### PR TITLE
chore: setting suggested filters as not ready for release

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tests.tsx
@@ -7,6 +7,7 @@ import {
   getArtworkFiltersModel,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { SavedSearchEntity } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -73,6 +74,9 @@ describe("CreateSavedSearchAlert", () => {
   beforeEach(() => {
     mockEnvironment = getMockRelayEnvironment()
     notificationPermissions.mockClear()
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableAlertsSuggestedFilters: true,
+    })
   })
 
   const TestRenderer = (params: Partial<CreateSavedSearchAlertParams>) => {

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
@@ -19,6 +20,9 @@ describe("EditSavedSearchAlert", () => {
     notificationPermissions.mockImplementationOnce((cb) =>
       cb(null, PushAuthorizationStatus.Authorized)
     )
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableAlertsSuggestedFilters: true,
+    })
   })
 
   const TestRenderer = () => {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -27,6 +27,7 @@ describe("SavedSearchAlertForm", () => {
   beforeEach(() => {
     __globalStoreTestUtils__?.injectFeatureFlags({
       AREnableAlertDetailsInput: true,
+      AREnableAlertsSuggestedFilters: true,
     })
 
     mockEnvironment = getMockRelayEnvironment()

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -248,7 +248,7 @@ export const features: { [key: string]: FeatureDescriptor } = {
   },
   AREnableAlertsSuggestedFilters: {
     description: "Enable alerts suggested filters",
-    readyForRelease: true,
+    readyForRelease: false,
     showInDevMenu: true,
     echoFlagKey: "AREnableAlertsSuggestedFilters",
   },


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR sets the suggested filters as not ready for release until we get an answer from the design team about how to proceed.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
