### PR TITLE
fix(DIA-343): controls when more than one Popover tries to appear

### DIFF
--- a/docs/add_progressive_onboarding.md
+++ b/docs/add_progressive_onboarding.md
@@ -5,6 +5,9 @@ Progressive Onboarding Model is a simple store that controlls dismissed messages
 - dismissed: array of dismissed strings triggered by the user and/or code
 - dismiss: function that dismisses one or more alerts at the same time
 - isDimissed: function that checks if a specific onboarding string is dismissed
+- sessionState:
+  - isReady: controls the feature if is ready to be used or not
+  - activePopover: sets an identifier of the current popover being displayed
 
 ## Create a Progressive Onboarding
 

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork.tsx
@@ -1,4 +1,5 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
+import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { GlobalStore } from "app/store/GlobalStore"
 
@@ -19,8 +20,9 @@ export const ProgressiveOnboardingFindSavedArtwork: React.FC<
     (state) => state.bottomTabs.sessionState.tabProps.profile
   )
 
-  const isFindSavedArtworkDisplayable =
+  const isDisplayable =
     isReady && !isDismissed("find-saved-artwork").status && !!profileTabProps?.savedArtwork
+  const { isActive } = useSetActivePopover(isDisplayable)
 
   if (tab !== "profile") {
     return <>{children}</>
@@ -32,7 +34,7 @@ export const ProgressiveOnboardingFindSavedArtwork: React.FC<
 
   return (
     <Popover
-      visible={isFindSavedArtworkDisplayable}
+      visible={!!isDisplayable && !!isActive}
       onDismiss={handleDismiss}
       onPressOutside={handleDismiss}
       title={

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -1,5 +1,6 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
 import { ProgressiveOnboardingSaveArtwork_Query } from "__generated__/ProgressiveOnboardingSaveArtwork_Query.graphql"
+import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
 import { GlobalStore } from "app/store/GlobalStore"
 import { ElementInView } from "app/utils/ElementInView"
 import { useState } from "react"
@@ -18,6 +19,7 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
   const savedArtworks = data?.me.counts.savedArtworks
   const isDismissed = _isDismissed("save-artwork").status
   const isDisplayable = isReady && !isDismissed && savedArtworks === 0 && isInView
+  const { isActive } = useSetActivePopover(isDisplayable)
 
   const handleDismiss = () => {
     setIsVisible(false)
@@ -28,7 +30,7 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
   if (isDisplayable) {
     return (
       <Popover
-        visible={isVisible}
+        visible={!!isVisible && !!isActive}
         onDismiss={handleDismiss}
         onPressOutside={handleDismiss}
         title={

--- a/src/app/Components/ProgressiveOnboarding/useSetActivePopover.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/useSetActivePopover.tests.tsx
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from "@testing-library/react-native"
+import { GlobalStoreProvider, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { useSetActivePopover } from "./useSetActivePopover"
+
+describe("useSetActivePopver", () => {
+  const wrapper = ({ children }: any) => <GlobalStoreProvider>{children}</GlobalStoreProvider>
+
+  it("isActive is true given isDisplayable true and no activePopover", () => {
+    const { result } = renderHook(() => useSetActivePopover(true), { wrapper })
+
+    expect(result.current.isActive).toBe(true)
+  })
+
+  it("isActive is false given isDisplayable true and a different activePopover", () => {
+    __globalStoreTestUtils__?.injectState({
+      progressiveOnboarding: { sessionState: { activePopover: "test-id" } },
+    })
+    const { result } = renderHook(() => useSetActivePopover(true), { wrapper })
+
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it("isActive is false given isDisplayable false and no activePopover", () => {
+    const { result } = renderHook(() => useSetActivePopover(false), { wrapper })
+
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it("isActive is false given isDisplayable false and a different activePopover", () => {
+    __globalStoreTestUtils__?.injectState({
+      progressiveOnboarding: { sessionState: { activePopover: "test-id" } },
+    })
+    const { result } = renderHook(() => useSetActivePopover(false), { wrapper })
+
+    expect(result.current.isActive).toBe(false)
+  })
+
+  it("should correctly set the active state of the 1st popover, 2nd should remain false", async () => {
+    const { result: result1 } = renderHook(() => useSetActivePopover(true), { wrapper })
+
+    await waitFor(() => expect(result1.current.isActive).toBe(true))
+
+    const { result: result2 } = renderHook(() => useSetActivePopover(true), { wrapper })
+    expect(result2.current.isActive).toBe(false)
+  })
+})

--- a/src/app/Components/ProgressiveOnboarding/useSetActivePopover.ts
+++ b/src/app/Components/ProgressiveOnboarding/useSetActivePopover.ts
@@ -1,0 +1,22 @@
+import { GlobalStore } from "app/store/GlobalStore"
+import { RandomNumberGenerator } from "app/utils/placeholders"
+import { useEffect, useState } from "react"
+
+export const useSetActivePopover = (isDisplayable: boolean) => {
+  const [popoverId] = useState(() => new RandomNumberGenerator(Math.random()).next().toString())
+  const {
+    sessionState: { activePopover },
+  } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
+  const { setActivePopover } = GlobalStore.actions.progressiveOnboarding
+
+  useEffect(() => {
+    if (!isDisplayable || activePopover || !popoverId) {
+      return
+    }
+    if (isDisplayable && !activePopover) {
+      setActivePopover(popoverId)
+    }
+  }, [activePopover, isDisplayable, popoverId])
+
+  return { isActive: !!isDisplayable && activePopover === popoverId }
+}

--- a/src/app/store/ProgressiveOnboardingModel.ts
+++ b/src/app/store/ProgressiveOnboardingModel.ts
@@ -19,8 +19,12 @@ export interface ProgressiveOnboardingModel {
     // Controls when the Progressive Onboarding Popovers are able to de displayed
     // Right now we dispatch it from the home screen once it has focus
     isReady: boolean
+    // we use this to control which popover is active, we cannot have 2 popovers
+    // active at the same time
+    activePopover?: string
   }
   setIsReady: Action<this>
+  setActivePopover: Action<this, string>
   __clearDissmissed: Action<this>
 }
 
@@ -37,6 +41,7 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
       [...state.dismissed, ...keys.map((k) => ({ key: k, timestamp }))],
       (d) => d.key
     )
+    state.sessionState = { isReady: state.sessionState.isReady }
   }),
   isDismissed: computed(({ dismissed }) => {
     return (key) => {
@@ -51,6 +56,9 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
     if (!state.sessionState.isReady) {
       state.sessionState.isReady = true
     }
+  }),
+  setActivePopover: action((state, id) => {
+    state.sessionState.activePopover = id
   }),
   __clearDissmissed: action((state) => {
     state.dismissed = []


### PR DESCRIPTION
This PR resolves [DIA-343] <!-- eg [PROJECT-XXXX] -->

### Description

We had a few bugs with the tool when multiple popovers(given the flexibility of the feature) were attempted to be shown at the same time, by default the element does not allow it, and it's hard to control.

This PR introduces another variable in the model's `sessionState` to control if a Popover from the ProgressiveOnboarding has already occurred to block another from being shown.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: ProgressiveOnboarding control active popover - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-343]: https://artsyproduct.atlassian.net/browse/DIA-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ