### PR TITLE
fix: artwork details year issues

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -39,7 +39,6 @@ export const SubmitArtworkAddDetails = () => {
               accessibilityLabel="Year"
               disabled={!!values.isYearUnknown}
               style={{ width: "50%" }}
-              required
             />
             <Spacer y={1} />
 


### PR DESCRIPTION
This PR resolves [ONYX-1001] [ONYX-1006] <!-- eg [PROJECT-XXXX] -->

### Description

This PR makes the following changes
- remove required from the year input
- fix validation after continue and save

**Before**

https://github.com/artsy/eigen/assets/11945712/b61dfabf-df32-4340-9805-b7968acc775f


**After**

https://github.com/artsy/eigen/assets/11945712/42e0a3cd-e814-4705-81f9-dadff850e6c4




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1001]: https://artsyproduct.atlassian.net/browse/ONYX-1001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1006]: https://artsyproduct.atlassian.net/browse/ONYX-1006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ