### PR TITLE
feat: Allow creating and saving alerts with disabled notifications

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -96,11 +96,6 @@ export const Form: React.FC<FormProps> = ({
     isSaveAlertButtonDisabled = false
   }
 
-  // Disable button if notification toggles were not enabled
-  if (!values.push && !values.email) {
-    isSaveAlertButtonDisabled = true
-  }
-
   const handleUpdateEmailPreferencesPress = () => {
     if (onUpdateEmailPreferencesPress) {
       return onUpdateEmailPreferencesPress()


### PR DESCRIPTION
This PR resolves [ONYX-586] <!-- eg [PROJECT-XXXX] -->

### Description

Allow creating and saving alerts with disabled notifications.

| | |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 Plus - 2023-12-07 at 15 03 11](https://github.com/artsy/eigen/assets/4691889/0e2c11a0-d021-4c8a-afc2-a7edec2ad0d7)| ![Simulator Screenshot - iPhone 15 Plus - 2023-12-07 at 15 03 31](https://github.com/artsy/eigen/assets/4691889/b5de93df-e231-4a45-ae13-815eb2d86d67)|

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Allow creating and saving alerts with disabled notifications. - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-586]: https://artsyproduct.atlassian.net/browse/ONYX-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ