### PR TITLE
chore: go to my collection artwork post-submission

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -41,6 +41,8 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
 
   const artworks = extractNodes(data?.myCollectionConnection)
 
+  const nonSubmittedArtworks = artworks.filter((artwork) => !artwork.submissionId)
+
   const RefreshControl = useRefreshControl(refetch)
 
   const { setValues, values } = useFormikContext<ArtworkDetailsFormModel>()
@@ -74,7 +76,7 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
     }
   }
 
-  if (!artworks.length) {
+  if (!nonSubmittedArtworks.length) {
     return (
       <Flex px={2}>
         <SubmitArtworkFromMyCollectionHeader />
@@ -111,7 +113,7 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
   return (
     <Flex flex={1}>
       <MasonryInfiniteScrollArtworkGrid
-        artworks={artworks}
+        artworks={nonSubmittedArtworks}
         contextScreenOwnerType={OwnerType.submitArtworkStepSelectArtworkMyCollectionArtwork}
         contextScreen={OwnerType.submitArtworkStepSelectArtworkMyCollectionArtwork}
         loadMore={(pageSize) => loadNext(pageSize)}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchSubmissionInformation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchSubmissionInformation.ts
@@ -1,0 +1,22 @@
+import { fetchSubmissionInformationQuery } from "__generated__/fetchSubmissionInformationQuery.graphql"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { fetchQuery, graphql } from "react-relay"
+
+export const fetchSubmissionInformation = (submissionID: string) => {
+  return fetchQuery<fetchSubmissionInformationQuery>(
+    getRelayEnvironment(),
+    FetchSubmissionInformationQuery,
+    {
+      submissionID,
+    }
+  ).toPromise()
+}
+
+const FetchSubmissionInformationQuery = graphql`
+  query fetchSubmissionInformationQuery($submissionID: ID!) {
+    submission(id: $submissionID) {
+      id
+      myCollectionArtworkID
+    }
+  }
+`

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/navigationHelpers.ts
@@ -86,8 +86,11 @@ export const useSubmissionContext = () => {
               artworkID: newValues.myCollectionArtworkID,
             })
           }
-
-          refreshMyCollection()
+          // Only refresh my collection after 2 seconds,
+          // this is in order to make sure that the images are done processing
+          setTimeout(() => {
+            refreshMyCollection()
+          }, 2000)
         }
       }
 


### PR DESCRIPTION
**Although this is 95% reviewable, I believe we should not merge it given the image processing issues which make the UX quite bad**

This PR resolves [ONYX-1007] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds go to my collection artwork post-submission logic. 
This wasn't possible in the past because we didn't get my collection artwork id, but we have it now.


https://github.com/artsy/eigen/assets/11945712/99685735-a198-46db-8230-84197e04683a

Unfortunately, the experience is not ideal currently because we have issues with images processing. This is why **I suggest keeping this PR as a draft because it will worse the UX**

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- go to my collection artwork post-submission - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1007]: https://artsyproduct.atlassian.net/browse/ONYX-1007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ