### PR TITLE
chore: make year component optional

### DIFF
--- a/src/app/Components/Select/Components/SelectModal.tsx
+++ b/src/app/Components/Select/Components/SelectModal.tsx
@@ -25,6 +25,7 @@ export const SelectModal: React.FC<{
   onSelectValue(value: unknown, index: number): any
   renderItemLabel?(value: SelectOption<unknown>): JSX.Element
   onModalFinishedClosing?(): void
+  testID?: string
 }> = ({
   options,
   value,
@@ -36,6 +37,7 @@ export const SelectModal: React.FC<{
   onSelectValue,
   renderItemLabel,
   onModalFinishedClosing,
+  testID,
 }) => {
   const color = useColor()
 
@@ -123,6 +125,7 @@ export const SelectModal: React.FC<{
       onBackgroundPressed={onDismiss}
       maxHeight={maxHeight}
       onModalFinishedClosing={onModalFinishedClosing}
+      testID={testID}
     >
       <Flex p={2} pb="15px" flexDirection="row" alignItems="center" flexGrow={0}>
         <Flex flex={1} />

--- a/src/app/Components/Select/Select.tsx
+++ b/src/app/Components/Select/Select.tsx
@@ -113,6 +113,7 @@ export const Select = <ValueType,>({
       <SelectModal
         visible={showingModal}
         title={title}
+        testID={`modal-${testID}`}
         enableSearch={enableSearch}
         value={value}
         options={options}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tests.tsx
@@ -15,49 +15,14 @@ describe("SubmitArtworkAddDetails", () => {
     expect(yearInput.props.value).toBe("2024")
 
     const mediumPicker = screen.getByTestId("CategorySelect")
-    expect(mediumPicker).toBeOnTheScreen()
     fireEvent.press(mediumPicker)
     // Wait for the select modal to show up
     await flushPromiseQueue()
     fireEvent.press(screen.getByText("Painting"))
-    // Wait for the select modal to dismiss
-    await flushPromiseQueue()
-    expect(screen.getByText("Painting")).toBeOnTheScreen()
-  })
 
-  describe("Year input", () => {
-    it("Hides input when the user taps on I don't know", async () => {
-      renderWithSubmitArtworkWrapper({
-        component: <SubmitArtworkAddDetails />,
-      })
-
-      const yearInput = screen.getByTestId("Submission_YearInput")
-      fireEvent.changeText(yearInput, "2024")
-      expect(yearInput.props.value).toBe("2024")
-
-      const iDontKnowButton = screen.getByText("I don't know")
-      fireEvent.press(iDontKnowButton)
-      await flushPromiseQueue()
-      expect(yearInput.props.value).toBe("")
-    })
-
-    it("Injects the previous value after deselecting I don't know", async () => {
-      renderWithSubmitArtworkWrapper({
-        component: <SubmitArtworkAddDetails />,
-      })
-
-      const yearInput = screen.getByTestId("Submission_YearInput")
-      fireEvent.changeText(yearInput, "2024")
-      expect(yearInput.props.value).toBe("2024")
-
-      const iDontKnowButton = screen.getByText("I don't know")
-      fireEvent.press(iDontKnowButton)
-      await flushPromiseQueue()
-      expect(yearInput.props.value).toBe("")
-
-      fireEvent.press(iDontKnowButton)
-      await flushPromiseQueue()
-      expect(yearInput.props.value).toBe("2024")
-    })
+    const materialsInput = screen.getByTestId("Submission_MaterialsInput")
+    expect(materialsInput).toBeOnTheScreen()
+    fireEvent.changeText(materialsInput, "Whatever")
+    expect(materialsInput.props.value).toBe("Whatever")
   })
 })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Flex, Input, Join, Spacer, Text } from "@artsy/palette-mobile"
+import { Flex, Input, Join, Spacer, Text } from "@artsy/palette-mobile"
 import { SelectOption } from "app/Components/Select"
 import { CategoryPicker } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/CategoryPicker"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
@@ -7,14 +7,11 @@ import {
   acceptableCategoriesForSubmission,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
 import { useFormikContext } from "formik"
-import { useRef, useState } from "react"
+import { useRef } from "react"
 import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddDetails = () => {
-  const [oldTypedYear, setOldTypedYear] = useState("")
-
-  const { handleChange, setFieldValue, values, setValues } =
-    useFormikContext<ArtworkDetailsFormModel>()
+  const { handleChange, setFieldValue, values } = useFormikContext<ArtworkDetailsFormModel>()
 
   const categories = useRef<Array<SelectOption<AcceptableCategoryValue>>>(
     acceptableCategoriesForSubmission()
@@ -37,33 +34,8 @@ export const SubmitArtworkAddDetails = () => {
               value={values.year}
               onChangeText={(e) => setFieldValue("year", e)}
               accessibilityLabel="Year"
-              disabled={!!values.isYearUnknown}
               style={{ width: "50%" }}
             />
-            <Spacer y={1} />
-
-            <Checkbox
-              checked={!!values.isYearUnknown}
-              onPress={() => {
-                // Save the old typed year to restore it if the user unchecks the checkbox
-                if (!values.isYearUnknown) {
-                  setOldTypedYear(values.year)
-                  setValues({
-                    ...values,
-                    year: "",
-                    isYearUnknown: true,
-                  })
-                } else {
-                  setValues({
-                    ...values,
-                    year: oldTypedYear,
-                    isYearUnknown: false,
-                  })
-                }
-              }}
-              text={<Text color="black60">I don't know</Text>}
-            />
-            <Spacer y={1} />
           </Flex>
 
           <CategoryPicker<AcceptableCategoryValue | null>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -18,7 +18,7 @@ export const SubmitArtworkAddDetails = () => {
   ).current
 
   return (
-    <Flex px={2}>
+    <Flex px={2} flex={1}>
       <ScrollView>
         <Text variant="lg-display" mb={2}>
           Artwork details
@@ -35,6 +35,7 @@ export const SubmitArtworkAddDetails = () => {
               onChangeText={(e) => setFieldValue("year", e)}
               accessibilityLabel="Year"
               style={{ width: "50%" }}
+              autoFocus
             />
           </Flex>
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhotos.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhotos.tsx
@@ -8,7 +8,7 @@ export const SubmitArtworkAddPhotos = () => {
   const { values } = useFormikContext<ArtworkDetailsFormModel>()
 
   return (
-    <Flex px={2}>
+    <Flex px={2} flex={1}>
       <ScrollView
         contentContainerStyle={{ paddingBottom: 80 }}
         showsVerticalScrollIndicator={false}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -30,8 +30,6 @@ export const getInitialSubmissionValues = (
     editionNumber: values.editionNumber ?? "",
     editionSizeFormatted: values.editionSize ?? "",
     height: values.height ?? "",
-    // Because we only use `isYearUnknown` for validating the form, we need to set this dependent on the value of `year`
-    isYearUnknown: ["", null, undefined].includes(values.year),
     width: values.width ?? "",
     depth: values.depth ?? "",
     dimensionsMetric: values.dimensionsMetric ?? "in",

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -79,12 +79,7 @@ const provenanceSchema = Yup.object().shape({
 const artworkDetailsValidationSchema = Yup.object().shape({
   category: Yup.string().required(),
   medium: Yup.string(),
-  year: Yup.string().when("isYearUnknown", {
-    is: false,
-    then: Yup.string().required(),
-    otherwise: Yup.string(),
-  }),
-  isYearUnknown: Yup.boolean(),
+  year: Yup.string(),
 })
 
 export interface Location {
@@ -107,7 +102,6 @@ export interface ArtworkDetailsFormModel {
   editionNumber: string
   editionSizeFormatted: string
   height: string
-  isYearUnknown: boolean | null
   location: Location
   medium: string
   myCollectionArtworkID: string | null
@@ -144,7 +138,6 @@ export const artworkDetailsEmptyInitialValues: ArtworkDetailsFormModel = {
   editionNumber: "",
   editionSizeFormatted: "",
   height: "",
-  isYearUnknown: false,
   location: {
     city: "",
     state: "",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
- Remove year input component

<img width="369" alt="Screenshot 2024-06-05 at 16 45 08" src="https://github.com/artsy/eigen/assets/11945712/c52f6326-5909-4993-9fbc-91abea23d411">

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
