### PR TITLE
feat(AMBER-704): Small updates to Eigen artwork page for private works

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -306,6 +306,18 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         excludeVerticalMargin: true,
       })
 
+      sections.push({
+        key: "artworkDetails",
+        element: (
+          <ArtworkDetails
+            artwork={artworkAboveTheFold}
+            showReadMore={artworkAboveTheFold.isUnlisted}
+          />
+        ),
+        excludeSeparator:
+          !!artworkAboveTheFold.isUnlisted || (artworkAboveTheFold.editionSets ?? []).length > 1,
+      })
+
       if (
         artworkBelowTheFold?.isForSale &&
         !isInAuction &&
@@ -327,18 +339,6 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
           excludeSeparator: true,
         })
       }
-
-      sections.push({
-        key: "artworkDetails",
-        element: (
-          <ArtworkDetails
-            artwork={artworkAboveTheFold}
-            showReadMore={artworkAboveTheFold.isUnlisted}
-          />
-        ),
-        excludeSeparator: !!artworkAboveTheFold.isUnlisted,
-        excludeVerticalMargin: true,
-      })
 
       if (artworkAboveTheFold.isUnlisted) {
         if (!!(artworkBelowTheFold?.isForSale && !isInAuction)) {

--- a/src/app/Scenes/Artwork/Components/ArtworkDetails.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDetails.tests.tsx
@@ -36,8 +36,8 @@ describe("ArtworkDetails", () => {
     await flushPromiseQueue()
 
     expect(screen.queryByText("Medium")).toBeTruthy()
-    expect(screen.queryByText("Edition")).toBeTruthy()
     expect(screen.queryByText("Condition")).toBeTruthy()
+    expect(screen.queryByText("Certificate of Authenticity")).toBeTruthy()
     expect(screen.queryByText("Signature")).toBeTruthy()
     expect(screen.queryByText("Series")).toBeTruthy()
     expect(screen.queryByText("Publisher")).toBeTruthy()
@@ -60,7 +60,6 @@ describe("ArtworkDetails", () => {
     await flushPromiseQueue()
 
     expect(screen.queryByText("Medium")).toBeTruthy()
-    expect(screen.queryByText("Edition")).toBeTruthy()
     expect(screen.queryByText("Condition")).toBeTruthy()
 
     expect(screen.queryByText("Signature")).toBeTruthy()
@@ -71,55 +70,6 @@ describe("ArtworkDetails", () => {
     expect(screen.queryByText("Frame")).toBeNull()
     expect(screen.queryByText("Publisher")).toBeNull()
     expect(screen.queryByText("Manufacturer")).toBeNull()
-  })
-
-  describe("Edition", () => {
-    it("should be rendered edition sets 0/1", async () => {
-      renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Artwork: () => ({
-          editionOf: "Edition Set",
-          editionSets: [
-            {
-              internalID: "edition-set",
-              editionOf: "Edition Set",
-              saleMessage: "$1000",
-            },
-          ],
-        }),
-      })
-      await flushPromiseQueue()
-
-      expect(screen.queryByText("Edition Set")).toBeTruthy()
-    })
-
-    it("should NOT be rendered edition sets 2 or more", async () => {
-      renderWithHookWrappersTL(<TestRenderer />, mockEnvironment)
-
-      resolveMostRecentRelayOperation(mockEnvironment, {
-        Artwork: () => ({
-          editionOf: null,
-          editionSets: [
-            {
-              internalID: "edition-set-one",
-              editionOf: "Edition Set One",
-              saleMessage: "$1000",
-            },
-            {
-              internalID: "edition-set-two",
-              editionOf: "Edition Set Two",
-              saleMessage: "$2000",
-            },
-          ],
-        }),
-      })
-      await flushPromiseQueue()
-
-      expect(screen.queryByText("Edition")).toBeNull()
-      expect(screen.queryByText("Edition Set One")).toBeNull()
-      expect(screen.queryByText("Edition Set Two")).toBeNull()
-    })
   })
 
   it("navigates to medium info when tapped", async () => {

--- a/src/app/Scenes/Artwork/Components/ArtworkDetails.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDetails.tsx
@@ -10,7 +10,7 @@ import { ArtworkDetailsRow } from "./ArtworkDetailsRow"
 import { RequestConditionReportQueryRenderer } from "./RequestConditionReport"
 
 // Number of items to display when read more is visible
-const COLLAPSED_COUNT = 4
+const COLLAPSED_COUNT = 3
 
 interface ArtworkDetailsProps {
   artwork: ArtworkDetails_artwork$key
@@ -35,10 +35,6 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
       ),
     },
     {
-      title: "Edition",
-      value: (artworkData.editionSets ?? []).length < 2 ? artworkData.editionOf : null,
-    },
-    {
       title: "Condition",
       value: artworkData?.canRequestLotConditionsReport ? (
         //  this is here to reset the margin that lives in the RequestConditionReport component
@@ -56,6 +52,14 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
       value: artworkData?.signatureInfo?.details,
     },
     {
+      title: "Certificate of Authenticity",
+      value: artworkData?.certificateOfAuthenticity?.details && (
+        <Text variant="xs" color="black100">
+          {artworkData?.certificateOfAuthenticity?.details}
+        </Text>
+      ),
+    },
+    {
       title: "Series",
       value: artworkData?.series,
     },
@@ -69,7 +73,9 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
 
   const allDisplayItems = listItems.filter((item) => !!item.value)
 
-  const [isCollapsed, setIsCollapsed] = React.useState(showReadMore && allDisplayItems.length > 4)
+  const [isCollapsed, setIsCollapsed] = React.useState(
+    showReadMore && allDisplayItems.length > COLLAPSED_COUNT
+  )
 
   const displayItems = isCollapsed ? allDisplayItems.slice(0, COLLAPSED_COUNT) : allDisplayItems
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [AMBER-704] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

As discussed with Peter, we would like to re-add the COA info to the artwork details, move the edition radio buttons to match web, and make some small design adjustments

<img width="445" alt="Screenshot 2024-05-30 at 2 13 34 PM" src="https://github.com/artsy/eigen/assets/5643895/5b726abc-2148-4a20-9e56-eb0b22e71a27">

<img width="458" alt="Screenshot 2024-05-30 at 2 09 07 PM" src="https://github.com/artsy/eigen/assets/5643895/e7e2333c-daa7-4543-9c02-11165cce894c">

<img width="451" alt="Screenshot 2024-05-30 at 2 10 14 PM" src="https://github.com/artsy/eigen/assets/5643895/94e6c2a0-87a2-4840-836e-a41adc3ec039">



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
Adds COA back to artwork details and adjusts styling - lfp
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
