### PR TITLE
fix(onyx-892): fixes bug in alerts tracking

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -88,6 +88,7 @@ const defaultProps: CreateSavedSearchModalProps = {
 
 const mockedMutationResult: SavedSearchAlertMutationResult = {
   id: "savedSearchAlertId",
+  searchCriteriaID: "searchCriteriaID",
 }
 
 const TestWrapper: React.FC = ({ children }) => (
@@ -118,7 +119,7 @@ describe("CreateSavedSearchModal", () => {
     createSavedSearchAlert.props.params.onComplete(mockedMutationResult)
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
-      tracks.toggleSavedSearch(true, OwnerType.artist, "ownerId", "ownerSlug", "savedSearchAlertId")
+      tracks.toggleSavedSearch(true, OwnerType.artist, "ownerId", "ownerSlug", "searchCriteriaID")
     )
   })
 

--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tsx
@@ -57,11 +57,13 @@ export const CreateSavedSearchModal: React.FC<CreateSavedSearchModalProps> = (pr
   const handleComplete = (result: SavedSearchAlertMutationResult) => {
     const { owner } = entity
 
-    if (!result.id) {
+    if (!result.searchCriteriaID) {
       return
     }
 
-    tracking.trackEvent(tracks.toggleSavedSearch(true, owner.type, owner.id, owner.slug, result.id))
+    tracking.trackEvent(
+      tracks.toggleSavedSearch(true, owner.type, owner.id, owner.slug, result.searchCriteriaID)
+    )
   }
 
   const params: CreateSavedSearchAlertParams = {


### PR DESCRIPTION
This PR resolves [ONYX-892]

### Description

Recently we migrated alerts from using stitched gravity schema to a new un-stitched one. During this migration I made a mistake an started sending alert ID instead of search criteria ID as part of `toggleSavedSearch` (which tracks created alerts) payload. This resulted to a broken statistics in Looker.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fixes bug in alerts tracking - @nickskalkin 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-892]: https://artsyproduct.atlassian.net/browse/ONYX-892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ