### PR TITLE
feat(AMBER-715): Add 'Frame not included' to artwork details

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tests.tsx
@@ -57,4 +57,20 @@ describe("ArtworkDimensionsClassificationAndAuthenticity", () => {
     fireEvent.press(screen.getByText("Certificate of Authenticity"))
     expect(navigate).toHaveBeenCalledWith(`/artwork-certificate-of-authenticity`)
   })
+
+  it("renders 'Frame not included' when there is no frame", () => {
+    renderWithRelay({
+      Artwork: () => ({ framed: { details: "not included" } }),
+    })
+
+    expect(screen.getByText("Frame not included")).toBeTruthy()
+  })
+
+  it("renders 'Frame included' when the frame is included", () => {
+    renderWithRelay({
+      Artwork: () => ({ framed: { details: "Included" } }),
+    })
+
+    expect(screen.getByText("Frame included")).toBeTruthy()
+  })
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tsx
@@ -18,7 +18,7 @@ const ArtworkDimensionsClassificationAndAuthenticity: React.FC<
 
   const getFrameString = (frameDetails?: string | null) => {
     if (frameDetails !== "Included") {
-      return
+      return "Frame not included"
     }
 
     return `Frame ${frameDetails.toLowerCase()}`


### PR DESCRIPTION
This PR resolves [AMBER-715] <!-- eg [PROJECT-XXXX] -->

### Description
As discussed with Peter, we want to explicitely indicate to the user when the frame is not included, not just by omission.

__Before:__
<img width="457" alt="Screenshot 2024-06-05 at 12 35 36 PM" src="https://github.com/artsy/eigen/assets/5643895/f56bed51-fe29-4045-8fd0-fe7489e367c9">

__After:__
<img width="437" alt="Screenshot 2024-06-05 at 12 35 10 PM" src="https://github.com/artsy/eigen/assets/5643895/9c62d4c8-d4e7-4015-9693-ea6da72ff02f">

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Adds 'Frame not included' to artwork details - lfp

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[AMBER-715]: https://artsyproduct.atlassian.net/browse/AMBER-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ