### PR TITLE
feat: update terms of service checkbox (DIA-552)

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tests.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { TermsOfServiceCheckbox } from "app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("TermsOfServiceCheckbox", () => {
+  it("displays a disclaimer", () => {
+    renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+    expect(screen.getByTestId("disclaimer")).toHaveTextContent(
+      "By checking this box, you consent to our Terms of Use, Privacy Policy, and Conditions of Sale."
+    )
+  })
+
+  it("navigates to the terms of use", () => {
+    renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+    fireEvent.press(screen.getByText("Terms of Use"))
+    expect(navigateMock).toHaveBeenCalledWith("OnboardingWebView", { url: "/terms" })
+  })
+
+  it("navigates to the privacy policy", () => {
+    renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+    fireEvent.press(screen.getByText("Privacy Policy"))
+    expect(navigateMock).toHaveBeenCalledWith("OnboardingWebView", { url: "/privacy" })
+  })
+
+  it("navigates to the conditions of sale", () => {
+    renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+    fireEvent.press(screen.getByText("Conditions of Sale"))
+    expect(navigateMock).toHaveBeenCalledWith("OnboardingWebView", { url: "/conditions-of-sale" })
+  })
+
+  describe("when AREnableNewTermsAndConditions is enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewTermsAndConditions: true })
+    })
+
+    it("displays a disclaimer", () => {
+      renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+
+      expect(screen.getByTestId("disclaimer")).toHaveTextContent(
+        "I accept Artsy's General Terms and Conditions of Sale and Privacy Policy."
+      )
+    })
+
+    it("navigates to the terms of use", () => {
+      renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+      fireEvent.press(screen.getByText("General Terms and Conditions of Sale"))
+      expect(navigateMock).toHaveBeenCalledWith("OnboardingWebView", { url: "/terms" })
+    })
+
+    it("navigates to the privacy policy", () => {
+      renderWithWrappers(<TermsOfServiceCheckbox {...initialProps} />)
+      fireEvent.press(screen.getByText("Privacy Policy"))
+      expect(navigateMock).toHaveBeenCalledWith("OnboardingWebView", { url: "/privacy" })
+    })
+  })
+})
+
+const navigateMock = jest.fn()
+const initialProps = {
+  checked: false,
+  error: false,
+  setChecked: jest.fn(),
+  navigation: {
+    navigate: navigateMock,
+  } as any,
+}

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
@@ -1,6 +1,7 @@
 import { Flex, Text, Touchable, Checkbox } from "@artsy/palette-mobile"
 import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 
 interface TermsOfServiceCheckboxProps {
   checked: boolean
@@ -15,6 +16,8 @@ export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = ({
   error,
   navigation,
 }) => {
+  const showNewDisclaimer = useFeatureFlag("AREnableNewTermsAndConditions")
+
   return (
     <Touchable haptic onPress={() => setChecked(!checked)}>
       <Flex flexDirection="row" alignItems="flex-start">
@@ -32,36 +35,59 @@ export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = ({
               checked,
             },
           }}
+          testID="termsCheckbox"
         >
-          <Text variant="xs">
-            By checking this box, you consent to our{" "}
-            <Text
-              onPress={() => navigation.navigate("OnboardingWebView", { url: "/terms" })}
-              variant="xs"
-              style={{ textDecorationLine: "underline" }}
-            >
-              Terms of Use
+          {showNewDisclaimer ? (
+            <Text variant="xs" testID="disclaimer">
+              I accept Artsy's{" "}
+              <Text
+                onPress={() => navigation.navigate("OnboardingWebView", { url: "/terms" })}
+                variant="xs"
+                style={{ textDecorationLine: "underline" }}
+              >
+                General Terms and Conditions of Sale
+              </Text>{" "}
+              and{" "}
+              <Text
+                onPress={() => navigation.navigate("OnboardingWebView", { url: "/privacy" })}
+                variant="xs"
+                style={{ textDecorationLine: "underline" }}
+              >
+                Privacy Policy
+              </Text>
+              .
             </Text>
-            ,{" "}
-            <Text
-              onPress={() => navigation.navigate("OnboardingWebView", { url: "/privacy" })}
-              variant="xs"
-              style={{ textDecorationLine: "underline" }}
-            >
-              Privacy Policy
+          ) : (
+            <Text variant="xs" testID="disclaimer">
+              By checking this box, you consent to our{" "}
+              <Text
+                onPress={() => navigation.navigate("OnboardingWebView", { url: "/terms" })}
+                variant="xs"
+                style={{ textDecorationLine: "underline" }}
+              >
+                Terms of Use
+              </Text>
+              ,{" "}
+              <Text
+                onPress={() => navigation.navigate("OnboardingWebView", { url: "/privacy" })}
+                variant="xs"
+                style={{ textDecorationLine: "underline" }}
+              >
+                Privacy Policy
+              </Text>
+              , and{" "}
+              <Text
+                onPress={() =>
+                  navigation.navigate("OnboardingWebView", { url: "/conditions-of-sale" })
+                }
+                variant="xs"
+                style={{ textDecorationLine: "underline" }}
+              >
+                Conditions of Sale
+              </Text>
+              .
             </Text>
-            , and{" "}
-            <Text
-              onPress={() =>
-                navigation.navigate("OnboardingWebView", { url: "/conditions-of-sale" })
-              }
-              variant="xs"
-              style={{ textDecorationLine: "underline" }}
-            >
-              Conditions of Sale
-            </Text>
-            .
-          </Text>
+          )}
         </Checkbox>
       </Flex>
     </Touchable>


### PR DESCRIPTION
This PR updates the disclaimer that is displayed when a user enters their full name during sign-up.

| Before | After |
|-------|------|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-12 at 08 30 17](https://github.com/artsy/eigen/assets/44589599/ee7877e4-5a8f-4e10-8902-1dbcf97df040) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-12 at 08 30 39](https://github.com/artsy/eigen/assets/44589599/b11653bf-f806-4aa0-afc4-dcbe5d1c5934) |
| ![Screenshot_1712925362](https://github.com/artsy/eigen/assets/44589599/a0a68913-5614-4138-8554-d7d07b80e6f4) | ![Screenshot_1712925353](https://github.com/artsy/eigen/assets/44589599/d80bf6f0-fb4e-4828-b979-25a3a504cb55) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### Changelog updates

#### Cross-platform user-facing changes

- Displays a new disclaimer to agree to terms and conditions when signing up (behind a feature flag)
