### PR TITLE
fix: properly display privacy for newly created list

### DIFF
--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
@@ -90,6 +90,7 @@ const CreateNewArtworkListMutation = graphql`
           collection {
             internalID
             name
+            shareableWithPartners
             artworksCount(onlyVisible: true)
           }
         }


### PR DESCRIPTION
This PR resolves [EMI-1819](https://artsyproduct.atlassian.net/browse/EMI-1819)

### Description

Similar to https://github.com/artsy/force/pull/13628, this properly displays list privacy for newly created list by fetching `shareableWithPartners` of the list.


https://github.com/artsy/eigen/assets/796573/2a7a6476-1164-4091-8b3e-ddc179ed5675



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Properly display list privacy for newly created list - starsirius

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
