### PR TITLE
fix: android anrs due to popover

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkList/MyCollectionArtworkGridItem.tests.tsx
@@ -41,11 +41,11 @@ describe("MyCollectionArtworkGridItem", () => {
       }),
     })
 
-    expect(screen.queryByLabelText("Go to artwork details")).toBeOnTheScreen()
-    expect(screen.queryByTestId("Fallback")).toBeOnTheScreen()
+    expect(screen.getByLabelText("Go to artwork details")).toBeOnTheScreen()
+    expect(screen.getByTestId("Fallback")).toBeOnTheScreen()
 
-    expect(screen.queryByText("artistNames")).toBeOnTheScreen()
-    expect(screen.queryByText("title")).toBeOnTheScreen()
+    expect(screen.getByText("artistNames")).toBeOnTheScreen()
+    expect(screen.getByText("title")).toBeOnTheScreen()
   })
 
   it("navigates to artwork detail on tap", () => {
@@ -95,7 +95,7 @@ describe("MyCollectionArtworkGridItem", () => {
       }),
     })
 
-    expect(screen.queryByTestId("Fallback")).toBeOnTheScreen()
+    expect(screen.getByTestId("Fallback")).toBeOnTheScreen()
   })
 
   it("renders the high demand icon if artist is P1 and demand rank is over 9", () => {


### PR DESCRIPTION
This PR resolves [PHIRE-949] <!-- eg [PROJECT-XXXX] -->

### Description

> [!IMPORTANT]  
> This is affecting users in production on Android only - iOS works as expected.

Android users (tested in Android 12) that are eligible for seeing the new popover on MyCollection are not be able to access or interact with anything in the app (Application Not Responding) when they press the profile icon.

This is due to a bug with the popover - it needs to wrap the whole component.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- android anrs due to popover in myc screen - gkartalis

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-949]: https://artsyproduct.atlassian.net/browse/PHIRE-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ