### PR TITLE
feat: Display all notifications in Activity rail and add preview image

### DIFF
--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -80,11 +80,7 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 const notificationsConnectionFragment = graphql`
   fragment ActivityRail_notificationsConnection on Viewer
   @argumentDefinitions(count: { type: "Int" }) {
-    # Filtering out notifications without associated artworks to avoid displaying notifications without image
-    notificationsConnection(
-      first: $count
-      notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED, PARTNER_OFFER_CREATED]
-    ) {
+    notificationsConnection(first: $count) {
       edges {
         node {
           internalID

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -90,10 +90,6 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
 
 const getPreviewImage = (item: ActivityRailItem_item$data) => {
   switch (item.notificationType) {
-    case "ARTWORK_ALERT":
-    case "ARTWORK_PUBLISHED":
-    case "PARTNER_OFFER_CREATED":
-      return extractNodes(item?.artworksConnection)?.[0]?.image?.preview?.src
     case "VIEWING_ROOM_PUBLISHED":
       return extractNodes(item?.item?.viewingRoomsConnection)?.[0]?.image?.imageURLs?.normalized
     case "ARTICLE_FEATURED_ARTIST":
@@ -101,7 +97,7 @@ const getPreviewImage = (item: ActivityRailItem_item$data) => {
     case "PARTNER_SHOW_OPENED":
       return extractNodes(item?.item?.showsConnection)?.[0]?.coverImage?.preview?.src
     default:
-      return null
+      return extractNodes(item?.artworksConnection)?.[0]?.image?.preview?.src
   }
 }
 

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -1,9 +1,8 @@
-import { Flex, Text } from "@artsy/palette-mobile"
+import { Flex, Image, Text } from "@artsy/palette-mobile"
 import {
   ActivityRailItem_item$data,
   ActivityRailItem_item$key,
 } from "__generated__/ActivityRailItem_item.graphql"
-import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { ActivityItemTypeLabel } from "app/Scenes/Activity/ActivityItemTypeLabel"
 import {
   ExpiresInTimer,
@@ -30,7 +29,6 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const markAsRead = useMarkNotificationAsRead()
 
   const item = useFragment(ActivityRailItemFragment, props.item)
-  const artworks = extractNodes(item.artworksConnection)
 
   const handlePress = () => {
     props.onPress?.(item)
@@ -44,20 +42,25 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
     }
   }
 
-  const imageURL = artworks[0]?.image?.preview?.src
+  const imageURL = getPreviewImage(item)
 
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
       <Flex flexDirection="row">
-        {!!imageURL ? (
-          <Flex mr={1} accessibilityLabel="Activity Artwork Image">
-            <OpaqueImageView
-              imageURL={imageURL}
+        <Flex
+          mr={1}
+          accessibilityLabel="Activity Artwork Image"
+          width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+          height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+        >
+          {!!imageURL && (
+            <Image
+              src={imageURL}
               width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
               height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
             />
-          </Flex>
-        ) : null}
+          )}
+        </Flex>
 
         <Flex maxWidth={MAX_WIDTH} overflow="hidden">
           <Flex flexDirection="row" style={{ marginTop: -4 }}>
@@ -85,6 +88,23 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   )
 }
 
+const getPreviewImage = (item: ActivityRailItem_item$data) => {
+  switch (item.notificationType) {
+    case "ARTWORK_ALERT":
+    case "ARTWORK_PUBLISHED":
+    case "PARTNER_OFFER_CREATED":
+      return extractNodes(item?.artworksConnection)?.[0]?.image?.preview?.src
+    case "VIEWING_ROOM_PUBLISHED":
+      return extractNodes(item?.item?.viewingRoomsConnection)?.[0]?.image?.imageURLs?.normalized
+    case "ARTICLE_FEATURED_ARTIST":
+      return item?.item?.article?.thumbnailImage?.preview?.src
+    case "PARTNER_SHOW_OPENED":
+      return extractNodes(item?.item?.showsConnection)?.[0]?.coverImage?.preview?.src
+    default:
+      return null
+  }
+}
+
 const ActivityRailItemFragment = graphql`
   fragment ActivityRailItem_item on Notification {
     internalID
@@ -96,12 +116,6 @@ const ActivityRailItemFragment = graphql`
     isUnread
     notificationType
     objectsCount
-    item {
-      ... on PartnerOfferCreatedNotificationItem {
-        available
-        expiresAt
-      }
-    }
     artworksConnection(first: 1) {
       edges {
         node {
@@ -109,8 +123,49 @@ const ActivityRailItemFragment = graphql`
           title
           image {
             aspectRatio
-            preview: cropped(width: 116, height: 116, version: "normalized") {
+            preview: cropped(width: 55, height: 55, version: "normalized") {
               src
+            }
+          }
+        }
+      }
+    }
+    item {
+      ... on PartnerOfferCreatedNotificationItem {
+        available
+        expiresAt
+      }
+      ... on ViewingRoomPublishedNotificationItem {
+        viewingRoomsConnection(first: 1) {
+          edges {
+            node {
+              image {
+                imageURLs {
+                  normalized
+                }
+              }
+            }
+          }
+        }
+      }
+      ... on ArticleFeaturedArtistNotificationItem {
+        article {
+          thumbnailImage {
+            preview: cropped(width: 55, height: 55, version: "normalized") {
+              src
+            }
+          }
+        }
+      }
+      ... on ShowOpenedNotificationItem {
+        showsConnection(first: 1) {
+          edges {
+            node {
+              coverImage {
+                preview: cropped(width: 55, height: 55, version: "normalized") {
+                  src
+                }
+              }
             }
           }
         }

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -514,10 +514,7 @@ export const HomeFragmentContainer = memo(
       notificationsConnection: graphql`
         fragment Home_notificationsConnection on Viewer {
           ...ActivityRail_notificationsConnection @arguments(count: 10)
-          notificationsConnection(
-            first: 10
-            notificationTypes: [ARTWORK_ALERT, ARTWORK_PUBLISHED, PARTNER_OFFER_CREATED]
-          ) {
+          notificationsConnection(first: 10) {
             edges {
               node {
                 internalID


### PR DESCRIPTION
This PR resolves [ONYX-660] <!-- eg [PROJECT-XXXX] -->

### Description

This PR removes the activity type filter for the home screen's Activity rail and adds logic to get a preview image for all notification types. The missing preview images were the reason why we introduced the filter initially.

The logic to get a preview image could also be implemented in Metaphysics or Gravity, but I thought it might be more complex because we need data from additional associations, such as 'article'.

In case an image cannot be loaded (because of some missing data or if we introduce a new notification type, we display a gray box, which should be ok since it's an edge case.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Display images for all Activity types in the home screens Latest Activity rail - ole
- Remove activity type filter from  Latest Activity rail  to display all activities - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-660]: https://artsyproduct.atlassian.net/browse/ONYX-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ