### PR TITLE
fix: extract artist series title for alert criteria pills

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/helpers.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/helpers.tests.ts
@@ -1,5 +1,5 @@
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { clearDefaultAttributes } from "./helpers"
+import { clearDefaultAttributes, inferSeriesName } from "./helpers"
 
 describe("clearDefaultAttributes", () => {
   it("should remove all default values", () => {
@@ -17,6 +17,46 @@ describe("clearDefaultAttributes", () => {
       sizes: ["SMALL", "MEDIUM"],
       atAuction: true,
       artistIDs: ["artistID"],
+    })
+  })
+})
+
+describe(inferSeriesName, () => {
+  // cases where this workaround will succeed in removing the artist name (>90% of series)
+  const goodCases: [string, string, string[]][] = [
+    // common case
+    ["yayoi-kusama-pumpkins", "Pumpkins", ["Yayoi Kusama"]],
+    // capitalization
+    ["sol-lewitt-cubes", "Cubes", ["Sol LeWitt"]],
+    // diacritics
+    ["joan-miro-etchings", "Etchings", ["Joan Miró"]],
+    // hyphen
+    ["pierre-auguste-renoir-portraits", "Portraits", ["Pierre-Auguste Renoir"]],
+    // @ symbol
+    ["be-at-rbrick-andy-warhol", "Andy Warhol", ["BE@RBRICK"]],
+  ]
+
+  // cases where this workaround will fail to remove the artist name (<10% of series)
+  const badCases: [string, string, string[]][] = [
+    // Unusual capitalization in series name
+    ["kaws-bff", "BFF", ["KAWS"]],
+    // Non-latin characters in artist name, transliterated in slug
+    ["zao-wou-ki-zhao-wu-ji-etchings", "Etchings", ["Zao Wou-Ki 趙無極"]],
+    // Punctuation in series title, not present in slug
+    ["invader-rubiks-cubes", "Rubik’s Cubes", ["Invader"]],
+  ]
+
+  it("should return a properly formatted series name", () => {
+    //
+    goodCases.forEach(([slug, title, names]) => {
+      names.forEach((name) => {
+        expect(inferSeriesName(slug, [name])).toEqual(title)
+      })
+    })
+    badCases.forEach(([slug, title, names]) => {
+      names.forEach((name) => {
+        expect(inferSeriesName(slug, [name])).not.toEqual(title)
+      })
     })
   })
 })

--- a/src/app/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/app/Scenes/SavedSearchAlert/helpers.ts
@@ -1,3 +1,4 @@
+import { toTitleCase } from "@artsy/to-title-case"
 import { cmToIn, inToCm, parseRange } from "app/Components/ArtworkFilter/Filters/helpers"
 import {
   SearchCriteria,
@@ -246,4 +247,42 @@ export const localizeHeightAndWidthAttributes = ({
   }
 
   return localizedAttributes
+}
+
+export const inferSeriesName = (seriesValue: string, artistNames: string[]) => {
+  let label = seriesValue.replaceAll("-", " ")
+  artistNames.forEach((artistName) => {
+    artistName = artistName
+      .replace(/[-'()@àáâãäéíóöúüćōș’\.]/g, (m): string => {
+        return (
+          {
+            "-": " ",
+            "'": "",
+            "(": "",
+            ")": "",
+            ".": "",
+            "’": "",
+            "@": " at ",
+            à: "a",
+            á: "a",
+            â: "a",
+            ã: "a",
+            ä: "a",
+            é: "e",
+            í: "i",
+            ó: "o",
+            ö: "o",
+            ú: "u",
+            ü: "u",
+            ć: "c",
+            ō: "o",
+            ș: "s",
+          }[m] || ""
+        )
+      })
+      .trim()
+    label = label.replace(new RegExp(`${artistName}`, "i"), "")
+  })
+  label = toTitleCase(label.replace(/\s\s+/, " ").trim())
+  return label
 }

--- a/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
+++ b/src/app/Scenes/SavedSearchAlert/pillExtractors.tests.ts
@@ -1,5 +1,7 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Aggregations } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import {
+  SavedSearchEntity,
   SavedSearchEntityArtist,
   SearchCriteria,
   SearchCriteriaAttributes,
@@ -88,7 +90,7 @@ describe("extractPillsFromCriteria", () => {
       colors: ["unknown-color"],
     }
 
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     const pills = [
       {
@@ -141,7 +143,7 @@ describe("extractPillsFromCriteria", () => {
       offerable: true,
       atAuction: true,
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     const pills = [
       {
@@ -165,7 +167,7 @@ describe("extractPillsFromCriteria", () => {
     }
 
     // with unit inches
-    const inResult = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const inResult = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(inResult).toEqual([
       {
@@ -181,7 +183,7 @@ describe("extractPillsFromCriteria", () => {
     ])
 
     // with unit centimeters
-    const cmResult = extractPillsFromCriteria({ attributes, aggregations, unit: "cm" })
+    const cmResult = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "cm" })
 
     expect(cmResult).toEqual([
       {
@@ -201,7 +203,7 @@ describe("extractPillsFromCriteria", () => {
     const attributes: SearchCriteriaAttributes = {
       majorPeriods: ["2020", "2010"],
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -221,7 +223,7 @@ describe("extractPillsFromCriteria", () => {
     const attributes: SearchCriteriaAttributes = {
       colors: ["pink", "orange"],
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -241,7 +243,7 @@ describe("extractPillsFromCriteria", () => {
     const attributes: SearchCriteriaAttributes = {
       attributionClass: ["unique"],
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -256,7 +258,7 @@ describe("extractPillsFromCriteria", () => {
     const attributes: SearchCriteriaAttributes = {
       additionalGeneIDs: ["painting", "work-on-paper"],
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -276,7 +278,7 @@ describe("extractPillsFromCriteria", () => {
     const attributes: SearchCriteriaAttributes = {
       priceRange: "1000-1500",
     }
-    const result = extractPillsFromCriteria({ attributes, aggregations, unit: "in" })
+    const result = extractPillsFromCriteria({ attributes, aggregations, entity, unit: "in" })
 
     expect(result).toEqual([
       {
@@ -333,6 +335,11 @@ const firstArtist: SavedSearchEntityArtist = {
 const secondArtist: SavedSearchEntityArtist = {
   id: "secondArtistId",
   name: "secondArtistName",
+}
+
+const entity: SavedSearchEntity = {
+  artists: [firstArtist],
+  owner: { type: OwnerType.artist, slug: "first-artist", id: firstArtist.id },
 }
 
 const aggregations: Aggregations = [


### PR DESCRIPTION
This PR resolves [ONYX-634] <!-- eg [PROJECT-XXXX] -->

### Description

This implements @olerichter00 's suggestion for a workaround for better parsing of artist series titles from slugs.

Works as follows…

```ts
inferSeriesName("yayoi-kusama-pumpkins", ["Yayoi Kusama"])
// => "Pumpkins"
```

This is not the ideal solution, but a short-term expedient solution. Better long-term would be to make this work [as Force does](https://github.com/artsy/eigen/pull/9691#pullrequestreview-1803800447).



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- improve logic for inferring artists series titles in alert criteria pills

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-634]: https://artsyproduct.atlassian.net/browse/ONYX-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ