### PR TITLE
fix: photo picker crash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
     steps:
       - node/install-packages:
           pkg-manager: yarn
-          cache-version: v6
+          cache-version: v7
   run-relay-compiler:
     steps:
       - run:

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1384,7 +1384,7 @@ SPEC CHECKSUMS:
   appcenter-core: e192ea8b373bebd3e44998882b43311078bd7dda
   AppCenterReactNativeShared: 01df23849b1c3c6eb8c4049f54322635650e98f0
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  boost: 57d2868c099736d80fcd648bf211b4431e51a558
+  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da

--- a/patches/react-native-image-crop-picker+0.38.1.patch
+++ b/patches/react-native-image-crop-picker+0.38.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-index 3b867d1..6a19214 100644
+index 7101410..2fd5436 100644
 --- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 +++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-@@ -123,8 +123,19 @@ - (void) setConfiguration:(NSDictionary *)options
+@@ -124,8 +124,21 @@ RCT_EXPORT_MODULE();
      }
  }
  
@@ -10,14 +10,16 @@ index 3b867d1..6a19214 100644
 -    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
 +- (UIViewController *) getRootVC {
 +    UIWindow *presentingWindow;
-+    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
-+        if ([window isKindOfClass:NSClassFromString(@"ARWindow")]) {
-+            presentingWindow = window;
++    if (!presentingWindow) {
++        for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
++            if (![window isHidden] && [window windowLevel] == UIWindowLevelNormal) {
++                presentingWindow = window;
++            }
 +        }
 +    }
++
 +    if (!presentingWindow) {
-+        NSAssert(false, @"Unable to find ARWindow did it get renamed?");
-+        presentingWindow = [[[UIApplication sharedApplication] windows] lastObject];
++        presentingWindow = [[[UIApplication sharedApplication] windows] firstObject];
 +    }
 +
 +    UIViewController *root = [presentingWindow rootViewController];

--- a/patches/react-native-image-crop-picker+0.38.1.patch
+++ b/patches/react-native-image-crop-picker+0.38.1.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-index 7101410..2fd5436 100644
+index 7101410..de44b83 100644
 --- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 +++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-@@ -124,8 +124,21 @@ RCT_EXPORT_MODULE();
+@@ -124,8 +124,19 @@ RCT_EXPORT_MODULE();
      }
  }
  
@@ -10,11 +10,9 @@ index 7101410..2fd5436 100644
 -    UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
 +- (UIViewController *) getRootVC {
 +    UIWindow *presentingWindow;
-+    if (!presentingWindow) {
-+        for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
-+            if (![window isHidden] && [window windowLevel] == UIWindowLevelNormal) {
-+                presentingWindow = window;
-+            }
++    for (UIWindow *window in [[UIApplication sharedApplication] windows]) {
++        if (![window isHidden] && [window windowLevel] == UIWindowLevelNormal) {
++            presentingWindow = window;
 +        }
 +    }
 +


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

our patch for finding the root window in the photo stopped working reliably, this updates the window finding to a more robust method. 

It is still not totally clear why / under what conditions this doesn't work, it might be an iOS update or another dep update that broke it. 

### Follow-ups:
- There are issues in the upstream repo about windows not being found? Maybe we could contribute this back if this is the root of the problem?

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Fix photo picker crash - Brian + George 

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
