### PR TITLE
fix: broken pod-install command

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -40,6 +40,8 @@ When updating to rn-0.69.10 we had to patch this due to kotlin version missmatch
 
 ## react-native patch
 
+### react-native prop-types patch
+
 #### When can we remove this:
 
 When we upgrade our deps to a version of react-native that includes removal of deprecated PropTypes.
@@ -47,6 +49,16 @@ When we upgrade our deps to a version of react-native that includes removal of d
 #### Explanation/Context:
 
 When updating to rn-0.69.10 we had to patch this due to deprecation of PropTypes. For this reason we also installed `deprecated-react-native-prop-types` to avoid errors and we patched the `react-native` package to use the deprecated PropTypes coming from the `deprecated-react-native-prop-types` package.
+
+### react-native boost.podspec patch
+
+#### When can we remove this:
+
+When react-native points to the right `boost.podspec` file.
+
+#### Explanation/Context:
+
+JFrog has been having issues lately and it's been causing those instances. More details here: https://github.com/facebook/react-native/issues/42180
 
 ## deprecated-react-native-prop-types dependency
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1309,7 +1309,7 @@ SPEC CHECKSUMS:
   appcenter-core: e192ea8b373bebd3e44998882b43311078bd7dda
   AppCenterReactNativeShared: 01df23849b1c3c6eb8c4049f54322635650e98f0
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da

--- a/patches/react-native+0.72.7.patch
+++ b/patches/react-native+0.72.7.patch
@@ -46,3 +46,16 @@ index 7149c64..6939b48 100644
      return require('deprecated-react-native-prop-types').ViewPropTypes;
    },
  };
+diff --git a/node_modules/react-native/third-party-podspecs/boost.podspec b/node_modules/react-native/third-party-podspecs/boost.podspec
+index 3d9331c..bbbb738 100644
+--- a/node_modules/react-native/third-party-podspecs/boost.podspec
++++ b/node_modules/react-native/third-party-podspecs/boost.podspec
+@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
+   spec.homepage = 'http://www.boost.org'
+   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+   spec.authors = 'Rene Rivera'
+-  spec.source = { :http => 'https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2',
++  spec.source = { :http => 'https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2',
+                   :sha256 => 'f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41' }
+ 
+   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
### Description

This PR comes as a fix to broken `pod update boost` command. This is coming from issues related `JFrog`. I did the workaround suggested by the community while we're waiting for this to get solved in RN.

![Screenshot 2024-01-08 at 14 52 51](https://github.com/artsy/eigen/assets/11945712/64da57f9-23ee-4aff-a9c8-c1f9b405bbcc)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Patch boost.podspec - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
