### PR TITLE
fix: Update Activity panel Partner Offer purchase button

### DIFF
--- a/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
+++ b/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
@@ -77,6 +77,7 @@ const CommercialButtons: React.FC<{
       {!hasEnded && !noLongerAvailable && (
         <BuyNowButton
           artwork={artworkData as BuyNowButton_artwork$key}
+          partnerOffer={partnerOffer}
           editionSetID={null}
           buttonText="Continue to Purchase"
         />

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
@@ -2,6 +2,7 @@ import { ActionType, ContextModule, OwnerType, TappedBuyNow } from "@artsy/cohes
 import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { BuyNowButtonOrderMutation } from "__generated__/BuyNowButtonOrderMutation.graphql"
 import { BuyNowButton_artwork$key } from "__generated__/BuyNowButton_artwork.graphql"
+import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import { navigate } from "app/system/navigation/navigate"
 import { promptForReview } from "app/utils/promptForReview"
 import { useSetWebViewCallback } from "app/utils/useWebViewEvent"
@@ -12,6 +13,7 @@ import { useTracking } from "react-tracking"
 
 export interface BuyNowButtonProps {
   artwork: BuyNowButton_artwork$key
+  partnerOffer?: PartnerOffer
   variant?: ButtonProps["variant"]
   // EditionSetID is passed down from the edition selected by the user
   editionSetID: string | null
@@ -21,6 +23,7 @@ export interface BuyNowButtonProps {
 
 export const BuyNowButton = ({
   artwork,
+  partnerOffer,
   variant,
   editionSetID,
   renderSaleMessage,
@@ -45,6 +48,11 @@ export const BuyNowButton = ({
 
   const handleCreateOrder = () => {
     trackEvent(tracks.tappedBuyNow(slug, internalID))
+
+    if (partnerOffer?.targetHref) {
+      navigate(partnerOffer.targetHref)
+      return
+    }
 
     if (isCommittingCreateOrderMutation) {
       return


### PR DESCRIPTION
This PR resolves [EMI-1759] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR fixes an issue with the "Continue to Purchase" button in the Partner Offer screen from the Activity Panel

The issue was the Continue to Purchase button would go on to create an order to the artwork without applying the offer on the price, hence breaking the flow of the Partner Offer feature

### Videos
| Before | After |
|---|---|
| <video src="https://github.com/artsy/eigen/assets/20655703/9a16d991-a83a-4017-9e09-caa993ddcd67" /> | <video src="https://github.com/artsy/eigen/assets/20655703/a4648701-2acc-413a-910e-c015d56526ae" /> |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix the "Continue to Purchase" button in the Partner Offer Activity screen - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1759]: https://artsyproduct.atlassian.net/browse/EMI-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ