### PR TITLE
feat(EMI-1766): Show partner offer details on Artwork screeen

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -23,6 +23,7 @@ import {
   AuctionWebsocketChannelInfo,
   AuctionWebsocketContextProvider,
 } from "app/utils/Websockets/auctions/AuctionSocketContext"
+import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -437,7 +438,11 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
       />
 
       {!!(artworkAboveTheFold && me) && (
-        <ArtworkStickyBottomContent artwork={artworkAboveTheFold} me={me} />
+        <ArtworkStickyBottomContent
+          artwork={artworkAboveTheFold}
+          me={me}
+          partnerOffer={extractNodes(me.partnerOffersConnection)[0]}
+        />
       )}
 
       <QAInfo />
@@ -626,6 +631,7 @@ export const ArtworkContainer = createRefetchContainer(
           edges {
             node {
               internalID
+              ...ArtworkStickyBottomContent_partnerOfferToCollector
             }
           }
         }

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -79,7 +79,7 @@ describe("ArtworkPrice", () => {
 
   describe("Partner Offer", () => {
     beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferV1Improvements: true })
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferOnArtworkScreen: true })
     })
 
     it("should NOT render if there is not partner offers", () => {

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -7,6 +7,7 @@ import {
   artworkModel,
 } from "app/Scenes/Artwork/ArtworkStore"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { extractNodes } from "app/utils/extractNodes"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { DateTime } from "luxon"
 import { graphql } from "react-relay"
@@ -21,7 +22,10 @@ describe("ArtworkPrice", () => {
     Component: ({ artwork, me, initialData }) => {
       return (
         <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
-          <ArtworkPrice artwork={artwork!} me={me!} />
+          <ArtworkPrice
+            artwork={artwork!}
+            partnerOffer={extractNodes(me!.partnerOffersConnection)[0]}
+          />
         </ArtworkStoreProvider>
       )
     },
@@ -31,7 +35,13 @@ describe("ArtworkPrice", () => {
           ...ArtworkPrice_artwork
         }
         me {
-          ...ArtworkPrice_me @arguments(artworkID: "artworkID")
+          partnerOffersConnection(first: 1) {
+            edges {
+              node {
+                ...ArtworkPrice_partnerOfferToCollector
+              }
+            }
+          }
         }
       }
     `,

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -58,56 +58,6 @@ describe("ArtworkPrice", () => {
     })
   })
 
-  describe("Exclude shipping and taxes label", () => {
-    it("should NOT be displayed", () => {
-      renderWithRelay({
-        Artwork: () => ({
-          isEligibleForOnPlatformTransaction: false,
-          isInAuction: false,
-          isPriceHidden: false,
-        }),
-      })
-
-      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
-    })
-
-    it("should NOT be displayed when artworks is in auction", () => {
-      renderWithRelay({
-        Artwork: () => ({
-          isEligibleForOnPlatformTransaction: true,
-          isInAuction: true,
-          isPriceHidden: false,
-        }),
-      })
-
-      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
-    })
-
-    it("should NOT be displayed when price is hidden for artwork", () => {
-      renderWithRelay({
-        Artwork: () => ({
-          isEligibleForOnPlatformTransaction: true,
-          isInAuction: false,
-          isPriceHidden: true,
-        }),
-      })
-
-      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
-    })
-
-    it("should be displayed when artworks is eligible for on-platform transaction", () => {
-      renderWithRelay({
-        Artwork: () => ({
-          isEligibleForOnPlatformTransaction: true,
-          isInAuction: false,
-          isPriceHidden: false,
-        }),
-      })
-
-      expect(screen.getByText("excl. Shipping and Taxes")).toBeOnTheScreen()
-    })
-  })
-
   it("should render the sale message of the selected edition set", () => {
     renderWithRelay(
       {

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { ArtworkPrice_Test_Query } from "__generated__/ArtworkPrice_Test_Query.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import {
@@ -5,182 +6,188 @@ import {
   ArtworkStoreProvider,
   artworkModel,
 } from "app/Scenes/Artwork/ArtworkStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
-import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { graphql, useLazyLoadQuery } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { DateTime } from "luxon"
+import { graphql } from "react-relay"
 import { ArtworkPrice } from "./ArtworkPrice"
 
-interface TestRendererProps {
+interface TestProps {
   initialData?: Partial<ArtworkStoreModel>
 }
 
 describe("ArtworkPrice", () => {
-  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const { renderWithRelay } = setupTestWrapper<ArtworkPrice_Test_Query, TestProps>({
+    Component: ({ artwork, me, initialData }) => {
+      if (artwork && me) {
+        return (
+          <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
+            <ArtworkPrice artwork={artwork} me={me} />
+          </ArtworkStoreProvider>
+        )
+      }
 
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
+      return null
+    },
+    query: graphql`
+      query ArtworkPrice_Test_Query {
+        artwork(id: "artworkID") {
+          ...ArtworkPrice_artwork
+        }
+        me {
+          ...ArtworkPrice_me @arguments(artworkID: "artworkID")
+        }
+      }
+    `,
   })
 
-  const TestRenderer = (props?: TestRendererProps) => {
-    const data = useLazyLoadQuery<ArtworkPrice_Test_Query>(
-      graphql`
-        query ArtworkPrice_Test_Query {
-          artwork(id: "artworkID") {
-            ...ArtworkPrice_artwork
-          }
-        }
-      `,
-      {}
-    )
-
-    if (data.artwork) {
-      return (
-        <ArtworkStoreProvider
-          runtimeModel={{
-            ...artworkModel,
-            ...props?.initialData,
-          }}
-        >
-          <ArtworkPrice artwork={data.artwork} />
-        </ArtworkStoreProvider>
-      )
-    }
-
-    return null
-  }
-
   describe("Auction bid info", () => {
-    it("should be displayed", async () => {
-      const { getByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+    it("should be displayed", () => {
+      renderWithRelay({ Artwork: () => ({ isInAuction: true }) })
 
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Artwork: () => ({
-          isInAuction: true,
-        }),
-      })
-      await flushPromiseQueue()
-
-      expect(getByLabelText("Auction Bid Info")).toBeTruthy()
+      expect(screen.getByLabelText("Auction Bid Info")).toBeOnTheScreen()
     })
 
-    it("should NOT be displayed for live sale in progress", async () => {
-      const { queryByLabelText } = renderWithHookWrappersTL(
-        <TestRenderer initialData={{ auctionState: AuctionTimerState.LIVE_INTEGRATION_ONGOING }} />,
-        mockEnvironment
+    it("should NOT be displayed for live sale in progress", () => {
+      renderWithRelay(
+        { Artwork: () => ({ isInAuction: true }) },
+        { initialData: { auctionState: AuctionTimerState.LIVE_INTEGRATION_ONGOING } }
       )
 
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Artwork: () => ({
-          isInAuction: true,
-        }),
-      })
-      await flushPromiseQueue()
-
-      expect(queryByLabelText("Auction Bid Info")).toBeNull()
+      expect(screen.queryByLabelText("Auction Bid Info")).not.toBeOnTheScreen()
     })
   })
 
   describe("Exclude shipping and taxes label", () => {
-    it("should NOT be displayed", async () => {
-      const { queryByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
+    it("should NOT be displayed", () => {
+      renderWithRelay({
         Artwork: () => ({
           isEligibleForOnPlatformTransaction: false,
           isInAuction: false,
           isPriceHidden: false,
         }),
       })
-      await flushPromiseQueue()
 
-      expect(queryByText("excl. Shipping and Taxes")).toBeNull()
+      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
     })
 
-    it("should NOT be displayed when artworks is in auction", async () => {
-      const { queryByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
+    it("should NOT be displayed when artworks is in auction", () => {
+      renderWithRelay({
         Artwork: () => ({
           isEligibleForOnPlatformTransaction: true,
           isInAuction: true,
           isPriceHidden: false,
         }),
       })
-      await flushPromiseQueue()
 
-      expect(queryByText("excl. Shipping and Taxes")).toBeNull()
+      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
     })
 
-    it("should NOT be displayed when price is hidden for artwork", async () => {
-      const { queryByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
+    it("should NOT be displayed when price is hidden for artwork", () => {
+      renderWithRelay({
         Artwork: () => ({
           isEligibleForOnPlatformTransaction: true,
           isInAuction: false,
           isPriceHidden: true,
         }),
       })
-      await flushPromiseQueue()
 
-      expect(queryByText("excl. Shipping and Taxes")).toBeNull()
+      expect(screen.queryByText("excl. Shipping and Taxes")).not.toBeOnTheScreen()
     })
 
-    it("should be displayed when artworks is eligible for on-platform transaction", async () => {
-      const { queryByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
+    it("should be displayed when artworks is eligible for on-platform transaction", () => {
+      renderWithRelay({
         Artwork: () => ({
           isEligibleForOnPlatformTransaction: true,
           isInAuction: false,
           isPriceHidden: false,
         }),
       })
-      await flushPromiseQueue()
 
-      expect(queryByText("excl. Shipping and Taxes")).toBeTruthy()
+      expect(screen.getByText("excl. Shipping and Taxes")).toBeOnTheScreen()
     })
   })
 
-  it("should render the sale message of the selected edition set", async () => {
-    const { queryByText } = renderWithHookWrappersTL(
-      <TestRenderer initialData={{ selectedEditionId: "edition-set-one" }} />,
-      mockEnvironment
+  it("should render the sale message of the selected edition set", () => {
+    renderWithRelay(
+      {
+        Artwork: () => ({
+          isInAuction: false,
+          editionSets: [
+            { internalID: "edition-set-one", saleMessage: "$1000" },
+            { internalID: "edition-set-two", saleMessage: "$2000" },
+          ],
+        }),
+      },
+      { initialData: { selectedEditionId: "edition-set-one" } }
     )
 
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        isInAuction: false,
-        editionSets: [
-          {
-            internalID: "edition-set-one",
-            saleMessage: "$1000",
-          },
-          {
-            internalID: "edition-set-two",
-            saleMessage: "$2000",
-          },
-        ],
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(queryByText("$1000")).toBeTruthy()
+    expect(screen.getByText("$1000")).toBeOnTheScreen()
   })
 
-  it("should render the sale message", async () => {
-    const { getByText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
+  it("should render the sale message", () => {
+    renderWithRelay({ Artwork: () => ({ isInAuction: false, saleMessage: "$1000" }) })
 
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        isInAuction: false,
-        saleMessage: "$1000",
-      }),
+    expect(screen.getByText("$1000")).toBeOnTheScreen()
+  })
+
+  describe("Partner Offer", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferV1Improvements: true })
     })
-    await flushPromiseQueue()
 
-    expect(getByText("$1000")).toBeTruthy()
+    it("should NOT render if there is not partner offers", () => {
+      renderWithRelay({
+        Artwork: () => ({ isInAuction: false }),
+        Me: () => ({ partnerOffersConnection: { edges: [] } }),
+      })
+
+      expect(screen.queryByText("Limited-Time Offer")).not.toBeOnTheScreen()
+    })
+
+    it("should NOT render if the partner offer is not available", () => {
+      renderWithRelay({
+        Artwork: () => ({ isInAuction: false }),
+        Me: () => ({ partnerOffersConnection: { edges: [{ node: unavailablePartnerOffer }] } }),
+      })
+
+      expect(screen.queryByText("Limited-Time Offer")).not.toBeOnTheScreen()
+    })
+
+    describe("when a Partner Offer is available", () => {
+      it("should render the partner offer details", () => {
+        renderWithRelay({
+          Artwork: () => ({ isInAuction: false, isPriceHidden: false, saleMessage: "US$500" }),
+          Me: () => ({ partnerOffersConnection: { edges: [{ node: testPartnerOffer }] } }),
+        })
+
+        expect(screen.getByText("Limited-Time Offer")).toBeOnTheScreen()
+        expect(screen.getByText("$350")).toBeOnTheScreen()
+        expect(screen.getByText("(List Price: US$500)")).toBeOnTheScreen()
+      })
+
+      it("should render 'Not publicly listed' if the artwork price is hidden", () => {
+        renderWithRelay({
+          Artwork: () => ({ isInAuction: false, isPriceHidden: true }),
+          Me: () => ({ partnerOffersConnection: { edges: [{ node: testPartnerOffer }] } }),
+        })
+
+        expect(screen.getByText("(List Price: Not publicly listed)")).toBeOnTheScreen()
+      })
+    })
   })
 })
+
+const testPartnerOffer = {
+  endAt: DateTime.now().toUTC().plus({ days: 3 }).toISO(),
+  internalID: "partner-offer-id",
+  isAvailable: true,
+  priceWithDiscount: {
+    display: "$350",
+  },
+}
+
+const unavailablePartnerOffer = {
+  ...testPartnerOffer,
+  isAvailable: false,
+}

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -19,15 +19,11 @@ interface TestProps {
 describe("ArtworkPrice", () => {
   const { renderWithRelay } = setupTestWrapper<ArtworkPrice_Test_Query, TestProps>({
     Component: ({ artwork, me, initialData }) => {
-      if (artwork && me) {
-        return (
-          <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
-            <ArtworkPrice artwork={artwork} me={me} />
-          </ArtworkStoreProvider>
-        )
-      }
-
-      return null
+      return (
+        <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
+          <ArtworkPrice artwork={artwork!} me={me!} />
+        </ArtworkStoreProvider>
+      )
     },
     query: graphql`
       query ArtworkPrice_Test_Query {

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -38,22 +38,6 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
     return selectedEdition?.saleMessage
   }
 
-  const renderShippingAndTaxesInfo = () => {
-    if (
-      !artworkData.isEligibleForOnPlatformTransaction ||
-      artworkData.isInAuction ||
-      artworkData.isPriceHidden
-    ) {
-      return null
-    }
-
-    return (
-      <Text variant="xs" color="black60">
-        excl. Shipping and Taxes
-      </Text>
-    )
-  }
-
   if (artworkData.isInAuction) {
     if (auctionState === AuctionTimerState.LIVE_INTEGRATION_ONGOING) {
       return null
@@ -100,7 +84,6 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
     return (
       <Flex {...flexProps}>
         <Text variant="lg-display">{message}</Text>
-        {renderShippingAndTaxesInfo()}
       </Flex>
     )
   }
@@ -113,7 +96,6 @@ const artworkPriceFragment = graphql`
     saleMessage
     availability
     isInAuction
-    isEligibleForOnPlatformTransaction
     isPriceHidden
     taxInfo {
       displayText

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -22,10 +22,10 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
   const editionSets = artworkData.editionSets ?? []
   let message = null
 
-  const AREnablePartnerOfferV1Improvements = useFeatureFlag("AREnablePartnerOfferV1Improvements")
+  const AREnablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
 
   const partnerOffer =
-    (!!AREnablePartnerOfferV1Improvements &&
+    (!!AREnablePartnerOfferOnArtworkScreen &&
       meData.partnerOffersConnection &&
       extractNodes(meData.partnerOffersConnection)[0]) ||
     null

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -69,7 +69,7 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
   }
 
   if (!!partnerOffer && partnerOffer.isAvailable) {
-    const listPrice = message || "Not publicly listed"
+    const listPrice = artworkData.isPriceHidden ? "Not publicly listed" : message
 
     return (
       <Flex {...flexProps}>

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -58,7 +58,7 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
     return (
       <Flex {...flexProps}>
         <Flex flexDirection="row">
-          <Box borderRadius="3px" backgroundColor="blue10" px={0.5}>
+          <Box borderRadius={3} backgroundColor="blue10" px={0.5}>
             <Text variant="xs" color="blue100">
               Limited-Time Offer
             </Text>

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -70,9 +70,11 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
         </Flex>
 
         <Flex flexDirection="row" flexWrap="wrap" mt={1} alignItems="flex-end">
-          <Text variant="lg-display">{partnerOffer.priceWithDiscount?.display}</Text>
+          <Text variant="lg-display" mr={1}>
+            {partnerOffer.priceWithDiscount?.display}
+          </Text>
 
-          <Text variant="xs" color="black60" ml={1}>
+          <Text variant="xs" color="black60">
             (List Price: {listPrice})
           </Text>
         </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -58,7 +58,7 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
     return (
       <Flex {...flexProps}>
         <Flex flexDirection="row">
-          <Box borderRadius={3} backgroundColor="blue10" px={0.5}>
+          <Box borderRadius={3} backgroundColor="blue10" px={0.5} pb="2px">
             <Text variant="xs" color="blue100">
               Limited-Time Offer
             </Text>

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -1,20 +1,34 @@
-import { Flex, FlexProps, Text } from "@artsy/palette-mobile"
+import { Box, Flex, FlexProps, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkPrice_artwork$key } from "__generated__/ArtworkPrice_artwork.graphql"
+import { ArtworkPrice_me$key } from "__generated__/ArtworkPrice_me.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
-import { useFragment, graphql } from "react-relay"
+import { ExpiresInTimer } from "app/Scenes/Artwork/Components/ExpiresInTimer"
+import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { graphql, useFragment } from "react-relay"
 import { ArtworkAuctionBidInfo } from "./ArtworkAuctionBidInfo"
 
 interface ArtworkPriceProps extends FlexProps {
   artwork: ArtworkPrice_artwork$key
+  me: ArtworkPrice_me$key
 }
 
-export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, ...flexProps }) => {
-  const data = useFragment(artworkPriceFragment, artwork)
+export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flexProps }) => {
+  const artworkData = useFragment(artworkPriceFragment, artwork)
+  const meData = useFragment(mePriceFragment, me)
   const selectedEditionId = ArtworkStore.useStoreState((state) => state.selectedEditionId)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
-  const editionSets = data.editionSets ?? []
+  const editionSets = artworkData.editionSets ?? []
   let message = null
+
+  const AREnablePartnerOfferV1Improvements = useFeatureFlag("AREnablePartnerOfferV1Improvements")
+
+  const partnerOffer =
+    (!!AREnablePartnerOfferV1Improvements &&
+      meData.partnerOffersConnection &&
+      extractNodes(meData.partnerOffersConnection)[0]) ||
+    null
 
   const getEditionSetMessage = () => {
     const selectedEdition = editionSets.find((editionSet) => {
@@ -25,7 +39,11 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, ...flexProp
   }
 
   const renderShippingAndTaxesInfo = () => {
-    if (!data.isEligibleForOnPlatformTransaction || data.isInAuction || data.isPriceHidden) {
+    if (
+      !artworkData.isEligibleForOnPlatformTransaction ||
+      artworkData.isInAuction ||
+      artworkData.isPriceHidden
+    ) {
       return null
     }
 
@@ -36,18 +54,46 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, ...flexProp
     )
   }
 
-  if (data.isInAuction) {
+  if (artworkData.isInAuction) {
     if (auctionState === AuctionTimerState.LIVE_INTEGRATION_ONGOING) {
       return null
     }
 
-    return <ArtworkAuctionBidInfo artwork={data} {...flexProps} />
+    return <ArtworkAuctionBidInfo artwork={artworkData} {...flexProps} />
   }
 
   if (editionSets.length > 1) {
     message = getEditionSetMessage()
   } else {
-    message = data.saleMessage
+    message = artworkData.saleMessage
+  }
+
+  if (!!partnerOffer && partnerOffer.isAvailable) {
+    const listPrice = message || "Not publicly listed"
+
+    return (
+      <Flex {...flexProps}>
+        <Flex flexDirection="row">
+          <Box borderRadius="3px" backgroundColor="blue10" px={0.5}>
+            <Text variant="xs" color="blue100">
+              Limited-Time Offer
+            </Text>
+          </Box>
+
+          <Spacer x={1} />
+
+          <ExpiresInTimer item={partnerOffer} />
+        </Flex>
+
+        <Flex flexDirection="row" flexWrap="wrap" mt={1} alignItems="flex-end">
+          <Text variant="lg-display">{partnerOffer.priceWithDiscount?.display}</Text>
+
+          <Text variant="xs" color="black60" ml={1}>
+            (List Price: {listPrice})
+          </Text>
+        </Flex>
+      </Flex>
+    )
   }
 
   if (message) {
@@ -77,5 +123,22 @@ const artworkPriceFragment = graphql`
       saleMessage
     }
     ...ArtworkAuctionBidInfo_artwork
+  }
+`
+
+const mePriceFragment = graphql`
+  fragment ArtworkPrice_me on Me @argumentDefinitions(artworkID: { type: "String!" }) {
+    partnerOffersConnection(artworkID: $artworkID, first: 1) {
+      edges {
+        node {
+          endAt
+          internalID
+          isAvailable
+          priceWithDiscount {
+            display
+          }
+        }
+      }
+    }
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -1,34 +1,31 @@
 import { Box, Flex, FlexProps, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkPrice_artwork$key } from "__generated__/ArtworkPrice_artwork.graphql"
-import { ArtworkPrice_me$key } from "__generated__/ArtworkPrice_me.graphql"
+import { ArtworkPrice_partnerOfferToCollector$key } from "__generated__/ArtworkPrice_partnerOfferToCollector.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
 import { ExpiresInTimer } from "app/Scenes/Artwork/Components/ExpiresInTimer"
-import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
 import { ArtworkAuctionBidInfo } from "./ArtworkAuctionBidInfo"
 
 interface ArtworkPriceProps extends FlexProps {
   artwork: ArtworkPrice_artwork$key
-  me: ArtworkPrice_me$key
+  partnerOffer: ArtworkPrice_partnerOfferToCollector$key
 }
 
-export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flexProps }) => {
+export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({
+  artwork,
+  partnerOffer,
+  ...flexProps
+}) => {
   const artworkData = useFragment(artworkPriceFragment, artwork)
-  const meData = useFragment(mePriceFragment, me)
+  const partnerOfferData = useFragment(partnerOfferPriceFragment, partnerOffer)
   const selectedEditionId = ArtworkStore.useStoreState((state) => state.selectedEditionId)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
   const editionSets = artworkData.editionSets ?? []
   let message = null
 
   const AREnablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
-
-  const partnerOffer =
-    (!!AREnablePartnerOfferOnArtworkScreen &&
-      meData.partnerOffersConnection &&
-      extractNodes(meData.partnerOffersConnection)[0]) ||
-    null
 
   const getEditionSetMessage = () => {
     const selectedEdition = editionSets.find((editionSet) => {
@@ -52,7 +49,7 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
     message = artworkData.saleMessage
   }
 
-  if (!!partnerOffer && partnerOffer.isAvailable) {
+  if (!!AREnablePartnerOfferOnArtworkScreen && !!partnerOfferData && partnerOfferData.isAvailable) {
     const listPrice = artworkData.isPriceHidden ? "Not publicly listed" : message
 
     return (
@@ -66,12 +63,12 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({ artwork, me, ...flex
 
           <Spacer x={1} />
 
-          <ExpiresInTimer item={partnerOffer} />
+          <ExpiresInTimer item={partnerOfferData} />
         </Flex>
 
         <Flex flexDirection="row" flexWrap="wrap" mt={1} alignItems="flex-end">
           <Text variant="lg-display" mr={1}>
-            {partnerOffer.priceWithDiscount?.display}
+            {partnerOfferData.priceWithDiscount?.display}
           </Text>
 
           <Text variant="xs" color="black60">
@@ -110,19 +107,12 @@ const artworkPriceFragment = graphql`
   }
 `
 
-const mePriceFragment = graphql`
-  fragment ArtworkPrice_me on Me @argumentDefinitions(artworkID: { type: "String!" }) {
-    partnerOffersConnection(artworkID: $artworkID, first: 1) {
-      edges {
-        node {
-          endAt
-          internalID
-          isAvailable
-          priceWithDiscount {
-            display
-          }
-        }
-      }
+const partnerOfferPriceFragment = graphql`
+  fragment ArtworkPrice_partnerOfferToCollector on PartnerOfferToCollector {
+    endAt
+    isAvailable
+    priceWithDiscount {
+      display
     }
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { ArtworkStickyBottomContent_Test_Query } from "__generated__/ArtworkStickyBottomContent_Test_Query.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import {
@@ -5,148 +6,97 @@ import {
   ArtworkStoreProvider,
   artworkModel,
 } from "app/Scenes/Artwork/ArtworkStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
-import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { DateTime } from "luxon"
-import { graphql, useLazyLoadQuery } from "react-relay"
-import { createMockEnvironment } from "relay-test-utils"
+import { graphql } from "react-relay"
 import { ArtworkStickyBottomContent } from "./ArtworkStickyBottomContent"
 
-interface TestRendererProps {
+interface TestProps {
   initialData?: Partial<ArtworkStoreModel>
 }
 
 describe("ArtworkStickyBottomContent", () => {
-  let mockEnvironment: ReturnType<typeof createMockEnvironment>
+  const { renderWithRelay } = setupTestWrapper<ArtworkStickyBottomContent_Test_Query, TestProps>({
+    Component: ({ artwork, me, initialData }) => {
+      if (artwork && me) {
+        return (
+          <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
+            <ArtworkStickyBottomContent artwork={artwork} me={me} />
+          </ArtworkStoreProvider>
+        )
+      }
 
-  beforeEach(() => {
-    mockEnvironment = createMockEnvironment()
-  })
-
-  const TestRenderer = (props: TestRendererProps) => {
-    const data = useLazyLoadQuery<ArtworkStickyBottomContent_Test_Query>(
-      graphql`
-        query ArtworkStickyBottomContent_Test_Query {
-          artwork(id: "artworkID") {
-            ...ArtworkStickyBottomContent_artwork
-          }
-          me {
-            ...ArtworkStickyBottomContent_me
-          }
+      return null
+    },
+    query: graphql`
+      query ArtworkStickyBottomContent_Test_Query {
+        artwork(id: "artworkID") {
+          ...ArtworkStickyBottomContent_artwork
         }
-      `,
-      {}
+        me {
+          ...ArtworkStickyBottomContent_me @arguments(artworkID: "artworkID")
+        }
+      }
+    `,
+  })
+
+  it("should NOT be rendered when artwork is NOT for sale", () => {
+    renderWithRelay({ Artwork: () => ({ ...artwork, isForSale: false }) })
+
+    expect(screen.queryByLabelText("Sticky bottom commercial section")).not.toBeOnTheScreen()
+  })
+
+  it("should NOT be rendered when artwork is sold", () => {
+    renderWithRelay({ Artwork: () => ({ ...artwork, isSold: true }) })
+
+    expect(screen.queryByLabelText("Sticky bottom commercial section")).not.toBeOnTheScreen()
+  })
+
+  it("should NOT be rendered when auction is closed", () => {
+    renderWithRelay(
+      { Artwork: () => artwork },
+      { initialData: { auctionState: AuctionTimerState.CLOSED } }
     )
 
-    if (data.artwork && data.me) {
-      return (
-        <ArtworkStoreProvider
-          runtimeModel={{
-            ...artworkModel,
-            ...props.initialData,
-          }}
-        >
-          <ArtworkStickyBottomContent artwork={data.artwork} me={data.me} />
-        </ArtworkStoreProvider>
-      )
-    }
-
-    return null
-  }
-
-  it("should NOT be rendered when artwork is NOT for sale", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        ...artwork,
-        isForSale: false,
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeNull()
+    expect(screen.queryByLabelText("Sticky bottom commercial section")).not.toBeOnTheScreen()
   })
 
-  it("should NOT be rendered when artwork is sold", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        ...artwork,
-        isSold: true,
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeNull()
-  })
-
-  it("should NOT be rendered when auction is closed", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(
-      <TestRenderer initialData={{ auctionState: AuctionTimerState.CLOSED }} />,
-      mockEnvironment
+  it("should NOT be rendered when lot is ended", () => {
+    renderWithRelay(
+      {
+        Artwork: () => ({
+          ...artwork,
+          saleArtwork: { ...artwork.saleArtwork, endAt: DateTime.now().minus({ day: 1 }).toISO() },
+        }),
+      },
+      { initialData: { auctionState: AuctionTimerState.CLOSING } }
     )
 
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => artwork,
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeNull()
+    expect(screen.queryByLabelText("Sticky bottom commercial section")).not.toBeOnTheScreen()
   })
 
-  it("should NOT be rendered when lot is ended", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(
-      <TestRenderer initialData={{ auctionState: AuctionTimerState.CLOSING }} />,
-      mockEnvironment
+  it("should NOT be rendered when extended lot is ended", () => {
+    renderWithRelay(
+      {
+        Artwork: () => ({
+          ...artwork,
+          saleArtwork: {
+            ...artwork.saleArtwork,
+            endAt: DateTime.now().minus({ minutes: 20 }).toISO(),
+            extendedBiddingEndAt: DateTime.now().minus({ minutes: 5 }).toISO(),
+          },
+        }),
+      },
+      { initialData: { auctionState: AuctionTimerState.CLOSING } }
     )
 
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        ...artwork,
-        saleArtwork: {
-          ...artwork.saleArtwork,
-          endAt: DateTime.now().minus({ day: 1 }).toISO(),
-        },
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeNull()
+    expect(screen.queryByLabelText("Sticky bottom commercial section")).not.toBeOnTheScreen()
   })
 
-  it("should NOT be rendered when extended lot is ended", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(
-      <TestRenderer initialData={{ auctionState: AuctionTimerState.CLOSING }} />,
-      mockEnvironment
-    )
+  it("should be rendered", () => {
+    renderWithRelay({ Artwork: () => artwork })
 
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => ({
-        ...artwork,
-        saleArtwork: {
-          ...artwork.saleArtwork,
-          endAt: DateTime.now().minus({ minutes: 20 }).toISO(),
-          extendedBiddingEndAt: DateTime.now().minus({ minutes: 5 }).toISO(),
-        },
-      }),
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeNull()
-  })
-
-  it("should be rendered", async () => {
-    const { queryByLabelText } = renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-    resolveMostRecentRelayOperation(mockEnvironment, {
-      Artwork: () => artwork,
-    })
-    await flushPromiseQueue()
-
-    expect(queryByLabelText("Sticky bottom commercial section")).toBeTruthy()
+    expect(screen.getByLabelText("Sticky bottom commercial section")).toBeOnTheScreen()
   })
 })
 

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
@@ -18,13 +18,11 @@ interface TestProps {
 describe("ArtworkStickyBottomContent", () => {
   const { renderWithRelay } = setupTestWrapper<ArtworkStickyBottomContent_Test_Query, TestProps>({
     Component: ({ artwork, me, initialData }) => {
-      if (artwork && me) {
-        return (
-          <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
-            <ArtworkStickyBottomContent artwork={artwork} me={me} />
-          </ArtworkStoreProvider>
-        )
-      }
+      return (
+        <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
+          <ArtworkStickyBottomContent artwork={artwork!} me={me!} />
+        </ArtworkStoreProvider>
+      )
 
       return null
     },

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
@@ -6,6 +6,7 @@ import {
   ArtworkStoreProvider,
   artworkModel,
 } from "app/Scenes/Artwork/ArtworkStore"
+import { extractNodes } from "app/utils/extractNodes"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { DateTime } from "luxon"
 import { graphql } from "react-relay"
@@ -20,7 +21,11 @@ describe("ArtworkStickyBottomContent", () => {
     Component: ({ artwork, me, initialData }) => {
       return (
         <ArtworkStoreProvider runtimeModel={{ ...artworkModel, ...initialData }}>
-          <ArtworkStickyBottomContent artwork={artwork!} me={me!} />
+          <ArtworkStickyBottomContent
+            artwork={artwork!}
+            me={me!}
+            partnerOffer={extractNodes(me!.partnerOffersConnection)[0]}
+          />
         </ArtworkStoreProvider>
       )
 
@@ -32,7 +37,14 @@ describe("ArtworkStickyBottomContent", () => {
           ...ArtworkStickyBottomContent_artwork
         }
         me {
-          ...ArtworkStickyBottomContent_me @arguments(artworkID: "artworkID")
+          ...ArtworkStickyBottomContent_me
+          partnerOffersConnection(artworkID: "artworkID", first: 1) {
+            edges {
+              node {
+                ...ArtworkStickyBottomContent_partnerOfferToCollector
+              }
+            }
+          }
         }
       }
     `,

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -72,7 +72,7 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
     >
       <Separator />
       <Box px={2} py={1}>
-        <ArtworkPrice artwork={artworkData} mb={1} />
+        <ArtworkPrice artwork={artworkData} me={meData} mb={1} />
         <ArtworkCommercialButtons artwork={artworkData} me={meData} />
       </Box>
     </Box>
@@ -93,7 +93,9 @@ const artworkFragment = graphql`
 `
 
 const meFragment = graphql`
-  fragment ArtworkStickyBottomContent_me on Me {
+  fragment ArtworkStickyBottomContent_me on Me
+  @argumentDefinitions(artworkID: { type: "String!" }) {
     ...ArtworkCommercialButtons_me
+    ...ArtworkPrice_me @arguments(artworkID: $artworkID)
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -1,6 +1,7 @@
 import { Box, Separator } from "@artsy/palette-mobile"
 import { ArtworkStickyBottomContent_artwork$key } from "__generated__/ArtworkStickyBottomContent_artwork.graphql"
 import { ArtworkStickyBottomContent_me$key } from "__generated__/ArtworkStickyBottomContent_me.graphql"
+import { ArtworkStickyBottomContent_partnerOfferToCollector$key } from "__generated__/ArtworkStickyBottomContent_partnerOfferToCollector.graphql"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
@@ -14,15 +15,18 @@ import { ArtworkPrice } from "./ArtworkPrice"
 interface ArtworkStickyBottomContentProps {
   artwork: ArtworkStickyBottomContent_artwork$key
   me: ArtworkStickyBottomContent_me$key
+  partnerOffer: ArtworkStickyBottomContent_partnerOfferToCollector$key
 }
 
 export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProps> = ({
   artwork,
   me,
+  partnerOffer,
 }) => {
   const { safeAreaInsets } = useScreenDimensions()
   const artworkData = useFragment(artworkFragment, artwork)
   const meData = useFragment(meFragment, me)
+  const partnerOfferData = useFragment(partnerOfferFragment, partnerOffer)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
 
   const { bottom: bottomSafeAreaInset } = useScreenDimensions().safeAreaInsets
@@ -72,7 +76,7 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
     >
       <Separator />
       <Box px={2} py={1}>
-        <ArtworkPrice artwork={artworkData} me={meData} mb={1} />
+        <ArtworkPrice artwork={artworkData} partnerOffer={partnerOfferData} mb={1} />
         <ArtworkCommercialButtons artwork={artworkData} me={meData} />
       </Box>
     </Box>
@@ -93,9 +97,13 @@ const artworkFragment = graphql`
 `
 
 const meFragment = graphql`
-  fragment ArtworkStickyBottomContent_me on Me
-  @argumentDefinitions(artworkID: { type: "String!" }) {
+  fragment ArtworkStickyBottomContent_me on Me {
     ...ArtworkCommercialButtons_me
-    ...ArtworkPrice_me @arguments(artworkID: $artworkID)
+  }
+`
+
+const partnerOfferFragment = graphql`
+  fragment ArtworkStickyBottomContent_partnerOfferToCollector on PartnerOfferToCollector {
+    ...ArtworkPrice_partnerOfferToCollector
   }
 `

--- a/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
+++ b/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
@@ -1,14 +1,13 @@
 import { Color, Flex, Stopwatch, Text } from "@artsy/palette-mobile"
-import { ArtworkPrice_me$data } from "__generated__/ArtworkPrice_me.graphql"
+import { ArtworkPrice_partnerOfferToCollector$data } from "__generated__/ArtworkPrice_partnerOfferToCollector.graphql"
 import { formattedTimeLeftForPartnerOffer } from "app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer"
 import { getTimer } from "app/utils/getTimer"
-import { ExtractNodeType } from "app/utils/relayHelpers"
 import { FC, useEffect, useRef, useState } from "react"
 
 const INTERVAL = 1000
 
 interface ExpiresInTimerProps {
-  item: ExtractNodeType<ArtworkPrice_me$data["partnerOffersConnection"]>
+  item: Pick<ArtworkPrice_partnerOfferToCollector$data, "endAt">
 }
 
 const WatchIcon: FC<{ fill?: Color }> = ({ fill = "red100" }) => {

--- a/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
+++ b/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
@@ -1,0 +1,61 @@
+import { Color, Flex, Stopwatch, Text } from "@artsy/palette-mobile"
+import { ArtworkPrice_me$data } from "__generated__/ArtworkPrice_me.graphql"
+import { formattedTimeLeftInArtworkScreen } from "app/Scenes/Artwork/utils/formattedTimeLeft"
+import { getTimer } from "app/utils/getTimer"
+import { ExtractNodeType } from "app/utils/relayHelpers"
+import { FC, useEffect, useRef, useState } from "react"
+
+const INTERVAL = 1000
+
+interface ExpiresInTimerProps {
+  item: ExtractNodeType<ArtworkPrice_me$data["partnerOffersConnection"]>
+}
+
+const WatchIcon: FC<{ fill?: Color }> = ({ fill = "red100" }) => {
+  return <Stopwatch fill={fill} height={15} width={15} mr="2px" />
+}
+
+export const ExpiresInTimer: FC<ExpiresInTimerProps> = ({ item }) => {
+  const expiresAt = item?.endAt ?? ""
+
+  const intervalId = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [time, setTime] = useState(getTimer(expiresAt)["time"])
+  const [hasEnded, setHasEnded] = useState(getTimer(expiresAt)["hasEnded"])
+
+  useEffect(() => {
+    intervalId.current = setInterval(() => {
+      const { hasEnded: timerHasEnded, time: timerTime } = getTimer(expiresAt)
+
+      setHasEnded(timerHasEnded)
+      setTime(timerTime)
+    }, INTERVAL)
+
+    return () => {
+      if (intervalId.current) clearInterval(intervalId.current)
+    }
+  }, [])
+
+  if (hasEnded) {
+    return (
+      <Flex flexDirection="row" alignItems="center">
+        <WatchIcon />
+
+        <Text variant="xs" color="red100">
+          Expired
+        </Text>
+      </Flex>
+    )
+  }
+
+  const { timerCopy, textColor } = formattedTimeLeftInArtworkScreen(time)
+
+  return (
+    <Flex flexDirection="row" alignItems="center">
+      <WatchIcon fill={textColor} />
+
+      <Text variant="xs" color={textColor}>
+        Expires in {timerCopy}
+      </Text>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
+++ b/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
@@ -1,6 +1,6 @@
 import { Color, Flex, Stopwatch, Text } from "@artsy/palette-mobile"
 import { ArtworkPrice_me$data } from "__generated__/ArtworkPrice_me.graphql"
-import { formattedTimeLeftInArtworkScreen } from "app/Scenes/Artwork/utils/formattedTimeLeft"
+import { formattedTimeLeftForPartnerOffer } from "app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer"
 import { getTimer } from "app/utils/getTimer"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { FC, useEffect, useRef, useState } from "react"
@@ -21,6 +21,8 @@ export const ExpiresInTimer: FC<ExpiresInTimerProps> = ({ item }) => {
   const intervalId = useRef<ReturnType<typeof setInterval> | null>(null)
   const [time, setTime] = useState(getTimer(expiresAt)["time"])
   const [hasEnded, setHasEnded] = useState(getTimer(expiresAt)["hasEnded"])
+
+  const { timerCopy, textColor } = formattedTimeLeftForPartnerOffer(time)
 
   useEffect(() => {
     intervalId.current = setInterval(() => {
@@ -46,8 +48,6 @@ export const ExpiresInTimer: FC<ExpiresInTimerProps> = ({ item }) => {
       </Flex>
     )
   }
-
-  const { timerCopy, textColor } = formattedTimeLeftInArtworkScreen(time)
 
   return (
     <Flex flexDirection="row" alignItems="center">

--- a/src/app/Scenes/Artwork/utils/formattedTimeLeft.ts
+++ b/src/app/Scenes/Artwork/utils/formattedTimeLeft.ts
@@ -1,0 +1,17 @@
+import { formattedTimeLeft } from "app/Scenes/Activity/utils/formattedTimeLeft"
+
+export const formattedTimeLeftInArtworkScreen = (time: {
+  days: string
+  hours: string
+  minutes: string
+  seconds: string
+}) => {
+  const { textColor: timerColor, timerCopy } = formattedTimeLeft(time)
+
+  let textColor = timerColor
+  if (timerColor === "orange100") {
+    textColor = "red100"
+  }
+
+  return { timerCopy, textColor }
+}

--- a/src/app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer.ts
+++ b/src/app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer.ts
@@ -1,6 +1,6 @@
 import { formattedTimeLeft } from "app/Scenes/Activity/utils/formattedTimeLeft"
 
-export const formattedTimeLeftInArtworkScreen = (time: {
+export const formattedTimeLeftForPartnerOffer = (time: {
   days: string
   hours: string
   minutes: string


### PR DESCRIPTION
This PR resolves [EMI-1766] <!-- eg [PROJECT-XXXX] -->


> [!NOTE]
> This work is hidden behind `AREnablePartnerOfferV1Improvements` feature flag

### Description
This PR adds the partner offer details in the artwork screen
It also removes the `Exclude shipping and taxes` label from the artwork screen
And refactors a few tests 

### Screenshots

#### Removing excl. shipping and taxes label

| | Before | After |
|---|---|---|
| Android | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/598cf3f5-438e-45fe-9ec3-1afaa746d721"> | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/11c63587-ec7c-4fda-84c2-c4077a8c45b3"> |
| iOS | ![image](https://github.com/artsy/eigen/assets/20655703/f667408e-a5d1-436f-a0a8-19cc1997a4f7) | ![image](https://github.com/artsy/eigen/assets/20655703/08d4dd9e-a2ef-4bee-bfbf-f7623d5963c0) |


#### New Partner Offer details statuses

| | Android | iOS |
|---|---|---|
| Exact Price | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/de0dbab6-4781-4776-bca0-d6270dc0a702"> | ![image](https://github.com/artsy/eigen/assets/20655703/c276f60c-57aa-4d85-9ad2-7dc76e22dd9d) |
| Expiring soon + range | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/09cb943e-6e5a-4a00-b9da-cca051ce8639"> | ![image](https://github.com/artsy/eigen/assets/20655703/7ccfcb93-0a9d-49ea-a7c2-1d4daa0ff4aa) |
| Hidden price | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/2d11e385-b4a4-44ea-a71e-74f9f481d802"> | ![image](https://github.com/artsy/eigen/assets/20655703/cb857843-d00c-4276-abe2-8bd38b27a353) |
| Large price display | <img width="469" alt="image" src="https://github.com/artsy/eigen/assets/20655703/ac1596f3-f113-40d6-9d81-041e20292272"> | ![image](https://github.com/artsy/eigen/assets/20655703/ef6c5e89-04a6-4274-a7a4-4b264fdd4015) |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Adds partner offer details to artwork screen (behind FF: AREnablePartnerOfferV1Improvements) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

@artsy/emerald-devs 

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1766]: https://artsyproduct.atlassian.net/browse/EMI-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ