### PR TITLE
fix(EMI-1787): Swap positions of Create New List and Offer Settings buttons

### DIFF
--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
@@ -344,7 +344,7 @@ describe("ArtworkListsProvider", () => {
     it("should not be displayed by default", () => {
       renderOfferSettings({}, { artwork: null, artworkListOfferSettingsViewVisible: false })
 
-      expect(screen.queryByText("Offer settings")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Offer Settings")).not.toBeOnTheScreen()
     })
 
     it("should display the artwork lists", async () => {
@@ -354,7 +354,7 @@ describe("ArtworkListsProvider", () => {
         mockResolveLastOperation({ Me: () => ({ savedArtworksArtworkList, customArtworkLists }) })
       )
 
-      expect(screen.getByText("Offer settings")).toBeOnTheScreen()
+      expect(screen.getByText("Offer Settings")).toBeOnTheScreen()
 
       expect(screen.getByText("Saved Artworks")).toBeOnTheScreen()
       expect(screen.getByText("Custom Artwork List 1")).toBeOnTheScreen()

--- a/src/app/Components/ArtworkLists/views/ArtworkListOfferSettingsView/components/ArtworkListOfferSettingsHeader.tsx
+++ b/src/app/Components/ArtworkLists/views/ArtworkListOfferSettingsView/components/ArtworkListOfferSettingsHeader.tsx
@@ -8,7 +8,7 @@ export const ArtworkListOfferSettingsHeader = () => {
 
   return (
     <Box mx={2} mb={2}>
-      <Text variant="sm-display">Offer settings</Text>
+      <Text variant="sm-display">Offer Settings</Text>
 
       <Spacer y={2} />
 

--- a/src/app/Scenes/ArtworkLists/SavesTabHeader.tsx
+++ b/src/app/Scenes/ArtworkLists/SavesTabHeader.tsx
@@ -55,7 +55,7 @@ export const SavesTabHeader = () => {
         {!!isArtworkListOfferabilityEnabled && (
           <ProgressiveOnboardingOfferSettings>
             <Button haptic variant="text" size="small" onPress={handleOfferSettings}>
-              Offer settings
+              Offer Settings
             </Button>
           </ProgressiveOnboardingOfferSettings>
         )}

--- a/src/app/Scenes/ArtworkLists/SavesTabHeader.tsx
+++ b/src/app/Scenes/ArtworkLists/SavesTabHeader.tsx
@@ -52,6 +52,14 @@ export const SavesTabHeader = () => {
       </ProgressiveOnboardingSignalInterest>
 
       <Flex flexDirection="row" justifyContent="space-between" alignItems="center" my={2}>
+        {!!isArtworkListOfferabilityEnabled && (
+          <ProgressiveOnboardingOfferSettings>
+            <Button haptic variant="text" size="small" onPress={handleOfferSettings}>
+              Offer settings
+            </Button>
+          </ProgressiveOnboardingOfferSettings>
+        )}
+
         <Button
           haptic
           variant="text"
@@ -62,14 +70,6 @@ export const SavesTabHeader = () => {
         >
           Create New List
         </Button>
-
-        {!!isArtworkListOfferabilityEnabled && (
-          <ProgressiveOnboardingOfferSettings>
-            <Button haptic variant="text" size="small" onPress={handleOfferSettings}>
-              Offer settings
-            </Button>
-          </ProgressiveOnboardingOfferSettings>
-        )}
       </Flex>
     </Box>
   )


### PR DESCRIPTION
This PR resolves [EMI-1787] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR swaps the positions of the "Create New List" button and the "Offer Settings" button
as well as capitalizing the S in "Offer Settings" across the app

### Screenshots

| | Android | iOS |
|---|---|---|
| Feature Flag Enabled | <img width="466" alt="image" src="https://github.com/artsy/eigen/assets/20655703/272a1878-520f-4969-801f-6f4286b7eef7"> | ![image](https://github.com/artsy/eigen/assets/20655703/b9423722-b2b4-4b1a-a76f-7110c8bcda00) |
| Feature Flag Disabled | <img width="466" alt="image" src="https://github.com/artsy/eigen/assets/20655703/b6c8887a-2b2a-4f32-a475-a8515b15f501"> | ![image](https://github.com/artsy/eigen/assets/20655703/720e07ef-a6b7-483c-82cd-d0de5cb5fdc3) |


### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Update buttons positions in Saves header + capitalize S in "Offer Settings" - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1787]: https://artsyproduct.atlassian.net/browse/EMI-1787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ