### PR TITLE
fix(ONYX-648): allow saving alerts after tapping on a suggested filter

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -82,13 +82,6 @@ export const Form: React.FC<FormProps> = ({
     isSaveAlertButtonDisabled = true
   }
 
-  // If the saved search alert doesn't have a name, a user can click the save button without any changes.
-  // This situation is possible if a user created an alert in Saved Search V1,
-  // since we didn't have the opportunity to specify custom name for the alert
-  if (isEditMode && !dirty && values.name.length === 0) {
-    isSaveAlertButtonDisabled = false
-  }
-
   // Enable "Save Alert" button if the user has removed the filters or changed data
   if (hasChangedFilters || dirty) {
     isSaveAlertButtonDisabled = false

--- a/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPill.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/SavedSearchFilterPill.tsx
@@ -11,7 +11,7 @@ export const SavedSearchFilterPill: React.FC<PillProps> = (props) => {
         props.onPress?.()
       }
     },
-    200,
+    __TEST__ ? 0 : 200,
     [selected]
   )
 

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tests.tsx
@@ -583,17 +583,6 @@ describe("SavedSearchAlertForm", () => {
         expect(screen.getByTestId("save-alert-button")).toBeDisabled()
       })
 
-      it("should be enabled if alert doesn't have name", () => {
-        renderWithWrappers(
-          <TestRenderer
-            savedSearchAlertId="savedSearchAlertId"
-            initialValues={{ ...baseProps.initialValues, name: "" }}
-          />
-        )
-
-        expect(screen.getByTestId("save-alert-button")).not.toBeDisabled()
-      })
-
       it("should be enabled if changes have been made by the user", () => {
         renderWithWrappers(
           <TestRenderer

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchStore.tsx
@@ -67,6 +67,7 @@ export const savedSearchModel: SavedSearchModel = {
       state.attributes[payload.key] = payload.value === "*-*" ? null : payload.value
     } else {
       state.attributes[payload.key] = payload.value as unknown as null | undefined
+      state.dirty = true
     }
   }),
 
@@ -91,6 +92,7 @@ export const savedSearchModel: SavedSearchModel = {
 
   setAttributeAction: action((state, payload) => {
     state.attributes[payload.key] = payload.value
+    state.dirty = true
   }),
 
   setUnitAction: action((state, payload) => {


### PR DESCRIPTION
This PR resolves [ONYX-648] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue affecting the edit alert screen. When the user taps on a suggested filter, it should be possible for them to save an alert.

**Before: Broken behaviour**

https://github.com/artsy/eigen/assets/11945712/02ee7361-5896-49af-9754-859f38bb7523


**After: Expected behaviour**

https://github.com/artsy/eigen/assets/11945712/ea6a4b35-c15d-445c-9ab1-dce137d41f28


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- allow saving alerts after tapping on a suggested filter - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-648]: https://artsyproduct.atlassian.net/browse/ONYX-648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ