### PR TITLE
refactor(masonry): Replace artwork autosuggest results with Masonry

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
@@ -1,13 +1,21 @@
-import { Flex } from "@artsy/palette-mobile"
+import { Box, Flex, Spinner, Text, quoteLeft, quoteRight, useSpace } from "@artsy/palette-mobile"
+import { MasonryFlashList } from "@shopify/flash-list"
 import { ArtworkAutosuggestResultsContainerQuery } from "__generated__/ArtworkAutosuggestResultsContainerQuery.graphql"
 import { ArtworkAutosuggestResults_viewer$data } from "__generated__/ArtworkAutosuggestResults_viewer.graphql"
+import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
-import { InfiniteScrollArtworksGridContainer } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { LoadFailureView } from "app/Components/LoadFailureView"
+import { PAGE_SIZE } from "app/Components/constants"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
+import {
+  ESTIMATED_MASONRY_ITEM_SIZE,
+  NUM_COLUMNS_MASONRY,
+  ON_END_REACHED_THRESHOLD_MASONRY,
+} from "app/utils/masonryHelpers"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import React, { useEffect } from "react"
+import React, { useCallback, useEffect } from "react"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
 
 export interface ArtworkAutosuggestResultsProps {
@@ -25,27 +33,81 @@ const ArtworkAutosuggestResults: React.FC<ArtworkAutosuggestResultsProps> = ({
   onPress,
   setShowSkipAheadToAddArtworkLink,
 }) => {
+  const { width } = useScreenDimensions()
+  const space = useSpace()
+
   const handlePress = (artworkId: string) => {
     // TODO: Tracking
     onPress?.(artworkId)
   }
+
+  const artworks = extractNodes(viewer.artworks)
+  const shouldDisplaySpinner = !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
+
+  const loadMore = useCallback(() => {
+    if (relay.hasMore() && !relay.isLoading()) {
+      relay.loadMore(PAGE_SIZE)
+    }
+  }, [relay.hasMore(), relay.isLoading()])
 
   useEffect(() => {
     setShowSkipAheadToAddArtworkLink(!!viewer.artworks?.edges?.length)
   }, [viewer.artworks?.edges?.length])
 
   return (
-    <Flex py={2}>
-      <InfiniteScrollArtworksGridContainer
-        connection={viewer.artworks}
-        loadMore={relay.loadMore}
-        hasMore={relay.hasMore}
-        contextScreenQuery={keyword}
-        useParentAwareScrollView={false}
-        itemComponentProps={{ hideSaleInfo: true, hidePartner: true, onPress: handlePress }}
-        hideSaveIcon
-      />
-    </Flex>
+    <MasonryFlashList
+      contentContainerStyle={{ paddingBottom: space(12) }}
+      showsVerticalScrollIndicator={false}
+      data={artworks}
+      numColumns={NUM_COLUMNS_MASONRY}
+      keyExtractor={(item) => item.id}
+      estimatedItemSize={ESTIMATED_MASONRY_ITEM_SIZE}
+      keyboardShouldPersistTaps="handled"
+      onEndReached={loadMore}
+      onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
+      ListFooterComponent={
+        shouldDisplaySpinner ? (
+          <Flex my={4} flexDirection="row" justifyContent="center">
+            <Spinner />
+          </Flex>
+        ) : null
+      }
+      ListEmptyComponent={
+        <Box pt={4}>
+          <Box px={2}>
+            <Text variant="sm-display" textAlign="center">
+              Sorry, we couldn’t find any Artworks for {quoteLeft}
+              {keyword}.{quoteRight}
+            </Text>
+            <Text variant="sm-display" color="black60" textAlign="center">
+              Please try searching again with a different spelling.
+            </Text>
+          </Box>
+        </Box>
+      }
+      renderItem={({ item, index, columnIndex }) => {
+        const imgAspectRatio = item.image?.aspectRatio ?? 1
+        const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+
+        const imgHeight = imgWidth / imgAspectRatio
+
+        return (
+          <Flex
+            pl={columnIndex === 0 ? 0 : 1}
+            pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+            mt={2}
+          >
+            <ArtworkGridItem
+              itemIndex={index}
+              contextScreenQuery={keyword}
+              artwork={item}
+              height={imgHeight}
+              onPress={handlePress}
+            />
+          </Flex>
+        )
+      }}
+    />
   )
 }
 
@@ -55,7 +117,7 @@ export const ArtworkAutosuggestResultsPaginationContainer = createPaginationCont
     viewer: graphql`
       fragment ArtworkAutosuggestResults_viewer on Viewer
       @argumentDefinitions(
-        count: { type: "Int", defaultValue: 20 }
+        count: { type: "Int", defaultValue: 30 }
         cursor: { type: "String" }
         keyword: { type: "String" }
         input: { type: "FilterArtworksInput" }
@@ -74,9 +136,9 @@ export const ArtworkAutosuggestResultsPaginationContainer = createPaginationCont
               image(includeAll: false) {
                 aspectRatio
               }
+              ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
             }
           }
-          ...InfiniteScrollArtworksGrid_connection
         }
       }
     `,

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent } from "@testing-library/react-native"
+import { act, fireEvent, screen } from "@testing-library/react-native"
 import { AutosuggestResultsQuery } from "__generated__/AutosuggestResultsQuery.graphql"
 import { myCollectionCreateArtworkMutation } from "__generated__/myCollectionCreateArtworkMutation.graphql"
 import { saveOrUpdateArtwork } from "app/Scenes/MyCollection/Screens/ArtworkForm/methods/uploadArtwork"
@@ -42,7 +42,7 @@ describe("MyCollectionArtworkForm", () => {
 
   describe("Editing an artwork", () => {
     it("renders the main form", async () => {
-      const { getByText, getByTestId } = renderWithHookWrappersTL(
+      renderWithHookWrappersTL(
         <MyCollectionArtworkFormScreen artwork={mockArtwork as any} mode="edit" />,
         mockEnvironment
       )
@@ -51,13 +51,13 @@ describe("MyCollectionArtworkForm", () => {
 
       await flushPromiseQueue()
 
-      expect(getByTestId("TitleInput").props.value).toBe("Morons")
-      expect(getByTestId("DateInput").props.value).toBe("2007")
-      expect(getByTestId("MaterialsInput").props.value).toBe("Screen print")
-      expect(getByTestId("WidthInput").props.value).toBe("30")
-      expect(getByTestId("HeightInput").props.value).toBe("20")
-      expect(getByTestId("DepthInput").props.value).toBe("40")
-      expect(getByText("1 photo added")).toBeTruthy()
+      expect(screen.getByTestId("TitleInput").props.value).toBe("Morons")
+      expect(screen.getByTestId("DateInput").props.value).toBe("2007")
+      expect(screen.getByTestId("MaterialsInput").props.value).toBe("Screen print")
+      expect(screen.getByTestId("WidthInput").props.value).toBe("30")
+      expect(screen.getByTestId("HeightInput").props.value).toBe("20")
+      expect(screen.getByTestId("DepthInput").props.value).toBe("40")
+      expect(screen.getByText("1 photo added")).toBeTruthy()
     })
   })
 
@@ -85,7 +85,7 @@ describe("MyCollectionArtworkForm", () => {
         getGeminiCredentialsForEnvironmentMock.mockReturnValue(Promise.resolve(assetCredentials))
         uploadFileToS3Mock.mockReturnValue(Promise.resolve("some-s3-url"))
 
-        const { getByText, getByTestId, getByPlaceholderText } = renderWithHookWrappersTL(
+        renderWithHookWrappersTL(
           <MyCollectionArtworkFormScreen mode="add" source={Tab.collection} />,
           mockEnvironment
         )
@@ -101,9 +101,9 @@ describe("MyCollectionArtworkForm", () => {
 
         // Select Artist Screen
 
-        expect(getByText("Select an Artist")).toBeTruthy()
+        expect(screen.getByText("Select an Artist")).toBeTruthy()
 
-        fireEvent.changeText(getByPlaceholderText("Search for artists on Artsy"), "banksy")
+        fireEvent.changeText(screen.getByPlaceholderText("Search for artists on Artsy"), "banksy")
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({
             errors: [],
@@ -113,22 +113,22 @@ describe("MyCollectionArtworkForm", () => {
 
         await flushPromiseQueue()
 
-        fireEvent.press(getByTestId("autosuggest-search-result-Banksy"))
+        fireEvent.press(screen.getByTestId("autosuggest-search-result-Banksy"))
 
         await flushPromiseQueue()
 
         // Select Artwork Screen
 
-        expect(getByText("Select an Artwork")).toBeTruthy()
+        expect(screen.getByText("Select an Artwork")).toBeTruthy()
 
-        fireEvent.changeText(getByPlaceholderText("Search artworks"), "banksy")
+        fireEvent.changeText(screen.getByPlaceholderText("Search artworks"), "banksy")
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({
             errors: [],
             data: mockArtworkSearchResult,
           })
         )
-        fireEvent.press(getByTestId("artworkGridItem-Morons"))
+        fireEvent.press(screen.getByTestId("artworkGridItem-Morons"))
 
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({ errors: [], data: mockArtworkResult })
@@ -138,20 +138,20 @@ describe("MyCollectionArtworkForm", () => {
 
         // Edit Details Screen
 
-        expect(getByText("Add Details")).toBeTruthy()
+        expect(screen.getByText("Add Details")).toBeTruthy()
 
-        expect(getByTestId("TitleInput").props.value).toBe("Morons")
-        expect(getByTestId("DateInput").props.value).toBe("2007")
-        expect(getByTestId("MaterialsInput").props.value).toBe("Screen print")
-        expect(getByTestId("WidthInput").props.value).toBe(30)
-        expect(getByTestId("HeightInput").props.value).toBe(20)
-        expect(getByTestId("DepthInput").props.value).toBe(40)
-        expect(getByTestId("NotesInput").props.value).toBe(undefined)
-        expect(getByText("1 photo added")).toBeTruthy()
+        expect(screen.getByTestId("TitleInput").props.value).toBe("Morons")
+        expect(screen.getByTestId("DateInput").props.value).toBe("2007")
+        expect(screen.getByTestId("MaterialsInput").props.value).toBe("Screen print")
+        expect(screen.getByTestId("WidthInput").props.value).toBe(30)
+        expect(screen.getByTestId("HeightInput").props.value).toBe(20)
+        expect(screen.getByTestId("DepthInput").props.value).toBe(40)
+        expect(screen.getByTestId("NotesInput").props.value).toBe(undefined)
+        expect(screen.getByText("1 photo added")).toBeTruthy()
 
         // Complete Form
 
-        fireEvent.press(getByTestId("CompleteButton"))
+        fireEvent.press(screen.getByTestId("CompleteButton"))
 
         await flushPromiseQueue()
 
@@ -159,7 +159,7 @@ describe("MyCollectionArtworkForm", () => {
 
         // debugger
 
-        const myCollectionArtworkFormDeleteArtworkModalQuery = mockOperations[0]
+        const myCollectionArtworkFormDeleteArtworkModalQuery = mockOperations[1]
         expect(myCollectionArtworkFormDeleteArtworkModalQuery.request.variables)
           .toMatchInlineSnapshot(`
           {
@@ -167,7 +167,7 @@ describe("MyCollectionArtworkForm", () => {
           }
         `)
 
-        const updatePreferencesOperation = mockOperations[1]
+        const updatePreferencesOperation = mockOperations[2]
         expect(updatePreferencesOperation.request.variables).toMatchInlineSnapshot(`
           {
             "input": {
@@ -177,7 +177,7 @@ describe("MyCollectionArtworkForm", () => {
           }
         `)
 
-        const createArtworkOperation = mockOperations[2]
+        const createArtworkOperation = mockOperations[3]
         expect(createArtworkOperation.request.variables).toMatchInlineSnapshot(`
           {
             "input": {
@@ -214,7 +214,7 @@ describe("MyCollectionArtworkForm", () => {
 
     describe("when skipping the artwork selection", () => {
       it("leaves the form empty", async () => {
-        const { getByText, getByTestId, getByPlaceholderText } = renderWithHookWrappersTL(
+        renderWithHookWrappersTL(
           <MyCollectionArtworkFormScreen mode="add" source={Tab.collection} />,
           mockEnvironment
         )
@@ -230,9 +230,9 @@ describe("MyCollectionArtworkForm", () => {
 
         // Select Artist Screen
 
-        expect(getByText("Select an Artist")).toBeTruthy()
+        expect(screen.getByText("Select an Artist")).toBeTruthy()
 
-        fireEvent.changeText(getByPlaceholderText("Search for artists on Artsy"), "banksy")
+        fireEvent.changeText(screen.getByPlaceholderText("Search for artists on Artsy"), "banksy")
 
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({
@@ -243,15 +243,15 @@ describe("MyCollectionArtworkForm", () => {
 
         await flushPromiseQueue()
 
-        fireEvent.press(getByTestId("autosuggest-search-result-Banksy"))
+        fireEvent.press(screen.getByTestId("autosuggest-search-result-Banksy"))
 
         await flushPromiseQueue()
 
         // Select Artwork Screen
 
-        expect(getByText("Select an Artwork")).toBeTruthy()
+        expect(screen.getByText("Select an Artwork")).toBeTruthy()
 
-        fireEvent.changeText(getByPlaceholderText("Search artworks"), "Test Artwork Title")
+        fireEvent.changeText(screen.getByPlaceholderText("Search artworks"), "Test Artwork Title")
 
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({
@@ -262,27 +262,27 @@ describe("MyCollectionArtworkForm", () => {
 
         await flushPromiseQueue()
 
-        fireEvent.press(getByTestId("my-collection-artwork-form-artwork-skip-button"))
+        fireEvent.press(screen.getByTestId("my-collection-artwork-form-artwork-skip-button"))
 
         await flushPromiseQueue()
 
         // Edit Details Screen
 
-        expect(getByText("Add Details")).toBeTruthy()
+        expect(screen.getByText("Add Details")).toBeTruthy()
 
-        expect(getByTestId("TitleInput").props.value).toBe("Test Artwork Title")
-        expect(getByTestId("DateInput").props.value).toBe(undefined)
-        expect(getByTestId("MaterialsInput").props.value).toBe(undefined)
-        expect(getByTestId("WidthInput").props.value).toBe(undefined)
-        expect(getByTestId("HeightInput").props.value).toBe(undefined)
-        expect(getByTestId("DepthInput").props.value).toBe(undefined)
-        expect(getByTestId("NotesInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("TitleInput").props.value).toBe("Test Artwork Title")
+        expect(screen.getByTestId("DateInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("MaterialsInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("WidthInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("HeightInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("DepthInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("NotesInput").props.value).toBe(undefined)
       })
     })
 
     describe("when skipping the artist selection", () => {
       it("initializes the artist name input field", async () => {
-        const { getByText, getByTestId, getByPlaceholderText } = renderWithHookWrappersTL(
+        renderWithHookWrappersTL(
           <MyCollectionArtworkFormScreen mode="add" source={Tab.collection} />,
           mockEnvironment
         )
@@ -298,9 +298,9 @@ describe("MyCollectionArtworkForm", () => {
 
         // Select Artist Screen
 
-        expect(getByText("Select an Artist")).toBeTruthy()
+        expect(screen.getByText("Select an Artist")).toBeTruthy()
 
-        fireEvent.changeText(getByPlaceholderText("Search for artists on Artsy"), "foo bar")
+        fireEvent.changeText(screen.getByPlaceholderText("Search for artists on Artsy"), "foo bar")
 
         act(() =>
           mockEnvironment.mock.resolveMostRecentOperation({
@@ -309,33 +309,33 @@ describe("MyCollectionArtworkForm", () => {
           })
         )
 
-        fireEvent.press(getByTestId("my-collection-artwork-form-artist-skip-button"))
+        fireEvent.press(screen.getByTestId("my-collection-artwork-form-artist-skip-button"))
 
         await flushPromiseQueue()
 
         // Add Artist Screen
 
-        fireEvent.changeText(getByPlaceholderText("Artist Name"), "My Artist")
-        fireEvent.changeText(getByPlaceholderText("Nationality"), "bar foo")
+        fireEvent.changeText(screen.getByPlaceholderText("Artist Name"), "My Artist")
+        fireEvent.changeText(screen.getByPlaceholderText("Nationality"), "bar foo")
 
         await flushPromiseQueue()
 
-        fireEvent.press(getByTestId("submit-add-artist-button"))
+        fireEvent.press(screen.getByTestId("submit-add-artist-button"))
 
         await flushPromiseQueue()
 
         // Edit Details Screen
 
-        expect(getByText("Add Details")).toBeTruthy()
+        expect(screen.getByText("Add Details")).toBeTruthy()
 
-        expect(getByText("My Artist")).toBeTruthy()
-        expect(getByTestId("TitleInput").props.value).toBe("")
-        expect(getByTestId("DateInput").props.value).toBe(undefined)
-        expect(getByTestId("MaterialsInput").props.value).toBe(undefined)
-        expect(getByTestId("WidthInput").props.value).toBe(undefined)
-        expect(getByTestId("HeightInput").props.value).toBe(undefined)
-        expect(getByTestId("DepthInput").props.value).toBe(undefined)
-        expect(getByTestId("NotesInput").props.value).toBe(undefined)
+        expect(screen.getByText("My Artist")).toBeTruthy()
+        expect(screen.getByTestId("TitleInput").props.value).toBe("")
+        expect(screen.getByTestId("DateInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("MaterialsInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("WidthInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("HeightInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("DepthInput").props.value).toBe(undefined)
+        expect(screen.getByTestId("NotesInput").props.value).toBe(undefined)
       })
     })
   })
@@ -520,83 +520,83 @@ describe("MyCollectionArtworkForm", () => {
         })
       })
     })
-  })
 
-  describe("loading screens", () => {
-    afterEach(() => {
-      jest.clearAllMocks()
-    })
+    describe("loading screens", () => {
+      afterEach(() => {
+        jest.clearAllMocks()
+      })
 
-    it("displays saving artwork loading modal", async () => {
-      const assetCredentials = {
-        signature: "some-signature",
-        credentials: "some-credentials",
-        policyEncoded: "some-policy-encoded",
-        policyDocument: {
-          expiration: "some-expiration",
-          conditions: {
-            acl: "some-acl",
-            bucket: "some-bucket",
-            geminiKey: "some-gemini-key",
-            successActionStatus: "some-success-action-status",
+      it("displays saving artwork loading modal", async () => {
+        const assetCredentials = {
+          signature: "some-signature",
+          credentials: "some-credentials",
+          policyEncoded: "some-policy-encoded",
+          policyDocument: {
+            expiration: "some-expiration",
+            conditions: {
+              acl: "some-acl",
+              bucket: "some-bucket",
+              geminiKey: "some-gemini-key",
+              successActionStatus: "some-success-action-status",
+            },
           },
-        },
-      }
-      getGeminiCredentialsForEnvironmentMock.mockReturnValue(Promise.resolve(assetCredentials))
-      uploadFileToS3Mock.mockReturnValue(Promise.resolve("some-s3-url"))
+        }
+        getGeminiCredentialsForEnvironmentMock.mockReturnValue(Promise.resolve(assetCredentials))
+        uploadFileToS3Mock.mockReturnValue(Promise.resolve("some-s3-url"))
 
-      const { getByTestId, getByPlaceholderText } = renderWithHookWrappersTL(
-        <MyCollectionArtworkFormScreen mode="add" source={Tab.collection} />,
-        mockEnvironment
-      )
+        renderWithHookWrappersTL(
+          <MyCollectionArtworkFormScreen mode="add" source={Tab.collection} />,
+          mockEnvironment
+        )
 
-      act(() =>
-        mockEnvironment.mock.resolveMostRecentOperation({
-          errors: [],
-          data: mockCollectedArtistsResult,
-        })
-      )
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({
+            errors: [],
+            data: mockCollectedArtistsResult,
+          })
+        )
 
-      await flushPromiseQueue()
+        await flushPromiseQueue()
 
-      // Select Artist Screen
+        // Select Artist Screen
 
-      fireEvent.changeText(getByPlaceholderText("Search for artists on Artsy"), "banksy")
-      act(() =>
-        mockEnvironment.mock.resolveMostRecentOperation({
-          errors: [],
-          data: mockArtistSearchResult,
-        })
-      )
-      await flushPromiseQueue()
+        fireEvent.changeText(screen.getByPlaceholderText("Search for artists on Artsy"), "banksy")
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({
+            errors: [],
+            data: mockArtistSearchResult,
+          })
+        )
+        await flushPromiseQueue()
 
-      fireEvent.press(getByTestId("autosuggest-search-result-Banksy"))
+        fireEvent.press(screen.getByTestId("autosuggest-search-result-Banksy"))
 
-      await flushPromiseQueue()
+        await flushPromiseQueue()
 
-      // Select Artwork Screen
+        // Select Artwork Screen
 
-      fireEvent.changeText(getByPlaceholderText("Search artworks"), "banksy")
-      act(() =>
-        mockEnvironment.mock.resolveMostRecentOperation({
-          errors: [],
-          data: mockArtworkSearchResult,
-        })
-      )
-      fireEvent.press(getByTestId("artworkGridItem-Morons"))
+        fireEvent.changeText(screen.getByPlaceholderText("Search artworks"), "banksy")
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({
+            errors: [],
+            data: mockArtworkSearchResult,
+          })
+        )
+        fireEvent.press(screen.getByTestId("artworkGridItem-Morons"))
 
-      act(() =>
-        mockEnvironment.mock.resolveMostRecentOperation({ errors: [], data: mockArtworkResult })
-      )
+        act(() =>
+          mockEnvironment.mock.resolveMostRecentOperation({ errors: [], data: mockArtworkResult })
+        )
 
-      await flushPromiseQueue()
+        await flushPromiseQueue()
 
-      // Complete Form
-      fireEvent.press(getByTestId("CompleteButton"))
+        // Complete Form
+        fireEvent.press(screen.getByTestId("CompleteButton"))
 
-      await flushPromiseQueue()
+        await flushPromiseQueue()
 
-      expect(getByTestId("saving-artwork-modal")).toBeDefined()
+        expect(screen.getByTestId("saving-artwork-modal")).toBeDefined()
+      })
     })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
@@ -1,10 +1,9 @@
 import { ActionType, ContextModule, OwnerType, TappedSkip } from "@artsy/cohesion"
-import { Spacer } from "@artsy/palette-mobile"
+import { Flex, Spacer } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { MyCollectionArtworkFormArtworkQuery } from "__generated__/MyCollectionArtworkFormArtworkQuery.graphql"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import LoadingModal from "app/Components/Modals/LoadingModal"
-import { ScreenMargin } from "app/Scenes/MyCollection/Components/ScreenMargin"
 import { ArtistSearchResult } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult"
 import { ArtworkAutosuggest } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest"
 import { useArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm"
@@ -14,7 +13,6 @@ import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { getAttributionClassValueByName } from "app/utils/artworkRarityClassifications"
 import { omit, pickBy } from "lodash"
 import React, { useEffect, useState } from "react"
-import { ScrollView } from "react-native"
 import { fetchQuery, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -82,13 +80,19 @@ export const MyCollectionArtworkFormArtwork: React.FC<
     GlobalStore.actions.myCollection.artwork.updateFormValues({
       title: artworkTitle,
     })
-    trackEvent(
-      tracks.tappedOnSkip(
-        formik.values.artistSearchResult?.internalID!,
-        formik.values.artistSearchResult?.slug!,
-        "Skip choosing artwork"
+
+    if (
+      !!formik.values.artistSearchResult?.internalID &&
+      !!formik.values.artistSearchResult?.slug
+    ) {
+      trackEvent(
+        tracks.tappedOnSkip(
+          formik.values.artistSearchResult.internalID,
+          formik.values.artistSearchResult.slug,
+          "Skip choosing artwork"
+        )
       )
-    )
+    }
 
     requestAnimationFrame(() => {
       GlobalStore.actions.myCollection.artwork.updateFormValues({
@@ -115,15 +119,13 @@ export const MyCollectionArtworkFormArtwork: React.FC<
       >
         Select an Artwork
       </FancyModalHeader>
-      <ScrollView keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
-        <ScreenMargin>
-          {!!formik.values.artistSearchResult && (
-            <ArtistSearchResult result={formik.values.artistSearchResult} />
-          )}
-          <Spacer y={2} />
-          <ArtworkAutosuggest onResultPress={updateFormValues} onSkipPress={onSkip} />
-        </ScreenMargin>
-      </ScrollView>
+      <Flex flex={1} px={2}>
+        {!!formik.values.artistSearchResult && (
+          <ArtistSearchResult result={formik.values.artistSearchResult} />
+        )}
+        <Spacer y={2} />
+        <ArtworkAutosuggest onResultPress={updateFormValues} onSkipPress={onSkip} />
+      </Flex>
       <LoadingModal isVisible={loading} />
     </>
   )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Refactors the autosuggest results on adding an artwork in my collection to use MasonryFlashList.

No changes are expected ui wise.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Replace artwork autosuggest results with Masonry - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
