### PR TITLE
fix: wrong artwork image flashing onScoll

### DIFF
--- a/src/app/Scenes/NewWorksForYou/Components/NewWorksForYouList.tsx
+++ b/src/app/Scenes/NewWorksForYou/Components/NewWorksForYouList.tsx
@@ -1,5 +1,4 @@
 import { Flex, Text, useSpace } from "@artsy/palette-mobile"
-import { FlashList } from "@shopify/flash-list"
 import { NewWorksForYouListQuery } from "__generated__/NewWorksForYouListQuery.graphql"
 import { NewWorksForYouList_viewer$key } from "__generated__/NewWorksForYouList_viewer.graphql"
 import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
@@ -38,8 +37,7 @@ export const NewWorksForYouList: React.FC<NewWorksForYouListProps> = ({ viewer }
   })
   return (
     <Flex style={{ height: "100%" }}>
-      <AnimatedFlashlist
-        estimatedItemSize={400}
+      <Animated.FlatList
         data={artworks}
         keyExtractor={(item) => item.id}
         ListHeaderComponent={() => (
@@ -78,8 +76,6 @@ export const NewWorksForYouList: React.FC<NewWorksForYouListProps> = ({ viewer }
     </Flex>
   )
 }
-
-const AnimatedFlashlist = Animated.createAnimatedComponent(FlashList) as unknown as typeof FlashList
 
 const newWorksForYouListFragment = graphql`
   fragment NewWorksForYouList_viewer on Viewer


### PR DESCRIPTION
This PR resolves [ONYX-653] <!-- eg [PROJECT-XXXX] -->

### Description

This PR solves the following issue with the new works for you screen: When the user scrolls down, and starts seeing new artwork images, the image flashes and a wrong ones shows up initially. 

The fix, since this screen has no pagination logic and it only shows a small list of artworks, we can avoid this by using RN default `Flatlist` here.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- NWFY: fix wrong artwork image flashing onScoll - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-653]: https://artsyproduct.atlassian.net/browse/ONYX-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ