### PR TITLE
chore: fix submit artwork from my collection comments

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -72,12 +72,12 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
     return (
       <Flex px={2}>
         <SubmitArtworkFromMyCollectionHeader />
-        <Spacer y={4} />
+        <Spacer y={2} />
         <Message title="">
-          <Text variant="sm-display" color="black60">
+          <Text variant="xs" color="black60">
             You have no eligible works in{" "}
             <LinkText
-              variant="sm-display"
+              variant="xs"
               onPress={() => {
                 dismissModal()
                 switchTab("profile")
@@ -88,7 +88,7 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
           </Text>
         </Message>
 
-        <Spacer y={4} />
+        <Spacer y={2} />
 
         <Button
           block
@@ -99,7 +99,7 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
             })
           }}
         >
-          Add details manually
+          Add Details Manually
         </Button>
       </Flex>
     )
@@ -130,7 +130,8 @@ export const SubmitArtworkFromMyCollectionHeader: React.FC = () => {
   return (
     <>
       <Text variant="lg-display">Select artwork from My Collection</Text>
-      <Text color="black60" variant="xs" mt={1}>
+      <Spacer y={2} />
+      <Text color="black60" variant="xs">
         You will only see eligible artworks. Artworks that have already been submitted won't be
         shown.
       </Text>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Button, Flex, LinkText, Spacer, Text } from "@artsy/palette-mobile"
+import { Button, Flex, LinkText, Message, Spacer, Text } from "@artsy/palette-mobile"
 import { SubmitArtworkFromMyCollectionArtworksQuery } from "__generated__/SubmitArtworkFromMyCollectionArtworksQuery.graphql"
 import { SubmitArtworkFromMyCollectionArtworks_me$key } from "__generated__/SubmitArtworkFromMyCollectionArtworks_me.graphql"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
@@ -73,17 +73,20 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
       <Flex px={2}>
         <SubmitArtworkFromMyCollectionHeader />
         <Spacer y={4} />
-        <Text>
-          You have no eligible artworks in{" "}
-          <LinkText
-            onPress={() => {
-              dismissModal()
-              switchTab("profile")
-            }}
-          >
-            My Collection.
-          </LinkText>{" "}
-        </Text>
+        <Message title="">
+          <Text variant="sm-display" color="black60">
+            You have no eligible works in{" "}
+            <LinkText
+              variant="sm-display"
+              onPress={() => {
+                dismissModal()
+                switchTab("profile")
+              }}
+            >
+              My Collection.{"\n"}
+            </LinkText>{" "}
+          </Text>
+        </Message>
 
         <Spacer y={4} />
 
@@ -126,8 +129,8 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
 export const SubmitArtworkFromMyCollectionHeader: React.FC = () => {
   return (
     <>
-      <Text variant="lg">Select artwork from My Collection</Text>
-      <Text color="black60" variant="xs">
+      <Text variant="lg-display">Select artwork from My Collection</Text>
+      <Text color="black60" variant="xs" mt={1}>
         You will only see eligible artworks. Artworks that have already been submitted won't be
         shown.
       </Text>


### PR DESCRIPTION
### Description

This PR address design comments on the submit artwork from my collection

_Tomorrow is release day, I will merge this to make sure it makes it - glad to address comments separately_

<img src="https://github.com/artsy/eigen/assets/11945712/83f1c986-224b-4fd8-b41b-a5a40cdb1668" width="400" />


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
