### PR TITLE
fix(EMI-1785): Update create/edit artwork list name input design

### DIFF
--- a/src/app/Components/ArtworkLists/components/CreateOrEditArtworkListForm.tsx
+++ b/src/app/Components/ArtworkLists/components/CreateOrEditArtworkListForm.tsx
@@ -72,6 +72,7 @@ export const CreateOrEditArtworkListForm: FC<CreateOrEditArtworkListFormProps> =
               maxLength={MAX_NAME_LENGTH}
               onBlur={formik.handleBlur("name")}
               onChangeText={formik.handleChange("name")}
+              required
             />
 
             {!!AREnableArtworkListOfferability && (

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
@@ -160,7 +160,7 @@ describe("CreateNewArtworkListView", () => {
 
     // Known issue with react native testing library
     // context: https://github.com/callstack/react-native-testing-library/issues/1239
-    it.skip("when user has reached the allowed limit", async () => {
+    it.skip("when user has reached the allowed limit", () => {
       renderWithRelay()
 
       const longText = "a".repeat(100)

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
@@ -133,6 +133,42 @@ describe("CreateNewArtworkListView", () => {
       expect(screen.getByText("Shared list")).toBeOnTheScreen()
     })
   })
+
+  describe("Remaining characters", () => {
+    it("default state", () => {
+      renderWithRelay()
+
+      expect(screen.getByText("0 / 40")).toBeOnTheScreen()
+    })
+
+    it("when user entered 39 characters", () => {
+      renderWithRelay()
+
+      const longText = "a".repeat(39)
+      fireEvent.changeText(screen.getByPlaceholderText(inputPlaceholder), longText)
+
+      expect(screen.getByText("39 / 40")).toBeOnTheScreen()
+    })
+
+    it("when user entered something", () => {
+      renderWithRelay()
+
+      fireEvent.changeText(screen.getByPlaceholderText(inputPlaceholder), "abc")
+
+      expect(screen.getByText("3 / 40")).toBeOnTheScreen()
+    })
+
+    // Known issue with react native testing library
+    // context: https://github.com/callstack/react-native-testing-library/issues/1239
+    it.skip("when user has reached the allowed limit", async () => {
+      renderWithRelay()
+
+      const longText = "a".repeat(100)
+      fireEvent(screen.getByPlaceholderText(inputPlaceholder), "changeText", longText)
+
+      expect(screen.getByText("40 / 40")).toBeOnTheScreen()
+    })
+  })
 })
 
 const artworkEntity: ArtworkEntity = {


### PR DESCRIPTION
This PR resolves [EMI-1785] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates the input field inside the Create/Edit Artwork List bottom sheet to show `* Required`
It also adds tests for the character limit 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### Screenshots
| Android | iOS |
|---|---|
| ![image](https://github.com/artsy/eigen/assets/20655703/b1c642a0-ca95-4839-af80-663e07627154) | ![image](https://github.com/artsy/eigen/assets/20655703/f8eb9fda-bdf5-40b6-8d58-5c15bca11b5d) |


### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update create/edit artwork list input field to show `required` - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1785]: https://artsyproduct.atlassian.net/browse/EMI-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ