### PR TITLE
chore(ONYX-955): update artwork details screen to match new designs

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tests.tsx
@@ -23,16 +23,6 @@ describe("SubmitArtworkAddDetails", () => {
     // Wait for the select modal to dismiss
     await flushPromiseQueue()
     expect(screen.getByText("Painting")).toBeOnTheScreen()
-
-    const rarityPicker = screen.getByTestId("Submission_RaritySelect")
-    expect(rarityPicker).toBeOnTheScreen()
-    fireEvent.press(rarityPicker)
-    // Wait for the select modal to show up
-    await flushPromiseQueue()
-    fireEvent.press(screen.getByText("Unique"))
-    // Wait for the select modal to dismiss
-    await flushPromiseQueue()
-    expect(screen.getByText("Unique")).toBeOnTheScreen()
   })
 
   describe("Year input", () => {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -1,34 +1,16 @@
-import {
-  Box,
-  Checkbox,
-  Flex,
-  Input,
-  InputTitle,
-  Join,
-  LinkButton,
-  Spacer,
-  Text,
-} from "@artsy/palette-mobile"
-import { Select, SelectOption } from "app/Components/Select"
-import { ArtistSearchResult } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult"
+import { Checkbox, Flex, Input, Join, Spacer, Text } from "@artsy/palette-mobile"
+import { SelectOption } from "app/Components/Select"
 import { CategoryPicker } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/CategoryPicker"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
-import { InfoModal } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/InfoModal/InfoModal"
 import {
   AcceptableCategoryValue,
   acceptableCategoriesForSubmission,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
-import {
-  limitedEditionValue,
-  rarityOptions,
-} from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/rarityOptions"
-import { artworkRarityClassifications } from "app/utils/artworkRarityClassifications"
 import { useFormikContext } from "formik"
 import { useRef, useState } from "react"
 import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddDetails = () => {
-  const [isRarityInfoModalVisible, setIsRarityInfoModalVisible] = useState(false)
   const [isYearUnknown, setIsYearUnknown] = useState(false)
   const [oldTypedYear, setOldTypedYear] = useState("")
 
@@ -40,8 +22,6 @@ export const SubmitArtworkAddDetails = () => {
 
   return (
     <ScrollView>
-      {!!values.artistSearchResult && <ArtistSearchResult result={values.artistSearchResult} />}
-
       <Spacer y={2} />
 
       <Text variant="lg" mb={2}>
@@ -49,75 +29,6 @@ export const SubmitArtworkAddDetails = () => {
       </Text>
 
       <Join separator={<Spacer y={2} />}>
-        <CategoryPicker<AcceptableCategoryValue | null>
-          handleChange={(category) => setFieldValue("category", category)}
-          options={categories}
-          required
-          value={values.category}
-        />
-
-        <Flex>
-          <Select
-            onSelectValue={(e) => setFieldValue("attributionClass", e)}
-            onTooltipPress={() => setIsRarityInfoModalVisible(true)}
-            value={values.attributionClass}
-            enableSearch={false}
-            title="Rarity"
-            tooltipText={
-              <LinkButton
-                variant="xs"
-                color="black60"
-                onPress={() => setIsRarityInfoModalVisible(true)}
-              >
-                What's this?
-              </LinkButton>
-            }
-            placeholder="Select a classification"
-            options={rarityOptions}
-            testID="Submission_RaritySelect"
-          />
-
-          <InfoModal
-            title="Classifications"
-            visible={isRarityInfoModalVisible}
-            onDismiss={() => setIsRarityInfoModalVisible(false)}
-          >
-            {artworkRarityClassifications.map((classification) => (
-              <Flex mb={2} key={classification.label}>
-                <InputTitle>{classification.label}</InputTitle>
-                <Text>{classification.description}</Text>
-              </Flex>
-            ))}
-          </InfoModal>
-        </Flex>
-
-        {values.attributionClass === limitedEditionValue && (
-          <>
-            <Flex flexDirection="row" justifyContent="space-between">
-              <Box width="48%" mr={1}>
-                <Input
-                  title="Edition Number"
-                  keyboardType="decimal-pad"
-                  testID="Submission_EditionNumberInput"
-                  value={values.editionNumber}
-                  onChangeText={(e) => setFieldValue("editionNumber", e)}
-                  accessibilityLabel="Edition Number"
-                />
-              </Box>
-              <Box width="48%">
-                <Input
-                  title="Edition Size"
-                  keyboardType="decimal-pad"
-                  testID="Submission_EditionSizeInput"
-                  value={values.editionSizeFormatted}
-                  onChangeText={(e) => setFieldValue("editionSizeFormatted", e)}
-                  accessibilityLabel="Edition Size"
-                />
-              </Box>
-            </Flex>
-          </>
-        )}
-
         <Flex>
           <Input
             title="Year"
@@ -128,6 +39,7 @@ export const SubmitArtworkAddDetails = () => {
             onChangeText={(e) => setFieldValue("year", e)}
             accessibilityLabel="Year"
             disabled={isYearUnknown}
+            style={{ width: "50%" }}
           />
           <Spacer y={2} />
 
@@ -145,25 +57,28 @@ export const SubmitArtworkAddDetails = () => {
               }
             }}
             text="I don't know"
-            // TODO: Add support of checkbox colors
-            // color="black60"
           />
         </Flex>
 
-        <Flex>
-          <Input
-            title="Materials"
-            placeholder={[
-              "Oil on canvas, mixed media, lithograph, etc.",
-              "Oil on canvas, mixed media, etc.",
-              "Oil on canvas, etc.",
-            ]}
-            testID="Submission_MaterialsInput"
-            value={values.medium}
-            onChangeText={handleChange("medium")}
-            accessibilityLabel="Materials"
-          />
-        </Flex>
+        <CategoryPicker<AcceptableCategoryValue | null>
+          handleChange={(category) => setFieldValue("category", category)}
+          options={categories}
+          required
+          value={values.category}
+        />
+
+        <Input
+          title="Materials"
+          placeholder={[
+            "Oil on canvas, mixed media, lithograph, etc.",
+            "Oil on canvas, mixed media, etc.",
+            "Oil on canvas, etc.",
+          ]}
+          testID="Submission_MaterialsInput"
+          value={values.medium}
+          onChangeText={handleChange("medium")}
+          accessibilityLabel="Materials"
+        />
       </Join>
     </ScrollView>
     // </KeyboardAvoidingView>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -11,7 +11,6 @@ import {
   SubmitArtworkStackNavigation,
   getCurrentRoute,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
-import { limitedEditionValue } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/rarityOptions"
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import * as Yup from "yup"
@@ -83,15 +82,6 @@ const provenanceSchema = Yup.object().shape({
 
 const artworkDetailsValidationSchema = Yup.object().shape({
   category: Yup.string().required(),
-  attributionClass: Yup.string().nullable(),
-  editionNumber: Yup.string().when("attributionClass", {
-    is: limitedEditionValue,
-    then: Yup.string().required().trim(),
-  }),
-  editionSizeFormatted: Yup.string().when("attributionClass", {
-    is: limitedEditionValue,
-    then: Yup.string().required().trim(),
-  }),
   medium: Yup.string(),
   year: Yup.string(),
 })

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission.ts
@@ -12,25 +12,15 @@ export type AcceptableCategoryValue = AcceptableValuesMapKey
 
 // By having this ACCEPTABLE_VALUES_MAP structure, we are forced to update this list
 // whenever ConsignmentSubmissionCategoryAggregation changes, because yarn tsc will fail
-export const ACCEPTABLE_CATEGORY_VALUES_MAP: Record<
-  AcceptableValuesMapKey,
-  AcceptableCategoryValue
+export const ACCEPTABLE_CATEGORY_VALUES_MAP: Partial<
+  Record<AcceptableValuesMapKey, AcceptableCategoryValue>
 > = {
-  ARCHITECTURE: "ARCHITECTURE",
-  DESIGN_DECORATIVE_ART: "DESIGN_DECORATIVE_ART",
-  DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER",
-  FASHION_DESIGN_AND_WEARABLE_ART: "FASHION_DESIGN_AND_WEARABLE_ART",
-  INSTALLATION: "INSTALLATION",
-  JEWELRY: "JEWELRY",
-  MIXED_MEDIA: "MIXED_MEDIA",
   OTHER: "OTHER",
   PAINTING: "PAINTING",
-  PERFORMANCE_ART: "PERFORMANCE_ART",
+  DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER: "DRAWING_COLLAGE_OR_OTHER_WORK_ON_PAPER",
   PHOTOGRAPHY: "PHOTOGRAPHY",
   PRINT: "PRINT",
   SCULPTURE: "SCULPTURE",
-  TEXTILE_ARTS: "TEXTILE_ARTS",
-  VIDEO_FILM_ANIMATION: "VIDEO_FILM_ANIMATION",
 }
 
 export const formatCategoryValueForSubmission = (categoryValue: string) => {


### PR DESCRIPTION
This PR resolves [ONYX-955] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the artwork details screen to match the Figma designs. There are mainly two changes here: 
- Make the year input small
- Remove the rarity picker (including removing it from the validation schema for now + updating the list of accepted mediums)
- [The checkbox color in the design **doesn't** match the palette component, so I am using the palette component design now until I discuss this with Barney later if this change is intentional]

![Group 14](https://github.com/artsy/eigen/assets/11945712/3b089418-2e52-4097-b2dd-c79689fd1636)


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- [New SWA Flow] update artwork details screen to match new designs - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-955]: https://artsyproduct.atlassian.net/browse/ONYX-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ