### PR TITLE
feat(my collection): present disambiguating info when selecting an artist

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtistsAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtistsAutosuggest.tsx
@@ -7,6 +7,7 @@ import {
   Spacer,
   Text,
   Touchable,
+  nbsp,
 } from "@artsy/palette-mobile"
 import { ArtistAutosuggestQuery } from "__generated__/ArtistAutosuggestQuery.graphql"
 import {
@@ -245,6 +246,7 @@ const CollectedArtistListItem: React.FC<{
 
         <ResultWithHighlight
           displayLabel={artist.displayLabel!}
+          secondaryLabel={artist.formattedNationalityAndBirthday || nbsp}
           numberOfLines={2}
           highlight={highlight}
           textAlign="center"

--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
@@ -4,8 +4,7 @@ import { SearchContext } from "app/Scenes/Search/SearchContext"
 import { GlobalStore, GlobalStoreProvider } from "app/store/GlobalStore"
 import { EntityType, navigate, navigateToEntity, SlugType } from "app/system/navigation/navigate"
 import { CatchErrors } from "app/utils/CatchErrors"
-import { extractText } from "app/utils/tests/extractText"
-import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { Pressable } from "react-native"
 import { act } from "react-test-renderer"
 import { AutosuggestSearchResult } from "./AutosuggestSearchResult"
@@ -86,9 +85,9 @@ describe(AutosuggestSearchResult, () => {
   })
 
   it("blurs the input and navigates to the correct page when tapped", async () => {
-    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
+    renderWithWrappers(<TestWrapper result={result} />)
     expect(navigate).not.toHaveBeenCalled()
-    root.findByType(Touchable).props.onPress()
+    screen.UNSAFE_getByType(Touchable).props.onPress()
     await new Promise((r) => setTimeout(r, 50))
     expect(inputBlurMock).toHaveBeenCalled()
     expect(navigate).toHaveBeenCalledWith(`${result.href}`)
@@ -109,43 +108,41 @@ describe(AutosuggestSearchResult, () => {
   })
 
   it(`updates recent searches by default`, async () => {
-    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
+    renderWithWrappers(<TestWrapper result={result} />)
     expect(navigate).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
-      root.findByType(Touchable).props.onPress()
+      screen.UNSAFE_getByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(recentSearchesArray).toHaveLength(1)
   })
 
   it(`won't update recent searches if told not to`, async () => {
-    const { root } = renderWithWrappersLEGACY(
-      <TestWrapper result={result} updateRecentSearchesOnTap={false} />
-    )
+    renderWithWrappers(<TestWrapper result={result} updateRecentSearchesOnTap={false} />)
     expect(navigate).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
-      root.findByType(Touchable).props.onPress()
+      screen.UNSAFE_getByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(recentSearchesArray).toHaveLength(0)
   })
 
   it(`optionally hides the entity type`, () => {
-    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
-    expect(extractText(root)).not.toContain("Artist")
+    renderWithWrappers(<TestWrapper result={result} showResultType={false} />)
+    expect(screen.queryByText("Artist")).toBeFalsy()
   })
 
   it(`allows for custom touch handlers on search result items`, () => {
     const spy = jest.fn()
-    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} onResultPress={spy} />)
-    root.findByType(Touchable).props.onPress()
+    renderWithWrappers(<TestWrapper result={result} onResultPress={spy} />)
+    screen.UNSAFE_getByType(Touchable).props.onPress()
     expect(spy).toHaveBeenCalled()
   })
 
   it(`navigates correctly when the item is a fair`, async () => {
-    const { root } = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <TestWrapper
         result={{
           displayLabel: "Art Expo 2020",
@@ -158,7 +155,7 @@ describe(AutosuggestSearchResult, () => {
       />
     )
     act(() => {
-      root.findByType(Touchable).props.onPress()
+      screen.UNSAFE_getByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigateToEntity).toHaveBeenCalledWith(
@@ -169,7 +166,7 @@ describe(AutosuggestSearchResult, () => {
   })
 
   it(`shows navigation buttons when enabled and available`, async () => {
-    const { root } = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -185,12 +182,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(root)).toContain("Auction Results")
-    expect(extractText(root)).toContain("Artworks")
+    expect(screen.getByText("Auction Results")).toBeTruthy()
+    expect(screen.getByText("Artworks")).toBeTruthy()
   })
 
   it(`does not show navigation buttons when disabled`, async () => {
-    const { root } = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -206,12 +203,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(root)).not.toContain("Auction Results")
-    expect(extractText(root)).not.toContain("Artworks")
+    expect(screen.queryByText("Auction Results")).toBeFalsy()
+    expect(screen.queryByText("Artworks")).toBeFalsy()
   })
 
   it(`does not show navigation buttons when enabled, but unavailable`, async () => {
-    const { root } = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -227,12 +224,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(root)).not.toContain("Auction Results")
-    expect(extractText(root)).not.toContain("Artworks")
+    expect(screen.queryByText("Auction Results")).toBeFalsy()
+    expect(screen.queryByText("Artworks")).toBeFalsy()
   })
 
   it(`quick navigation buttons navigate correctly`, async () => {
-    const { root } = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -249,7 +246,7 @@ describe(AutosuggestSearchResult, () => {
     )
 
     act(() => {
-      root.findAllByType(Pressable)[0].props.onPress()
+      screen.UNSAFE_getAllByType(Pressable)[0].props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigate).toHaveBeenCalledWith("/artist/anto-carte/artworks", {
@@ -257,7 +254,7 @@ describe(AutosuggestSearchResult, () => {
     })
 
     act(() => {
-      root.findAllByType(Pressable)[1].props.onPress()
+      screen.UNSAFE_getAllByType(Pressable)[1].props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigate).toHaveBeenCalledWith("/artist/anto-carte/auction-results", {

--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
@@ -50,54 +50,52 @@ describe(AutosuggestSearchResult, () => {
   })
 
   it(`works`, async () => {
-    const { queryAllByText } = renderWithWrappers(<TestWrapper result={result} showResultType />)
+    renderWithWrappers(<TestWrapper result={result} showResultType />)
 
-    expect(queryAllByText("Banksy")).toBeTruthy()
-    expect(queryAllByText("Artist")).toBeTruthy()
+    expect(screen.getByText("Banksy")).toBeTruthy()
+    expect(screen.getByText("Artist")).toBeTruthy()
   })
 
   it("does not render result type when showResultType prop is not passed", async () => {
-    const { queryByText } = renderWithWrappers(<TestWrapper result={result} />)
-    expect(queryByText("Artist")).toBeFalsy()
+    renderWithWrappers(<TestWrapper result={result} />)
+    expect(screen.queryByText("Artist")).toBeFalsy()
   })
 
   it("renders result type when showResultType prop is passed", async () => {
-    const { queryByText } = renderWithWrappers(<TestWrapper result={result} showResultType />)
-    expect(queryByText("Artist")).toBeTruthy()
+    renderWithWrappers(<TestWrapper result={result} showResultType />)
+    expect(screen.getByText("Artist")).toBeTruthy()
   })
 
   it("renders result and highlights the query", async () => {
-    const { getByText } = renderWithWrappers(<TestWrapper result={result} highlight="Ban" />)
+    renderWithWrappers(<TestWrapper result={result} highlight="Ban" />)
 
-    expect(getByText("Ban")).toHaveProp("color", "blue100")
-    expect(getByText("ksy")).toHaveProp("color", "black100")
+    expect(screen.getByText("Ban")).toHaveProp("color", "blue100")
+    expect(screen.getByText("ksy")).toHaveProp("color", "black100")
   })
 
   it("does not render delete button when onDelete callback is not passed", async () => {
-    const { queryByLabelText } = renderWithWrappers(<TestWrapper result={result} />)
-    expect(queryByLabelText("Remove recent search item")).toBeFalsy()
+    renderWithWrappers(<TestWrapper result={result} />)
+    expect(screen.queryByLabelText("Remove recent search item")).toBeFalsy()
   })
 
   it("calls onDelete calback when pressing on delete button", async () => {
-    const { getByLabelText } = renderWithWrappers(
-      <TestWrapper result={result} onDelete={onDeleteMock} />
-    )
+    renderWithWrappers(<TestWrapper result={result} onDelete={onDeleteMock} />)
 
-    fireEvent.press(getByLabelText("Remove recent search item"))
+    fireEvent.press(screen.getByLabelText("Remove recent search item"))
     expect(onDeleteMock).toHaveBeenCalled()
   })
 
   it("blurs the input and navigates to the correct page when tapped", async () => {
-    const tree = renderWithWrappersLEGACY(<TestWrapper result={result} />)
+    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
     expect(navigate).not.toHaveBeenCalled()
-    tree.root.findByType(Touchable).props.onPress()
+    root.findByType(Touchable).props.onPress()
     await new Promise((r) => setTimeout(r, 50))
     expect(inputBlurMock).toHaveBeenCalled()
     expect(navigate).toHaveBeenCalledWith(`${result.href}`)
   })
 
   it(`highlights a part of the string even when the string has diacritics but the highlight doesn't`, async () => {
-    const { queryByText } = renderWithWrappers(
+    renderWithWrappers(
       <TestWrapper
         result={{
           ...result,
@@ -107,47 +105,47 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(queryByText("Miró")).toHaveProp("color", "blue100")
+    expect(screen.queryByText("Miró")).toHaveProp("color", "blue100")
   })
 
   it(`updates recent searches by default`, async () => {
-    const tree = renderWithWrappersLEGACY(<TestWrapper result={result} />)
+    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
     expect(navigate).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
-      tree.root.findByType(Touchable).props.onPress()
+      root.findByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(recentSearchesArray).toHaveLength(1)
   })
 
   it(`won't update recent searches if told not to`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper result={result} updateRecentSearchesOnTap={false} />
     )
     expect(navigate).not.toHaveBeenCalled()
     expect(recentSearchesArray).toHaveLength(0)
     act(() => {
-      tree.root.findByType(Touchable).props.onPress()
+      root.findByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(recentSearchesArray).toHaveLength(0)
   })
 
   it(`optionally hides the entity type`, () => {
-    const tree = renderWithWrappersLEGACY(<TestWrapper result={result} />)
-    expect(extractText(tree.root)).not.toContain("Artist")
+    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} />)
+    expect(extractText(root)).not.toContain("Artist")
   })
 
   it(`allows for custom touch handlers on search result items`, () => {
     const spy = jest.fn()
-    const tree = renderWithWrappersLEGACY(<TestWrapper result={result} onResultPress={spy} />)
-    tree.root.findByType(Touchable).props.onPress()
+    const { root } = renderWithWrappersLEGACY(<TestWrapper result={result} onResultPress={spy} />)
+    root.findByType(Touchable).props.onPress()
     expect(spy).toHaveBeenCalled()
   })
 
   it(`navigates correctly when the item is a fair`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper
         result={{
           displayLabel: "Art Expo 2020",
@@ -160,7 +158,7 @@ describe(AutosuggestSearchResult, () => {
       />
     )
     act(() => {
-      tree.root.findByType(Touchable).props.onPress()
+      root.findByType(Touchable).props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigateToEntity).toHaveBeenCalledWith(
@@ -171,7 +169,7 @@ describe(AutosuggestSearchResult, () => {
   })
 
   it(`shows navigation buttons when enabled and available`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -187,12 +185,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(tree.root)).toContain("Auction Results")
-    expect(extractText(tree.root)).toContain("Artworks")
+    expect(extractText(root)).toContain("Auction Results")
+    expect(extractText(root)).toContain("Artworks")
   })
 
   it(`does not show navigation buttons when disabled`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -208,12 +206,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(tree.root)).not.toContain("Auction Results")
-    expect(extractText(tree.root)).not.toContain("Artworks")
+    expect(extractText(root)).not.toContain("Auction Results")
+    expect(extractText(root)).not.toContain("Artworks")
   })
 
   it(`does not show navigation buttons when enabled, but unavailable`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -229,12 +227,12 @@ describe(AutosuggestSearchResult, () => {
       />
     )
 
-    expect(extractText(tree.root)).not.toContain("Auction Results")
-    expect(extractText(tree.root)).not.toContain("Artworks")
+    expect(extractText(root)).not.toContain("Auction Results")
+    expect(extractText(root)).not.toContain("Artworks")
   })
 
   it(`quick navigation buttons navigate correctly`, async () => {
-    const tree = renderWithWrappersLEGACY(
+    const { root } = renderWithWrappersLEGACY(
       <TestWrapper
         result={{
           displayLabel: "Banksy",
@@ -251,7 +249,7 @@ describe(AutosuggestSearchResult, () => {
     )
 
     act(() => {
-      tree.root.findAllByType(Pressable)[0].props.onPress()
+      root.findAllByType(Pressable)[0].props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigate).toHaveBeenCalledWith("/artist/anto-carte/artworks", {
@@ -259,7 +257,7 @@ describe(AutosuggestSearchResult, () => {
     })
 
     act(() => {
-      tree.root.findAllByType(Pressable)[1].props.onPress()
+      root.findAllByType(Pressable)[1].props.onPress()
     })
     await new Promise((r) => setTimeout(r, 50))
     expect(navigate).toHaveBeenCalledWith("/artist/anto-carte/auction-results", {
@@ -269,11 +267,11 @@ describe(AutosuggestSearchResult, () => {
 
   it("should call custom event track handler when search result is pressed", () => {
     const trackResultPressMock = jest.fn()
-    const { getAllByText } = renderWithWrappers(
+    renderWithWrappers(
       <TestWrapper result={result} itemIndex={1} trackResultPress={trackResultPressMock} />
     )
 
-    fireEvent.press(getAllByText("Banksy")[0])
+    fireEvent.press(screen.getAllByText("Banksy")[0])
 
     expect(trackResultPressMock).toBeCalledWith(result, 1)
   })

--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tests.tsx
@@ -1,5 +1,5 @@
 import { Touchable } from "@artsy/palette-mobile"
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { SearchContext } from "app/Scenes/Search/SearchContext"
 import { GlobalStore, GlobalStoreProvider } from "app/store/GlobalStore"
 import { EntityType, navigate, navigateToEntity, SlugType } from "app/system/navigation/navigate"
@@ -15,6 +15,7 @@ const onDeleteMock = jest.fn()
 
 const result = {
   displayLabel: "Banksy",
+  formattedNationalityAndBirthday: "British, b. 1974",
   href: "banksy-href",
   imageUrl: "blah",
   displayType: "Artist",
@@ -275,5 +276,10 @@ describe(AutosuggestSearchResult, () => {
     fireEvent.press(getAllByText("Banksy")[0])
 
     expect(trackResultPressMock).toBeCalledWith(result, 1)
+  })
+
+  it("renders disambiguating info for artists", () => {
+    renderWithWrappers(<TestWrapper result={result} highlight="Ban" />)
+    expect(screen.getByText("British, b. 1974")).toBeTruthy()
   })
 })

--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
@@ -110,7 +110,12 @@ export const AutosuggestSearchResult: React.FC<{
 
   const resultType = getResultType(result)
 
-  const initials = result.__typename === "Artist" ? result.initials : undefined
+  let initials, secondaryLabel
+
+  if (result.__typename === "Artist") {
+    initials = result.initials
+    secondaryLabel = result.formattedNationalityAndBirthday || undefined
+  }
 
   return (
     <>
@@ -128,7 +133,11 @@ export const AutosuggestSearchResult: React.FC<{
           <Spacer x={1} />
 
           <Flex flex={1}>
-            <ResultWithHighlight displayLabel={result.displayLabel ?? ""} highlight={highlight} />
+            <ResultWithHighlight
+              displayLabel={result.displayLabel ?? ""}
+              secondaryLabel={secondaryLabel}
+              highlight={highlight}
+            />
 
             {!!showResultType && !!resultType && (
               <Text variant="xs" color="black60">

--- a/src/app/Scenes/Search/components/ResultWithHighlight.tsx
+++ b/src/app/Scenes/Search/components/ResultWithHighlight.tsx
@@ -4,25 +4,40 @@ import parse from "autosuggest-highlight/parse"
 
 export const ResultWithHighlight: React.FC<{
   displayLabel: string
+  secondaryLabel?: string
   highlight?: string
   numberOfLines?: number
   textAlign?: "center" | "end" | "justify" | "left" | "match-parent" | "right" | "start"
-}> = ({ displayLabel, highlight, numberOfLines = 1, textAlign }) => {
-  const matches = match(displayLabel, highlight!)
+}> = ({ displayLabel, secondaryLabel, highlight, numberOfLines = 1, textAlign }) => {
+  const matches = match(displayLabel, highlight || "")
   const parts = parse(displayLabel, matches)
 
   return (
-    <Text variant="xs" numberOfLines={numberOfLines} textAlign={textAlign}>
-      {parts.map((part, i) => (
+    <>
+      <Text variant="xs" numberOfLines={numberOfLines} textAlign={textAlign}>
+        {parts.map((part, i) => (
+          <Text
+            key={i}
+            variant="xs"
+            color={part.highlight ? "blue100" : "black100"}
+            weight={part.highlight ? "medium" : "regular"}
+          >
+            {part.text}
+          </Text>
+        ))}
+      </Text>
+
+      {!!secondaryLabel && (
         <Text
-          key={i}
           variant="xs"
-          color={part.highlight ? "blue100" : "black100"}
-          weight={part.highlight ? "medium" : "regular"}
+          numberOfLines={1}
+          textAlign={textAlign}
+          ellipsizeMode="middle"
+          color="black60"
         >
-          {part.text}
+          {secondaryLabel}
         </Text>
-      ))}
-    </Text>
+      )}
+    </>
   )
 }


### PR DESCRIPTION
> [!IMPORTANT]  
> As a reminder, **any** time we present a list of artists from which a user will select, we should also display disambiguating info: nationality, birth date, death date.

This PR resolves [ONYX-231] <!-- eg [PROJECT-XXXX] -->

### Description

This addresses a long-standing issue in MyC: we do not consistently display disambiguating info about artists, which increases the risk of misattributed artworks and duplicative artist data entering the platform.

If you're thinking there's already disambiguating info in the **Before** screenshots below — that's true, but only because people have abused one of the other name fields, presumably in response to ambiguous displays somewhere in the product:

<img width=500 src="https://github.com/artsy/eigen/assets/140521/9e020a78-3a2c-4a91-baaa-3ae0faed08a2)" />

The better we are about displaying the disambiguating info, the less the chance of that happening.

### Adding a collected artist to MyC

|Before|After (iOS)|After (Android)|
|---|---|---|
|<img height=400 width=209 src="https://github.com/artsy/eigen/assets/140521/2b6f4306-cf27-4f90-b80f-5c97b9c3e4ef" />|<img height=400 width=209 src="https://github.com/artsy/eigen/assets/140521/cad47a22-ea92-4606-8c39-db848ba4ea5b" />|<img height=300 src="https://github.com/artsy/eigen/assets/140521/ffebca41-9ec2-4018-9ac2-912d393013a1" />|

### Adding an artwork to MyC

|Before|After (iOS)|After (Android)|
|---|---|---|
|<img height=400 width=209  src="https://github.com/artsy/eigen/assets/140521/854605f4-543f-440f-b2a5-ea0ac1c15bb7" />|<img height=400 width=209 src="https://github.com/artsy/eigen/assets/140521/cc1cd756-f2b5-4ca8-9d50-2fd3d567928c" />|<img height=300 src="https://github.com/artsy/eigen/assets/140521/8ebd35de-4421-4b1d-aa6f-17037f710527" />|

Note that the gist of this PR is in the first three commits. I also tried to be a good citizen 😇 and address a bunch of linting errors and deprecations in the existing tests, that's the last two commits.





### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Artist search results present disambiguating information - anandaroop

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-231]: https://artsyproduct.atlassian.net/browse/ONYX-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ