### PR TITLE
chore(sentry): remove fetch notifications info failed message

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -820,7 +820,7 @@ PODS:
     - React-Core
     - React-hermes
     - Sentry/HybridSDK (= 8.15.2)
-  - RNShare (8.2.1):
+  - RNShare (10.0.2):
     - React-Core
   - RNSVG (14.1.0):
     - React-Core
@@ -1438,7 +1438,7 @@ SPEC CHECKSUMS:
   RNReanimated: 9f7068e43b9358a46a688d94a5a3adb258139457
   RNScreens: 3c5b9f4a9dcde752466854b6109b79c0e205dad3
   RNSentry: ee1a9a80996414205d84ce9180c31bd855fd4641
-  RNShare: eaee3dd5a06dad397c7d3b14762007035c5de405
+  RNShare: 859ff710211285676b0bcedd156c12437ea1d564
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageWebPCoder: 908b83b6adda48effe7667cd2b7f78c897e5111d

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "react-native-safe-area-context": "3.4.0",
     "react-native-screens": "3.29.0",
     "react-native-shake": "5.5.2",
-    "react-native-share": "8.2.1",
+    "react-native-share": "10.0.2",
     "react-native-svg": "14.1.0",
     "react-native-url-polyfill": "2.0.0",
     "react-native-view-shot": "3.4.0",

--- a/src/app/Components/ShareSheet/ShareSheet.tsx
+++ b/src/app/Components/ShareSheet/ShareSheet.tsx
@@ -33,7 +33,7 @@ import { useCanOpenURL } from "app/utils/useCanOpenURL"
 import { useRef } from "react"
 import { ScrollView } from "react-native"
 import Config from "react-native-config"
-import Share from "react-native-share"
+import Share, { Social } from "react-native-share"
 import ViewShot from "react-native-view-shot"
 import { useTracking } from "react-tracking"
 
@@ -76,7 +76,7 @@ export const ShareSheet = () => {
 
       await Share.shareSingle({
         appId: Config.ARTSY_FACEBOOK_APP_ID,
-        social: Share.Social.INSTAGRAM_STORIES,
+        social: Social.InstagramStories,
         backgroundImage: base64Data,
       })
     } catch (error) {
@@ -91,7 +91,7 @@ export const ShareSheet = () => {
     const details = shareContent(data)
 
     await Share.shareSingle({
-      social: Share.Social.WHATSAPP,
+      social: Social.Whatsapp,
       message: details.message ?? "",
       url: details.url,
     })

--- a/src/app/Components/ShareSheet/ShareSheet.tsx
+++ b/src/app/Components/ShareSheet/ShareSheet.tsx
@@ -74,7 +74,6 @@ export const ShareSheet = () => {
         )
       }
 
-      // run the share after the analytics and hideShareSheet interactions are done
       await Share.shareSingle({
         appId: Config.ARTSY_FACEBOOK_APP_ID,
         social: Share.Social.INSTAGRAM_STORIES,

--- a/src/app/Components/ShareSheet/helpers.ts
+++ b/src/app/Components/ShareSheet/helpers.ts
@@ -20,7 +20,7 @@ export const getShareMessage = (artistNames: string[], title?: string) => {
 }
 
 export const getBase64Data = async (viewShot: ViewShot) => {
-  const base64RawData = await viewShot.capture!()
+  const base64RawData = await viewShot.capture?.()
   const base64Data = `data:image/png;base64,${base64RawData}`
 
   return base64Data

--- a/src/app/Scenes/BottomTabs/BottomTabsModel.ts
+++ b/src/app/Scenes/BottomTabs/BottomTabsModel.ts
@@ -134,7 +134,6 @@ export const getBottomTabsModel = (): BottomTabsModel => ({
         )
         console.log(e)
       } else {
-        captureMessage(`fetchNotificationsInfo failed: `)
         captureException(e)
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11830,10 +11830,10 @@ react-native-shake@5.5.2:
   resolved "https://registry.yarnpkg.com/react-native-shake/-/react-native-shake-5.5.2.tgz#1e73cfb3dcefc9980f604d08a87cdc6ba3f3a479"
   integrity sha512-GWQc/2h33u3ma2bBUEFG4sEQXfSmu2azEF1bUaqu+d0TeAT3vvmxpw3u6k7Z9XiZk4uRJ+NCVifx4JTHF5n67g==
 
-react-native-share@8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-8.2.1.tgz#f9933852de3ddd0f474ab63448e06c22cfecc9d4"
-  integrity sha512-dUIgrcdg4nOHrbKN1w+hs17RZ+51NeXd62CEezPAd4tEyj2Ki1qeAxWnJe8ZPRwvB5/6ml7YUR/2PJApxGHCAQ==
+react-native-share@10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-10.0.2.tgz#ba517d20a3bf20385eeeea32d9be9b41395f4dc7"
+  integrity sha512-EZs4MtsyauAI1zP8xXT1hIFB/pXOZJNDCKcgCpEfTZFXgCUzz8MDVbI1ocP2hA59XHRSkqAQdbJ0BFTpjxOBlg==
 
 react-native-svg@14.1.0:
   version "14.1.0"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Removes fetch notifications info failed message from sentry since it doesn't group it along with the exception. We still keep the captureException though.

[event in sentry](https://artsynet.sentry.io/issues/4450613635/events/d034549605e24675bfafea924f2180d4/) - that we are removing - as you can see it is not that helpful

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- remove fetch notifications info failed message - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
