### PR TITLE
fix: replace active route after starting my collection

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
@@ -92,6 +92,7 @@ describe("SubmitArtworkBottomNavigation", () => {
       fireEvent(addToMyCollectionButton, "onPress")
       expect(navigate).toHaveBeenCalledWith("/my-collection/artworks/new", {
         showInTabName: "profile",
+        replaceActiveModal: true,
       })
     })
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -117,6 +117,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
             onPress={() => {
               navigate("/my-collection/artworks/new", {
                 showInTabName: "profile",
+                replaceActiveModal: true,
               })
             }}
           >


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

```
After adding a non-p1 artist to mycollection, the flow loads but then goes back to the rejection screen

Link: https://www.notion.so/artsy/After-adding-a-non-p1-artist-to-mycollection-the-flow-loads-but-then-goes-back-to-the-rejection-scr-1db618b7dc05445c80635c4f2f982fca?pvs=4
```


https://github.com/artsy/eigen/assets/11945712/57d4c669-a3da-46b8-8c3c-ddd94bc87d10



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
