### PR TITLE
fix(private-artworks): Defer to artsy bio

### DIFF
--- a/src/app/Scenes/Artwork/Components/AboutArtist.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tests.tsx
@@ -56,9 +56,16 @@ describe("AboutArtist", () => {
       Artwork: () => ({
         isUnlisted: true,
         displayArtistBio: false,
+        artists: [
+          {
+            biographyBlurb: {
+              text: "Biography of Abbas Kiarostami",
+            },
+          },
+        ],
       }),
     })
 
-    expect(screen.queryByText("About the artist")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Biography of Abbas Kiarostami")).not.toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -11,11 +11,6 @@ interface AboutArtistProps {
 }
 
 export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
-  // Possibly hide the artist bio if the artwork is unlisted and the artist bio is not displayed
-  if (artwork.isUnlisted && !artwork.displayArtistBio) {
-    return null
-  }
-
   const artists = artwork.artists || []
 
   const hasSingleArtist = artists && artists.length === 1
@@ -23,9 +18,7 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
   const biographyBlurb =
     hasSingleArtist && artists[0]?.biographyBlurb?.text ? artists[0]?.biographyBlurb?.text : null
 
-  const partnerBiographyBlurb = artwork.artist?.partnerBiographyBlurb?.text
-
-  const text = partnerBiographyBlurb ?? biographyBlurb
+  const text = biographyBlurb
 
   const textLimit = truncatedTextLimit()
 
@@ -56,7 +49,7 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
           )}
         </Join>
       </Flex>
-      {!!hasSingleArtist && !!text && (
+      {!!hasSingleArtist && !!text && !artwork.isUnlisted && !artwork.displayArtistBio && (
         <Box mt={2} mb={artwork.isUnlisted ? 1 : 0}>
           <ReadMore
             content={text}


### PR DESCRIPTION
Related:
- https://github.com/artsy/force/pull/13809

The type of this PR is: **Fix**

### Description

Only show artsy bio, and make sure to still show rest of artist section if bio is disabled.

cc @artsy/amber-devs 
