### PR TITLE
fix: swap view mode icons on the NWFY and similar screens

### DIFF
--- a/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
+++ b/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
@@ -93,9 +93,9 @@ export const NewWorksForYouQueryRenderer: React.FC<NewWorksForYouQueryRendererPr
                 style={{ top: 5 }}
               >
                 {defaultViewOption === "grid" ? (
-                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
-                ) : (
                   <GridIcon height={ICON_SIZE} width={ICON_SIZE} />
+                ) : (
+                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
                 )}
               </MotiPressable>
             ) : undefined

--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tsx
@@ -53,9 +53,9 @@ export const NewWorksFromGalleriesYouFollowScreen: React.FC = () => {
                 style={{ top: 5 }}
               >
                 {defaultViewOption === "grid" ? (
-                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
-                ) : (
                   <GridIcon height={ICON_SIZE} width={ICON_SIZE} />
+                ) : (
+                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
                 )}
               </MotiPressable>
             ) : undefined

--- a/src/app/Scenes/RecentlyViewed/RecentlyViewed.tsx
+++ b/src/app/Scenes/RecentlyViewed/RecentlyViewed.tsx
@@ -53,9 +53,9 @@ export const RecentlyViewedScreen: React.FC = () => {
                 style={{ top: 5 }}
               >
                 {defaultViewOption === "grid" ? (
-                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
-                ) : (
                   <GridIcon height={ICON_SIZE} width={ICON_SIZE} />
+                ) : (
+                  <FullWidthIcon height={ICON_SIZE} width={ICON_SIZE} />
                 )}
               </MotiPressable>
             ) : undefined


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Swap icons on the NWFY and similar screens
[Slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1706283868890749) with discussion and before/after

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- swap view mode icons on the NWFY and similar screens - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
