### PR TITLE
feat(EMI-1593): Update save tooltip content for Partner Offer

### DIFF
--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, act } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { useEffect } from "react"
@@ -52,9 +52,7 @@ describe("ProgressiveOnboardingSaveArtwork", () => {
 
     expect(screen.getByText("Popover")).toBeOnTheScreen()
 
-    act(() => {
-      fireEvent.press(screen.getByText("Popover"))
-    })
+    fireEvent.press(screen.getByText("Popover"))
 
     expect(__globalStoreTestUtils__?.getLastAction().type).toContain(
       "progressiveOnboarding.dismiss"

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -3,6 +3,7 @@ import { ProgressiveOnboardingSaveArtwork_Query } from "__generated__/Progressiv
 import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
 import { GlobalStore } from "app/store/GlobalStore"
 import { ElementInView } from "app/utils/ElementInView"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
@@ -20,6 +21,7 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
   const isDismissed = _isDismissed("save-artwork").status
   const isDisplayable = isReady && !isDismissed && savedArtworks === 0 && isInView
   const { isActive } = useSetActivePopover(isDisplayable)
+  const isPartnerOfferEnabled = useFeatureFlag("AREnablePartnerOffer")
 
   const handleDismiss = () => {
     setIsVisible(false)
@@ -28,6 +30,14 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
 
   // all conditions met we show the popover
   if (isDisplayable) {
+    const content = (
+      <Text color="white100">
+        {isPartnerOfferEnabled
+          ? "Tap the heart to save an artwork\nand signal your interest to galleries."
+          : "Hit the heart to save an artwork."}
+      </Text>
+    )
+
     return (
       <Popover
         visible={!!isVisible && !!isActive}
@@ -38,7 +48,7 @@ export const ProgressiveOnboardingSaveArtwork: React.FC = ({ children }) => {
             Like what you see?
           </Text>
         }
-        content={<Text color="white100">Hit the heart to save an artwork.</Text>}
+        content={content}
       >
         <Flex>{children}</Flex>
       </Popover>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -231,6 +231,12 @@ export const features: { [key: string]: FeatureDescriptor } = {
     showInDevMenu: true,
     echoFlagKey: "AREnableNewWorksForYouScreenFeed",
   },
+  AREnablePartnerOffer: {
+    description: "Enable partner offer content in the app",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnablePartnerOffer",
+  },
 }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [EMI-1593] <!-- eg [PROJECT-XXXX] -->

> [!Note]
> This change is hidden behind the feature flag `AREnablePartnerOffer`

### Description
This PR updates the content of the Progressive Onboarding tooltip for saves to match the new content for Partner Offer

### Screenshots

| | Before | After |
|---|---|---|
| Android | <img width="455" alt="image" src="https://github.com/artsy/eigen/assets/20655703/f0f2367b-3f5a-48dc-a7d6-5b03fe3b4500"> | <img width="457" alt="image" src="https://github.com/artsy/eigen/assets/20655703/c6b71ac3-ee51-441a-bd4b-e5b233c00cde"> |
| iOS | ![image](https://github.com/artsy/eigen/assets/20655703/ae681748-1ecb-44f0-91c2-a28d7ac31e24) | ![image](https://github.com/artsy/eigen/assets/20655703/55fadecd-339f-4e16-8b8c-8334d5ddfb0e) |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update progressive onboarding tooltip content for Partner Offer - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1593]: https://artsyproduct.atlassian.net/browse/EMI-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ