### PR TITLE
fix: in app notification text cut off

### DIFF
--- a/ios/Artsy/Views/Notifications/ARNotificationView.m
+++ b/ios/Artsy/Views/Notifications/ARNotificationView.m
@@ -71,7 +71,7 @@ static NSMutableArray *notificationQueue = nil; // Global notification queue
 
 + (CGFloat)estimatedTextSizeForTitle:(NSString *)title inView:(UIView *)view {
     UIFont *font = [UIFont serifFontWithSize:16];
-    CGFloat maxWidth = view.bounds.size.width - panelMargin;
+    CGFloat maxWidth = view.bounds.size.width - (panelMargin * 2);
     NSDictionary *attributes = @{NSFontAttributeName: font};
 
     CGRect textRect = [title boundingRectWithSize:CGSizeMake(maxWidth, CGFLOAT_MAX)


### PR DESCRIPTION
This PR resolves [PHIRE-848] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Fixes text being cut off in certain in app notifications due to a bad width calculation for the text field.

<details>

<summary>
Before
</summary>

![before-cutoff](https://github.com/artsy/eigen/assets/49686530/47553fec-1226-4b5e-b19c-11b6265f9270)

</details>


<details>

<summary>
After
</summary>

![after-cutoff](https://github.com/artsy/eigen/assets/49686530/d0bf8004-72ff-436a-9bac-0120ec3f0ec5)

</details>


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix in app notification text cut off - Brian 

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-848]: https://artsyproduct.atlassian.net/browse/PHIRE-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ