### PR TITLE
fix: display MyC Interested in selling tooltip only for P1 artists

### DIFF
--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -330,7 +330,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
           isMyCollection &&
           !isDismissed(PROGRESSIVE_ONBOARDING_MY_COLLECTION_SELL_THIS_WORK).status &&
           itemIndex === 0 &&
-          !!artwork.artist?.targetSupply?.priority
+          artwork.artist?.targetSupply?.priority === "TRUE"
 
         artworkComponents.push(
           <ItemComponent


### PR DESCRIPTION
[ <!-- eg [PROJECT-XXXX] -->](https://www.notion.so/artsy/Adding-a-P1-artwork-tooltip-not-showing-up-5fcae97fdde24d65a2bb25e25eb9c056?pvs=4)

### Description

We want to display "MyC Interested in selling" tooltip only for P1 artists. `artwork.artist?.targetSupply?.priority` is not a boolean and this PR adjusts the check



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix display "MyC Interested in selling" tooltip only for P1 artists - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
