### PR TITLE
chore: show loading spinner and disable submit button on submit artwork mutation

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetails.tsx
@@ -3,15 +3,16 @@ import { CTAButton } from "app/Components/Button/CTAButton"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { Formik } from "formik"
-import React from "react"
+import React, { useState } from "react"
 import { ArtworkDetailsForm } from "./ArtworkDetailsForm"
 import { ArtworkDetailsFormModel, artworkDetailsValidationSchema } from "./validation"
 
 export const ArtworkDetails: React.FC<{
-  handlePress: (formValues: ArtworkDetailsFormModel) => void
+  handlePress: (formValues: ArtworkDetailsFormModel) => Promise<void>
   isLastStep: boolean
   scrollToTop?: () => void
 }> = ({ handlePress, isLastStep, scrollToTop }) => {
+  const [isLoading, setIsLoading] = useState(false)
   const { artworkDetails } = GlobalStore.useAppState((state) => state.artworkSubmission.submission)
 
   return (
@@ -48,15 +49,20 @@ export const ArtworkDetails: React.FC<{
               <ArtworkDetailsForm />
               <Spacer y={2} />
               <CTAButton
-                disabled={!isValid && dirty}
-                onPress={() => {
-                  validateForm().then((errors) => {
+                disabled={(!isValid && dirty) || isLoading}
+                loading={isLoading}
+                onPress={async () => {
+                  try {
+                    setIsLoading(true)
+                    const errors = await validateForm()
                     if (Object.keys(errors).length === 0) {
-                      handlePress(values)
+                      await handlePress(values)
                     } else {
                       scrollToTop?.()
                     }
-                  })
+                  } finally {
+                    setIsLoading(false)
+                  }
                 }}
                 testID="Submission_ArtworkDetails_Button"
               >

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetailsForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/ArtworkDetailsForm.tsx
@@ -49,7 +49,9 @@ export const ArtworkDetailsForm: React.FC = () => {
         testID="Submission_TitleInput"
         value={values.title}
         onChangeText={(text) => {
-          validateField("title")
+          if (errors.title) {
+            validateField("title")
+          }
           handleChange("title")(text)
         }}
         onBlur={() => validateField("title")}
@@ -62,7 +64,9 @@ export const ArtworkDetailsForm: React.FC = () => {
 
       <CategoryPicker<AcceptableCategoryValue>
         handleChange={(category) => {
-          validateField("category")
+          if (errors.category) {
+            validateField("category")
+          }
           setFieldValue("category", category)
         }}
         options={categories}

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotos.tsx
@@ -1,4 +1,4 @@
-import { BulletedItem, Spacer, Flex } from "@artsy/palette-mobile"
+import { BulletedItem, Flex, Spacer } from "@artsy/palette-mobile"
 import { CTAButton } from "app/Components/Button/CTAButton"
 import { useBottomTabBarHeight } from "app/Scenes/BottomTabs/useBottomTabBarHeight"
 import {
@@ -8,7 +8,7 @@ import {
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { GlobalStore } from "app/store/GlobalStore"
 import { Formik } from "formik"
-import { useRef } from "react"
+import { useRef, useState } from "react"
 import { UploadPhotosForm } from "./UploadPhotosForm"
 import { isSizeLimitExceeded } from "./utils/calculatePhotoSize"
 
@@ -16,9 +16,10 @@ export const UploadPhotos = ({
   handlePress,
   isLastStep,
 }: {
-  handlePress: ({}) => void
+  handlePress: ({}) => Promise<void>
   isLastStep: boolean
 }) => {
+  const [isLoading, setIsLoading] = useState(false)
   const { submission } = GlobalStore.useAppState((state) => state.artworkSubmission)
   const initialSubmissionPhotos = useRef(submission.photos).current
   const bottomTabBarHeight = useBottomTabBarHeight()
@@ -54,8 +55,18 @@ export const UploadPhotos = ({
               <UploadPhotosForm isAnyPhotoLoading={isAnyPhotoLoading} />
               <Spacer y={2} />
               <CTAButton
-                disabled={!isValid || isAnyPhotoLoading || isSizeLimitExceeded(values.photos)}
-                onPress={() => submitUploadPhotosStep()}
+                disabled={
+                  !isValid || isAnyPhotoLoading || isSizeLimitExceeded(values.photos) || isLoading
+                }
+                loading={isLoading}
+                onPress={async () => {
+                  try {
+                    setIsLoading(true)
+                    await handlePress({})
+                  } finally {
+                    setIsLoading(false)
+                  }
+                }}
                 testID="Submission_Save_Photos_Button"
               >
                 {!!isAnyPhotoLoading


### PR DESCRIPTION
This PR resolves [ONYX-963] <!-- eg [PROJECT-XXXX] -->

### Description

This PR makes the following changes to the submit button on the existing submit flow
- Disable the button when it's loading
- Show loading spinner during the create mutation


https://github.com/artsy/eigen/assets/11945712/4199ed4d-d2ba-4f36-bf8e-01f73d8c4323



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- show loading spinner and disable submit button on submit artwork mutation - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
