### PR TITLE
fix: make the screen responsive again

### DIFF
--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingOfferSettings.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingOfferSettings.tests.tsx
@@ -49,6 +49,7 @@ describe("ProgressiveOnboardingOfferSettings", () => {
     __globalStoreTestUtils__?.injectState({
       progressiveOnboarding: { sessionState: { isReady: true } },
     })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkListOfferability: true })
     wrapper()
 
     expect(screen.getByText("Popover")).toBeOnTheScreen()
@@ -58,6 +59,7 @@ describe("ProgressiveOnboardingOfferSettings", () => {
     __globalStoreTestUtils__?.injectState({
       progressiveOnboarding: { sessionState: { isReady: true } },
     })
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkListOfferability: true })
     wrapper()
 
     fireEvent.press(screen.getByText("Popover"))

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingOfferSettings.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingOfferSettings.tsx
@@ -14,26 +14,27 @@ export const ProgressiveOnboardingOfferSettings: React.FC = ({ children }) => {
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
   const { dismiss, setIsReady } = GlobalStore.actions.progressiveOnboarding
   const isFocused = useIsFocused()
-  const isPartnerOfferEnabled = useFeatureFlag("AREnablePartnerOffer")
+  const isArtworkListOfferabilityEnabled = useFeatureFlag("AREnableArtworkListOfferability")
 
   const isDisplayable =
-    isPartnerOfferEnabled &&
+    isArtworkListOfferabilityEnabled &&
     isReady &&
     !isDismissed("offer-settings").status &&
     !!isDismissed("signal-interest").status &&
     isFocused &&
     isInView
-  const { isActive, clearActivePopover } = useSetActivePopover(isDisplayable)
+
+  const { clearActivePopover } = useSetActivePopover(isDisplayable)
 
   const handleDismiss = () => {
     setIsReady(false)
     dismiss("offer-settings")
   }
 
-  if (isDisplayable && isActive) {
+  if (isInView) {
     return (
       <Popover
-        visible
+        visible={!!isDisplayable}
         onDismiss={handleDismiss}
         onPressOutside={handleDismiss}
         onCloseComplete={clearActivePopover}
@@ -45,13 +46,9 @@ export const ProgressiveOnboardingOfferSettings: React.FC = ({ children }) => {
           </Text>
         }
       >
-        <Flex pointerEvents="none">{children}</Flex>
+        <Flex>{children}</Flex>
       </Popover>
     )
-  }
-
-  if (isInView) {
-    return <>{children}</>
   }
 
   return <ElementInView onVisible={() => setIsInView(true)}>{children}</ElementInView>

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSignalInterest.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingSignalInterest.tsx
@@ -2,9 +2,12 @@ import { Flex, Popover, Text } from "@artsy/palette-mobile"
 import { useIsFocused } from "@react-navigation/native"
 import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
 import { GlobalStore } from "app/store/GlobalStore"
+import { ElementInView } from "app/utils/ElementInView"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useState } from "react"
 
 export const ProgressiveOnboardingSignalInterest: React.FC = ({ children }) => {
+  const [isInView, setIsInView] = useState(false)
   const {
     isDismissed,
     sessionState: { isReady },
@@ -14,7 +17,12 @@ export const ProgressiveOnboardingSignalInterest: React.FC = ({ children }) => {
   const isPartnerOfferEnabled = useFeatureFlag("AREnablePartnerOffer")
 
   const isDisplayable =
-    isPartnerOfferEnabled && isReady && !isDismissed("signal-interest").status && isFocused
+    isPartnerOfferEnabled &&
+    isReady &&
+    !isDismissed("signal-interest").status &&
+    isFocused &&
+    isInView
+
   const { clearActivePopover } = useSetActivePopover(isDisplayable)
 
   const handleDismiss = () => {
@@ -22,20 +30,24 @@ export const ProgressiveOnboardingSignalInterest: React.FC = ({ children }) => {
     dismiss("signal-interest")
   }
 
-  return (
-    <Popover
-      visible={!!isDisplayable}
-      onDismiss={handleDismiss}
-      onPressOutside={handleDismiss}
-      onCloseComplete={clearActivePopover}
-      placement="top"
-      title={
-        <Text variant="xs" color="white100">
-          Learn more about saves and how to{"\n"}manage your preferences.
-        </Text>
-      }
-    >
-      <Flex>{children}</Flex>
-    </Popover>
-  )
+  if (isInView) {
+    return (
+      <Popover
+        visible={!!isDisplayable}
+        onDismiss={handleDismiss}
+        onPressOutside={handleDismiss}
+        onCloseComplete={clearActivePopover}
+        placement="top"
+        title={
+          <Text variant="xs" color="white100">
+            Learn more about saves and how to{"\n"}manage your preferences.
+          </Text>
+        }
+      >
+        <Flex>{children}</Flex>
+      </Popover>
+    )
+  }
+
+  return <ElementInView onVisible={() => setIsInView(true)}>{children}</ElementInView>
 }


### PR DESCRIPTION
This PR resolves [APPL-871] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue in Android where the screen gets frozen after navigating to the Saves tab
It also fixes the issue where two back-to-back onboarding popovers that weren't working well

### Videos

#### Fixing the issue on Android
https://github.com/artsy/eigen/assets/20655703/ee212051-150a-4194-8355-00f9e953ec61

#### Back to Back Popovers
| | Android | iOS |
|---|---|---|
| back to back popovers | <video src="https://github.com/artsy/eigen/assets/20655703/25d6b53f-d7a7-43aa-95be-74efbbe6342b" /> | <video src="https://github.com/artsy/eigen/assets/20655703/cd2b60f4-b50f-4301-9b51-1aa0cdc013a2" /> |	

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix frozen saves tab + fix back-to-back popovers issue - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-871]: https://artsyproduct.atlassian.net/browse/APPL-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ