### PR TITLE
feat: [EMI-1753] artwork screen partner offer button behavior

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1379,7 +1379,7 @@ SPEC CHECKSUMS:
   appcenter-core: e192ea8b373bebd3e44998882b43311078bd7dda
   AppCenterReactNativeShared: 01df23849b1c3c6eb8c4049f54322635650e98f0
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  boost: 7dcd2de282d72e344012f7d6564d024930a6a440
+  boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
@@ -1389,7 +1389,7 @@ SPEC CHECKSUMS:
   CwlMachBadInstructionHandler: ea1030428925d9bf340882522af30712fb4bf356
   CwlPosixPreconditionTesting: a125dee731883f2582715f548c6b6c92c7fde145
   CwlPreconditionTesting: ccfd08aca58d14e04062b2a3dd2fd52e09857453
-  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
+  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": 7a3ac7ad2b9bae43aadb4dca08113bb495c98f3e
   FBAEMKit: 6c7b5eb77c96861bb59e040842c6e55bf39512ce
@@ -1419,7 +1419,7 @@ SPEC CHECKSUMS:
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  glog: 5337263514dd6f09803962437687240c5dc39aa4
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152

--- a/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
+++ b/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
@@ -11,6 +11,7 @@ import { useFragment, graphql } from "react-relay"
 
 export interface PartnerOffer {
   id: string
+  internalID: string
   endAt: string
   isAvailable: boolean
   targetHref: string

--- a/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
+++ b/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
@@ -14,7 +14,6 @@ export interface PartnerOffer {
   internalID: string
   endAt: string
   isAvailable: boolean
-  targetHref: string
   note?: string
 }
 

--- a/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
+++ b/src/app/Scenes/Activity/components/NotificationArtworkList.tsx
@@ -10,7 +10,6 @@ import { ImageBackground } from "react-native"
 import { useFragment, graphql } from "react-relay"
 
 export interface PartnerOffer {
-  id: string
   internalID: string
   endAt: string
   isAvailable: boolean

--- a/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
+++ b/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
@@ -119,7 +119,9 @@ export const CommercialButtons: React.FC<{
         <RowContainer>
           <Button
             onPress={() => {
-              navigate(`/artwork/${artworkID}`, { passProps: { partnerOfferId: partnerOffer?.id } })
+              navigate(`/artwork/${artworkID}`, {
+                passProps: { partnerOfferId: partnerOffer?.internalID },
+              })
             }}
             variant="outline"
             accessibilityLabel="View Work"

--- a/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
@@ -20,7 +20,7 @@ export const PartnerOfferCreatedNotification: React.FC<PartnerOfferCreatedNotifi
 }) => {
   const notificationData = useFragment(PartnerOfferCreatedNotificationFragment, notification)
 
-  const { headline, item, notificationType, artworksConnection, targetHref } = notificationData
+  const { headline, item, notificationType, artworksConnection } = notificationData
 
   const { hasEnded } = getTimer(item?.partnerOffer?.endAt || "")
   const noLongerAvailable = !item?.partnerOffer?.isAvailable
@@ -80,7 +80,6 @@ export const PartnerOfferCreatedNotification: React.FC<PartnerOfferCreatedNotifi
               internalID: item?.partnerOffer?.internalID || "",
               endAt: item?.partnerOffer?.endAt || "",
               isAvailable: item?.partnerOffer?.isAvailable || false,
-              targetHref: targetHref,
               note: item?.partnerOffer?.note || "",
               id: item?.partnerOffer?.internalID || "",
             }}

--- a/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
@@ -77,6 +77,7 @@ export const PartnerOfferCreatedNotification: React.FC<PartnerOfferCreatedNotifi
               priceWithDiscountMessage: item?.partnerOffer?.priceWithDiscount?.display || "",
             }}
             partnerOffer={{
+              internalID: item?.partnerOffer?.internalID || "",
               endAt: item?.partnerOffer?.endAt || "",
               isAvailable: item?.partnerOffer?.isAvailable || false,
               targetHref: targetHref,
@@ -101,6 +102,7 @@ export const PartnerOfferCreatedNotificationFragment = graphql`
         expiresAt
         available
         partnerOffer {
+          internalID
           note
           internalID
           endAt

--- a/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
@@ -81,7 +81,6 @@ export const PartnerOfferCreatedNotification: React.FC<PartnerOfferCreatedNotifi
               endAt: item?.partnerOffer?.endAt || "",
               isAvailable: item?.partnerOffer?.isAvailable || false,
               note: item?.partnerOffer?.note || "",
-              id: item?.partnerOffer?.internalID || "",
             }}
             showArtworkCommercialButtons
           />

--- a/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerOfferCreatedNotification.tsx
@@ -100,7 +100,6 @@ export const PartnerOfferCreatedNotificationFragment = graphql`
         expiresAt
         available
         partnerOffer {
-          internalID
           note
           internalID
           endAt

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -646,7 +646,7 @@ export const ArtworkContainer = createRefetchContainer(
           edges {
             node {
               internalID
-              ...ArtworkStickyBottomContent_partnerOfferToCollector
+              ...ArtworkStickyBottomContent_partnerOffer
               ...ArtworkPartnerOfferNote_partnerOfferToCollector
             }
           }

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -647,7 +647,7 @@ export const ArtworkContainer = createRefetchContainer(
             node {
               internalID
               ...ArtworkStickyBottomContent_partnerOffer
-              ...ArtworkPartnerOfferNote_partnerOfferToCollector
+              ...ArtworkPartnerOfferNote_partnerOffer
             }
           }
         }

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -32,7 +32,7 @@ describe("ArtworkCommercialButtons", () => {
         >
           <ArtworkStoreProvider>
             <ArtworkCommercialButtons
-              partnerOfferToCollector={partnerOffer}
+              partnerOffer={partnerOffer}
               artwork={props.artwork!}
               me={props.me!}
             />
@@ -51,7 +51,7 @@ describe("ArtworkCommercialButtons", () => {
           partnerOffersConnection(artworkID: "artworkID") {
             edges {
               node {
-                ...ArtworkCommercialButtons_partnerOfferToCollector
+                ...ArtworkCommercialButtons_partnerOffer
               }
             }
           }

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -1,7 +1,7 @@
 import { Spacer, Flex, Join } from "@artsy/palette-mobile"
 import { ArtworkCommercialButtons_artwork$key } from "__generated__/ArtworkCommercialButtons_artwork.graphql"
 import { ArtworkCommercialButtons_me$key } from "__generated__/ArtworkCommercialButtons_me.graphql"
-import { ArtworkCommercialButtons_partnerOfferToCollector$key } from "__generated__/ArtworkCommercialButtons_partnerOfferToCollector.graphql"
+import { ArtworkCommercialButtons_partnerOffer$key } from "__generated__/ArtworkCommercialButtons_partnerOffer.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
 import { BuyNowButton } from "app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton"
@@ -14,7 +14,7 @@ import { BidButtonFragmentContainer } from "./CommercialButtons/BidButton"
 interface ArtworkCommercialButtonsProps {
   artwork: ArtworkCommercialButtons_artwork$key
   me: ArtworkCommercialButtons_me$key
-  partnerOfferToCollector: ArtworkCommercialButtons_partnerOfferToCollector$key
+  partnerOffer: ArtworkCommercialButtons_partnerOffer$key
 }
 
 const RowContainer: React.FC = ({ children }) => {
@@ -31,12 +31,12 @@ const RowContainer: React.FC = ({ children }) => {
 
 export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> = ({
   artwork,
-  partnerOfferToCollector,
+  partnerOffer,
   me,
 }) => {
   const artworkData = useFragment(artworkFragment, artwork)
   const meData = useFragment(meFragment, me)
-  const partnerOfferData = useFragment(partnerOfferFragment, partnerOfferToCollector)
+  const partnerOfferData = useFragment(partnerOfferFragment, partnerOffer)
   const selectedEditionId = ArtworkStore.useStoreState((state) => state.selectedEditionId)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
   const isBiddableInAuction = artworkData.isInAuction && artworkData.sale
@@ -156,7 +156,7 @@ const meFragment = graphql`
 `
 
 const partnerOfferFragment = graphql`
-  fragment ArtworkCommercialButtons_partnerOfferToCollector on PartnerOfferToCollector {
+  fragment ArtworkCommercialButtons_partnerOffer on PartnerOfferToCollector {
     internalID
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -1,18 +1,20 @@
 import { Spacer, Flex, Join } from "@artsy/palette-mobile"
 import { ArtworkCommercialButtons_artwork$key } from "__generated__/ArtworkCommercialButtons_artwork.graphql"
 import { ArtworkCommercialButtons_me$key } from "__generated__/ArtworkCommercialButtons_me.graphql"
+import { ArtworkCommercialButtons_partnerOfferToCollector$key } from "__generated__/ArtworkCommercialButtons_partnerOfferToCollector.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
+import { BuyNowButton } from "app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton"
+import { InquiryButtonsFragmentContainer } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons"
+import { MakeOfferButtonFragmentContainer } from "app/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton"
 import { Children } from "react"
 import { useFragment, graphql } from "react-relay"
 import { BidButtonFragmentContainer } from "./CommercialButtons/BidButton"
-import { BuyNowButton } from "./CommercialButtons/BuyNowButton"
-import { InquiryButtonsFragmentContainer } from "./CommercialButtons/InquiryButtons"
-import { MakeOfferButtonFragmentContainer } from "./CommercialButtons/MakeOfferButton"
 
 interface ArtworkCommercialButtonsProps {
   artwork: ArtworkCommercialButtons_artwork$key
   me: ArtworkCommercialButtons_me$key
+  partnerOfferToCollector: ArtworkCommercialButtons_partnerOfferToCollector$key
 }
 
 const RowContainer: React.FC = ({ children }) => {
@@ -29,10 +31,12 @@ const RowContainer: React.FC = ({ children }) => {
 
 export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> = ({
   artwork,
+  partnerOfferToCollector,
   me,
 }) => {
   const artworkData = useFragment(artworkFragment, artwork)
   const meData = useFragment(meFragment, me)
+  const partnerOfferData = useFragment(partnerOfferFragment, partnerOfferToCollector)
   const selectedEditionId = ArtworkStore.useStoreState((state) => state.selectedEditionId)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
   const isBiddableInAuction = artworkData.isInAuction && artworkData.sale
@@ -57,7 +61,12 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
             auctionState={auctionState as AuctionTimerState}
             variant="outline"
           />
-          <BuyNowButton artwork={artworkData} editionSetID={selectedEditionId} renderSaleMessage />
+          <BuyNowButton
+            partnerOffer={partnerOfferData}
+            artwork={artworkData}
+            editionSetID={selectedEditionId}
+            renderSaleMessage
+          />
         </RowContainer>
       )
     }
@@ -79,13 +88,23 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
           editionSetID={selectedEditionId}
           variant="outline"
         />
-        <BuyNowButton artwork={artworkData} editionSetID={selectedEditionId} />
+        <BuyNowButton
+          partnerOffer={partnerOfferData}
+          artwork={artworkData}
+          editionSetID={selectedEditionId}
+        />
       </RowContainer>
     )
   }
 
   if (artworkData.isAcquireable) {
-    return <BuyNowButton artwork={artworkData} editionSetID={selectedEditionId} />
+    return (
+      <BuyNowButton
+        partnerOffer={partnerOfferData}
+        artwork={artworkData}
+        editionSetID={selectedEditionId}
+      />
+    )
   }
 
   if (artworkData.isInquireable && artworkData.isOfferable) {
@@ -133,5 +152,11 @@ const artworkFragment = graphql`
 const meFragment = graphql`
   fragment ArtworkCommercialButtons_me on Me {
     ...BidButton_me
+  }
+`
+
+const partnerOfferFragment = graphql`
+  fragment ArtworkCommercialButtons_partnerOfferToCollector on PartnerOfferToCollector {
+    internalID
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -158,5 +158,6 @@ const meFragment = graphql`
 const partnerOfferFragment = graphql`
   fragment ArtworkCommercialButtons_partnerOffer on PartnerOfferToCollector {
     internalID
+    endAt
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
@@ -22,7 +22,7 @@ describe("ArtworkPartnerOfferNote", () => {
           partnerOffersConnection(artworkID: "test-artwork", first: 1) {
             edges {
               node {
-                ...ArtworkPartnerOfferNote_partnerOfferToCollector
+                ...ArtworkPartnerOfferNote_partnerOffer
               }
             }
           }

--- a/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tsx
@@ -1,12 +1,12 @@
 import { Box, Flex, Text, useColor } from "@artsy/palette-mobile"
 import { ArtworkPartnerOfferNote_artwork$key } from "__generated__/ArtworkPartnerOfferNote_artwork.graphql"
-import { ArtworkPartnerOfferNote_partnerOfferToCollector$key } from "__generated__/ArtworkPartnerOfferNote_partnerOfferToCollector.graphql"
+import { ArtworkPartnerOfferNote_partnerOffer$key } from "__generated__/ArtworkPartnerOfferNote_partnerOffer.graphql"
 import { ImageBackground } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtworkPartnerOfferNoteProps {
   artwork: ArtworkPartnerOfferNote_artwork$key
-  partnerOffer: ArtworkPartnerOfferNote_partnerOfferToCollector$key
+  partnerOffer: ArtworkPartnerOfferNote_partnerOffer$key
 }
 
 export const ArtworkPartnerOfferNote: React.FC<ArtworkPartnerOfferNoteProps> = ({
@@ -68,7 +68,7 @@ const artworkFragment = graphql`
 `
 
 const partnerOfferFragment = graphql`
-  fragment ArtworkPartnerOfferNote_partnerOfferToCollector on PartnerOfferToCollector {
+  fragment ArtworkPartnerOfferNote_partnerOffer on PartnerOfferToCollector {
     note
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tests.tsx
@@ -38,7 +38,7 @@ describe("ArtworkPrice", () => {
           partnerOffersConnection(first: 1) {
             edges {
               node {
-                ...ArtworkPrice_partnerOfferToCollector
+                ...ArtworkPrice_partnerOffer
               }
             }
           }

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, FlexProps, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkPrice_artwork$key } from "__generated__/ArtworkPrice_artwork.graphql"
-import { ArtworkPrice_partnerOfferToCollector$key } from "__generated__/ArtworkPrice_partnerOfferToCollector.graphql"
+import { ArtworkPrice_partnerOffer$key } from "__generated__/ArtworkPrice_partnerOffer.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
 import { ExpiresInTimer } from "app/Scenes/Artwork/Components/ExpiresInTimer"
@@ -10,7 +10,7 @@ import { ArtworkAuctionBidInfo } from "./ArtworkAuctionBidInfo"
 
 interface ArtworkPriceProps extends FlexProps {
   artwork: ArtworkPrice_artwork$key
-  partnerOffer: ArtworkPrice_partnerOfferToCollector$key
+  partnerOffer: ArtworkPrice_partnerOffer$key
 }
 
 export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({
@@ -108,7 +108,7 @@ const artworkPriceFragment = graphql`
 `
 
 const partnerOfferPriceFragment = graphql`
-  fragment ArtworkPrice_partnerOfferToCollector on PartnerOfferToCollector {
+  fragment ArtworkPrice_partnerOffer on PartnerOfferToCollector {
     endAt
     isAvailable
     priceWithDiscount {

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
@@ -41,7 +41,7 @@ describe("ArtworkStickyBottomContent", () => {
           partnerOffersConnection(artworkID: "artworkID", first: 1) {
             edges {
               node {
-                ...ArtworkStickyBottomContent_partnerOfferToCollector
+                ...ArtworkStickyBottomContent_partnerOffer
               }
             }
           }

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -20,8 +20,8 @@ interface ArtworkStickyBottomContentProps {
 
 export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProps> = ({
   artwork,
-  me,
   partnerOffer,
+  me,
 }) => {
   const { safeAreaInsets } = useScreenDimensions()
   const artworkData = useFragment(artworkFragment, artwork)
@@ -77,7 +77,11 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
       <Separator />
       <Box px={2} py={1}>
         <ArtworkPrice artwork={artworkData} partnerOffer={partnerOfferData} mb={1} />
-        <ArtworkCommercialButtons artwork={artworkData} me={meData} />
+        <ArtworkCommercialButtons
+          artwork={artworkData}
+          partnerOfferToCollector={partnerOfferData}
+          me={meData}
+        />
       </Box>
     </Box>
   )
@@ -104,6 +108,8 @@ const meFragment = graphql`
 
 const partnerOfferFragment = graphql`
   fragment ArtworkStickyBottomContent_partnerOfferToCollector on PartnerOfferToCollector {
+    internalID
     ...ArtworkPrice_partnerOfferToCollector
+    ...ArtworkCommercialButtons_partnerOfferToCollector
   }
 `

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -20,8 +20,8 @@ interface ArtworkStickyBottomContentProps {
 
 export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProps> = ({
   artwork,
-  partnerOffer,
   me,
+  partnerOffer,
 }) => {
   const { safeAreaInsets } = useScreenDimensions()
   const artworkData = useFragment(artworkFragment, artwork)

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -1,7 +1,7 @@
 import { Box, Separator } from "@artsy/palette-mobile"
 import { ArtworkStickyBottomContent_artwork$key } from "__generated__/ArtworkStickyBottomContent_artwork.graphql"
 import { ArtworkStickyBottomContent_me$key } from "__generated__/ArtworkStickyBottomContent_me.graphql"
-import { ArtworkStickyBottomContent_partnerOfferToCollector$key } from "__generated__/ArtworkStickyBottomContent_partnerOfferToCollector.graphql"
+import { ArtworkStickyBottomContent_partnerOffer$key } from "__generated__/ArtworkStickyBottomContent_partnerOffer.graphql"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
@@ -15,7 +15,7 @@ import { ArtworkPrice } from "./ArtworkPrice"
 interface ArtworkStickyBottomContentProps {
   artwork: ArtworkStickyBottomContent_artwork$key
   me: ArtworkStickyBottomContent_me$key
-  partnerOffer: ArtworkStickyBottomContent_partnerOfferToCollector$key
+  partnerOffer: ArtworkStickyBottomContent_partnerOffer$key
 }
 
 export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProps> = ({
@@ -79,7 +79,7 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
         <ArtworkPrice artwork={artworkData} partnerOffer={partnerOfferData} mb={1} />
         <ArtworkCommercialButtons
           artwork={artworkData}
-          partnerOfferToCollector={partnerOfferData}
+          partnerOffer={partnerOfferData}
           me={meData}
         />
       </Box>
@@ -107,9 +107,9 @@ const meFragment = graphql`
 `
 
 const partnerOfferFragment = graphql`
-  fragment ArtworkStickyBottomContent_partnerOfferToCollector on PartnerOfferToCollector {
+  fragment ArtworkStickyBottomContent_partnerOffer on PartnerOfferToCollector {
     internalID
-    ...ArtworkPrice_partnerOfferToCollector
-    ...ArtworkCommercialButtons_partnerOfferToCollector
+    ...ArtworkPrice_partnerOffer
+    ...ArtworkCommercialButtons_partnerOffer
   }
 `

--- a/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
+++ b/src/app/Scenes/Artwork/Components/ExpiresInTimer.tsx
@@ -1,5 +1,5 @@
 import { Color, Flex, Stopwatch, Text } from "@artsy/palette-mobile"
-import { ArtworkPrice_partnerOfferToCollector$data } from "__generated__/ArtworkPrice_partnerOfferToCollector.graphql"
+import { ArtworkPrice_partnerOffer$data } from "__generated__/ArtworkPrice_partnerOffer.graphql"
 import { formattedTimeLeftForPartnerOffer } from "app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer"
 import { getTimer } from "app/utils/getTimer"
 import { FC, useEffect, useRef, useState } from "react"
@@ -7,7 +7,7 @@ import { FC, useEffect, useRef, useState } from "react"
 const INTERVAL = 1000
 
 interface ExpiresInTimerProps {
-  item: Pick<ArtworkPrice_partnerOfferToCollector$data, "endAt">
+  item: Pick<ArtworkPrice_partnerOffer$data, "endAt">
 }
 
 const WatchIcon: FC<{ fill?: Color }> = ({ fill = "red100" }) => {

--- a/src/app/Scenes/Artwork/hooks/useCreateOrder.ts
+++ b/src/app/Scenes/Artwork/hooks/useCreateOrder.ts
@@ -1,0 +1,49 @@
+import {
+  useCreateOrderMutation,
+  useCreateOrderMutation$data,
+  CommerceCreateOrderWithArtworkInput,
+} from "__generated__/useCreateOrderMutation.graphql"
+import { graphql, useMutation } from "react-relay"
+
+export const useCreateOrder = () => {
+  const [commit] = useMutation<useCreateOrderMutation>(MUTATION)
+
+  const commitMutation = (input: CommerceCreateOrderWithArtworkInput) => {
+    return new Promise<useCreateOrderMutation$data>((resolve, reject) => {
+      commit({
+        variables: { input },
+        onCompleted(response) {
+          resolve(response)
+        },
+        onError(e) {
+          reject(e)
+        },
+      })
+    })
+  }
+
+  return { commitMutation }
+}
+
+const MUTATION = graphql`
+  mutation useCreateOrderMutation($input: CommerceCreateOrderWithArtworkInput!) {
+    commerceCreateOrderWithArtwork(input: $input) {
+      orderOrError {
+        __typename
+        ... on CommerceOrderWithMutationSuccess {
+          order {
+            internalID
+            mode
+          }
+        }
+        ... on CommerceOrderWithMutationFailure {
+          error {
+            type
+            code
+            data
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/PartnerOffer/PartnerOfferContainer.tsx
+++ b/src/app/Scenes/PartnerOffer/PartnerOfferContainer.tsx
@@ -1,5 +1,4 @@
 import { Flex } from "@artsy/palette-mobile"
-import { usePartnerOfferCheckoutMutation$data } from "__generated__/usePartnerOfferCheckoutMutation.graphql"
 import { LoadingSpinner } from "app/Components/Modals/LoadingModal"
 import { Toast } from "app/Components/Toast/Toast"
 import { usePartnerOfferMutation } from "app/Scenes/PartnerOffer/mutations/usePartnerOfferCheckoutMutation"
@@ -7,49 +6,58 @@ import { goBack, navigate } from "app/system/navigation/navigate"
 import { useEffect } from "react"
 
 export const PartnerOfferContainer: React.FC<{ partnerOfferID: string }> = ({ partnerOfferID }) => {
-  const handleRedirect = (response: usePartnerOfferCheckoutMutation$data) => {
-    const orderOrError = response.commerceCreatePartnerOfferOrder?.orderOrError
+  const { commitMutation } = usePartnerOfferMutation()
 
-    if (orderOrError?.error) {
-      const { code: errorCode, data: artwork } = orderOrError.error
-      const artworkId = JSON.parse(artwork?.toString() ?? "{}")?.artwork_id
+  const handleGenericError = () => {
+    Toast.show("An error occurred.", "bottom")
+    goBack()
+  }
 
-      if (errorCode === "expired_partner_offer") {
-        navigate(`/artwork/${artworkId}`, {
-          replaceActiveScreen: true,
-          passProps: { artworkOfferExpired: true },
-        })
+  const createOrderFromPartnerOffer = async () => {
+    try {
+      const response = await commitMutation({ partnerOfferId: partnerOfferID })
+      const orderOrError = response.commerceCreatePartnerOfferOrder?.orderOrError
 
-        return
-      }
+      if (orderOrError?.error) {
+        const { code: errorCode, data: artwork } = orderOrError.error
+        const artworkId = JSON.parse(artwork?.toString() ?? "{}")?.artwork_id
 
-      if (errorCode === "not_acquireable") {
-        navigate(`/artwork/${artworkId}`, {
-          replaceActiveScreen: true,
-          passProps: { artworkOfferUnavailable: true },
-        })
+        if (errorCode === "expired_partner_offer") {
+          navigate(`/artwork/${artworkId}`, {
+            replaceActiveScreen: true,
+            passProps: { artworkOfferExpired: true },
+          })
+
+          return
+        }
+
+        if (errorCode === "not_acquireable") {
+          navigate(`/artwork/${artworkId}`, {
+            replaceActiveScreen: true,
+            passProps: { artworkOfferUnavailable: true },
+          })
+
+          return
+        } else {
+          handleGenericError()
+        }
+      } else if (orderOrError?.order) {
+        // we need to go back to the home screen before navigating to the orders screen
+        // to prevent the user from closing the modal and navigating back to the this screen
+        goBack()
+        navigate(`/orders/${orderOrError.order?.internalID}`)
 
         return
       } else {
-        Toast.show("An error occurred.", "bottom")
-        goBack()
+        handleGenericError()
       }
-    } else if (orderOrError?.order) {
-      // we need to go back to the home screen before navigating to the orders screen
-      // to prevent the user from closing the modal and navigating back to the this screen
-      goBack()
-      navigate(`/orders/${orderOrError.order?.internalID}`)
-
-      return
-    } else {
-      goBack()
+    } catch (e) {
+      handleGenericError()
     }
   }
 
-  const { commitMutation } = usePartnerOfferMutation(handleRedirect)
-
   useEffect(() => {
-    commitMutation({ partnerOfferId: partnerOfferID })
+    createOrderFromPartnerOffer()
   }, [])
 
   return (

--- a/src/app/Scenes/PartnerOffer/mutations/usePartnerOfferCheckoutMutation.tsx
+++ b/src/app/Scenes/PartnerOffer/mutations/usePartnerOfferCheckoutMutation.tsx
@@ -6,24 +6,25 @@ import {
 } from "__generated__/usePartnerOfferCheckoutMutation.graphql"
 import { graphql, useMutation } from "react-relay"
 
-export const usePartnerOfferMutation = (
-  onMutationComplete?: (response: usePartnerOfferCheckoutMutation$data) => void
-) => {
+export const usePartnerOfferMutation = () => {
   const [commit] = useMutation<usePartnerOfferCheckoutMutation>(PartnerOfferCheckoutMutation)
 
   const commitMutation = (input: CommerceCreatePartnerOfferOrderInput) => {
-    commit({
-      variables: { input },
-      onCompleted(response) {
-        onMutationComplete?.(response)
-      },
-      onError(err) {
-        if (__DEV__) {
-          console.error(err)
-        } else {
-          captureMessage(`usePartnerOfferMutation: ${JSON.stringify(err)}`)
-        }
-      },
+    return new Promise<usePartnerOfferCheckoutMutation$data>((resolve, reject) => {
+      commit({
+        variables: { input },
+        onCompleted(response) {
+          resolve(response)
+        },
+        onError(err) {
+          if (__DEV__) {
+            console.error(err)
+          } else {
+            captureMessage(`usePartnerOfferMutation: ${JSON.stringify(err)}`)
+            reject(err)
+          }
+        },
+      })
     })
   }
 


### PR DESCRIPTION
This PR resolves [EMI-1753] 

### Description
This PR changes the behavior of the purchase button when a partner offer is available. It was a little tricky because the button is also used in our partner offer notification panel.

I started out by following the patterns we used in artsy/force#13647 and its followup PRs, but ran into some typing issues due to the re-use of the button and the need to add our own checkout link (gravity attaches one to the notification which is separate from the object we are querying here). Ended up piggybacking off of work in #10085 and #10117 to make sure we didn't duplicate each other's work.

In the process I also converted some order creation mutations to the `useMutation => Promise` style for more consistent response handling, which also means that the creation action doesn't require navigating to a special screen that creates the order in a side effect. **This affects our existing, non-feature-flagged behavior in the activity panel, so needs QA.**


### PR Checklist

- [x] I have tested my changes on **iOS** [x] and **Android** [ ]. _iOS only_
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Example of the partner offer expiring and using the list price (also works with partner offer)</summary>

![2024-04-23 13 02 20](https://github.com/artsy/eigen/assets/9088720/c4678eea-afe2-40c7-a976-1b82a48e5c69)

</details>
<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- UX improvements

#### Android user-facing changes

-

#### Dev changes

- Add feature-flagged partner offer checkout to artwork screen purchase button when available
- Partner offer order creation uses a mutation rather than navigating to a special screen that creates the mutation as a side effect.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1753]: https://artsyproduct.atlassian.net/browse/EMI-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ