### PR TITLE
feat(ONYX-778): match Alerts filters empty states to the design

### DIFF
--- a/src/app/Scenes/Activity/ActivityEmptyView.tsx
+++ b/src/app/Scenes/Activity/ActivityEmptyView.tsx
@@ -1,4 +1,5 @@
-import { Flex, Spacer, Text } from "@artsy/palette-mobile"
+import { Flex, Spacer, Text, Touchable } from "@artsy/palette-mobile"
+import { navigate } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NotificationType } from "./types"
 
@@ -6,24 +7,66 @@ interface ActivityEmptyViewProps {
   type: NotificationType
 }
 
-const entityByType: Record<NotificationType, { title: string; message: string }> = {
+const artistLink = (
+  <Touchable onPress={() => navigate("/artists")}>
+    <Text variant="xs" underline>
+      Artists
+    </Text>
+  </Touchable>
+)
+
+const galleriesLink = (
+  <Touchable onPress={() => navigate("/galleries")}>
+    <Text variant="xs" underline>
+      Galeries
+    </Text>
+  </Touchable>
+)
+
+const entityByType: Record<
+  NotificationType,
+  { title: string; message: string; geStartedMessage?: any; links?: any }
+> = {
   all: {
-    title: `Follow artists and galleries to stay up to date`,
+    title: "Stay up to date with the artists and artworks you love",
     message:
-      "Keep track of the art and events you love, and get recommendations based on who you follow.",
+      "Follow artists and galleries to keep track of their latest updates. Or create an alert and we’ll let you know when there’s a matching work.",
+    geStartedMessage: "Get started with:",
+    links: (
+      <>
+        {artistLink}
+        {galleriesLink}
+      </>
+    ),
   },
   follows: {
     title: "Follow artists and galleries to stay up to date",
-    message:
-      "Keep track of the art and events you love, and get recommendations based on who you follow.",
+    message: "Keep track of the art and events you love, and get updates based on who you follow.",
+    geStartedMessage: "Get started with:",
+    links: (
+      <>
+        {artistLink}
+        {galleriesLink}
+      </>
+    ),
   },
   alerts: {
-    title: `Hunting for a particular artwork?`,
-    message: `Create alerts on an artist or artwork page and get notifications here when there’s a match.`,
+    title: "Hunting for a particular artwork?",
+    message:
+      "Create alerts on an artist or artwork page and get notifications here when there’s a match.",
+    geStartedMessage: "Get started with:",
+    links: artistLink,
   },
   offers: {
-    title: `Your offers will appear here`,
-    message: `When you receive an offer on an artwork, it will appear here.`,
+    title: "Your offers will appear here",
+    message: "When you receive an offer on an artwork, it will appear here.",
+    geStartedMessage: "Get started with:",
+    links: (
+      <>
+        {artistLink}
+        {galleriesLink}
+      </>
+    ),
   },
 }
 
@@ -31,12 +74,29 @@ export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) =>
   const entity = entityByType[type]
   const enableNewActivityPanelManagement = useFeatureFlag("AREnableNewActivityPanelManagement")
 
+  if (enableNewActivityPanelManagement) {
+    return (
+      <Flex mx={4} accessibilityLabel="Activities are empty" pt={4}>
+        <Text textAlign="start" variant="sm-display">
+          {entity.title}
+        </Text>
+        <Spacer y={2} />
+        <Text variant="xs" color="black60" textAlign="start">
+          {entity.message}
+        </Text>
+        <Spacer y={2} />
+        <Flex flexDirection="row" gap={10}>
+          <Text variant="xs" color="black60" textAlign="start">
+            {entity.geStartedMessage}
+          </Text>
+          {entity.links}
+        </Flex>
+      </Flex>
+    )
+  }
+
   return (
-    <Flex
-      mx={2}
-      accessibilityLabel="Activities are empty"
-      pt={enableNewActivityPanelManagement ? 2 : 0}
-    >
+    <Flex mx={2} accessibilityLabel="Activities are empty" pt={0}>
       <Text textAlign="center">{entity.title}</Text>
       <Spacer y={2} />
       <Text variant="xs" color="black60" textAlign="center">

--- a/src/app/Scenes/Activity/ActivityEmptyView.tsx
+++ b/src/app/Scenes/Activity/ActivityEmptyView.tsx
@@ -25,7 +25,7 @@ const galleriesLink = (
 
 const entityByType: Record<
   NotificationType,
-  { title: string; message: string; geStartedMessage?: any; links?: any }
+  { title: string; message: string; geStartedMessage?: any; links?: any } | null
 > = {
   all: {
     title: "Stay up to date with the artists and artworks you love",
@@ -57,24 +57,18 @@ const entityByType: Record<
     geStartedMessage: "Get started with:",
     links: artistLink,
   },
-  offers: {
-    title: "Your offers will appear here",
-    message: "When you receive an offer on an artwork, it will appear here.",
-    geStartedMessage: "Get started with:",
-    links: (
-      <>
-        {artistLink}
-        {galleriesLink}
-      </>
-    ),
-  },
+  // we do not display the offers pill when the user has no offers
+  // will not reach the empty state of this filter
+  offers: null,
 }
 
 export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) => {
   const entity = entityByType[type]
   const enableNewActivityPanelManagement = useFeatureFlag("AREnableNewActivityPanelManagement")
 
-  if (enableNewActivityPanelManagement) {
+  if (!entity) return <></>
+
+  if (enableNewActivityPanelManagement && type !== "offers") {
     return (
       <Flex mx={4} accessibilityLabel="Activities are empty" pt={4}>
         <Text textAlign="start" variant="sm-display">


### PR DESCRIPTION
This PR resolves [ONYX-778] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Match Alerts filters empty states to the design
[Figma](https://www.figma.com/file/PO3rjpDV29YOFR8kLI4InJ/Activity-Panel-%26-Alerts-Management?node-id=2766%3A4986&mode=dev)

| All | Alerts | Follows |
| --- | --- | --- |
| ![image](https://github.com/artsy/eigen/assets/36167539/c1e9494a-4b01-4ea5-820e-d10827a593c2) | ![image](https://github.com/artsy/eigen/assets/36167539/894042cf-aaa7-4b59-b3a3-fd73a2a37403) | ![image](https://github.com/artsy/eigen/assets/36167539/32cf3a2f-cc7a-4de5-9cb1-8837b2dc9b61) |
### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- match Alerts filters empty states to the design  (behind a ff) - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-778]: https://artsyproduct.atlassian.net/browse/ONYX-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ