### PR TITLE
fix: broken validation on artwork details screen

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -39,6 +39,7 @@ export const SubmitArtworkAddDetails = () => {
               accessibilityLabel="Year"
               disabled={!!values.isYearUnknown}
               style={{ width: "50%" }}
+              autoFocus
             />
             <Spacer y={1} />
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -30,7 +30,7 @@ export const getInitialSubmissionValues = (
     editionNumber: values.editionNumber ?? "",
     editionSizeFormatted: values.editionSize ?? "",
     height: values.height ?? "",
-    isYearUnknown: null,
+    isYearUnknown: values.year ? false : true,
     width: values.width ?? "",
     depth: values.depth ?? "",
     dimensionsMetric: values.dimensionsMetric ?? "in",


### PR DESCRIPTION
### Description

Fix broken validation on artwork details screen
**Before**

https://github.com/artsy/eigen/assets/11945712/52c468a2-0be1-413b-986e-f13e01948c57

**After**

https://github.com/artsy/eigen/assets/11945712/f85d9850-2f31-4a70-a68b-60c6dd741fe8


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
