### PR TITLE
Fix: Adds test-id to properly test tracking event fire

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tests.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tests.tsx
@@ -1008,7 +1008,7 @@ describe("Artwork", () => {
 
       await flushPromiseQueue()
 
-      fireEvent.press(screen.getByText("Test Partner"))
+      fireEvent.press(screen.getByTestId("test-partner-button"))
 
       expect(mockTrackEvent).toBeCalledWith({
         context_module: "artworkDetails",

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkExclusiveAccess.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkExclusiveAccess.tsx
@@ -55,7 +55,9 @@ export const PrivateArtworkExclusiveAccess: React.FC<PrivateArtworkExclusiveAcce
         </Text>
         This work was privately shared by{" "}
         {data.partner?.profile?.isPubliclyVisible ? (
-          <LinkText onPress={handleLinkPress}>{data.partner?.name}</LinkText>
+          <LinkText testID="test-partner-button" onPress={handleLinkPress}>
+            {data.partner?.name}
+          </LinkText>
         ) : (
           <>{data.partner?.name}</>
         )}


### PR DESCRIPTION
This PR resolves Fix for failing test when merged into main

### Description

Patch fix for failing test that was caused when [this PR ](https://github.com/artsy/eigen/pull/10178)was merged into main branch. Apologies all, I thought the PR being green was all good!


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Patch fix for failing test on main 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
