### PR TITLE
fix: crash on android when pressing skip twice fast

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -15,6 +15,7 @@ import {
   useOnboardingContext,
 } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
+import { debounce } from "lodash"
 import React, { FC, useCallback, useState } from "react"
 import { LayoutAnimation } from "react-native"
 import { AnimatedFadingPill, FADE_OUT_PILL_ANIMATION_DURATION } from "./AnimatedFadingPill"
@@ -100,9 +101,11 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
 
   const isDisabled = isNextBtnDisabled || !state[stateKey] || state[stateKey]?.length === 0
 
+  const debouncedHandleSkip = debounce(onDone, 1000)
+
   return (
     <LegacyScreen>
-      <LegacyScreen.Header onBack={handleBack} onSkip={onDone} />
+      <LegacyScreen.Header onBack={handleBack} onSkip={debouncedHandleSkip} />
       <LegacyScreen.Body>
         <Box pt={2}>
           <ProgressBar progress={progress} />


### PR DESCRIPTION
This PR resolves [APPL-826] <!-- eg [PROJECT-XXXX] -->

### Description

On android when we press the `skip` twice on onboarding it results into making the app unresponsive and then it crashes.

Debouncing the skip works as expected.

|Before|After|
|---|---|
|<video src="https://github.com/artsy/eigen/assets/21178754/5fc9c508-e7de-40a8-a1e5-ce4834628378" width="300" />|<video src="https://github.com/artsy/eigen/assets/21178754/8c57b7a2-0314-4b40-a0a9-c8655d2e8268" width="300" />|


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- crash on android when pressing onboarding skip twice fast - gkartalis

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-826]: https://artsyproduct.atlassian.net/browse/APPL-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ