### PR TITLE
chore: silence sentry noise for codepush deploys #trivial

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -470,7 +470,8 @@ lane :deploy_to_codepush do |options|
     sentry_release_name: release_name,
     dist: dist_version,
     bundle_path: bundle_path,
-    sourcemap_path: sourcemap_output
+    sourcemap_path: sourcemap_output,
+    silence_failures: true # we ship codepush releases every commit to main, failures are noisy
   )
 
   tag_and_push(tag: release_name)

--- a/fastlane/sentry_fastlane.rb
+++ b/fastlane/sentry_fastlane.rb
@@ -69,6 +69,7 @@ lane :upload_sentry_sourcemaps do |options|
   dist = options[:dist]
   bundle_path = options[:bundle_path]
   sourcemap_path = options[:sourcemap_path]
+  silence_failures = options[:silence_failures]
 
   begin
     sentry_upload_sourcemap(
@@ -84,7 +85,9 @@ lane :upload_sentry_sourcemaps do |options|
     puts "Uploaded source js and js.map for #{project_slug}"
   rescue StandardError => e
     message = 'Uploading the JS bundle and/or sourcemap to Sentry failed. This sometimes happens when shipping many builds to Sentry.'
-    handle_error(e, message)
+    if !silence_failures
+      handle_error(e, message)
+    end
   end
 end
 


### PR DESCRIPTION
This PR resolves [PHIRE-915] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Silences sentry errors when shipping builds to codepush, we do this every merge to main for both Android and iOS so in the event of a failure we get 2x messages to the practice-mobile channel. Will also fail in nightly betas if for example cli is out of date so we should still catch it. 

https://artsy.slack.com/archives/C02BAQ5K7/p1715942419895869

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- silence sentry errors for codepush deploys - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-915]: https://artsyproduct.atlassian.net/browse/PHIRE-915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ