### PR TITLE
fix: SWA form header improvement

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -641,7 +641,7 @@ export const modules = defineModules({
     hidesBackButton: true,
     fullBleed: true,
   }),
-  SubmitArtwork: reactModule(SubmitArtwork, { hidesBackButton: true }),
+  SubmitArtwork: reactModule(SubmitArtwork, { hidesBackButton: true, fullBleed: true }),
   Tag: reactModule(TagQueryRenderer, { hidesBackButton: true, fullBleed: true }),
   UnlistedArtworksFAQScreen: reactModule(UnlistedArtworksFAQScreen),
   VanityURLEntity: reactModule(VanityURLEntityRenderer, { fullBleed: true }),

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -1,5 +1,5 @@
 import { OwnerType, ContextModule } from "@artsy/cohesion"
-import { CollapsibleMenuItem, Spacer, Flex, Text, Separator, Join } from "@artsy/palette-mobile"
+import { CollapsibleMenuItem, Text, Separator, Join, Screen } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { NavigationContainer } from "@react-navigation/native"
 import { createStackNavigator, StackScreenProps } from "@react-navigation/stack"
@@ -15,7 +15,6 @@ import {
   uploadPhotosCompletedEvent,
 } from "app/Scenes/SellWithArtsy/utils/TrackingEvent"
 import { GlobalStore } from "app/store/GlobalStore"
-import { BackButton } from "app/system/navigation/BackButton"
 import { goBack } from "app/system/navigation/navigate"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
@@ -187,7 +186,7 @@ export const SubmitSWAArtworkFlow: React.FC<SubmitSWAArtworkFlowProps> = ({
 
     const scrollToStep = () =>
       stepsRefs[indexToExpand].offsetTop().then((offset) => {
-        scrollViewRef.current?.scrollTo({ y: offset - 20 || 0 })
+        scrollViewRef.current?.scrollTo({ y: offset - 120 || 0 })
       })
 
     if (indexToCollapse >= 0) {
@@ -244,44 +243,46 @@ export const SubmitSWAArtworkFlow: React.FC<SubmitSWAArtworkFlowProps> = ({
         context_screen_owner_type: OwnerType.consignmentFlow,
       })}
     >
-      <ArtsyKeyboardAvoidingView>
-        <Flex>
-          <BackButton onPress={handleBackPress} style={{ top: 10, zIndex: 100 }} />
+      <Screen>
+        <Screen.Body fullwidth>
+          <Screen.Header onBack={handleBackPress} />
+
           <ScrollView
             ref={scrollViewRef}
             contentContainerStyle={{
-              paddingVertical: 50,
+              paddingBottom: 50,
               paddingHorizontal: 20,
               justifyContent: "center",
             }}
             keyboardShouldPersistTaps="handled"
           >
-            <Spacer y={4} />
-            <Join separator={<Separator my={2} marginTop="40" marginBottom="20" />}>
-              {items.map(({ overtitle, title, Content, contextModule }, index) => (
-                <CollapsibleMenuItem
-                  key={index}
-                  overtitle={overtitle}
-                  title={title}
-                  onExpand={() => {
-                    trackEvent(toggledAccordionEvent(submissionID, contextModule, title, true))
-                    expandCollapsibleMenuContent(index)
-                  }}
-                  onCollapse={() => {
-                    trackEvent(toggledAccordionEvent(submissionID, contextModule, title, false))
-                  }}
-                  isExpanded={index === 0}
-                  disabled={activeStep !== index}
-                  ref={(ref) => {
-                    if (ref) {
-                      stepsRefs[index] = ref
-                    }
-                  }}
-                >
-                  {Content}
-                </CollapsibleMenuItem>
-              ))}
-            </Join>
+            <ArtsyKeyboardAvoidingView>
+              <Join separator={<Separator my={2} marginTop="40" marginBottom="20" />}>
+                {items.map(({ overtitle, title, Content, contextModule }, index) => (
+                  <CollapsibleMenuItem
+                    key={index}
+                    overtitle={overtitle}
+                    title={title}
+                    onExpand={() => {
+                      trackEvent(toggledAccordionEvent(submissionID, contextModule, title, true))
+                      expandCollapsibleMenuContent(index)
+                    }}
+                    onCollapse={() => {
+                      trackEvent(toggledAccordionEvent(submissionID, contextModule, title, false))
+                    }}
+                    isExpanded={index === 0}
+                    disabled={activeStep !== index}
+                    ref={(ref) => {
+                      if (ref) {
+                        stepsRefs[index] = ref
+                      }
+                    }}
+                  >
+                    {Content}
+                  </CollapsibleMenuItem>
+                ))}
+              </Join>
+            </ArtsyKeyboardAvoidingView>
           </ScrollView>
           <FancyModal visible={hasError} onBackgroundPressed={() => setHasError(false)}>
             <FancyModalHeader onRightButtonPress={() => setHasError(false)} rightCloseButton>
@@ -293,8 +294,8 @@ export const SubmitSWAArtworkFlow: React.FC<SubmitSWAArtworkFlowProps> = ({
               } the Artwork. Please try again shortly`}
             />
           </FancyModal>
-        </Flex>
-      </ArtsyKeyboardAvoidingView>
+        </Screen.Body>
+      </Screen>
     </ProvideScreenTrackingWithCohesionSchema>
   )
 }
@@ -306,7 +307,7 @@ export type SubmitArtworkOverviewNavigationStack = {
 
 const StackNavigator = createStackNavigator<SubmitArtworkOverviewNavigationStack>()
 
-export const SubmitArtwork = () => {
+export const SubmitArtwork: React.FC = () => {
   return (
     <NavigationContainer independent>
       <StackNavigator.Navigator


### PR DESCRIPTION
This PR resolves [ONYX-814] <!-- eg [PROJECT-XXXX] -->

### Description

SWA form header improvement.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- SWA form header improvement - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-814]: https://artsyproduct.atlassian.net/browse/ONYX-814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ