### PR TITLE
fix: more defensive markdown links mailto #trivial

### DIFF
--- a/src/app/Components/ReadMore.tsx
+++ b/src/app/Components/ReadMore.tsx
@@ -84,7 +84,7 @@ export const ReadMore = React.memo(
         ) => {
           state.withinText = true
           const openUrl = (url: string) => {
-            if (node.target.startsWith("mailto:")) {
+            if (node?.target?.startsWith("mailto:")) {
               sendEmailWithMailTo(url)
             } else if (presentLinksModally) {
               navigate(url, { modal: true })

--- a/src/app/utils/renderMarkdown.tsx
+++ b/src/app/utils/renderMarkdown.tsx
@@ -47,7 +47,7 @@ export function defaultRules({
       react: (node, output, state) => {
         state.withinText = true
         const openUrl = (url: string) => {
-          if (node.target.startsWith("mailto:")) {
+          if (node?.target?.startsWith("mailto:")) {
             sendEmailWithMailTo(url)
           } else if (modal) {
             navigate(url, { modal: true })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Solves the [sentry issue](https://artsynet.sentry.io/issues/4774030999/events/fa2ed8bf06f54fd399ad6749d7eb7625/) where `if (node.target.startsWith("mailto:")) {` wasn't defensive

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>
#nochangelog