### PR TITLE
fix: hide keyboard after each step on new submission flow

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhotos.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhotos.tsx
@@ -3,15 +3,11 @@ import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Ut
 import { UploadPhotosForm } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm"
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { useFormikContext } from "formik"
-import { useEffect } from "react"
-import { Keyboard, ScrollView } from "react-native"
+import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddPhotos = () => {
   const { values } = useFormikContext<ArtworkDetailsFormModel>()
 
-  useEffect(() => {
-    Keyboard.dismiss()
-  }, [])
   const isAnyPhotoLoading = values.photos.some((photo: Photo) => photo.loading)
 
   return (

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -13,7 +13,7 @@ import { navigate } from "app/system/navigation/navigate"
 import { PlaceholderBox, PlaceholderText, ProvidePlaceholderContext } from "app/utils/placeholders"
 import { useFormikContext } from "formik"
 import { Suspense } from "react"
-import { Keyboard, TouchableOpacity } from "react-native"
+import { TouchableOpacity } from "react-native"
 
 export const SubmitArtworkSelectArtist = () => {
   const { navigateToNextStep } = useSubmissionContext()
@@ -41,7 +41,6 @@ export const SubmitArtworkSelectArtist = () => {
     const isTargetSupply = artist.__typename === "Artist" && artist.targetSupply?.isTargetSupply
 
     if (!isTargetSupply) {
-      Keyboard.dismiss()
       navigateToNextStep({
         step: "ArtistRejected",
         skipMutation: true,

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -31,6 +31,7 @@ import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
 import { FormikProvider, useFormik } from "formik"
 import { useEffect } from "react"
+import { Keyboard } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 export type SubmitArtworkStackNavigation = {
@@ -109,6 +110,7 @@ const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
   // Revalidate form on step change because the validation schema changes and it does not happen automatically
   useEffect(() => {
     formik.validateForm()
+    Keyboard.dismiss()
   }, [currentStep])
 
   return (


### PR DESCRIPTION
This PR resolves [ONYX-996] <!-- eg [PROJECT-XXXX] -->

### Description
This PR hides the keyboard after each step on the new submission flow


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-996]: https://artsyproduct.atlassian.net/browse/ONYX-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ