### PR TITLE
fix: icon alignment with text

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -1,5 +1,5 @@
 import { tappedTabBar } from "@artsy/cohesion"
-import { useColor, Text, PopIn, VisualClueDot, Flex } from "@artsy/palette-mobile"
+import { Flex, PopIn, Text, VisualClueDot, useColor } from "@artsy/palette-mobile"
 import { ProgressiveOnboardingFindSavedArtwork } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFindSavedArtwork"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { unsafe__getSelectedTab } from "app/store/GlobalStore"
@@ -87,7 +87,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
       <View style={{ flex: 1 }}>
         <ProgressiveOnboardingFindSavedArtwork tab={tab}>
           <Flex flex={1} alignItems="center">
-            <Flex flex={1}>
+            <Flex flex={1} height={ICON_HEIGHT}>
               <IconWrapper>
                 <BottomTabsIcon tab={tab} state="inactive" />
               </IconWrapper>
@@ -105,7 +105,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
               </IconWrapper>
             </Flex>
 
-            <Flex height={BOTTOM_TABS_TEXT_HEIGHT}>
+            <Flex height={BOTTOM_TABS_TEXT_HEIGHT} width="100%" alignItems="center">
               <Text variant="xxs">{bottomTabsConfig[tab].name}</Text>
             </Flex>
           </Flex>

--- a/src/app/Scenes/BottomTabs/BottomTabsIcon.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsIcon.tsx
@@ -15,7 +15,7 @@ export const BottomTabsIcon: React.FC<{ tab: BottomTabType; state: "active" | "i
     <Svg
       width={ICON_WIDTH}
       height={ICON_HEIGHT}
-      viewBox={`0 0 ${ICON_WIDTH} ${ICON_HEIGHT}`}
+      viewBox={`1 0 ${ICON_WIDTH} ${ICON_HEIGHT}`}
       fill={state === "active" ? color("appBackground") : color("appForeground")}
     >
       {ICONS[tab][state]}


### PR DESCRIPTION
### Description
This PR fixes the alignment on the bottom tabs. I found out now why we had a hard typed pixel before, I brought it back again now.

<img width="782" alt="Screenshot 2024-06-07 at 17 07 42" src="https://github.com/artsy/eigen/assets/11945712/bed71068-aa6d-4d6b-8135-f873d96d444b">

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
