### PR TITLE
feat(EMI-1781): Add Partner Offer note in the artwork screen

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -11,6 +11,7 @@ import { AuctionTimerState, currentTimerState } from "app/Components/Bidding/Com
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { ArtworkAuctionCreateAlertHeader } from "app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader"
 import { ArtworkErrorScreen } from "app/Scenes/Artwork/Components/ArtworkError"
+import { ArtworkPartnerOfferNote } from "app/Scenes/Artwork/Components/ArtworkPartnerOfferNote"
 import { ArtworkScreenHeader } from "app/Scenes/Artwork/Components/ArtworkScreenHeader"
 import { OfferSubmittedModal } from "app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -95,7 +96,10 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
   const { contextGrids, artistSeriesConnection, artist, context } = artworkBelowTheFold || {}
   const auctionTimerState = ArtworkStore.useStoreState((state) => state.auctionState)
 
+  const partnerOffer = extractNodes(me?.partnerOffersConnection)[0]
+
   const enableAuctionHeaderAlertCTA = useFeatureFlag("AREnableAuctionHeaderAlertCTA")
+  const enablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
 
   const shouldRenderPartner = () => {
     const { sale, partner } = artworkBelowTheFold ?? {}
@@ -263,6 +267,16 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         sections.push({
           key: "selectEditionSet",
           element: <ArtworkEditionSetInformation artwork={artworkAboveTheFold} />,
+          excludeSeparator: true,
+        })
+      }
+
+      if (!!enablePartnerOfferOnArtworkScreen) {
+        sections.push({
+          key: "partnerOfferNote",
+          element: (
+            <ArtworkPartnerOfferNote artwork={artworkAboveTheFold} partnerOffer={partnerOffer} />
+          ),
           excludeSeparator: true,
         })
       }
@@ -533,6 +547,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkStickyBottomContent_artwork
         ...ArtworkDetails_artwork
         ...ArtworkEditionSetInformation_artwork
+        ...ArtworkPartnerOfferNote_artwork
         slug
         internalID
         isAcquireable
@@ -632,6 +647,7 @@ export const ArtworkContainer = createRefetchContainer(
             node {
               internalID
               ...ArtworkStickyBottomContent_partnerOfferToCollector
+              ...ArtworkPartnerOfferNote_partnerOfferToCollector
             }
           }
         }

--- a/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
@@ -67,4 +67,15 @@ describe("ArtworkPartnerOfferNote", () => {
     expect(screen.getByText("Note from the gallery")).toBeOnTheScreen()
     expect(screen.getByText("“This is a note”")).toBeOnTheScreen()
   })
+
+  it("does not render anything if there is no partner offer", () => {
+    renderWithRelay({
+      Artwork: () => ({ partner: { profile: { icon: { url: "https://testurl" } } } }),
+      Me: () => ({ partnerOffersConnection: { edges: [] } }),
+    })
+
+    expect(screen.queryByLabelText("Partner icon")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Note from the gallery")).not.toBeOnTheScreen()
+    expect(screen.queryByText("“This is a note”")).not.toBeOnTheScreen()
+  })
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tests.tsx
@@ -1,0 +1,70 @@
+import { screen } from "@testing-library/react-native"
+import { ArtworkPartnerOfferNote_Test_Query } from "__generated__/ArtworkPartnerOfferNote_Test_Query.graphql"
+import { ArtworkPartnerOfferNote } from "app/Scenes/Artwork/Components/ArtworkPartnerOfferNote"
+import { extractNodes } from "app/utils/extractNodes"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("ArtworkPartnerOfferNote", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkPartnerOfferNote_Test_Query>({
+    Component: ({ artwork, me }) => (
+      <ArtworkPartnerOfferNote
+        artwork={artwork!}
+        partnerOffer={extractNodes(me?.partnerOffersConnection)[0]}
+      />
+    ),
+    query: graphql`
+      query ArtworkPartnerOfferNote_Test_Query @relay_test_operation {
+        artwork(id: "test-artwork") {
+          ...ArtworkPartnerOfferNote_artwork
+        }
+        me {
+          partnerOffersConnection(artworkID: "test-artwork", first: 1) {
+            edges {
+              node {
+                ...ArtworkPartnerOfferNote_partnerOfferToCollector
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders the note correctly", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        partner: { profile: { icon: { url: "https://testurl" } } },
+      }),
+      Me: () => ({
+        partnerOffersConnection: { edges: [{ node: { note: "This is a note" } }] },
+      }),
+    })
+
+    expect(screen.getByLabelText("Partner icon")).toBeOnTheScreen()
+    expect(screen.getByText("Note from the gallery")).toBeOnTheScreen()
+    expect(screen.getByText("“This is a note”")).toBeOnTheScreen()
+  })
+
+  it("does not render anything if there is no note", () => {
+    renderWithRelay({
+      Artwork: () => ({ partner: { profile: { icon: { url: "https://testurl" } } } }),
+      Me: () => ({ partnerOffersConnection: { edges: [{ node: { note: null } }] } }),
+    })
+
+    expect(screen.queryByLabelText("Partner icon")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Note from the gallery")).not.toBeOnTheScreen()
+    expect(screen.queryByText("“This is a note”")).not.toBeOnTheScreen()
+  })
+
+  it("does not render the partner icon if there is none", () => {
+    renderWithRelay({
+      Artwork: () => ({ partner: { profile: null } }),
+      Me: () => ({ partnerOffersConnection: { edges: [{ node: { note: "This is a note" } }] } }),
+    })
+
+    expect(screen.queryByLabelText("Partner icon")).not.toBeOnTheScreen()
+    expect(screen.getByText("Note from the gallery")).toBeOnTheScreen()
+    expect(screen.getByText("“This is a note”")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPartnerOfferNote.tsx
@@ -1,0 +1,74 @@
+import { Box, Flex, Text, useColor } from "@artsy/palette-mobile"
+import { ArtworkPartnerOfferNote_artwork$key } from "__generated__/ArtworkPartnerOfferNote_artwork.graphql"
+import { ArtworkPartnerOfferNote_partnerOfferToCollector$key } from "__generated__/ArtworkPartnerOfferNote_partnerOfferToCollector.graphql"
+import { ImageBackground } from "react-native"
+import { graphql, useFragment } from "react-relay"
+
+interface ArtworkPartnerOfferNoteProps {
+  artwork: ArtworkPartnerOfferNote_artwork$key
+  partnerOffer: ArtworkPartnerOfferNote_partnerOfferToCollector$key
+}
+
+export const ArtworkPartnerOfferNote: React.FC<ArtworkPartnerOfferNoteProps> = ({
+  artwork,
+  partnerOffer,
+}) => {
+  const artworkData = useFragment(artworkFragment, artwork)
+  const partnerOfferData = useFragment(partnerOfferFragment, partnerOffer)
+
+  const color = useColor()
+
+  const note = partnerOfferData?.note
+  const partnerIcon = artworkData.partner?.profile?.icon?.url
+
+  if (!note) {
+    return null
+  }
+
+  return (
+    <Flex flexDirection="row" p={1} backgroundColor="black5">
+      {!!partnerIcon && (
+        <Flex mr={1}>
+          <ImageBackground
+            accessibilityLabel="Partner icon"
+            source={{ uri: partnerIcon }}
+            style={{ width: 30, height: 30 }}
+            imageStyle={{
+              borderRadius: 15,
+              borderColor: color("black30"),
+              borderWidth: 1,
+            }}
+          />
+        </Flex>
+      )}
+
+      <Box>
+        <Text variant="sm-display" color="black100" fontWeight="bold">
+          Note from the gallery
+        </Text>
+
+        <Text variant="sm" color="black100">
+          “{note}”
+        </Text>
+      </Box>
+    </Flex>
+  )
+}
+
+const artworkFragment = graphql`
+  fragment ArtworkPartnerOfferNote_artwork on Artwork {
+    partner {
+      profile {
+        icon {
+          url(version: "square140")
+        }
+      }
+    }
+  }
+`
+
+const partnerOfferFragment = graphql`
+  fragment ArtworkPartnerOfferNote_partnerOfferToCollector on PartnerOfferToCollector {
+    note
+  }
+`


### PR DESCRIPTION
This PR resolves [EMI-1781] <!-- eg [PROJECT-XXXX] -->

> [!NOTE]
> This work is hidden behind `AREnablePartnerOfferOnArtworkScreen` feature flag

### Description
This PR adds the partner offer note, if available, to the artwork screen

### Screenshots
| | Android | iOS |
|---|---|---|
| with icon | ![image](https://github.com/artsy/eigen/assets/20655703/4088f836-a952-4d95-be04-547a9d2be819) | <img width="542" alt="image" src="https://github.com/artsy/eigen/assets/20655703/4903ff59-7f0e-41fe-b6f6-33e118b04840"> |
| without icon | ![image](https://github.com/artsy/eigen/assets/20655703/7948a826-172d-4cae-934c-638519856353) | <img width="542" alt="image" src="https://github.com/artsy/eigen/assets/20655703/0e2800ee-1a2a-4f51-834a-305183970eed"> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add parter offer note to artwork screen (behind FF AREnablePartnerOfferOnArtworkScreen) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

@artsy/emerald-devs 

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1781]: https://artsyproduct.atlassian.net/browse/EMI-1781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ