### PR TITLE
chore(AMBER-769): Remove "Bidding closed" logic from the artwork grid

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -532,13 +532,8 @@ export const saleMessageOrBidInfo = ({
   }
 
   // Auction specs are available at https://artsyproduct.atlassian.net/browse/MX-482
-  if (sale?.isAuction) {
-    // The auction is closed
-    if (sale.isClosed) {
-      return "Bidding closed"
-    }
-
-    // The auction is open
+  // The auction is open
+  if (sale?.isAuction && !sale.isClosed) {
     const bidderPositions = saleArtwork?.counts?.bidderPositions
     const currentBid = saleArtwork?.currentBid?.display
     // If there are no current bids we show the starting price with an indication that it's a new bid

--- a/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tests.tsx
+++ b/src/app/Components/SaleArtworkTileRailCard/SaleArtworkTileRailCard.tests.tsx
@@ -71,7 +71,7 @@ describe("SaleArtworkTileRailCard", () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer useCustomSaleMessage />)
 
     resolveMostRecentRelayOperation(mockEnvironment, mockProps)
-    expect(extractText(tree.root)).toContain("Bidding closed")
+    expect(extractText(tree.root)).toContain("(14 bids)")
   })
 
   it("renders square image when useSquareAspectRatio is set to true ", () => {
@@ -111,7 +111,7 @@ const mockProps = {
     lotLabel: "66002",
     sale: {
       isAuction: true,
-      isClosed: true,
+      isClosed: false,
       displayTimelyAt: null,
     },
   }),


### PR DESCRIPTION
https://github.com/artsy/gravity/pull/17866


This PR resolves [AMBER-769] <!-- eg [PROJECT-XXXX] -->

### Description

It now comes straight from Gravity, we don't need it set on the clients anymore

<img width="451" alt="Screenshot 2024-07-02 at 10 32 57" src="https://github.com/artsy/eigen/assets/8002618/09bf0e16-164e-4e4b-b752-1ff862373e93">


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Remove "Bidding closed" logic from the Artwork Grid implementation and fetch it from Gravity instead

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

cc @artsy/amber-devs 

[AMBER-769]: https://artsyproduct.atlassian.net/browse/AMBER-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ