### PR TITLE
chore: adjust toast placement on screens without tab bar

### DIFF
--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Text, Touchable, useColor } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
-import { modules } from "app/AppRegistry"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { __unsafe_mainModalStackRef } from "app/NativeModules/ARScreenPresenterModule"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -64,6 +63,13 @@ export const ToastComponent = ({
   }, toastDuration)
 
   const toastBottomPadding = useMemo(() => {
+    // This is needed to avoid importing modules during tests
+    if (__TEST__) {
+      return TABBAR_HEIGHT
+    }
+
+    const { modules } = require("app/AppRegistry")
+
     const moduleName = __unsafe_mainModalStackRef.current?.getCurrentRoute()?.params // @ts-expect-error
       ?.moduleName as keyof typeof modules
 

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -1,9 +1,11 @@
 import { Box, Flex, Text, Touchable, useColor } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
+import { modules } from "app/AppRegistry"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
+import { __unsafe_mainModalStackRef } from "app/NativeModules/ARScreenPresenterModule"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useScreenDimensions } from "app/utils/hooks"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Animated } from "react-native"
 import useTimeoutFn from "react-use/lib/useTimeoutFn"
 import { ToastDetails, ToastDuration } from "./types"
@@ -61,7 +63,20 @@ export const ToastComponent = ({
     }).start(() => GlobalStore.actions.toast.remove(id))
   }, toastDuration)
 
-  const toastBottomPadding = bottomPadding ?? TABBAR_HEIGHT
+  const toastBottomPadding = useMemo(() => {
+    const moduleName = __unsafe_mainModalStackRef.current?.getCurrentRoute()?.params // @ts-expect-error
+      ?.moduleName as keyof typeof modules
+
+    const isBottomTabHidden = modules[moduleName].options.hidesBottomTabs
+
+    // We currently handle custom bottom padding only for when the bottom tab bar is hidden
+    // We can change this later if we need to handle custom bottom padding for when the bottom tab bar is visible
+    if (isBottomTabHidden) {
+      return bottomPadding || 0
+    }
+
+    return TABBAR_HEIGHT
+  }, [])
 
   if (placement === "middle") {
     const innerMiddle = (

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -67,7 +67,7 @@ export const ToastComponent = ({
     const moduleName = __unsafe_mainModalStackRef.current?.getCurrentRoute()?.params // @ts-expect-error
       ?.moduleName as keyof typeof modules
 
-    const isBottomTabHidden = modules[moduleName].options.hidesBottomTabs
+    const isBottomTabHidden = modules[moduleName]?.options?.hidesBottomTabs
 
     // We currently handle custom bottom padding only for when the bottom tab bar is hidden
     // We can change this later if we need to handle custom bottom padding for when the bottom tab bar is visible


### PR DESCRIPTION
This PR resolves [ONYX-655] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the toast placement on screens that hide the bottom tab.

**Logic:**
When toast positioning is set to `bottom` we always show it far from the bottom by `TAB_BAR_HEIGHT`. This is not accurate in some screens that have no tab bar. We fix that by returning `0` in case there is no bottom tab. In screens like the `Artwork` screen, we can also inject a custom value using `useArtworkListsContext` and dipatching a `SET_TOAST_BOTTOM_PADDING` action

Related PR: https://github.com/artsy/eigen/pull/9720

https://github.com/artsy/eigen/assets/11945712/88c4b758-c5ec-4240-91d5-902f52a2d421


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- adjust toast placement on screens without tab bar - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-655]: https://artsyproduct.atlassian.net/browse/ONYX-655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ