### PR TITLE
chore(tracking): Add Private Artwork Tracking (mobile)

### DIFF
--- a/src/app/Components/Expandable.tsx
+++ b/src/app/Components/Expandable.tsx
@@ -7,6 +7,7 @@ interface ExpandableProps {
   label?: string
   expanded?: boolean
   children: React.ReactNode
+  trackingFunction?: () => void
 }
 
 /**
@@ -17,21 +18,26 @@ export const Expandable: React.FC<ExpandableProps> = ({
   children,
   expanded: propExpanded,
   label,
+  trackingFunction,
 }) => {
   const [expanded, setExpanded] = useState(propExpanded)
 
   const handleToggle = () => {
     setExpanded((prev) => !prev)
+    if (trackingFunction) {
+      trackingFunction()
+    }
   }
 
   return (
     <Flex borderTopWidth={1} py={1} accessibilityHint="Toggles the accordion" maxWidth={MAX_WIDTH}>
       <Touchable
-        onPress={handleToggle}
+        onPress={() => handleToggle()}
         accessibilityRole="togglebutton"
         accessibilityLabel={label}
         accessibilityState={{ expanded }}
         hitSlop={{ top: 10, bottom: 10 }}
+        testID="expandableAccordion"
       >
         <Flex flexDirection="row" alignItems="center" justifyContent="space-between">
           <Text variant="sm">{label}</Text>

--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -978,7 +978,7 @@ describe("Artwork", () => {
       expect(screen.getByText("Read More")).toBeOnTheScreen()
     })
 
-    fit("tracks partner name taps", async () => {
+    it("tracks partner name taps", async () => {
       renderWithWrappers(<TestRenderer />)
 
       // ArtworkAboveTheFoldQuery

--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -977,5 +977,45 @@ describe("Artwork", () => {
 
       expect(screen.getByText("Read More")).toBeOnTheScreen()
     })
+
+    fit("tracks partner name taps", async () => {
+      renderWithWrappers(<TestRenderer />)
+
+      // ArtworkAboveTheFoldQuery
+      resolveMostRecentRelayOperation(environment, {
+        Artwork: () => ({
+          isUnlisted: true,
+        }),
+      })
+      // ArtworkMarkAsRecentlyViewedQuery
+      resolveMostRecentRelayOperation(environment)
+      // ArtworkBelowTheFoldQuery
+      resolveMostRecentRelayOperation(environment, {
+        Artwork: () => ({
+          isUnlisted: true,
+          isForSale: true,
+          isInAuction: false,
+          partner: {
+            name: "Test Partner",
+            type: "foo",
+          },
+          sale: {
+            isBenefit: false,
+            isGalleryAuction: false,
+          },
+        }),
+      })
+
+      await flushPromiseQueue()
+
+      fireEvent.press(screen.getByText("Test Partner"))
+
+      expect(mockTrackEvent).toBeCalledWith({
+        context_module: "artworkDetails",
+        subject: "Gallery Name",
+        type: "Link",
+        flow: "Exclusive access",
+      })
+    })
   })
 })

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tests.tsx
@@ -1,4 +1,5 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 import { AboutArtistFragmentContainer } from "./AboutArtist"
@@ -67,5 +68,30 @@ describe("AboutArtist", () => {
     })
 
     expect(screen.queryByText("Biography of Abbas Kiarostami")).not.toBeOnTheScreen()
+  })
+
+  it("tracks taps on artist bio read more", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        isUnlisted: true,
+        displayArtistBio: true,
+        artists: [
+          {
+            biographyBlurb: {
+              text: "Jon Allured, an acclaimed contemporary artist, has carved a niche for himself in the art world with his vibrant and thought-provoking abstract paintings. Born and raised in a small coastal town, Jon's early exposure to the raw beauty of nature deeply influenced his artistic perspective. He studied fine arts at a prestigious university, where he honed his skills and developed his distinctive style. Jon's work is characterized by bold color palettes, dynamic textures, and fluid, organic shapes that invite viewers to interpret their own meanings. His paintings often incorporate mixed media, using everything from traditional oils to experimental materials, which add depth and intrigue to his canvases.",
+            },
+          },
+        ],
+      }),
+    })
+
+    const readMoreLink = screen.getByText("Read more")
+    fireEvent.press(readMoreLink)
+    expect(mockTrackEvent).toBeCalledWith({
+      action_name: "readMore",
+      action_type: "tap",
+      context_module: "ArtistBiography",
+      flow: "AboutTheArtist",
+    })
   })
 })

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -49,7 +49,7 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
           )}
         </Join>
       </Flex>
-      {!!hasSingleArtist && !!text && !artwork.isUnlisted && !artwork.displayArtistBio && (
+      {!!hasSingleArtist && !!text && !!artwork.displayArtistBio && (
         <Box mt={2} mb={artwork.isUnlisted ? 1 : 0}>
           <ReadMore
             content={text}

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkExclusiveAccess.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkExclusiveAccess.tsx
@@ -3,6 +3,7 @@ import { PrivateArtworkExclusiveAccess_artwork$key } from "__generated__/Private
 import { navigate } from "app/system/navigation/navigate"
 import React from "react"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface PrivateArtworkExclusiveAccessProps {
   artwork: PrivateArtworkExclusiveAccess_artwork$key
@@ -28,11 +29,14 @@ export const PrivateArtworkExclusiveAccess: React.FC<PrivateArtworkExclusiveAcce
     artwork
   )
 
+  const tracking = useTracking()
+
   if (!data.isUnlisted) {
     return null
   }
 
   const handleLinkPress = () => {
+    tracking.trackEvent(tracks.tappedGalleryName())
     navigate(`/partner/${data.partner?.slug}`)
   }
 
@@ -58,4 +62,13 @@ export const PrivateArtworkExclusiveAccess: React.FC<PrivateArtworkExclusiveAcce
       </Text>
     </Flex>
   )
+}
+
+const tracks = {
+  tappedGalleryName: () => ({
+    context_module: "artworkDetails",
+    subject: "Gallery Name",
+    type: "Link",
+    flow: "Exclusive access",
+  }),
 }

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -14,7 +14,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
         conditionDescription {
           details
         }
-        provenance(format: HTML)
+        privateProvenance: provenance(format: HTML)
         privateExhibitionHistory: exhibitionHistory(format: HTML)
       }
     `,

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -33,14 +33,6 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
     !data.conditionDescription?.details && !data.privateProvenance && data.privateExhibitionHistory
   )
 
-  console.log("isFirstItemExpanded", isFirstItemExpanded)
-  console.log("isSecondItemExpanded", isSecondItemExpanded)
-  console.log("isThirdItemExpanded", isThirdItemExpanded)
-
-  console.log("cond disc", !!data.conditionDescription?.details)
-  console.log("provenance", !!data.privateProvenance)
-  console.log("ex hist", !!data.privateExhibitionHistory)
-
   return (
     <>
       {!!data.conditionDescription?.details && (

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -2,6 +2,7 @@ import { PrivateArtworkMetadata_artwork$key } from "__generated__/PrivateArtwork
 import { Expandable } from "app/Components/Expandable"
 import { HTML } from "app/Components/HTML"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 interface PrivateArtworkMetadataProps {
   artwork: PrivateArtworkMetadata_artwork$key
 }
@@ -13,12 +14,14 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
         conditionDescription {
           details
         }
-        privateProvenance: provenance(format: HTML)
+        provenance(format: HTML)
         privateExhibitionHistory: exhibitionHistory(format: HTML)
       }
     `,
     artwork
   )
+
+  const tracking = useTracking()
 
   const isFirstItemExpanded = Boolean(data.conditionDescription?.details)
 
@@ -30,11 +33,25 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
     !data.conditionDescription?.details && !data.privateProvenance && data.privateExhibitionHistory
   )
 
+  console.log("isFirstItemExpanded", isFirstItemExpanded)
+  console.log("isSecondItemExpanded", isSecondItemExpanded)
+  console.log("isThirdItemExpanded", isThirdItemExpanded)
+
+  console.log("cond disc", !!data.conditionDescription?.details)
+  console.log("provenance", !!data.privateProvenance)
+  console.log("ex hist", !!data.privateExhibitionHistory)
+
   return (
     <>
       {!!data.conditionDescription?.details && (
         <>
-          <Expandable label="Condition" expanded={isFirstItemExpanded}>
+          <Expandable
+            trackingFunction={() => {
+              tracking.trackEvent(tracks.tappedConditionExpand(isFirstItemExpanded))
+            }}
+            label="Condition"
+            expanded={isFirstItemExpanded}
+          >
             <HTML html={data.conditionDescription?.details} variant="sm" />
           </Expandable>
         </>
@@ -42,17 +59,50 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
 
       {!!data.privateProvenance && (
         <>
-          <Expandable label="Provenance" expanded={isSecondItemExpanded}>
+          <Expandable
+            trackingFunction={() => {
+              tracking.trackEvent(tracks.tappedProvenanceExpand(isSecondItemExpanded))
+            }}
+            label="Provenance"
+            expanded={isSecondItemExpanded}
+          >
             <HTML variant="sm" html={data.privateProvenance} />
           </Expandable>
         </>
       )}
 
       {!!data.privateExhibitionHistory && (
-        <Expandable label="Exhibition History" expanded={isThirdItemExpanded}>
+        <Expandable
+          trackingFunction={() => {
+            tracking.trackEvent(tracks.tappedExhibitionHistoryExpand(isThirdItemExpanded))
+          }}
+          label="Exhibition History"
+          expanded={isThirdItemExpanded}
+        >
           <HTML variant="sm" html={data.privateExhibitionHistory} />
         </Expandable>
       )}
     </>
   )
+}
+
+const tracks = {
+  tappedConditionExpand: (isExpanded: boolean) => ({
+    context_module: "aboutTheWork",
+    context_owner_type: "artwork",
+    expand: isExpanded,
+    subject: "Condition",
+  }),
+  tappedProvenanceExpand: (isExpanded: boolean) => ({
+    context_module: "aboutTheWork",
+    context_owner_type: "artwork",
+    expand: isExpanded,
+    subject: "Provenance",
+  }),
+  tappedExhibitionHistoryExpand: (isExpanded: boolean) => ({
+    context_module: "aboutTheWork",
+    context_owner_type: "artwork",
+    expand: isExpanded,
+    subject: "Exhibition History",
+  }),
 }

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
@@ -52,7 +52,7 @@ describe("PrivateArtworkMetadata", () => {
           conditionDescription: {
             details: null,
           },
-          provenance: "Test Provenance Details",
+          privateProvenance: "Test Provenance Details",
         }
       },
     })
@@ -63,7 +63,7 @@ describe("PrivateArtworkMetadata", () => {
     renderWithRelay({
       Artwork: () => {
         return {
-          provenance: null,
+          privateProvenance: null,
         }
       },
     })
@@ -77,8 +77,8 @@ describe("PrivateArtworkMetadata", () => {
           conditionDescription: {
             details: null,
           },
-          provenance: null,
-          exhibitionHistory: "Test Exhibition History Details",
+          privateProvenance: null,
+          privateExhibitionHistory: "Test Exhibition History Details",
         }
       },
     })
@@ -89,7 +89,7 @@ describe("PrivateArtworkMetadata", () => {
     renderWithRelay({
       Artwork: () => {
         return {
-          exhibitionHistory: null,
+          privateExhibitionHistory: null,
         }
       },
     })
@@ -120,7 +120,7 @@ describe("PrivateArtworkMetadata", () => {
     renderWithRelay({
       Artwork: () => {
         return {
-          provenance: "Test Provenance Details",
+          privateProvenance: "Test Provenance Details",
         }
       },
     })
@@ -134,11 +134,11 @@ describe("PrivateArtworkMetadata", () => {
     })
   })
 
-  it("tracks provenance expand press", async () => {
+  it("tracks exhibition history expand press", async () => {
     renderWithRelay({
       Artwork: () => {
         return {
-          exhibitionHistory: "Test Exhibition History Details",
+          privateExhibitionHistory: "Test Exhibition History Details",
         }
       },
     })

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
@@ -1,6 +1,7 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { PrivateArtworkMetadataQuery } from "__generated__/PrivateArtworkMetadataQuery.graphql"
 import { PrivateArtworkMetadata } from "app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -93,5 +94,61 @@ describe("PrivateArtworkMetadata", () => {
       },
     })
     expect(screen.queryByText("Test Exhibition History Details")).not.toBeTruthy()
+  })
+
+  it("tracks condition expand press", async () => {
+    renderWithRelay({
+      Artwork: () => {
+        return {
+          conditionDescription: {
+            details: "Test Condition Description Details",
+          },
+        }
+      },
+    })
+
+    fireEvent.press(screen.getAllByTestId("expandableAccordion")[0])
+    expect(mockTrackEvent).toBeCalledWith({
+      context_module: "aboutTheWork",
+      context_owner_type: "artwork",
+      expand: true,
+      subject: "Condition",
+    })
+  })
+
+  it("tracks provenance expand press", async () => {
+    renderWithRelay({
+      Artwork: () => {
+        return {
+          provenance: "Test Provenance Details",
+        }
+      },
+    })
+
+    fireEvent.press(screen.getAllByTestId("expandableAccordion")[1])
+    expect(mockTrackEvent).toBeCalledWith({
+      context_module: "aboutTheWork",
+      context_owner_type: "artwork",
+      expand: false,
+      subject: "Provenance",
+    })
+  })
+
+  it("tracks provenance expand press", async () => {
+    renderWithRelay({
+      Artwork: () => {
+        return {
+          exhibitionHistory: "Test Exhibition History Details",
+        }
+      },
+    })
+
+    fireEvent.press(screen.getAllByTestId("expandableAccordion")[2])
+    expect(mockTrackEvent).toBeCalledWith({
+      context_module: "aboutTheWork",
+      context_owner_type: "artwork",
+      expand: false,
+      subject: "Exhibition History",
+    })
   })
 })


### PR DESCRIPTION
This PR resolves [AMBER-592](https://artsyproduct.atlassian.net/browse/AMBER-592) <!-- eg [AMBER-592] -->

### Description
Description

We want to add tracking to 5 behaviours found on [this spreadsheet](https://docs.google.com/spreadsheets/d/1zaFOn-bDKzYiK07sYoOYUwd7c4R5aAGzRA5oNmgZ5qs/edit#gid=0). If any of the methods do not already exist, then a separate PR will need to be made to Cohesion and to tag Louis so he can give feedback.

Some of the events were already being tracked (discussion [here](https://artsy.slack.com/archives/C05F8TNKGAV/p1714421942657479)) so I left those as is

This PR also includes some test fixes because those tests were not running due to an incorrect filepath

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Bugfix for displaying artist bio on private artwork screen - Lily

#### Dev changes
- Adds tracking events for user interaction of private artwork elements - Lily
<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[AMBER-592]: https://artsyproduct.atlassian.net/browse/AMBER-592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ