### PR TITLE
fix: hideSaveIcon from artwork autosuggest myc

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
@@ -1,4 +1,13 @@
-import { Box, Flex, Spinner, Text, quoteLeft, quoteRight, useSpace } from "@artsy/palette-mobile"
+import {
+  Box,
+  Flex,
+  Spacer,
+  Spinner,
+  Text,
+  quoteLeft,
+  quoteRight,
+  useSpace,
+} from "@artsy/palette-mobile"
 import { MasonryFlashList } from "@shopify/flash-list"
 import { ArtworkAutosuggestResultsContainerQuery } from "__generated__/ArtworkAutosuggestResultsContainerQuery.graphql"
 import { ArtworkAutosuggestResults_viewer$data } from "__generated__/ArtworkAutosuggestResults_viewer.graphql"
@@ -70,7 +79,9 @@ const ArtworkAutosuggestResults: React.FC<ArtworkAutosuggestResultsProps> = ({
           <Flex my={4} flexDirection="row" justifyContent="center">
             <Spinner />
           </Flex>
-        ) : null
+        ) : (
+          <Spacer y={6} />
+        )
       }
       ListEmptyComponent={
         <Box pt={4}>
@@ -98,6 +109,7 @@ const ArtworkAutosuggestResults: React.FC<ArtworkAutosuggestResultsProps> = ({
             mt={2}
           >
             <ArtworkGridItem
+              hideSaveIcon
               itemIndex={index}
               contextScreenQuery={keyword}
               artwork={item}

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -159,7 +159,7 @@ describe("MyCollectionArtworkForm", () => {
 
         // debugger
 
-        const myCollectionArtworkFormDeleteArtworkModalQuery = mockOperations[1]
+        const myCollectionArtworkFormDeleteArtworkModalQuery = mockOperations[0]
         expect(myCollectionArtworkFormDeleteArtworkModalQuery.request.variables)
           .toMatchInlineSnapshot(`
           {
@@ -167,7 +167,7 @@ describe("MyCollectionArtworkForm", () => {
           }
         `)
 
-        const updatePreferencesOperation = mockOperations[2]
+        const updatePreferencesOperation = mockOperations[1]
         expect(updatePreferencesOperation.request.variables).toMatchInlineSnapshot(`
           {
             "input": {
@@ -177,7 +177,7 @@ describe("MyCollectionArtworkForm", () => {
           }
         `)
 
-        const createArtworkOperation = mockOperations[3]
+        const createArtworkOperation = mockOperations[2]
         expect(createArtworkOperation.request.variables).toMatchInlineSnapshot(`
           {
             "input": {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Removes the save icon from the icons of the autosuggest - [Mobile QA ticket](https://www.notion.so/artsy/MyCollection-autosuggest-artworks-grid-shows-save-artwork-button-we-dont-want-that-3f8aae74f5224541b0bf3b730214a87b?pvs=4)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- hideSaveIcon from artwork autosuggest myc - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
