### PR TITLE
chore: Use totalCount for offer notifications

### DIFF
--- a/src/app/Scenes/Activity/components/NewActivityHeader.tsx
+++ b/src/app/Scenes/Activity/components/NewActivityHeader.tsx
@@ -9,7 +9,7 @@ export const NewActivityHeader: React.FC = () => {
   const type = ActivityScreenStore.useStoreState((state) => state.type)
   const setType = ActivityScreenStore.useStoreActions((actions) => actions.setType)
 
-  const displayOffersFilter = !!data?.viewer?.partnerOfferNotifications?.edges?.length
+  const displayOffersFilter = !!data?.viewer?.partnerOfferNotifications?.totalCount
 
   return (
     <Flex px={2} pb={2}>
@@ -55,13 +55,7 @@ const query = graphql`
         first: 1
         notificationTypes: [PARTNER_OFFER_CREATED]
       ) {
-        # Total count does not work and returns a value even when there are no notifications
-        # TODO: Use totalCount once the issue is fixed
-        edges {
-          node {
-            id
-          }
-        }
+        totalCount
       }
     }
   }


### PR DESCRIPTION
This PR resolves [ONYX-757] <!-- eg [PROJECT-XXXX] -->

### Description

Use totalCount for offer notifications because the workaround is not needed in production.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Use totalCount for offer notifications - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-757]: https://artsyproduct.atlassian.net/browse/ONYX-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ