### PR TITLE
fix: adjust bottom tab icons height on tablets

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -22,7 +22,7 @@ export interface BottomTabsButtonProps {
   forceDisplayVisualClue?: boolean
 }
 
-export const BOTTOM_TABS_TEXT_HEIGHT = 13
+export const BOTTOM_TABS_TEXT_HEIGHT = 15
 
 export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
   tab,
@@ -105,7 +105,12 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
               </IconWrapper>
             </Flex>
 
-            <Flex height={BOTTOM_TABS_TEXT_HEIGHT} width="100%" alignItems="center">
+            <Flex
+              height={BOTTOM_TABS_TEXT_HEIGHT}
+              width="100%"
+              alignItems="center"
+              justifyContent="center"
+            >
               <Text variant="xxs">{bottomTabsConfig[tab].name}</Text>
             </Flex>
           </Flex>


### PR DESCRIPTION
This PR resolves [ONYX-1065] <!-- eg [PROJECT-XXXX] -->

### Description
- Fix bottom tab icons height on tablets

![Screenshot_1718199572](https://github.com/artsy/eigen/assets/11945712/000439d6-d1b1-4994-aa80-95bf929f70cf)
![simulator_screenshot_05C9A974-8A4D-4DD9-85F1-0FBB86FC51E5](https://github.com/artsy/eigen/assets/11945712/45ffb283-401b-4092-805f-3fc848e0eeef)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1065]: https://artsyproduct.atlassian.net/browse/ONYX-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ