### PR TITLE
fix: first two artworks on collections are truncated

### DIFF
--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -32,7 +32,6 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({
   })
 
   const tracking = useTracking()
-  const { isDepartment } = collection
   const artworks = get(collection, (p) => p.collectionArtworks)
   const artworksTotal = artworks?.counts?.total
   const initialArtworksTotal = useRef(artworksTotal)
@@ -83,7 +82,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({
   }
 
   return artworks ? (
-    <ArtworkGridWrapper isDepartment={isDepartment}>
+    <ArtworkGridWrapper>
       <InfiniteScrollArtworksGrid
         connection={artworks}
         loadMore={relay.loadMore}
@@ -96,8 +95,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({
   ) : null
 }
 
-const ArtworkGridWrapper = styled(Box)<{ isDepartment: boolean }>`
-  margin-top: ${(p: any /* STRICTNESS_MIGRATION */) => (p.isDepartment ? "0px" : "-50px")};
+const ArtworkGridWrapper = styled(Box)`
   padding-bottom: 50px;
 `
 


### PR DESCRIPTION
This PR resolves [APPL-922] <!-- eg [PROJECT-XXXX] -->

### Description

|Before|After|
|---|---|
|**Android**||
|<img width="365" alt="Screenshot 2024-05-31 at 15 41 46" src="https://github.com/artsy/eigen/assets/21178754/47a6bdb0-eaf6-4552-8c3f-b7c16248771f">|<img width="364" alt="Screenshot 2024-05-31 at 15 41 59" src="https://github.com/artsy/eigen/assets/21178754/e8f29d9a-6cd5-441c-a2de-74a832f4319b">|
|**iOS**||
|![Simulator Screenshot - iPhone 14 Pro - 2024-05-31 at 15 46 09](https://github.com/artsy/eigen/assets/21178754/813a8532-cff8-4da3-9b6c-bb794535dc0e)|![Simulator Screenshot - iPhone 14 Pro - 2024-05-31 at 15 45 47](https://github.com/artsy/eigen/assets/21178754/b08670be-beb0-48b8-853e-891bd6cf733f)|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- first collection artworks are truncated - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
