### PR TITLE
chore: retire AREnableArtworkGridSaveIcon ff

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -27,7 +27,6 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { PageableRouteProps } from "app/system/navigation/useNavigateToPageableRoute"
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { RandomNumberGenerator } from "app/utils/placeholders"
 import {
@@ -102,7 +101,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const itemRef = useRef<any>()
   const color = useColor()
   const tracking = useTracking()
-  const eableArtworkGridSaveIcon = useFeatureFlag("AREnableArtworkGridSaveIcon")
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
 
   let filterParams: any = undefined
@@ -177,16 +175,20 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
     addArtworkToRecentSearches()
     trackArtworkTap()
-    navigateToPageableRoute?.(artwork.href!)
+    if (artwork.href) {
+      navigateToPageableRoute?.(artwork.href)
+    }
   }
 
   const trackArtworkTap = () => {
     // Unless you explicitly pass in a tracking function or provide a contextScreenOwnerType, we won't track
     // taps from the grid.
-    if (trackTap || contextScreenOwnerType) {
+    if (trackTap) {
+      trackTap(artwork.slug, itemIndex)
+    } else if (contextScreenOwnerType) {
       const genericTapEvent = tappedMainArtworkGrid({
         contextScreen,
-        contextScreenOwnerType: contextScreenOwnerType!,
+        contextScreenOwnerType: contextScreenOwnerType,
         contextScreenOwnerId,
         contextScreenOwnerSlug,
         destinationScreenOwnerId: artwork.internalID,
@@ -196,8 +198,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
         sort: String(filterParams?.sort),
         query: contextScreenQuery,
       })
-
-      trackTap ? trackTap(artwork.slug, itemIndex) : tracking.trackEvent(genericTapEvent)
+      tracking.trackEvent(genericTapEvent)
     }
   }
 
@@ -341,7 +342,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
                   </Text>
                 )}
               </Flex>
-              {!!eableArtworkGridSaveIcon && !hideSaveIcon && (
+              {!hideSaveIcon && (
                 <Flex>
                   <Touchable
                     haptic

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -59,11 +59,6 @@ export const features: { [key: string]: FeatureDescriptor } = {
     description: "Use artworksConnection for Auction screen",
     echoFlagKey: "AREnableArtworksConnectionForAuction",
   },
-  AREnableArtworkGridSaveIcon: {
-    description: "Enable artwork grid save icon",
-    readyForRelease: true,
-    echoFlagKey: "AREnableArtworkGridSaveIcon",
-  },
   AREnableAndroidImagesGallery: {
     description: "Enable images gallery on Android",
     readyForRelease: true,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- retire AREnableArtworkGridSaveIcon ff - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
