### PR TITLE
fix(ONYX-825): "Latest Activity" rail item design fixes

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -215,7 +215,7 @@ describe("ActivityItem with feature flags disabled", () => {
   })
 
   describe("Notification type", () => {
-    it("should NOT be rendered by default", async () => {
+    it("should be rendered by default", async () => {
       renderWithRelay({
         Notification: () => notification,
       })
@@ -223,7 +223,7 @@ describe("ActivityItem with feature flags disabled", () => {
       await flushPromiseQueue()
 
       const label = screen.queryByLabelText(/Notification type: .+/i)
-      expect(label).toBeNull()
+      expect(label).not.toBeNull()
     })
 
     it("should render 'Alert'", async () => {
@@ -315,7 +315,7 @@ describe("ActivityItem", () => {
 
     await flushPromiseQueue()
 
-    expect(screen.queryByText("2 days ago")).toBeFalsy()
+    expect(screen.getByText("2 days ago")).toBeTruthy()
   })
 
   it("should render artwork images", async () => {

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -114,12 +114,11 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
                       <ActivityItemTypeLabel notificationType={item.notificationType} />
                       {!isPartnerOffer && (
                         <Text variant="xs" mr={0.5}>
-                          {" "}
-                          • {item.publishedAt}
+                          {item.publishedAt}
                         </Text>
                       )}
                       {shouldDisplayExpiresInTimer(item.notificationType, item.item) && (
-                        <Flex ml={0.5}>
+                        <Flex ml="1px">
                           <ExpiresInTimer item={item.item} />
                         </Flex>
                       )}
@@ -149,7 +148,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
               <ActivityItemTypeLabel notificationType={item.notificationType} />
 
               {!isPartnerOffer && (
-                <Text variant="xs" color="black60">
+                <Text variant="xs" mr={0.5}>
                   {item.publishedAt}
                 </Text>
               )}

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -110,7 +110,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
 
                     {!!isEditorial && <Text variant="xs">{item.message}</Text>}
 
-                    <Flex flexDirection="row">
+                    <Flex flexDirection="row" mt="1px">
                       <ActivityItemTypeLabel notificationType={item.notificationType} />
                       {!isPartnerOffer && (
                         <Text variant="xs" mr={0.5}>

--- a/src/app/Scenes/Activity/ActivityItemTypeLabel.tsx
+++ b/src/app/Scenes/Activity/ActivityItemTypeLabel.tsx
@@ -1,49 +1,28 @@
 import { Text } from "@artsy/palette-mobile"
 import { NotificationTypesEnum } from "__generated__/ActivityRail_notificationsConnection.graphql"
-import {
-  getNewNotificationTypeLabel,
-  getNotificationTypeColor,
-  getNotificationTypeLabel,
-} from "app/Scenes/Activity/utils/getNotificationTypeLabel"
-import { shouldDisplayNotificationTypeLabel } from "app/Scenes/Activity/utils/shouldDisplayNotificationTypeLabel"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { getNotificationTypeLabel } from "app/Scenes/Activity/utils/getNotificationTypeLabel"
 
 interface Props {
   notificationType: NotificationTypesEnum
 }
 
 export const ActivityItemTypeLabel: React.FC<Props> = ({ notificationType }) => {
-  const enableNewActivityPanelManagement = useFeatureFlag("AREnableNewActivityPanelManagement")
-
-  if (!shouldDisplayNotificationTypeLabel(notificationType) && !enableNewActivityPanelManagement) {
-    return null
-  }
-
-  const notificationTypeLabel = enableNewActivityPanelManagement
-    ? getNewNotificationTypeLabel(notificationType)
-    : getNotificationTypeLabel(notificationType)
-  const notificationTypeColor = getNotificationTypeColor(notificationType)
-
-  if (enableNewActivityPanelManagement) {
-    return (
-      <Text
-        variant="xs"
-        fontWeight="bold"
-        accessibilityLabel={`Notification type: ${notificationTypeLabel}`}
-      >
-        {notificationTypeLabel}
-      </Text>
-    )
-  }
+  const isPartnerOffer = notificationType === "PARTNER_OFFER_CREATED"
+  const notificationTypeLabel = getNotificationTypeLabel(notificationType)
 
   return (
     <Text
       variant="xs"
+      fontWeight="bold"
       accessibilityLabel={`Notification type: ${notificationTypeLabel}`}
-      color={notificationTypeColor}
     >
-      {notificationTypeLabel}
-      {notificationType !== "PARTNER_OFFER_CREATED" && " • "}
+      {notificationTypeLabel}{" "}
+      {!isPartnerOffer && (
+        <Text variant="xs" mr={0.5}>
+          {" "}
+          •{" "}
+        </Text>
+      )}
     </Text>
   )
 }

--- a/src/app/Scenes/Activity/utils/getNotificationTypeLabel.ts
+++ b/src/app/Scenes/Activity/utils/getNotificationTypeLabel.ts
@@ -1,18 +1,5 @@
 import { NotificationTypesEnum } from "__generated__/ActivityRail_notificationsConnection.graphql"
 
-export const getNotificationTypeLabel = (notificationType: NotificationTypesEnum) => {
-  switch (notificationType) {
-    case "ARTICLE_FEATURED_ARTIST":
-      return "Editorial"
-    case "ARTWORK_ALERT":
-      return "Alert"
-    case "PARTNER_OFFER_CREATED":
-      return "Limited Time Offer"
-    default:
-      return null
-  }
-}
-
 export const getNotificationTypeBadge = (notificationType: NotificationTypesEnum) => {
   switch (notificationType) {
     case "PARTNER_OFFER_CREATED":
@@ -22,7 +9,7 @@ export const getNotificationTypeBadge = (notificationType: NotificationTypesEnum
   }
 }
 
-export const getNewNotificationTypeLabel = (notificationType: NotificationTypesEnum) => {
+export const getNotificationTypeLabel = (notificationType: NotificationTypesEnum) => {
   switch (notificationType) {
     case "ARTICLE_FEATURED_ARTIST":
       return "Editorial"
@@ -38,16 +25,5 @@ export const getNewNotificationTypeLabel = (notificationType: NotificationTypesE
       return "Viewing Room"
     default:
       return null
-  }
-}
-
-export const getNotificationTypeColor = (notificationType: NotificationTypesEnum) => {
-  switch (notificationType) {
-    case "ARTWORK_ALERT":
-      return "blue100"
-    case "PARTNER_OFFER_CREATED":
-      return "blue100"
-    default:
-      return "black60"
   }
 }

--- a/src/app/Scenes/Activity/utils/shouldDisplayNotificationTypeLabel.ts
+++ b/src/app/Scenes/Activity/utils/shouldDisplayNotificationTypeLabel.ts
@@ -1,5 +1,0 @@
-export const shouldDisplayNotificationTypeLabel = (notificationType: string) => {
-  return ["ARTWORK_ALERT", "ARTICLE_FEATURED_ARTIST", "PARTNER_OFFER_CREATED"].includes(
-    notificationType
-  )
-}

--- a/src/app/Scenes/Home/Components/ActivityRail.tests.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tests.tsx
@@ -30,7 +30,7 @@ describe("ActivityRail", () => {
     })
 
     expect(screen.getByText("Latest Activity Rail")).toBeOnTheScreen()
-    expect(screen.getByText(/mock-value-for-field-"title"/)).toBeOnTheScreen()
+    expect(screen.getByText(/mock-value-for-field-"headline"/)).toBeOnTheScreen()
   })
 
   it("handles header tap", () => {
@@ -98,7 +98,7 @@ describe("ActivityRail", () => {
       }),
     })
 
-    fireEvent.press(screen.getByText(/mock-value-for-field-"title"/))
+    fireEvent.press(screen.getByText(/mock-value-for-field-"headline"/))
 
     expect(navigate).toHaveBeenCalledWith("/notification/id-1")
 

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -123,7 +123,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
             </Text>
           )}
 
-          <Flex flexDirection="row">
+          <Flex flexDirection="row" mt="1px">
             <ActivityItemTypeLabel notificationType={item.notificationType} />
 
             {item.notificationType !== "PARTNER_OFFER_CREATED" &&

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -50,7 +50,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const isPartnerOffer = item.notificationType === "PARTNER_OFFER_CREATED"
   const isEditorial = item.notificationType === "ARTICLE_FEATURED_ARTIST"
 
-  if (!enableNavigateToASingleNotification) {
+  if (!enableNewActivityPanelManagement) {
     return (
       <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
         <Flex flexDirection="row">

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -23,7 +23,7 @@ interface ActivityRailItemProps {
 }
 
 export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 60
-const MAX_WIDTH = 180
+const ACTIVITY_RAIL_ITEM_WIDTH = 240
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
@@ -49,7 +49,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   if (!enableNewActivityPanelManagement) {
     return (
       <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
-        <Flex flexDirection="row">
+        <Flex flexDirection="row" width={ACTIVITY_RAIL_ITEM_WIDTH} overflowX="hidden">
           <Flex
             mr={1}
             accessibilityLabel="Activity Artwork Image"
@@ -65,7 +65,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
             )}
           </Flex>
 
-          <Flex maxWidth={MAX_WIDTH} overflow="hidden">
+          <Flex flex={1} overflow="hidden">
             <Flex flexDirection="row">
               <ActivityItemTypeLabel notificationType={item.notificationType} />
 
@@ -95,7 +95,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
 
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
-      <Flex flexDirection="row">
+      <Flex flexDirection="row" width={ACTIVITY_RAIL_ITEM_WIDTH}>
         <Flex
           mr={1}
           accessibilityLabel="Activity Artwork Image"
@@ -111,7 +111,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
           )}
         </Flex>
 
-        <Flex maxWidth={MAX_WIDTH} overflow="hidden">
+        <Flex flex={1} overflow="hidden">
           {!!isPartnerOffer && <PartnerOfferBadge notificationType={item.notificationType} />}
 
           <Headline headline={item.headline} notificationType={item.notificationType} />
@@ -151,6 +151,7 @@ interface HeadlineProps {
 
 const Headline: React.FC<HeadlineProps> = ({ headline, notificationType }) => {
   if (["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)) {
+    // Splitting the headline by " by " to display the artist name on a new line
     return (
       <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={2}>
         {headline.split(" by ")[0] + " by \n" + headline.split(" by ")[1]}
@@ -159,6 +160,7 @@ const Headline: React.FC<HeadlineProps> = ({ headline, notificationType }) => {
   }
 
   if (["PARTNER_OFFER_CREATED"].includes(notificationType)) {
+    // Splitting the headline by " by " to only display the artist name
     return (
       <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
         {headline.split(" by ")[1]}

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -8,6 +8,7 @@ import {
   ExpiresInTimer,
   shouldDisplayExpiresInTimer,
 } from "app/Scenes/Activity/components/ExpiresInTimer"
+import { PartnerOfferBadge } from "app/Scenes/Activity/components/PartnerOffeBadge"
 import { useMarkNotificationAsRead } from "app/Scenes/Activity/mutations/useMarkNotificationAsRead"
 import { navigateToActivityItem } from "app/Scenes/Activity/utils/navigateToActivityItem"
 import { extractNodes } from "app/utils/extractNodes"
@@ -21,7 +22,7 @@ interface ActivityRailItemProps {
 }
 
 export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 55
-const MAX_WIDTH = 220
+const MAX_WIDTH = 240
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
@@ -40,6 +41,56 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   }
 
   const imageURL = getPreviewImage(item)
+
+  const isPartnerOffer = item.notificationType === "PARTNER_OFFER_CREATED"
+  const isEditorial = item.notificationType === "ARTICLE_FEATURED_ARTIST"
+
+  if (!enableNavigateToASingleNotification) {
+    return (
+      <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
+        <Flex flexDirection="row">
+          <Flex
+            mr={1}
+            accessibilityLabel="Activity Artwork Image"
+            width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+            height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+          >
+            {!!imageURL && (
+              <Image
+                src={imageURL}
+                width={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+                height={ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE}
+              />
+            )}
+          </Flex>
+
+          <Flex maxWidth={MAX_WIDTH} overflow="hidden">
+            <Flex flexDirection="row">
+              <ActivityItemTypeLabel notificationType={item.notificationType} />
+
+              {item.notificationType !== "PARTNER_OFFER_CREATED" && (
+                <Text variant="xs">{item.publishedAt}</Text>
+              )}
+            </Flex>
+
+            <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
+              {item.title}
+            </Text>
+
+            {item.notificationType !== "PARTNER_OFFER_CREATED" && (
+              <Text variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>
+                {item.message}
+              </Text>
+            )}
+
+            {shouldDisplayExpiresInTimer(item.notificationType, item.item) && (
+              <ExpiresInTimer item={item.item} />
+            )}
+          </Flex>
+        </Flex>
+      </TouchableOpacity>
+    )
+  }
 
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
@@ -60,33 +111,34 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
         </Flex>
 
         <Flex maxWidth={MAX_WIDTH} overflow="hidden">
-          <Flex flexDirection="row" style={{ marginTop: -4 }}>
+          {!!isPartnerOffer && <PartnerOfferBadge notificationType={item.notificationType} />}
+
+          <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
+            {item.headline}
+          </Text>
+
+          {!!isEditorial && (
+            <Text variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>
+              {item.message}
+            </Text>
+          )}
+
+          <Flex flexDirection="row">
             <ActivityItemTypeLabel notificationType={item.notificationType} />
 
             {item.notificationType !== "PARTNER_OFFER_CREATED" &&
               (enableNewActivityPanelManagement ? (
-                <Text variant="xs" color="black60">
-                  {" "}
-                  • {item.publishedAt}
-                </Text>
+                <Text variant="xs">{item.publishedAt}</Text>
               ) : (
                 <Text variant="xs" color="black60">
                   {item.publishedAt}
                 </Text>
               ))}
+
+            {shouldDisplayExpiresInTimer(item.notificationType, item.item) && (
+              <ExpiresInTimer item={item.item} />
+            )}
           </Flex>
-
-          <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
-            {item.title}
-          </Text>
-
-          {item.notificationType !== "PARTNER_OFFER_CREATED" && (
-            <Text variant="sm-display">{item.message}</Text>
-          )}
-
-          {shouldDisplayExpiresInTimer(item.notificationType, item.item) && (
-            <ExpiresInTimer item={item.item} />
-          )}
         </Flex>
       </Flex>
     </TouchableOpacity>
@@ -110,6 +162,7 @@ const ActivityRailItemFragment = graphql`
   fragment ActivityRailItem_item on Notification {
     internalID
     id
+    headline
     title
     message
     publishedAt(format: "RELATIVE")

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -2,6 +2,7 @@ import { Flex, Image, Text } from "@artsy/palette-mobile"
 import {
   ActivityRailItem_item$data,
   ActivityRailItem_item$key,
+  NotificationTypesEnum,
 } from "__generated__/ActivityRailItem_item.graphql"
 import { ActivityItemTypeLabel } from "app/Scenes/Activity/ActivityItemTypeLabel"
 import {
@@ -23,6 +24,10 @@ interface ActivityRailItemProps {
 
 export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 55
 const MAX_WIDTH = 240
+const NOTIFICATION_TYPES_WITH_TWO_LINE_HEADLINE: NotificationTypesEnum[] = [
+  "ARTWORK_ALERT",
+  "ARTWORK_PUBLISHED",
+]
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
@@ -92,6 +97,10 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
     )
   }
 
+  const hasTwoLineHeadline = NOTIFICATION_TYPES_WITH_TWO_LINE_HEADLINE.includes(
+    item.notificationType
+  )
+
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
       <Flex flexDirection="row">
@@ -113,7 +122,12 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
         <Flex maxWidth={MAX_WIDTH} overflow="hidden">
           {!!isPartnerOffer && <PartnerOfferBadge notificationType={item.notificationType} />}
 
-          <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
+          <Text
+            variant="sm-display"
+            fontWeight="bold"
+            ellipsizeMode="tail"
+            numberOfLines={hasTwoLineHeadline ? 2 : 1}
+          >
             {item.headline}
           </Text>
 

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -24,10 +24,6 @@ interface ActivityRailItemProps {
 
 export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 60
 const MAX_WIDTH = 180
-const NOTIFICATION_TYPES_WITH_TWO_LINE_HEADLINE: NotificationTypesEnum[] = [
-  "ARTWORK_ALERT",
-  "ARTWORK_PUBLISHED",
-]
 
 export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
   const enableNavigateToASingleNotification = useFeatureFlag("AREnableSingleActivityPanelScreen")
@@ -97,10 +93,6 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
     )
   }
 
-  const hasTwoLineHeadline = NOTIFICATION_TYPES_WITH_TWO_LINE_HEADLINE.includes(
-    item.notificationType
-  )
-
   return (
     <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
       <Flex flexDirection="row">
@@ -122,14 +114,7 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
         <Flex maxWidth={MAX_WIDTH} overflow="hidden">
           {!!isPartnerOffer && <PartnerOfferBadge notificationType={item.notificationType} />}
 
-          <Text
-            variant="sm-display"
-            fontWeight="bold"
-            ellipsizeMode="tail"
-            numberOfLines={hasTwoLineHeadline ? 2 : 1}
-          >
-            {item.headline}
-          </Text>
+          <Headline headline={item.headline} notificationType={item.notificationType} />
 
           {!!isEditorial && (
             <Text variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>
@@ -156,6 +141,35 @@ export const ActivityRailItem: React.FC<ActivityRailItemProps> = (props) => {
         </Flex>
       </Flex>
     </TouchableOpacity>
+  )
+}
+
+interface HeadlineProps {
+  headline: string
+  notificationType: NotificationTypesEnum
+}
+
+const Headline: React.FC<HeadlineProps> = ({ headline, notificationType }) => {
+  if (["ARTWORK_ALERT", "ARTWORK_PUBLISHED"].includes(notificationType)) {
+    return (
+      <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={2}>
+        {headline.split(" by ")[0] + " by \n" + headline.split(" by ")[1]}
+      </Text>
+    )
+  }
+
+  if (["PARTNER_OFFER_CREATED"].includes(notificationType)) {
+    return (
+      <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
+        {headline.split(" by ")[1]}
+      </Text>
+    )
+  }
+
+  return (
+    <Text variant="sm-display" fontWeight="bold" ellipsizeMode="tail" numberOfLines={1}>
+      {headline}
+    </Text>
   )
 }
 

--- a/src/app/Scenes/Home/Components/ActivityRailItem.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRailItem.tsx
@@ -22,8 +22,8 @@ interface ActivityRailItemProps {
   onPress?: (item: ActivityRailItem_item$data) => void
 }
 
-export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 55
-const MAX_WIDTH = 240
+export const ACTIVITY_RAIL_ARTWORK_IMAGE_SIZE = 60
+const MAX_WIDTH = 180
 const NOTIFICATION_TYPES_WITH_TWO_LINE_HEADLINE: NotificationTypesEnum[] = [
   "ARTWORK_ALERT",
   "ARTWORK_PUBLISHED",


### PR DESCRIPTION
Resolve [ONYX-825](https://artsyproduct.atlassian.net/browse/ONYX-825)

- [Slack Discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1709544179604239)
### Description

This PR adjusts the "Latest Activity" rail items to match new design:

* Alert & Follow notifications: Artist name should be dropped to second line 
* Offer notifications: remove ‘Saved work by’ so just the name displays
* 240px width for each activity
* Text readjustments


### Figma Design


<img width="1107" alt="Screenshot 2024-03-11 at 09 44 29" src="https://github.com/artsy/eigen/assets/4691889/281128a0-eaf3-4e61-9e86-0bed271f677b">

[Figma Design](https://www.figma.com/file/PO3rjpDV29YOFR8kLI4InJ/Activity-Panel-%26-Alerts-Management?type=design&node-id=1001-21829&mode=design&t=wyetZPbufCxQsXZ7-0)

## Screenshots


| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-11 at 09 52 34](https://github.com/artsy/eigen/assets/4691889/270f4d7e-88d8-4bbb-b0d0-8332172c8575) |![Simulator Screenshot - iPhone 15 Pro - 2024-03-11 at 09 52 41](https://github.com/artsy/eigen/assets/4691889/d60bbcd8-977a-4eb5-a6f7-50d566db443d) |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-03-11 at 09 55 43](https://github.com/artsy/eigen/assets/4691889/27e9f581-6343-4115-8bde-53502bc4b47a) |![Simulator Screenshot - iPhone 15 Pro - 2024-03-11 at 10 01 58](https://github.com/artsy/eigen/assets/4691889/cbd0b6aa-0aa7-46d6-ac6e-d90955f8f2f3) |







### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Update "Latest Activity" rail item design - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-825]: https://artsyproduct.atlassian.net/browse/ONYX-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ