### PR TITLE
feat: add revert sort ability on ff dev menu

### DIFF
--- a/src/app/system/devTools/DevMenu/DevMenu.tsx
+++ b/src/app/system/devTools/DevMenu/DevMenu.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   Join,
   LogoutIcon,
+  Pill,
   ReloadIcon,
   Screen,
   Separator,
@@ -71,6 +72,13 @@ export const DevMenu = ({ onClose = () => goBack() }: { onClose(): void }) => {
   const [featureFlagQuery, setFeatureFlagQuery] = useState("")
   const [devToolQuery, setDevToolQuery] = useState("")
   const [url, setUrl] = useState("")
+
+  const [isFeatureFlagOrderReversed, setIsFeatureFlagOrderReversed] = useState(true)
+
+  const toggleFeatureFlagDirection = () => {
+    setIsFeatureFlagOrderReversed(!isFeatureFlagOrderReversed)
+  }
+
   const migrationVersion = GlobalStore.useAppState((s) => s.version)
   const server = GlobalStore.useAppState((s) => s.devicePrefs.environment.strings.webURL).slice(
     "https://".length
@@ -160,20 +168,42 @@ export const DevMenu = ({ onClose = () => goBack() }: { onClose(): void }) => {
         <Flex mx={2}>
           <Expandable label="Feature Flags" expanded={false}>
             <Spacer y={1} />
-            <Flex mb={1}>
-              <SearchInput onChangeText={setFeatureFlagQuery} placeholder="Search feature flags" />
+            <Flex mb={1} flexDirection="row" flex={1}>
+              <Flex flex={8}>
+                <SearchInput
+                  onChangeText={setFeatureFlagQuery}
+                  placeholder="Search feature flags"
+                />
+              </Flex>
+              <Flex flex={3} justifyContent="center" pr={2}>
+                <Pill onPress={toggleFeatureFlagDirection}>
+                  {isFeatureFlagOrderReversed ? "Sort ↓" : "Sort ↑"}
+                </Pill>
+              </Flex>
             </Flex>
             <Flex mx={-2}>
-              {configurableFeatureFlagKeys
-                .filter(
-                  (flagKey) =>
-                    features[flagKey].description
-                      ?.toLowerCase()
-                      .includes(featureFlagQuery.toLowerCase())
-                )
-                .map((flagKey) => {
-                  return <FeatureFlagItem key={flagKey} flagKey={flagKey} />
-                })}
+              {isFeatureFlagOrderReversed
+                ? configurableFeatureFlagKeys
+                    .filter(
+                      (flagKey) =>
+                        features[flagKey].description
+                          ?.toLowerCase()
+                          .includes(featureFlagQuery.toLowerCase())
+                    )
+                    .map((flagKey) => {
+                      return <FeatureFlagItem key={flagKey} flagKey={flagKey} />
+                    })
+                : configurableFeatureFlagKeys
+                    .filter(
+                      (flagKey) =>
+                        features[flagKey].description
+                          ?.toLowerCase()
+                          .includes(featureFlagQuery.toLowerCase())
+                    )
+                    .reverse()
+                    .map((flagKey) => {
+                      return <FeatureFlagItem key={flagKey} flagKey={flagKey} />
+                    })}
               <DevMenuButtonItem
                 title="Revert all feature flags to default"
                 titleColor="red100"

--- a/src/app/system/devTools/DevMenu/DevMenu.tsx
+++ b/src/app/system/devTools/DevMenu/DevMenu.tsx
@@ -101,6 +101,13 @@ export const DevMenu = ({ onClose = () => goBack() }: { onClose(): void }) => {
 
   const androidTopInset = Platform.OS === "android" ? topInset : 0
 
+  const filteredAndMappedKeys = configurableFeatureFlagKeys
+    .filter(
+      (flagKey) =>
+        features[flagKey].description?.toLowerCase().includes(featureFlagQuery.toLowerCase())
+    )
+    .map((flagKey) => <FeatureFlagItem key={flagKey} flagKey={flagKey} />)
+
   return (
     <Screen>
       <Flex flexDirection="row" justifyContent="space-between" mt={`${androidTopInset}px`}>
@@ -182,28 +189,7 @@ export const DevMenu = ({ onClose = () => goBack() }: { onClose(): void }) => {
               </Flex>
             </Flex>
             <Flex mx={-2}>
-              {isFeatureFlagOrderReversed
-                ? configurableFeatureFlagKeys
-                    .filter(
-                      (flagKey) =>
-                        features[flagKey].description
-                          ?.toLowerCase()
-                          .includes(featureFlagQuery.toLowerCase())
-                    )
-                    .map((flagKey) => {
-                      return <FeatureFlagItem key={flagKey} flagKey={flagKey} />
-                    })
-                : configurableFeatureFlagKeys
-                    .filter(
-                      (flagKey) =>
-                        features[flagKey].description
-                          ?.toLowerCase()
-                          .includes(featureFlagQuery.toLowerCase())
-                    )
-                    .reverse()
-                    .map((flagKey) => {
-                      return <FeatureFlagItem key={flagKey} flagKey={flagKey} />
-                    })}
+              {isFeatureFlagOrderReversed ? filteredAndMappedKeys.reverse() : filteredAndMappedKeys}
               <DevMenuButtonItem
                 title="Revert all feature flags to default"
                 titleColor="red100"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Adds revert sort ability on ff dev menu:

<img src="https://github.com/artsy/eigen/assets/21178754/c807ea4d-c34f-4f12-8af8-2fb09732fa2f" width="300" />

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Adds revert sort ability on ff dev menu - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
