### PR TITLE
feat(onyx-915): use new consignmentSubmission MP fields when rendering submission state section

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -26,6 +26,8 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
   const { trackEvent } = useTracking()
 
   const hasImages = artwork?.figures?.length > 0
+  const displaySubmissionStateSection =
+    consignmentSubmission?.state && consignmentSubmission?.state !== "DRAFT"
 
   return (
     <Join separator={<Spacer y={1} />}>
@@ -71,9 +73,9 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
         </Text>
       </Flex>
 
-      {!!consignmentSubmission?.displayText && (
+      {!!displaySubmissionStateSection && (
         <Flex px={2} mt={2}>
-          <MyCollectionArtworkSubmissionStatus displayText={consignmentSubmission?.displayText} />
+          <MyCollectionArtworkSubmissionStatus artwork={artwork} />
         </Flex>
       )}
 
@@ -98,9 +100,10 @@ const myCollectionArtworkHeaderFragment = graphql`
     slug
     title
     consignmentSubmission {
-      displayText
+      state
     }
     submissionId
+    ...MyCollectionArtworkSubmissionStatus_submissionState
   }
 `
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [ONYX-915] -->

### Description

Same as https://github.com/artsy/force/pull/13849 - Force/Eigen hardcode submission status labels and help messages.  We've moved this logic to `myCollectionConnection...consignmentSubmission` MP field (https://github.com/artsy/metaphysics/pull/5702) and in this PR we are replacing old "hardcoded" data with the new one taken from MP. Nothing should change visually, so I am not attaching screenshots.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-915]: https://artsyproduct.atlassian.net/browse/ONYX-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ