### PR TITLE
chore: regenerate .secrets.baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -66,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -1119,5 +1134,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-23T18:49:08Z"
+  "generated_at": "2024-05-08T20:37:46Z"
 }

--- a/scripts/detect-secrets/secrets-generate-baseline
+++ b/scripts/detect-secrets/secrets-generate-baseline
@@ -11,4 +11,5 @@ detect-secrets scan \
   --exclude-files "\.jar$"    `# ignore jar files`   \
   --exclude-files "__generated__"      `# ignore relay generated files` \
   --exclude-files "ios\/.*\.xcscheme$" `# ignore Xcode scheme files`    \
+  --exclude-secrets '[a-fA-F0-9]{24}' \
   > .secrets.baseline

--- a/scripts/detect-secrets/secrets-generate-baseline
+++ b/scripts/detect-secrets/secrets-generate-baseline
@@ -11,5 +11,5 @@ detect-secrets scan \
   --exclude-files "\.jar$"    `# ignore jar files`   \
   --exclude-files "__generated__"      `# ignore relay generated files` \
   --exclude-files "ios\/.*\.xcscheme$" `# ignore Xcode scheme files`    \
-  --exclude-secrets '[a-fA-F0-9]{24}' \
+  --exclude-secrets '[a-fA-F0-9]{24}' `# ignore mongoid like patterns` \
   > .secrets.baseline


### PR DESCRIPTION
This adds to the `.secrets.baseline` the plugins released in new version and also updates `secrets-generate-baseline` script to include an exclusion that is in the baseline but not in that script.

### Changelog updates

#### Dev changes

- add plugins to `.secrets.baseline`
- add an exclusion to `secrets-generate-baseline` script