### PR TITLE
fix: eligibility alignment on artist rejected screen

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkArtistRejected.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkArtistRejected.tsx
@@ -46,13 +46,13 @@ export const SubmitArtworkArtistRejected: React.FC<{}> = () => {
       >
         <ScrollView>
           <Text>
-            {"  "}We are currently accepting unique and limited-edition works of art by modern,
+            We are currently accepting unique and limited-edition works of art by modern,
             contemporary, and emerging artists who have collector demand on Artsy. Our in-house
             experts cover Post-War and Contemporary Art, Prints and Multiples, Street Art and
             Photographs.{"\n"}
             {"\n"}
-            {"  "}Our experts assess a number of factors to determine whether your work qualifies
-            for our program, including the following:{"\n"}
+            Our experts assess a number of factors to determine whether your work qualifies for our
+            program, including the following:{"\n"}
             {"\n"}
             {"    "}• Market data like the number, recency, and value of auction results for works
             by the artist.{"\n"}


### PR DESCRIPTION
This PR resolves [ONYX-1010] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the text alignment on the artist rejected screen


![Group 16](https://github.com/artsy/eigen/assets/11945712/ad801f30-38b9-46b3-878a-6a63e84eb5f3)



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1010]: https://artsyproduct.atlassian.net/browse/ONYX-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ