### PR TITLE
feat: support replace routes on navigation

### DIFF
--- a/src/app/NativeModules/ARScreenPresenterModule.tsx
+++ b/src/app/NativeModules/ARScreenPresenterModule.tsx
@@ -130,12 +130,21 @@ export const ARScreenPresenterModule: typeof NativeModules["ARScreenPresenterMod
   },
   pushView(selectedTab: BottomTabType, viewDescriptor: ViewDescriptor) {
     const stackKey = getCurrentlyPresentedModalNavStackKey() ?? selectedTab
-    dispatchNavAction(
-      StackActions.push("screen:" + stackKey, {
-        moduleName: viewDescriptor.moduleName,
-        props: viewDescriptor.props,
-      })
-    )
+    if (viewDescriptor.replaceActiveScreen) {
+      dispatchNavAction(
+        StackActions.replace("screen:" + stackKey, {
+          moduleName: viewDescriptor.moduleName,
+          props: viewDescriptor.props,
+        })
+      )
+    } else {
+      dispatchNavAction(
+        StackActions.push("screen:" + stackKey, {
+          moduleName: viewDescriptor.moduleName,
+          props: viewDescriptor.props,
+        })
+      )
+    }
   },
   popStack(selectedTab: BottomTabType) {
     updateTabStackState(selectedTab, (state) => {

--- a/src/app/NativeModules/ARScreenPresenterModule.tsx
+++ b/src/app/NativeModules/ARScreenPresenterModule.tsx
@@ -94,7 +94,7 @@ export const ARScreenPresenterModule: typeof NativeModules["ARScreenPresenterMod
     dispatchNavAction(TabActions.jumpTo(tab))
   },
   presentModal(viewDescriptor: ViewDescriptor) {
-    if (viewDescriptor.replace) {
+    if (viewDescriptor.replaceActiveModal) {
       dispatchNavAction(
         StackActions.replace("modal", {
           rootModuleName: viewDescriptor.moduleName,

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tests.tsx
@@ -83,7 +83,7 @@ describe("Inquiry make offer button", () => {
     })
     expect(navigate).toHaveBeenCalledWith("/orders/4567", {
       modal: true,
-      replace: true,
+      replaceActiveModal: true,
       passProps: { orderID: "4567", title: "Make Offer" },
     })
   })

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryMakeOfferButton.tsx
@@ -103,7 +103,7 @@ export class InquiryMakeOfferButton extends React.Component<InquiryMakeOfferButt
               } else if (orderOrError.__typename === "CommerceOrderWithMutationSuccess") {
                 navigate(`/orders/${orderOrError.order.internalID}`, {
                   modal: true,
-                  replace: !!replaceModalView,
+                  replaceActiveModal: !!replaceModalView,
                   passProps: {
                     orderID: orderOrError.order.internalID,
                     title: "Make Offer",

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tests.tsx
@@ -84,7 +84,7 @@ describe("InquiryPurchaseButton", () => {
 
     expect(navigate).toHaveBeenCalledWith("/orders/4567", {
       modal: true,
-      replace: true,
+      replaceActiveModal: true,
       passProps: { orderID: "4567", title: "Purchase" },
     })
   })

--- a/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/InquiryPurchaseButton.tsx
@@ -93,21 +93,23 @@ export const InquiryPurchaseButton: React.FC<InquiryPurchaseButtonProps> = ({
       onCompleted: (data) => {
         setIsCommittingMutation(false)
 
-        const orderOrError = data.createInquiryOrder?.orderOrError!
-        if (orderOrError.__typename === "CommerceOrderWithMutationFailure") {
-          onMutationError(orderOrError.error)
-          return
-        }
+        if (data.createInquiryOrder?.orderOrError) {
+          const orderOrError = data.createInquiryOrder?.orderOrError
+          if (orderOrError.__typename === "CommerceOrderWithMutationFailure") {
+            onMutationError(orderOrError.error)
+            return
+          }
 
-        if (orderOrError.__typename === "CommerceOrderWithMutationSuccess") {
-          navigate(`/orders/${orderOrError.order.internalID}`, {
-            modal: true,
-            replace: !!replaceModalView,
-            passProps: {
-              orderID: orderOrError.order.internalID,
-              title: "Purchase",
-            },
-          })
+          if (orderOrError.__typename === "CommerceOrderWithMutationSuccess") {
+            navigate(`/orders/${orderOrError.order.internalID}`, {
+              modal: true,
+              replaceActiveModal: !!replaceModalView,
+              passProps: {
+                orderID: orderOrError.order.internalID,
+                title: "Purchase",
+              },
+            })
+          }
         }
       },
       onError: (error) => {

--- a/src/app/system/navigation/navigate.tests.tsx
+++ b/src/app/system/navigation/navigate.tests.tsx
@@ -54,7 +54,8 @@ describe(navigate, () => {
             "props": {
               "artworkID": "josef-albers-homage-to-the-square",
             },
-            "replace": false,
+            "replaceActiveModal": false,
+            "replaceActiveScreen": false,
             "type": "react",
           },
         ]
@@ -74,7 +75,8 @@ describe(navigate, () => {
             "props": {
               "artistID": "banksy",
             },
-            "replace": false,
+            "replaceActiveModal": false,
+            "replaceActiveScreen": false,
             "type": "react",
           },
         ]
@@ -93,7 +95,8 @@ describe(navigate, () => {
             "props": {
               "slug": "artsy-vanguard-2019",
             },
-            "replace": false,
+            "replaceActiveModal": false,
+            "replaceActiveScreen": false,
             "type": "react",
           },
         ]
@@ -125,7 +128,8 @@ describe(navigate, () => {
             "artistID": "banksy",
             "someAdditionalKey": "value",
           },
-          "replace": false,
+          "replaceActiveModal": false,
+          "replaceActiveScreen": false,
           "type": "react",
         },
       ]
@@ -157,7 +161,8 @@ describe(navigate, () => {
             "props": {
               "artistID": "kaws",
             },
-            "replace": false,
+            "replaceActiveModal": false,
+            "replaceActiveScreen": false,
             "type": "react",
           },
         ]
@@ -179,7 +184,8 @@ describe(navigate, () => {
             "props": {
               "slug": "blah",
             },
-            "replace": false,
+            "replaceActiveModal": false,
+            "replaceActiveScreen": false,
             "type": "react",
           },
         ]
@@ -229,7 +235,8 @@ describe(navigate, () => {
           "props": {
             "conversationID": "234",
           },
-          "replace": false,
+          "replaceActiveModal": false,
+          "replaceActiveScreen": false,
           "type": "react",
         },
       ]
@@ -254,7 +261,8 @@ describe(navigate, () => {
         {
           "moduleName": "SavedSearchAlertsList",
           "props": {},
-          "replace": false,
+          "replaceActiveModal": false,
+          "replaceActiveScreen": false,
           "type": "react",
         },
       ]

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -17,6 +17,7 @@ export interface ViewDescriptor extends ViewOptions {
   moduleName: AppModule
   // Whether the new view should replace the previous (modal only)
   replaceActiveModal?: boolean
+  replaceActiveScreen?: boolean
   props: object
 }
 
@@ -31,6 +32,7 @@ export interface NavigateOptions {
     [key: string]: any
   }
   replaceActiveModal?: boolean
+  replaceActiveScreen?: boolean
   // Only when onlyShowInTabName specified
   popToRootTabView?: boolean
   ignoreDebounce?: boolean
@@ -96,12 +98,18 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
 
   const module = modules[result.module]
   const presentModally = options.modal ?? module.options.alwaysPresentModally ?? false
-  const { replaceActiveModal = false, popToRootTabView, showInTabName } = options
+  const {
+    replaceActiveModal = false,
+    replaceActiveScreen = false,
+    popToRootTabView,
+    showInTabName,
+  } = options
 
   const screenDescriptor: ViewDescriptor = {
     type: module.type,
     moduleName: result.module,
     replaceActiveModal,
+    replaceActiveScreen,
     props: {
       ...result.params,
       ...options.passProps,

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -16,7 +16,7 @@ export interface ViewDescriptor extends ViewOptions {
   type: "react" | "native"
   moduleName: AppModule
   // Whether the new view should replace the previous (modal only)
-  replace?: boolean
+  replaceActiveModal?: boolean
   props: object
 }
 
@@ -30,7 +30,7 @@ export interface NavigateOptions {
     backProps?: GoBackProps
     [key: string]: any
   }
-  replace?: boolean
+  replaceActiveModal?: boolean
   // Only when onlyShowInTabName specified
   popToRootTabView?: boolean
   ignoreDebounce?: boolean
@@ -96,12 +96,12 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
 
   const module = modules[result.module]
   const presentModally = options.modal ?? module.options.alwaysPresentModally ?? false
-  const { replace = false, popToRootTabView, showInTabName } = options
+  const { replaceActiveModal = false, popToRootTabView, showInTabName } = options
 
   const screenDescriptor: ViewDescriptor = {
     type: module.type,
     moduleName: result.module,
-    replace,
+    replaceActiveModal,
     props: {
       ...result.params,
       ...options.passProps,


### PR DESCRIPTION
### Description

This PR updates the `navigate` function to include `replaceActiveScreen` to update current screen in the stack

**Example with `replaceActiveScreen`**

https://github.com/artsy/eigen/assets/11945712/b68553df-7ba7-4db0-b8ff-3f828e13fa13


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Support replaceActiveScreen in navigation - mounir + sultan

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
