### PR TITLE
build(deps): bumps @artsy/palette-mobile from 13.1.29 to 13.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "dependencies": {
     "@artsy/cohesion": "4.171.0",
-    "@artsy/palette-mobile": "13.1.29",
+    "@artsy/palette-mobile": "13.1.30",
     "@artsy/to-title-case": "1.1.0",
     "@expo/react-native-action-sheet": "4.0.1",
     "@gorhom/bottom-sheet": "4.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,10 @@
   dependencies:
     core-js "3"
 
-"@artsy/palette-mobile@13.1.29":
-  version "13.1.29"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.1.29.tgz#b4ec9ce56c26c5ae4b9bc9f5740078462e3bbd2f"
-  integrity sha512-sm7xpvXMOwu63t4wjFWmHOAitpM17nr4/bWpfjGLkVyMUlItp0vAzK/MSkjy/jN2PwQikgEk0I1NsnjcxTnGvg==
+"@artsy/palette-mobile@13.1.30":
+  version "13.1.30"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-13.1.30.tgz#578003dd33cbfc71b29b40f51805e22c697ee35a"
+  integrity sha512-0US/25TNl25ZJGdmOisc7SyRgjvsNJMXBQcfDwBuSCS5bPcSNq/vSRT9aqqs7YecWrm+octuoYT2GNBrp4yfgg==
   dependencies:
     "@artsy/palette-tokens" "^5.0.0"
     "@shopify/flash-list" "^1.5.0"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

bumps @artsy/palette-mobile from 13.1.29 to 13.1.30

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#nochangelog