### PR TITLE
feat(ONYX-986): support save and exit in new submission flow

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -31,10 +31,8 @@ import { RecentlyViewedScreen } from "app/Scenes/RecentlyViewed/RecentlyViewed"
 import { SavedArtworks } from "app/Scenes/SavedArtworks/SavedArtworks"
 import { AlertArtworks } from "app/Scenes/SavedSearchAlert/AlertArtworks"
 import { SearchScreen, SearchScreenQuery } from "app/Scenes/Search/Search"
-import {
-  SubmitArtworkForm,
-  SubmitArtworkFormEdit,
-} from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { SubmitArtworkForm } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { SubmitArtworkFormEdit } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit"
 import { SimilarToRecentlyViewedScreen } from "app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed"
 import { ArtsyKeyboardAvoidingViewContext } from "app/utils/ArtsyKeyboardAvoidingView"
 import { SafeAreaInsets, useScreenDimensions } from "app/utils/hooks"

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -31,7 +31,10 @@ import { RecentlyViewedScreen } from "app/Scenes/RecentlyViewed/RecentlyViewed"
 import { SavedArtworks } from "app/Scenes/SavedArtworks/SavedArtworks"
 import { AlertArtworks } from "app/Scenes/SavedSearchAlert/AlertArtworks"
 import { SearchScreen, SearchScreenQuery } from "app/Scenes/Search/Search"
-import { SubmitArtworkForm } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import {
+  SubmitArtworkForm,
+  SubmitArtworkFormEdit,
+} from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { SimilarToRecentlyViewedScreen } from "app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed"
 import { ArtsyKeyboardAvoidingViewContext } from "app/utils/ArtsyKeyboardAvoidingView"
 import { SafeAreaInsets, useScreenDimensions } from "app/utils/hooks"
@@ -656,6 +659,10 @@ export const modules = defineModules({
         hidesBottomTabs: true,
       })
     : reactModule(SubmitArtwork, { hidesBackButton: true, hidesBottomTabs: true }),
+  SubmitArtworkEdit: reactModule(SubmitArtworkFormEdit, {
+    hidesBackButton: true,
+    hidesBottomTabs: true,
+  }),
   Tag: reactModule(TagQueryRenderer, { hidesBackButton: true, fullBleed: true }),
   UnlistedArtworksFAQScreen: reactModule(UnlistedArtworksFAQScreen),
   VanityURLEntity: reactModule(VanityURLEntityRenderer, { fullBleed: true }),

--- a/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
+++ b/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
@@ -1,9 +1,21 @@
+import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { Action, action } from "easy-peasy"
 import { MyCollectionArtworkModel } from "./MyCollectionArtworkModel"
 
 export interface MyCollectionModel {
   artwork: MyCollectionArtworkModel
+  draft: {
+    values: ArtworkDetailsFormModel
+    currentStep: string
+    navigationState: any
+  } | null
+  setDraft: Action<this, this["draft"]>
 }
 
 export const getMyCollectionModel = (): MyCollectionModel => ({
   artwork: MyCollectionArtworkModel,
+  draft: null,
+  setDraft: action((state, payload) => {
+    state.draft = payload
+  }),
 })

--- a/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
+++ b/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
@@ -1,19 +1,9 @@
-import { Action, action } from "easy-peasy"
 import { MyCollectionArtworkModel } from "./MyCollectionArtworkModel"
 
 export interface MyCollectionModel {
   artwork: MyCollectionArtworkModel
-  draft: {
-    submissionID: string
-    currentStep: string
-  } | null
-  setDraft: Action<this, this["draft"]>
 }
 
 export const getMyCollectionModel = (): MyCollectionModel => ({
   artwork: MyCollectionArtworkModel,
-  draft: null,
-  setDraft: action((state, payload) => {
-    state.draft = payload
-  }),
 })

--- a/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
+++ b/src/app/Scenes/MyCollection/State/MyCollectionModel.tsx
@@ -1,13 +1,11 @@
-import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { Action, action } from "easy-peasy"
 import { MyCollectionArtworkModel } from "./MyCollectionArtworkModel"
 
 export interface MyCollectionModel {
   artwork: MyCollectionArtworkModel
   draft: {
-    values: ArtworkDetailsFormModel
+    submissionID: string
     currentStep: string
-    navigationState: any
   } | null
   setDraft: Action<this, this["draft"]>
 }

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkPurchaseHistory.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkPurchaseHistory.tests.tsx
@@ -20,8 +20,6 @@ describe("SubmitArtworkPurchaseHistory", () => {
     await flushPromiseQueue()
 
     fireEvent.press(screen.getByText(PROVENANCE_LIST[0].label))
-    // Wait for the select modal to dismiss
-    await flushPromiseQueue()
-    expect(screen.getByText(PROVENANCE_LIST[0].label)).toBeOnTheScreen()
+    expect(screen.getAllByText(PROVENANCE_LIST[0].label)).toHaveLength(2)
   })
 })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -48,7 +48,7 @@ export const SubmitArtworkSelectArtist = () => {
 
     const updatedValues = {
       artistId: result.internalID,
-      artist: result.displayLabel,
+      artist: result.displayLabel || "",
       artistSearchResult: result,
       userPhone: formik.values.userPhone,
       userEmail: formik.values.userEmail,

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -1,6 +1,5 @@
 import { BackButton, Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
-import { __unsafe__SubmissionArtworkFormNavigationRef } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
@@ -26,13 +25,12 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
       return goBack()
     }
 
-    GlobalStore.actions.myCollection.setDraft({
-      values: values,
-      currentStep,
-      navigationState: JSON.stringify(
-        __unsafe__SubmissionArtworkFormNavigationRef.current?.getState()
-      ),
-    })
+    if (values.submissionId) {
+      GlobalStore.actions.myCollection.setDraft({
+        submissionID: values.submissionId,
+        currentStep,
+      })
+    }
     goBack()
   }
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -1,24 +1,39 @@
 import { BackButton, Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
-import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
+import { __unsafe__SubmissionArtworkFormNavigationRef } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
+import { useFormikContext } from "formik"
 import { MotiView } from "moti"
 import { useEffect } from "react"
 import { LayoutAnimation } from "react-native"
 
 export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
-  const { navigateToNextStep } = useSubmissionContext()
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const isKeyboardVisible = useIsKeyboardVisible(true)
   const hasCompletedForm = currentStep === "CompleteYourSubmission"
 
+  const { values } = useFormikContext<ArtworkDetailsFormModel>()
+
   const handleSaveAndExitPress = () => {
     if (hasCompletedForm) {
+      // Reset form if user is on the last step
+      // This is to ensure that the user can start a new submission
+      // This is not required but is a nice to have as a second layer of protection
+      GlobalStore.actions.myCollection.setDraft(null)
       return goBack()
     }
 
-    navigateToNextStep()
+    GlobalStore.actions.myCollection.setDraft({
+      values: values,
+      currentStep,
+      navigationState: JSON.stringify(
+        __unsafe__SubmissionArtworkFormNavigationRef.current?.getState()
+      ),
+    })
+    goBack()
   }
 
   useEffect(() => {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -21,12 +21,12 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
       // Reset form if user is on the last step
       // This is to ensure that the user can start a new submission
       // This is not required but is a nice to have as a second layer of protection
-      GlobalStore.actions.myCollection.setDraft(null)
+      GlobalStore.actions.artworkSubmission.setDraft(null)
       return goBack()
     }
 
     if (values.submissionId) {
-      GlobalStore.actions.myCollection.setDraft({
+      GlobalStore.actions.artworkSubmission.setDraft({
         submissionID: values.submissionId,
         currentStep,
       })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -1,7 +1,6 @@
-import { Flex, Text, useSpace } from "@artsy/palette-mobile"
+import { Flex, useSpace } from "@artsy/palette-mobile"
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
-import { SubmitArtworkFormQuery } from "__generated__/SubmitArtworkFormQuery.graphql"
 import { SubmitArtworkAddDetails } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails"
 import { SubmitArtworkAddDimensions } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDimensions"
 import { SubmitArtworkAddPhotos } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhotos"
@@ -18,11 +17,8 @@ import { SubmitArtworkSelectArtist } from "app/Scenes/SellWithArtsy/ArtworkForm/
 import { SelectArtworkMyCollectionArtwork } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtworkMyCollectionArtwork"
 import { SubmitArtworkStartFlow } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkStartFlow"
 import { SubmitArtworkTopNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation"
-import {
-  ARTWORK_FORM_STEPS,
-  SubmitArtworkScreen,
-} from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
-import { getInitialSubmissionValues } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues"
+import { SubmitArtworkScreen } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
+import { getInitialNavigationState } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialNavigationState"
 import {
   ArtworkDetailsFormModel,
   artworkDetailsEmptyInitialValues,
@@ -33,11 +29,9 @@ import { fetchUserContactInformation } from "app/Scenes/SellWithArtsy/SubmitArtw
 import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
-import { withSuspense } from "app/utils/hooks/withSuspense"
 import { FormikProvider, useFormik } from "formik"
 import { useEffect } from "react"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { graphql, useLazyLoadQuery } from "react-relay"
 
 export type SubmitArtworkStackNavigation = {
   StartFlow: undefined
@@ -51,34 +45,6 @@ export type SubmitArtworkStackNavigation = {
   CompleteYourSubmission: undefined
   ArtistRejected: undefined
 }
-
-export const SubmitArtworkFormEdit: React.FC<SubmitArtworkProps> = withSuspense((props) => {
-  const data = useLazyLoadQuery<SubmitArtworkFormQuery>(
-    submitArtworkFormQuery,
-    {
-      id: props.submissionID,
-    },
-    { fetchPolicy: "store-and-network" }
-  )
-
-  // TODO: Better error handling
-  if (!data?.submission) {
-    return (
-      <Flex flex={1} alignItems="center" justifyContent="center">
-        <Text variant="sm-display">Submission not found</Text>
-      </Flex>
-    )
-  }
-
-  return (
-    <SubmitArtworkForm
-      submissionID={props.submissionID}
-      initialValues={getInitialSubmissionValues(data.submission)}
-      initialStep={props.initialStep}
-      navigationState={props.navigationState}
-    />
-  )
-})
 
 export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
   const initialScreen: SubmitArtworkScreen = props.initialStep || "StartFlow"
@@ -97,50 +63,6 @@ export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
     </SubmitArtworkFormStoreProvider>
   )
 }
-
-const submitArtworkFormQuery = graphql`
-  query SubmitArtworkFormQuery($id: ID) {
-    submission(id: $id) {
-      id
-      externalId
-      artist {
-        internalID
-        name
-      }
-      category
-      locationCity
-      locationCountry
-      locationState
-      locationPostalCode
-      locationCountryCode
-      year
-      title
-      signature
-      medium
-      attributionClass
-      editionNumber
-      editionSize
-      height
-      width
-      depth
-      dimensionsMetric
-      provenance
-      userId
-      userEmail
-      userName
-      userPhone
-      source
-      sourceArtworkID
-      assets {
-        id
-        imageUrls
-        geminiToken
-        size
-        filename
-      }
-    }
-  }
-`
 
 const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
   initialValues: injectedValuesProp,
@@ -272,17 +194,3 @@ export const getCurrentRoute = () =>
   __unsafe__SubmissionArtworkFormNavigationRef.current?.getCurrentRoute()?.name as
     | keyof SubmitArtworkStackNavigation
     | undefined
-
-const getInitialNavigationState = (initialStep: SubmitArtworkScreen) => {
-  if (ARTWORK_FORM_STEPS.includes(initialStep)) {
-    return {
-      routes: ARTWORK_FORM_STEPS.slice(0, ARTWORK_FORM_STEPS.indexOf(initialStep) + 1).map(
-        (routeName) => ({
-          name: routeName,
-        })
-      ),
-    }
-  }
-
-  return undefined
-}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
@@ -1,0 +1,74 @@
+import { SubmitArtworkFormEditQuery } from "__generated__/SubmitArtworkFormEditQuery.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
+import { SubmitArtworkForm } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { getInitialSubmissionValues } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues"
+import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { graphql, useLazyLoadQuery } from "react-relay"
+
+export const SubmitArtworkFormEdit: React.FC<SubmitArtworkProps> = withSuspense((props) => {
+  const data = useLazyLoadQuery<SubmitArtworkFormEditQuery>(
+    submitArtworkFormEditQuery,
+    {
+      id: props.submissionID,
+    },
+    { fetchPolicy: "store-and-network" }
+  )
+
+  if (!data?.submission) {
+    return <LoadFailureView />
+  }
+
+  return (
+    <SubmitArtworkForm
+      submissionID={props.submissionID}
+      initialValues={getInitialSubmissionValues(data.submission)}
+      initialStep={props.initialStep}
+      navigationState={props.navigationState}
+    />
+  )
+})
+
+const submitArtworkFormEditQuery = graphql`
+  query SubmitArtworkFormEditQuery($id: ID) {
+    submission(id: $id) {
+      id
+      externalId
+      artist {
+        internalID
+        name
+      }
+      category
+      locationCity
+      locationCountry
+      locationState
+      locationPostalCode
+      locationCountryCode
+      year
+      title
+      signature
+      medium
+      attributionClass
+      editionNumber
+      editionSize
+      height
+      width
+      depth
+      dimensionsMetric
+      provenance
+      userId
+      userEmail
+      userName
+      userPhone
+      source
+      sourceArtworkID
+      assets {
+        id
+        imageUrls
+        geminiToken
+        size
+        filename
+      }
+    }
+  }
+`

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
@@ -4,7 +4,6 @@ export type SubmitArtworkScreen = keyof SubmitArtworkStackNavigation
 
 export const ARTWORK_FORM_STEPS: SubmitArtworkScreen[] = [
   "StartFlow",
-  "SelectArtworkMyCollectionArtwork",
   "SelectArtist",
   "AddTitle",
   "AddPhotos",
@@ -13,4 +12,5 @@ export const ARTWORK_FORM_STEPS: SubmitArtworkScreen[] = [
   "PurchaseHistory",
   "CompleteYourSubmission",
   "ArtistRejected",
+  "SelectArtworkMyCollectionArtwork",
 ]

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialNavigationState.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialNavigationState.ts
@@ -1,0 +1,18 @@
+import {
+  ARTWORK_FORM_STEPS,
+  SubmitArtworkScreen,
+} from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
+
+export const getInitialNavigationState = (initialStep: SubmitArtworkScreen) => {
+  if (ARTWORK_FORM_STEPS.includes(initialStep)) {
+    return {
+      routes: ARTWORK_FORM_STEPS.slice(0, ARTWORK_FORM_STEPS.indexOf(initialStep) + 1).map(
+        (routeName) => ({
+          name: routeName,
+        })
+      ),
+    }
+  }
+
+  return undefined
+}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -1,0 +1,54 @@
+import {
+  ConsignmentAttributionClass,
+  SubmitArtworkFormQuery$data,
+} from "__generated__/SubmitArtworkFormQuery.graphql"
+import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { acceptableCategoriesForSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
+export const getInitialSubmissionValues = (
+  values: NonNullable<SubmitArtworkFormQuery$data["submission"]>
+): ArtworkDetailsFormModel => {
+  const initialPhotos = values.assets?.map((asset) => asset?.imageUrls) ?? []
+
+  const allVersions = Object.values(initialPhotos).filter(
+    (image) => Object.values(image).length >= 1
+  )
+  const largestImages = allVersions.map((image) => Object.values(image)[0] as string)
+
+  const categories = acceptableCategoriesForSubmission()
+
+  return {
+    artist: values.artist?.name ?? "",
+    artistId: values.artist?.internalID ?? "",
+    category: categories.find((category) => category.label === values.category)?.value as any,
+    year: values.year ?? "",
+    title: values.title ?? "",
+    medium: values.medium ?? "",
+    attributionClass:
+      (values.attributionClass?.replace("_", " ").toLowerCase() as ConsignmentAttributionClass) ??
+      null,
+    editionNumber: values.editionNumber ?? "",
+    editionSizeFormatted: values.editionSize ?? "",
+    height: values.height ?? "",
+    width: values.width ?? "",
+    depth: values.depth ?? "",
+    dimensionsMetric: values.dimensionsMetric ?? "in",
+    provenance: values.provenance ?? "",
+    location: {
+      city: values.locationCity ?? "",
+      country: values.locationCountry ?? "",
+      state: values.locationState ?? "",
+      countryCode: values.locationCountryCode ?? "",
+    },
+    signature: values.signature ?? null,
+    userEmail: values.userEmail ?? "",
+    userName: values.userId ?? "",
+    userPhone: values.userPhone ?? "",
+    submissionId: values.id,
+    artistSearchResult: null,
+    source: values.source ?? null,
+    myCollectionArtworkID: values.sourceArtworkID ?? null,
+    photos: largestImages.map((imageUrl: string) => ({
+      path: imageUrl || "",
+    })),
+  }
+}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -1,11 +1,11 @@
 import {
   ConsignmentAttributionClass,
-  SubmitArtworkFormQuery$data,
-} from "__generated__/SubmitArtworkFormQuery.graphql"
+  SubmitArtworkFormEditQuery$data,
+} from "__generated__/SubmitArtworkFormEditQuery.graphql"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { acceptableCategoriesForSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
 export const getInitialSubmissionValues = (
-  values: NonNullable<SubmitArtworkFormQuery$data["submission"]>
+  values: NonNullable<SubmitArtworkFormEditQuery$data["submission"]>
 ): ArtworkDetailsFormModel => {
   const initialPhotos = values.assets?.map((asset) => asset?.imageUrls) ?? []
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -9,6 +9,7 @@ import {
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
+import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFormikContext } from "formik"
 import { Alert } from "react-native"
@@ -46,6 +47,11 @@ export const useSubmissionContext = () => {
         if (!values.submissionId && submissionId) {
           setFieldValue("submissionId", submissionId)
         }
+      }
+
+      if (newValues.state === "SUBMITTED") {
+        // Reset saved draft if submission is successful
+        GlobalStore.actions.myCollection.setDraft(null)
       }
 
       __unsafe__SubmissionArtworkFormNavigationRef.current?.navigate?.(nextStep)

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -51,7 +51,7 @@ export const useSubmissionContext = () => {
 
       if (newValues.state === "SUBMITTED") {
         // Reset saved draft if submission is successful
-        GlobalStore.actions.myCollection.setDraft(null)
+        GlobalStore.actions.artworkSubmission.setDraft(null)
       }
 
       __unsafe__SubmissionArtworkFormNavigationRef.current?.navigate?.(nextStep)

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -54,8 +54,8 @@ const artworkFormPhotosSchema = Yup.object().shape({
     .min(__TEST__ ? 0 : 1)
     .of(
       Yup.object().shape({
-        id: Yup.string().required(),
-        geminiToken: Yup.string().required(),
+        id: Yup.string(),
+        geminiToken: Yup.string(),
         path: Yup.string().required(),
       })
     ),
@@ -97,7 +97,7 @@ export interface Location {
 
 export interface ArtworkDetailsFormModel {
   submissionId: string | null
-  artist: string | null
+  artist: string
   artistId: string
   artistSearchResult: AutosuggestResult | null
   attributionClass: ConsignmentAttributionClass | null

--- a/src/app/Scenes/SellWithArtsy/Components/Header.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/Header.tsx
@@ -10,9 +10,10 @@ export const Header: React.FC = () => {
   const { width } = useScreenDimensions()
   const space = useSpace()
   const enableSaveAndContinue = useFeatureFlag("AREnableSaveAndContinueSubmission")
-  const { draft } = GlobalStore.useAppState((state) => state.myCollection)
+  const { draft } = GlobalStore.useAppState((state) => state.artworkSubmission)
 
   const showContinueSubmission = !!enableSaveAndContinue && !!draft?.submissionID
+
   return (
     <Flex>
       <Image
@@ -44,7 +45,7 @@ export const Header: React.FC = () => {
                   {
                     text: "Disard Draft",
                     onPress: () => {
-                      GlobalStore.actions.myCollection.setDraft(null)
+                      GlobalStore.actions.artworkSubmission.setDraft(null)
                       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
                     },
                     style: "destructive",

--- a/src/app/Scenes/SellWithArtsy/Components/Header.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/Header.tsx
@@ -12,7 +12,7 @@ export const Header: React.FC = () => {
   const enableSaveAndContinue = useFeatureFlag("AREnableSaveAndContinueSubmission")
   const { draft } = GlobalStore.useAppState((state) => state.myCollection)
 
-  const showContinueSubmission = !!enableSaveAndContinue && !!draft?.values
+  const showContinueSubmission = !!enableSaveAndContinue && !!draft?.submissionID
   return (
     <Flex>
       <Image
@@ -28,13 +28,9 @@ export const Header: React.FC = () => {
           <Touchable
             style={{ paddingHorizontal: space(2), flex: 1 }}
             onPress={() => {
-              navigate("/sell/submissions/new", {
-                passProps: {
-                  initialValues: draft.values,
-                  initialStep: draft.currentStep,
-                  navigationState: draft.navigationState,
-                },
-              })
+              navigate(
+                `/sell/submissions/${draft.submissionID}/edit?initialStep=${draft.currentStep}`
+              )
             }}
             onLongPress={() => {
               Alert.alert(

--- a/src/app/Scenes/SellWithArtsy/Components/Header.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/Header.tsx
@@ -1,11 +1,18 @@
-import { Flex, Text } from "@artsy/palette-mobile"
+import { ArrowRightIcon, Flex, Spacer, Text, Touchable, useSpace } from "@artsy/palette-mobile"
+import { GlobalStore } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 import { useScreenDimensions } from "app/utils/hooks"
-import { Image } from "react-native"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { Alert, Image, LayoutAnimation } from "react-native"
 import { isTablet } from "react-native-device-info"
 
 export const Header: React.FC = () => {
   const { width } = useScreenDimensions()
+  const space = useSpace()
+  const enableSaveAndContinue = useFeatureFlag("AREnableSaveAndContinueSubmission")
+  const { draft } = GlobalStore.useAppState((state) => state.myCollection)
 
+  const showContinueSubmission = !!enableSaveAndContinue && !!draft?.values
   return (
     <Flex>
       <Image
@@ -14,7 +21,55 @@ export const Header: React.FC = () => {
         resizeMode={isTablet() ? "contain" : "cover"}
       />
 
-      <Flex mx={2} mt={1}>
+      {!!showContinueSubmission && (
+        <>
+          <Spacer y={2} />
+
+          <Touchable
+            style={{ paddingHorizontal: space(2), flex: 1 }}
+            onPress={() => {
+              navigate("/sell/submissions/new", {
+                passProps: {
+                  initialValues: draft.values,
+                  initialStep: draft.currentStep,
+                  navigationState: draft.navigationState,
+                },
+              })
+            }}
+            onLongPress={() => {
+              Alert.alert(
+                "Discard draft",
+                "Are you sure you want to discard your draft? This action cannot be undone.",
+                [
+                  {
+                    text: "Cancel",
+                    style: "cancel",
+                  },
+                  {
+                    text: "Disard Draft",
+                    onPress: () => {
+                      GlobalStore.actions.myCollection.setDraft(null)
+                      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+                    },
+                    style: "destructive",
+                  },
+                ]
+              )
+            }}
+          >
+            <Flex backgroundColor="blue100" px={2} py={1} flex={1} flexDirection="row">
+              <Text variant="sm-display" color="white" style={{ flex: 1 }}>
+                Continue previous submission
+              </Text>
+              <ArrowRightIcon fill="white100" height={18} width={18} />
+            </Flex>
+          </Touchable>
+        </>
+      )}
+
+      <Spacer y={showContinueSubmission ? 1 : 2} />
+
+      <Flex mx={2}>
         <Text variant="xl" mb={1}>
           Sell art from your collection
         </Text>

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/validation.ts
@@ -18,6 +18,10 @@ export interface Location {
   zipCode?: string
 }
 
+/**
+ * @deprecated
+ * Please use ArtworkDetailsFormModel from app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+ */
 export interface ArtworkDetailsFormModel {
   artist: string
   artistId: string

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -330,6 +330,7 @@ const StackNavigator = createStackNavigator<SubmitArtworkOverviewNavigationStack
 export interface SubmitArtworkProps {
   initialValues: Partial<ArtworkDetailsFormModel>
   initialStep: SubmitArtworkScreenT
+  navigationState?: string
 }
 
 export const SubmitArtwork: React.FC<SubmitArtworkProps> = (props) => {

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork.tsx
@@ -331,6 +331,7 @@ export interface SubmitArtworkProps {
   initialValues: Partial<ArtworkDetailsFormModel>
   initialStep: SubmitArtworkScreenT
   navigationState?: string
+  submissionID?: string
 }
 
 export const SubmitArtwork: React.FC<SubmitArtworkProps> = (props) => {

--- a/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
+++ b/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
@@ -33,10 +33,16 @@ export interface ArtworkSubmissionModel {
 }
 
 export interface SubmissionModel {
+  draft: {
+    submissionID: string
+    currentStep: string
+  } | null
   submission: ArtworkSubmissionModel
+  setDraft: Action<this, this["draft"]>
 }
 
 export const getSubmissionModel = (): SubmissionModel => ({
+  draft: null,
   submission: {
     submissionId: "",
     submissionIdForMyCollection: "",
@@ -78,4 +84,7 @@ export const getSubmissionModel = (): SubmissionModel => ({
       state.photos = photosEmptyInitialValues
     }),
   },
+  setDraft: action((state, payload) => {
+    state.draft = payload
+  }),
 })

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -249,6 +249,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     addRoute("/search", "Search"),
     addRoute("/sell/inquiry", "ConsignmentInquiry"),
     addRoute("/sell/submissions/new", "SubmitArtwork"),
+    addRoute("/sell/submissions/:submissionID/edit", "SubmitArtworkEdit"),
     addRoute("/selling-with-artsy", "MyCollectionSellingWithartsyFAQ"),
     addRoute("/settings/alerts", "SavedSearchAlertsList"),
     addRoute("/settings/alerts/:savedSearchAlertId/edit", "EditSavedSearchAlert"),

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -1018,8 +1018,8 @@ describe("App version Versions.AddProgressiveOnboardingModel", () => {
     })
   })
 
-  describe("App version Versions.AddMyCollectionDraft", () => {
-    const migrationToTest = Versions.AddMyCollectionDraft
+  describe("App version Versions.AddSubmissionDraft", () => {
+    const migrationToTest = Versions.AddSubmissionDraft
 
     it("adds submission to my collection artwork", () => {
       const previousState = migrate({
@@ -1027,14 +1027,14 @@ describe("App version Versions.AddProgressiveOnboardingModel", () => {
         toVersion: migrationToTest - 1,
       }) as any
 
-      expect(previousState.myCollection.draft).not.toBeDefined()
+      expect(previousState.artworkSubmission.draft).not.toBeDefined()
 
       const migratedState = migrate({
         state: previousState,
         toVersion: migrationToTest,
       }) as any
 
-      expect(migratedState.myCollection.draft).toEqual(null)
+      expect(migratedState.artworkSubmission.draft).toEqual(null)
     })
   })
 })

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -1017,4 +1017,24 @@ describe("App version Versions.AddProgressiveOnboardingModel", () => {
       )
     })
   })
+
+  describe("App version Versions.AddMyCollectionDraft", () => {
+    const migrationToTest = Versions.AddMyCollectionDraft
+
+    it("adds submission to my collection artwork", () => {
+      const previousState = migrate({
+        state: { version: 0 },
+        toVersion: migrationToTest - 1,
+      }) as any
+
+      expect(previousState.myCollection.draft).not.toBeDefined()
+
+      const migratedState = migrate({
+        state: previousState,
+        toVersion: migrationToTest,
+      }) as any
+
+      expect(migratedState.myCollection.draft).toEqual(null)
+    })
+  })
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -280,6 +280,11 @@ export const features = {
     readyForRelease: false,
     showInDevMenu: true,
   },
+  AREnableSaveAndContinueSubmission: {
+    description: "Enable save and continue submission flow",
+    readyForRelease: false,
+    showInDevMenu: true,
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -55,9 +55,10 @@ export const Versions = {
   RenameDefaultViewOption: 42,
   AddExperimentsOverrides: 43,
   DeleteDirtyArtworkDetails: 44,
+  AddMyCollectionDraft: 45,
 }
 
-export const CURRENT_APP_VERSION = Versions.DeleteDirtyArtworkDetails
+export const CURRENT_APP_VERSION = Versions.AddMyCollectionDraft
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -319,6 +320,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.DeleteDirtyArtworkDetails]: (state) => {
     delete state.artworkSubmission.submission.dirtyArtworkDetailsValues
+  },
+  [Versions.AddMyCollectionDraft]: (state) => {
+    state.myCollection.draft = null
   },
 }
 

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -55,10 +55,10 @@ export const Versions = {
   RenameDefaultViewOption: 42,
   AddExperimentsOverrides: 43,
   DeleteDirtyArtworkDetails: 44,
-  AddMyCollectionDraft: 45,
+  AddSubmissionDraft: 45,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddMyCollectionDraft
+export const CURRENT_APP_VERSION = Versions.AddSubmissionDraft
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -321,8 +321,8 @@ export const artsyAppMigrations: Migrations = {
   [Versions.DeleteDirtyArtworkDetails]: (state) => {
     delete state.artworkSubmission.submission.dirtyArtworkDetailsValues
   },
-  [Versions.AddMyCollectionDraft]: (state) => {
-    state.myCollection.draft = null
+  [Versions.AddSubmissionDraft]: (state) => {
+    state.artworkSubmission.draft = null
   },
 }
 

--- a/src/app/utils/hooks/withSuspense.tsx
+++ b/src/app/utils/hooks/withSuspense.tsx
@@ -1,9 +1,16 @@
-import { Spinner } from "@artsy/palette-mobile"
+import { Flex, Spinner } from "@artsy/palette-mobile"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { Suspense } from "react"
 
 export const withSuspense =
-  (Component: React.FC<any>, Fallback: React.FC<any> = () => <Spinner />) =>
+  (
+    Component: React.FC<any>,
+    Fallback: React.FC<any> = () => (
+      <Flex flex={1} justifyContent="center" alignItems="center">
+        <Spinner />
+      </Flex>
+    )
+  ) =>
   (props: any) => {
     return (
       <Suspense


### PR DESCRIPTION
## ⟥⸻PR Description Up To Date [Friday 24th May 10:47 CEST] ⸻⟤
This PR resolves [ONYX-986] <!-- eg [PROJECT-XXXX] -->

## Description

This PR makes the **Save & Exit** button in the new submission flow functional.

#### What we currently have:
- The **Save & Exit** Button simply closes the modal or navigates you to the next screen
Expected behaviour:
- When the user taps on **Save & Exit**, we should save their progress, and allow them to continue from where they left when they tap on **Continue Previous Submission**


## Main challenges:

### 1. What data to save when the user taps on **Save & Exit**?
   - Data to inject for the submission
     - ~~Currently, I am saving the entire formik state and injecting it as it is, **However**, we can soon move toward saving only the submission id and querying for the data on screen mount. I didn't do that initially because we are going to get rid of this logic once we back up submissions with my collection artworks and have cross platform save and exit experience.~~
     - Currently, we only store the `submissionID` and the last active step. We use the `submissionID` to query for the data
   - Navigation progress 👇  [see question 2]


### 2.  How to restore the previous navigation state and get the user to continue from where they left
   - For that, we are leveraging `initialState` prop to inject the a partial navigation state. We are rebuilding it on mount and validating that the routes exist

## Downsides of this approach
This works **only** for App. This is _fine_ though since we want to first see how it performs when it comes to clicks before investing more effort.

https://github.com/artsy/eigen/assets/11945712/5f86dcbd-62b4-4592-b2b7-67c0bcf357ce


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- support save and exit in new submission flow - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-986]: https://artsyproduct.atlassian.net/browse/ONYX-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ