### PR TITLE
fix: show exit if save and exit ff is disabled

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -6,7 +6,7 @@ import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
 import { useEffect } from "react"
-import { LayoutAnimation } from "react-native"
+import { Alert, LayoutAnimation } from "react-native"
 
 export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   const enableSaveAndExit = useFeatureFlag("AREnableSaveAndContinueSubmission")
@@ -16,6 +16,31 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   const { values } = useFormikContext<ArtworkDetailsFormModel>()
 
   const handleSaveAndExitPress = () => {
+    if (!enableSaveAndExit) {
+      if (hasCompletedForm) {
+        goBack()
+        return
+      }
+
+      Alert.alert(
+        "Are you sure you want to exit?",
+        "Your artwork will not be submitted.",
+        [
+          {
+            text: "Cancel",
+            style: "cancel",
+          },
+          {
+            text: "Yes",
+            onPress: () => goBack(),
+            style: "destructive",
+          },
+        ],
+        { cancelable: true }
+      )
+      return
+    }
+
     if (hasCompletedForm) {
       // Reset form if user is on the last step
       // This is to ensure that the user can start a new submission
@@ -55,10 +80,10 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
           <BackButton showX style={{ zIndex: 100, overflow: "visible" }} onPress={goBack} />
         )}
 
-        {currentStep !== "SelectArtist" && !!enableSaveAndExit && (
+        {currentStep !== "SelectArtist" && (
           <Flex style={{ flexGrow: 1, alignItems: "flex-end" }}>
             <Touchable onPress={handleSaveAndExitPress}>
-              <Text>{!hasCompletedForm ? "Save & " : ""}Exit</Text>
+              <Text>{!hasCompletedForm && !!enableSaveAndExit ? "Save & " : ""}Exit</Text>
             </Touchable>
           </Flex>
         )}


### PR DESCRIPTION
This PR resolves [ONYX-1009] <!-- eg [PROJECT-XXXX] -->

### Description
This PR shows **Exit** if the user has the save and exit feature flag disabled

https://github.com/artsy/eigen/assets/11945712/539ede38-35bf-449e-a83f-f2d314b2e11e



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1009]: https://artsyproduct.atlassian.net/browse/ONYX-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ