### PR TITLE
feat: make AREnableNewTermsAndConditions releasable

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -252,7 +252,7 @@ export const features = {
   },
   AREnableNewTermsAndConditions: {
     description: "Enable new terms and conditions",
-    readyForRelease: false,
+    readyForRelease: true,
     showInDevMenu: true,
     echoFlagKey: "AREnableNewTermsAndConditions",
   },


### PR DESCRIPTION
This PR marks the `AREnableNewTermsAndConditions` feature flag as ready for release so that it can be turned on in the next release.

#nochangelog