### PR TITLE
docs: remove confusing line from getting started #trivial

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -60,7 +60,6 @@ yarn relay
 
 You will need [awscli](https://formulae.brew.sh/formula/awscli) to get our ENV vars.
 
-1. `Artsy/App/EchoNew.json` is used to toggle features and it is not checked in (a sample file is included for OSS contributors). When you run `pod install`, the latest `EchoNew.json` file will be downloaded for you.
 </details>
 
 <details><summary>Independent Contributor?</summary>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This line reads like a step but this should happen automatically so there is nothing to be done for contributor. 

#nochangelog