### PR TITLE
fix(onyx-736): refetch pills and artworks when navigating to alerts View Artworks screen

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/AlertArtworks.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworks.tsx
@@ -1,4 +1,5 @@
 import { Flex, Screen, Spacer } from "@artsy/palette-mobile"
+import { useFocusEffect } from "@react-navigation/native"
 import {
   AlertArtworksGrid,
   AlertArtworksGridPlaceholder,
@@ -8,13 +9,22 @@ import {
   AlertArtworksPillsPlaceholder,
 } from "app/Scenes/SavedSearchAlert/AlertArtworksPills"
 import { goBack } from "app/system/navigation/navigate"
-import { FC, Suspense } from "react"
+import { FC, Suspense, useCallback, useState } from "react"
 
 interface AlertArtworksProps {
   alertId: string
 }
 
 export const AlertArtworks: FC<AlertArtworksProps> = ({ alertId }) => {
+  // This is a workaround to force the component to re-fetch data when navigating back
+  const [fetchKey, setFetchKey] = useState(0)
+
+  useFocusEffect(
+    useCallback(() => {
+      setFetchKey((prev) => prev + 1)
+    }, [])
+  )
+
   return (
     <Screen>
       <Screen.AnimatedHeader onBack={goBack} title="View Artworks" />
@@ -27,11 +37,11 @@ export const AlertArtworks: FC<AlertArtworksProps> = ({ alertId }) => {
         <Screen.ScrollView>
           <Flex mx={2}>
             <Suspense fallback={<AlertArtworksPillsPlaceholder />}>
-              <AlertArtworksPills alertId={alertId} />
+              <AlertArtworksPills alertId={alertId} fetchKey={fetchKey} />
             </Suspense>
             <Spacer y={1} />
             <Suspense fallback={<AlertArtworksGridPlaceholder />}>
-              <AlertArtworksGrid alertId={alertId} />
+              <AlertArtworksGrid alertId={alertId} fetchKey={fetchKey} />
             </Suspense>
           </Flex>
         </Screen.ScrollView>

--- a/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tests.tsx
@@ -19,7 +19,7 @@ describe("AlertArtworksGrid", () => {
   })
 
   describe("no artworks matches", () => {
-    it("shows no matches message and manage alert button", async () => {
+    it("shows no matches message and edit alert button", async () => {
       renderWithRelay({
         Me: () => ({
           alert: {
@@ -36,9 +36,9 @@ describe("AlertArtworksGrid", () => {
       expect(
         screen.getByText("There aren't any works available that meet the criteria at this time.")
       ).toBeOnTheScreen()
-      expect(screen.getByText("Manage Alert")).toBeOnTheScreen()
+      expect(screen.getByText("Edit Alert")).toBeOnTheScreen()
 
-      fireEvent.press(screen.getByText("Manage Alert"))
+      fireEvent.press(screen.getByText("Edit Alert"))
       await flushPromiseQueue()
 
       expect(navigate).toHaveBeenCalledWith("settings/alerts/alert-id/edit")

--- a/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
@@ -18,18 +18,26 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 
 interface AlertArtworksGridProps {
   alertId: string
+  fetchKey?: number
 }
 
 const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
-export const AlertArtworksGrid: FC<AlertArtworksGridProps> = ({ alertId }) => {
+export const AlertArtworksGrid: FC<AlertArtworksGridProps> = ({ alertId, fetchKey }) => {
   const screen = useScreenDimensions()
   const { space } = useTheme()
 
-  const data = useLazyLoadQuery<AlertArtworksGridQuery>(alertArtworksGridQuery, {
-    alertId: alertId,
-    first: NUMBER_OF_ARTWORKS_TO_SHOW,
-  })
+  const data = useLazyLoadQuery<AlertArtworksGridQuery>(
+    alertArtworksGridQuery,
+    {
+      alertId: alertId,
+      first: NUMBER_OF_ARTWORKS_TO_SHOW,
+    },
+    {
+      fetchPolicy: "network-only",
+      fetchKey: fetchKey ?? 0,
+    }
+  )
   const artworks = extractNodes(data.me?.alert?.artworksConnection)
   const artworksCount = data.me?.alert?.artworksConnection?.counts?.total ?? 0
   const artistIDs = data.me?.alert?.artistIDs ?? []
@@ -89,7 +97,7 @@ export const AlertArtworksGrid: FC<AlertArtworksGridProps> = ({ alertId }) => {
       )}
 
       <Button onPress={handleManageAlert} block mb={1} variant="outline">
-        {artworksCount === 0 ? "Manage Alert" : "Edit Alert"}
+        Edit Alert
       </Button>
 
       <Spacer y={2} />

--- a/src/app/Scenes/SavedSearchAlert/AlertArtworksPills.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworksPills.tsx
@@ -6,12 +6,20 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 
 interface AlertArtworksPillsProps {
   alertId: string
+  fetchKey?: number
 }
 
-export const AlertArtworksPills: FC<AlertArtworksPillsProps> = ({ alertId }) => {
-  const data = useLazyLoadQuery<AlertArtworksPillsQuery>(alertArtworksPillsQuery, {
-    alertId: alertId,
-  })
+export const AlertArtworksPills: FC<AlertArtworksPillsProps> = ({ alertId, fetchKey }) => {
+  const data = useLazyLoadQuery<AlertArtworksPillsQuery>(
+    alertArtworksPillsQuery,
+    {
+      alertId: alertId,
+    },
+    {
+      fetchPolicy: "network-only",
+      fetchKey: fetchKey ?? 0,
+    }
+  )
 
   const pills = data.me?.alert?.pills || []
 


### PR DESCRIPTION
This PR resolves [ONYX-736]

### Description

In before video, when I add/remove pills and go back to the previous screen - neither artworks grid or pills are updated. This PR makes the View Artworks screen to forcefully refetch data to reflect changes.

| Before | After |
|---|---|
| <video src="https://github.com/artsy/eigen/assets/3934579/859f1c6e-5743-4cfc-88e9-f2faba95349f" /> | <video src="https://github.com/artsy/eigen/assets/3934579/6b325211-53fb-420b-b246-e297e4e9634f" /> |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog
Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-736]: https://artsyproduct.atlassian.net/browse/ONYX-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ