### PR TITLE
fix: Make location input dropdown visible when keyboard is up in MyC artwork form

### DIFF
--- a/src/app/Components/LocationAutocomplete.tsx
+++ b/src/app/Components/LocationAutocomplete.tsx
@@ -35,6 +35,7 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   placeholder,
   initialLocation,
   onChange,
+  onFocus,
   displayLocation = "",
   floating,
   FooterComponent,
@@ -121,7 +122,10 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
         title={title}
         placeholder={placeholder}
         onChangeText={setQuery}
-        onFocus={reset}
+        onFocus={(e) => {
+          onFocus?.(e)
+          reset()
+        }}
         onBlur={handleBlur}
         value={selectedLocation ? selectedLocation.name : query}
       />

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -43,7 +43,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
 import { isEmpty } from "lodash"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { Alert, Image, Platform, ScrollView, TouchableOpacity } from "react-native"
 import { useTracking } from "react-tracking"
 
@@ -223,6 +223,15 @@ export const MyCollectionArtworkFormMain: React.FC<
     )
   }
 
+  // To make the location input auto-suggestion dropdown visible when the keyboard is up,
+  // we scroll the y position of the location input to move it to the top of the screen.
+  const [locationInputYCoordinate, setLocationInputYCoordinate] = useState<number>(0)
+  const scrollViewRef = useRef<ScrollView>(null)
+
+  const scrollToLocationInput = useCallback(() => {
+    scrollViewRef.current?.scrollTo({ y: locationInputYCoordinate })
+  }, [locationInputYCoordinate])
+
   const deleteArtwork = async (shouldDeleteArtist?: boolean) => {
     if (!artwork) return
 
@@ -298,170 +307,183 @@ export const MyCollectionArtworkFormMain: React.FC<
           onLeave={handleBackButtonPress}
         />
 
-        <ScrollView keyboardDismissMode="on-drag" keyboardShouldPersistTaps="handled">
-          {!!isSubmission && (
-            <Message
-              containerStyle={{ mx: `${space(2)}px` }}
-              title="Changes will only appear in My Collection. They will not be applied to your sale submission."
-              IconComponent={() => (
-                <Image
-                  source={require("images/info.webp")}
-                  style={{ tintColor: color("black100") }}
-                />
-              )}
-            />
-          )}
-
-          <Flex p={2}>
-            <Join separator={<Spacer y={2} />}>
-              <ArtistField />
-
-              <Input
-                title="Title"
-                onChangeText={formik.handleChange("title")}
-                onBlur={formik.handleBlur("title")}
-                testID="TitleInput"
-                required
-                accessibilityLabel="Title"
-                value={formikValues.title}
+        <ScrollView
+          keyboardDismissMode="on-drag"
+          keyboardShouldPersistTaps="handled"
+          ref={scrollViewRef}
+        >
+          <Flex style={{ paddingBottom: 160 }}>
+            {!!isSubmission && (
+              <Message
+                containerStyle={{ mx: `${space(2)}px` }}
+                title="Changes will only appear in My Collection. They will not be applied to your sale submission."
+                IconComponent={() => (
+                  <Image
+                    source={require("images/info.webp")}
+                    style={{ tintColor: color("black100") }}
+                  />
+                )}
               />
-
-              <CategoryPicker<string>
-                value={formikValues.category}
-                options={artworkMediumCategories}
-                handleChange={handleCategory}
-              />
-
-              <Input
-                title="Year"
-                keyboardType="number-pad"
-                placeholder="Year created"
-                onChangeText={formik.handleChange("date")}
-                onBlur={formik.handleBlur("date")}
-                testID="DateInput"
-                accessibilityLabel="Year"
-                value={formikValues.date}
-              />
-
-              <Input
-                title="Materials"
-                placeholder="Oil on canvas, mixed media, lithograph.."
-                onChangeText={formik.handleChange("medium")}
-                onBlur={formik.handleBlur("medium")}
-                testID="MaterialsInput"
-                accessibilityLabel="Materials"
-                value={formikValues.medium}
-              />
-
-              <Rarity />
-
-              <Dimensions />
-
-              <MoneyInput
-                accessibilityLabel="Price paid"
-                currencyTextVariant="xs"
-                format
-                initialValues={{
-                  currency: initialCurrency as Currency,
-                  amount: formikValues.pricePaidDollars,
-                }}
-                keyboardType="decimal-pad"
-                onChange={(values) => {
-                  formik.handleChange("pricePaidDollars")(values.amount ?? "")
-                  formik.handleChange("pricePaidCurrency")(values.currency ?? "")
-                  GlobalStore.actions.userPrefs.setCurrency(values.currency as Currency)
-                }}
-                placeholder="Price paid"
-                shouldDisplayLocalError={false}
-                title="Price Paid"
-              />
-
-              <Input
-                multiline
-                title="Provenance"
-                maxLength={500}
-                showLimit
-                placeholder="Describe how you acquired the artwork"
-                value={formikValues.provenance}
-                accessibilityLabel="Describe how you acquired the artwork"
-                onChangeText={formik.handleChange("provenance")}
-                testID="ProvenanceInput"
-              />
-
-              <LocationAutocomplete
-                allowCustomLocation
-                title="Location"
-                testID="LocationInput"
-                placeholder="Enter city where artwork is located"
-                displayLocation={buildLocationDisplay(formikValues.collectorLocation)}
-                onChange={(location: LocationWithDetails) => {
-                  formik.setFieldValue("collectorLocation", {
-                    city: location.city,
-                    state: location.state,
-                    country: location.country,
-                    countryCode: location.countryCode,
-                  })
-                }}
-                accessibilityLabel="Enter city where the artwork is located"
-              />
-
-              <Input
-                multiline
-                maxLength={500}
-                showLimit
-                title="Notes"
-                onChangeText={formik.handleChange("confidentialNotes")}
-                onBlur={formik.handleBlur("confidentialNotes")}
-                testID="NotesInput"
-                accessibilityLabel="Notes"
-                value={formikValues.confidentialNotes}
-              />
-            </Join>
-          </Flex>
-
-          <Spacer y={1} />
-
-          <PhotosButton
-            testID="PhotosButton"
-            onPress={() => {
-              if (isEmpty(artworkState.sessionState.formValues.photos)) {
-                showPhotoActionSheet(showActionSheetWithOptions, true).then((photos) => {
-                  artworkActions.addPhotos(photos)
-                })
-              } else {
-                requestAnimationFrame(() => {
-                  navigation.navigate("AddPhotos")
-                })
-              }
-            }}
-          />
-
-          <Spacer y={2} />
-
-          <ScreenMargin>
-            {mode === "edit" && !!artwork && (
-              <Text
-                my={4}
-                variant="sm"
-                underline
-                color={color("red100")}
-                textAlign="center"
-                onPress={handleDelete}
-                testID="DeleteButton"
-              >
-                Delete artwork
-              </Text>
             )}
-          </ScreenMargin>
 
-          {/* Show validation errors during development */}
-          {!!(SHOW_FORM_VALIDATION_ERRORS_IN_DEV && __DEV__ && formik.errors) && (
+            <Flex p={2}>
+              <Join separator={<Spacer y={2} />}>
+                <ArtistField />
+
+                <Input
+                  title="Title"
+                  onChangeText={formik.handleChange("title")}
+                  onBlur={formik.handleBlur("title")}
+                  testID="TitleInput"
+                  required
+                  accessibilityLabel="Title"
+                  value={formikValues.title}
+                />
+
+                <CategoryPicker<string>
+                  value={formikValues.category}
+                  options={artworkMediumCategories}
+                  handleChange={handleCategory}
+                />
+
+                <Input
+                  title="Year"
+                  keyboardType="number-pad"
+                  placeholder="Year created"
+                  onChangeText={formik.handleChange("date")}
+                  onBlur={formik.handleBlur("date")}
+                  testID="DateInput"
+                  accessibilityLabel="Year"
+                  value={formikValues.date}
+                />
+
+                <Input
+                  title="Materials"
+                  placeholder="Oil on canvas, mixed media, lithograph.."
+                  onChangeText={formik.handleChange("medium")}
+                  onBlur={formik.handleBlur("medium")}
+                  testID="MaterialsInput"
+                  accessibilityLabel="Materials"
+                  value={formikValues.medium}
+                />
+
+                <Rarity />
+
+                <Dimensions />
+
+                <MoneyInput
+                  accessibilityLabel="Price paid"
+                  currencyTextVariant="xs"
+                  format
+                  initialValues={{
+                    currency: initialCurrency as Currency,
+                    amount: formikValues.pricePaidDollars,
+                  }}
+                  keyboardType="decimal-pad"
+                  onChange={(values) => {
+                    formik.handleChange("pricePaidDollars")(values.amount ?? "")
+                    formik.handleChange("pricePaidCurrency")(values.currency ?? "")
+                    GlobalStore.actions.userPrefs.setCurrency(values.currency as Currency)
+                  }}
+                  placeholder="Price paid"
+                  shouldDisplayLocalError={false}
+                  title="Price Paid"
+                />
+
+                <Input
+                  multiline
+                  title="Provenance"
+                  maxLength={500}
+                  showLimit
+                  placeholder="Describe how you acquired the artwork"
+                  value={formikValues.provenance}
+                  accessibilityLabel="Describe how you acquired the artwork"
+                  onChangeText={formik.handleChange("provenance")}
+                  testID="ProvenanceInput"
+                />
+
+                <Box
+                  onLayout={({ nativeEvent }) => {
+                    setLocationInputYCoordinate(nativeEvent.layout.y)
+                  }}
+                >
+                  <LocationAutocomplete
+                    allowCustomLocation
+                    title="Location"
+                    testID="LocationInput"
+                    placeholder="Enter city where artwork is located"
+                    displayLocation={buildLocationDisplay(formikValues.collectorLocation)}
+                    onFocus={scrollToLocationInput}
+                    onChange={(location: LocationWithDetails) => {
+                      formik.setFieldValue("collectorLocation", {
+                        city: location.city,
+                        state: location.state,
+                        country: location.country,
+                        countryCode: location.countryCode,
+                      })
+                    }}
+                    accessibilityLabel="Enter city where the artwork is located"
+                  />
+                </Box>
+
+                <Input
+                  multiline
+                  maxLength={500}
+                  showLimit
+                  title="Notes"
+                  onChangeText={formik.handleChange("confidentialNotes")}
+                  onBlur={formik.handleBlur("confidentialNotes")}
+                  testID="NotesInput"
+                  accessibilityLabel="Notes"
+                  value={formikValues.confidentialNotes}
+                />
+              </Join>
+            </Flex>
+
+            <Spacer y={1} />
+
+            <PhotosButton
+              testID="PhotosButton"
+              onPress={() => {
+                if (isEmpty(artworkState.sessionState.formValues.photos)) {
+                  showPhotoActionSheet(showActionSheetWithOptions, true).then((photos) => {
+                    artworkActions.addPhotos(photos)
+                  })
+                } else {
+                  requestAnimationFrame(() => {
+                    navigation.navigate("AddPhotos")
+                  })
+                }
+              }}
+            />
+
+            <Spacer y={2} />
+
             <ScreenMargin>
-              <Box my={2}>
-                <Text variant="sm">Errors: {JSON.stringify(formik.errors)}</Text>
-              </Box>
+              {mode === "edit" && !!artwork && (
+                <Text
+                  my={4}
+                  variant="sm"
+                  underline
+                  color={color("red100")}
+                  textAlign="center"
+                  onPress={handleDelete}
+                  testID="DeleteButton"
+                >
+                  Delete artwork
+                </Text>
+              )}
             </ScreenMargin>
-          )}
+
+            {/* Show validation errors during development */}
+            {!!(SHOW_FORM_VALIDATION_ERRORS_IN_DEV && __DEV__ && formik.errors) && (
+              <ScreenMargin>
+                <Box my={2}>
+                  <Text variant="sm">Errors: {JSON.stringify(formik.errors)}</Text>
+                </Box>
+              </ScreenMargin>
+            )}
+          </Flex>
         </ScrollView>
 
         <Flex p={2} pb={Platform.OS === "android" ? 2 : 0}>


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

This makes the location input dropdown visible when the keyboard is up in the My Collection artwork form.

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 11 41 06](https://github.com/artsy/eigen/assets/4691889/85200c8c-3ec6-42ca-8afe-652589dfd208)|![Simulator Screenshot - iPhone 15 Pro - 2024-05-29 at 11 41 28](https://github.com/artsy/eigen/assets/4691889/2eec11b0-4efe-48bb-98f4-cb56a713d8de)|


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Make location input dropdown visible when keyboard is up in MyC artwork - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
