### PR TITLE
fix: gallery locations copy + tests

### DIFF
--- a/src/app/Scenes/Partner/Components/PartnerLocationSection.tests.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerLocationSection.tests.tsx
@@ -1,7 +1,9 @@
+import { screen } from "@testing-library/react-native"
 import { PartnerLocationSectionTestQuery } from "__generated__/PartnerLocationSectionTestQuery.graphql"
+import { PartnerLocationSection_partner$data } from "__generated__/PartnerLocationSection_partner.graphql"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
-import { PartnerLocationSectionContainer } from "./PartnerLocationSection"
+import { PartnerLocationSectionContainer, createLocationsString } from "./PartnerLocationSection"
 
 describe("PartnerLoationSection", () => {
   const { renderWithRelay } = setupTestWrapper<PartnerLocationSectionTestQuery>({
@@ -16,7 +18,7 @@ describe("PartnerLoationSection", () => {
   })
 
   it("renders the locations text correctly", async () => {
-    const { queryByText } = renderWithRelay({
+    renderWithRelay({
       Partner: () => ({
         name: "Gagosian",
         locations: {
@@ -26,16 +28,76 @@ describe("PartnerLoationSection", () => {
       }),
     })
 
-    expect(queryByText(/Gagosian has 14 locations in/)).toBeTruthy()
+    expect(screen.getByText(/Gagosian has 14 locations in/)).toBeTruthy()
     expect(
-      queryByText(
+      screen.getByText(
         /New York, Beverly Hills, San Francisco, London, Paris, Le Bourget, Geneva, Basel, Rome, Athens/
       )
     ).toBeTruthy()
-    expect(queryByText(/and/)).toBeTruthy()
-    expect(queryByText(/Central, Hong Kong/)).toBeTruthy()
+    expect(screen.getByText(/and/)).toBeTruthy()
+    expect(screen.getByText(/Central, Hong Kong/)).toBeTruthy()
 
-    expect(queryByText("See all location details")).toBeTruthy()
+    expect(screen.getByText("See all location details")).toBeTruthy()
+  })
+})
+
+describe("createLocationsString", () => {
+  it("should return correct location string for single location", () => {
+    const partner: PartnerLocationSection_partner$data = {
+      name: "Test Partner",
+      slug: "test-partner",
+      locations: {
+        totalCount: 1,
+      },
+      cities: ["New York"],
+      " $fragmentType": "PartnerLocationSection_partner",
+    }
+
+    const result = createLocationsString(partner)
+
+    expect(result).toEqual({
+      locationText: "Test Partner has 1 location in",
+      cityText: "New York",
+    })
+  })
+
+  it("should return correct location string for multiple locations", () => {
+    const partner: PartnerLocationSection_partner$data = {
+      name: "Test Partner",
+      slug: "test-partner",
+      locations: {
+        totalCount: 3,
+      },
+      cities: ["New York", "Los Angeles", "Chicago"],
+      " $fragmentType": "PartnerLocationSection_partner",
+    }
+
+    const result = createLocationsString(partner)
+
+    expect(result).toEqual({
+      locationText: "Test Partner has 3 locations in",
+      cityText: "New York, Los Angeles",
+      lastCity: "Chicago",
+    })
+  })
+
+  it("should return correct location string for multiple locations with one city", () => {
+    const partner: PartnerLocationSection_partner$data = {
+      name: "Test Partner",
+      slug: "test-partner",
+      locations: {
+        totalCount: 3,
+      },
+      cities: ["New York"],
+      " $fragmentType": "PartnerLocationSection_partner",
+    }
+
+    const result = createLocationsString(partner)
+
+    expect(result).toEqual({
+      locationText: "Test Partner has 3 locations in",
+      cityText: "New York",
+    })
   })
 })
 

--- a/src/app/Scenes/Partner/Components/PartnerLocationSection.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerLocationSection.tsx
@@ -8,8 +8,8 @@ interface PartnerLocationSectionProps {
   partner: PartnerLocationSection_partner$data
 }
 
-const createLocationsString = (partner: PartnerLocationSection_partner$data) => {
-  const locationsCount = partner.locations?.totalCount
+export const createLocationsString = (partner: PartnerLocationSection_partner$data) => {
+  const locationsCount = partner.locations?.totalCount ?? 0
 
   let lastUniqCity
   const uniqCities = (partner.cities || []).slice(0)
@@ -21,7 +21,7 @@ const createLocationsString = (partner: PartnerLocationSection_partner$data) => 
   const joinedCities = uniqCities.join(", ")
 
   const locationCountText = `${partner.name} has ${locationsCount} ${
-    cityLength < 2 ? "location" : "locations"
+    locationsCount < 2 ? "location" : "locations"
   } in`
 
   return { locationText: locationCountText, cityText: joinedCities, lastCity: lastUniqCity }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

It was reported that when a gallery has 1 city and multiple locations we don't do the pluralization of the word `location` correctly. This PR addresses that.

Bug was reported in slack [here](https://artsy.slack.com/archives/C03N12SR0RK/p1706691425884869)

|Before|After|
|---|---|
|![IMG_8807](https://github.com/artsy/eigen/assets/21178754/c6688904-1e29-45b1-9375-338ec312cb93)|![Simulator Screenshot - iPhone 14 Pro - 2024-01-31 at 10 18 39](https://github.com/artsy/eigen/assets/21178754/007b5563-5771-439a-a910-ad761180e313)|
|![IMG_8806](https://github.com/artsy/eigen/assets/21178754/8ef6804c-fb03-49d8-a5c9-eb1a875e0a40)|![Simulator Screenshot - iPhone 14 Pro - 2024-01-31 at 10 18 11](https://github.com/artsy/eigen/assets/21178754/2a92ddbf-9326-4223-a0c2-8382a6859af3)|


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix pluralization on galleries location - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
