### PR TITLE
feat: dismiss modal before opening new submission flow

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails.tsx
@@ -30,7 +30,7 @@ export const SubmitArtworkAddDetails = () => {
       })}
     >
       <Flex px={2} flex={1}>
-        <ScrollView>
+        <ScrollView keyboardShouldPersistTaps="handled">
           <Text variant="lg-display" mb={2}>
             Artwork details
           </Text>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDimensions.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDimensions.tsx
@@ -5,6 +5,7 @@ import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { useFormikContext } from "formik"
 import { useRef, useState } from "react"
+import { ScrollView } from "react-native"
 import { useDebounce } from "react-use"
 
 export const SubmitArtworkAddDimensions = () => {
@@ -30,77 +31,79 @@ export const SubmitArtworkAddDimensions = () => {
         context_screen_owner_id: values.submissionId || undefined,
       })}
     >
-      <Flex px={2}>
-        <Text variant="lg-display" mb={2}>
-          Artwork dimensions
-        </Text>
+      <Flex px={2} flex={1}>
+        <ScrollView>
+          <Text variant="lg-display" mb={2}>
+            Artwork dimensions
+          </Text>
 
-        <Flex flexDirection="row">
-          <RadioButton
-            mr={2}
-            text="in"
-            selected={dimensionMetric === "in"}
-            onPress={() => {
-              setDimensionMetric("in")
-            }}
-          />
-          <RadioButton
-            text="cm"
-            selected={dimensionMetric === "cm"}
-            onPress={() => {
-              setDimensionMetric("cm")
-            }}
-          />
-        </Flex>
-
-        <Spacer y={1} />
-
-        <Flex flexDirection="row" justifyContent="space-between">
-          <Box flex={1}>
-            <Input
-              title="Height"
-              keyboardType="decimal-pad"
-              testID="Submission_HeightInput"
-              value={values.height}
-              onChangeText={(e) => setFieldValue("height", e)}
-              fixedRightPlaceholder={dimensionMetric}
-              accessibilityLabel="Height"
-              onSubmitEditing={() => {
-                widthRef.current?.focus()
+          <Flex flexDirection="row">
+            <RadioButton
+              mr={2}
+              text="in"
+              selected={dimensionMetric === "in"}
+              onPress={() => {
+                setDimensionMetric("in")
               }}
-              returnKeyLabel="Next"
+            />
+            <RadioButton
+              text="cm"
+              selected={dimensionMetric === "cm"}
+              onPress={() => {
+                setDimensionMetric("cm")
+              }}
+            />
+          </Flex>
+
+          <Spacer y={1} />
+
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Box flex={1}>
+              <Input
+                title="Height"
+                keyboardType="decimal-pad"
+                testID="Submission_HeightInput"
+                value={values.height}
+                onChangeText={(e) => setFieldValue("height", e)}
+                fixedRightPlaceholder={dimensionMetric}
+                accessibilityLabel="Height"
+                onSubmitEditing={() => {
+                  widthRef.current?.focus()
+                }}
+                returnKeyLabel="Next"
+              />
+            </Box>
+            <Spacer x={2} />
+            <Box flex={1}>
+              <Input
+                title="Width"
+                keyboardType="decimal-pad"
+                testID="Submission_WidthInput"
+                value={values.width}
+                onChangeText={(e) => setFieldValue("width", e)}
+                fixedRightPlaceholder={dimensionMetric}
+                accessibilityLabel="Width"
+                ref={widthRef}
+                onSubmitEditing={() => {
+                  depthRef.current?.focus()
+                }}
+                returnKeyLabel="Next"
+              />
+            </Box>
+          </Flex>
+          <Box width="50%" pr={1}>
+            <Input
+              title="Depth"
+              keyboardType="decimal-pad"
+              testID="Submission_DepthInput"
+              value={values.depth}
+              onChangeText={(e) => setFieldValue("depth", e)}
+              fixedRightPlaceholder={dimensionMetric}
+              accessibilityLabel="Depth"
+              ref={depthRef}
             />
           </Box>
-          <Spacer x={2} />
-          <Box flex={1}>
-            <Input
-              title="Width"
-              keyboardType="decimal-pad"
-              testID="Submission_WidthInput"
-              value={values.width}
-              onChangeText={(e) => setFieldValue("width", e)}
-              fixedRightPlaceholder={dimensionMetric}
-              accessibilityLabel="Width"
-              ref={widthRef}
-              onSubmitEditing={() => {
-                depthRef.current?.focus()
-              }}
-              returnKeyLabel="Next"
-            />
-          </Box>
-        </Flex>
-        <Box width="50%" pr={1}>
-          <Input
-            title="Depth"
-            keyboardType="decimal-pad"
-            testID="Submission_DepthInput"
-            value={values.depth}
-            onChangeText={(e) => setFieldValue("depth", e)}
-            fixedRightPlaceholder={dimensionMetric}
-            accessibilityLabel="Depth"
-            ref={depthRef}
-          />
-        </Box>
+        </ScrollView>
       </Flex>
     </ProvideScreenTrackingWithCohesionSchema>
   )

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkArtistRejected.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkArtistRejected.tsx
@@ -81,12 +81,15 @@ export const SubmitArtworkArtistRejected: React.FC<{}> = () => {
         </ScrollView>
         <InfoModal
           visible={isEligibilityModalVisible}
-          title="Eligible artist criteria"
           onDismiss={() => setIsEligibilityModalVisible(false)}
           buttonVariant="outline"
           fullScreen
         >
           <ScrollView>
+            <Text variant="lg-display">Eligible artist criteria</Text>
+
+            <Spacer y={2} />
+
             <Text>
               We are currently accepting unique and limited-edition works of art by modern,
               contemporary, and emerging artists who have collector demand on Artsy.

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tests.tsx
@@ -2,7 +2,7 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { SubmitArtworkBottomNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation"
 import { renderWithSubmitArtworkWrapper } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/testWrappers"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { navigate, switchTab } from "app/system/navigation/navigate"
+import { dismissModal, navigate, switchTab } from "app/system/navigation/navigate"
 
 const mockNavigateToNextStep = jest.fn()
 const mockNavigateToPreviousStep = jest.fn()
@@ -60,9 +60,7 @@ describe("SubmitArtworkBottomNavigation", () => {
       expect(submitAnotherWork).toBeOnTheScreen()
 
       fireEvent(submitAnotherWork, "onPress")
-      expect(navigate).toHaveBeenCalledWith("/sell/submissions/new", {
-        replaceActiveModal: true,
-      })
+      expect(dismissModal).toHaveBeenCalled()
     })
 
     it("Shows a functional Submit Another Artwork button", () => {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -29,7 +29,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
   )
   const showStartFromMyCollection = useFeatureFlag("AREnableSubmitMyCollectionArtworkInSubmitFlow")
 
-  const { currentStep, isLoading } = SubmitArtworkFormStore.useStoreState((state) => state)
+  const { isLoading, currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
   const { width: screenWidth } = useScreenDimensions()
 
   const handleBackPress = () => {
@@ -100,8 +100,8 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
             block
             onPress={() => {
               trackTappedSubmitAnotherWork(values.submissionId)
-              navigate("/sell/submissions/new", {
-                replaceActiveModal: true,
+              dismissModal(() => {
+                navigate("/sell/submissions/new")
               })
             }}
           >

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkSelectArtist.tsx
@@ -11,6 +11,7 @@ import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { navigate } from "app/system/navigation/navigate"
+import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { PlaceholderBox, PlaceholderText, ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
@@ -22,6 +23,8 @@ export const SubmitArtworkSelectArtist = () => {
   const { navigateToNextStep } = useSubmissionContext()
   const setIsLoading = SubmitArtworkFormStore.useStoreActions((actions) => actions.setIsLoading)
   const { isLoading, currentStep } = SubmitArtworkFormStore.useStoreState((state) => state)
+
+  const skipSubmissionCreation = useDevToggle("DTSkipSubmissionCreate")
 
   const formik = useFormikContext<ArtworkDetailsFormModel>()
 
@@ -68,9 +71,13 @@ export const SubmitArtworkSelectArtist = () => {
         skipMutation: true,
       })
 
-      const submissionId = await createOrUpdateSubmission(updatedValues, formik.values.submissionId)
-
-      formik.setFieldValue("submissionId", submissionId)
+      if (!skipSubmissionCreation) {
+        const submissionId = await createOrUpdateSubmission(
+          updatedValues,
+          formik.values.submissionId
+        )
+        formik.setFieldValue("submissionId", submissionId)
+      }
     } catch (error) {
       console.error("Error creating submission", error)
     } finally {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -1,4 +1,4 @@
-import { Flex, useScreenDimensions } from "@artsy/palette-mobile"
+import { Flex, Text, useScreenDimensions } from "@artsy/palette-mobile"
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { SubmitArtworkAddDetails } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddDetails"
@@ -29,6 +29,7 @@ import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork
 import { fetchUserContactInformation } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/fetchUserContactInformation"
 import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/SubmitArtwork/SubmitArtwork"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
+import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useIsKeyboardVisible } from "app/utils/hooks/useIsKeyboardVisible"
 import { FormikProvider, useFormik } from "formik"
 import { useEffect } from "react"
@@ -77,6 +78,7 @@ const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
   const currentStep = SubmitArtworkFormStore.useStoreState((state) => state.currentStep)
   const { bottom: bottomInset } = useSafeAreaInsets()
   const isKeyboardVisible = useIsKeyboardVisible(true)
+  const showDevHelpers = useDevToggle("DTShowSubmissionDevHelpers")
 
   const initialValues = {
     ...artworkDetailsEmptyInitialValues,
@@ -237,8 +239,18 @@ const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
                 />
               </Stack.Navigator>
             </NavigationContainer>
+            {!!showDevHelpers && (
+              <Flex alignItems="center" borderWidth={1} borderColor="devpurple">
+                <Text color="black60" variant="xs">
+                  currentStep: {currentStep}
+                </Text>
+                <Text color="black60" variant="xs">
+                  getCurrentRoute: {getCurrentRoute()}
+                </Text>
+              </Flex>
+            )}
+            <SubmitArtworkBottomNavigation />
           </Flex>
-          <SubmitArtworkBottomNavigation />
         </Flex>
       </ArtsyKeyboardAvoidingView>
     </FormikProvider>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -357,6 +357,12 @@ export const devToggles: { [key: string]: DevToggleDescriptor } = {
   DTEnableNewImageLabel: {
     description: "Show a label on new OpaqueImageView",
   },
+  DTSkipSubmissionCreate: {
+    description: "Skip submission creation",
+  },
+  DTShowSubmissionDevHelpers: {
+    description: "Show dev helpers in submission flow",
+  },
 }
 
 export const isDevToggle = (name: FeatureName | DevToggleName): name is DevToggleName => {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

_Drafting some description in a big_ 

https://github.com/artsy/eigen/assets/11945712/63bc768c-f412-4efa-a149-9db48a5d5d4a


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
