### PR TITLE
feat(onyx-1031): move sell progress bar to the top

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -1,6 +1,5 @@
 import { Button, Flex, Spacer, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
-import { SubmitArtworkProgressBar } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar"
 import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
@@ -72,14 +71,10 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
       <Flex
         borderTopWidth={1}
         borderTopColor="black10"
-        pb={2}
+        py={2}
         width={screenWidth}
         alignSelf="center"
       >
-        <Flex mx={2} my={1}>
-          <SubmitArtworkProgressBar />
-        </Flex>
-
         <Flex px={2}>
           <Spacer y={1} />
 
@@ -147,11 +142,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
   }
 
   return (
-    <Flex borderTopWidth={1} borderTopColor="black10" pb={2} width="100%" alignSelf="center">
-      <Flex mx={2} my={1}>
-        <SubmitArtworkProgressBar />
-      </Flex>
-
+    <Flex borderTopWidth={1} borderTopColor="black10" py={2} width="100%" alignSelf="center">
       <Flex px={2}>
         <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
           <Flex flexDirection="row" alignItems="center">

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar.tsx
@@ -61,7 +61,6 @@ export const SubmitArtworkProgressBar: React.FC = ({}) => {
       <Flex>
         <ProgressBar
           progress={progress * 100}
-          height={4}
           animationDuration={300}
           trackColor={hasCompletedForm ? "green100" : "blue100"}
         />

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar.tsx
@@ -61,6 +61,7 @@ export const SubmitArtworkProgressBar: React.FC = ({}) => {
       <Flex>
         <ProgressBar
           progress={progress * 100}
+          height={4}
           animationDuration={300}
           trackColor={hasCompletedForm ? "green100" : "blue100"}
         />

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -1,5 +1,6 @@
 import { BackButton, Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
+import { SubmitArtworkProgressBar } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkProgressBar"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -98,7 +99,7 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   }
 
   return (
-    <Flex mx={2} height={40}>
+    <Flex mx={2} height={40} mb={2}>
       <Flex flexDirection="row" justifyContent="space-between">
         {currentStep === "SelectArtist" && (
           <BackButton
@@ -112,13 +113,15 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
         )}
 
         {currentStep !== "SelectArtist" && (
-          <Flex style={{ flexGrow: 1, alignItems: "flex-end" }}>
+          <Flex style={{ flexGrow: 1, alignItems: "flex-end" }} mb={0.5}>
             <Touchable onPress={handleSaveAndExitPress}>
               <Text>{!hasCompletedForm && !!enableSaveAndExit ? "Save & " : ""}Exit</Text>
             </Touchable>
           </Flex>
         )}
       </Flex>
+
+      <SubmitArtworkProgressBar />
     </Flex>
   )
 }


### PR DESCRIPTION
This PR resolves [ONYX-1031]

### Description

Demo:

* In the recording progress bar is thin because I removed `height={4}`, but I brought it back as per design


https://github.com/artsy/eigen/assets/3934579/be010dce-41fb-40e5-87ad-a11950259d48





### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details>
#nochangelog
</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1031]: https://artsyproduct.atlassian.net/browse/ONYX-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ