### PR TITLE
fix: Make Activity screen header divider lighter

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.167.0",
-    "@artsy/palette-mobile": "13.1.9",
+    "@artsy/palette-mobile": "13.1.10",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@gorhom/bottom-sheet": "4.5.1",

--- a/src/app/Scenes/Activity/NewActivityScreen.tsx
+++ b/src/app/Scenes/Activity/NewActivityScreen.tsx
@@ -1,4 +1,4 @@
-import { MoreIcon, Screen, Touchable } from "@artsy/palette-mobile"
+import { MoreIcon, Screen, Separator, Touchable } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { ActivityContainer } from "app/Scenes/Activity/ActivityContainer"
 import { ActivityScreenStore } from "app/Scenes/Activity/ActivityScreenStore"
@@ -46,7 +46,10 @@ export const NewActivityContent: React.FC = () => {
           </Touchable>
         }
       />
-      <Screen.StickySubHeader title="Activity">
+      <Screen.StickySubHeader
+        title="Activity"
+        separatorComponent={<Separator borderColor="black5" />}
+      >
         <NewActivityHeader />
       </Screen.StickySubHeader>
       <ActivityContainer type={type} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@13.1.9":
-  version "13.1.9"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.1.9.tgz#2ed3f8b7dcbf3d56fc8fe4f7f79036dc66cd3bf1"
-  integrity sha512-zrCoFVvmdq8kWalNUBVcy1/rL7K/3eXRThj+6/VSKy9lPVLokByZsa+bAWrADwvpFSLS4aIqjI8tmG0A8Z2NKA==
+"@artsy/palette-mobile@13.1.10":
+  version "13.1.10"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.1.10.tgz#0ce9d18e1712267219250ff8973b9ac55ad874b7"
+  integrity sha512-0wzhtgyfDa5t1qDohKg5GVCzM/QeUG9o7LYwtRCvKdcyynyt/h4n4ZqlpL/gZLmiav1UtU4NUAVbkjHdId1dCA==
   dependencies:
     "@artsy/palette-tokens" "^5.0.0"
     "@shopify/flash-list" "^1.5.0"


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->
Resolves https://www.notion.so/artsy/All-grey-lines-are-the-same-light-grey-Currently-in-the-build-the-top-line-is-darker-should-be-ch-1f007c0745654e1ca995194a294db279?pvs=4


- https://github.com/artsy/palette-mobile/pull/192
### Description

Make Activity header divider lighter.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Make Activity screen header divider lighter - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
