### PR TITLE
fix(fairs): Scrolling on fair exhibitors crashes the app

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "appName": "eigen",
   "version": "8.30.0",
   "isAndroidBeta": false,
-  "codePushReleaseName": "none",
-  "codePushDist": "none"
+  "codePushReleaseName": "codepush-canary-android-8.30.0-2023.12.21.12",
+  "codePushDist": "2023.12.21.12"
 }

--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "appName": "eigen",
   "version": "8.30.0",
   "isAndroidBeta": false,
-  "codePushReleaseName": "none",
-  "codePushDist": "none"
+  "codePushReleaseName": "codepush-canary-android-8.30.0-2023.12.21.13",
+  "codePushDist": "2023.12.21.13"
 }

--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "appName": "eigen",
   "version": "8.30.0",
   "isAndroidBeta": false,
-  "codePushReleaseName": "codepush-canary-android-8.30.0-2023.12.21.13",
-  "codePushDist": "2023.12.21.13"
+  "codePushReleaseName": "none",
+  "codePushDist": "none"
 }

--- a/app.json
+++ b/app.json
@@ -2,6 +2,6 @@
   "appName": "eigen",
   "version": "8.30.0",
   "isAndroidBeta": false,
-  "codePushReleaseName": "codepush-canary-android-8.30.0-2023.12.21.12",
-  "codePushDist": "2023.12.21.12"
+  "codePushReleaseName": "none",
+  "codePushDist": "none"
 }

--- a/src/app/Components/constants.ts
+++ b/src/app/Components/constants.ts
@@ -1,6 +1,6 @@
 export const PAGE_SIZE = 10
 export const FAIR2_ARTWORKS_PAGE_SIZE = 30
-export const FAIR2_EXHIBITORS_PAGE_SIZE = 30
+export const FAIR2_EXHIBITORS_PAGE_SIZE = 10
 export const ARTIST_SERIES_PAGE_SIZE = 30
 export const SHOW2_ARTWORKS_PAGE_SIZE = 30
 export const SAVED_SERCHES_PAGE_SIZE = 20

--- a/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
@@ -21,10 +21,6 @@ const FairExhibitorRail: React.FC<FairExhibitorRailProps> = ({ show }) => {
   const partnerName = show?.partner?.name ?? ""
   const viewAllUrl = show?.href
 
-  if (count === 0) {
-    return null
-  }
-
   return (
     <>
       <Flex px={2}>

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -15,6 +15,7 @@ interface FairExhibitorsProps {
 
 const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
   const shows = extractNodes(fair?.exhibitors)
+  const showsWithArtworks = shows.filter((show) => show?.counts?.artworks ?? 0 > 0)
   const shouldDisplaySpinner = !!shows.length && !!relay.isLoading() && !!relay.hasMore()
 
   const loadMoreExhibitors = useCallback(() => {
@@ -41,7 +42,7 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
 
   return (
     <FlatList
-      data={shows}
+      data={showsWithArtworks}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
       onEndReached={loadMoreExhibitors}

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -29,22 +29,26 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
     })
   }, [relay.hasMore(), relay.isLoading()])
 
+  const renderItem = useCallback(({ item: show }) => {
+    if ((show?.counts?.artworks ?? 0) === 0 || !show?.partner) {
+      // Skip rendering of booths without artworks
+      return null
+    }
+
+    return (
+      <Box key={show.id} mb={4}>
+        <FairExhibitorRailFragmentContainer show={show} />
+      </Box>
+    )
+  }, [])
+
+  const keyExtractor = (item: any) => String(item?.id)
+
   return (
     <FlatList
       data={shows}
-      renderItem={({ item: show }) => {
-        if ((show?.counts?.artworks ?? 0) === 0 || !show?.partner) {
-          // Skip rendering of booths without artworks
-          return null
-        }
-
-        return (
-          <Box key={show.id} mb={4}>
-            <FairExhibitorRailFragmentContainer key={show.id} show={show} />
-          </Box>
-        )
-      }}
-      keyExtractor={(item) => String(item?.id)}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
       onEndReached={loadMoreExhibitors}
       ListFooterComponent={
         shouldDisplaySpinner ? (

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -4,7 +4,7 @@ import Spinner from "app/Components/Spinner"
 import { FAIR2_EXHIBITORS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import React, { useCallback } from "react"
-import { FlatList } from "react-native-gesture-handler"
+import { FlatList } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { FairExhibitorRailFragmentContainer } from "./FairExhibitorRail"
 

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -30,11 +30,6 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
   }, [relay.hasMore(), relay.isLoading()])
 
   const renderItem = useCallback(({ item: show }) => {
-    if ((show?.counts?.artworks ?? 0) === 0 || !show?.partner) {
-      // Skip rendering of booths without artworks
-      return null
-    }
-
     return (
       <Box key={show.id} mb={4}>
         <FairExhibitorRailFragmentContainer show={show} />

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -3,8 +3,8 @@ import { FairExhibitors_fair$data } from "__generated__/FairExhibitors_fair.grap
 import Spinner from "app/Components/Spinner"
 import { FAIR2_EXHIBITORS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
-import React, { useState } from "react"
-import { FlatList } from "react-native"
+import React, { useCallback } from "react"
+import { FlatList } from "react-native-gesture-handler"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { FairExhibitorRailFragmentContainer } from "./FairExhibitorRail"
 
@@ -14,24 +14,20 @@ interface FairExhibitorsProps {
 }
 
 const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
-  const [isLoading, setIsLoading] = useState(false)
-
   const shows = extractNodes(fair?.exhibitors)
+  const shouldDisplaySpinner = !!shows.length && !!relay.isLoading() && !!relay.hasMore()
 
-  const loadMoreExhibitors = () => {
+  const loadMoreExhibitors = useCallback(() => {
     if (!relay.hasMore() || relay.isLoading()) {
       return
     }
 
-    setIsLoading(true)
     relay.loadMore(FAIR2_EXHIBITORS_PAGE_SIZE, (err) => {
-      setIsLoading(false)
-
       if (err) {
         console.error(err)
       }
     })
-  }
+  }, [relay.hasMore(), relay.isLoading()])
 
   return (
     <FlatList
@@ -51,7 +47,7 @@ const FairExhibitors: React.FC<FairExhibitorsProps> = ({ fair, relay }) => {
       keyExtractor={(item) => String(item?.id)}
       onEndReached={loadMoreExhibitors}
       ListFooterComponent={
-        isLoading ? (
+        shouldDisplaySpinner ? (
           <Box p={2}>
             <Flex flex={1} flexDirection="row" justifyContent="center">
               <Spinner />

--- a/src/app/Scenes/Fair/Components/FairExhibitors.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitors.tsx
@@ -74,14 +74,6 @@ export const FairExhibitorsFragmentContainer = createPaginationContainer(
               counts {
                 artworks
               }
-              partner {
-                ... on Partner {
-                  id
-                }
-                ... on ExternalPartner {
-                  id
-                }
-              }
               ...FairExhibitorRail_show
             }
           }


### PR DESCRIPTION
This PR resolves [PHIRE-531] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the `ArrayIndexOutOfBoundsException` crash from [sentry](https://artsynet.sentry.io/issues/4733947512/events/42f7964bc17443e19690323a211f4ba5/) on the fair page.

The issue was located inside the renderItem functions ~ returning null instead of an element inside there caused the `ArrayIndexOutOfBoundsException` crash, filtering the data before passing them on the flatlist fixed the issue.

Beta that was failing: all of them ~ beta that it is fixed: `codepush-canary-android-8.30.0-2023.12.21.14`

Steps to reproduce:

- Open the artsy app on prod environment (fair exhibitors are empty on staging)
- scroll to the bottom of the homepage
- press any of the two first fairs on the last home rail 
- start scrolling up and down 

Previous behavior: 

App was crashing

Expected behavior:

users are able to scroll normally.

**Bonus fixes:**

- some tiny performance improvements by pulling out the `renderItem` and `keyExtractor`.
- fetches 10 exhibitors per fetchMore to reduce the load

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fixes scrolling on fair exhibitors crashes the app - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-531]: https://artsyproduct.atlassian.net/browse/PHIRE-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ