### PR TITLE
fix: broken profile header when navigating fast

### DIFF
--- a/ios/Artsy/App/main.m
+++ b/ios/Artsy/App/main.m
@@ -13,3 +13,4 @@ int main(int argc, char *argv[])
         return UIApplicationMain(argc, argv, @"UIApplication", appDelegate);
     }
 }
+

--- a/src/app/Scenes/MyAccount/updateMyUserProfile.ts
+++ b/src/app/Scenes/MyAccount/updateMyUserProfile.ts
@@ -16,6 +16,7 @@ export const updateMyUserProfile = async (
         mutation updateMyUserProfileMutation($input: UpdateMyProfileInput!) {
           updateMyUserProfile(input: $input) {
             me {
+              ...MyProfileHeader_me
               email
               name
               phone

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
@@ -8,7 +8,7 @@ import { graphql } from "react-relay"
 
 describe("MyProfileHeader", () => {
   const { renderWithRelay } = setupTestWrapper<MyProfileHeaderTestQuery>({
-    Component: ({ me }) => <MyProfileHeader data={me as any} />,
+    Component: ({ me }) => <MyProfileHeader meProp={me!} />,
     query: graphql`
       query MyProfileHeaderTestQuery @relay_test_operation {
         me {

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from "@testing-library/react-native"
+import { MyProfileHeaderTestQuery } from "__generated__/MyProfileHeaderTestQuery.graphql"
 import { MyProfileHeader } from "app/Scenes/MyProfile/MyProfileHeader"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
@@ -6,8 +7,8 @@ import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
 describe("MyProfileHeader", () => {
-  const { renderWithRelay } = setupTestWrapper({
-    Component: MyProfileHeader,
+  const { renderWithRelay } = setupTestWrapper<MyProfileHeaderTestQuery>({
+    Component: ({ me }) => <MyProfileHeader data={me as any} />,
     query: graphql`
       query MyProfileHeaderTestQuery @relay_test_operation {
         me {

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -35,9 +35,9 @@ import { normalizeMyProfileBio } from "./utils"
 
 const ICON_SIZE = 14
 
-export const MyProfileHeader: React.FC<{ data: MyProfileHeader_me$key }> = ({ data }) => {
+export const MyProfileHeader: React.FC<{ meProp: MyProfileHeader_me$key }> = ({ meProp }) => {
   const { fetchKey, refetch } = useRefetch()
-  const me = useFragment<MyProfileHeader_me$key>(myProfileHeaderFragment, data)
+  const me = useFragment<MyProfileHeader_me$key>(myProfileHeaderFragment, meProp)
 
   const localImage = useLocalImageStorage("profile", undefined, undefined, fetchKey)
   const userProfileImagePath = localImage?.path || me?.icon?.url
@@ -402,5 +402,5 @@ export const MyProfileHeaderQueryRenderer = withSuspense(() => {
   )
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return <MyProfileHeader data={data.me!} />
+  return <MyProfileHeader meProp={data.me!} />
 }, MyProfileHeaderPlaceholder)

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -35,17 +35,16 @@ import { normalizeMyProfileBio } from "./utils"
 
 const ICON_SIZE = 14
 
-export const MyProfileHeader: React.FC<{ me: MyProfileHeader_me$key }> = (props) => {
-  const newCollectorSettings = useFeatureFlag("AREnableNewCollectorSettings")
-  const space = useSpace()
+export const MyProfileHeader: React.FC<{ data: MyProfileHeader_me$key }> = ({ data }) => {
   const { fetchKey, refetch } = useRefetch()
-  const me = useFragment(myProfileHeaderFragment, props.me)
-
-  const color = useColor()
+  const me = useFragment<MyProfileHeader_me$key>(myProfileHeaderFragment, data)
 
   const localImage = useLocalImageStorage("profile", undefined, undefined, fetchKey)
-
   const userProfileImagePath = localImage?.path || me?.icon?.url
+
+  const newCollectorSettings = useFeatureFlag("AREnableNewCollectorSettings")
+  const space = useSpace()
+  const color = useColor()
 
   if (!me) {
     return null
@@ -272,32 +271,6 @@ export const MyProfileHeader: React.FC<{ me: MyProfileHeader_me$key }> = (props)
   )
 }
 
-const myProfileHeaderFragment = graphql`
-  fragment MyProfileHeader_me on Me
-  @refetchable(queryName: "MyProfileHeaderMyProfileHeaderFragmentRefetchQuery") {
-    name
-    bio
-    location {
-      display
-    }
-    otherRelevantPositions
-    profession
-    icon {
-      url(version: "thumbnail")
-    }
-    createdAt
-    isIdentityVerified
-    counts @required(action: NONE) {
-      followedArtists
-      savedArtworks
-      savedSearches
-    }
-    collectorProfile @required(action: NONE) {
-      confirmedBuyerAt
-    }
-  }
-`
-
 const MyProfileHeaderPlaceholder: React.FC<{}> = () => {
   const newCollectorSettings = useFeatureFlag("AREnableNewCollectorSettings")
   const space = useSpace()
@@ -383,6 +356,31 @@ const MyProfileHeaderPlaceholder: React.FC<{}> = () => {
   )
 }
 
+const myProfileHeaderFragment = graphql`
+  fragment MyProfileHeader_me on Me {
+    name
+    bio
+    location {
+      display
+    }
+    otherRelevantPositions
+    profession
+    icon {
+      url(version: "thumbnail")
+    }
+    createdAt
+    isIdentityVerified
+    counts @required(action: NONE) {
+      followedArtists
+      savedArtworks
+      savedSearches
+    }
+    collectorProfile @required(action: NONE) {
+      confirmedBuyerAt
+    }
+  }
+`
+
 const myProfileHeaderQuery = graphql`
   query MyProfileHeaderQuery {
     me {
@@ -392,8 +390,17 @@ const myProfileHeaderQuery = graphql`
 `
 
 export const MyProfileHeaderQueryRenderer = withSuspense(() => {
-  const data = useLazyLoadQuery<MyProfileHeaderQuery>(myProfileHeaderQuery, {})
+  const data = useLazyLoadQuery<MyProfileHeaderQuery>(
+    myProfileHeaderQuery,
+    {},
+    {
+      fetchPolicy: "network-only",
+      networkCacheConfig: {
+        force: true,
+      },
+    }
+  )
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return <MyProfileHeader me={data.me!} />
+  return <MyProfileHeader data={data.me!} />
 }, MyProfileHeaderPlaceholder)


### PR DESCRIPTION
### Description

The glitch of not showing the header on the profile screen was gone once I:
- removed the `@refetechable` annotation from the fragment(I don't know why someone would do it, this annotation should be only used with useRefetachableFragment hook, not with useFragment)
- force the query to run on the network

There are some extra things to be removed but it's a bit out of the scope of this fix, I'm handling it on behalf of Diamond but just to clarify it wasn't introduced by us.

Highly appreciate it if someone could test and merge this PR(tomorrow I will be roaming around some trains and then go for holidays)

https://github.com/artsy/eigen/assets/15792853/ae747c5e-e460-4977-a456-022846d9d425

https://github.com/artsy/eigen/assets/15792853/b333177e-11d6-4021-803c-c9fc1e6bf9c1



### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: my profile header missing when opening just after bootstrap quickly - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
