### PR TITLE
fix(onyx-1050): fix logic for checking if new works for you rail is empty

### DIFF
--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -533,6 +533,19 @@ export const HomeFragmentContainer = memo(
       newWorksForYou: graphql`
         fragment Home_newWorksForYou on Viewer {
           ...NewWorksForYouRail_artworkConnection
+          artworksConnection: artworksForUser(
+            maxWorksPerArtist: 3
+            includeBackfill: true
+            first: 40
+            version: $version
+            excludeDislikedArtworks: true
+          ) {
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
         }
       `,
       heroUnits: graphql`

--- a/src/app/Scenes/Home/useHomeModules.ts
+++ b/src/app/Scenes/Home/useHomeModules.ts
@@ -36,7 +36,7 @@ export const useHomeModules = (props: HomeProps) => {
         contextScreen: "home",
         contextScreenOwnerType: OwnerType.home,
         data: props.newWorksForYou,
-        isEmpty: isEmpty(props.newWorksForYou),
+        isEmpty: !props.newWorksForYou?.artworksConnection?.edges?.length,
         key: "newWorksForYouRail",
         title: "New Works for You",
         type: "newWorksForYou",


### PR DESCRIPTION
This PR resolves [ONYX-1050]

### Description

Solves this extra empty space issue:

| Before | After |
|---|---|
| <img src="https://github.com/artsy/eigen/assets/3934579/90a65bad-ae25-477b-adcb-429d5bacacce" /> | <img src="https://github.com/artsy/eigen/assets/3934579/3c58e2c3-3426-4c26-b606-7d21ac120291" /> |

If `artworksForUser` collection is empty - `isEmpty` condition in `useHomeModules` doesn't result in `true` and "empty" <></> component is rendered in home screen together with extra separator. This PR should fix it. 

The price of this fix is an extra request to metaphysics (or does relay cache the result and doesn't make a request when rendering the component?). I see that this approach is used for other modules on home page, but I am wondering - is it justified to make +1 request for each module or is it better if each module adds it's own separator? Ofc if no extra request is made then it's ok.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- bug fix: remove extra space on the home page when new for you rail is empty - @nickskalkin 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1050]: https://artsyproduct.atlassian.net/browse/ONYX-1050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ