### PR TITLE
refactor: stop tracking request errors in sentry

### DIFF
--- a/src/app/system/relay/middlewares/helpers.ts
+++ b/src/app/system/relay/middlewares/helpers.ts
@@ -1,41 +1,14 @@
-import * as Sentry from "@sentry/react-native"
 import { GraphQLRequest } from "app/system/relay/middlewares/types"
 import { volleyClient } from "app/utils/volleyClient"
 import { Platform } from "react-native"
 import { getVersion } from "react-native-device-info"
-import {
-  createRequestError,
-  formatGraphQLErrors,
-  GraphQLResponseErrors,
-  RelayNetworkLayerResponse,
-} from "react-relay-network-modern"
+import { RelayNetworkLayerResponse, createRequestError } from "react-relay-network-modern"
 
 export const isErrorStatus = (status: number | undefined) => {
   return (status ?? 200) >= 400
 }
 
 export const throwError = (req: GraphQLRequest, res: RelayNetworkLayerResponse) => {
-  Sentry.withScope((scope) => {
-    scope.setExtra("kind", req.operation.operationKind)
-    scope.setExtra("query-name", req.operation.name)
-    scope.setExtra("query-text", req.operation.text)
-
-    if (res.errors) {
-      scope.setExtra("formatted-error", formatGraphQLErrors(req, res.errors))
-    }
-
-    if (req.variables) {
-      scope.setExtra("variables", req.variables as any)
-    }
-
-    const sentryFormattedError = createRequestError(req, res)
-
-    // All errors returned by createRequestError are titled "RRNLRequestError", this makes it hard to identify which
-    // issues we should pay attention to in the issues list until we open the issue page separately
-    // We want to fix that by changing that title into a properly formatted error
-    sentryFormattedError.name = formatName(req, res.errors)
-    Sentry.captureException(sentryFormattedError)
-  })
   throw createRequestError(req, res)
 }
 
@@ -55,25 +28,4 @@ export const trackError = (
       `appVersion: ${getVersion()}`,
     ],
   })
-}
-
-const formatName = (req: GraphQLRequest, errors?: GraphQLResponseErrors) => {
-  let errorName = "Generic Error - see metadata"
-  if (errors) {
-    errorName = shortError(errors)
-  }
-  const queryName = req.operation.name
-  const name = queryName + " - " + errorName
-  return name
-}
-
-const shortError = (errors: GraphQLResponseErrors) => {
-  const firstError = errors[0]
-  const errorRegex = /{"error":"(?<Message>.+)"}/
-  const found = firstError.message.match(errorRegex)
-  if (found && found.groups) {
-    return found.groups.Message
-  } else {
-    return "Generic Error - see metadata"
-  }
 }

--- a/src/app/system/relay/middlewares/principalFieldErrorHandlerMiddleware.ts
+++ b/src/app/system/relay/middlewares/principalFieldErrorHandlerMiddleware.ts
@@ -1,4 +1,3 @@
-import { captureMessage } from "@sentry/react-native"
 import { isErrorStatus, throwError, trackError } from "app/system/relay/middlewares/helpers"
 import { GraphQLRequest } from "app/system/relay/middlewares/types"
 import { RelayNetworkLayerResponse } from "react-relay-network-modern"
@@ -17,10 +16,9 @@ export const principalFieldErrorHandlerMiddleware = async (
     resJson.extensions?.principalField?.httpStatusCode
   )
 
-  // query did not have a principal field, but experienced an error, we report it to sentry and volley
+  // query did not have a principal field, but experienced an error, we report it to volley
   if (!requestHasPrincipalField && !!res?.errors?.length) {
     trackError(req.operation.name, req.operation.operationKind, "default")
-    captureMessage(`${req.operation.operationKind} failed: ${req.operation.name}`)
   }
 
   if (principalFieldWasInvolvedInError) {


### PR DESCRIPTION
This PR resolves [PHIRE-592] <!-- eg [PROJECT-XXXX] -->

### Description

This pr removes tracking network request errors on Sentry and keeps using volley (sends request failures to datadog). 

We **should** create [boards](https://app.datadoghq.com/dashboard/ib7-8gr-u6x/eigen-graphql-requests-with-errors?refresh_mode=sliding&view=spans&from_ts=1706702432300&to_ts=1707307232300&live=true) similar to these with important areas that we want to track when it comes to request errors in the mobile app.

This way the sentry dashboard will be clean with non-important and non-actionable request failures like 404s or 401s.

I believe that we won't have any issues with either wrong variables or schema changes since TS is our friend and will prevent us from having those issues, but even if these issues happen we can leverage the datadog dashboards to get insights or even **create alerts** and send them on the new `#mobile-alerts` channel.

> [!IMPORTANT]  
> This PR is a suggestion on how to move forwards, please raise your feedback in case you disagree.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- stop tracking request errors in sentry - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-592]: https://artsyproduct.atlassian.net/browse/PHIRE-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ