### PR TITLE
feat(AMBER-551): Update Artwork information panel (Mobile)

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -33,7 +33,7 @@ import { useTracking } from "react-tracking"
 import { LARGE_RAIL_IMAGE_WIDTH } from "./LargeArtworkRail"
 import { SMALL_RAIL_IMAGE_WIDTH } from "./SmallArtworkRail"
 
-export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = 70
+export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = 90
 const SAVE_ICON_SIZE = 26
 
 export const ARTWORK_RAIL_CARD_IMAGE_HEIGHT = {
@@ -90,7 +90,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   const artwork = useFragment(artworkFragment, restProps.artwork)
   const { width: screenWidth } = useScreenDimensions()
 
-  const { artistNames, date, image, partner, title, sale, saleArtwork } = artwork
+  const { artistNames, date, image, partner, title, sale, saleArtwork, isUnlisted } = artwork
 
   const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
 
@@ -311,6 +311,18 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                     fontWeight="bold"
                   >
                     {saleMessage}
+                  </Text>
+                )}
+
+                {!!isUnlisted && (
+                  <Text
+                    lineHeight="20px"
+                    variant="xs"
+                    color={primaryTextColor}
+                    numberOfLines={1}
+                    fontWeight="bold"
+                  >
+                    Exclusive Access
                   </Text>
                 )}
               </Flex>
@@ -542,6 +554,7 @@ const artworkFragment = graphql`
       }
       aspectRatio
     }
+    isUnlisted
     sale {
       isAuction
       isClosed


### PR DESCRIPTION
This PR resolves [] <!-- eg [AMBER-551] -->

### Description

As part of the private artworks project, we want to ensure that collectors know which artworks are private. The collector facing terminology that we are using is exclusive access and we want to update this across artsy wherever a private artwork is being viewed.

We want to update this for the artwork panel which is used across the website. An example being on the saved artworks page, or the recently viewed Rail.

![Screenshot 2024-04-25 at 4 17 37 PM](https://github.com/artsy/eigen/assets/5643895/4893b881-6935-475a-9c2f-9739efff6a1a)

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog



[AMBER-551]: https://artsyproduct.atlassian.net/browse/AMBER-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ