### PR TITLE
feat(onyx-1034): update purchase history step

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkPurchaseHistory.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkPurchaseHistory.tsx
@@ -21,17 +21,11 @@ export const SubmitArtworkPurchaseHistory = () => {
   return (
     <Flex px={2}>
       <Text variant="lg" mb={2}>
-        Purchase history
+        Where did you purchase the artwork?
       </Text>
 
       <Join separator={<Spacer y={2} />}>
-        <Text variant="xs" color="black60">
-          The documented history of an artwork’s ownership and authenticity. Please add any
-          documentation you have that proves your artwork’s provenance:
-        </Text>
-
         <Flex>
-          <Text mb={2}>Where did you purchase the work?</Text>
           <Select
             options={PROVENANCE_LIST}
             title="Purchase information"

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -155,7 +155,7 @@ export const artworkDetailsEmptyInitialValues: ArtworkDetailsFormModel = {
   medium: "",
   myCollectionArtworkID: null,
   provenance: "",
-  signature: false,
+  signature: null,
   source: null,
   state: "DRAFT",
   utmMedium: "",

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -155,7 +155,7 @@ export const artworkDetailsEmptyInitialValues: ArtworkDetailsFormModel = {
   medium: "",
   myCollectionArtworkID: null,
   provenance: "",
-  signature: null,
+  signature: false,
   source: null,
   state: "DRAFT",
   utmMedium: "",


### PR DESCRIPTION
This PR resolves [ONYX-1034]

### Description

- Change title from "Purchase history" to "Where did you purchase the artwork?"
- Remove "The document history of an artwork's ownership and authenticity. Please add ..." text.

![Simulator Screenshot - iPhone 15 Pro - 2024-06-03 at 12 24 11](https://github.com/artsy/eigen/assets/3934579/9f1daff7-e353-4abf-9123-269838278a36)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details>
#nochangelog
</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1034]: https://artsyproduct.atlassian.net/browse/ONYX-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ