### PR TITLE
chore: change skeleton text for partners so as to not refer to a specific gallery

### DIFF
--- a/src/app/Scenes/Partner/Partner.tsx
+++ b/src/app/Scenes/Partner/Partner.tsx
@@ -179,7 +179,7 @@ export const PartnerSkeleton: React.FC = () => {
       <Screen.Body fullwidth>
         <Skeleton>
           <Flex px={2} flexDirection="column">
-            <SkeletonText variant="xl">Gagosian Gal</SkeletonText>
+            <SkeletonText variant="xl">Gallery Name</SkeletonText>
 
             <Spacer y={1} />
 


### PR DESCRIPTION
### Description

I noticed when loading a partner screen in Android the text `Gagosian Gal` flash up for 2-3 seconds until the actual gallery name populated. That would annoy me greatly if I was a gallery. As a user it was merely confusing. This just 
changes the placeholder text to not refer to a specific gallery.

#no-changelog

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
