### PR TITLE
Abbreviate time units to avoid overflow

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -445,7 +445,7 @@ describe("ActivityItem", () => {
 
       const label = screen.getByLabelText("Notification type: Offer")
       expect(label).toBeTruthy()
-      const badge = screen.getByText("Limited Time Offer")
+      const badge = screen.getByText("Limited-Time Offer")
       expect(badge).toBeTruthy()
     })
   })

--- a/src/app/Scenes/Activity/components/__tests__/PartnerOfferCreatedNotification.tests.tsx
+++ b/src/app/Scenes/Activity/components/__tests__/PartnerOfferCreatedNotification.tests.tsx
@@ -56,7 +56,7 @@ describe("PartnerOfferCreatedNotification", () => {
       await flushPromiseQueue()
 
       expect(screen.getByText("Offers")).toBeTruthy()
-      expect(screen.getByText("Limited Time Offer")).toBeTruthy()
+      expect(screen.getByText("Limited-Time Offer")).toBeTruthy()
       expect(screen.getByText(/Expires in/i)).toBeTruthy()
       expect(screen.getByText("$405,000")).toBeTruthy()
       expect(screen.getByText(/List price:\s*\$450,000\s*/)).toBeTruthy()
@@ -78,7 +78,7 @@ describe("PartnerOfferCreatedNotification", () => {
       await flushPromiseQueue()
 
       expect(screen.getByText("Offers")).toBeTruthy()
-      expect(screen.getByText("Limited Time Offer")).toBeTruthy()
+      expect(screen.getByText("Limited-Time Offer")).toBeTruthy()
       expect(
         screen.getByText("This offer has expired. Please make a new offer or contact the gallery")
       ).toBeTruthy()
@@ -129,7 +129,7 @@ describe("PartnerOfferCreatedNotification", () => {
       await flushPromiseQueue()
 
       expect(screen.getByText("Offers")).toBeTruthy()
-      expect(screen.getByText("Limited Time Offer")).toBeTruthy()
+      expect(screen.getByText("Limited-Time Offer")).toBeTruthy()
       expect(screen.getByText(/Expires in/i)).toBeTruthy()
       expect(screen.getByText("$405,000")).toBeTruthy()
       expect(screen.getByText(/Not publicly listed/i)).toBeTruthy()

--- a/src/app/Scenes/Activity/utils/__tests__/formattedTimeLeft.tests.ts
+++ b/src/app/Scenes/Activity/utils/__tests__/formattedTimeLeft.tests.ts
@@ -2,32 +2,40 @@ import { formattedTimeLeft } from "app/Scenes/Activity/utils/formattedTimeLeft"
 
 describe("formattedTimeLeft", () => {
   it("should return correct countdown copy and text color", () => {
-    expect(formattedTimeLeft({ days: "2", hours: "2", minutes: "2", seconds: "2" })).toEqual({
-      timerCopy: "2 days 2 hours",
+    expect(formattedTimeLeft({ days: "2", hours: "23", minutes: "2", seconds: "2" })).toEqual({
+      timerCopy: "2d 23h",
       textColor: "blue100",
     })
-    expect(formattedTimeLeft({ days: "1", hours: "1", minutes: "1", seconds: "1" })).toEqual({
-      timerCopy: "1 day 1 hour",
+    expect(formattedTimeLeft({ days: "2", hours: "0", minutes: "2", seconds: "2" })).toEqual({
+      timerCopy: "2d",
+      textColor: "blue100",
+    })
+    expect(formattedTimeLeft({ days: "1", hours: "0", minutes: "1", seconds: "1" })).toEqual({
+      timerCopy: "1d",
       textColor: "blue100",
     })
     expect(formattedTimeLeft({ days: "0", hours: "23", minutes: "59", seconds: "59" })).toEqual({
-      timerCopy: "23 hours",
+      timerCopy: "23h",
+      textColor: "blue100",
+    })
+    expect(formattedTimeLeft({ days: "0", hours: "1", minutes: "59", seconds: "59" })).toEqual({
+      timerCopy: "1h",
       textColor: "blue100",
     })
     expect(formattedTimeLeft({ days: "0", hours: "0", minutes: "59", seconds: "59" })).toEqual({
-      timerCopy: "59 minutes",
+      timerCopy: "59m",
       textColor: "orange100",
     })
     expect(formattedTimeLeft({ days: "0", hours: "0", minutes: "1", seconds: "59" })).toEqual({
-      timerCopy: "1 minute",
+      timerCopy: "1m",
       textColor: "orange100",
     })
     expect(formattedTimeLeft({ days: "0", hours: "0", minutes: "0", seconds: "59" })).toEqual({
-      timerCopy: "59 seconds",
+      timerCopy: "59s",
       textColor: "orange100",
     })
     expect(formattedTimeLeft({ days: "0", hours: "0", minutes: "0", seconds: "1" })).toEqual({
-      timerCopy: "1 second",
+      timerCopy: "1s",
       textColor: "orange100",
     })
   })

--- a/src/app/Scenes/Activity/utils/formattedTimeLeft.ts
+++ b/src/app/Scenes/Activity/utils/formattedTimeLeft.ts
@@ -1,5 +1,3 @@
-import { pluralize } from "app/utils/pluralize"
-
 export const formattedTimeLeft = (time: {
   days: string
   hours: string
@@ -15,19 +13,16 @@ export const formattedTimeLeft = (time: {
   let copy
 
   if (parsedDays >= 1 && parsedHours >= 1) {
-    copy = `${parsedDays} ${pluralize("day", parsedDays)} ${parsedHours} ${pluralize(
-      "hour",
-      parsedHours
-    )}`
+    copy = `${parsedDays}d ${parsedHours}h`
   } else if (parsedDays >= 1) {
-    copy = `${parsedDays} ${pluralize("day", parsedDays)}`
+    copy = `${parsedDays}d`
   } else if (parsedDays < 1 && parsedHours >= 1) {
-    copy = `${parsedHours} ${pluralize("hour", parsedHours)}`
+    copy = `${parsedHours}h`
   } else if (parsedHours < 1 && parsedMinutes >= 1) {
-    copy = `${parsedMinutes} ${pluralize("minute", parsedMinutes)}`
+    copy = `${parsedMinutes}m`
     textColor = "orange100"
   } else if (parsedMinutes < 1) {
-    copy = `${parsedSeconds} ${pluralize("second", parsedSeconds)}`
+    copy = `${parsedSeconds}s`
     textColor = "orange100"
   }
 

--- a/src/app/Scenes/Activity/utils/getNotificationTypeLabel.ts
+++ b/src/app/Scenes/Activity/utils/getNotificationTypeLabel.ts
@@ -3,7 +3,7 @@ import { NotificationTypesEnum } from "__generated__/ActivityRail_notificationsC
 export const getNotificationTypeBadge = (notificationType: NotificationTypesEnum) => {
   switch (notificationType) {
     case "PARTNER_OFFER_CREATED":
-      return "Limited Time Offer"
+      return "Limited-Time Offer"
     default:
       return null
   }


### PR DESCRIPTION
This PR resolves [EMI-1816](https://artsyproduct.atlassian.net/browse/EMI-1816)

### Description

This changes 2 things:

- Abbreviate units for partner offer remaining time across the app to avoid overflow
- Hyphenate "Limited Time Offer"

Note that while doing this, I noticed the remaining time format or precision are [inconsistent](https://artsy.slack.com/archives/C02JHHHKP5K/p1713201851488119?thread_ts=1712939704.237829&cid=C02JHHHKP5K) across surface areas (e.g. app, web checkout, CMS). This PR only address the overflow and keeps the current behavior. We can address the inconsistency separately.

| | Before | After |
|---|---|---|
| 2 days 23 hours | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 53 30](https://github.com/artsy/eigen/assets/796573/dfb0dd5a-a3a3-4fd1-a0da-a4e258cd2736) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 53 52](https://github.com/artsy/eigen/assets/796573/4e948bff-9db5-4cfe-80fe-e50f76b89dfd) |
| 23 hours | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 55 01](https://github.com/artsy/eigen/assets/796573/66d61b22-405f-4456-b6ff-b26e6fd916f3) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 55 18](https://github.com/artsy/eigen/assets/796573/7e3a2a6a-1fdc-4ff8-ab43-2a62ad819970) |
| 59 minutes | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 55 45](https://github.com/artsy/eigen/assets/796573/7d0a0931-57d2-4286-8ff0-c24c12aed260) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 56 00](https://github.com/artsy/eigen/assets/796573/f50362b1-b0bb-4a47-b238-ad67e05016ac) |
| 45 seconds | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 56 28](https://github.com/artsy/eigen/assets/796573/9336c893-941d-4153-87aa-cd545cb8b3a0) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-15 at 13 56 49](https://github.com/artsy/eigen/assets/796573/de836b20-ff48-4daa-8c17-1fe26cbee1ad) |

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
