### PR TITLE
fix: display alert artworks grid when there is only 1 artwork

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
@@ -52,7 +52,7 @@ export const AlertArtworksGrid: FC<AlertArtworksGridProps> = ({ alertId }) => {
 
   return (
     <Flex>
-      {artworksCount > 1 && (
+      {artworksCount > 0 && (
         <Flex>
           <Text variant="sm">
             {numWorks} currently on Artsy match your criteria. See our top picks for you:


### PR DESCRIPTION
This PR resolves [ONYX-736]

### Description

Previously - when there is only 1 matching artwork - no artworks were displayed at all. This PR solves this issue:

<img src="https://github.com/artsy/eigen/assets/3934579/f85872c8-1013-44f1-ace3-3ef3c9503374" width="300px" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-736]: https://artsyproduct.atlassian.net/browse/ONYX-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ