### PR TITLE
fix: follow up on Purchase button on artwork screen with partner offer

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ArtworkCommercialButtons_Test_Query } from "__generated__/ArtworkCommercialButtons_Test_Query.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
@@ -8,7 +8,6 @@ import { navigate } from "app/system/navigation/navigate"
 import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { ArtworkInquiryContextState } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { extractNodes } from "app/utils/extractNodes"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -60,83 +59,7 @@ describe("ArtworkCommercialButtons", () => {
     `,
   })
 
-  describe("with partner offer on artwork screen feature flag turned off", () => {
-    beforeEach(() => {
-      __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferOnArtworkScreen: false })
-    })
-
-    it("renders Purchase button if artwork is only acquireable and with a partner offer", async () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: true,
-        isOfferable: false,
-        isInquireable: false,
-      }
-
-      renderWithRelay({
-        Artwork: () => artwork,
-        Me: () => meWithPartnerOfferFixture,
-      })
-
-      expect(screen.getByText("Purchase")).toBeTruthy()
-      expect(screen.queryByText("Make an Offer")).toBeFalsy()
-      expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-    })
-
-    it("renders Make an Offer button if artwork is only offerable and with a partner offer", async () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: false,
-        isOfferable: true,
-        isInquireable: false,
-      }
-      renderWithRelay({
-        Artwork: () => artwork,
-        Me: () => meWithPartnerOfferFixture,
-      })
-
-      expect(screen.queryByText("Purchase")).toBeFalsy()
-      expect(screen.getByText("Make an Offer")).toBeTruthy()
-      expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-    })
-
-    it("renders Purchase and Make an Offer buttons if artwork is offerable and acquireable and with a partner offer", async () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: true,
-        isOfferable: true,
-        isInquireable: false,
-      }
-      renderWithRelay({
-        Artwork: () => artwork,
-        Me: () => meWithPartnerOfferFixture,
-      })
-
-      expect(screen.getByText("Purchase")).toBeTruthy()
-      expect(screen.getByText("Make an Offer")).toBeTruthy()
-      expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-    })
-
-    it("renders Make an Offer and Contact Gallery buttons if artwork is offerable and inquireable and with a partner offer", async () => {
-      const artwork = {
-        ...ArtworkFixture,
-        isAcquireable: false,
-        isOfferable: true,
-        isInquireable: true,
-      }
-
-      renderWithRelay({
-        Artwork: () => artwork,
-        Me: () => meWithPartnerOfferFixture,
-      })
-
-      expect(screen.queryByText("Purchase")).toBeFalsy()
-      expect(screen.getByText("Make an Offer")).toBeTruthy()
-      expect(screen.getByText("Contact Gallery")).toBeTruthy()
-    })
-  })
-
-  it("renders Purchase button if artwork is only acquireable", async () => {
+  it("renders Purchase button if artwork isAcquireable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: true,
@@ -149,30 +72,12 @@ describe("ArtworkCommercialButtons", () => {
       Me: () => meFixture,
     })
 
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.queryByText("Make an Offer")).toBeFalsy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
+    expect(screen.getByText("Purchase")).toBeOnTheScreen()
+    expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
   })
 
-  it("renders Purchase button if artwork is only acquireable and with a partner offer", async () => {
-    const artwork = {
-      ...ArtworkFixture,
-      isAcquireable: true,
-      isOfferable: false,
-      isInquireable: false,
-    }
-
-    renderWithRelay({
-      Artwork: () => artwork,
-      Me: () => meWithPartnerOfferFixture,
-    })
-
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.queryByText("Make an Offer")).toBeFalsy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-  })
-
-  it("renders Make an Offer button if artwork is only offerable", async () => {
+  it("renders Make an Offer button if artwork isOfferable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: false,
@@ -185,12 +90,12 @@ describe("ArtworkCommercialButtons", () => {
       Me: () => meFixture,
     })
 
-    expect(screen.queryByText("Purchase")).toBeFalsy()
-    expect(screen.getByText("Make an Offer")).toBeTruthy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
+    expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+    expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+    expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
   })
 
-  it("renders Contact Gallery button if artwork is only inquireable", async () => {
+  it("renders Contact Gallery button if artwork isInquireable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: false,
@@ -203,12 +108,12 @@ describe("ArtworkCommercialButtons", () => {
       Me: () => meFixture,
     })
 
-    expect(screen.queryByText("Purchase")).toBeFalsy()
-    expect(screen.queryByText("Make an Offer")).toBeFalsy()
-    expect(screen.getByText("Contact Gallery")).toBeTruthy()
+    expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+    expect(screen.getByText("Contact Gallery")).toBeOnTheScreen()
   })
 
-  it("renders Purchase and Make an Offer buttons if artwork is offerable and acquireable", async () => {
+  it("renders both Purchase and Make an Offer buttons if artwork isOfferable and isAcquireable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: true,
@@ -220,46 +125,12 @@ describe("ArtworkCommercialButtons", () => {
       Me: () => meFixture,
     })
 
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.getByText("Make an Offer")).toBeTruthy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
+    expect(screen.getByText("Purchase")).toBeOnTheScreen()
+    expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+    expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
   })
 
-  it("renders Purchase and Make an Offer buttons if artwork is only offerable and with a partner offer", async () => {
-    const artwork = {
-      ...ArtworkFixture,
-      isAcquireable: false,
-      isOfferable: true,
-      isInquireable: false,
-    }
-    renderWithRelay({
-      Artwork: () => artwork,
-      Me: () => meWithPartnerOfferFixture,
-    })
-
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.getByText("Make an Offer")).toBeTruthy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-  })
-
-  it("renders Purchase and Make an Offer buttons if artwork is offerable and acquireable and with a partner offer", async () => {
-    const artwork = {
-      ...ArtworkFixture,
-      isAcquireable: true,
-      isOfferable: true,
-      isInquireable: false,
-    }
-    renderWithRelay({
-      Artwork: () => artwork,
-      Me: () => meWithPartnerOfferFixture,
-    })
-
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.getByText("Make an Offer")).toBeTruthy()
-    expect(screen.queryByText("Contact Gallery")).toBeFalsy()
-  })
-
-  it("renders Make an Offer and Contact Gallery buttons if artwork is offerable and inquireable", async () => {
+  it("renders both Make an Offer and Contact Gallery buttons if artwork isOfferable and isInquireable", () => {
     const artwork = {
       ...ArtworkFixture,
       isOfferable: true,
@@ -276,30 +147,12 @@ describe("ArtworkCommercialButtons", () => {
       }
     )
 
-    expect(screen.queryByText("Purchase")).toBeFalsy()
-    expect(screen.getByText("Make an Offer")).toBeTruthy()
-    expect(screen.getByText("Contact Gallery")).toBeTruthy()
+    expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+    expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+    expect(screen.getByText("Contact Gallery")).toBeOnTheScreen()
   })
 
-  it("renders Purchase and Contact Gallery buttons if artwork is offerable and inquireable and with a partner offer", async () => {
-    const artwork = {
-      ...ArtworkFixture,
-      isAcquireable: false,
-      isOfferable: true,
-      isInquireable: true,
-    }
-
-    renderWithRelay({
-      Artwork: () => artwork,
-      Me: () => meWithPartnerOfferFixture,
-    })
-
-    expect(screen.getByText("Purchase")).toBeTruthy()
-    expect(screen.queryByText("Make an Offer")).toBeFalsy()
-    expect(screen.getByText("Contact Gallery")).toBeTruthy()
-  })
-
-  it("renders Bid button if artwork is in acution and biddable", async () => {
+  it("renders Bid button if artwork is in acution and biddable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: false,
@@ -335,10 +188,10 @@ describe("ArtworkCommercialButtons", () => {
       { auctionState: AuctionTimerState.LIVE_INTEGRATION_UPCOMING }
     )
 
-    expect(screen.getByText("Bid")).toBeTruthy()
+    expect(screen.getByText("Bid")).toBeOnTheScreen()
   })
 
-  it("renders Purchase and Bid buttons if artwork is in auction and buynowable", async () => {
+  it("renders Purchase and Bid buttons if artwork is in auction and buynowable", () => {
     const artwork = {
       ...ArtworkFixture,
       isAcquireable: true,
@@ -372,8 +225,97 @@ describe("ArtworkCommercialButtons", () => {
       }
     )
 
-    expect(screen.getByText("Bid")).toBeTruthy()
-    expect(screen.getByText("Purchase $8000")).toBeTruthy()
+    expect(screen.getByText("Bid")).toBeOnTheScreen()
+    expect(screen.getByText("Purchase $8000")).toBeOnTheScreen()
+  })
+
+  describe("with an active partner offer", () => {
+    it("renders Purchase button if artwork isAcquireable", () => {
+      const artwork = {
+        ...ArtworkFixture,
+        isAcquireable: true,
+        isOfferable: false,
+        isInquireable: false,
+      }
+
+      renderWithRelay({
+        Artwork: () => artwork,
+        Me: () => meWithPartnerOfferFixture,
+      })
+
+      expect(screen.getByText("Purchase")).toBeOnTheScreen()
+      expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+    })
+
+    it("renders both Purchase and Make an Offer buttons if artwork isOfferable", () => {
+      const artwork = {
+        ...ArtworkFixture,
+        isAcquireable: false,
+        isOfferable: true,
+        isInquireable: false,
+      }
+
+      renderWithRelay({
+        Artwork: () => artwork,
+        Me: () => meWithPartnerOfferFixture,
+      })
+
+      expect(screen.getByText("Purchase")).toBeOnTheScreen()
+      expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+      expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+    })
+
+    it("renders both Purchase and Make an Offer buttons if artwork isOfferable and isAcquireable", () => {
+      const artwork = {
+        ...ArtworkFixture,
+        isAcquireable: true,
+        isOfferable: true,
+        isInquireable: false,
+      }
+      renderWithRelay({
+        Artwork: () => artwork,
+        Me: () => meWithPartnerOfferFixture,
+      })
+
+      expect(screen.getByText("Purchase")).toBeOnTheScreen()
+      expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+      expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+    })
+
+    it("renders both Purchase and Contact Gallery buttons if artwork isOfferable and isInquireable", () => {
+      const artwork = {
+        ...ArtworkFixture,
+        isOfferable: true,
+        isInquireable: true,
+      }
+
+      renderWithRelay({
+        Artwork: () => artwork,
+        Me: () => meWithPartnerOfferFixture,
+      })
+
+      expect(screen.getByText("Purchase")).toBeOnTheScreen()
+      expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+      expect(screen.getByText("Contact Gallery")).toBeOnTheScreen()
+    })
+
+    it("renders both Purchase and Contact Gallery buttons if artwork isInquireable", () => {
+      const artwork = {
+        ...ArtworkFixture,
+        isOfferable: false,
+        isInquireable: true,
+      }
+
+      renderWithRelay({
+        Artwork: () => artwork,
+        Me: () => meWithPartnerOfferFixture,
+      })
+
+      expect(screen.getByText("Purchase")).toBeOnTheScreen()
+      expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+      expect(screen.getByText("Contact Gallery")).toBeOnTheScreen()
+    })
   })
 
   describe("commits", () => {
@@ -411,16 +353,16 @@ describe("ArtworkCommercialButtons", () => {
         "usePartnerOfferCheckoutMutation"
       )
 
-      mockResolveLastOperation({
-        CommerceOrderWithMutationSuccess: () => ({
-          order: {
-            internalID: "buyNowID",
-            mode: "BUY",
-          },
-        }),
-      })
-
-      await flushPromiseQueue()
+      await waitFor(() =>
+        mockResolveLastOperation({
+          CommerceOrderWithMutationSuccess: () => ({
+            order: {
+              internalID: "buyNowID",
+              mode: "BUY",
+            },
+          }),
+        })
+      )
 
       expect(navigate).toHaveBeenCalledWith("/orders/buyNowID")
     })
@@ -443,17 +385,17 @@ describe("ArtworkCommercialButtons", () => {
       expect(env.mock.getMostRecentOperation().request.node.operation.name).toBe(
         "useCreateOrderMutation"
       )
+      await waitFor(() =>
+        mockResolveLastOperation({
+          CommerceOrderWithMutationSuccess: () => ({
+            order: {
+              internalID: "buyNowID",
+              mode: "BUY",
+            },
+          }),
+        })
+      )
 
-      mockResolveLastOperation({
-        CommerceOrderWithMutationSuccess: () => ({
-          order: {
-            internalID: "buyNowID",
-            mode: "BUY",
-          },
-        }),
-      })
-
-      await flushPromiseQueue()
       expect(navigate).toHaveBeenCalledWith("/orders/buyNowID", {
         passProps: {
           title: "Purchase",
@@ -461,7 +403,7 @@ describe("ArtworkCommercialButtons", () => {
       })
     })
 
-    it("the Make Offer mutation", async () => {
+    it("the Make Offer mutation", () => {
       const artwork = {
         ...ArtworkFixture,
         isAcquireable: true,
@@ -495,7 +437,7 @@ describe("ArtworkCommercialButtons", () => {
   })
 
   describe("tracking", () => {
-    it("trackEvent called when Contact Gallery pressed given Offerable and Inquireable artwork", async () => {
+    it("trackEvent called when Contact Gallery pressed given Offerable and Inquireable artwork", () => {
       const artwork = {
         ...ArtworkFixture,
         isOfferable: true,
@@ -524,7 +466,7 @@ describe("ArtworkCommercialButtons", () => {
       `)
     })
 
-    it("trackEvent called when Contact Gallery pressed given Inquireable artwork", async () => {
+    it("trackEvent called when Contact Gallery pressed given Inquireable artwork", () => {
       const artwork = {
         ...ArtworkFixture,
         isOfferable: true,
@@ -553,6 +495,84 @@ describe("ArtworkCommercialButtons", () => {
           },
         ]
       `)
+    })
+  })
+
+  describe("With AREnablePartnerOfferOnArtworkScreen turned off", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferOnArtworkScreen: false })
+    })
+
+    describe("with an active partner offer", () => {
+      it("renders Purchase button if is acquireable", () => {
+        const artwork = {
+          ...ArtworkFixture,
+          isAcquireable: true,
+          isOfferable: false,
+          isInquireable: false,
+        }
+
+        renderWithRelay({
+          Artwork: () => artwork,
+          Me: () => meWithPartnerOfferFixture,
+        })
+
+        expect(screen.getByText("Purchase")).toBeOnTheScreen()
+        expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
+        expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+      })
+
+      it("renders Make an Offer button ifOfferable", () => {
+        const artwork = {
+          ...ArtworkFixture,
+          isAcquireable: false,
+          isOfferable: true,
+          isInquireable: false,
+        }
+        renderWithRelay({
+          Artwork: () => artwork,
+          Me: () => meWithPartnerOfferFixture,
+        })
+
+        expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+        expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+        expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+      })
+
+      it("renders both Purchase and Make an Offer buttons if artwork isOfferable and isAcquireable", () => {
+        const artwork = {
+          ...ArtworkFixture,
+          isAcquireable: true,
+          isOfferable: true,
+          isInquireable: false,
+        }
+        renderWithRelay({
+          Artwork: () => artwork,
+          Me: () => meWithPartnerOfferFixture,
+        })
+
+        expect(screen.getByText("Purchase")).toBeOnTheScreen()
+        expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+        expect(screen.queryByText("Contact Gallery")).not.toBeOnTheScreen()
+      })
+
+      it("renders both Make an Offer and Contact Gallery buttons if artwork isOfferable and isInquireable ", () => {
+        const artwork = {
+          ...ArtworkFixture,
+          isAcquireable: false,
+          isOfferable: true,
+          isInquireable: true,
+        }
+
+        renderWithRelay({
+          Artwork: () => artwork,
+          Me: () => meWithPartnerOfferFixture,
+        })
+
+        expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+        expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+        expect(screen.getByText("Contact Gallery")).toBeOnTheScreen()
+      })
     })
   })
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -7,6 +7,7 @@ import { ArtworkStore } from "app/Scenes/Artwork/ArtworkStore"
 import { BuyNowButton } from "app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton"
 import { InquiryButtonsFragmentContainer } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons"
 import { MakeOfferButtonFragmentContainer } from "app/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton"
+import { getTimer } from "app/utils/getTimer"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Children } from "react"
 import { useFragment, graphql } from "react-relay"
@@ -35,13 +36,15 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
   partnerOffer,
   me,
 }) => {
-  const AREnablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
   const artworkData = useFragment(artworkFragment, artwork)
   const meData = useFragment(meFragment, me)
   const partnerOfferData = useFragment(partnerOfferFragment, partnerOffer)
-  const isPartnerOffered = AREnablePartnerOfferOnArtworkScreen && !!partnerOfferData
   const selectedEditionId = ArtworkStore.useStoreState((state) => state.selectedEditionId)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
+
+  const AREnablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
+  const { hasEnded: partnerOfferEnded } = getTimer(partnerOfferData?.endAt || "")
+
   const isBiddableInAuction = artworkData.isInAuction && artworkData.sale
   const canTakeCommercialAction =
     artworkData.isAcquireable ||
@@ -50,11 +53,14 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
     isBiddableInAuction
   const noEditions = !artworkData.editionSets || artworkData.editionSets.length === 0
 
+  const hasActivePartnerOffer =
+    AREnablePartnerOfferOnArtworkScreen && partnerOfferData?.isAvailable && !partnerOfferEnded
+
   if (!canTakeCommercialAction) {
     return null
   }
 
-  if (artworkData.isInAuction && artworkData.sale) {
+  if (isBiddableInAuction) {
     if (artworkData.isBuyNowable && noEditions) {
       return (
         <RowContainer>
@@ -111,7 +117,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
   }
 
   if (artworkData.isInquireable && artworkData.isOfferable) {
-    if (isPartnerOffered) {
+    if (hasActivePartnerOffer) {
       return (
         <RowContainer>
           <InquiryButtonsFragmentContainer artwork={artworkData} variant="outline" block />
@@ -133,7 +139,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
   }
 
   if (artworkData.isOfferable) {
-    if (isPartnerOffered) {
+    if (hasActivePartnerOffer) {
       return (
         <RowContainer>
           <MakeOfferButtonFragmentContainer
@@ -156,6 +162,19 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
   }
 
   if (artworkData.isInquireable) {
+    if (hasActivePartnerOffer) {
+      return (
+        <RowContainer>
+          <InquiryButtonsFragmentContainer artwork={artworkData} variant="outline" block />
+          <BuyNowButton
+            partnerOffer={partnerOfferData}
+            artwork={artworkData}
+            editionSetID={selectedEditionId}
+          />
+        </RowContainer>
+      )
+    }
+
     return <InquiryButtonsFragmentContainer artwork={artworkData} block />
   }
 
@@ -191,6 +210,7 @@ const meFragment = graphql`
 const partnerOfferFragment = graphql`
   fragment ArtworkCommercialButtons_partnerOffer on PartnerOfferToCollector {
     internalID
+    isAvailable
     endAt
   }
 `


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR is a follow-up on #10144

This PR includes a missing state when the artwork is only inquiriable with a partner offer to show the Purchase button
It also refactors the tests for the ArtworkCommercialButtons component

### Screenshots

<details>
<summary>Details</summary>

#### States
| | State |
|---|---|
| `isAcquireable` + `isOfferable`  | <img src="https://github.com/artsy/eigen/assets/20655703/fa086921-be8f-4ed1-9d7f-62b5f5c5f9dc" width="320" /> |
| `isAcquireable`  | <img src="https://github.com/artsy/eigen/assets/20655703/074bfcab-d456-4e08-bcdc-26a6d92a9a9b" width="320" /> |
| `isOfferable` + `isInquireable `  | <img src="https://github.com/artsy/eigen/assets/20655703/5b696d7d-d8aa-4012-80b3-f837f71fd0d7" width="320" /> |
| `isOfferable`  | <img src="https://github.com/artsy/eigen/assets/20655703/0f5a331f-61f3-4ccd-bac1-698c17544c62" width="320" /> |
| `isInquireable `  |<img src="https://github.com/artsy/eigen/assets/20655703/076b9503-571a-41e8-aea6-03765107313c" width="320" /> |

#### iOS

| | Before | After |
|---|---|---|
| `isAcquireable` + `isOfferable` | ![image](https://github.com/artsy/eigen/assets/20655703/679e313b-3e58-4242-a1c7-a88cb1b18f51) | ![image](https://github.com/artsy/eigen/assets/20655703/b30a16dc-bfda-4dc3-83ec-2848542239bb) |
| `isAcquireable` | ![image](https://github.com/artsy/eigen/assets/20655703/1623aab1-69a7-41f2-ac7f-8281e1b8b389) | ![image](https://github.com/artsy/eigen/assets/20655703/c98b9920-da78-4e0c-8170-4998f00810fc) |
| `isOfferable` + `isInquireable` | ![image](https://github.com/artsy/eigen/assets/20655703/7b40ed51-1ce4-4cdd-b16c-854dd68baeb9) | ![image](https://github.com/artsy/eigen/assets/20655703/2b631822-5389-4b88-b1e8-92aa2b7f99cd) |
| `isOfferable` | ![image](https://github.com/artsy/eigen/assets/20655703/8c53675b-1ad7-48ea-b6b3-b5524e068f43) | ![image](https://github.com/artsy/eigen/assets/20655703/5384f703-61a1-4aa5-bcd0-22eedceb3d92) |
| `isInquireable ` | ![image](https://github.com/artsy/eigen/assets/20655703/0330a040-ca60-41e1-83c6-8d5385bb6a06) | ![image](https://github.com/artsy/eigen/assets/20655703/3b4e8f53-333e-4002-a242-210d35a1c11e) |




#### Android

| | Before | After |
|---|---|---|
| `isOfferable` + `isAcquireable ` | ![image](https://github.com/artsy/eigen/assets/20655703/7cf21b96-5854-4746-9476-42bf0bcd0f4d) | ![image](https://github.com/artsy/eigen/assets/20655703/1aa94712-0f26-44f0-8f60-36ebac3760fa) |
| `isAcquireable` | ![image](https://github.com/artsy/eigen/assets/20655703/2d247674-176a-42d3-96bc-98c8ce5c47f7) | ![image](https://github.com/artsy/eigen/assets/20655703/074227e6-bffd-4f3b-805f-3d71805d206b) |
| `isOfferable` + `isInquireable` | ![image](https://github.com/artsy/eigen/assets/20655703/0ee06e4f-4993-4e61-ae4f-4526113171b6) | ![image](https://github.com/artsy/eigen/assets/20655703/6dd2e577-d8db-4358-83de-8598d656b575) |
| `isOfferable` | ![image](https://github.com/artsy/eigen/assets/20655703/0be408f8-37fa-4aa7-9a6c-9fe3ff4f5aea) | ![image](https://github.com/artsy/eigen/assets/20655703/f9a3efd6-a1d9-4b8f-9a8e-83dc6ec98f06) |
| `isInquireable ` | ![image](https://github.com/artsy/eigen/assets/20655703/d1f8ccae-61ee-4138-8276-7d6addb3f2bd) | ![image](https://github.com/artsy/eigen/assets/20655703/5225de7d-2f96-4a0e-b37c-ddc22e420821) |

</details>


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- show purchase button for artwork with partner offer in case artwork is only inquireable - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
