### PR TITLE
fix: size options height conversion

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlertForm.tsx
@@ -82,9 +82,8 @@ export const SavedSearchAlertForm: React.FC<SavedSearchAlertFormProps> = (props)
 
   const tracking = useTracking()
   const [visibleDeleteDialog, setVisibleDeleteDialog] = useState(false)
-  const [shouldShowEmailSubscriptionWarning, setShouldShowEmailSubscriptionWarning] = useState(
-    !userAllowsEmails
-  )
+  const [shouldShowEmailSubscriptionWarning, setShouldShowEmailSubscriptionWarning] =
+    useState(!userAllowsEmails)
   const navigation =
     useNavigation<NavigationProp<CreateSavedSearchAlertNavigationStack, "CreateSavedSearchAlert">>()
 

--- a/src/app/Scenes/SavedSearchAlert/helpers.ts
+++ b/src/app/Scenes/SavedSearchAlert/helpers.ts
@@ -243,7 +243,7 @@ export const localizeHeightAndWidthAttributes = ({
     const range = parseRange(localizedAttributes[SearchCriteria.height])
     const localizedMinHeight = convert(range.min, true, roundDigits)
     const localizedMaxHeight = convert(range.max, true, roundDigits)
-    localizedAttributes[SearchCriteria.width] = `${localizedMinHeight}-${localizedMaxHeight}`
+    localizedAttributes[SearchCriteria.height] = `${localizedMinHeight}-${localizedMaxHeight}`
   }
 
   return localizedAttributes


### PR DESCRIPTION
This PR resolves [ONYX-379] <!-- eg [PROJECT-XXXX] -->

### Description

**Before**

https://github.com/artsy/eigen/assets/11945712/e0ebe4ef-9778-4c75-b4cf-e742946b907b


**After**

https://github.com/artsy/eigen/assets/11945712/bea17f84-6f3d-40cb-aad9-e4ba784671a8


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix size options height conversion - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-379]: https://artsyproduct.atlassian.net/browse/ONYX-379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ