### PR TITLE
chore: remove experiment viewed event from the home screen

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -60,7 +60,6 @@ import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { AboveTheFoldQueryRenderer } from "app/utils/AboveTheFoldQueryRenderer"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
-import { maybeReportExperimentVariant } from "app/utils/experiments/reporter"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import {
   PlaceholderBox,
@@ -742,22 +741,6 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
   }
 
   const worksForYouRecommendationsModel = useExperimentVariant(RECOMMENDATION_MODEL_EXPERIMENT_NAME)
-
-  useEffect(() => {
-    // We would like to trigger the tracking only if the experiment is enabled
-    if (worksForYouRecommendationsModel.enabled) {
-      maybeReportExperimentVariant({
-        experimentName: RECOMMENDATION_MODEL_EXPERIMENT_NAME,
-        enabled: worksForYouRecommendationsModel.enabled,
-        variantName: worksForYouRecommendationsModel.variant,
-        payload: worksForYouRecommendationsModel.payload,
-        context_module: ContextModule.newWorksForYouRail,
-        context_owner_type: OwnerType.home,
-        context_owner_screen: OwnerType.home,
-        storeContext: true,
-      })
-    }
-  }, [worksForYouRecommendationsModel.enabled])
 
   useEffect(() => {
     if (flash_message) {

--- a/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
+++ b/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Spacer, SimpleMessage } from "@artsy/palette-mobile"
+import { SimpleMessage, Spacer } from "@artsy/palette-mobile"
 import { NewWorksForYouQuery } from "__generated__/NewWorksForYouQuery.graphql"
 import { NewWorksForYou_viewer$data } from "__generated__/NewWorksForYou_viewer.graphql"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
@@ -7,14 +7,12 @@ import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/Ma
 import { PageWithSimpleHeader } from "app/Components/PageWithSimpleHeader"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
-import { maybeReportExperimentVariant } from "app/utils/experiments/reporter"
 import { extractNodes } from "app/utils/extractNodes"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
-import { useEffect } from "react"
-import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
+import { QueryRenderer, RelayPaginationProp, createPaginationContainer, graphql } from "react-relay"
 
 const SCREEN_TITLE = "New Works for You"
 const PAGE_SIZE = 100
@@ -155,25 +153,6 @@ export const NewWorksForYouQueryRenderer: React.FC<NewWorksForYouQueryRendererPr
   const version = isReferredFromEmail
     ? versionProp?.toUpperCase() || undefined
     : worksForYouRecommendationsModel.payload || DEFAULT_RECS_MODEL_VERSION
-
-  useEffect(() => {
-    if (isReferredFromEmail) {
-      return
-    }
-
-    // We would like to trigger the tracking only if the experiment is enabled
-    if (worksForYouRecommendationsModel.enabled) {
-      maybeReportExperimentVariant({
-        experimentName: RECOMMENDATION_MODEL_EXPERIMENT_NAME,
-        enabled: worksForYouRecommendationsModel.enabled,
-        variantName: worksForYouRecommendationsModel.variant,
-        payload: worksForYouRecommendationsModel.payload,
-        context_owner_type: OwnerType.newWorksForYou,
-        context_owner_screen: OwnerType.newWorksForYou,
-        storeContext: true,
-      })
-    }
-  }, [worksForYouRecommendationsModel.enabled])
 
   return (
     <QueryRenderer<NewWorksForYouQuery>


### PR DESCRIPTION
This PR resolves [ONYX-451] <!-- eg [PROJECT-XXXX] -->

### Description

This PR removes `experiment_viewed` tracking event from the home screen.

**PS:** I left `maybeReportExperimentVariant` intentionally since we might (_will_) need to use this for future experiments.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- remove experiment viewed event from the home screen - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-451]: https://artsyproduct.atlassian.net/browse/ONYX-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ