### PR TITLE
fix(ONYX-822): fix broken ArtsyWebView paddings

### DIFF
--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -14,6 +14,7 @@ import { useWebViewCallback } from "app/utils/useWebViewEvent"
 import { debounce } from "lodash"
 import { parse as parseQueryString } from "query-string"
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
+import { View } from "react-native"
 import { Edge, SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context"
 import Share from "react-native-share"
 import WebView, { WebViewNavigation, WebViewProps } from "react-native-webview"
@@ -253,8 +254,10 @@ export const ArtsyWebView = forwardRef<
       }
     }
 
+    const WebViewWrapper = isPresentedModally ? SafeAreaView : View
+
     return (
-      <SafeAreaView style={{ flex: 1 }} edges={safeAreaEdges}>
+      <WebViewWrapper style={{ flex: 1 }} edges={safeAreaEdges}>
         <WebView
           ref={innerRef}
           // sharedCookiesEnabled is required on iOS for the user to be implicitly logged into force/prediction
@@ -285,7 +288,7 @@ export const ArtsyWebView = forwardRef<
             <Text color="red">webview</Text>
           </Flex>
         )}
-      </SafeAreaView>
+      </WebViewWrapper>
     )
   }
 )
@@ -312,7 +315,10 @@ function useUrlCookies(url: string, accessToken: string | null, isLoggedIn: bool
 
 class CookieRequestAttempt {
   invalidated = false
-  constructor(public url: string, public accessToken: string) {}
+  constructor(
+    public url: string,
+    public accessToken: string
+  ) {}
   async makeAttempt() {
     if (this.invalidated) {
       return

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -95,7 +95,6 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
               )
             }
             data={notifications}
-            scrollEnabled={notifications.length > 1}
             onViewableItemsChanged={props.onViewableItemsChanged}
             viewabilityConfig={props.viewabilityConfig}
             keyExtractor={keyExtractor}

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -95,6 +95,7 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
               )
             }
             data={notifications}
+            scrollEnabled={notifications.length > 1}
             onViewableItemsChanged={props.onViewableItemsChanged}
             viewabilityConfig={props.viewabilityConfig}
             keyExtractor={keyExtractor}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -271,7 +271,6 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       alwaysPresentModally: true,
       safeAreaEdges: ["bottom"],
     }),
-    addWebViewRoute("/artists"),
     addWebViewRoute("/buy-now-feature-faq"),
     addWebViewRoute("/buyer-guarantee"),
     addWebViewRoute("/categories"),
@@ -280,7 +279,6 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       safeAreaEdges: ["bottom"],
     }),
     addWebViewRoute("/identity-verification-faq"),
-    addWebViewRoute("/galleries"),
     addWebViewRoute("/meet-the-specialists"),
     addWebViewRoute("/orders/:orderID", {
       mimicBrowserBackButton: true,

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -271,6 +271,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       alwaysPresentModally: true,
       safeAreaEdges: ["bottom"],
     }),
+    addWebViewRoute("/artists"),
     addWebViewRoute("/buy-now-feature-faq"),
     addWebViewRoute("/buyer-guarantee"),
     addWebViewRoute("/categories"),
@@ -279,6 +280,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
       safeAreaEdges: ["bottom"],
     }),
     addWebViewRoute("/identity-verification-faq"),
+    addWebViewRoute("/galleries"),
     addWebViewRoute("/meet-the-specialists"),
     addWebViewRoute("/orders/:orderID", {
       mimicBrowserBackButton: true,


### PR DESCRIPTION
This PR resolves [ONYX-822] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

The ArtsyWebView uses SafeAreaView. SafeAreaView adds paddings to the top and bottom of the page to make sure the active area of the screen can be assessed. We do not need this padding if we are not presenting the screen modally. When we do not the screen modally we can use a react-native View instead of SafeAreaView

| Before iOS | After iOS | Before Android | After Android |
| --- | --- | --- | --- |
| ![image](https://github.com/artsy/eigen/assets/36167539/a4dc33e5-74cc-4bf2-b677-08301140edf7) | ![image](https://github.com/artsy/eigen/assets/36167539/3ca4f7eb-0964-41c5-b356-e8e9522615df) | ![Screenshot_1709343815](https://github.com/artsy/eigen/assets/36167539/58ba30f0-4c7d-4499-9c8a-dffc5eb2095d) | ![Screenshot_1709344209](https://github.com/artsy/eigen/assets/36167539/b6e21408-3197-47b8-b10a-8b2b2be0cfae) |

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- in ArtsyWebView use SafeAreaView only if presented modally - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-822]: https://artsyproduct.atlassian.net/browse/ONYX-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ