### PR TITLE
chore: use rn-blurshash 1.1.11

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -562,8 +562,7 @@ PODS:
     - React
   - react-native-blob-util (0.19.2):
     - React-Core
-  - react-native-blurhash (2.0.0):
-    - RCT-Folly (= 2021.07.22.00)
+  - react-native-blurhash (1.1.11):
     - React-Core
   - react-native-config (1.4.11):
     - react-native-config/App (= 1.4.11)
@@ -1391,7 +1390,7 @@ SPEC CHECKSUMS:
   React-logger: dc3a2b174d79c2da635059212747d8d929b54e06
   react-native-appboy-sdk: e4e36787766637d5c60da264b66f4389ed479867
   react-native-blob-util: c74e4ce87c76d244761c68623df78bf0d1638271
-  react-native-blurhash: 684ec1be4719536f3f90129c7f6e3c6941768652
+  react-native-blurhash: a59e6bf8117a0304488ed576abd440f4b0777a8c
   react-native-config: bcafda5b4c51491ee1b0e1d0c4e3905bc7b56c1b
   react-native-context-menu-view: 4cd5ecaabd2cbb420018b3242ca1eef5efa0a629
   react-native-cookies: cd92f3824ed1e32a20802e8185101e14bb5b76da

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "react-native": "0.72.10",
     "react-native-appboy-sdk": "1.35.1",
     "react-native-blob-util": "0.19.2",
-    "react-native-blurhash": "2.0.0",
+    "react-native-blurhash": "1.1.11",
     "react-native-bootsplash": "3.2.0",
     "react-native-code-push": "8.1.0",
     "react-native-config": "https://github.com/artsy/react-native-config.git#v1.4.12-artsy",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11611,12 +11611,7 @@ react-native-blob-util@0.19.2:
     base-64 "0.1.0"
     glob "^7.2.3"
 
-react-native-blurhash@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-2.0.0.tgz#6c287836e107d3f89c77b2889c501af1f44af0db"
-  integrity sha512-sG63TByvMTRzZQ2oLPfBhGPBzKmnZiaF0A4CEIyRPjKVEKj++S6TT9J5PaXB8GkRNKHKLMo26bGVxLNYMaLmvA==
-
-react-native-blurhash@^1.1.11:
+react-native-blurhash@1.1.11, react-native-blurhash@^1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/react-native-blurhash/-/react-native-blurhash-1.1.11.tgz#cef102cc0239eb30c184235caf3fcb0b1f3ce33d"
   integrity sha512-lYFf0C6vBz+wr5p81ABlzT9vSWmg4qTrtYGObBzhPOFIM8T0BHXbz0cCIE/gWgKFohLEWrwXFQ78GgHLlw7Jig==


### PR DESCRIPTION
### Description

Use the same RN-blurhash version as in palette. 
I did this instead of upgrading palette to 2.0.0 because the latter breaks the android build. See: https://app.circleci.com/pipelines/github/artsy/eigen/51084/workflows/4cbd18bd-534f-4eec-84d7-487b41e467be/jobs/175225


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog