### PR TITLE
fix: prefilled artist in my collection flow

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -396,14 +396,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 624
+        "line_number": 628
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 710
+        "line_number": 714
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1134,5 +1134,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-23T09:06:35Z"
+  "generated_at": "2024-06-10T12:19:58Z"
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm.ts
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm.ts
@@ -1,12 +1,20 @@
 import { ArtworkFormValues } from "app/Scenes/MyCollection/State/MyCollectionArtworkModel"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { FormikProps, useFormikContext } from "formik"
 import { useEffect } from "react"
 
 export function useArtworkForm(): { formik: FormikProps<ArtworkFormValues> } {
   const formik = useFormikContext<ArtworkFormValues>()
+  const enableNewSubmissionFlow = useFeatureFlag("AREnableNewSubmissionFlow")
 
   useEffect(() => {
+    // We don't want to update the form values if the new submission flow is enabled
+    // because the form values are managed by the new submission flow
+    if (enableNewSubmissionFlow) {
+      return
+    }
+
     GlobalStore.actions.myCollection.artwork.setFormValues(formik.values)
   }, [formik.values])
 

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -10,7 +10,7 @@ import {
   getGeminiCredentialsForEnvironment,
   uploadFileToS3,
 } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/utils/uploadFileToS3"
-import { GlobalStore } from "app/store/GlobalStore"
+import { GlobalStore, __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import * as LocalImageStore from "app/utils/LocalImageStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
@@ -68,6 +68,10 @@ describe("MyCollectionArtworkForm", () => {
     })
 
     describe("when selecting an already existing artwork", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewSubmissionFlow: false })
+      })
+
       it("populates the form with the data from the artwork", async () => {
         const assetCredentials = {
           signature: "some-signature",

--- a/src/app/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
+++ b/src/app/Scenes/MyCollection/State/MyCollectionArtworkModel.tsx
@@ -3,6 +3,7 @@ import { ArtworkAttributionClassType } from "__generated__/myCollectionCreateArt
 import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
 import { MyCollectionCustomArtistSchema } from "app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist"
 import { GlobalStoreModel } from "app/store/GlobalStoreModel"
+import { assignDeep } from "app/store/persistence"
 import { getAttributionClassValueByName } from "app/utils/artworkRarityClassifications"
 import { Action, action, thunk, Thunk } from "easy-peasy"
 import { pick, uniqBy } from "lodash"
@@ -84,7 +85,7 @@ export interface MyCollectionArtworkModel {
     formValues: ArtworkFormValues
     artworkErrorOccurred: boolean
   }
-  setFormValues: Action<MyCollectionArtworkModel, ArtworkFormValues>
+  setFormValues: Action<MyCollectionArtworkModel, Partial<ArtworkFormValues>>
   updateFormValues: Action<MyCollectionArtworkModel, Partial<ArtworkFormValues>>
   setDirtyFormCheckValues: Action<MyCollectionArtworkModel, ArtworkFormValues>
   resetForm: Action<MyCollectionArtworkModel>
@@ -120,7 +121,7 @@ export const MyCollectionArtworkModel: MyCollectionArtworkModel = {
   },
 
   setFormValues: action((state, input) => {
-    state.sessionState.formValues = input
+    assignDeep(state.sessionState.formValues, input)
   }),
 
   updateFormValues: action((state, input) => {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -4,6 +4,7 @@ import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils
 import { ArtworkDetailsFormModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
 import { Photo } from "app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/validation"
+import { GlobalStore } from "app/store/GlobalStore"
 import { dismissModal, navigate, popToRoot, switchTab } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFormikContext } from "formik"
@@ -136,6 +137,11 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
           <Button
             block
             onPress={() => {
+              GlobalStore.actions.myCollection.artwork.setFormValues({
+                artist: values.artist,
+                artistSearchResult: values.artistSearchResult,
+              })
+
               navigate("/my-collection/artworks/new", {
                 showInTabName: "profile",
                 replaceActiveModal: true,


### PR DESCRIPTION
This PR resolves [ONYX-1047] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue with submit artwork flow where the artist details remain saved. This is because we are using a global artwork form. I am fixing the issue here by making sure that the values are not injected if you are within the submit artwork flow. I believe this was needed for the old flow, but the way things are now, we don't need that anymore. In the short/mid term, we should not handle these values using the global store and instead sending them as props because there is no value in persisting them + making sure they are reset each time we leave the screen.

https://github.com/artsy/eigen/assets/11945712/2cb4e0f0-cf31-41a3-8d7b-cd4bf982d7dc


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1047]: https://artsyproduct.atlassian.net/browse/ONYX-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ