### PR TITLE
chore: add A/B testing logic to NWFGYF and RecentlyViewed

### DIFF
--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
@@ -3,10 +3,13 @@ import { FullWidthIcon, GridIcon, Screen } from "@artsy/palette-mobile"
 import { NewWorksFromGalleriesYouFollowQR } from "app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
+import { useExperimentVariant } from "app/utils/experiments/hooks"
+import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { MotiPressable } from "moti/interactions"
+import { useEffect } from "react"
 import { isTablet } from "react-native-device-info"
 
 const SCREEN_TITLE = "New Works from Galleries You Follow"
@@ -14,10 +17,24 @@ const ICON_SIZE = 26
 
 export const NewWorksFromGalleriesYouFollowScreen: React.FC = () => {
   const enableArtworksFeedView = useFeatureFlag("AREnableArtworksFeedView")
+  const forceShowNewWorksForYouFeed = useDevToggle("DTForceShowNewWorksForYouScreenFeed")
+
+  const experiment = useExperimentVariant("onyx_new_works_for_you_feed")
+
   const defaultViewOption = GlobalStore.useAppState((state) => state.userPrefs.defaultViewOption)
   const setDefaultViewOption = GlobalStore.actions.userPrefs.setDefaultViewOption
 
-  const showToggleViewOptionIcon = !isTablet() && enableArtworksFeedView
+  useEffect(() => {
+    experiment.trackExperiment({
+      context_owner_type: OwnerType.newWorksFromGalleriesYouFollow,
+    })
+  }, [])
+
+  const showToggleViewOptionIcon =
+    !isTablet() &&
+    enableArtworksFeedView &&
+    experiment.enabled &&
+    (experiment.variant === "experiment" || forceShowNewWorksForYouFeed)
 
   return (
     <ProvideScreenTrackingWithCohesionSchema


### PR DESCRIPTION
This PR resolves [ONYX-690] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds the A/B testing logic to the new screens that support the feed view.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add A/B testing logic to NWFGYF and RecentlyViewed - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-690]: https://artsyproduct.atlassian.net/browse/ONYX-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ