### PR TITLE
fix: Refresh Sell screen when updating the current draft submission

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -6,6 +6,7 @@ import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { refreshSellScreen } from "app/utils/refreshHelpers"
 import { useFormikContext } from "formik"
 import { useEffect } from "react"
 import { Alert, Keyboard, LayoutAnimation } from "react-native"
@@ -62,6 +63,8 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
           currentStep,
         })
       }
+
+      refreshSellScreen()
     } catch (error) {
       console.error("Something went wrong. The submission could not be saved.", error)
 
@@ -90,7 +93,7 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
   return (
     <Flex mx={2} height={40} mb={2}>
       <Flex flexDirection="row" justifyContent="space-between">
-        {currentStep === "SelectArtist" && (
+        {currentStep === "SelectArtist" ? (
           <BackButton
             showX
             style={{ zIndex: 100, overflow: "visible" }}
@@ -101,9 +104,7 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
               }, 100)
             }}
           />
-        )}
-
-        {currentStep !== "SelectArtist" && (
+        ) : (
           <Flex style={{ flexGrow: 1, alignItems: "flex-end" }} mb={0.5}>
             <Touchable onPress={handleSaveAndExitPress}>
               <Text>{!hasCompletedForm && !!enableSaveAndExit ? "Save & " : ""}Exit</Text>

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tests.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, screen } from "@testing-library/react-native"
+import { SellWithArtsyHomeTestQuery } from "__generated__/SellWithArtsyHomeTestQuery.graphql"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
 import { SellWithArtsyHome } from "./SellWithArtsyHome"
 
 jest.mock("../../utils/useStatusBarStyle", () => {
@@ -42,16 +44,40 @@ jest.mock("./utils/useSWALandingPageData", () => {
   }
 })
 
-describe("New SellWithArtsyLandingPage", () => {
-  describe("Tracking", () => {
-    const TestWrapper = () => {
-      return <SellWithArtsyHome />
-    }
+describe("SellWithArtsyHome", () => {
+  const { renderWithRelay } = setupTestWrapper<SellWithArtsyHomeTestQuery>({
+    Component: (props) => {
+      if (props?.me) {
+        return <SellWithArtsyHome />
+      }
 
+      return null
+    },
+    variables: { submissionID: "1234", includeSubmission: false },
+    query: graphql`
+      query SellWithArtsyHomeTestQuery($submissionID: ID, $includeSubmission: Boolean = false)
+      @relay_test_operation {
+        recentlySoldArtworks {
+          ...SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection
+        }
+        me {
+          internalID
+          name
+          email
+          phone
+        }
+        submission(id: $submissionID) @include(if: $includeSubmission) {
+          ...Header_submission
+        }
+      }
+    `,
+  })
+
+  describe("Tracking", () => {
     // HEADER
     describe("Header Events", () => {
       it("tracks Consign Events", async () => {
-        renderWithWrappers(<TestWrapper />)
+        renderWithRelay({})
         const headerConsignButton = screen.getByTestId("header-consign-CTA")
 
         fireEvent(headerConsignButton, "onPress")
@@ -68,7 +94,7 @@ describe("New SellWithArtsyLandingPage", () => {
       })
 
       it("tracks Inquiry Events", () => {
-        renderWithWrappers(<TestWrapper />)
+        renderWithRelay({})
         const headerInquiryButton = screen.getByTestId("MeetTheSpecialists-contact-CTA")
 
         fireEvent(headerInquiryButton, "onPress")
@@ -88,7 +114,7 @@ describe("New SellWithArtsyLandingPage", () => {
     // MEETTHESPECIALISTS
     describe("MeetTheSpecialists Events", () => {
       it("tracks Inquiry Events", () => {
-        renderWithWrappers(<TestWrapper />)
+        renderWithRelay({})
         const headerConsignButton = screen.getByTestId("MeetTheSpecialists-inquiry-CTA")
 
         fireEvent(headerConsignButton, "onPress")
@@ -108,7 +134,7 @@ describe("New SellWithArtsyLandingPage", () => {
     // SPEAKTOTHETEAM
     describe("SpeakToTheTeam Events", () => {
       it("tracks Inquiry Events", () => {
-        renderWithWrappers(<TestWrapper />)
+        renderWithRelay({})
         const headerConsignButton = screen.getByTestId("SpeakToTheTeam-inquiry-CTA")
 
         fireEvent(headerConsignButton, "onPress")

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -184,43 +184,6 @@ export const SellWithArtsyHomeQueryRenderer: React.FC = () => {
   )
 }
 
-// export const SellWithArtsyHomeQueryRenderer: React.FC<SellWithArtsyHomeQueryRendererProps> = ({
-//   environment,
-// }) => {
-//   const { draft } = GlobalStore.useAppState((state) => state.artworkSubmission)
-
-//   const submissionID = draft?.submissionID
-
-//   const [refreshKey, setRefreshKey] = useState(0)
-
-//   useEffect(() => {
-//     RefreshEvents.addListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
-//     return () => {
-//       RefreshEvents.removeListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
-//     }
-//   }, [])
-
-//   const handleRefreshEvent = () => {
-//     setRefreshKey(refreshKey + 1)
-//   }
-
-//   console.log({ refreshKey })
-
-//   return (
-//     <QueryRenderer<SellWithArtsyHomeQuery>
-//       key={refreshKey}
-//       environment={environment || getRelayEnvironment()}
-//       variables={{ submissionID: submissionID, includeSubmission: !!submissionID }}
-//       query={SellWithArtsyHomeScreenQuery}
-//       cacheConfig={{ force: true, fetchPolicy: "network-only" }}
-//       render={renderWithPlaceholder({
-//         Container: SellWithArtsyHomeContainer,
-//         renderPlaceholder: () => <SellWithArtsyHomePlaceholder />,
-//       })}
-//     />
-//   )
-// }
-
 const SellWithArtsyHomePlaceholder: React.FC = () => {
   return (
     <Skeleton>

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -9,9 +9,6 @@ import {
   Spacer,
 } from "@artsy/palette-mobile"
 import { SellWithArtsyHomeQuery } from "__generated__/SellWithArtsyHomeQuery.graphql"
-import { SellWithArtsyHome_me$data } from "__generated__/SellWithArtsyHome_me.graphql"
-import { SellWithArtsyHome_recentlySoldArtworksTypeConnection$data } from "__generated__/SellWithArtsyHome_recentlySoldArtworksTypeConnection.graphql"
-import { SellWithArtsyHome_submission$data } from "__generated__/SellWithArtsyHome_submission.graphql"
 import { CollectorsNetwork } from "app/Scenes/SellWithArtsy/Components/CollectorsNetwork"
 import { FAQSWA } from "app/Scenes/SellWithArtsy/Components/FAQSWA"
 import { Highlights } from "app/Scenes/SellWithArtsy/Components/Highlights"
@@ -22,31 +19,46 @@ import { Testimonials } from "app/Scenes/SellWithArtsy/Components/Testimonials"
 import { WaysWeSell } from "app/Scenes/SellWithArtsy/Components/WaysWeSell"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
+import { RefreshEvents, SELL_SCREEN_REFRESH_KEY } from "app/utils/refreshHelpers"
 import { useSwitchStatusBarStyle } from "app/utils/useStatusBarStyle"
-import { useEffect } from "react"
+import { Suspense, useEffect, useReducer } from "react"
 import { ScrollView, StatusBarStyle } from "react-native"
-import { createFragmentContainer, Environment, graphql, QueryRenderer } from "react-relay"
+import { graphql, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
 import { Footer } from "./Components/Footer"
 import { Header } from "./Components/Header"
 import { HowItWorks } from "./Components/HowItWorks"
 import { SellWithArtsyRecentlySold } from "./Components/SellWithArtsyRecentlySold"
 
-interface SellWithArtsyHomeProps {
-  recentlySoldArtworks?: SellWithArtsyHome_recentlySoldArtworksTypeConnection$data
-  me?: SellWithArtsyHome_me$data
-  submission?: SellWithArtsyHome_submission$data
-}
+export const SellWithArtsyHome: React.FC = () => {
+  const { draft } = GlobalStore.useAppState((state) => state.artworkSubmission)
 
-export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({
-  recentlySoldArtworks,
-  me,
-  submission,
-}) => {
+  const submissionID = draft?.submissionID
+
+  const [fetchKey, increaseFetchKey] = useReducer((state) => state + 1, 0)
+
+  useEffect(() => {
+    RefreshEvents.addListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
+    return () => {
+      RefreshEvents.removeListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
+    }
+  }, [])
+
+  const handleRefreshEvent = () => {
+    increaseFetchKey()
+  }
+
+  const { recentlySoldArtworks, me, submission } = useLazyLoadQuery<SellWithArtsyHomeQuery>(
+    SellWithArtsyHomeScreenQuery,
+    { submissionID: submissionID, includeSubmission: !!submissionID },
+    {
+      fetchPolicy: "store-and-network",
+      fetchKey: fetchKey ?? 0,
+    }
+  )
+
   const onFocusStatusBarStyle: StatusBarStyle = "dark-content"
   const onBlurStatusBarStyle: StatusBarStyle = "dark-content"
 
@@ -147,64 +159,67 @@ export const SellWithArtsyHome: React.FC<SellWithArtsyHomeProps> = ({
   )
 }
 
-const SellWithArtsyHomeContainer = createFragmentContainer(SellWithArtsyHome, {
-  recentlySoldArtworks: graphql`
-    fragment SellWithArtsyHome_recentlySoldArtworksTypeConnection on RecentlySoldArtworkTypeConnection {
+export const SellWithArtsyHomeScreenQuery = graphql`
+  query SellWithArtsyHomeQuery($submissionID: ID, $includeSubmission: Boolean = false) {
+    recentlySoldArtworks {
       ...SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection
     }
-  `,
-  me: graphql`
-    fragment SellWithArtsyHome_me on Me {
+    me {
       internalID
       name
       email
       phone
     }
-  `,
-  submission: graphql`
-    fragment SellWithArtsyHome_submission on ConsignmentSubmission {
-      ...Header_submission
-    }
-  `,
-})
-
-interface SellWithArtsyHomeQueryRendererProps {
-  environment?: Environment
-}
-
-export const SellWithArtsyHomeScreenQuery = graphql`
-  query SellWithArtsyHomeQuery($submissionID: ID, $includeSubmission: Boolean = false) {
-    recentlySoldArtworks {
-      ...SellWithArtsyHome_recentlySoldArtworksTypeConnection
-    }
-    me {
-      ...SellWithArtsyHome_me
-    }
     submission(id: $submissionID) @include(if: $includeSubmission) {
-      ...SellWithArtsyHome_submission
+      ...Header_submission
     }
   }
 `
 
-export const SellWithArtsyHomeQueryRenderer: React.FC<SellWithArtsyHomeQueryRendererProps> = ({
-  environment,
-}) => {
-  const { draft } = GlobalStore.useAppState((state) => state.artworkSubmission)
-
-  const submissionID = draft?.submissionID
-
+export const SellWithArtsyHomeQueryRenderer: React.FC = () => {
   return (
-    <QueryRenderer<SellWithArtsyHomeQuery>
-      environment={environment || getRelayEnvironment()}
-      variables={{ submissionID: submissionID, includeSubmission: !!submissionID }}
-      query={SellWithArtsyHomeScreenQuery}
-      render={renderWithPlaceholder({
-        Container: SellWithArtsyHomeContainer,
-        renderPlaceholder: () => <SellWithArtsyHomePlaceholder />,
-      })}
-    />
+    <Suspense fallback={<SellWithArtsyHomePlaceholder />}>
+      <SellWithArtsyHome />
+    </Suspense>
   )
 }
+
+// export const SellWithArtsyHomeQueryRenderer: React.FC<SellWithArtsyHomeQueryRendererProps> = ({
+//   environment,
+// }) => {
+//   const { draft } = GlobalStore.useAppState((state) => state.artworkSubmission)
+
+//   const submissionID = draft?.submissionID
+
+//   const [refreshKey, setRefreshKey] = useState(0)
+
+//   useEffect(() => {
+//     RefreshEvents.addListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
+//     return () => {
+//       RefreshEvents.removeListener(SELL_SCREEN_REFRESH_KEY, handleRefreshEvent)
+//     }
+//   }, [])
+
+//   const handleRefreshEvent = () => {
+//     setRefreshKey(refreshKey + 1)
+//   }
+
+//   console.log({ refreshKey })
+
+//   return (
+//     <QueryRenderer<SellWithArtsyHomeQuery>
+//       key={refreshKey}
+//       environment={environment || getRelayEnvironment()}
+//       variables={{ submissionID: submissionID, includeSubmission: !!submissionID }}
+//       query={SellWithArtsyHomeScreenQuery}
+//       cacheConfig={{ force: true, fetchPolicy: "network-only" }}
+//       render={renderWithPlaceholder({
+//         Container: SellWithArtsyHomeContainer,
+//         renderPlaceholder: () => <SellWithArtsyHomePlaceholder />,
+//       })}
+//     />
+//   )
+// }
 
 const SellWithArtsyHomePlaceholder: React.FC = () => {
   return (

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -10,6 +10,7 @@ export const FAVORITE_ARTWORKS_REFRESH_KEY = "refreshFavoriteArtworks"
 export const MY_COLLECTION_REFRESH_KEY = "refreshMyCollection"
 export const MY_COLLECTION_INSIGHTS_REFRESH_KEY = "refreshMyCollectionInsights"
 export const SAVED_ALERT_REFRESH_KEY = "refreshSavedAlerts"
+export const SELL_SCREEN_REFRESH_KEY = "refreshSellScreen"
 
 export const refreshSavedAlerts = () => {
   RefreshEvents.emit(SAVED_ALERT_REFRESH_KEY)
@@ -29,6 +30,10 @@ export const refreshMyCollectionInsights = ({ collectionHasArtworksWithoutInsigh
 
 export const refreshFavoriteArtworks = () => {
   RefreshEvents.emit(FAVORITE_ARTWORKS_REFRESH_KEY)
+}
+
+export const refreshSellScreen = () => {
+  RefreshEvents.emit(SELL_SCREEN_REFRESH_KEY)
 }
 
 interface RefreshArgs extends Record<string, any> {


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

With this fix, the Sell screen refetches the current draft submission when clicking "Save & Exit" in the submission form.


### Before


https://github.com/artsy/eigen/assets/4691889/437ee2c7-7fb2-4dcf-aac5-68beb65e74ce


### After

https://github.com/artsy/eigen/assets/4691889/763da21c-e30f-4ff0-9ce5-f658027c933e



### PR Checklist



- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Refresh Sell screen when updating the current draft submission (behind ff) - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
