### PR TITLE
fix: fix stale alerts staying on alerts screen after deletion

### DIFF
--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -61,6 +61,10 @@ export const SavedSearchesList: React.FC<SavedSearchesListProps> = (props) => {
     }
   }, [])
 
+  useEffect(() => {
+    setItems(extractNodes(me.alertsConnection).map((node) => ({ ...node, isSwipingActive: false })))
+  }, [me.alertsConnection])
+
   if (refreshMode === "delete") {
     return (
       <ProvidePlaceholderContext>


### PR DESCRIPTION
This PR resolves [APPL-857]

### Description

Steps to reproduce: Go to Alerts screen, tap on an alert, delete it -> you can still see the alert in the list.

Why this happened: I've added state for keeping `alertsConnection` to deal with some slide-to-delete things. When `alertsConnection` changes - state becomes stale. I'm not sure if what I'm doing is a good approach, I'm open to suggestions.

Fixed behaviour demo:

<video src="https://github.com/artsy/eigen/assets/3934579/15f909aa-2fa4-4ad1-b0eb-c684f77fd393" width="400px;" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- bugfix: fix stale alerts staying on alerts screen after deletion - @nickskalkin 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-857]: https://artsyproduct.atlassian.net/browse/APPL-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ