### PR TITLE
feat(ONYX-379): add saved searches size filter

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -114,7 +114,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     }
   }, [scrollToArtworksGrid])
 
-  const { savedSearchEntity, attributes } = useCreateSavedSearchModalFilters({
+  const { savedSearchEntity, attributes, sizeMetric } = useCreateSavedSearchModalFilters({
     entityId: artist.internalID,
     entityName: artist.name ?? "",
     entitySlug: artist.slug,
@@ -209,6 +209,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
             entity={savedSearchEntity}
             onComplete={handleCompleteSavedSearch}
             visible={isCreateAlertModalVisible}
+            sizeMetric={sizeMetric}
           />
         )}
       </Tabs.ScrollView>

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -19,26 +19,28 @@ import { useEffect } from "react"
 import { useTracking } from "react-tracking"
 
 export interface CreateSavedSearchModalProps {
-  visible: boolean
-  entity: SavedSearchEntity
-  attributes: SearchCriteriaAttributes
   aggregations: Aggregations
+  attributes: SearchCriteriaAttributes
   closeModal: () => void
-  onComplete?: () => void
   contextModule?: ContextModule
   currentArtworkID?: string
+  entity: SavedSearchEntity
+  onComplete?: () => void
+  sizeMetric?: "cm" | "in" | undefined
+  visible: boolean
 }
 
 export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (props) => {
   const {
-    visible,
-    entity,
-    attributes,
     aggregations,
+    attributes,
     closeModal,
-    onComplete,
     contextModule,
     currentArtworkID,
+    entity,
+    onComplete,
+    sizeMetric,
+    visible,
   } = props
   const tracking = useTracking()
 
@@ -75,6 +77,7 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
       closeModal() // close the alert modal stack
     },
     onComplete: handleComplete,
+    sizeMetric,
   }
 
   if (!visible) return null

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useCreateSavedSearchModalFilters.ts
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useCreateSavedSearchModalFilters.ts
@@ -17,11 +17,11 @@ export const useCreateSavedSearchModalFilters = ({
   entityOwnerType: ScreenOwnerType
 }) => {
   const savedSearchEntity: SavedSearchEntity = {
-    artists: [{ id: entityId!, name: entityName! }],
+    artists: [{ id: entityId, name: entityName }],
     owner: {
       type: entityOwnerType,
-      id: entityId!,
-      slug: entitySlug!,
+      id: entityId,
+      slug: entitySlug,
     },
   }
 
@@ -32,5 +32,6 @@ export const useCreateSavedSearchModalFilters = ({
   return {
     attributes,
     savedSearchEntity,
+    sizeMetric: filterState.sizeMetric,
   }
 }

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -404,6 +404,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             onComplete={exitModal}
             attributes={attributes}
             aggregations={filterState.aggregations}
+            sizeMetric={filterState.sizeMetric}
           />
         </Flex>
       </FancyModal>

--- a/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/CustomSizeInputs.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Flex, Box, useColor, Text, Join } from "@artsy/palette-mobile"
+import { Box, Flex, Join, Spacer, Text, useColor } from "@artsy/palette-mobile"
 import { Input } from "app/Components/Input"
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import React, { useState } from "react"

--- a/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SizesOptionsScreen.tsx
@@ -10,7 +10,7 @@ import {
   useSelectedOptionsDisplay,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
-import React, { useEffect, useState } from "react"
+import { useEffect, useState, Fragment } from "react"
 import { CustomSizeInputs } from "./CustomSizeInputs"
 import { MultiSelectOptionScreen } from "./MultiSelectOption"
 import { localizeDimension, parseRange, Range, toIn } from "./helpers"
@@ -109,7 +109,7 @@ export const checkIsEmptyCustomValues = (values: CustomSize) => {
   })
 }
 
-const metrics: Metric[] = ["cm", "in"]
+export const UNIT_METRICS: Metric[] = ["cm", "in"]
 
 const CustomSizeInputsContainer: React.FC<CustomSizeInputsContainerProps> = ({
   values,
@@ -125,10 +125,10 @@ const CustomSizeInputsContainer: React.FC<CustomSizeInputsContainerProps> = ({
   return (
     <Box mx="15px" my={2}>
       <Flex flexDirection="row">
-        {metrics.map((currentMetric) => {
+        {UNIT_METRICS.map((currentMetric) => {
           const isSelected = metric === currentMetric
           return (
-            <React.Fragment key={currentMetric}>
+            <Fragment key={currentMetric}>
               <RadioButton
                 accessibilityState={{ checked: isSelected }}
                 accessibilityLabel={currentMetric}
@@ -136,7 +136,7 @@ const CustomSizeInputsContainer: React.FC<CustomSizeInputsContainerProps> = ({
                 onPress={() => handleMetricChange(currentMetric)}
               />
               <Text marginRight="4">{currentMetric}</Text>
-            </React.Fragment>
+            </Fragment>
           )
         })}
       </Flex>

--- a/src/app/Components/ArtworkFilter/Filters/helpers.ts
+++ b/src/app/Components/ArtworkFilter/Filters/helpers.ts
@@ -27,15 +27,20 @@ export const localizeDimension = (value: Numeric, unit: Metric) => {
   return round(value)
 }
 
-export const cmToIn = (centimeters: Numeric) => {
+export const cmToIn = (centimeters: Numeric, shouldRound = true, roundDigits = 2) => {
   if (centimeters === "*") {
     return centimeters
+  }
+
+  if (shouldRound) {
+    // Round off floating point precision errors.
+    return round(centimeters / ONE_IN_TO_CM, roundDigits)
   }
 
   return centimeters / ONE_IN_TO_CM
 }
 
-export const inToCm = (inches: Numeric, shouldRound = true) => {
+export const inToCm = (inches: Numeric, shouldRound = true, roundDigits = 2) => {
   if (inches === "*") {
     return inches
   }
@@ -44,7 +49,7 @@ export const inToCm = (inches: Numeric, shouldRound = true) => {
 
   if (shouldRound) {
     // Round off floating point precision errors.
-    return round(centimeters)
+    return round(centimeters, roundDigits)
   }
 
   return centimeters
@@ -63,12 +68,12 @@ export const toIn = (value: Numeric, unit: Metric): Numeric => {
  * e.g. `round(0.9999999999999999)` => `1`;
  * `round(1.19499)` => `1.19`
  */
-export const round = (value: Numeric) => {
+export const round = (value: Numeric, roundDigits = 2) => {
   if (value === "*") {
     return value
   }
 
-  return __round__(value, 2)
+  return __round__(value, roundDigits)
 }
 
 const enforceNumeric = (value: Numeric | undefined | null): Numeric => {

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkScreenHeaderTestQuery } from "__generated__/ArtworkScreenHeaderTestQuery.graphql"
-import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { goBack } from "app/system/navigation/navigate"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
@@ -13,11 +12,9 @@ describe("ArtworkScreenHeader", () => {
     Component: (props) => {
       if (props?.artwork) {
         return (
-          <ArtworkFiltersStoreProvider>
-            <ArtworkStoreProvider>
-              <ArtworkScreenHeader artwork={props.artwork} />
-            </ArtworkStoreProvider>
-          </ArtworkFiltersStoreProvider>
+          <ArtworkStoreProvider>
+            <ArtworkScreenHeader artwork={props.artwork} />
+          </ArtworkStoreProvider>
         )
       }
       return null

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeader.tests.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkScreenHeaderTestQuery } from "__generated__/ArtworkScreenHeaderTestQuery.graphql"
+import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { goBack } from "app/system/navigation/navigate"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
@@ -12,9 +13,11 @@ describe("ArtworkScreenHeader", () => {
     Component: (props) => {
       if (props?.artwork) {
         return (
-          <ArtworkStoreProvider>
-            <ArtworkScreenHeader artwork={props.artwork} />
-          </ArtworkStoreProvider>
+          <ArtworkFiltersStoreProvider>
+            <ArtworkStoreProvider>
+              <ArtworkScreenHeader artwork={props.artwork} />
+            </ArtworkStoreProvider>
+          </ArtworkFiltersStoreProvider>
         )
       }
       return null
@@ -35,15 +38,15 @@ describe("ArtworkScreenHeader", () => {
       }),
     })
 
-    expect(screen.queryByLabelText("Artwork page header")).toBeTruthy()
-    expect(screen.queryByLabelText("Go back")).toBeTruthy()
-    expect(screen.queryByText("Create Alert")).toBeTruthy()
+    expect(screen.getByLabelText("Artwork page header")).toBeTruthy()
+    expect(screen.getByLabelText("Go back")).toBeTruthy()
+    expect(screen.getByText("Create Alert")).toBeTruthy()
   })
 
   it("calls go back when the back button is pressed", () => {
     renderWithRelay({})
 
-    expect(screen.queryByLabelText("Go back")).toBeTruthy()
+    expect(screen.getByLabelText("Go back")).toBeTruthy()
 
     fireEvent.press(screen.getByLabelText("Go back"))
 
@@ -58,12 +61,12 @@ describe("ArtworkScreenHeader", () => {
         }),
       })
 
-      expect(screen.queryByLabelText("Go back")).toBeTruthy()
+      expect(screen.getByLabelText("Go back")).toBeTruthy()
       expect(screen.queryByText("Create Alert")).toBeFalsy()
     })
 
     it("should correctly track event when `Create Alert` button is pressed", () => {
-      const { getByText } = renderWithRelay({
+      renderWithRelay({
         Artwork: () => ({
           internalID: "internalID-1",
           slug: "slug-1",
@@ -71,7 +74,7 @@ describe("ArtworkScreenHeader", () => {
         }),
       })
 
-      fireEvent.press(getByText("Create Alert"))
+      fireEvent.press(screen.getByText("Create Alert"))
 
       expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
         [

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions.tsx
@@ -4,7 +4,7 @@ import { useArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/Form
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "app/store/GlobalStore"
 import { throttle } from "lodash"
-import React, { useState } from "react"
+import { useState } from "react"
 
 export const Dimensions: React.FC = () => {
   const { formik } = useArtworkForm()

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAppliedFilters.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAppliedFilters.tsx
@@ -8,8 +8,9 @@ export const SavedSearchFilterAppliedFilters: React.FC<{}> = ({}) => {
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (state) => state.removeValueFromAttributesByKeyAction
   )
+  const unit = SavedSearchStore.useStoreState((state) => state.unit)
 
-  const pills = useSavedSearchPills()
+  const pills = useSavedSearchPills({ unit })
 
   return (
     <Flex px={2}>

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
@@ -1,18 +1,19 @@
 import { Flex, RadioButton, Spacer, Text, Touchable } from "@artsy/palette-mobile"
+import { CustomSizeInputs } from "app/Components/ArtworkFilter/Filters/CustomSizeInputs"
 import {
   UNIT_METRICS,
   getSizeOptions,
 } from "app/Components/ArtworkFilter/Filters/SizesOptionsScreen"
+import { Range, parseRange, round } from "app/Components/ArtworkFilter/Filters/helpers"
 import { SearchCriteria } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { SavedSearchFilterPill } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPill"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSearchCriteriaAttributes } from "app/Scenes/SavedSearchAlert/helpers"
-import { GlobalStore } from "app/store/GlobalStore"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { getCountry } from "react-native-localize"
 
 // Helper to get the initial metric based on the user's country
-const getPreferredMetric = () => {
+export const getPreferredUnit = () => {
   const countryCode = getCountry()
   switch (countryCode) {
     case "US":
@@ -28,41 +29,73 @@ const getPreferredMetric = () => {
 export const SavedSearchFilterSize = () => {
   const selectedAttributes = useSearchCriteriaAttributes(SearchCriteria.sizes) as string[]
 
+  const customHeight = useSearchCriteriaAttributes(SearchCriteria.height)
+
+  const customWidth = useSearchCriteriaAttributes(SearchCriteria.width)
+
+  const [hasSelectedCustomInputValues, setHasSelectedCustomInput] = useState(
+    (customHeight || customWidth) !== undefined
+  )
+
   const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.addValueToAttributesByKeyAction
   )
   const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
     (actions) => actions.removeValueFromAttributesByKeyAction
   )
+  const setAttributeAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.setAttributeAction
+  )
 
-  const storeMetric = GlobalStore.useAppState((state) => state.userPrefs.metric)
-  const [selectedMetric, setSelectedMetric] = useState(storeMetric || getPreferredMetric())
+  const setUnitAction = SavedSearchStore.useStoreActions((actions) => actions.setUnitAction)
+  const unit = SavedSearchStore.useStoreState((state) => state.unit)
 
-  const setMetric = GlobalStore.actions.userPrefs.setMetric
+  const options = getSizeOptions(unit)
 
-  const options = getSizeOptions(selectedMetric)
+  const handlePressDefinedSizePill = (value: string) => {
+    const isSizeSelected = !!selectedAttributes?.includes(value)
 
-  useEffect(() => {
-    if (storeMetric !== selectedMetric) {
-      setMetric(selectedMetric)
+    // If the user presesses on unselected option
+    if (!isSizeSelected) {
+      // if we have custom input values, we need to remove them
+      if (hasSelectedCustomInputValues) {
+        setHasSelectedCustomInput(false)
+
+        queueMicrotask(() => {
+          removeValueFromAttributesByKeyAction({
+            key: SearchCriteria.height,
+            value: "*-*",
+          })
+          removeValueFromAttributesByKeyAction({
+            key: SearchCriteria.width,
+            value: "*-*",
+          })
+        })
+      }
+
+      const newValues = (selectedAttributes || []).concat(value)
+      queueMicrotask(() => {
+        addValueToAttributesByKeyAction({
+          key: SearchCriteria.sizes,
+          value: newValues,
+        })
+      })
     }
-  }, [selectedMetric])
-
-  const handlePress = (value: string) => {
-    const isSelected = !!selectedAttributes?.includes(value)
-
-    if (isSelected) {
+    // If  the user presesses on an already selected option
+    else {
+      // Remove the defined size from the selected attributes
       removeValueFromAttributesByKeyAction({
         key: SearchCriteria.sizes,
         value: value,
       })
-    } else {
-      const newValues = (selectedAttributes || []).concat(value)
-      addValueToAttributesByKeyAction({
-        key: SearchCriteria.sizes,
-        value: newValues,
-      })
     }
+  }
+
+  const handleCustomInputChange = (paramName: SearchCriteria) => (range: Range) => {
+    setAttributeAction({
+      key: paramName,
+      value: `${range.min}-${range.max}`,
+    })
   }
 
   return (
@@ -75,11 +108,11 @@ export const SavedSearchFilterSize = () => {
 
       <Flex flexDirection="row">
         {UNIT_METRICS.map((currentMetric) => {
-          const isSelected = selectedMetric === currentMetric
+          const isSelected = unit === currentMetric
           return (
             <Touchable
               onPress={() => {
-                setSelectedMetric(currentMetric)
+                setUnitAction(currentMetric)
               }}
               key={currentMetric}
             >
@@ -88,7 +121,7 @@ export const SavedSearchFilterSize = () => {
                   accessibilityState={{ checked: isSelected }}
                   accessibilityLabel={currentMetric}
                   selected={isSelected}
-                  onPress={() => setSelectedMetric(currentMetric)}
+                  onPress={() => setUnitAction(currentMetric)}
                 />
                 <Text marginRight="4">{currentMetric}</Text>
               </Flex>
@@ -105,14 +138,72 @@ export const SavedSearchFilterSize = () => {
               accessibilityLabel={option.displayText}
               selected={!!selectedAttributes?.includes(option.paramValue as string)}
               onPress={() => {
-                handlePress(option.paramValue as string)
+                handlePressDefinedSizePill(option.paramValue as string)
               }}
             >
               {option.displayText}
             </SavedSearchFilterPill>
           )
         })}
+        <SavedSearchFilterPill
+          key="custom-size"
+          accessibilityLabel="Custom Size"
+          selected={hasSelectedCustomInputValues}
+          onPress={() => {
+            if (!hasSelectedCustomInputValues) {
+              // Unselect all other options
+              options.forEach((option) => {
+                queueMicrotask(() => {
+                  removeValueFromAttributesByKeyAction({
+                    key: SearchCriteria.sizes,
+                    value: option.paramValue as string,
+                  })
+                })
+              })
+            } else {
+              queueMicrotask(() => {
+                removeValueFromAttributesByKeyAction({
+                  key: SearchCriteria.height,
+                  value: "*-*",
+                })
+                removeValueFromAttributesByKeyAction({
+                  key: SearchCriteria.width,
+                  value: "*-*",
+                })
+              })
+            }
+            setHasSelectedCustomInput(!hasSelectedCustomInputValues)
+          }}
+        >
+          Custom Size
+        </SavedSearchFilterPill>
       </Flex>
+
+      {!!hasSelectedCustomInputValues && (
+        <Flex mt={1}>
+          <CustomSizeInputs
+            label="Width"
+            range={{
+              min: round(parseRange(String(customWidth)).min),
+              max: round(parseRange(String(customWidth)).max),
+            }}
+            active
+            onChange={handleCustomInputChange(SearchCriteria.width)}
+            selectedMetric={unit}
+          />
+          <Spacer y={2} />
+          <CustomSizeInputs
+            label="Height"
+            range={{
+              min: round(parseRange(String(customHeight)).min),
+              max: round(parseRange(String(customHeight)).max),
+            }}
+            active
+            onChange={handleCustomInputChange(SearchCriteria.height)}
+            selectedMetric={unit}
+          />
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
@@ -4,6 +4,7 @@ import {
   getSizeOptions,
 } from "app/Components/ArtworkFilter/Filters/SizesOptionsScreen"
 import { SearchCriteria } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { SavedSearchFilterPill } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPill"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSearchCriteriaAttributes } from "app/Scenes/SavedSearchAlert/helpers"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -27,18 +28,42 @@ const getPreferredMetric = () => {
 export const SavedSearchFilterSize = () => {
   const selectedAttributes = useSearchCriteriaAttributes(SearchCriteria.sizes) as string[]
 
+  const addValueToAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.addValueToAttributesByKeyAction
+  )
+  const removeValueFromAttributesByKeyAction = SavedSearchStore.useStoreActions(
+    (actions) => actions.removeValueFromAttributesByKeyAction
+  )
+
   const storeMetric = GlobalStore.useAppState((state) => state.userPrefs.metric)
   const [selectedMetric, setSelectedMetric] = useState(storeMetric || getPreferredMetric())
 
   const setMetric = GlobalStore.actions.userPrefs.setMetric
 
-  const sizeOptions = getSizeOptions(selectedMetric)
+  const options = getSizeOptions(selectedMetric)
 
   useEffect(() => {
     if (storeMetric !== selectedMetric) {
-      setSelectedMetric(selectedMetric)
+      setMetric(selectedMetric)
     }
   }, [selectedMetric])
+
+  const handlePress = (value: string) => {
+    const isSelected = !!selectedAttributes?.includes(value)
+
+    if (isSelected) {
+      removeValueFromAttributesByKeyAction({
+        key: SearchCriteria.sizes,
+        value: value,
+      })
+    } else {
+      const newValues = (selectedAttributes || []).concat(value)
+      addValueToAttributesByKeyAction({
+        key: SearchCriteria.sizes,
+        value: newValues,
+      })
+    }
+  }
 
   return (
     <Flex px={2}>
@@ -68,6 +93,23 @@ export const SavedSearchFilterSize = () => {
                 <Text marginRight="4">{currentMetric}</Text>
               </Flex>
             </Touchable>
+          )
+        })}
+      </Flex>
+
+      <Flex flexDirection="row" flexWrap="wrap">
+        {options.map((option) => {
+          return (
+            <SavedSearchFilterPill
+              key={option.paramValue as string}
+              accessibilityLabel={option.displayText}
+              selected={!!selectedAttributes?.includes(option.paramValue as string)}
+              onPress={() => {
+                handlePress(option.paramValue as string)
+              }}
+            >
+              {option.displayText}
+            </SavedSearchFilterPill>
           )
         })}
       </Flex>

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
@@ -10,21 +10,6 @@ import { SavedSearchFilterPill } from "app/Scenes/SavedSearchAlert/Components/Sa
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSearchCriteriaAttributes } from "app/Scenes/SavedSearchAlert/helpers"
 import { useState } from "react"
-import { getCountry } from "react-native-localize"
-
-// Helper to get the initial metric based on the user's country
-export const getPreferredUnit = () => {
-  const countryCode = getCountry()
-  switch (countryCode) {
-    case "US":
-    case "LR":
-    case "MM":
-    case "GB":
-      return "in"
-    default:
-      return "cm"
-  }
-}
 
 export const SavedSearchFilterSize = () => {
   const selectedAttributes = useSearchCriteriaAttributes(SearchCriteria.sizes) as string[]

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize.tsx
@@ -1,0 +1,76 @@
+import { Flex, RadioButton, Spacer, Text, Touchable } from "@artsy/palette-mobile"
+import {
+  UNIT_METRICS,
+  getSizeOptions,
+} from "app/Components/ArtworkFilter/Filters/SizesOptionsScreen"
+import { SearchCriteria } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
+import { useSearchCriteriaAttributes } from "app/Scenes/SavedSearchAlert/helpers"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useEffect, useState } from "react"
+import { getCountry } from "react-native-localize"
+
+// Helper to get the initial metric based on the user's country
+const getPreferredMetric = () => {
+  const countryCode = getCountry()
+  switch (countryCode) {
+    case "US":
+    case "LR":
+    case "MM":
+    case "GB":
+      return "in"
+    default:
+      return "cm"
+  }
+}
+
+export const SavedSearchFilterSize = () => {
+  const selectedAttributes = useSearchCriteriaAttributes(SearchCriteria.sizes) as string[]
+
+  const storeMetric = GlobalStore.useAppState((state) => state.userPrefs.metric)
+  const [selectedMetric, setSelectedMetric] = useState(storeMetric || getPreferredMetric())
+
+  const setMetric = GlobalStore.actions.userPrefs.setMetric
+
+  const sizeOptions = getSizeOptions(selectedMetric)
+
+  useEffect(() => {
+    if (storeMetric !== selectedMetric) {
+      setSelectedMetric(selectedMetric)
+    }
+  }, [selectedMetric])
+
+  return (
+    <Flex px={2}>
+      <Text variant="sm" fontWeight={500}>
+        Size
+      </Text>
+
+      <Spacer y={1} />
+
+      <Flex flexDirection="row">
+        {UNIT_METRICS.map((currentMetric) => {
+          const isSelected = selectedMetric === currentMetric
+          return (
+            <Touchable
+              onPress={() => {
+                setSelectedMetric(currentMetric)
+              }}
+              key={currentMetric}
+            >
+              <Flex flexDirection="row">
+                <RadioButton
+                  accessibilityState={{ checked: isSelected }}
+                  accessibilityLabel={currentMetric}
+                  selected={isSelected}
+                  onPress={() => setSelectedMetric(currentMetric)}
+                />
+                <Text marginRight="4">{currentMetric}</Text>
+              </Flex>
+            </Touchable>
+          )
+        })}
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchNameInput.tsx
@@ -64,7 +64,7 @@ export const SavedSearchNameInputQueryRenderer: React.FC<
         }
       `}
       variables={{
-        attributes: omit(attributes, ["displayName", "dimensionRange"]),
+        attributes: omit(attributes, ["displayName", "dimensionRange", "height", "width"]),
       }}
       render={({ props, error }) => {
         if (error) {

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,16 +1,18 @@
 import { ArtsyKeyboardAvoidingView, Box } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
-import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import {
   savedSearchModel,
   SavedSearchStoreProvider,
 } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { CreateSavedSearchAlertContentQueryRenderer } from "app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer"
+import { localizeHeightAndWidthAttributes } from "app/Scenes/SavedSearchAlert/helpers"
 import { AlertPriceRangeScreenQueryRenderer } from "app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen"
 import { ConfirmationScreen } from "app/Scenes/SavedSearchAlert/screens/ConfirmationScreen"
 import { SavedSearchFilterScreen } from "app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen"
+import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import {
   CreateSavedSearchAlertNavigationStack,
   CreateSavedSearchAlertProps,
@@ -22,16 +24,23 @@ const Stack = createStackNavigator<CreateSavedSearchAlertNavigationStack>()
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
   const { visible, params } = props
   const { attributes, aggregations, entity, currentArtworkID } = params
+  const selectedMetric = ArtworksFiltersStore.useStoreState((state) => state.sizeMetric)
+  const { localizedUnit } = useLocalizedUnit()
 
   return (
     <ArtsyKeyboardAvoidingView>
       <SavedSearchStoreProvider
         runtimeModel={{
           ...savedSearchModel,
-          attributes: attributes as SearchCriteriaAttributes,
+          attributes: localizeHeightAndWidthAttributes({
+            attributes: attributes,
+            from: "in",
+            to: selectedMetric || localizedUnit,
+          }),
           aggregations,
-          entity,
           currentArtworkID,
+          entity,
+          unit: selectedMetric || localizedUnit,
         }}
       >
         <NavigationContainer independent>
@@ -46,6 +55,20 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                   cardStyle: { backgroundColor: "white" },
                 }}
               >
+                <Stack.Screen
+                  name="CreateSavedSearchAlert"
+                  component={CreateSavedSearchAlertContentQueryRenderer}
+                  initialParams={params}
+                />
+                <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
+                <Stack.Screen
+                  name="AlertPriceRange"
+                  component={AlertPriceRangeScreenQueryRenderer}
+                  options={{
+                    // Avoid PanResponser conflicts between the slider and the slide back gesture
+                    gestureEnabled: false,
+                  }}
+                />
                 <Stack.Screen
                   name="CreateSavedSearchAlert"
                   component={CreateSavedSearchAlertContentQueryRenderer}

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -68,34 +68,6 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                   }}
                 />
                 <Stack.Screen
-                  name="CreateSavedSearchAlert"
-                  component={CreateSavedSearchAlertContentQueryRenderer}
-                  initialParams={params}
-                />
-                <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
-                <Stack.Screen
-                  name="AlertPriceRange"
-                  component={AlertPriceRangeScreenQueryRenderer}
-                  options={{
-                    // Avoid PanResponser conflicts between the slider and the slide back gesture
-                    gestureEnabled: false,
-                  }}
-                />
-                <Stack.Screen
-                  name="CreateSavedSearchAlert"
-                  component={CreateSavedSearchAlertContentQueryRenderer}
-                  initialParams={params}
-                />
-                <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
-                <Stack.Screen
-                  name="AlertPriceRange"
-                  component={AlertPriceRangeScreenQueryRenderer}
-                  options={{
-                    // Avoid PanResponser conflicts between the slider and the slide back gesture
-                    gestureEnabled: false,
-                  }}
-                />
-                <Stack.Screen
                   name="ConfirmationScreen"
                   component={ConfirmationScreen}
                   options={{

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,7 +1,6 @@
 import { ArtsyKeyboardAvoidingView, Box } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
-import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import {
   savedSearchModel,
@@ -23,8 +22,7 @@ const Stack = createStackNavigator<CreateSavedSearchAlertNavigationStack>()
 
 export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (props) => {
   const { visible, params } = props
-  const { attributes, aggregations, entity, currentArtworkID } = params
-  const selectedMetric = ArtworksFiltersStore.useStoreState((state) => state.sizeMetric)
+  const { attributes, aggregations, entity, currentArtworkID, sizeMetric } = params
   const { localizedUnit } = useLocalizedUnit()
 
   return (
@@ -35,12 +33,12 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
           attributes: localizeHeightAndWidthAttributes({
             attributes: attributes,
             from: "in",
-            to: selectedMetric || localizedUnit,
+            to: sizeMetric || localizedUnit,
           }),
           aggregations,
           currentArtworkID,
           entity,
-          unit: selectedMetric || localizedUnit,
+          unit: sizeMetric || localizedUnit,
         }}
       >
         <NavigationContainer independent>
@@ -55,6 +53,20 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                   cardStyle: { backgroundColor: "white" },
                 }}
               >
+                <Stack.Screen
+                  name="CreateSavedSearchAlert"
+                  component={CreateSavedSearchAlertContentQueryRenderer}
+                  initialParams={params}
+                />
+                <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
+                <Stack.Screen
+                  name="AlertPriceRange"
+                  component={AlertPriceRangeScreenQueryRenderer}
+                  options={{
+                    // Avoid PanResponser conflicts between the slider and the slide back gesture
+                    gestureEnabled: false,
+                  }}
+                />
                 <Stack.Screen
                   name="CreateSavedSearchAlert"
                   component={CreateSavedSearchAlertContentQueryRenderer}

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tests.tsx
@@ -26,7 +26,7 @@ describe("EditSavedSearchAlert", () => {
   }
 
   it("renders without throwing an error", async () => {
-    const { getAllByTestId, getByTestId } = renderWithWrappers(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment, {
@@ -45,13 +45,17 @@ describe("EditSavedSearchAlert", () => {
       })
     })
 
-    expect(getAllByTestId("alert-pill").map(extractText)).toEqual(["name-1", "Lithograph", "Paper"])
-    expect(getByTestId("alert-input-name").props.value).toBe("")
-    expect(getByTestId("alert-input-name").props.placeholder).toBe("Banana")
+    expect(screen.getAllByTestId("alert-pill").map(extractText)).toEqual([
+      "name-1",
+      "Lithograph",
+      "Paper",
+    ])
+    expect(screen.getByTestId("alert-input-name").props.value).toBe("")
+    expect(screen.getByTestId("alert-input-name").props.placeholder).toBe("Banana")
   })
 
   it("should navigate go back if the update mutation is successful", async () => {
-    const { getByTestId } = renderWithWrappers(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment, {
@@ -69,8 +73,8 @@ describe("EditSavedSearchAlert", () => {
       })
     })
 
-    fireEvent.changeText(getByTestId("alert-input-name"), "something new")
-    fireEvent.press(getByTestId("save-alert-button"))
+    fireEvent.changeText(screen.getByTestId("alert-input-name"), "something new")
+    fireEvent.press(screen.getByTestId("save-alert-button"))
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment, {
@@ -82,7 +86,7 @@ describe("EditSavedSearchAlert", () => {
   })
 
   it("should pass updated criteria to update mutation when pills are removed", async () => {
-    const { getByText, getAllByText } = renderWithWrappers(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
 
     resolveMostRecentRelayOperation(mockEnvironment, {
       SearchCriteria: () => searchCriteria,
@@ -102,8 +106,8 @@ describe("EditSavedSearchAlert", () => {
 
     await flushPromiseQueue()
 
-    fireEvent.press(getByText("Lithograph"))
-    fireEvent.press(getAllByText("Save Alert")[0])
+    fireEvent.press(screen.getByText("Lithograph"))
+    fireEvent.press(screen.getAllByText("Save Alert")[0])
 
     await waitFor(() => {
       const operation = mockEnvironment.mock.getMostRecentOperation()
@@ -136,7 +140,7 @@ describe("EditSavedSearchAlert", () => {
   })
 
   it("should display saved search preview display name as placeholder for input name", async () => {
-    const { getByPlaceholderText } = renderWithWrappers(<TestRenderer />)
+    renderWithWrappers(<TestRenderer />)
 
     await waitFor(() => {
       resolveMostRecentRelayOperation(mockEnvironment, {
@@ -166,7 +170,7 @@ describe("EditSavedSearchAlert", () => {
       })
     })
 
-    expect(getByPlaceholderText("Banana")).toBeTruthy()
+    expect(screen.getByPlaceholderText("Banana")).toBeTruthy()
   })
 
   describe("Notificaton toggles", () => {

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -18,6 +18,7 @@ import {
   EditSavedSearchAlertNavigationStack,
   EditSavedSearchAlertParams,
 } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
+import { localizeHeightAndWidthAttributes } from "app/Scenes/SavedSearchAlert/helpers"
 import { AlertPriceRangeScreenQueryRenderer } from "app/Scenes/SavedSearchAlert/screens/AlertPriceRangeScreen"
 import { EmailPreferencesScreen } from "app/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen"
 import { SavedSearchFilterScreen } from "app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen"
@@ -25,6 +26,7 @@ import { GoBackProps, goBack, navigationEvents } from "app/system/navigation/nav
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
+import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import React, { useCallback, useEffect } from "react"
 import { QueryRenderer, RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
 import { EditSavedSearchFormPlaceholder } from "./Components/EditSavedSearchAlertPlaceholder"
@@ -48,6 +50,8 @@ const Stack = createStackNavigator<EditSavedSearchAlertNavigationStack>()
 
 export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props) => {
   const { me, viewer, artists, artworksConnection, savedSearchAlertId, relay } = props
+  const { localizedUnit } = useLocalizedUnit()
+
   const aggregations = (artworksConnection.aggregations ?? []) as Aggregations
   const { userAlertSettings, ...attributes } = me?.savedSearch ?? {}
   const isCustomAlertsNotificationsEnabled = viewer.notificationPreferences.some((preference) => {
@@ -115,9 +119,16 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
         <SavedSearchStoreProvider
           runtimeModel={{
             ...savedSearchModel,
-            attributes: attributes as SearchCriteriaAttributes,
+            currentSavedSearchID: savedSearchAlertId,
+            attributes: localizeHeightAndWidthAttributes({
+              attributes: attributes as SearchCriteriaAttributes,
+              // Sizes are always injected in inches
+              from: "in",
+              to: localizedUnit,
+            }),
             aggregations,
             entity,
+            unit: localizedUnit,
           }}
         >
           <NavigationContainer independent>
@@ -130,6 +141,20 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
                 cardStyle: { backgroundColor: "white" },
               }}
             >
+              <Stack.Screen
+                name="EditSavedSearchAlertContent"
+                component={EditSavedSearchAlertContent}
+                initialParams={params}
+              />
+              <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
+              <Stack.Screen
+                name="AlertPriceRange"
+                component={AlertPriceRangeScreenQueryRenderer}
+                options={{
+                  // Avoid PanResponser conflicts between the slider and the slide back gesture
+                  gestureEnabled: false,
+                }}
+              />
               <Stack.Screen
                 name="EditSavedSearchAlertContent"
                 component={EditSavedSearchAlertContent}

--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -156,20 +156,6 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
                 }}
               />
               <Stack.Screen
-                name="EditSavedSearchAlertContent"
-                component={EditSavedSearchAlertContent}
-                initialParams={params}
-              />
-              <Stack.Screen name="EmailPreferences" component={EmailPreferencesScreen} />
-              <Stack.Screen
-                name="AlertPriceRange"
-                component={AlertPriceRangeScreenQueryRenderer}
-                options={{
-                  // Avoid PanResponser conflicts between the slider and the slide back gesture
-                  gestureEnabled: false,
-                }}
-              />
-              <Stack.Screen
                 name="SavedSearchFilterScreen"
                 component={SavedSearchFilterScreen}
                 options={{

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertModel.ts
@@ -24,6 +24,7 @@ export interface CreateSavedSearchAlertParams {
   currentArtworkID?: string
   onClosePress: () => void
   onComplete: (response: SavedSearchAlertMutationResult) => void
+  sizeMetric?: "cm" | "in" | undefined
 }
 
 export interface CreateSavedSearchAlertProps {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -5,7 +5,6 @@ import {
   SearchCriteria,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { getPreferredUnit } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize"
 import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import { Action, action, createContextStore } from "easy-peasy"
 import { pick } from "lodash"
@@ -54,7 +53,8 @@ export const savedSearchModel: SavedSearchModel = {
       slug: "",
     },
   },
-  unit: getPreferredUnit(),
+  // this will be overwritten by the user's default unit when we initialize the store
+  unit: "in",
 
   addValueToAttributesByKeyAction: action((state, payload) => {
     if (payload.key === "priceRange" && typeof payload.value === "string") {

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -5,18 +5,21 @@ import {
   SearchCriteria,
   SearchCriteriaAttributes,
 } from "app/Components/ArtworkFilter/SavedSearch/types"
+import { getPreferredUnit } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize"
+import { Metric } from "app/Scenes/Search/UserPrefsModel"
 import { Action, action, createContextStore } from "easy-peasy"
 import { pick } from "lodash"
 
 export interface SavedSearchModel {
-  attributes: SearchCriteriaAttributes
   aggregations: Aggregations
-  entity: SavedSearchEntity
-  dirty: boolean
+  attributes: SearchCriteriaAttributes
   /** Artwork ID, if the current saved search alert is being set from an artwork */
   currentArtworkID?: string
+  currentSavedSearchID?: string
+  dirty: boolean
+  entity: SavedSearchEntity
+  unit: Metric
 
-  setAttributeAction: Action<this, { key: SearchCriteria; value: any }>
   addValueToAttributesByKeyAction: Action<
     this,
     {
@@ -24,6 +27,7 @@ export interface SavedSearchModel {
       value: string | string[] | boolean | null
     }
   >
+  clearAllAttributesAction: Action<this>
   removeValueFromAttributesByKeyAction: Action<
     this,
     {
@@ -31,12 +35,16 @@ export interface SavedSearchModel {
       value: string | string[] | number | boolean
     }
   >
-  clearAllAttributesAction: Action<this>
+  setAttributeAction: Action<this, { key: SearchCriteria; value: any }>
+  setUnitAction: Action<this, Metric>
+  setCurrentSavedSearchID: Action<this, string>
 }
 
 export const savedSearchModel: SavedSearchModel = {
   attributes: {},
   aggregations: [],
+  currentArtworkID: undefined,
+  currentSavedSearchID: undefined,
   dirty: false,
   entity: {
     artists: [],
@@ -46,11 +54,7 @@ export const savedSearchModel: SavedSearchModel = {
       slug: "",
     },
   },
-  currentArtworkID: undefined,
-
-  setAttributeAction: action((state, payload) => {
-    state.attributes[payload.key] = payload.value
-  }),
+  unit: getPreferredUnit(),
 
   addValueToAttributesByKeyAction: action((state, payload) => {
     if (payload.key === "priceRange" && typeof payload.value === "string") {
@@ -64,6 +68,11 @@ export const savedSearchModel: SavedSearchModel = {
     } else {
       state.attributes[payload.key] = payload.value as unknown as null | undefined
     }
+  }),
+
+  clearAllAttributesAction: action((state) => {
+    state.attributes = pick(state.attributes, ["artistIDs", "artistID"])
+    state.dirty = true
   }),
 
   removeValueFromAttributesByKeyAction: action((state, payload) => {
@@ -80,9 +89,16 @@ export const savedSearchModel: SavedSearchModel = {
     state.dirty = true
   }),
 
-  clearAllAttributesAction: action((state) => {
-    state.attributes = pick(state.attributes, ["artistIDs", "artistID"])
-    state.dirty = true
+  setAttributeAction: action((state, payload) => {
+    state.attributes[payload.key] = payload.value
+  }),
+
+  setUnitAction: action((state, payload) => {
+    state.unit = payload
+  }),
+
+  setCurrentSavedSearchID: action((state, payload) => {
+    state.currentSavedSearchID = payload
   }),
 }
 

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -137,7 +137,9 @@ export const CreateSavedSearchAlertContentQueryRenderer: React.FC<
           if (__DEV__) {
             console.error(error)
           } else {
-            captureMessage(error.stack!)
+            if (error.stack) {
+              captureMessage(error.stack)
+            }
           }
         }
 

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -137,9 +137,7 @@ export const CreateSavedSearchAlertContentQueryRenderer: React.FC<
           if (__DEV__) {
             console.error(error)
           } else {
-            if (error.stack) {
-              captureMessage(error.stack)
-            }
+            captureMessage(`CreateSavedSearchAlertContentContainer ${error?.message}`)
           }
         }
 

--- a/src/app/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/app/Scenes/SavedSearchAlert/helpers.ts
@@ -1,3 +1,4 @@
+import { cmToIn, inToCm, parseRange } from "app/Components/ArtworkFilter/Filters/helpers"
 import {
   SearchCriteria,
   SearchCriteriaAttributes,
@@ -208,4 +209,40 @@ export const useSavedSearchFilter = ({ criterion }: { criterion: SearchCriteria 
   return {
     handlePress,
   }
+}
+
+export const localizeHeightAndWidthAttributes = ({
+  attributes,
+  from,
+  to,
+}: {
+  attributes: SearchCriteriaAttributes
+  from: "cm" | "in"
+  to: "cm" | "in"
+}) => {
+  if (from === to) {
+    return attributes
+  }
+
+  const localizedAttributes = { ...attributes }
+
+  const convert = from === "cm" && to === "in" ? cmToIn : inToCm
+
+  const roundDigits = to == "in" ? 2 : 0
+
+  if (localizedAttributes[SearchCriteria.width]) {
+    const range = parseRange(localizedAttributes[SearchCriteria.width])
+    const localizedMinWidth = convert(range.min, true, roundDigits)
+    const localizedMaxWidth = convert(range.max, true, roundDigits)
+    localizedAttributes[SearchCriteria.width] = `${localizedMinWidth}-${localizedMaxWidth}`
+  }
+
+  if (localizedAttributes[SearchCriteria.height]) {
+    const range = parseRange(localizedAttributes[SearchCriteria.height])
+    const localizedMinHeight = convert(range.min, true, roundDigits)
+    const localizedMaxHeight = convert(range.max, true, roundDigits)
+    localizedAttributes[SearchCriteria.width] = `${localizedMinHeight}-${localizedMaxHeight}`
+  }
+
+  return localizedAttributes
 }

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.ts
@@ -15,6 +15,7 @@ import {
   localizeDimension,
   parsePriceRangeLabel,
   parseRange,
+  round,
 } from "app/Components/ArtworkFilter/Filters/helpers"
 import { shouldExtractValueNamesFromAggregation } from "app/Components/ArtworkFilter/SavedSearch/constants"
 import {
@@ -32,6 +33,7 @@ interface ExtractFromCriteriaOptions {
   attributes: SearchCriteriaAttributes
   aggregations: Aggregations
   unit: Metric
+  convertUnit?: boolean // default true
 }
 
 type ExtractPillsOptions = ExtractFromCriteriaOptions & {
@@ -66,14 +68,18 @@ export const extractSizeLabel = ({
   prefix,
   value,
   unit,
+  convertUnit = true,
 }: {
   prefix: string
   value: string
   unit: Metric
+  convertUnit?: boolean
 }) => {
   const range = parseRange(value)
-  const min = localizeDimension(range.min, unit)
-  const max = localizeDimension(range.max, unit)
+
+  const min = convertUnit ? localizeDimension(range.min, unit) : round(range.min)
+  const max = convertUnit ? localizeDimension(range.max, unit) : round(range.max)
+
   let label
 
   if (max === "*") {
@@ -185,7 +191,12 @@ export const extractPillsFromCriteria = (
 
     if (paramName === SearchCriteria.width) {
       return {
-        label: extractSizeLabel({ prefix: "w", value: paramValue, unit }),
+        label: extractSizeLabel({
+          prefix: "w",
+          value: paramValue,
+          unit,
+          convertUnit: !!options.convertUnit,
+        }),
         value: paramValue,
         paramName: SearchCriteria.width,
       } as SavedSearchPill
@@ -193,7 +204,12 @@ export const extractPillsFromCriteria = (
 
     if (paramName === SearchCriteria.height) {
       return {
-        label: extractSizeLabel({ prefix: "h", value: paramValue, unit }),
+        label: extractSizeLabel({
+          prefix: "h",
+          value: paramValue,
+          unit,
+          convertUnit: !!options.convertUnit,
+        }),
         value: paramValue,
         paramName: SearchCriteria.height,
       } as SavedSearchPill
@@ -261,6 +277,7 @@ export const extractPills = (options: ExtractPillsOptions) => {
     attributes,
     aggregations,
     unit,
+    convertUnit: !!options.convertUnit,
   })
 
   return compact([...artistPills, ...pillsFromCriteria])

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -31,7 +31,11 @@ export const ConfirmationScreen: React.FC = () => {
   const route = useRoute<RouteProp<CreateSavedSearchAlertNavigationStack, "ConfirmationScreen">>()
   const { closeModal } = route.params
   const { bottom: bottomInset } = useSafeAreaInsets()
-  const pills = useSavedSearchPills()
+
+  const unit = SavedSearchStore.useStoreState((state) => state.unit)
+  const pills = useSavedSearchPills({
+    unit,
+  })
 
   const { space } = useTheme()
 

--- a/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
@@ -17,6 +17,7 @@ import { SavedSearchFilterAppliedFilters } from "app/Scenes/SavedSearchAlert/Com
 import { SavedSearchFilterColor } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterColor"
 import { SavedSearchFilterPriceRangeQR } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPriceRange"
 import { SavedSearchFilterRarity } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterRarity"
+import { SavedSearchFilterSize } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize"
 import { SavedSearchFilterWaysToBuy } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterWaysToBuy"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
@@ -45,11 +46,12 @@ export const SavedSearchFilterScreen: React.FC<{}> = () => {
       <ScrollView>
         <Join separator={<Separator my={2} borderColor="black10" />}>
           <SavedSearchFilterAppliedFilters />
-          <SavedSearchFilterAdditionalGeneIDs />
-          <SavedSearchFilterRarity />
-          <SavedSearchFilterPriceRangeQR />
-          <SavedSearchFilterWaysToBuy />
-          <SavedSearchFilterColor />
+          {/* <SavedSearchFilterPriceRangeQR /> */}
+          {/* <SavedSearchFilterRarity /> */}
+          {/* <SavedSearchFilterAdditionalGeneIDs /> */}
+          <SavedSearchFilterSize />
+          {/* <SavedSearchFilterWaysToBuy /> */}
+          {/* <SavedSearchFilterColor /> */}
         </Join>
 
         <Spacer y={2} />

--- a/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
@@ -20,6 +20,7 @@ import { SavedSearchFilterRarity } from "app/Scenes/SavedSearchAlert/Components/
 import { SavedSearchFilterSize } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterSize"
 import { SavedSearchFilterWaysToBuy } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterWaysToBuy"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { MotiView } from "moti"
@@ -28,6 +29,7 @@ import { Alert, Platform, ScrollView } from "react-native"
 export const SavedSearchFilterScreen: React.FC<{}> = () => {
   const navigation = useNavigation()
   const { bottom } = useScreenDimensions().safeAreaInsets
+  const enableAlertsFiltersSizeFiltering = useFeatureFlag("AREnableAlertsFiltersSizeFiltering")
 
   return (
     <ProvideScreenTrackingWithCohesionSchema
@@ -46,11 +48,11 @@ export const SavedSearchFilterScreen: React.FC<{}> = () => {
       <ScrollView>
         <Join separator={<Separator my={2} borderColor="black10" />}>
           <SavedSearchFilterAppliedFilters />
-          <SavedSearchFilterAppliedFilters />
           <SavedSearchFilterAdditionalGeneIDs />
           <SavedSearchFilterRarity />
           <SavedSearchFilterPriceRangeQR />
-          <SavedSearchFilterSize />
+          {!!enableAlertsFiltersSizeFiltering && <SavedSearchFilterSize />}
+
           <SavedSearchFilterWaysToBuy />
           <SavedSearchFilterColor />
         </Join>

--- a/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
@@ -46,12 +46,13 @@ export const SavedSearchFilterScreen: React.FC<{}> = () => {
       <ScrollView>
         <Join separator={<Separator my={2} borderColor="black10" />}>
           <SavedSearchFilterAppliedFilters />
-          {/* <SavedSearchFilterPriceRangeQR /> */}
-          {/* <SavedSearchFilterRarity /> */}
-          {/* <SavedSearchFilterAdditionalGeneIDs /> */}
+          <SavedSearchFilterAppliedFilters />
+          <SavedSearchFilterAdditionalGeneIDs />
+          <SavedSearchFilterRarity />
+          <SavedSearchFilterPriceRangeQR />
           <SavedSearchFilterSize />
-          {/* <SavedSearchFilterWaysToBuy /> */}
-          {/* <SavedSearchFilterColor /> */}
+          <SavedSearchFilterWaysToBuy />
+          <SavedSearchFilterColor />
         </Join>
 
         <Spacer y={2} />

--- a/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
+++ b/src/app/Scenes/SavedSearchAlert/useSavedSearchPills.ts
@@ -3,14 +3,21 @@ import { useMemo } from "react"
 import { SavedSearchStore } from "./SavedSearchStore"
 import { extractPills } from "./pillExtractors"
 
-export const useSavedSearchPills = () => {
+export const useSavedSearchPills = (options?: { convertUnit?: boolean; unit: "cm" | "in" }) => {
   const { localizedUnit } = useLocalizedUnit()
   const attributes = SavedSearchStore.useStoreState((state) => state.attributes)
   const aggregations = SavedSearchStore.useStoreState((state) => state.aggregations)
   const entity = SavedSearchStore.useStoreState((state) => state.entity)
 
   return useMemo(
-    () => extractPills({ attributes, aggregations, unit: localizedUnit, entity }),
-    [attributes, aggregations, localizedUnit, entity]
+    () =>
+      extractPills({
+        attributes,
+        aggregations,
+        unit: options?.unit ?? localizedUnit,
+        entity,
+        convertUnit: !!options?.convertUnit,
+      }),
+    [attributes, aggregations, localizedUnit, entity, options?.convertUnit, options?.unit]
   )
 }


### PR DESCRIPTION
This PR resolves [ONYX-379] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds the size filters to saved searches fitlers

### Adding a defined size

https://github.com/artsy/eigen/assets/11945712/4f2b9696-9c42-4283-af39-936358ebdf36


### Size overrides

https://github.com/artsy/eigen/assets/11945712/d450c148-bf14-4470-b287-3865106a4625


### Adding a custom size + Injecting a custom size


https://github.com/artsy/eigen/assets/11945712/9bcbd934-c4a5-48f1-ab39-b9e3adedb41e


### Edit screen


https://github.com/artsy/eigen/assets/11945712/2b6614f3-fc3a-4dc5-acb8-da4304b3f29d


**Challenges faced with custom sizes here:**
- The height and width are stored only in inches
- The metric selected while injecting the size filter might be different from your favourite unit
  - Opportunity to unite both (**Did that on save!**)
- The name preview does not support a unit

**Follow-up suggestions:**

Continuing to support both inches and cm in all size screens will continue to be challenging and it's probably a behaviour that no one is in need for and will take lots of dev time to nail. I would suggest therefore to do the same thing most apps and websites do, and it's to set a favorite metric + favourite currency as a part of your profile and use it everywhere.



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add saved searches size filter - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-379]: https://artsyproduct.atlassian.net/browse/ONYX-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ