### PR TITLE
fix(tracking): Private artwork metadata toggle event is firing as a page view event

### DIFF
--- a/src/app/Components/Expandable.tsx
+++ b/src/app/Components/Expandable.tsx
@@ -7,7 +7,7 @@ interface ExpandableProps {
   label?: string
   expanded?: boolean
   children: React.ReactNode
-  trackingFunction?: () => void
+  onTrack?: () => void
 }
 
 /**
@@ -18,14 +18,14 @@ export const Expandable: React.FC<ExpandableProps> = ({
   children,
   expanded: propExpanded,
   label,
-  trackingFunction,
+  onTrack,
 }) => {
   const [expanded, setExpanded] = useState(propExpanded)
 
   const handleToggle = () => {
     setExpanded((prev) => !prev)
-    if (trackingFunction) {
-      trackingFunction()
+    if (onTrack) {
+      onTrack()
     }
   }
 

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -1,3 +1,5 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { ToggledAccordion } from "@artsy/cohesion/dist/Schema/Events/UserExperienceInteractions"
 import { PrivateArtworkMetadata_artwork$key } from "__generated__/PrivateArtworkMetadata_artwork.graphql"
 import { Expandable } from "app/Components/Expandable"
 import { HTML } from "app/Components/HTML"
@@ -79,22 +81,25 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
 }
 
 const tracks = {
-  tappedConditionExpand: (isExpanded: boolean) => ({
-    context_module: "aboutTheWork",
-    context_owner_type: "artwork",
-    expand: isExpanded,
+  tappedConditionExpand: (expand: boolean): ToggledAccordion => ({
+    action: ActionType.toggledAccordion,
+    context_module: ContextModule.aboutTheWork,
+    context_owner_type: OwnerType.artwork,
+    expand: expand,
     subject: "Condition",
   }),
-  tappedProvenanceExpand: (isExpanded: boolean) => ({
-    context_module: "aboutTheWork",
-    context_owner_type: "artwork",
-    expand: isExpanded,
+  tappedProvenanceExpand: (expand: boolean): ToggledAccordion => ({
+    action: ActionType.toggledAccordion,
+    context_module: ContextModule.aboutTheWork,
+    context_owner_type: OwnerType.artwork,
+    expand: expand,
     subject: "Provenance",
   }),
-  tappedExhibitionHistoryExpand: (isExpanded: boolean) => ({
-    context_module: "aboutTheWork",
-    context_owner_type: "artwork",
-    expand: isExpanded,
+  tappedExhibitionHistoryExpand: (expand: boolean): ToggledAccordion => ({
+    action: ActionType.toggledAccordion,
+    context_module: ContextModule.aboutTheWork,
+    context_owner_type: OwnerType.artwork,
+    expand: expand,
     subject: "Exhibition History",
   }),
 }

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -23,7 +23,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
     artwork
   )
 
-  const tracking = useTracking()
+  const { trackEvent } = useTracking()
 
   const isFirstItemExpanded = Boolean(data.conditionDescription?.details)
 
@@ -41,7 +41,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
         <>
           <Expandable
             trackingFunction={() => {
-              tracking.trackEvent(tracks.tappedConditionExpand(isFirstItemExpanded))
+              trackEvent(tracks.toggledMetadataAccordion("Condition", isFirstItemExpanded))
             }}
             label="Condition"
             expanded={isFirstItemExpanded}
@@ -55,7 +55,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
         <>
           <Expandable
             trackingFunction={() => {
-              tracking.trackEvent(tracks.tappedProvenanceExpand(isSecondItemExpanded))
+              trackEvent(tracks.toggledMetadataAccordion("Provenance", isSecondItemExpanded))
             }}
             label="Provenance"
             expanded={isSecondItemExpanded}
@@ -68,7 +68,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
       {!!data.privateExhibitionHistory && (
         <Expandable
           trackingFunction={() => {
-            tracking.trackEvent(tracks.tappedExhibitionHistoryExpand(isThirdItemExpanded))
+            trackEvent(tracks.toggledMetadataAccordion("Exhibition History", isThirdItemExpanded))
           }}
           label="Exhibition History"
           expanded={isThirdItemExpanded}
@@ -81,25 +81,11 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
 }
 
 const tracks = {
-  tappedConditionExpand: (expand: boolean): ToggledAccordion => ({
+  toggledMetadataAccordion: (subject: string, expand: boolean): ToggledAccordion => ({
     action: ActionType.toggledAccordion,
     context_module: ContextModule.aboutTheWork,
     context_owner_type: OwnerType.artwork,
     expand: expand,
-    subject: "Condition",
-  }),
-  tappedProvenanceExpand: (expand: boolean): ToggledAccordion => ({
-    action: ActionType.toggledAccordion,
-    context_module: ContextModule.aboutTheWork,
-    context_owner_type: OwnerType.artwork,
-    expand: expand,
-    subject: "Provenance",
-  }),
-  tappedExhibitionHistoryExpand: (expand: boolean): ToggledAccordion => ({
-    action: ActionType.toggledAccordion,
-    context_module: ContextModule.aboutTheWork,
-    context_owner_type: OwnerType.artwork,
-    expand: expand,
-    subject: "Exhibition History",
+    subject: subject,
   }),
 }

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -40,7 +40,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
       {!!data.conditionDescription?.details && (
         <>
           <Expandable
-            trackingFunction={() => {
+            onTrack={() => {
               trackEvent(tracks.toggledMetadataAccordion("Condition", isFirstItemExpanded))
             }}
             label="Condition"
@@ -54,7 +54,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
       {!!data.privateProvenance && (
         <>
           <Expandable
-            trackingFunction={() => {
+            onTrack={() => {
               trackEvent(tracks.toggledMetadataAccordion("Provenance", isSecondItemExpanded))
             }}
             label="Provenance"
@@ -67,7 +67,7 @@ export const PrivateArtworkMetadata: React.FC<PrivateArtworkMetadataProps> = ({ 
 
       {!!data.privateExhibitionHistory && (
         <Expandable
-          trackingFunction={() => {
+          onTrack={() => {
             trackEvent(tracks.toggledMetadataAccordion("Exhibition History", isThirdItemExpanded))
           }}
           label="Exhibition History"

--- a/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkMetadata.tests.tsx
@@ -109,6 +109,7 @@ describe("PrivateArtworkMetadata", () => {
 
     fireEvent.press(screen.getAllByTestId("expandableAccordion")[0])
     expect(mockTrackEvent).toBeCalledWith({
+      action: "toggledAccordion",
       context_module: "aboutTheWork",
       context_owner_type: "artwork",
       expand: true,
@@ -127,6 +128,7 @@ describe("PrivateArtworkMetadata", () => {
 
     fireEvent.press(screen.getAllByTestId("expandableAccordion")[1])
     expect(mockTrackEvent).toBeCalledWith({
+      action: "toggledAccordion",
       context_module: "aboutTheWork",
       context_owner_type: "artwork",
       expand: false,
@@ -145,6 +147,7 @@ describe("PrivateArtworkMetadata", () => {
 
     fireEvent.press(screen.getAllByTestId("expandableAccordion")[2])
     expect(mockTrackEvent).toBeCalledWith({
+      action: "toggledAccordion",
       context_module: "aboutTheWork",
       context_owner_type: "artwork",
       expand: false,


### PR DESCRIPTION
This PR resolves  bug reported by Louis on data team

### Description

Toggling the metadata component was firing a pagview event and not a toggled accordion event type

This code changes the event structure from

this:
```
{"context_module": "aboutTheWork", "context_owner_type": "artwork", "expand": true, "subject": "Condition"}
```

to this:
```
{"actionType": "toggledAccordion", "context_module": "aboutTheWork", "context_owner_type": "artwork", "expand": true, "subject": "Condition"}
```

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Adjust tracking event action type to be of ToggledAccordion

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
