### PR TITLE
fix(appl-883): fixes Search results displayed too closely as though overlapping on search page

### DIFF
--- a/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
+++ b/src/app/Scenes/Search/components/AutosuggestSearchResult.tsx
@@ -123,7 +123,11 @@ export const AutosuggestSearchResult: React.FC<{
         onPress={() => onPress()}
         testID={`autosuggest-search-result-${result.displayLabel}`}
       >
-        <Flex height={IMAGE_SIZE} flexDirection="row" alignItems="center">
+        <Flex
+          height={secondaryLabel ? IMAGE_SIZE + 12 : IMAGE_SIZE}
+          flexDirection="row"
+          alignItems="center"
+        >
           <SearchResultImage
             imageURL={result.imageUrl}
             initials={initials}


### PR DESCRIPTION
This PR resolves [APPL-883]

### Description

Recently we've added nationality / birth year info label to artist search results. The gap between search results became too small when there is such label.

| Before adding disambiguating info | Before this change | After |
|---|---|---|
| <img src="https://github.com/artsy/eigen/assets/3934579/78130ce8-bde6-484f-acb3-5793e7afee9b" /> | <img src="https://github.com/artsy/eigen/assets/3934579/72694ab1-8bd8-4344-a64e-85952bc2fc40" /> | <img src="https://github.com/artsy/eigen/assets/3934579/8c4cf43a-856b-4c99-8beb-f045959eef44" /> |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-883]: https://artsyproduct.atlassian.net/browse/APPL-883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ