### PR TITLE
fix: Set final step in submission form correctly

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -10,7 +10,7 @@ import { useEffect } from "react"
 import { LayoutAnimation } from "react-native"
 
 export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
-  const { navigateToNextStep, navigateToPreviousStep, isLastStep } = useSubmissionContext()
+  const { navigateToNextStep, navigateToPreviousStep, isFinalStep } = useSubmissionContext()
   const { isValid, values } = useFormikContext<ArtworkDetailsFormModel>()
   const isUploadingPhotos = values.photos.some((photo: Photo) => photo.loading)
   const allPhotosAreValid = values.photos.every(
@@ -153,7 +153,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
             disabled={!isValid || isLoading || isUploadingPhotos || !allPhotosAreValid}
             loading={isLoading || isUploadingPhotos}
           >
-            {isLastStep ? "Submit Artwork" : "Continue"}
+            {isFinalStep ? "Submit Artwork" : "Continue"}
           </Button>
         </Flex>
       </Flex>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
@@ -2,6 +2,8 @@ import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkFo
 
 export type SubmitArtworkScreen = keyof SubmitArtworkStackNavigation
 
+export const ARTWORK_FORM_FINAL_STEP = "AddPhoneNumber"
+
 export const ARTWORK_FORM_STEPS: SubmitArtworkScreen[] = [
   "StartFlow",
   "SelectArtist",

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -4,6 +4,7 @@ import {
   getCurrentRoute,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import {
+  ARTWORK_FORM_FINAL_STEP,
   ARTWORK_FORM_STEPS,
   SubmitArtworkScreen,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
@@ -22,7 +23,7 @@ export const useSubmissionContext = () => {
 
   const { values, setFieldValue } = useFormikContext<ArtworkDetailsFormModel>()
 
-  const isLastStep = currentStep === ARTWORK_FORM_STEPS[ARTWORK_FORM_STEPS.length - 1]
+  const isFinalStep = currentStep === ARTWORK_FORM_FINAL_STEP
 
   const navigateToNextStep = async (props?: {
     step?: SubmitArtworkScreen
@@ -42,7 +43,7 @@ export const useSubmissionContext = () => {
 
       const newValues = {
         ...values,
-        state: (isLastStep ? "SUBMITTED" : undefined) as ArtworkDetailsFormModel["state"],
+        state: (isFinalStep ? "SUBMITTED" : "DRAFT") as ArtworkDetailsFormModel["state"],
       }
 
       if (!props?.skipMutation) {
@@ -93,5 +94,5 @@ export const useSubmissionContext = () => {
     }
   }
 
-  return { isLastStep, navigateToNextStep, navigateToPreviousStep }
+  return { isFinalStep, navigateToNextStep, navigateToPreviousStep }
 }


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/morning-build-artwork-is-not-in-my-collection-after-completing-the-flow-908968ea497349169b25862543e73efc?pvs=4

### Description

This sets the final step in the submission form correctly. 

I have accidentally set it to the last entry in `ARTWORK_FORM_STEPS`, which is not the final step before the submission gets submitted.

With this fix, an artwork in My Collection gets created after submitting the submission (because the state change from "DRAFT" to "SUBMITTED" happens and the "Add Phone Number" step now displays `Submit Artwork` instead of `Continue`.

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro - 2024-06-05 at 19 35 59](https://github.com/artsy/eigen/assets/4691889/da82195e-a580-4357-96af-b2e7c9c238c4) |![Simulator Screenshot - iPhone 15 Pro - 2024-06-05 at 19 37 54](https://github.com/artsy/eigen/assets/4691889/f9fa56af-a3f7-4cbf-850e-6b1b9d2d9556)|


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
