### PR TITLE
feat: initialize submission from my collection artwork

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
@@ -1,10 +1,17 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import { Spacer, Flex, Text, Separator, Button } from "@artsy/palette-mobile"
+import { Button, Flex, Separator, Spacer, Text } from "@artsy/palette-mobile"
 import { MyCollectionWhySell_artwork$key } from "__generated__/MyCollectionWhySell_artwork.graphql"
-import { initializeSubmissionArtworkForm } from "app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm"
+import {
+  initializeNewSubmissionArtworkForm,
+  initializeSubmissionArtworkForm,
+} from "app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm"
+import { SubmitArtworkScreen } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
+import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation"
+import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { navigate } from "app/system/navigation/navigate"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
-import { useFragment, graphql } from "react-relay"
+import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
 interface MyCollectionWhySellProps {
@@ -16,6 +23,7 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
   const { contextModule } = props
   const { trackEvent } = useTracking()
   const artwork = useFragment(artworkFragment, props.artwork)
+  const enableNewSubmissionFlow = useFeatureFlag("AREnableNewSubmissionFlow")
 
   const submissionId = artwork.submissionId
 
@@ -59,8 +67,20 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
                 "Submit This Artwork to Sell"
               )
             )
-            initializeSubmissionArtworkForm(artwork)
-            navigate("/sell/submissions/new")
+            if (enableNewSubmissionFlow) {
+              const initialValues: Partial<ArtworkDetailsFormModel> =
+                initializeNewSubmissionArtworkForm(artwork)
+              const initialStep: SubmitArtworkScreen = "SelectArtist"
+
+              const passProps: SubmitArtworkProps = {
+                initialValues,
+                initialStep,
+              }
+              navigate("/sell/submissions/new", { passProps })
+            } else {
+              initializeSubmissionArtworkForm(artwork)
+              navigate("/sell/submissions/new")
+            }
           }}
           testID="submitArtworkToSellButton"
         >

--- a/src/app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm.ts
+++ b/src/app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm.ts
@@ -1,5 +1,4 @@
 import { MyCollectionWhySell_artwork$data } from "__generated__/MyCollectionWhySell_artwork.graphql"
-import { ConsignmentSubmissionSource } from "__generated__/createConsignSubmissionMutation.graphql"
 import {
   ACCEPTABLE_CATEGORY_VALUES_MAP,
   AcceptableCategoryValue,
@@ -29,7 +28,7 @@ export const initializeNewSubmissionArtworkForm = (artwork: MyCollectionWhySell_
     width: artwork.width ?? "",
     depth: artwork.depth ?? "",
     provenance: artwork.provenance ?? "",
-    source: "MY_COLLECTION" as ConsignmentSubmissionSource | null,
+    source: "MY_COLLECTION" as const,
     myCollectionArtworkID: artwork.internalID,
     initialPhotos: artwork.images?.map((image) => ({
       path: image?.url?.replace(":version", "large") ?? "",

--- a/src/app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm.ts
+++ b/src/app/Scenes/MyCollection/utils/initializeSubmissionArtworkForm.ts
@@ -1,4 +1,5 @@
 import { MyCollectionWhySell_artwork$data } from "__generated__/MyCollectionWhySell_artwork.graphql"
+import { ConsignmentSubmissionSource } from "__generated__/createConsignSubmissionMutation.graphql"
 import {
   ACCEPTABLE_CATEGORY_VALUES_MAP,
   AcceptableCategoryValue,
@@ -6,6 +7,45 @@ import {
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
 import { GlobalStore } from "app/store/GlobalStore"
 import { getAttributionClassValueByName } from "app/utils/artworkRarityClassifications"
+
+export const initializeNewSubmissionArtworkForm = (artwork: MyCollectionWhySell_artwork$data) => {
+  let category = artwork.mediumType?.name
+    ? (formatCategoryValueForSubmission(artwork.mediumType?.name) as AcceptableCategoryValue)
+    : null
+  category = (category && ACCEPTABLE_CATEGORY_VALUES_MAP[category]) ?? null
+
+  return {
+    artist: artwork.artist?.name ?? "",
+    artistId: artwork.artist?.internalID ?? "",
+    title: artwork.title ?? "",
+    year: artwork.date ?? "",
+    medium: artwork.medium ?? "",
+    category,
+    attributionClass: getAttributionClassValueByName(artwork.attributionClass?.name),
+    editionNumber: artwork.editionNumber ?? "",
+    editionSizeFormatted: artwork.editionSize ?? "",
+    dimensionsMetric: artwork.metric ?? "",
+    height: artwork.height ?? "",
+    width: artwork.width ?? "",
+    depth: artwork.depth ?? "",
+    provenance: artwork.provenance ?? "",
+    source: "MY_COLLECTION" as ConsignmentSubmissionSource | null,
+    myCollectionArtworkID: artwork.internalID,
+    initialPhotos: artwork.images?.map((image) => ({
+      path: image?.url?.replace(":version", "large") ?? "",
+      automaticallyAdded: true,
+    })),
+  }
+}
+
+export const initializeNewSubmissionPhotos = (artwork: MyCollectionWhySell_artwork$data) => {
+  const photos = artwork.images?.map((image) => ({
+    path: image?.url?.replace(":version", "large") ?? "",
+    automaticallyAdded: true,
+  }))
+
+  GlobalStore.actions.artworkSubmission.submission.initializePhotos(photos ?? [])
+}
 
 export const initializeSubmissionArtworkForm = (artwork: MyCollectionWhySell_artwork$data) => {
   GlobalStore.actions.artworkSubmission.submission.resetSessionState()

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
@@ -28,7 +28,7 @@ describe("SubmitArtworkBottomNavigation", () => {
 
       fireEvent(startSubmissionButton, "onPress")
 
-      expect(mockNavigateToNextStep).toHaveBeenCalledWith("SelectArtist")
+      expect(mockNavigateToNextStep).toHaveBeenCalledWith({ step: "SelectArtist" })
     })
 
     it("Shows a functional Start from My Collection button", () => {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Spacer, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
-import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation"
+import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { navigate } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -37,7 +37,9 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
       <Flex borderTopWidth={1} borderTopColor="black10" py={2} alignSelf="center" mx={-2} px={2}>
         <Button
           onPress={() => {
-            navigateToNextStep("SelectArtist")
+            navigateToNextStep({
+              step: "SelectArtist",
+            })
           }}
           block
         >

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -38,8 +38,6 @@ export const SubmitArtworkSelectArtist = () => {
     }
 
     try {
-      // TODO: Does it make sense to create a new submission here?
-      // We might end up with a lot of submissions that are never completed
       const submissionId = await createOrUpdateSubmission(updatedValues, formik.values.submissionId)
       formik.setFieldValue("submissionId", submissionId)
       navigateToNextStep()

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -40,7 +40,10 @@ export const SubmitArtworkSelectArtist = () => {
     try {
       const submissionId = await createOrUpdateSubmission(updatedValues, formik.values.submissionId)
       formik.setFieldValue("submissionId", submissionId)
-      navigateToNextStep()
+      navigateToNextStep({
+        step: "AddTitle",
+        skipMutation: true,
+      })
     } catch (error) {
       console.error("Error creating submission", error)
     } finally {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -2,6 +2,7 @@ import { Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { SubmitArtworkProgressBar } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar"
 import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
+import { goBack } from "app/system/navigation/navigate"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
 import { MotiView } from "moti"
 import { useEffect } from "react"
@@ -11,8 +12,13 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   const { navigateToNextStep } = useSubmissionContext()
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const isKeyboardVisible = useIsKeyboardVisible(true)
+  const hasCompletedForm = currentStep === "CompleteYourSubmission"
 
   const handleSaveAndExitPress = () => {
+    if (hasCompletedForm) {
+      return goBack()
+    }
+
     navigateToNextStep()
   }
 
@@ -24,29 +30,25 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
     return null
   }
 
-  const hasCompletedForm = currentStep === "CompleteYourSubmission"
-
   return (
     <Flex mx={2}>
-      {!hasCompletedForm && (
-        <MotiView
-          animate={{
-            height: isKeyboardVisible ? 0 : 30,
-          }}
-          transition={{
-            type: "timing",
-            duration: 200,
-          }}
-        >
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Flex style={{ flexGrow: 1, alignItems: "flex-end" }}>
-              <Touchable onPress={handleSaveAndExitPress}>
-                <Text>Save & Exit</Text>
-              </Touchable>
-            </Flex>
+      <MotiView
+        animate={{
+          height: isKeyboardVisible ? 0 : 30,
+        }}
+        transition={{
+          type: "timing",
+          duration: 200,
+        }}
+      >
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Flex style={{ flexGrow: 1, alignItems: "flex-end" }}>
+            <Touchable onPress={handleSaveAndExitPress}>
+              <Text>{!hasCompletedForm ? "Save & " : ""}Exit</Text>
+            </Touchable>
           </Flex>
-        </MotiView>
-      )}
+        </Flex>
+      </MotiView>
 
       <SubmitArtworkProgressBar />
     </Flex>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -45,6 +45,7 @@ export type SubmitArtworkStackNavigation = {
 
 export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
   const initialScreen: SubmitArtworkScreen = props.initialStep || "StartFlow"
+
   return (
     <SubmitArtworkFormStoreProvider
       runtimeModel={{

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -16,6 +16,7 @@ import { SubmitArtworkSelectArtist } from "app/Scenes/SellWithArtsy/ArtworkForm/
 import { SelectArtworkMyCollectionArtwork } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtworkMyCollectionArtwork"
 import { SubmitArtworkStartFlow } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkStartFlow"
 import { SubmitArtworkTopNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation"
+import { SubmitArtworkScreen } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import {
   ArtworkDetailsFormModel,
   artworkDetailsEmptyInitialValues,
@@ -23,6 +24,7 @@ import {
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { fetchUserContactInformation } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/fetchUserContactInformation"
+import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
 import { FormikProvider, useFormik } from "formik"
@@ -41,21 +43,31 @@ export type SubmitArtworkStackNavigation = {
   CompleteYourSubmission: undefined
 }
 
-export const SubmitArtworkForm: React.FC = ({}) => {
+export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
+  const initialScreen: SubmitArtworkScreen = props.initialStep || "StartFlow"
   return (
-    <SubmitArtworkFormStoreProvider>
-      <SubmitArtworkFormContent />
+    <SubmitArtworkFormStoreProvider
+      runtimeModel={{
+        currentStep: initialScreen,
+      }}
+    >
+      <SubmitArtworkFormContent initialValues={props.initialValues} initialStep={initialScreen} />
     </SubmitArtworkFormStoreProvider>
   )
 }
 
-const SubmitArtworkFormContent: React.FC = ({}) => {
+const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
+  initialValues: injectedValuesProp,
+}) => {
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const space = useSpace()
   const { bottom: bottomInset } = useSafeAreaInsets()
   const isKeyboardVisible = useIsKeyboardVisible(true)
 
-  const initialValues = artworkDetailsEmptyInitialValues as any
+  const initialValues = {
+    ...artworkDetailsEmptyInitialValues,
+    ...injectedValuesProp,
+  }
 
   const handleSubmit = (values: ArtworkDetailsFormModel) => {
     createOrUpdateSubmission(values, "")
@@ -112,6 +124,8 @@ const SubmitArtworkFormContent: React.FC = ({}) => {
                 keyboardHandlingEnabled: false,
                 gestureEnabled: false,
               }}
+              // Skip the start flow screen when user starts the flow from my collection
+              initialRouteName={formik.values.myCollectionArtworkID ? "SelectArtist" : "StartFlow"}
             >
               <Stack.Screen name="StartFlow" component={SubmitArtworkStartFlow} />
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -58,6 +58,7 @@ export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
 
 const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
   initialValues: injectedValuesProp,
+  initialStep,
 }) => {
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const space = useSpace()
@@ -124,8 +125,7 @@ const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
                 keyboardHandlingEnabled: false,
                 gestureEnabled: false,
               }}
-              // Skip the start flow screen when user starts the flow from my collection
-              initialRouteName={formik.values.myCollectionArtworkID ? "SelectArtist" : "StartFlow"}
+              initialRouteName={initialStep}
             >
               <Stack.Screen name="StartFlow" component={SubmitArtworkStartFlow} />
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -16,27 +16,36 @@ import { Alert } from "react-native"
 export const useSubmissionContext = () => {
   const setCurrentStep = SubmitArtworkFormStore.useStoreActions((actions) => actions.setCurrentStep)
   const setIsLoading = SubmitArtworkFormStore.useStoreActions((actions) => actions.setIsLoading)
+  const { currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
 
-  const { values } = useFormikContext<ArtworkDetailsFormModel>()
+  const { values, setFieldValue } = useFormikContext<ArtworkDetailsFormModel>()
 
   const navigateToNextStep = async (step?: SubmitArtworkScreen) => {
     try {
       setIsLoading(true)
-      const currentStepId = getCurrentRoute()
-      const nextStepId =
-        step || ARTWORK_FORM_STEPS[ARTWORK_FORM_STEPS.indexOf(currentStepId as any) + 1]
+      const nextStep =
+        step || ARTWORK_FORM_STEPS[ARTWORK_FORM_STEPS.indexOf(currentStep as any) + 1]
 
-      if (!nextStepId) {
+      if (!nextStep) {
         console.error("No next step found")
         return
       }
 
-      if (values.submissionId) {
-        await createOrUpdateSubmission(values, values.submissionId)
+      const submissionId = await createOrUpdateSubmission(
+        {
+          ...values,
+          state: (currentStep === "AddProvenance"
+            ? "SUBMITTED"
+            : undefined) as ArtworkDetailsFormModel["state"],
+        },
+        values.submissionId
+      )
+      if (!values.submissionId && submissionId) {
+        setFieldValue("submissionId", submissionId)
       }
 
-      setCurrentStep(nextStepId)
-      __unsafe__SubmissionArtworkFormNavigationRef.current?.navigate?.(nextStepId)
+      setCurrentStep(nextStep)
+      __unsafe__SubmissionArtworkFormNavigationRef.current?.navigate?.(nextStep)
     } catch (error) {
       console.error("Error navigating to next step", error)
       Alert.alert("Could not navigate to next step")
@@ -46,7 +55,7 @@ export const useSubmissionContext = () => {
   }
 
   const navigateToPreviousStep = () => {
-    if (getCurrentRoute() === ARTWORK_FORM_STEPS[0]) {
+    if (!__unsafe__SubmissionArtworkFormNavigationRef.current?.canGoBack()) {
       return goBack()
     }
     // Order is important here to make sure getCurrentRoute returns the correct value

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -20,28 +20,32 @@ export const useSubmissionContext = () => {
 
   const { values, setFieldValue } = useFormikContext<ArtworkDetailsFormModel>()
 
-  const navigateToNextStep = async (step?: SubmitArtworkScreen) => {
+  const navigateToNextStep = async (props?: {
+    step?: SubmitArtworkScreen
+    skipMutation?: boolean
+  }) => {
     try {
       setIsLoading(true)
       const nextStep =
-        step || ARTWORK_FORM_STEPS[ARTWORK_FORM_STEPS.indexOf(currentStep as any) + 1]
+        props?.step || ARTWORK_FORM_STEPS[ARTWORK_FORM_STEPS.indexOf(currentStep as any) + 1]
 
       if (!nextStep) {
         console.error("No next step found")
         return
       }
 
-      const submissionId = await createOrUpdateSubmission(
-        {
-          ...values,
-          state: (currentStep === "AddProvenance"
-            ? "SUBMITTED"
-            : undefined) as ArtworkDetailsFormModel["state"],
-        },
-        values.submissionId
-      )
-      if (!values.submissionId && submissionId) {
-        setFieldValue("submissionId", submissionId)
+      const newValues = {
+        ...values,
+        state: (currentStep === "AddProvenance"
+          ? "SUBMITTED"
+          : undefined) as ArtworkDetailsFormModel["state"],
+      }
+
+      if (!props?.skipMutation) {
+        const submissionId = await createOrUpdateSubmission(newValues, values.submissionId)
+        if (!values.submissionId && submissionId) {
+          setFieldValue("submissionId", submissionId)
+        }
       }
 
       setCurrentStep(nextStep)

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -39,6 +39,7 @@ import { createOrUpdateSubmission } from "./ArtworkDetails/utils/createOrUpdateS
 import { ArtworkDetailsFormModel, ContactInformationFormModel } from "./ArtworkDetails/validation"
 import { ArtworkSubmittedScreen } from "./ArtworkSubmitted"
 import { UploadPhotos } from "./UploadPhotos/UploadPhotos"
+import type { SubmitArtworkScreen as SubmitArtworkScreenT } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 
 const SUBMIT_ARTWORK_NAVIGATION_STACK_STATE_KEY = "SUBMIT_ARTWORK_NAVIGATION_STACK_STATE_KEY"
 
@@ -326,7 +327,12 @@ export type SubmitArtworkOverviewNavigationStack = {
 
 const StackNavigator = createStackNavigator<SubmitArtworkOverviewNavigationStack>()
 
-export const SubmitArtwork = () => {
+export interface SubmitArtworkProps {
+  initialValues: Partial<ArtworkDetailsFormModel>
+  initialStep: SubmitArtworkScreenT
+}
+
+export const SubmitArtwork: React.FC<SubmitArtworkProps> = (props) => {
   const { isReady, initialState, saveSession } = useReloadedDevNavigationState(
     SUBMIT_ARTWORK_NAVIGATION_STACK_STATE_KEY
   )
@@ -337,7 +343,7 @@ export const SubmitArtwork = () => {
   }
 
   if (enableNewSubmissionFlow) {
-    return <SubmitArtworkForm />
+    return <SubmitArtworkForm {...props} />
   }
 
   return (


### PR DESCRIPTION
This PR resolves [ONYX-978] <!-- eg [PROJECT-XXXX] -->

### Description
This PR adds support to initializing a submission from my collection. 
**Note:** While working on this I noticed a lot of code related to this in the global store that we can get rid of as soon as we release the feature and have a more clean global store. We can as well use it for the save & exit 🤷 

https://github.com/artsy/eigen/assets/11945712/de949e3d-b0c8-47dc-9ea8-23a34a4dd32d

<img width="1051" alt="Screenshot 2024-05-17 at 15 50 37" src="https://github.com/artsy/eigen/assets/11945712/5c7616f3-15e5-4176-9041-a6ccd3fd9bb7">

<img width="630" alt="Screenshot 2024-05-17 at 15 51 38" src="https://github.com/artsy/eigen/assets/11945712/1b0c8f18-7f76-407d-b4e4-a43773f02e2f">

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- initialize submission from my collection artwork in new submission flow - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-978]: https://artsyproduct.atlassian.net/browse/ONYX-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ