### PR TITLE
fix: google signup / singin on cancel improvement

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -1,7 +1,7 @@
 import { ActionType, AuthService, CreatedAccount } from "@artsy/cohesion"
 import { appleAuth } from "@invertase/react-native-apple-authentication"
 import CookieManager from "@react-native-cookies/cookies"
-import { GoogleSignin } from "@react-native-google-signin/google-signin"
+import { GoogleSignin, statusCodes } from "@react-native-google-signin/google-signin"
 import * as Sentry from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import * as RelayCache from "app/system/relay/RelayCache"
@@ -164,6 +164,7 @@ export interface AuthPromiseResolveType {
 export interface AuthPromiseRejectType {
   error?: string
   message: string
+  code?: string
   meta?: {
     email: string
     provider: OAuthProvider
@@ -772,18 +773,24 @@ export const getAuthModel = (): AuthModel => ({
             }
           }
         }
-      } catch (e) {
+      } catch (e: any) {
+        if (statusCodes.SIGN_IN_CANCELLED === e?.code) {
+          reject(new AuthError(statusCodes.SIGN_IN_CANCELLED))
+          return
+        }
+
         if (e instanceof Error) {
-          if (e.message === "DEVELOPER_ERROR") {
+          if (e?.message === "DEVELOPER_ERROR") {
             reject(
               new AuthError(
                 "Google auth does not work in firebase beta, try again in a playstore beta",
-                e.message
+                e?.message
               )
             )
             return
           }
-          reject(new AuthError("Error logging in with google", e.message))
+
+          reject(new AuthError("Error logging in with google", e?.message))
           return
         }
         reject(new AuthError("Error logging in with google"))


### PR DESCRIPTION
This PR resolves [PHIRE-784] <!-- eg [PROJECT-XXXX] -->

### Description

Removes the warning popup - "no artsy account found" when user cancels the sign in / sign up flow (see videos below)

|Before|After|
|---|---|
|<video width="400" src="https://github.com/artsy/eigen/assets/21178754/da10080c-2558-4c5c-83de-93fedac8a332" />|<video width="400" src="https://github.com/artsy/eigen/assets/21178754/2fd07839-d271-4bcc-8730-8563ad0ef41f" />|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- google signup / singin on cancel improvement - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-784]: https://artsyproduct.atlassian.net/browse/PHIRE-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ