### PR TITLE
fix: enable scroll only when there is more than one elements in the a…

### DIFF
--- a/src/app/Scenes/Activity/ActivityEmptyView.tsx
+++ b/src/app/Scenes/Activity/ActivityEmptyView.tsx
@@ -1,10 +1,12 @@
 import { Flex, Spacer, Text, Touchable } from "@artsy/palette-mobile"
 import { navigate } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { ScrollView } from "react-native-gesture-handler"
 import { NotificationType } from "./types"
 
 interface ActivityEmptyViewProps {
   type: NotificationType
+  refreshControl?: React.ReactElement
 }
 
 const artistLink = (
@@ -62,7 +64,7 @@ const entityByType: Record<
   offers: null,
 }
 
-export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) => {
+export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type, refreshControl }) => {
   const entity = entityByType[type]
   const enableNewActivityPanelManagement = useFeatureFlag("AREnableNewActivityPanelManagement")
 
@@ -70,22 +72,22 @@ export const ActivityEmptyView: React.FC<ActivityEmptyViewProps> = ({ type }) =>
 
   if (enableNewActivityPanelManagement && type !== "offers") {
     return (
-      <Flex mx={4} accessibilityLabel="Activities are empty" pt={4}>
-        <Text textAlign="start" variant="sm-display">
-          {entity.title}
-        </Text>
-        <Spacer y={2} />
-        <Text variant="xs" color="black60" textAlign="start">
-          {entity.message}
-        </Text>
-        <Spacer y={2} />
-        <Flex flexDirection="row" gap={10}>
-          <Text variant="xs" color="black60" textAlign="start">
-            {entity.geStartedMessage}
+      <ScrollView contentContainerStyle={{ height: 500 }} refreshControl={refreshControl}>
+        <Flex mx={4} accessibilityLabel="Activities are empty" pt={4}>
+          <Text variant="sm-display">{entity.title}</Text>
+          <Spacer y={2} />
+          <Text variant="xs" color="black60">
+            {entity.message}
           </Text>
-          {entity.links}
+          <Spacer y={2} />
+          <Flex flexDirection="row" gap={10}>
+            <Text variant="xs" color="black60">
+              {entity.geStartedMessage}
+            </Text>
+            {entity.links}
+          </Flex>
         </Flex>
-      </Flex>
+      </ScrollView>
     )
   }
 

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -95,6 +95,7 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
               )
             }
             data={notifications}
+            scrollEnabled={notifications.length > 1}
             onViewableItemsChanged={props.onViewableItemsChanged}
             viewabilityConfig={props.viewabilityConfig}
             keyExtractor={keyExtractor}

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -114,14 +114,23 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type, me }) 
             }}
             ListEmptyComponent={
               <Flex flex={1} justifyContent="center">
-                <ActivityEmptyView type={type} />
+                <ActivityEmptyView
+                  type={type}
+                  refreshControl={
+                    <RefreshControl onRefresh={handleRefresh} refreshing={refreshing} />
+                  }
+                />
               </Flex>
             }
             contentContainerStyle={{
               // This is required because Tabs.Flatlist has a marginHorizontal of 20
               marginHorizontal: 0,
             }}
-            refreshControl={<RefreshControl onRefresh={handleRefresh} refreshing={refreshing} />}
+            refreshControl={
+              notifications.length > 1 ? (
+                <RefreshControl onRefresh={handleRefresh} refreshing={refreshing} />
+              ) : undefined
+            }
             ListFooterComponent={
               <Flex
                 alignItems="center"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

Enable scroll on the activity screen only when there is more than one elements in the array

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- enable scroll on the activity screen only when there is more than one elements in the array - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
