### PR TITLE
fix: search input line break

### DIFF
--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -27,10 +27,12 @@ import { SEARCH_PILLS, SEARCH_THROTTLE_INTERVAL, TOP_PILL } from "./constants"
 import { getContextModuleByPillName } from "./helpers"
 import { PillType } from "./types"
 
+// This is a workaround for the placeholder text not truncated on android
+// See https://github.com/facebook/react-native/issues/29663
 const SEARCH_INPUT_PLACEHOLDER =
-  Dimensions.get("screen").width - 150 > 250
-    ? "Search artists, artworks, galleries, etc"
-    : "Search artists, artworks,  etc"
+  Platform.OS === "android" && Dimensions.get("screen").width - 150 < 250
+    ? "Search artists, artworks,  etc"
+    : "Search artists, artworks, galleries, etc"
 
 export const searchQueryDefaultVariables: SearchQuery$variables = {
   term: "",

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -11,7 +11,7 @@ import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { Schema } from "app/utils/track"
 import { throttle } from "lodash"
 import { Suspense, useEffect, useMemo, useRef, useState } from "react"
-import { Platform, ScrollView } from "react-native"
+import { Dimensions, Platform, ScrollView } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -27,7 +27,10 @@ import { SEARCH_PILLS, SEARCH_THROTTLE_INTERVAL, TOP_PILL } from "./constants"
 import { getContextModuleByPillName } from "./helpers"
 import { PillType } from "./types"
 
-const SEARCH_INPUT_PLACEHOLDER = "Search artists, artworks, galleries, etc"
+const SEARCH_INPUT_PLACEHOLDER =
+  Dimensions.get("screen").width - 150 > 250
+    ? "Search artists, artworks, galleries, etc"
+    : "Search artists, artworks,  etc"
 
 export const searchQueryDefaultVariables: SearchQuery$variables = {
   term: "",


### PR DESCRIPTION
This PR resolves [ONYX-931] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue where the search input placeholder breaks on Android.
The issue comes from React-native and is still not fixed even in the latest version.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- search input placeholder cropped - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-931]: https://artsyproduct.atlassian.net/browse/ONYX-931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ