### PR TITLE
fix: broken start selling button padding on android

### DIFF
--- a/src/app/Scenes/SellWithArtsy/Components/StickySWAHeader.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/StickySWAHeader.tsx
@@ -5,8 +5,7 @@ import {
   TappedConsignArgs,
   TappedConsignmentInquiry,
 } from "@artsy/cohesion"
-import { Button, Flex, LinkText, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
-import { Platform } from "react-native"
+import { Button, Flex, LinkText, Spacer, Text } from "@artsy/palette-mobile"
 
 interface StickySWAHeaderProps {
   onConsignPress: (tappedConsignArgs: TappedConsignArgs) => void
@@ -17,8 +16,6 @@ export const StickySWAHeader: React.FC<StickySWAHeaderProps> = ({
   onConsignPress,
   onInquiryPress,
 }) => {
-  const { bottom } = useScreenDimensions().safeAreaInsets
-
   const handleSubmitPress = (subject: string) => {
     onConsignPress(tracks.consignArgs(subject))
   }
@@ -29,13 +26,7 @@ export const StickySWAHeader: React.FC<StickySWAHeaderProps> = ({
 
   return (
     <>
-      <Flex
-        p={2}
-        mb={`${bottom}px`}
-        pb={Platform.OS === "android" ? 2 : 0}
-        borderTopWidth={1}
-        borderTopColor="black10"
-      >
+      <Flex p={2} borderTopWidth={1} borderTopColor="black10">
         <Button
           testID="header-consign-CTA"
           block
@@ -49,7 +40,7 @@ export const StickySWAHeader: React.FC<StickySWAHeaderProps> = ({
 
         <Spacer y={1} />
 
-        <Text variant="xs" mb={1}>
+        <Text variant="xs">
           Not sure what you’re looking for?{" "}
           <LinkText testID="StickySWAHeader-inquiry-CTA" onPress={handleInquiryPress}>
             <Text variant="xs">Speak to an advisor</Text>

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -1,5 +1,5 @@
 import { tappedConsign, TappedConsignArgs, TappedConsignmentInquiry } from "@artsy/cohesion"
-import { Flex, Join, LegacyScreen, Spacer } from "@artsy/palette-mobile"
+import { Join, Screen, Spacer } from "@artsy/palette-mobile"
 import { SellWithArtsyHomeQuery } from "__generated__/SellWithArtsyHomeQuery.graphql"
 import { SellWithArtsyHome_me$data } from "__generated__/SellWithArtsyHome_me.graphql"
 import { SellWithArtsyHome_recentlySoldArtworksTypeConnection$data } from "__generated__/SellWithArtsyHome_recentlySoldArtworksTypeConnection.graphql"
@@ -15,7 +15,6 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
-import { useScreenDimensions } from "app/utils/hooks"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import { useSwitchStatusBarStyle } from "app/utils/useStatusBarStyle"
@@ -44,7 +43,6 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({
 
   useSwitchStatusBarStyle(onFocusStatusBarStyle, onBlurStatusBarStyle)
 
-  const { height: screenHeight, safeAreaInsets } = useScreenDimensions()
   const enableNewSubmissionFlow = useFeatureFlag("AREnableNewSubmissionFlow")
 
   const tracking = useTracking()
@@ -100,15 +98,8 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({
   }, [])
 
   return (
-    <LegacyScreen.Background>
-      <Flex
-        flex={1}
-        justifyContent="center"
-        alignItems="center"
-        minHeight={screenHeight}
-        style={{ paddingTop: safeAreaInsets.top }}
-        pb={6}
-      >
+    <Screen>
+      <Screen.Body fullwidth>
         <ScrollView showsVerticalScrollIndicator={false} ref={scrollViewRef}>
           <Join separator={<Spacer y={6} />}>
             <Header />
@@ -140,8 +131,8 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({
         </ScrollView>
 
         <StickySWAHeader onConsignPress={handleConsignPress} onInquiryPress={handleInquiryPress} />
-      </Flex>
-    </LegacyScreen.Background>
+      </Screen.Body>
+    </Screen>
   )
 }
 


### PR DESCRIPTION
**[Bug bash]**

This PR resolves [ONYX-950] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the broken start selling button padding on Android

<img width="680" alt="Screenshot 2024-05-17 at 10 03 10" src="https://github.com/artsy/eigen/assets/11945712/d3ab96e0-8e82-4ddd-b7af-165673ed8f8d">


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-950]: https://artsyproduct.atlassian.net/browse/ONYX-950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ