### PR TITLE
fix(ONYX-1026): navigate to the previous screen only after the keyboard is closed

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -5,13 +5,14 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
-import { useEffect } from "react"
-import { Alert, LayoutAnimation } from "react-native"
+import { useEffect, useState } from "react"
+import { Alert, Keyboard, LayoutAnimation } from "react-native"
 
 export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   const enableSaveAndExit = useFeatureFlag("AREnableSaveAndContinueSubmission")
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const hasCompletedForm = currentStep === "CompleteYourSubmission"
+  const [backPressed, setBackPressed] = useState(false)
 
   const { values } = useFormikContext<ArtworkDetailsFormModel>()
 
@@ -62,6 +63,18 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
   }, [currentStep])
 
+  useEffect(() => {
+    const hideSubscription = Keyboard.addListener("keyboardDidHide", () => {
+      if (backPressed) {
+        goBack()
+      }
+    })
+
+    return () => {
+      hideSubscription.remove()
+    }
+  }, [backPressed])
+
   if (!currentStep) {
     return null
   }
@@ -73,11 +86,19 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
       </Flex>
     )
   }
+
   return (
     <Flex mx={2} height={40}>
       <Flex flexDirection="row" justifyContent="space-between">
         {currentStep === "SelectArtist" && (
-          <BackButton showX style={{ zIndex: 100, overflow: "visible" }} onPress={goBack} />
+          <BackButton
+            showX
+            style={{ zIndex: 100, overflow: "visible" }}
+            onPress={() => {
+              Keyboard.dismiss()
+              setBackPressed(true)
+            }}
+          />
         )}
 
         {currentStep !== "SelectArtist" && (


### PR DESCRIPTION
This PR resolves [ONYX-1026] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

When we go back from a modal where we used a keyboard to the previous screen, it takes time for the keyboard to close. We need to make sure the keyboard is closed before navigating back.

In this PR we added a keyboard listener that allows us to know when the keyboard is closed. After the keyboard is closed, we navigate back to the previous screen.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

- navigate to the previous screen only after the keyboard is closed -daria

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1026]: https://artsyproduct.atlassian.net/browse/ONYX-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ