### PR TITLE
fix(ONYX-1026): start selling sticky button hoisted up (attempt 2)

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -7,18 +7,19 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { Alert, Keyboard, LayoutAnimation } from "react-native"
 
 export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   const enableSaveAndExit = useFeatureFlag("AREnableSaveAndContinueSubmission")
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const hasCompletedForm = currentStep === "CompleteYourSubmission"
-  const [backPressed, setBackPressed] = useState(false)
 
   const { values } = useFormikContext<ArtworkDetailsFormModel>()
 
   const handleSaveAndExitPress = async () => {
+    Keyboard.dismiss()
+
     if (!enableSaveAndExit) {
       if (hasCompletedForm) {
         goBack()
@@ -74,18 +75,6 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
   }, [currentStep])
 
-  useEffect(() => {
-    const hideSubscription = Keyboard.addListener("keyboardDidHide", () => {
-      if (backPressed) {
-        goBack()
-      }
-    })
-
-    return () => {
-      hideSubscription.remove()
-    }
-  }, [backPressed])
-
   if (!currentStep) {
     return null
   }
@@ -105,9 +94,11 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
           <BackButton
             showX
             style={{ zIndex: 100, overflow: "visible" }}
-            onPress={() => {
-              Keyboard.dismiss()
-              setBackPressed(true)
+            onPress={async () => {
+              await Keyboard.dismiss()
+              setTimeout(() => {
+                goBack()
+              }, 100)
             }}
           />
         )}

--- a/src/app/Scenes/SellWithArtsy/Components/StickySWAHeader.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/StickySWAHeader.tsx
@@ -25,29 +25,27 @@ export const StickySWAHeader: React.FC<StickySWAHeaderProps> = ({
   }
 
   return (
-    <>
-      <Flex p={2} borderTopWidth={1} borderTopColor="black10">
-        <Button
-          testID="header-consign-CTA"
-          block
-          onPress={() => {
-            handleSubmitPress("Start Selling")
-          }}
-          variant="fillDark"
-        >
-          Start Selling
-        </Button>
+    <Flex p={2} borderTopWidth={1} borderTopColor="black10">
+      <Button
+        testID="header-consign-CTA"
+        block
+        onPress={() => {
+          handleSubmitPress("Start Selling")
+        }}
+        variant="fillDark"
+      >
+        Start Selling
+      </Button>
 
-        <Spacer y={1} />
+      <Spacer y={1} />
 
-        <Text variant="xs">
-          Not sure what you’re looking for?{" "}
-          <LinkText testID="StickySWAHeader-inquiry-CTA" onPress={handleInquiryPress}>
-            <Text variant="xs">Speak to an advisor</Text>
-          </LinkText>
-        </Text>
-      </Flex>
-    </>
+      <Text variant="xs">
+        Not sure what you’re looking for?{" "}
+        <LinkText testID="StickySWAHeader-inquiry-CTA" onPress={handleInquiryPress}>
+          <Text variant="xs">Speak to an advisor</Text>
+        </LinkText>
+      </Text>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
This PR resolves [ONYX-1026] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Turned out the fix in this PR was breaking the flow ([that's why](https://github.com/artsy/eigen/pull/10321#pullrequestreview-2093435900)). We paired with Ole and decided to proceed with the solution which seems to work fine. We added a timeout to let the keyboard have more time to close and made the function asynchronous
Also, we found out that the issue is present on iOS as well, it's just not so obvious

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- wait for the keyboard to close before navigating back on the Sell flow -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1026]: https://artsyproduct.atlassian.net/browse/ONYX-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ