### PR TITLE
chore: do not throttle experiment_viewed events

### DIFF
--- a/docs/add_an_experiment.md
+++ b/docs/add_an_experiment.md
@@ -64,6 +64,14 @@ You can access the variant value in a functional react component using `useExper
   )
 ```
 
+### Tracking an experiment
+
+In order to track an experiment, you can use the `trackExperiment` helper that comes from `useExperimentVariant` hook,
+
+```diff
++ const { trackExperiment } = useExperimentVariant("our-new-experiment")
+```
+
 ## Removing/Killing an Experiment
 
 Once an experiment is done, usually we have a winner variant. In order to roll out that variant for everyone targeted by it, we will need to set it as a default strategy before "killing" it.

--- a/docs/add_an_experiment.md
+++ b/docs/add_an_experiment.md
@@ -31,7 +31,7 @@ or if we want a variant we can use something like
 
 _The `fallback*` values are values we would like to fall back to in case something goes wrong with the client sdk_
 
-Don't forget to add some tracking on this, using `maybeReportExperimentFlag`. Look for other examples in the code.
+Don't forget to add some tracking on this, using `reportExperimentVariant`. Look for other examples in the code.
 
 ## Using an experiment
 

--- a/src/app/utils/experiments/hooks.ts
+++ b/src/app/utils/experiments/hooks.ts
@@ -1,3 +1,4 @@
+import { ContextProps, reportExperimentVariant } from "app/utils/experiments/reporter"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useIsStaging } from "app/utils/hooks/useIsStaging"
 import { useContext, useEffect, useState } from "react"
@@ -20,6 +21,7 @@ export function useExperimentVariant(name: string): {
   enabled: boolean
   variant: string
   payload?: string
+  trackExperiment: (contextProps?: ContextProps) => void
 } {
   const client = getUnleashClient()
   const [enabled, setEnabled] = useState(client.isEnabled(name))
@@ -31,10 +33,24 @@ export function useExperimentVariant(name: string): {
     setVariant(client.getVariant(name))
   }, [lastUpdate])
 
+  const trackExperiment = (contextProps?: ContextProps) => {
+    if (!enabled) {
+      return
+    }
+
+    reportExperimentVariant({
+      experimentName: name,
+      variantName: variant?.name ?? "default-variant",
+      payload: variant?.payload?.value,
+      ...(contextProps as ContextProps),
+    })
+  }
+
   return {
     enabled: enabled ?? false,
     variant: variant?.name ?? "default-variant",
     payload: variant?.payload?.value,
+    trackExperiment,
   }
 }
 

--- a/src/app/utils/experiments/reporter.ts
+++ b/src/app/utils/experiments/reporter.ts
@@ -1,10 +1,7 @@
 import { ActionType, ContextModule, ExperimentViewed, OwnerType } from "@artsy/cohesion"
 import { postEventToProviders } from "app/utils/track/providers"
 
-interface TrackVariantArgs {
-  experimentName: string
-  variantName: string
-  payload?: string
+export interface ContextProps {
   context_module?: ContextModule
   context_owner_screen: OwnerType
   context_owner_id?: string
@@ -12,18 +9,14 @@ interface TrackVariantArgs {
   context_owner_type: OwnerType
 }
 
-export function reportExperimentVariant({
-  experimentName,
-  enabled,
-  variantName,
-  payload,
-  ...rest
-}: TrackVariantArgs & { enabled: boolean; storeContext?: boolean }) {
-  if (!enabled) {
-    return
-  }
+interface TrackVariantArgs extends ContextProps {
+  experimentName: string
+  variantName: string
+  payload?: string
+}
 
-  postEventToProviders(tracks.experimentVariant({ experimentName, variantName, payload, ...rest }))
+export function reportExperimentVariant(props: TrackVariantArgs) {
+  postEventToProviders(tracks.experimentVariant(props))
 }
 
 const tracks = {

--- a/src/app/utils/experiments/reporter.ts
+++ b/src/app/utils/experiments/reporter.ts
@@ -11,26 +11,17 @@ interface TrackVariantArgs {
   context_owner_slug?: string
   context_owner_type: OwnerType
 }
-const reportedExperimentVariants: Record<string, string> = {}
-export function maybeReportExperimentVariant({
+
+export function reportExperimentVariant({
   experimentName,
   enabled,
   variantName,
   payload,
-  // include context when storing the experiment variants
-  storeContext = false,
   ...rest
 }: TrackVariantArgs & { enabled: boolean; storeContext?: boolean }) {
-  let combinedValue = ""
-  if (!storeContext) {
-    combinedValue = `${enabled}-${variantName}-${payload}`
-  } else {
-    combinedValue = `${enabled}-${variantName}-${payload}-${rest.context_owner_screen}`
-  }
-  if (reportedExperimentVariants[experimentName] === combinedValue) {
+  if (!enabled) {
     return
   }
-  reportedExperimentVariants[experimentName] = `${combinedValue}`
 
   postEventToProviders(tracks.experimentVariant({ experimentName, variantName, payload, ...rest }))
 }


### PR DESCRIPTION
This PR resolves [ONYX-652] <!-- eg [PROJECT-XXXX] -->

### Description

This PR removes throttling from `ExperimentViewed` events. This comes as a request from Data.

**Bonus:**
To avoid injecting values that are already available in the hook context, I am not exporting the tracking helper within the same hook as we do in Force

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-652]: https://artsyproduct.atlassian.net/browse/ONYX-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ