### PR TITLE
fix(artwork): only show partner bio if enabled

### DIFF
--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -11,6 +11,11 @@ interface AboutArtistProps {
 }
 
 export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
+  // Possibly hide the artist bio if the artwork is unlisted and the artist bio is not displayed
+  if (artwork.isUnlisted && !artwork.displayArtistBio) {
+    return null
+  }
+
   const artists = artwork.artists || []
 
   const hasSingleArtist = artists && artists.length === 1
@@ -72,6 +77,7 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
 export const AboutArtistFragmentContainer = createFragmentContainer(AboutArtist, {
   artwork: graphql`
     fragment AboutArtist_artwork on Artwork {
+      displayArtistBio
       artists {
         id
         biographyBlurb {


### PR DESCRIPTION
### Description

Support for private artworks: This fixes things so we only display the partner bio section if isUnlisted is true and displayPartnerBio isn't false. Also updated the tests to use latest relay patterns. 

cc @artsy/amber-devs 