### PR TITLE
feat: navigate users to terms and conditions when bidding (DIA-546)

### DIFF
--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -18,6 +18,7 @@ import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { partnerName } from "app/Scenes/Artwork/Components/ArtworkExtraLinks/partnerName"
+import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { AuctionWebsocketContextProvider } from "app/utils/Websockets/auctions/AuctionSocketContext"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
@@ -348,6 +349,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     this.setState({ conditionsOfSaleChecked: !this.state.conditionsOfSaleChecked })
   }
 
+  onGeneralTermsAndConditionsOfSaleLinkPressed() {
+    navigate("/terms")
+  }
+
   onConditionsOfSaleLinkPressed() {
     navigate("/conditions-of-sale")
   }
@@ -452,6 +457,8 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
 
     const websocketEnabled = !!sale?.cascadingEndTimeIntervalMinutes
 
+    const showNewDisclaimer = unsafe_getFeatureFlag("AREnableNewTermsAndConditions")
+
     return (
       <AuctionWebsocketContextProvider
         channelInfo={{
@@ -551,7 +558,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
           </ScrollView>
           <Divider />
 
-          <Box>
+          <Box testID="disclaimer">
             {requiresCheckbox ? (
               <Checkbox
                 mt={4}
@@ -560,14 +567,22 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                 onPress={() => this.onConditionsOfSaleCheckboxPressed()}
                 disabled={isLoading}
                 flex={undefined}
+                testID="disclaimer-checkbox"
               >
                 <Text color="black60" variant="xs">
                   I agree to{" "}
                   <LinkText
                     variant="xs"
-                    onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}
+                    onPress={
+                      isLoading
+                        ? undefined
+                        : showNewDisclaimer
+                          ? () => this.onGeneralTermsAndConditionsOfSaleLinkPressed()
+                          : () => this.onConditionsOfSaleLinkPressed()
+                    }
                   >
-                    {partnerName(sale!)} Conditions of Sale
+                    {partnerName(sale!)} {showNewDisclaimer ? "General Terms and " : ""}Conditions
+                    of Sale
                   </LinkText>
                   . I understand that all bids are binding and may not be retracted.
                 </Text>
@@ -578,9 +593,16 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
                   I agree to{" "}
                   <LinkText
                     variant="xs"
-                    onPress={isLoading ? undefined : () => this.onConditionsOfSaleLinkPressed()}
+                    onPress={
+                      isLoading
+                        ? undefined
+                        : showNewDisclaimer
+                          ? () => this.onGeneralTermsAndConditionsOfSaleLinkPressed()
+                          : () => this.onConditionsOfSaleLinkPressed()
+                    }
                   >
-                    {partnerName(sale!)} Conditions of Sale
+                    {partnerName(sale!)} {showNewDisclaimer ? "General Terms and " : ""}Conditions
+                    of Sale
                   </LinkText>
                   . I understand that all bids are binding and may not be retracted.
                 </Text>

--- a/src/app/Components/Bidding/Screens/Registration.tests.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tests.tsx
@@ -11,6 +11,7 @@ import { Address } from "app/Components/Bidding/types"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import * as navigation from "app/system/navigation/navigate"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { TouchableWithoutFeedback } from "react-native"
 import relay from "react-relay"
@@ -649,10 +650,25 @@ it("shows a checkbox for agreeing to the conditions of sale", () => {
   ).toBeOnTheScreen()
 })
 
-describe("when AREnableNewTermsAndConditions is enabled", () => {
-  it("shows a checkbox for agreeing to the conditions of sale", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewTermsAndConditions: true })
+it("navigates to the conditions of sale when the user taps the link", () => {
+  jest.mock("app/system/navigation/navigate", () => ({
+    ...jest.requireActual("app/system/navigation/navigate"),
+    navigate: jest.fn(),
+  }))
 
+  renderWithWrappers(<Registration {...initialPropsForUserWithCreditCardAndPhone} />)
+
+  fireEvent.press(screen.getByText("Conditions of Sale"))
+
+  expect(navigation.navigate).toHaveBeenCalledWith("/conditions-of-sale")
+})
+
+describe("when AREnableNewTermsAndConditions is enabled", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewTermsAndConditions: true })
+  })
+
+  it("shows a checkbox for agreeing to the conditions of sale", () => {
     renderWithWrappers(<Registration {...initialPropsForUserWithCreditCardAndPhone} />)
 
     expect(
@@ -660,6 +676,19 @@ describe("when AREnableNewTermsAndConditions is enabled", () => {
         "I agree to Artsy's General Terms and Conditions of Sale. I understand that all bids are binding and may not be retracted."
       )
     ).toBeOnTheScreen()
+  })
+
+  it("navigates to the terms when the user taps the link", () => {
+    jest.mock("app/system/navigation/navigate", () => ({
+      ...jest.requireActual("app/system/navigation/navigate"),
+      navigate: jest.fn(),
+    }))
+
+    renderWithWrappers(<Registration {...initialPropsForUserWithCreditCardAndPhone} />)
+
+    fireEvent.press(screen.getByText("General Terms and Conditions of Sale"))
+
+    expect(navigation.navigate).toHaveBeenCalledWith("/terms")
   })
 })
 

--- a/src/app/Components/Bidding/Screens/Registration.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tsx
@@ -116,6 +116,10 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     return true
   }
 
+  onPressGeneralTermsAndConditionsOfSale = () => {
+    navigate("/terms")
+  }
+
   onPressConditionsOfSale = () => {
     navigate("/conditions-of-sale")
   }
@@ -406,7 +410,8 @@ export class Registration extends React.Component<RegistrationProps, Registratio
     const { isLoading, missingInformation: missingInformation } = this.state
 
     const saleTimeDetails = saleTime(sale)
-    const newTermsAndConditionsEnabled = unsafe_getFeatureFlag("AREnableNewTermsAndConditions")
+
+    const showNewDisclaimer = unsafe_getFeatureFlag("AREnableNewTermsAndConditions")
 
     return (
       <ScrollView
@@ -456,10 +461,12 @@ export class Registration extends React.Component<RegistrationProps, Registratio
             closeModal={this.closeModal.bind(this)}
           />
           <Checkbox mb={4} onPress={() => this.conditionsOfSalePressed()} disabled={isLoading}>
-            {newTermsAndConditionsEnabled ? (
+            {showNewDisclaimer ? (
               <Text variant="xs" fontSize="2">
                 I agree to Artsy's{" "}
-                <LinkText onPress={isLoading ? undefined : this.onPressConditionsOfSale}>
+                <LinkText
+                  onPress={isLoading ? undefined : this.onPressGeneralTermsAndConditionsOfSale}
+                >
                   General Terms and Conditions of Sale
                 </LinkText>
                 . I understand that all bids are binding and may not be retracted.


### PR DESCRIPTION
This PR updates the copy and link of the disclaimer displayed on the "confirm bid" step. It also updates the link on the "register to bid" step that was previously missed.

| Before | After |
|-------|-------|
| ![before_ios](https://github.com/artsy/eigen/assets/44589599/8af30865-a1e1-41bf-88ea-50c0c7d78140) | ![after_ios](https://github.com/artsy/eigen/assets/44589599/a9778b33-db8d-429f-b62d-83b9d18e5454) |
| ![before_ios_checkbox](https://github.com/artsy/eigen/assets/44589599/83a630b0-cd21-4db6-9fc6-01da1fa76349) | ![after_ios_checkbox](https://github.com/artsy/eigen/assets/44589599/4a7d6673-2d22-4b89-83ae-5e07a21a5b27) |
| ![before_android](https://github.com/artsy/eigen/assets/44589599/fce5bb0e-b3cf-4bd7-9c40-628745d3aa06) | ![after_android](https://github.com/artsy/eigen/assets/44589599/76e8933f-d623-4ddb-83e0-e68ee75b4233) |
| ![before_android_checkbox](https://github.com/artsy/eigen/assets/44589599/dd2849b2-7788-4813-9516-ca01dde9d39b) | ![after_android_checkbox](https://github.com/artsy/eigen/assets/44589599/e0e6e336-954b-42d2-a153-c9a1fca3b42d) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog