### PR TITLE
fix(onyx-724): hide partner show notifications with unpublished artwork

### DIFF
--- a/src/app/Scenes/Activity/utils/isArtworksBasedNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/isArtworksBasedNotification.tests.ts
@@ -7,6 +7,9 @@ describe("isArtworksBasedNotification", () => {
 
     const result2 = isArtworksBasedNotification("ARTWORK_PUBLISHED")
     expect(result2).toEqual(true)
+
+    const result3 = isArtworksBasedNotification("PARTNER_OFFER_CREATED")
+    expect(result3).toEqual(true)
   })
 
   it("returns false for all other notification types", () => {

--- a/src/app/Scenes/Activity/utils/isArtworksBasedNotification.ts
+++ b/src/app/Scenes/Activity/utils/isArtworksBasedNotification.ts
@@ -1,3 +1,3 @@
 export const isArtworksBasedNotification = (notificationType: string) => {
-  return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)
+  return ["ARTWORK_ALERT", "ARTWORK_PUBLISHED", "PARTNER_OFFER_CREATED"].includes(notificationType)
 }


### PR DESCRIPTION
This PR resolves [Onyx-724]

### Description

Do not show partner offers with unpublished artwork.
[Slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1707233138078489)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
