### PR TITLE
fix: onboarding follow galleries follow btn state

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingPartnerListItem.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingPartnerListItem.tsx
@@ -1,6 +1,5 @@
-import { EntityHeader } from "@artsy/palette-mobile"
+import { EntityHeader, FollowButton } from "@artsy/palette-mobile"
 import { OnboardingPartnerListItem_partner$key } from "__generated__/OnboardingPartnerListItem_partner.graphql"
-import { FollowButton } from "app/Components/Button/FollowButton"
 import { extractNodes } from "app/utils/extractNodes"
 import { uniq } from "lodash"
 import { graphql, useFragment, useMutation } from "react-relay"

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -14,7 +14,7 @@ import {
   State,
   useOnboardingContext,
 } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
-import { FC, useCallback, useState } from "react"
+import React, { FC, useCallback, useState } from "react"
 import { LayoutAnimation } from "react-native"
 import { AnimatedFadingPill, FADE_OUT_PILL_ANIMATION_DURATION } from "./AnimatedFadingPill"
 
@@ -106,12 +106,12 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
             </>
           )}
           <Spacer y={2} />
-          {answers.map((answer) => {
+          {answers.map((answer, index) => {
             const isVisible = !hideUnselectedPills || !!selected(answer)
             const shouldShowPillTick = showPillTick && selected(answer)
 
             return (
-              <>
+              <React.Fragment key={`${answer}+${index}`}>
                 <AnimatedFadingPill
                   variant="default"
                   isVisible={isVisible}
@@ -126,7 +126,7 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
                   </Text>
                 </AnimatedFadingPill>
                 {!!isVisible && <Spacer y={2} />}
-              </>
+              </React.Fragment>
             )
           })}
         </Flex>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

[Ticket](https://www.notion.so/artsy/Follow-button-loading-state-broken-in-onboarding-d71c5f4f193f404798a0265de1a2cb35) from mobile QA session.

- [x] Fixes the follow button on onboarding follow galleries page. 
- [x] Bonus: Also adds key to onboardingQuestionTemplate

|Before|After|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/21178754/022c07d1-b64e-434d-a39c-846d1206f443" width="350" />|<video src="https://github.com/artsy/eigen/assets/21178754/eafc8984-a16d-462f-b86f-827bec48ea12" width="350" />|



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- onboarding follow galleries follow btn state - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
