### PR TITLE
chore: upload photos fixes

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -4,16 +4,25 @@ import {
 } from "__generated__/SubmitArtworkFormEditQuery.graphql"
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { acceptableCategoriesForSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
+import { compact } from "lodash"
 
 export const getInitialSubmissionValues = (
   values: NonNullable<SubmitArtworkFormEditQuery$data["submission"]>
 ): ArtworkDetailsFormModel => {
-  const initialPhotos = values.assets?.map((asset) => asset?.imageUrls) ?? []
+  const photos =
+    values.assets?.map((asset) => {
+      const path = (Object.values(asset?.imageUrls || {})?.[0] as string) ?? ""
 
-  const allVersions = Object.values(initialPhotos).filter(
-    (image) => Object.values(image).length >= 1
-  )
-  const largestImages = allVersions.map((image) => Object.values(image)[0] as string)
+      if (!path) {
+        return null
+      }
+
+      return {
+        path: (Object.values(asset?.imageUrls || {})?.[0] as string) ?? "",
+        id: asset?.id ?? "",
+        geminiToken: asset?.geminiToken ?? "",
+      }
+    }) ?? []
 
   const categories = acceptableCategoriesForSubmission()
 
@@ -48,8 +57,6 @@ export const getInitialSubmissionValues = (
     artistSearchResult: null,
     source: values.source ?? null,
     myCollectionArtworkID: values.sourceArtworkID ?? null,
-    photos: largestImages.map((imageUrl: string) => ({
-      path: imageUrl || "",
-    })),
+    photos: compact(photos),
   }
 }

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -13,12 +13,8 @@ export const getInitialSubmissionValues = (
     values.assets?.map((asset) => {
       const path = (Object.values(asset?.imageUrls || {})?.[0] as string) ?? ""
 
-      if (!path) {
-        return null
-      }
-
       return {
-        path: (Object.values(asset?.imageUrls || {})?.[0] as string) ?? "",
+        path,
         id: asset?.id ?? "",
         geminiToken: asset?.geminiToken ?? "",
       }

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -165,6 +165,7 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
             key={idx}
             photo={photo}
             onPhotoDelete={handlePhotoDelete}
+            onPress={handleAddPhotoPress}
             progress={progress[photo.path] ?? 0}
           />
         )

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -103,48 +103,6 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
         }
       })
     )
-    // for (const photo of photos) {
-    //   try {
-    //     // upload & size the photo, and add it to processed photos
-    //     const uploadedPhoto = await addPhotoToConsignment({
-    //       asset: photo,
-    //       submissionID: submissionId,
-    //       updateProgress: (newProgress) => {
-    //         setProgress((prevState) => {
-    //           const newState = { ...prevState, [photo.path]: newProgress }
-    //           return newState
-    //         })
-    //       },
-    //     })
-    //     if (uploadedPhoto?.id) {
-    //       const sizedPhoto = calculateSinglePhotoSize(uploadedPhoto)
-
-    //       const availablePhotos = [...values.photos, ...processedPhotos, sizedPhoto]
-    //       const isTotalSizeLimitExceeded = isSizeLimitExceeded(availablePhotos)
-    //       // when total size limit exceeded, set photo's err state and stop the upload loop
-    //       if (isTotalSizeLimitExceeded) {
-    //         sizedPhoto.error = true
-    //         sizedPhoto.errorMessage =
-    //           "File exceeds the total size limit. Please delete photos or upload smaller file sizes."
-    //         processedPhotos.push(sizedPhoto)
-
-    //         trackEvent(
-    //           tracks.hasExceededUploadSize(getPhotosSize(availablePhotos), availablePhotos.length)
-    //         )
-    //         break
-    //       }
-    //       processedPhotos.push(sizedPhoto)
-    //     }
-    //   } catch (error) {
-    //     // set photo's error state and set it to processed photos
-    //     photo.error = true
-    //     photo.errorMessage = "Photo could not be uploaded"
-    //     processedPhotos.push(photo)
-    //     captureMessage(JSON.stringify(error))
-    //   } finally {
-    //     photo.loading = false
-    //   }
-    // }
 
     const allPhotos = [...values.photos, ...processedPhotos]
 

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -175,7 +175,6 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
             key={idx}
             photo={photo}
             onPhotoDelete={handlePhotoDelete}
-            onPress={handleAddPhotoPress}
             progress={progress[photo.path] ?? 0}
           />
         )

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
 import { removeAssetFromSubmission } from "app/Scenes/SellWithArtsy/mutations/removeAssetFromConsignmentSubmissionMutation"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
 import { useFormikContext } from "formik"
 import React, { useEffect, useState } from "react"
@@ -29,6 +30,8 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
   isAnyPhotoLoading,
 }) => {
   const space = useSpace()
+  const enableNewSubmissionFlow = useFeatureFlag("AREnableNewSubmissionFlow")
+
   const { values, setFieldValue } = useFormikContext<PhotosFormModel>()
   const { submission } = GlobalStore.useAppState((state) => state.artworkSubmission)
   const submissionId = submission.submissionId || values.submissionId
@@ -106,14 +109,16 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
 
     const allPhotos = [...values.photos, ...processedPhotos]
 
-    // set photos for my collection, and submission flow state and Formik
-    GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
-      photos: allPhotos,
-    })
-    GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(submissionId)
-    GlobalStore.actions.artworkSubmission.submission.setPhotos({
-      photos: allPhotos,
-    })
+    if (!enableNewSubmissionFlow) {
+      // set photos for my collection, and submission flow state and Formik
+      GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
+        photos: allPhotos,
+      })
+      GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(submissionId)
+      GlobalStore.actions.artworkSubmission.submission.setPhotos({
+        photos: allPhotos,
+      })
+    }
 
     setFieldValue("photos", allPhotos)
   }
@@ -132,20 +137,24 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
       console.error("Submission ID not found")
       return null
     }
-
     try {
       const filteredPhotos = values.photos.filter((p: Photo) => p.id !== photo.id)
 
-      // set photos for my collection, and submission flow state and Formik
-      GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
-        photos: filteredPhotos,
-      })
+      if (!enableNewSubmissionFlow) {
+        // set photos for my collection, and submission flow state and Formik
+        GlobalStore.actions.artworkSubmission.submission.setPhotosForMyCollection({
+          photos: filteredPhotos,
+        })
 
-      GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(submissionId)
+        GlobalStore.actions.artworkSubmission.submission.setSubmissionIdForMyCollection(
+          submissionId
+        )
 
-      GlobalStore.actions.artworkSubmission.submission.setPhotos({
-        photos: filteredPhotos,
-      })
+        GlobalStore.actions.artworkSubmission.submission.setPhotos({
+          photos: filteredPhotos,
+        })
+      }
+
       setFieldValue("photos", filteredPhotos)
 
       await removeAssetFromSubmission({ assetID: photo.id })

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm.tsx
@@ -60,48 +60,91 @@ export const UploadPhotosForm: React.FC<{ isAnyPhotoLoading?: boolean }> = ({
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     setFieldValue("photos", [...values.photos, ...photos])
 
-    for (const photo of photos) {
-      try {
-        // upload & size the photo, and add it to processed photos
-        const uploadedPhoto = await addPhotoToConsignment({
-          asset: photo,
-          submissionID: submissionId,
-          updateProgress: (newProgress) => {
-            setProgress((prevState) => {
-              const newState = { ...prevState, [photo.path]: newProgress }
-              return newState
-            })
-          },
-        })
-        if (uploadedPhoto?.id) {
-          const sizedPhoto = calculateSinglePhotoSize(uploadedPhoto)
+    await Promise.all(
+      photos.map(async (photo) => {
+        try {
+          // upload & size the photo, and add it to processed photos
+          const uploadedPhoto = await addPhotoToConsignment({
+            asset: photo,
+            submissionID: submissionId,
+            updateProgress: (newProgress) => {
+              setProgress((prevState) => {
+                const newState = { ...prevState, [photo.path]: newProgress }
+                return newState
+              })
+            },
+          })
+          if (uploadedPhoto?.id) {
+            const sizedPhoto = calculateSinglePhotoSize(uploadedPhoto)
 
-          const availablePhotos = [...values.photos, ...processedPhotos, sizedPhoto]
-          const isTotalSizeLimitExceeded = isSizeLimitExceeded(availablePhotos)
-          // when total size limit exceeded, set photo's err state and stop the upload loop
-          if (isTotalSizeLimitExceeded) {
-            sizedPhoto.error = true
-            sizedPhoto.errorMessage =
-              "File exceeds the total size limit. Please delete photos or upload smaller file sizes."
+            const availablePhotos = [...values.photos, ...processedPhotos, sizedPhoto]
+            const isTotalSizeLimitExceeded = isSizeLimitExceeded(availablePhotos)
+            // when total size limit exceeded, set photo's err state and stop the upload loop
+            if (isTotalSizeLimitExceeded) {
+              sizedPhoto.error = true
+              sizedPhoto.errorMessage =
+                "File exceeds the total size limit. Please delete photos or upload smaller file sizes."
+              processedPhotos.push(sizedPhoto)
+
+              trackEvent(
+                tracks.hasExceededUploadSize(getPhotosSize(availablePhotos), availablePhotos.length)
+              )
+            }
             processedPhotos.push(sizedPhoto)
-
-            trackEvent(
-              tracks.hasExceededUploadSize(getPhotosSize(availablePhotos), availablePhotos.length)
-            )
-            break
           }
-          processedPhotos.push(sizedPhoto)
+        } catch (error) {
+          // set photo's error state and set it to processed photos
+          photo.error = true
+          photo.errorMessage = "Photo could not be uploaded"
+          processedPhotos.push(photo)
+          captureMessage(JSON.stringify(error))
+        } finally {
+          photo.loading = false
         }
-      } catch (error) {
-        // set photo's error state and set it to processed photos
-        photo.error = true
-        photo.errorMessage = "Photo could not be uploaded"
-        processedPhotos.push(photo)
-        captureMessage(JSON.stringify(error))
-      } finally {
-        photo.loading = false
-      }
-    }
+      })
+    )
+    // for (const photo of photos) {
+    //   try {
+    //     // upload & size the photo, and add it to processed photos
+    //     const uploadedPhoto = await addPhotoToConsignment({
+    //       asset: photo,
+    //       submissionID: submissionId,
+    //       updateProgress: (newProgress) => {
+    //         setProgress((prevState) => {
+    //           const newState = { ...prevState, [photo.path]: newProgress }
+    //           return newState
+    //         })
+    //       },
+    //     })
+    //     if (uploadedPhoto?.id) {
+    //       const sizedPhoto = calculateSinglePhotoSize(uploadedPhoto)
+
+    //       const availablePhotos = [...values.photos, ...processedPhotos, sizedPhoto]
+    //       const isTotalSizeLimitExceeded = isSizeLimitExceeded(availablePhotos)
+    //       // when total size limit exceeded, set photo's err state and stop the upload loop
+    //       if (isTotalSizeLimitExceeded) {
+    //         sizedPhoto.error = true
+    //         sizedPhoto.errorMessage =
+    //           "File exceeds the total size limit. Please delete photos or upload smaller file sizes."
+    //         processedPhotos.push(sizedPhoto)
+
+    //         trackEvent(
+    //           tracks.hasExceededUploadSize(getPhotosSize(availablePhotos), availablePhotos.length)
+    //         )
+    //         break
+    //       }
+    //       processedPhotos.push(sizedPhoto)
+    //     }
+    //   } catch (error) {
+    //     // set photo's error state and set it to processed photos
+    //     photo.error = true
+    //     photo.errorMessage = "Photo could not be uploaded"
+    //     processedPhotos.push(photo)
+    //     captureMessage(JSON.stringify(error))
+    //   } finally {
+    //     photo.loading = false
+    //   }
+    // }
 
     const allPhotos = [...values.photos, ...processedPhotos]
 

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
@@ -13,12 +13,11 @@ import {
   IMAGE_SIZE,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm"
 import { Photo as TPhoto } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
-import { Image, TouchableWithoutFeedback } from "react-native"
+import { Image } from "react-native"
 
 interface PhotoProps {
   hideDeleteButton?: boolean
   onPhotoDelete: (arg: TPhoto) => void
-  onPress?: () => void
   photo: TPhoto
   progress: number
 }
@@ -26,7 +25,6 @@ interface PhotoProps {
 export const PhotoItem = ({
   hideDeleteButton = false,
   onPhotoDelete,
-  onPress,
   photo,
   progress,
 }: PhotoProps) => {
@@ -68,26 +66,20 @@ export const PhotoItem = ({
 
   return (
     <Flex height={IMAGE_SIZE} width={IMAGE_SIZE} mt={1} justifyContent="flex-end">
-      <TouchableWithoutFeedback
-        onPress={() => {
-          onPress?.()
-        }}
-      >
-        {photo.path ? (
-          <Image
-            style={{
-              height: IMAGE_SIZE,
-              width: IMAGE_SIZE,
-              position: "absolute",
-            }}
-            resizeMode="cover"
-            source={{ uri: photo.path }}
-            testID="Submission_Image"
-          />
-        ) : (
-          <SkeletonBox height={IMAGE_SIZE} width={IMAGE_SIZE}></SkeletonBox>
-        )}
-      </TouchableWithoutFeedback>
+      {photo.path ? (
+        <Image
+          style={{
+            height: IMAGE_SIZE,
+            width: IMAGE_SIZE,
+            position: "absolute",
+          }}
+          resizeMode="cover"
+          source={{ uri: photo.path }}
+          testID="Submission_Image"
+        />
+      ) : (
+        <SkeletonBox height={IMAGE_SIZE} width={IMAGE_SIZE}></SkeletonBox>
+      )}
       {!hideDeleteButton && (
         <Flex
           height={ICON_SIZE}

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
@@ -73,16 +73,20 @@ export const PhotoItem = ({
           onPress?.()
         }}
       >
-        <Image
-          style={{
-            height: IMAGE_SIZE,
-            width: IMAGE_SIZE,
-            position: "absolute",
-          }}
-          resizeMode="cover"
-          source={{ uri: photo.path }}
-          testID="Submission_Image"
-        />
+        {photo.path ? (
+          <Image
+            style={{
+              height: IMAGE_SIZE,
+              width: IMAGE_SIZE,
+              position: "absolute",
+            }}
+            resizeMode="cover"
+            source={{ uri: photo.path }}
+            testID="Submission_Image"
+          />
+        ) : (
+          <SkeletonBox height={IMAGE_SIZE} width={IMAGE_SIZE}></SkeletonBox>
+        )}
       </TouchableWithoutFeedback>
       {!hideDeleteButton && (
         <Flex

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
@@ -13,20 +13,22 @@ import {
   IMAGE_SIZE,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosForm"
 import { Photo as TPhoto } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
-import { Image } from "react-native"
+import { Image, TouchableWithoutFeedback } from "react-native"
 
 interface PhotoProps {
-  photo: TPhoto
   hideDeleteButton?: boolean
   onPhotoDelete: (arg: TPhoto) => void
+  onPress?: () => void
+  photo: TPhoto
   progress: number
 }
 
 export const PhotoItem = ({
-  photo,
-  progress,
   hideDeleteButton = false,
   onPhotoDelete,
+  onPress,
+  photo,
+  progress,
 }: PhotoProps) => {
   const space = useSpace()
 
@@ -66,16 +68,22 @@ export const PhotoItem = ({
 
   return (
     <Flex height={IMAGE_SIZE} width={IMAGE_SIZE} mt={1} justifyContent="flex-end">
-      <Image
-        style={{
-          height: IMAGE_SIZE,
-          width: IMAGE_SIZE,
-          position: "absolute",
+      <TouchableWithoutFeedback
+        onPress={() => {
+          onPress?.()
         }}
-        resizeMode="cover"
-        source={{ uri: photo.path }}
-        testID="Submission_Image"
-      />
+      >
+        <Image
+          style={{
+            height: IMAGE_SIZE,
+            width: IMAGE_SIZE,
+            position: "absolute",
+          }}
+          resizeMode="cover"
+          source={{ uri: photo.path }}
+          testID="Submission_Image"
+        />
+      </TouchableWithoutFeedback>
       {!hideDeleteButton && (
         <Flex
           height={ICON_SIZE}
@@ -91,7 +99,16 @@ export const PhotoItem = ({
           hitSlop={{ top: space(0.5), right: space(0.5), bottom: space(0.5), left: space(0.5) }}
           testID="Submission_Delete_Photo_Button"
         >
-          <Touchable onPress={() => onPhotoDelete(photo)} haptic="impactHeavy">
+          <Touchable
+            onPress={() => onPhotoDelete(photo)}
+            haptic="impactHeavy"
+            hitSlop={{
+              top: 5,
+              right: 5,
+              bottom: 5,
+              left: 5,
+            }}
+          >
             <CloseIcon height={16} width={16} fill="white100" />
           </Touchable>
         </Flex>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR makes the following fixes:
- Make the full image clickable, no need for feedback here because it's not the main way to add an image and it could make deleting a photo experience worse
- Add hitslop to delete icon
- Fix delete artwork image after you tap on continue and save. This was broken because the id was missing ⭐ 
- Make the photos upload in parallel
- Show processing images instead of hiding them (with gray background - in production this is not going to be happening much)


Example:

Uploading Screen Recording 2024-06-06 at 09.44.16.mov…



_The images do not show up immediately because of processing, this is why I was waiting on the video before tapping on delete 😢_ 

https://github.com/artsy/eigen/assets/11945712/a64b8704-4824-440c-b2e8-96223bdc97a9


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
