### PR TITLE
fix(EMI-1900): Fix issue with sold edition sets being able to go to Purchase flow

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkEditionSetInformation.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkEditionSetInformation.tests.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@artsy/palette-mobile"
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkEditionSetInformation_Test_Query } from "__generated__/ArtworkEditionSetInformation_Test_Query.graphql"
 import { ArtworkStore, ArtworkStoreProvider, artworkModel } from "app/Scenes/Artwork/ArtworkStore"
 import { extractText } from "app/utils/tests/extractText"
@@ -16,21 +16,17 @@ describe("ArtworkEditionSetInformation", () => {
 
   const { renderWithRelay } = setupTestWrapper<ArtworkEditionSetInformation_Test_Query>({
     Component: (props) => {
-      if (props?.artwork) {
-        return (
-          <ArtworkStoreProvider
-            runtimeModel={{
-              ...artworkModel,
-              selectedEditionId: artwork.editionSets[0].internalID,
-            }}
-          >
-            <ArtworkEditionSetInformation artwork={props.artwork} />
-            <ArtworkStoreDebug />
-          </ArtworkStoreProvider>
-        )
-      }
-
-      return null
+      return (
+        <ArtworkStoreProvider
+          runtimeModel={{
+            ...artworkModel,
+            selectedEditionId: artwork.editionSets[0].internalID,
+          }}
+        >
+          <ArtworkEditionSetInformation artwork={props.artwork!} />
+          <ArtworkStoreDebug />
+        </ArtworkStoreProvider>
+      )
     },
     query: graphql`
       query ArtworkEditionSetInformation_Test_Query @relay_test_operation {
@@ -42,21 +38,17 @@ describe("ArtworkEditionSetInformation", () => {
   })
 
   it("the sale message for the selected edition set should NOT be rendered", () => {
-    const { queryByLabelText } = renderWithRelay({
-      Artwork: () => artwork,
-    })
+    renderWithRelay({ Artwork: () => artwork })
 
-    expect(queryByLabelText("Selected edition set")).toBeNull()
+    expect(screen.queryByLabelText("Selected edition set")).not.toBeOnTheScreen()
   })
 
   it("should keep the selected edtion set id in artwork store", () => {
-    const { getByText, getByTestId } = renderWithRelay({
-      Artwork: () => artwork,
-    })
+    renderWithRelay({ Artwork: () => artwork })
 
-    fireEvent.press(getByText("Edition Set Two"))
+    fireEvent.press(screen.getByText("Edition Set Two"))
 
-    const artworkStateRaw = extractText(getByTestId("debug"))
+    const artworkStateRaw = extractText(screen.getByTestId("debug"))
     const artworkState = JSON.parse(artworkStateRaw)
 
     expect(artworkState.selectedEditionId).toBe("edition-set-two")
@@ -69,11 +61,15 @@ const artwork = {
       internalID: "edition-set-one",
       editionOf: "Edition Set One",
       saleMessage: "$1000",
+      isAcquireable: true,
+      isOfferable: true,
     },
     {
       internalID: "edition-set-two",
       editionOf: "Edition Set Two",
       saleMessage: "$2000",
+      isAcquireable: true,
+      isOfferable: true,
     },
   ],
 }

--- a/src/app/Scenes/Artwork/Components/ArtworkEditionSetItem.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkEditionSetItem.tsx
@@ -8,12 +8,14 @@ interface ArtworkEditionSetItemProps {
   item: ArtworkEditionSetItem_item$data
   isSelected: boolean
   onPress: (id: string) => void
+  disabled?: boolean
 }
 
 const ArtworkEditionSetItem: React.FC<ArtworkEditionSetItemProps> = ({
   item,
   isSelected,
   onPress,
+  disabled,
 }) => {
   const preferredMetric = GlobalStore.useAppState((state) => state.userPrefs.metric)
   const { dimensions, editionOf, saleMessage } = item
@@ -38,9 +40,9 @@ const ArtworkEditionSetItem: React.FC<ArtworkEditionSetItemProps> = ({
   const metric = getMetricLabel()
 
   return (
-    <TouchableWithoutFeedback onPress={handlePress}>
+    <TouchableWithoutFeedback onPress={handlePress} disabled={disabled}>
       <Flex flexDirection="row" justifyContent="flex-start" py={2}>
-        <RadioButton selected={isSelected} onPress={handlePress} />
+        <RadioButton selected={isSelected} onPress={handlePress} disabled={disabled} />
 
         <Spacer x={1} />
 

--- a/src/app/Scenes/Artwork/Components/ArtworkEditionSets.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkEditionSets.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkEditionSets_Test_Query } from "__generated__/ArtworkEditionSets_Test_Query.graphql"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -8,13 +8,9 @@ describe("ArtworkEditionSets", () => {
   const onSelectEditionMock = jest.fn()
 
   const { renderWithRelay } = setupTestWrapper<ArtworkEditionSets_Test_Query>({
-    Component: (props) => {
-      if (props?.artwork) {
-        return <ArtworkEditionSets artwork={props.artwork} onSelectEdition={onSelectEditionMock} />
-      }
-
-      return null
-    },
+    Component: (props) => (
+      <ArtworkEditionSets artwork={props.artwork!} onSelectEdition={onSelectEditionMock} />
+    ),
     query: graphql`
       query ArtworkEditionSets_Test_Query @relay_test_operation {
         artwork(id: "artworkID") {
@@ -24,23 +20,39 @@ describe("ArtworkEditionSets", () => {
     `,
   })
 
-  it("should render all edition sets", () => {
-    const { getByText } = renderWithRelay({
-      Artwork: () => artwork,
-    })
-
-    expect(getByText("Edition Set One")).toBeTruthy()
-    expect(getByText("Edition Set Two")).toBeTruthy()
+  beforeEach(() => {
+    jest.clearAllMocks()
   })
 
-  it("should call `onSelectEdition` handler with the selected edition set id", () => {
-    const { getByText } = renderWithRelay({
-      Artwork: () => artwork,
-    })
+  it("should render all edition sets", () => {
+    renderWithRelay({ Artwork: () => artwork })
 
-    fireEvent.press(getByText("Edition Set Two"))
+    expect(screen.getByText("Edition Set One")).toBeOnTheScreen()
+    expect(screen.getByText("Edition Set Two")).toBeOnTheScreen()
+    expect(screen.getByText("Edition Set Three")).toBeOnTheScreen()
+
+    // pre-selecting the first ecommerce enabled edition set
+    expect(onSelectEditionMock).toBeCalledWith("edition-set-two")
+  })
+
+  it("should call `onSelectEdition` handler with the selected edition set id if acquireable or offerable", () => {
+    renderWithRelay({ Artwork: () => artwork })
+
+    fireEvent.press(screen.getByText("Edition Set Three"))
+
+    expect(onSelectEditionMock).toBeCalledWith("edition-set-three")
+
+    fireEvent.press(screen.getByText("Edition Set Two"))
 
     expect(onSelectEditionMock).toBeCalledWith("edition-set-two")
+  })
+
+  it("should not call `onSelectEdition` handler when the edition set is not acquireable or offerable", () => {
+    renderWithRelay({ Artwork: () => artwork })
+
+    fireEvent.press(screen.getByText("Edition Set One"))
+
+    expect(onSelectEditionMock).not.toBeCalledWith("edition-set-one")
   })
 })
 
@@ -50,11 +62,22 @@ const artwork = {
       internalID: "edition-set-one",
       editionOf: "Edition Set One",
       saleMessage: "$1000",
+      isAcquireable: false,
+      isOfferable: false,
     },
     {
       internalID: "edition-set-two",
       editionOf: "Edition Set Two",
       saleMessage: "$2000",
+      isAcquireable: true,
+      isisOfferable: false,
+    },
+    {
+      internalID: "edition-set-three",
+      editionOf: "Edition Set Three",
+      saleMessage: "$3000",
+      isAcquireable: false,
+      isOfferable: true,
     },
   ],
 }


### PR DESCRIPTION
This PR resolves [EMI-1900] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue with selecting already sold edition sets and navigating to the checkout flow

### Videos
#### Selecting sold edition sets
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/artsy/eigen/assets/20655703/a0de929b-103b-452a-99ad-76273fbd5151" /> | <video src="https://github.com/artsy/eigen/assets/20655703/e618fc74-d42a-478e-90a0-22e544ff6605" /> |
| iOS | <video src="https://github.com/artsy/eigen/assets/20655703/234a5dae-90ac-46a9-a81f-3adf6627cb1f" /> | <video src="https://github.com/artsy/eigen/assets/20655703/dfc893a3-0a17-4c92-8bbb-8aba8720cd3d" /> |


#### Preselecting sold edition sets
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/artsy/eigen/assets/20655703/7063aa53-5b6a-481b-a6f7-922e61aff6e3" /> | <video src="https://github.com/artsy/eigen/assets/20655703/a14316fc-8f40-48d4-ba65-e3a06e22960c" /> |
| iOS | <video src="https://github.com/artsy/eigen/assets/20655703/36569979-b65d-4b6c-a50b-cdaddb202163" /> | <video src="https://github.com/artsy/eigen/assets/20655703/710a0df2-f6de-4d21-9ee4-de3f87c7c524" /> |	


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix selecting sold artwork edition sets issue - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

@artsy/emerald-devs 

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1900]: https://artsyproduct.atlassian.net/browse/EMI-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ