### PR TITLE
fix: leave without sending contact information

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -458,6 +458,7 @@ export const modules = defineModules({
   CitySectionList: reactModule(CitySectionListQueryRenderer),
   Collection: reactModule(CollectionQueryRenderer, { fullBleed: true }),
   ConsignmentInquiry: reactModule(ConsignmentInquiryScreen, {
+    hidesBottomTabs: true,
     screenOptions: {
       gestureEnabled: false,
     },

--- a/src/app/Scenes/SellWithArtsy/ConsignmentInquiry/ConsignmentInquiryScreen.tsx
+++ b/src/app/Scenes/SellWithArtsy/ConsignmentInquiry/ConsignmentInquiryScreen.tsx
@@ -5,6 +5,7 @@ import { AbandonFlowModal } from "app/Components/AbandonFlowModal"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { useToast } from "app/Components/Toast/toastHook"
+import { goBack } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { FormikProvider, useFormik } from "formik"
@@ -150,6 +151,7 @@ export const ConsignmentInquiryScreen: React.FC<InquiryScreenProps> = ({
           leaveButtonTitle="Leave Without Sending"
           continueButtonTitle="Continue Editing Message"
           onDismiss={() => setShowAbandonModal(false)}
+          onLeave={goBack}
         />
 
         <FancyModal


### PR DESCRIPTION
This PR resolves [ONYX-1063] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue with the contact information screen where the user can not leave the screen after they edit it. 
**Bonus:** I noticed that the bottom tabs are visible and hid them as well

https://github.com/artsy/eigen/assets/11945712/7b485c87-54ed-44a0-b3be-ecd4ecc5bc24


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1063]: https://artsyproduct.atlassian.net/browse/ONYX-1063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ