### PR TITLE
fix: crash on masonry dynamic columns empty state

### DIFF
--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -97,19 +97,31 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
 
   const FlashlistComponent = animated ? AnimatedMasonryFlashList : MasonryFlashList
 
+  const hasArtworks = artworks.length > 0
+
+  const getAdjustedNumColumns = () => {
+    if (hasArtworks) {
+      return rest.numColumns ?? NUM_COLUMNS_MASONRY
+    }
+    // WARNING: if the masonry is empty we need to have numColumns=1 to avoid a crash
+    // that happens only when we dynamically change the number of columns see more here:
+    // https://github.com/artsy/eigen/pull/10319
+    return 1
+  }
+
   return (
     <FlashlistComponent
       keyboardShouldPersistTaps="handled"
       contentContainerStyle={{
         // No paddings are needed for single column grids
-        paddingHorizontal: rest.numColumns === 1 ? 0 : space(2),
+        paddingHorizontal: getAdjustedNumColumns() === 1 ? 0 : space(2),
         paddingBottom: artworks.length === 1 ? 0 : space(6),
       }}
       data={artworks}
       keyExtractor={(item) => item.id}
       onEndReached={onEndReached}
       onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-      numColumns={rest.numColumns ?? NUM_COLUMNS_MASONRY}
+      numColumns={getAdjustedNumColumns()}
       estimatedItemSize={ESTIMATED_MASONRY_ITEM_SIZE}
       ListHeaderComponent={shouldDisplayHeader ? ListHeaderComponent : null}
       ListEmptyComponent={ListEmptyComponent}

--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
@@ -45,6 +45,9 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
       loadMore={() => loadNext(PAGE_SIZE)}
       isLoading={isLoadingNext}
       onScroll={scrollHandler}
+      // WARNING: if the masonry is empty we need to have numColumns=1 to avoid a crash
+      // that happens only when we dynamically change the number of columns see more here:
+      // https://github.com/artsy/eigen/pull/10319
       numColumns={hasArtworks ? numOfColumns : 1}
     />
   )

--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
@@ -28,7 +28,7 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
 
   const artworks = extractNodes(data?.newWorksFromGalleriesYouFollowConnection)
   const RefreshControl = useRefreshControl(refetch)
-
+  const hasArtworks = artworks.length > 0
   const numOfColumns = defaultViewOption === "grid" ? NUM_COLUMNS_MASONRY : 1
 
   return (
@@ -45,7 +45,7 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
       loadMore={() => loadNext(PAGE_SIZE)}
       isLoading={isLoadingNext}
       onScroll={scrollHandler}
-      numColumns={numOfColumns}
+      numColumns={hasArtworks ? numOfColumns : 1}
     />
   )
 }

--- a/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
+++ b/src/app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow.tsx
@@ -28,7 +28,6 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
 
   const artworks = extractNodes(data?.newWorksFromGalleriesYouFollowConnection)
   const RefreshControl = useRefreshControl(refetch)
-  const hasArtworks = artworks.length > 0
   const numOfColumns = defaultViewOption === "grid" ? NUM_COLUMNS_MASONRY : 1
 
   return (
@@ -45,10 +44,7 @@ export const NewWorksFromGalleriesYouFollow: React.FC = () => {
       loadMore={() => loadNext(PAGE_SIZE)}
       isLoading={isLoadingNext}
       onScroll={scrollHandler}
-      // WARNING: if the masonry is empty we need to have numColumns=1 to avoid a crash
-      // that happens only when we dynamically change the number of columns see more here:
-      // https://github.com/artsy/eigen/pull/10319
-      numColumns={hasArtworks ? numOfColumns : 1}
+      numColumns={numOfColumns}
     />
   )
 }

--- a/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
+++ b/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
@@ -27,6 +27,7 @@ export const RecentlyViewedArtworks: React.FC = () => {
   >(artworkConnectionFragment, queryData.me)
 
   const artworks = extractNodes(data?.recentlyViewedArtworksConnection)
+  const hasArtworks = artworks.length > 0
   const RefreshControl = useRefreshControl(refetch)
 
   const numOfColumns = defaultViewOption === "grid" ? NUM_COLUMNS_MASONRY : 1
@@ -44,7 +45,7 @@ export const RecentlyViewedArtworks: React.FC = () => {
       hasMore={hasNext}
       loadMore={(pageSize) => loadNext(pageSize)}
       isLoading={isLoadingNext}
-      numColumns={numOfColumns}
+      numColumns={hasArtworks ? numOfColumns : 1}
       onScroll={scrollHandler}
     />
   )

--- a/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
+++ b/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
@@ -45,6 +45,9 @@ export const RecentlyViewedArtworks: React.FC = () => {
       hasMore={hasNext}
       loadMore={(pageSize) => loadNext(pageSize)}
       isLoading={isLoadingNext}
+      // WARNING: if the masonry is empty we need to have numColumns=1 to avoid a crash
+      // that happens only when we dynamically change the number of columns see more here:
+      // https://github.com/artsy/eigen/pull/10319
       numColumns={hasArtworks ? numOfColumns : 1}
       onScroll={scrollHandler}
     />

--- a/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
+++ b/src/app/Scenes/RecentlyViewed/Components/RecentlyViewedArtworks.tsx
@@ -27,7 +27,6 @@ export const RecentlyViewedArtworks: React.FC = () => {
   >(artworkConnectionFragment, queryData.me)
 
   const artworks = extractNodes(data?.recentlyViewedArtworksConnection)
-  const hasArtworks = artworks.length > 0
   const RefreshControl = useRefreshControl(refetch)
 
   const numOfColumns = defaultViewOption === "grid" ? NUM_COLUMNS_MASONRY : 1
@@ -45,10 +44,7 @@ export const RecentlyViewedArtworks: React.FC = () => {
       hasMore={hasNext}
       loadMore={(pageSize) => loadNext(pageSize)}
       isLoading={isLoadingNext}
-      // WARNING: if the masonry is empty we need to have numColumns=1 to avoid a crash
-      // that happens only when we dynamically change the number of columns see more here:
-      // https://github.com/artsy/eigen/pull/10319
-      numColumns={hasArtworks ? numOfColumns : 1}
+      numColumns={numOfColumns}
       onScroll={scrollHandler}
     />
   )


### PR DESCRIPTION
This PR resolves [APPL-933] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes a crash that was happening on masonry surfaces that we were changing the `numColumns` dynamically. This occurred only when the artworks array was empty.

#### Android

|Before|After|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/21178754/f9d921dd-542a-432b-8715-0a3c193771fe" width="400" />|<video src="https://github.com/artsy/eigen/assets/21178754/bd4928bc-8e75-4695-b031-2635c3261c2f" width="400" />|

### iOS

|Before|After|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/21178754/710fde47-a9ed-4763-880e-2210ef9a05c3" width="400" />|<video src="https://github.com/artsy/eigen/assets/21178754/a3b39d89-c756-4213-9c0e-d8b9d6e6694e" width="400" />|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- crash on masonry dynamic columns empty state - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-933]: https://artsyproduct.atlassian.net/browse/APPL-933?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ