### PR TITLE
fix: Avoid displaying wrong cached data when rendering artworks for you

### DIFF
--- a/src/app/Components/WorksForYouArtworks.tests.tsx
+++ b/src/app/Components/WorksForYouArtworks.tests.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react-native"
-import { NewWorksForYouArtworksTestsQuery } from "__generated__/NewWorksForYouArtworksTestsQuery.graphql"
-import { NewWorksForYouArtworks } from "app/Scenes/NewWorksForYou/Components/NewWorksForYouArtworks"
+import { WorksForYouArtworksTestsQuery } from "__generated__/WorksForYouArtworksTestsQuery.graphql"
+import { WorksForYouArtworks } from "app/Components/WorksForYouArtworks"
 import { DEFAULT_RECS_MODEL_VERSION } from "app/Scenes/NewWorksForYou/NewWorksForYou"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -13,11 +13,11 @@ describe("NewWorksForYouGrid", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
 
   const TestRenderer = () => (
-    <QueryRenderer<NewWorksForYouArtworksTestsQuery>
+    <QueryRenderer<WorksForYouArtworksTestsQuery>
       query={graphql`
-        query NewWorksForYouArtworksTestsQuery($version: String, $maxWorksPerArtist: Int) {
+        query WorksForYouArtworksTestsQuery($version: String, $maxWorksPerArtist: Int) {
           viewer {
-            ...NewWorksForYouArtworks_viewer
+            ...WorksForYouArtworks_viewer
               @arguments(version: $version, maxWorksPerArtist: $maxWorksPerArtist)
           }
         }
@@ -27,7 +27,7 @@ describe("NewWorksForYouGrid", () => {
           return
         }
 
-        return <NewWorksForYouArtworks viewer={props.viewer} />
+        return <WorksForYouArtworks viewer={props.viewer} />
       }}
       variables={{
         version: DEFAULT_RECS_MODEL_VERSION,

--- a/src/app/Components/WorksForYouArtworks.tsx
+++ b/src/app/Components/WorksForYouArtworks.tsx
@@ -1,7 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Screen, SimpleMessage, Text } from "@artsy/palette-mobile"
-import { NewWorksForYouArtworksQuery } from "__generated__/NewWorksForYouArtworksQuery.graphql"
-import { NewWorksForYouArtworks_viewer$key } from "__generated__/NewWorksForYouArtworks_viewer.graphql"
+import { WorksForYouArtworksQuery } from "__generated__/WorksForYouArtworksQuery.graphql"
+import { WorksForYouArtworks_viewer$key } from "__generated__/WorksForYouArtworks_viewer.graphql"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { NewWorksForYouPlaceholder } from "app/Scenes/NewWorksForYou/NewWorksForYou"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -14,10 +14,10 @@ import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 export const PAGE_SIZE = 100
 
 interface NewWorksForYouProps {
-  viewer: NewWorksForYouArtworks_viewer$key
+  viewer: WorksForYouArtworks_viewer$key
 }
 
-export const NewWorksForYouArtworks: React.FC<NewWorksForYouProps> = ({ viewer }) => {
+export const WorksForYouArtworks: React.FC<NewWorksForYouProps> = ({ viewer }) => {
   const defaultViewOption = GlobalStore.useAppState((state) => state.userPrefs.defaultViewOption)
 
   const { data } = usePaginationFragment(newWorksForYouArtworksFragment, viewer)
@@ -54,8 +54,8 @@ export const NewWorksForYouArtworks: React.FC<NewWorksForYouProps> = ({ viewer }
 }
 
 export const newWorksForYouArtworksFragment = graphql`
-  fragment NewWorksForYouArtworks_viewer on Viewer
-  @refetchable(queryName: "NewWorksForYouArtworks_viewerRefetch")
+  fragment WorksForYouArtworks_viewer on Viewer
+  @refetchable(queryName: "WorksForYouArtworks_viewerRefetch")
   @argumentDefinitions(
     count: { type: "Int", defaultValue: 100 }
     cursor: { type: "String" }
@@ -90,13 +90,13 @@ export const newWorksForYouArtworksFragment = graphql`
 `
 
 export const newWorksForYouArtworksQuery = graphql`
-  query NewWorksForYouArtworksQuery(
+  query WorksForYouArtworksQuery(
     $version: String
     $maxWorksPerArtist: Int
     $onlyAtAuction: Boolean = false
   ) {
     viewer @principalField {
-      ...NewWorksForYouArtworks_viewer
+      ...WorksForYouArtworks_viewer
         @arguments(
           version: $version
           maxWorksPerArtist: $maxWorksPerArtist
@@ -106,15 +106,15 @@ export const newWorksForYouArtworksQuery = graphql`
   }
 `
 
-interface NewWorksForYouArtworksQRProps {
+interface WorksForYouArtworksQRProps {
   maxWorksPerArtist?: number
   version?: string
   onlyAtAuction?: boolean
 }
 
-export const NewWorksForYouArtworksQR: React.FC<NewWorksForYouArtworksQRProps> = withSuspense(
+export const WorksForYouArtworksQR: React.FC<WorksForYouArtworksQRProps> = withSuspense(
   ({ version, onlyAtAuction = false, maxWorksPerArtist = 3 }) => {
-    const data = useLazyLoadQuery<NewWorksForYouArtworksQuery>(
+    const data = useLazyLoadQuery<WorksForYouArtworksQuery>(
       newWorksForYouArtworksQuery,
       {
         version,
@@ -122,7 +122,8 @@ export const NewWorksForYouArtworksQR: React.FC<NewWorksForYouArtworksQRProps> =
         onlyAtAuction,
       },
       {
-        fetchPolicy: "store-and-network",
+        // This is necessary to avoid displaying cached because this component is used in more than one place and Relay returns data from another screen before the new data is loaded.
+        fetchPolicy: "network-only",
       }
     )
 
@@ -132,7 +133,7 @@ export const NewWorksForYouArtworksQR: React.FC<NewWorksForYouArtworksQRProps> =
       return <Text>Something went wrong.</Text>
     }
 
-    return <NewWorksForYouArtworks viewer={data.viewer} />
+    return <WorksForYouArtworks viewer={data.viewer} />
   },
   () => <NewWorksForYouPlaceholder defaultViewOption="grid" />
 )

--- a/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
+++ b/src/app/Scenes/NewWorksForYou/NewWorksForYou.tsx
@@ -10,7 +10,7 @@ import {
   Spacer,
 } from "@artsy/palette-mobile"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { NewWorksForYouArtworksQR } from "app/Scenes/NewWorksForYou/Components/NewWorksForYouArtworks"
+import { WorksForYouArtworksQR } from "app/Components/WorksForYouArtworks"
 import { ViewOption } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
@@ -100,7 +100,7 @@ export const NewWorksForYouQueryRenderer: React.FC<NewWorksForYouQueryRendererPr
         />
         <Screen.StickySubHeader title={SCREEN_TITLE} />
         <Screen.Body fullwidth>
-          <NewWorksForYouArtworksQR maxWorksPerArtist={maxWorksPerArtist} version={version} />
+          <WorksForYouArtworksQR maxWorksPerArtist={maxWorksPerArtist} version={version} />
         </Screen.Body>
       </Screen>
     </ProvideScreenTrackingWithCohesionSchema>

--- a/src/app/Scenes/RecommendedAuctionLots/RecommendedAuctionLots.tsx
+++ b/src/app/Scenes/RecommendedAuctionLots/RecommendedAuctionLots.tsx
@@ -10,10 +10,7 @@ import {
   Spacer,
 } from "@artsy/palette-mobile"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import {
-  NewWorksForYouArtworksQR,
-  PAGE_SIZE,
-} from "app/Scenes/NewWorksForYou/Components/NewWorksForYouArtworks"
+import { WorksForYouArtworksQR, PAGE_SIZE } from "app/Components/WorksForYouArtworks"
 import { ICON_SIZE } from "app/Scenes/NewWorksForYou/NewWorksForYou"
 import { ViewOption } from "app/Scenes/Search/UserPrefsModel"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -58,7 +55,7 @@ export const RecommendedAuctionLotsQueryRenderer: React.FC = () => {
         />
         <Screen.StickySubHeader title={SCREEN_TITLE} />
         <Screen.Body fullwidth>
-          <NewWorksForYouArtworksQR onlyAtAuction />
+          <WorksForYouArtworksQR onlyAtAuction />
         </Screen.Body>
       </Screen>
     </ProvideScreenTrackingWithCohesionSchema>


### PR DESCRIPTION
This PR resolves [ONYX-932] <!-- eg [PROJECT-XXXX] -->

### Description

Some cached data persists when navigating between “New Works for You” and “Auction Lots for You” This change avoid displaying wrong cached data when rendering artworks for you by changing the Relay cache policy.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Avoid displaying wrong cached data etween “New Works for You” and “Auction Lots for You” - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-932]: https://artsyproduct.atlassian.net/browse/ONYX-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ