### PR TITLE
fix: Correctly update unreadNotificationsCount when reading notification

### DIFF
--- a/src/app/Scenes/Activity/hooks/useMarkAllNotificationsAsRead.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkAllNotificationsAsRead.ts
@@ -74,6 +74,10 @@ const MarkAllAsReadMutation = graphql`
     markAllNotificationsAsRead(input: {}) {
       responseOrError {
         ... on MarkAllNotificationsAsReadSuccess {
+          me {
+            unreadNotificationsCount
+          }
+
           success
         }
         ... on MarkAllNotificationsAsReadFailure {

--- a/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
+++ b/src/app/Scenes/Activity/hooks/useMarkNotificationsAsSeen.ts
@@ -55,6 +55,10 @@ const MarkNotificationsAsSeenMutation = graphql`
     markNotificationsAsSeen(input: $input) {
       responseOrError {
         ... on MarkNotificationsAsSeenSuccess {
+          me {
+            unseenNotificationsCount
+          }
+
           success
         }
         ... on MarkNotificationsAsSeenFailure {

--- a/src/app/Scenes/Activity/mutations/useMarkNotificationAsRead.ts
+++ b/src/app/Scenes/Activity/mutations/useMarkNotificationAsRead.ts
@@ -3,24 +3,26 @@ import { useMarkNotificationAsReadMutation } from "__generated__/useMarkNotifica
 import { graphql, useMutation } from "react-relay"
 
 export const useMarkNotificationAsRead = () => {
-  const [commitMutation] = useMutation<useMarkNotificationAsReadMutation>(
-    graphql`
-      mutation useMarkNotificationAsReadMutation($input: MarkNotificationAsReadInput!) {
-        markNotificationAsRead(input: $input) {
-          responseOrError {
-            ... on MarkNotificationAsReadSuccess {
-              success
+  const [commitMutation] = useMutation<useMarkNotificationAsReadMutation>(graphql`
+    mutation useMarkNotificationAsReadMutation($input: MarkNotificationAsReadInput!) {
+      markNotificationAsRead(input: $input) {
+        responseOrError {
+          ... on MarkNotificationAsReadSuccess {
+            me {
+              unreadNotificationsCount
             }
-            ... on MarkNotificationAsReadFailure {
-              mutationError {
-                message
-              }
+
+            success
+          }
+          ... on MarkNotificationAsReadFailure {
+            mutationError {
+              message
             }
           }
         }
       }
-    `
-  )
+    }
+  `)
 
   return (item: { id: string; internalID: string; isUnread: boolean }) => {
     if (!item.isUnread) {


### PR DESCRIPTION
This PR resolves [ONYX-750] <!-- eg [PROJECT-XXXX] -->

### Description

Correctly update unreadNotificationsCount when reading notification.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Correctly update unreadNotificationsCount when opening a notification/activity - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-750]: https://artsyproduct.atlassian.net/browse/ONYX-750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ