### PR TITLE
fix(onyx-756): hide unpublished viewing room / editorial notifications from activity panel

### DIFF
--- a/src/app/Scenes/Activity/Activity.tests.tsx
+++ b/src/app/Scenes/Activity/Activity.tests.tsx
@@ -127,6 +127,11 @@ const notifications = {
       node: {
         title: "Notification One",
         notificationType: "VIEWING_ROOM_PUBLISHED",
+        item: {
+          viewingRoomsConnection: {
+            totalCount: 1,
+          },
+        },
       },
     },
     {

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -131,7 +131,6 @@ const notificationsConnectionFragment = graphql`
           artworks: artworksConnection {
             totalCount
           }
-          ...ActivityItem_notification
           item {
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {
@@ -145,6 +144,7 @@ const notificationsConnectionFragment = graphql`
               }
             }
           }
+          ...ActivityItem_notification
         }
       }
     }

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -2,6 +2,10 @@ import { Flex, Screen, Separator, Spinner, Tabs } from "@artsy/palette-mobile"
 import { ActivityList_me$key } from "__generated__/ActivityList_me.graphql"
 import { ActivityList_viewer$key } from "__generated__/ActivityList_viewer.graphql"
 
+import {
+  shouldDisplayNotification,
+  Notification,
+} from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { useState } from "react"
@@ -11,7 +15,6 @@ import { ActivityEmptyView } from "./ActivityEmptyView"
 import { ActivityItem } from "./ActivityItem"
 import { ActivityMarkAllAsReadSection } from "./ActivityMarkAllAsReadSection"
 import { NotificationType } from "./types"
-import { isArtworksBasedNotification } from "./utils/isArtworksBasedNotification"
 
 interface ActivityListProps {
   viewer: ActivityList_viewer$key | null | undefined
@@ -36,14 +39,9 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
   const hasUnreadNotifications = (meData?.unreadNotificationsCount ?? 0) > 0
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter((notification) => {
-    if (isArtworksBasedNotification(notification.notificationType)) {
-      const artworksCount = notification.artworks?.totalCount ?? 0
-      return artworksCount > 0
-    }
-
-    return true
-  })
+  const notifications = notificationsNodes.filter((notification) =>
+    shouldDisplayNotification(notification as Notification)
+  )
 
   const handleLoadMore = () => {
     if (!hasNext || isLoadingNext) {
@@ -134,6 +132,19 @@ const notificationsConnectionFragment = graphql`
             totalCount
           }
           ...ActivityItem_notification
+          item {
+            ... on ViewingRoomPublishedNotificationItem {
+              viewingRoomsConnection(first: 1) {
+                totalCount
+              }
+            }
+
+            ... on ArticleFeaturedArtistNotificationItem {
+              article {
+                internalID
+              }
+            }
+          }
         }
       }
     }

--- a/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
@@ -1,0 +1,73 @@
+import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
+
+describe("shouldDisplayNotification", () => {
+  it("returns true when notification satisfies conditions", () => {
+    // artwork based notifications have artworks
+    const result = shouldDisplayNotification({
+      notificationType: "ARTWORK_ALERT",
+      artworks: { totalCount: 1 },
+    })
+    expect(result).toEqual(true)
+
+    const result2 = shouldDisplayNotification({
+      notificationType: "ARTWORK_PUBLISHED",
+      artworks: { totalCount: 1 },
+    })
+    expect(result2).toEqual(true)
+
+    const result3 = shouldDisplayNotification({
+      notificationType: "PARTNER_OFFER_CREATED",
+      artworks: { totalCount: 1 },
+    })
+    expect(result3).toEqual(true)
+
+    // viewing room notification has viewing rooms
+    const result4 = shouldDisplayNotification({
+      notificationType: "VIEWING_ROOM_PUBLISHED",
+      item: { viewingRoomsConnection: { totalCount: 1 } },
+    })
+    expect(result4).toEqual(true)
+
+    // editorial notification has article
+    const result5 = shouldDisplayNotification({
+      notificationType: "ARTICLE_FEATURED_ARTIST",
+      item: { article: { internalID: 1 } },
+    })
+    expect(result5).toEqual(true)
+  })
+
+  it("returns false when notification does not satisfy conditions", () => {
+    // artwork based notifications have no artworks
+    const result = shouldDisplayNotification({
+      notificationType: "ARTWORK_ALERT",
+      artworks: { totalCount: 0 },
+    })
+    expect(result).toEqual(false)
+
+    const result2 = shouldDisplayNotification({
+      notificationType: "ARTWORK_PUBLISHED",
+      artworks: { totalCount: 0 },
+    })
+    expect(result2).toEqual(false)
+
+    const result3 = shouldDisplayNotification({
+      notificationType: "PARTNER_OFFER_CREATED",
+      artworks: { totalCount: 0 },
+    })
+    expect(result3).toEqual(false)
+
+    // viewing room notification has no viewing rooms
+    const result4 = shouldDisplayNotification({
+      notificationType: "VIEWING_ROOM_PUBLISHED",
+      item: { viewingRoomsConnection: { totalCount: 0 } },
+    })
+    expect(result4).toEqual(false)
+
+    // editorial notification has no article
+    const result5 = shouldDisplayNotification({
+      notificationType: "ARTICLE_FEATURED_ARTIST",
+      item: {},
+    })
+    expect(result5).toEqual(false)
+  })
+})

--- a/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
+++ b/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
@@ -1,0 +1,28 @@
+import { isArtworksBasedNotification } from "app/Scenes/Activity/utils/isArtworksBasedNotification"
+
+export interface Notification {
+  notificationType?: string | null
+  artworks?: { totalCount?: number | null } | null
+  item?: {
+    viewingRoomsConnection?: { totalCount?: number | null } | null
+    article?: { internalID?: number | null } | null
+  } | null
+}
+
+export const shouldDisplayNotification = (notification: Notification) => {
+  if (isArtworksBasedNotification(notification?.notificationType ?? "")) {
+    const artworksCount = notification.artworks?.totalCount ?? 0
+    return artworksCount > 0
+  }
+
+  if (notification.notificationType === "VIEWING_ROOM_PUBLISHED") {
+    const viewingRoomsCount = notification.item?.viewingRoomsConnection?.totalCount ?? 0
+    return viewingRoomsCount > 0
+  }
+
+  if (notification.notificationType === "ARTICLE_FEATURED_ARTIST") {
+    return !!notification.item?.article?.internalID
+  }
+
+  return true
+}

--- a/src/app/Scenes/Home/Components/ActivityRail.tests.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tests.tsx
@@ -23,7 +23,9 @@ describe("ActivityRail", () => {
   it("renders", () => {
     renderWithRelay({
       Viewer: () => ({
-        notificationsConnection: { edges: [{ node: { internalID: "id-1" } }] },
+        notificationsConnection: {
+          edges: [{ node: { internalID: "id-1", notificationType: "ARTWORK_ALERT" } }],
+        },
       }),
     })
 
@@ -34,7 +36,9 @@ describe("ActivityRail", () => {
   it("handles header tap", () => {
     renderWithRelay({
       Viewer: () => ({
-        notificationsConnection: { edges: [{ node: { internalID: "id-1" } }] },
+        notificationsConnection: {
+          edges: [{ node: { internalID: "id-1", notificationType: "ARTWORK_ALERT" } }],
+        },
       }),
     })
 
@@ -60,7 +64,9 @@ describe("ActivityRail", () => {
   it("handles See All tap", () => {
     renderWithRelay({
       Viewer: () => ({
-        notificationsConnection: { edges: [{ node: { internalID: "id-1" } }] },
+        notificationsConnection: {
+          edges: [{ node: { internalID: "id-1", notificationType: "ARTWORK_ALERT" } }],
+        },
       }),
     })
 
@@ -86,7 +92,9 @@ describe("ActivityRail", () => {
   it("handles item tap", () => {
     renderWithRelay({
       Viewer: () => ({
-        notificationsConnection: { edges: [{ node: { internalID: "id-1" } }] },
+        notificationsConnection: {
+          edges: [{ node: { internalID: "id-1", notificationType: "ARTWORK_ALERT" } }],
+        },
       }),
     })
 

--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -92,7 +92,6 @@ const notificationsConnectionFragment = graphql`
           artworks: artworksConnection {
             totalCount
           }
-          ...ActivityRailItem_item
           item {
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {
@@ -106,6 +105,7 @@ const notificationsConnectionFragment = graphql`
               }
             }
           }
+          ...ActivityRailItem_item
         }
       }
     }

--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -1,7 +1,10 @@
 import { Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import { ActivityRail_notificationsConnection$key } from "__generated__/ActivityRail_notificationsConnection.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { isArtworksBasedNotification } from "app/Scenes/Activity/utils/isArtworksBasedNotification"
+import {
+  shouldDisplayNotification,
+  Notification,
+} from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { ActivityRailItem } from "app/Scenes/Home/Components/ActivityRailItem"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { matchRoute } from "app/routes"
@@ -23,14 +26,9 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter((notification) => {
-    if (isArtworksBasedNotification(notification.notificationType)) {
-      const artworksCount = notification.artworks?.totalCount ?? 0
-      return artworksCount > 0
-    }
-
-    return true
-  })
+  const notifications = notificationsNodes.filter((notification) =>
+    shouldDisplayNotification(notification as Notification)
+  )
 
   if (notifications.length === 0) {
     return null
@@ -95,6 +93,19 @@ const notificationsConnectionFragment = graphql`
             totalCount
           }
           ...ActivityRailItem_item
+          item {
+            ... on ViewingRoomPublishedNotificationItem {
+              viewingRoomsConnection(first: 1) {
+                totalCount
+              }
+            }
+
+            ... on ArticleFeaturedArtistNotificationItem {
+              article {
+                internalID
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR resolves [ONYX-756]

### Description

Hides notifications which do not have published viewing rooms / article within them.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-756]: https://artsyproduct.atlassian.net/browse/ONYX-756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ