### PR TITLE
fix: Remove "Edit Follows" button from notification screen

### DIFF
--- a/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
+++ b/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
@@ -52,12 +52,6 @@ export const ArtworkPublishedNotification: FC<ArtworkPublishedNotificationProps>
     })
   }
 
-  const handleEditFollowsButton = () => {
-    // TODO: Add tracking
-
-    navigate("/favorites")
-  }
-
   const handleViewAllWorksPress = () => {
     // TODO: Add tracking
 

--- a/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
+++ b/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Flex,
   Text,
   Screen,
@@ -89,18 +88,6 @@ export const ArtworkPublishedNotification: FC<ArtworkPublishedNotificationProps>
         <NotificationArtworkList artworksConnection={artworksConnection} />
 
         <Flex mx={2} mt={1} mb={2}>
-          <Button
-            block
-            variant="outline"
-            onPress={handleEditFollowsButton}
-            testID="edit-follows-CTA"
-            mb={1}
-          >
-            Edit Follows
-          </Button>
-
-          <Spacer y={2} />
-
           <Touchable onPress={handleViewAllWorksPress}>
             <Flex mx={2} flexDirection="row">
               <Text fontWeight="bold">View all works by {artist.name}</Text>

--- a/src/app/Scenes/Activity/components/__tests__/ArtworkPublishedNotification.tests.tsx
+++ b/src/app/Scenes/Activity/components/__tests__/ArtworkPublishedNotification.tests.tsx
@@ -52,26 +52,6 @@ describe("ArtworkPublishedNotification", () => {
     expect(screen.getByText("View all works by Tracey Emin")).toBeTruthy()
   })
 
-  describe("Edit Follows CTA", () => {
-    it("links to the edit follows screen", async () => {
-      renderWithRelay({
-        Me: () => ({
-          notification,
-        }),
-      })
-
-      await flushPromiseQueue()
-
-      const editAlertButton = screen.getByTestId("edit-follows-CTA")
-
-      fireEvent.press(editAlertButton)
-
-      await flushPromiseQueue()
-
-      expect(navigate).toHaveBeenCalledWith("/favorites")
-    })
-  })
-
   describe("'View all works by ...' link", () => {
     it("links to follows target href", async () => {
       renderWithRelay({


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Removing the "Edit Follows" button from notification screen. I've accidentally added it again because I haven't seen [this](https://www.notion.so/artsy/Should-we-remove-Edit-Alert-CTA-as-well-as-Edit-Follows-CTA-cc-117ce6c3fbfa40ac896e8ffb48e8f4c9?pvs=4) card from the QA session.

- [Context](https://www.notion.so/artsy/Should-we-remove-Edit-Alert-CTA-as-well-as-Edit-Follows-CTA-cc-117ce6c3fbfa40ac896e8ffb48e8f4c9?pvs=4)

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
