### PR TITLE
fix: images in view in room, gallery, show not rendering

### DIFF
--- a/src/app/Components/Cards/SmallCard.tsx
+++ b/src/app/Components/Cards/SmallCard.tsx
@@ -1,13 +1,5 @@
-import {
-  Spacer,
-  Box,
-  useSpace,
-  Text,
-  useScreenDimensions,
-  Flex,
-  Image,
-  BoxProps,
-} from "@artsy/palette-mobile"
+import { Spacer, Box, useSpace, Text, Flex, BoxProps } from "@artsy/palette-mobile"
+import FastImage from "react-native-fast-image"
 import { CardTag, CardTagProps } from "./CardTag"
 export interface SmallCardProps extends BoxProps {
   images: string[]
@@ -21,15 +13,9 @@ export interface SmallCardProps extends BoxProps {
  * one tall or two square images on the right, and text for title and subtitle
  * at the bottom.
  */
+// TODO: Fix palette image to accept aspectRatio only and respect flex props and use it here
 export const SmallCard: React.FC<SmallCardProps> = ({ images, title, subtitle, tag, ...rest }) => {
   const space = useSpace()
-  const { width: screenWidth } = useScreenDimensions()
-
-  const sectionWidth = screenWidth - space(4)
-
-  const heroImageWidth = (2 * sectionWidth) / 3
-
-  const smallImageWidth = sectionWidth / 3
 
   return (
     <Box {...rest}>
@@ -42,20 +28,22 @@ export const SmallCard: React.FC<SmallCardProps> = ({ images, title, subtitle, t
           aspectRatio: 1.5 / 1.0,
         }}
       >
-        <Flex flex={2} bg="black10" my="auto" mr={2} backgroundColor="red10">
-          <Image src={images[0]} width={heroImageWidth} aspectRatio={1} />
+        <Flex flex={2} bg="black10" my="auto" mr={2}>
+          <FastImage source={{ uri: images[0] }} style={{ flex: 1, aspectRatio: 1 }} />
         </Flex>
 
         <Spacer x="2px" />
 
-        <Flex flex={1} my="auto" alignItems="center" backgroundColor="green10">
+        <Flex flex={1} my="auto" alignItems="center">
           {images.length < 2 && <Flex flex={1} />}
-          {!!images[1] && <Image src={images[1]} width={smallImageWidth} aspectRatio={1} />}
+          {!!images[1] && (
+            <FastImage source={{ uri: images[1] }} style={{ flex: 1, aspectRatio: 1 }} />
+          )}
 
           {!!images[2] && (
             <>
               <Spacer y="2px" />
-              <Image src={images[2]} width={smallImageWidth} aspectRatio={1} />
+              <FastImage source={{ uri: images[2] }} style={{ flex: 1, aspectRatio: 1 }} />
             </>
           )}
         </Flex>

--- a/src/app/Components/Cards/SmallCard.tsx
+++ b/src/app/Components/Cards/SmallCard.tsx
@@ -1,8 +1,14 @@
-import { Spacer, Box, BoxProps, useSpace, Text } from "@artsy/palette-mobile"
-import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import {
+  Spacer,
+  Box,
+  useSpace,
+  Text,
+  useScreenDimensions,
+  Flex,
+  Image,
+} from "@artsy/palette-mobile"
 import { CardTag, CardTagProps } from "./CardTag"
-
-export interface SmallCardProps extends BoxProps {
+export interface SmallCardProps {
   images: string[]
   title?: string
   subtitle?: string
@@ -16,6 +22,14 @@ export interface SmallCardProps extends BoxProps {
  */
 export const SmallCard: React.FC<SmallCardProps> = ({ images, title, subtitle, tag, ...rest }) => {
   const space = useSpace()
+  const { width: screenWidth } = useScreenDimensions()
+
+  const sectionWidth = screenWidth - space(4)
+
+  const heroImageWidth = (2 * sectionWidth) / 3
+
+  const smallImageWidth = sectionWidth / 3
+
   return (
     <Box {...rest}>
       <Box
@@ -27,24 +41,23 @@ export const SmallCard: React.FC<SmallCardProps> = ({ images, title, subtitle, t
           aspectRatio: 1.5 / 1.0,
         }}
       >
-        <Box flex={2} bg="black10">
-          <OpaqueImageView imageURL={images[0]} style={{ flex: 1 }} />
-        </Box>
+        <Flex flex={2} bg="black10" my="auto" mr={2} backgroundColor="red10">
+          <Image src={images[0]} width={heroImageWidth} aspectRatio={1} />
+        </Flex>
 
         <Spacer x="2px" />
 
-        <Box flex={1}>
-          {images.length < 2 && <Box flex={1} bg="black10" />}
-
-          {!!images[1] && <OpaqueImageView imageURL={images[1]} style={{ flex: 1 }} />}
+        <Flex flex={1} my="auto" alignItems="center" backgroundColor="green10">
+          {images.length < 2 && <Flex flex={1} />}
+          {!!images[1] && <Image src={images[1]} width={smallImageWidth} aspectRatio={1} />}
 
           {!!images[2] && (
             <>
               <Spacer y="2px" />
-              <OpaqueImageView imageURL={images[2]} style={{ flex: 1 }} />
+              <Image src={images[2]} width={smallImageWidth} aspectRatio={1} />
             </>
           )}
-        </Box>
+        </Flex>
       </Box>
 
       {!!title && (

--- a/src/app/Components/Cards/SmallCard.tsx
+++ b/src/app/Components/Cards/SmallCard.tsx
@@ -6,9 +6,10 @@ import {
   useScreenDimensions,
   Flex,
   Image,
+  BoxProps,
 } from "@artsy/palette-mobile"
 import { CardTag, CardTagProps } from "./CardTag"
-export interface SmallCardProps {
+export interface SmallCardProps extends BoxProps {
   images: string[]
   title?: string
   subtitle?: string

--- a/src/app/Scenes/Show/ShowContextCard.tests.tsx
+++ b/src/app/Scenes/Show/ShowContextCard.tests.tsx
@@ -6,6 +6,7 @@ import { extractText } from "app/utils/tests/extractText"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { TouchableOpacity } from "react-native"
+import FastImage from "react-native-fast-image"
 import { graphql, QueryRenderer } from "react-relay"
 import { act } from "react-test-renderer"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
@@ -79,6 +80,7 @@ describe("ShowContextCard", () => {
       const renderedImages = wrapper.root
         .findAllByType(OpaqueImageView)
         .map((img) => img.props.imageURL)
+
       expect(renderedImages).toContain("http://test.artsy.net/fair-logo.jpg")
       expect(renderedImages).toContain("http://test.artsy.net/fair-main.jpg")
     })
@@ -153,8 +155,8 @@ describe("ShowContextCard", () => {
       expect(text).toMatch("New York, London")
 
       const renderedImages = wrapper.root
-        .findAllByType(OpaqueImageView)
-        .map((img) => img.props.imageURL)
+        .findAllByType(FastImage)
+        .map((img) => img.props.source.uri)
       expect(renderedImages).toContain("http://test.artsy.net/artwork-1.jpg")
       expect(renderedImages).toContain("http://test.artsy.net/artwork-2.jpg")
       expect(renderedImages).toContain("http://test.artsy.net/artwork-3.jpg")


### PR DESCRIPTION
This PR resolves [APPL-875] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Updates small grid to use fast image since currently the image from palette mobile doesn't allow only passing an aspect ratio + doesn't respect flex styles. 

The red boxes in before images are a dev only thing, rendering as gray boxes in prod.

<details>
<summary>
Before
</summary>

![view-in-room-before](https://github.com/artsy/eigen/assets/49686530/222b2ceb-932a-4003-b51e-7bf53be1592c)
![gallery-before](https://github.com/artsy/eigen/assets/49686530/45126c4a-6eae-431b-a05f-f1ed52b72be4)
![show-before](https://github.com/artsy/eigen/assets/49686530/5f139410-57e7-4014-9b98-0d69aa1550cc)

</details>

<details>
<summary>
After
</summary>

![view-in-room-after](https://github.com/artsy/eigen/assets/49686530/70cc5028-cfb0-4692-8cb3-8fb8a3dbae91)
![gallery-after](https://github.com/artsy/eigen/assets/49686530/3a9b1f5d-b776-4514-8f57-c25493c80073)
![show-after](https://github.com/artsy/eigen/assets/49686530/475d2195-1b6f-441c-a731-1d72386d8d32)

</details>

#### Follow-ups

- [ ] Update palette mobile image to respect aspect ratio + flex props
- [ ] Update this component to use palette mobile image
- [ ] Noticed while testing fair booth shows use old opaqueImageView, worth a check to see if that is broken

### PR Checklist

- [] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix image display in viewing rooms list, gallery details, show details

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-875]: https://artsyproduct.atlassian.net/browse/APPL-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ