### PR TITLE
fix: do not show keyboard on open after continue submission

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest.tsx
@@ -32,6 +32,7 @@ interface ArtistAutosuggestProps {
   onlyP1Artists?: boolean
   onResultPress: (result: AutosuggestResult) => void
   onSkipPress?: (artistDisplayName: string) => void
+  autoFocus?: boolean
 }
 
 export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
@@ -42,6 +43,7 @@ export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
   onlyP1Artists = false,
   onResultPress,
   onSkipPress,
+  autoFocus = typeof jest === "undefined",
 }) => {
   const enableCollectedArtists = useFeatureFlag("AREnableMyCollectionCollectedArtists")
 
@@ -115,7 +117,7 @@ export const ArtistAutosuggest: React.FC<ArtistAutosuggestProps> = ({
           onBlur={formik.handleBlur("artist")}
           value={formik.values.artist}
           enableClearButton
-          autoFocus={typeof jest === "undefined"}
+          autoFocus={autoFocus}
           autoCorrect={false}
           spellCheck={false}
           loading={loading}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -1,6 +1,7 @@
 import { Flex, Input, Join, Spacer, Text } from "@artsy/palette-mobile"
 import { SelectOption } from "app/Components/Select"
 import { CategoryPicker } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/CategoryPicker"
+import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import {
   AcceptableCategoryValue,
@@ -12,6 +13,7 @@ import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddDetails = () => {
   const { handleChange, setFieldValue, values } = useFormikContext<ArtworkDetailsFormModel>()
+  const { currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
 
   const categories = useRef<Array<SelectOption<AcceptableCategoryValue>>>(
     acceptableCategoriesForSubmission()
@@ -35,7 +37,7 @@ export const SubmitArtworkAddDetails = () => {
               onChangeText={(e) => setFieldValue("year", e)}
               accessibilityLabel="Year"
               style={{ width: "50%" }}
-              autoFocus
+              autoFocus={currentStep === "AddTitle"}
             />
           </Flex>
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -21,7 +21,6 @@ export const SubmitArtworkAddDetails = () => {
 
   return (
     <Flex px={2} flex={1}>
-      s
       <ScrollView>
         <Text variant="lg-display" mb={2}>
           Artwork details

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -1,7 +1,7 @@
 import { Flex, Input, Join, Spacer, Text } from "@artsy/palette-mobile"
 import { SelectOption } from "app/Components/Select"
 import { CategoryPicker } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/CategoryPicker"
-import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
+import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import {
   AcceptableCategoryValue,
@@ -13,7 +13,7 @@ import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddDetails = () => {
   const { handleChange, setFieldValue, values } = useFormikContext<ArtworkDetailsFormModel>()
-  const { currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
+  const { currentStep } = useSubmissionContext()
 
   const categories = useRef<Array<SelectOption<AcceptableCategoryValue>>>(
     acceptableCategoriesForSubmission()
@@ -21,6 +21,7 @@ export const SubmitArtworkAddDetails = () => {
 
   return (
     <Flex px={2} flex={1}>
+      s
       <ScrollView>
         <Text variant="lg-display" mb={2}>
           Artwork details
@@ -37,7 +38,8 @@ export const SubmitArtworkAddDetails = () => {
               onChangeText={(e) => setFieldValue("year", e)}
               accessibilityLabel="Year"
               style={{ width: "50%" }}
-              autoFocus={currentStep === "AddTitle"}
+              // Only focus on the input and toggle the keyboard if this step is visible to the user.
+              autoFocus={currentStep === "AddDetails"}
             />
           </Flex>
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
@@ -1,11 +1,13 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { PhoneInput } from "app/Components/Input/PhoneInput"
+import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useFormikContext } from "formik"
 import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddPhoneNumber = () => {
   const { handleChange, values } = useFormikContext<ArtworkDetailsFormModel>()
+  const { currentStep } = useSubmissionContext()
 
   return (
     <Flex px={2}>
@@ -26,7 +28,8 @@ export const SubmitArtworkAddPhoneNumber = () => {
           accessibilityLabel="Phone number"
           shouldDisplayLocalError={false}
           testID="phone-input"
-          autoFocus
+          // Only focus on the input and toggle the keyboard if this step is visible to the user.
+          autoFocus={currentStep === "AddPhoneNumber"}
         />
       </ScrollView>
     </Flex>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
@@ -26,6 +26,7 @@ export const SubmitArtworkAddPhoneNumber = () => {
           accessibilityLabel="Phone number"
           shouldDisplayLocalError={false}
           testID="phone-input"
+          autoFocus
         />
       </ScrollView>
     </Flex>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
@@ -1,10 +1,12 @@
 import { Flex, Input, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtistSearchResult } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult"
+import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useFormikContext } from "formik"
 
 export const SubmitArtworkAddTitle = () => {
   const { handleChange, values } = useFormikContext<ArtworkDetailsFormModel>()
+  const { currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
 
   return (
     <Flex px={2}>
@@ -21,7 +23,7 @@ export const SubmitArtworkAddTitle = () => {
           placeholder="Artwork Title"
           onChangeText={handleChange("title")}
           value={values.title}
-          autoFocus
+          autoFocus={currentStep === "AddTitle"}
           spellCheck={false}
           autoCorrect={false}
         />

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
@@ -1,12 +1,12 @@
 import { Flex, Input, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtistSearchResult } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult"
-import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
+import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useFormikContext } from "formik"
 
 export const SubmitArtworkAddTitle = () => {
   const { handleChange, values } = useFormikContext<ArtworkDetailsFormModel>()
-  const { currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
+  const { currentStep } = useSubmissionContext()
 
   return (
     <Flex px={2}>
@@ -23,6 +23,7 @@ export const SubmitArtworkAddTitle = () => {
           placeholder="Artwork Title"
           onChangeText={handleChange("title")}
           value={values.title}
+          // Only focus on the input and toggle the keyboard if this step is visible to the user.
           autoFocus={currentStep === "AddTitle"}
           spellCheck={false}
           autoCorrect={false}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -18,7 +18,7 @@ import { TouchableOpacity } from "react-native"
 export const SubmitArtworkSelectArtist = () => {
   const { navigateToNextStep } = useSubmissionContext()
   const setIsLoading = SubmitArtworkFormStore.useStoreActions((actions) => actions.setIsLoading)
-  const { isLoading } = SubmitArtworkFormStore.useStoreState((state) => state)
+  const { isLoading, currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
 
   const formik = useFormikContext<ArtworkDetailsFormModel>()
 
@@ -89,6 +89,7 @@ export const SubmitArtworkSelectArtist = () => {
             onlyP1Artists
             loading={isLoading}
             hideCollectedArtists
+            autoFocus={currentStep === "SelectArtist"}
             Hint={
               <Flex py={1}>
                 <Text variant="xs" color="black60">

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -94,5 +94,5 @@ export const useSubmissionContext = () => {
     }
   }
 
-  return { isFinalStep, navigateToNextStep, navigateToPreviousStep }
+  return { currentStep, isFinalStep, navigateToNextStep, navigateToPreviousStep }
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue where the keyboard gets visible after one opens the submission flow after pressing on continue your submission.

**Rationale:**
Because we inject a **partial** `initialState` in the `NavigationContainer` on mount. React-navigation has no reliable way to rebuilt the full `initialState` other than going through all the routes again. This means that if for example, the active step is `AddPhotos`, we will go through `StartFlow`, `SelectArtist` and `AddTitle`. And because `SelectArtist` and `AddTitle` both have inputs with autofocus, the keyboard then shows up there. I am fixing that by making sure that the input is only focused if the screen is active

**Before**

https://github.com/artsy/eigen/assets/11945712/9153de8f-60e4-4705-a400-776cc0278abc



**After**

https://github.com/artsy/eigen/assets/11945712/02ffb737-7052-4d82-a00a-cf1c6080424c


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
