### PR TITLE
feat: add a profile update modal (DIA-695)

### DIFF
--- a/src/app/Components/LocationAutocomplete.tsx
+++ b/src/app/Components/LocationAutocomplete.tsx
@@ -1,4 +1,5 @@
 import { Flex, Input, InputProps, MapPinIcon, Text, Touchable } from "@artsy/palette-mobile"
+import { BottomSheetInput } from "app/Components/BottomSheetInput"
 import {
   LocationWithDetails,
   SimpleLocation,
@@ -18,6 +19,7 @@ interface LocationAutocompleteProps extends Omit<InputProps, "onChange"> {
   showError?: boolean
   onChange: (l: LocationWithDetails) => void
   FooterComponent?: () => JSX.Element
+  useBottomSheetInput?: boolean
 }
 
 /**
@@ -42,6 +44,7 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   inputRef,
   allowCustomLocation = false,
   showError,
+  useBottomSheetInput,
   ...restProps
 }) => {
   const [predictions, setPredictions] = useState<SimpleLocation[]>([])
@@ -51,6 +54,8 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   const ref = inputRef || innerRef
 
   const selectedLocationQuery = selectedLocation?.name || displayLocation
+
+  const InputComponent = useBottomSheetInput ? BottomSheetInput : Input
 
   useEffect(() => {
     if (selectedLocation) {
@@ -115,7 +120,7 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
 
   return (
     <Flex>
-      <Input
+      <InputComponent
         {...restProps}
         ref={ref}
         testID="autocomplete-location-input"

--- a/src/app/Components/LocationAutocomplete.tsx
+++ b/src/app/Components/LocationAutocomplete.tsx
@@ -19,7 +19,7 @@ interface LocationAutocompleteProps extends Omit<InputProps, "onChange"> {
   showError?: boolean
   onChange: (l: LocationWithDetails) => void
   FooterComponent?: () => JSX.Element
-  useBottomSheetInput?: boolean
+  bottomSheetInput?: boolean
 }
 
 /**
@@ -44,7 +44,7 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
   inputRef,
   allowCustomLocation = false,
   showError,
-  useBottomSheetInput,
+  bottomSheetInput,
   ...restProps
 }) => {
   const [predictions, setPredictions] = useState<SimpleLocation[]>([])
@@ -55,7 +55,7 @@ export const LocationAutocomplete: React.FC<LocationAutocompleteProps> = ({
 
   const selectedLocationQuery = selectedLocation?.name || displayLocation
 
-  const InputComponent = useBottomSheetInput ? BottomSheetInput : Input
+  const InputComponent = bottomSheetInput ? BottomSheetInput : Input
 
   useEffect(() => {
     if (selectedLocation) {

--- a/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
@@ -1,0 +1,114 @@
+import { Input, Spacer } from "@artsy/palette-mobile"
+import { EditableLocation } from "__generated__/updateMyUserProfileMutation.graphql"
+import { BottomSheetInput } from "app/Components/BottomSheetInput"
+import { LocationAutocomplete, buildLocationDisplay } from "app/Components/LocationAutocomplete"
+import { useFormikContext } from "formik"
+import { useRef } from "react"
+import * as Yup from "yup"
+
+interface EditableLocationProps extends EditableLocation {
+  display: string | null
+}
+
+export interface UserProfileFormikSchema {
+  name: string
+  displayLocation: { display: string | null }
+  location: Partial<EditableLocationProps> | null | undefined
+  profession: string
+  otherRelevantPositions: string
+}
+
+export const userProfileYupSchema = Yup.object().shape({
+  name: Yup.string().required("Name is required"),
+})
+
+interface UserProfileFieldsProps {
+  nextInputRef?: React.RefObject<Input>
+  useBottomSheetInputs?: boolean
+}
+
+export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
+  nextInputRef,
+  useBottomSheetInputs,
+}) => {
+  const formikBag = useFormikContext<UserProfileFormikSchema>()
+  const { values, setFieldValue, handleChange, errors, validateForm } = formikBag
+
+  const nameInputRef = useRef<Input>(null)
+  const locationInputRef = useRef<Input>(null)
+  const professionInputRef = useRef<Input>(null)
+  const relevantPositionsInputRef = useRef<Input>(null)
+
+  const InputComponent = useBottomSheetInputs ? BottomSheetInput : Input
+
+  return (
+    <>
+      <InputComponent
+        ref={nameInputRef}
+        title="Full name"
+        onChangeText={handleChange("name")}
+        onBlur={() => validateForm()}
+        error={errors.name}
+        returnKeyType="next"
+        value={values.name}
+        onSubmitEditing={() => {
+          locationInputRef.current?.focus()
+        }}
+      />
+      <Spacer y={2} />
+      <LocationAutocomplete
+        allowCustomLocation
+        enableClearButton
+        inputRef={locationInputRef}
+        title="Primary location"
+        placeholder="City name"
+        returnKeyType="next"
+        onSubmitEditing={() => {
+          professionInputRef.current?.focus()
+        }}
+        displayLocation={buildLocationDisplay(values.location)}
+        onChange={({ city, country, postalCode, state, stateCode, coordinates }) => {
+          setFieldValue("location", {
+            city: city ?? "",
+            country: country ?? "",
+            postalCode: postalCode ?? "",
+            state: state ?? "",
+            stateCode: stateCode ?? "",
+            coordinates,
+          })
+        }}
+        useBottomSheetInput={useBottomSheetInputs}
+      />
+      <Spacer y={2} />
+      <InputComponent
+        ref={professionInputRef}
+        title="Profession"
+        onChangeText={handleChange("profession")}
+        onBlur={() => validateForm()}
+        error={errors.name}
+        returnKeyType="next"
+        value={values.profession}
+        placeholder="Profession or job title"
+        onSubmitEditing={() => {
+          relevantPositionsInputRef.current?.focus()
+        }}
+      />
+      <Spacer y={2} />
+      <InputComponent
+        ref={relevantPositionsInputRef}
+        title="Other Relevant Positions"
+        onChangeText={handleChange("otherRelevantPositions")}
+        onBlur={() => validateForm()}
+        error={errors.name}
+        value={values.otherRelevantPositions}
+        placeholder="Memberships, institutions, positions"
+        {...(nextInputRef
+          ? {
+              returnKeyType: "next",
+              onSubmitEditing: () => nextInputRef.current?.focus(),
+            }
+          : {})}
+      />
+    </>
+  )
+}

--- a/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
@@ -23,14 +23,10 @@ export const userProfileYupSchema = Yup.object().shape({
 })
 
 interface UserProfileFieldsProps {
-  nextInputRef?: React.RefObject<Input>
   bottomSheetInput?: boolean
 }
 
-export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
-  nextInputRef,
-  bottomSheetInput,
-}) => {
+export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({ bottomSheetInput }) => {
   const formikBag = useFormikContext<UserProfileFormikSchema>()
   const { values, setFieldValue, handleChange, errors, validateForm } = formikBag
 
@@ -50,6 +46,7 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
         title="Full name"
         onChangeText={handleChange("name")}
         onBlur={() => validateForm()}
+        blurOnSubmit={false}
         error={errors.name}
         returnKeyType="next"
         value={values.name}
@@ -65,6 +62,7 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
           title="Primary location"
           placeholder="City name"
           returnKeyType="next"
+          blurOnSubmit={false}
           onSubmitEditing={() => {
             professionInputRef.current?.focus()
           }}
@@ -87,7 +85,8 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
         title="Profession"
         onChangeText={handleChange("profession")}
         onBlur={() => validateForm()}
-        error={errors.name}
+        blurOnSubmit={false}
+        error={errors.profession}
         returnKeyType="next"
         value={values.profession}
         placeholder="Profession or job title"
@@ -100,15 +99,10 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
         title="Other Relevant Positions"
         onChangeText={handleChange("otherRelevantPositions")}
         onBlur={() => validateForm()}
-        error={errors.name}
+        error={errors.otherRelevantPositions}
         value={values.otherRelevantPositions}
         placeholder="Memberships, institutions, positions"
-        {...(nextInputRef
-          ? {
-              returnKeyType: "next",
-              onSubmitEditing: () => nextInputRef.current?.focus(),
-            }
-          : {})}
+        returnKeyType="done"
       />
     </Flex>
   )

--- a/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
@@ -57,29 +57,31 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
           locationInputRef.current?.focus()
         }}
       />
-      <LocationAutocomplete
-        allowCustomLocation
-        enableClearButton
-        inputRef={locationInputRef}
-        title="Primary location"
-        placeholder="City name"
-        returnKeyType="next"
-        onSubmitEditing={() => {
-          professionInputRef.current?.focus()
-        }}
-        displayLocation={buildLocationDisplay(values.location)}
-        onChange={({ city, country, postalCode, state, stateCode, coordinates }) => {
-          setFieldValue("location", {
-            city: city ?? "",
-            country: country ?? "",
-            postalCode: postalCode ?? "",
-            state: state ?? "",
-            stateCode: stateCode ?? "",
-            coordinates,
-          })
-        }}
-        bottomSheetInput={bottomSheetInput}
-      />
+      <Flex>
+        <LocationAutocomplete
+          allowCustomLocation
+          enableClearButton
+          inputRef={locationInputRef}
+          title="Primary location"
+          placeholder="City name"
+          returnKeyType="next"
+          onSubmitEditing={() => {
+            professionInputRef.current?.focus()
+          }}
+          displayLocation={buildLocationDisplay(values.location)}
+          onChange={({ city, country, postalCode, state, stateCode, coordinates }) => {
+            setFieldValue("location", {
+              city: city ?? "",
+              country: country ?? "",
+              postalCode: postalCode ?? "",
+              state: state ?? "",
+              stateCode: stateCode ?? "",
+              coordinates,
+            })
+          }}
+          bottomSheetInput={bottomSheetInput}
+        />
+      </Flex>
       <InputComponent
         ref={professionInputRef}
         title="Profession"

--- a/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/Components/UserProfileFields.tsx
@@ -1,4 +1,4 @@
-import { Input, Spacer } from "@artsy/palette-mobile"
+import { Flex, Input, useSpace } from "@artsy/palette-mobile"
 import { EditableLocation } from "__generated__/updateMyUserProfileMutation.graphql"
 import { BottomSheetInput } from "app/Components/BottomSheetInput"
 import { LocationAutocomplete, buildLocationDisplay } from "app/Components/LocationAutocomplete"
@@ -24,12 +24,12 @@ export const userProfileYupSchema = Yup.object().shape({
 
 interface UserProfileFieldsProps {
   nextInputRef?: React.RefObject<Input>
-  useBottomSheetInputs?: boolean
+  bottomSheetInput?: boolean
 }
 
 export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
   nextInputRef,
-  useBottomSheetInputs,
+  bottomSheetInput,
 }) => {
   const formikBag = useFormikContext<UserProfileFormikSchema>()
   const { values, setFieldValue, handleChange, errors, validateForm } = formikBag
@@ -39,10 +39,12 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
   const professionInputRef = useRef<Input>(null)
   const relevantPositionsInputRef = useRef<Input>(null)
 
-  const InputComponent = useBottomSheetInputs ? BottomSheetInput : Input
+  const space = useSpace()
+
+  const InputComponent = bottomSheetInput ? BottomSheetInput : Input
 
   return (
-    <>
+    <Flex gap={space(2)}>
       <InputComponent
         ref={nameInputRef}
         title="Full name"
@@ -55,7 +57,6 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
           locationInputRef.current?.focus()
         }}
       />
-      <Spacer y={2} />
       <LocationAutocomplete
         allowCustomLocation
         enableClearButton
@@ -77,9 +78,8 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
             coordinates,
           })
         }}
-        useBottomSheetInput={useBottomSheetInputs}
+        bottomSheetInput={bottomSheetInput}
       />
-      <Spacer y={2} />
       <InputComponent
         ref={professionInputRef}
         title="Profession"
@@ -93,7 +93,6 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
           relevantPositionsInputRef.current?.focus()
         }}
       />
-      <Spacer y={2} />
       <InputComponent
         ref={relevantPositionsInputRef}
         title="Other Relevant Positions"
@@ -109,6 +108,6 @@ export const UserProfileFields: React.FC<UserProfileFieldsProps> = ({
             }
           : {})}
       />
-    </>
+    </Flex>
   )
 }

--- a/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
@@ -12,6 +12,7 @@ import {
   Text,
   Touchable,
   useColor,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { useNavigation } from "@react-navigation/native"
@@ -67,6 +68,7 @@ export const MyProfileEditForm: React.FC<MyProfileEditFormProps> = ({ onSuccess 
   )
 
   const color = useColor()
+  const space = useSpace()
   const navigation = useNavigation()
 
   const { showActionSheetWithOptions } = useActionSheet()
@@ -240,24 +242,22 @@ export const MyProfileEditForm: React.FC<MyProfileEditFormProps> = ({ onSuccess 
               <Text style={{ textDecorationLine: "underline" }}>Choose an Image</Text>
             </Touchable>
           </Flex>
-          <Flex m={2}>
-            <Join separator={<Spacer y={2} />}>
-              <FormikProvider value={formikBag}>
-                <UserProfileFields />
-              </FormikProvider>
+          <Flex m={2} gap={space(2)}>
+            <FormikProvider value={formikBag}>
+              <UserProfileFields />
+            </FormikProvider>
 
-              <ProfileVerifications
-                isIDVerified={!!me?.isIdentityVerified}
-                canRequestEmailConfirmation={!!me?.canRequestEmailConfirmation}
-                isEmailConfirmed={!!me?.isEmailConfirmed}
-                handleEmailVerification={handleEmailVerification}
-                handleIDVerification={handleIDVerification}
-              />
+            <ProfileVerifications
+              isIDVerified={!!me?.isIdentityVerified}
+              canRequestEmailConfirmation={!!me?.canRequestEmailConfirmation}
+              isEmailConfirmed={!!me?.isEmailConfirmed}
+              handleEmailVerification={handleEmailVerification}
+              handleIDVerification={handleIDVerification}
+            />
 
-              <Button flex={1} disabled={!touched} onPress={handleSubmit} mb={2}>
-                Save
-              </Button>
-            </Join>
+            <Button flex={1} disabled={!touched} onPress={handleSubmit} mb={2}>
+              Save
+            </Button>
           </Flex>
         </Join>
       </ScrollView>

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -48,7 +48,9 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
    *
    * 1. The modal glitches during autocompletion
    * 2. The submit button doesn't work after selecting a location
+   *   - This also happens on the settings screen (on the main branch)
    * 3. The primary location field title is behind the outline
+   *   - This does not happen in the settings screen (on the feature branch)
    */
 
   return (

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -43,9 +43,17 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   onClose,
   visible,
 }) => {
+  /**
+   * TODO: On Android
+   *
+   * 1. The modal glitches during autocompletion
+   * 2. The submit button doesn't work after selecting a location
+   * 3. The primary location field title is behind the outline
+   */
+
   return (
     <AutomountedBottomSheetModal visible={visible} enableDynamicSizing>
-      <BottomSheetScrollView>
+      <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <MyProfileEditModalWithSuspense onClose={onClose} message={message} />
       </BottomSheetScrollView>
     </AutomountedBottomSheetModal>

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -79,37 +79,13 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
   message,
   onClose,
 }) => {
-  const data = useFragment(
-    graphql`
-      fragment MyProfileEditModal_me on Me {
-        name
-        location {
-          city
-          state
-          country
-        }
-        profession
-        otherRelevantPositions
-      }
-    `,
-    me
-  )
+  const data = useFragment(meFragmentQuery, me)
 
   const [loading, setLoading] = useState<boolean>(false)
   const { trackEvent } = useTracking()
 
   // TODO: what am I suposed to do with inProgress?
   const [commit, _inProgress] = useUpdateUserProfileFields()
-
-  // TODO: update cohesion and pass a better context_screen and context_screen_owner_type
-  const tracks = {
-    editedUserProfile: (): EditedUserProfile => ({
-      action: ActionType.editedUserProfile,
-      context_screen: ContextModule.collectorProfile,
-      context_screen_owner_type: OwnerType.editProfile,
-      platform: "mobile",
-    }),
-  }
 
   const formikBag = useFormik<UserProfileFormikSchema>({
     enableReinitialize: true,
@@ -161,7 +137,7 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
     <Box p={2} testID="my-profile-edit-modal-content">
       <Text>{message}</Text>
       <FormikProvider value={formikBag}>
-        <UserProfileFields useBottomSheetInputs />
+        <UserProfileFields bottomSheetInput />
         <Button block mt={2} onPress={handleSubmit} disabled={!isValid} loading={loading}>
           Save and Continue
         </Button>
@@ -201,4 +177,27 @@ const MyProfileEditModalSkeleton = () => {
       </Box>
     </Skeleton>
   )
+}
+
+const meFragmentQuery = graphql`
+  fragment MyProfileEditModal_me on Me {
+    name
+    location {
+      city
+      state
+      country
+    }
+    profession
+    otherRelevantPositions
+  }
+`
+
+// TODO: update cohesion and pass a better context_screen and context_screen_owner_type
+const tracks = {
+  editedUserProfile: (): EditedUserProfile => ({
+    action: ActionType.editedUserProfile,
+    context_screen: ContextModule.collectorProfile,
+    context_screen_owner_type: OwnerType.editProfile,
+    platform: "mobile",
+  }),
 }

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -1,0 +1,204 @@
+import { ActionType, ContextModule, EditedUserProfile, OwnerType } from "@artsy/cohesion"
+import {
+  Box,
+  Button,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+  Text,
+} from "@artsy/palette-mobile"
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
+import { MyProfileEditModalQuery } from "__generated__/MyProfileEditModalQuery.graphql"
+import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
+import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
+import { buildLocationDisplay } from "app/Components/LocationAutocomplete"
+import {
+  UserProfileFields,
+  UserProfileFormikSchema,
+  userProfileYupSchema,
+} from "app/Scenes/MyProfile/Components/UserProfileFields"
+import { useUpdateUserProfileFields } from "app/Scenes/MyProfile/useUpdateUserProfileFields"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { FormikProvider, useFormik } from "formik"
+import { useState } from "react"
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface SharedProps {
+  message: string
+  onClose: () => void
+}
+
+interface MyProfileEditModalProps extends SharedProps {
+  visible: boolean
+}
+
+interface MyProfileEditModalContentProps extends SharedProps {
+  me: MyProfileEditModal_me$key
+}
+
+export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
+  message,
+  onClose,
+  visible,
+}) => {
+  return (
+    <AutomountedBottomSheetModal visible={visible} enableDynamicSizing>
+      <BottomSheetScrollView>
+        <MyProfileEditModalWithSuspense onClose={onClose} message={message} />
+      </BottomSheetScrollView>
+    </AutomountedBottomSheetModal>
+  )
+}
+
+const MyProfileEditModalWithSuspense: React.FC<SharedProps> = withSuspense(
+  ({ message, onClose }) => {
+    const data = useLazyLoadQuery<MyProfileEditModalQuery>(
+      graphql`
+        query MyProfileEditModalQuery {
+          me @required(action: NONE) {
+            ...MyProfileEditModal_me
+          }
+        }
+      `,
+      {}
+    )
+
+    if (!data?.me) {
+      return null
+    }
+
+    return <MyProfileEditModalContent me={data.me} onClose={onClose} message={message} />
+  },
+  () => <MyProfileEditModalSkeleton />
+)
+
+const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
+  me,
+  message,
+  onClose,
+}) => {
+  const data = useFragment(
+    graphql`
+      fragment MyProfileEditModal_me on Me {
+        name
+        location {
+          city
+          state
+          country
+        }
+        profession
+        otherRelevantPositions
+      }
+    `,
+    me
+  )
+
+  const [loading, setLoading] = useState<boolean>(false)
+  const { trackEvent } = useTracking()
+
+  // TODO: what am I suposed to do with inProgress?
+  const [commit, _inProgress] = useUpdateUserProfileFields()
+
+  // TODO: update cohesion and pass a better context_screen and context_screen_owner_type
+  const tracks = {
+    editedUserProfile: (): EditedUserProfile => ({
+      action: ActionType.editedUserProfile,
+      context_screen: ContextModule.collectorProfile,
+      context_screen_owner_type: OwnerType.editProfile,
+      platform: "mobile",
+    }),
+  }
+
+  const formikBag = useFormik<UserProfileFormikSchema>({
+    enableReinitialize: true,
+    validateOnChange: true,
+    validateOnBlur: true,
+    initialValues: {
+      name: data.name ?? "",
+      displayLocation: { display: buildLocationDisplay(data.location ?? null) },
+      location:
+        {
+          ...data.location,
+        } ?? undefined,
+      profession: data.profession ?? "",
+      otherRelevantPositions: data.otherRelevantPositions ?? "",
+    },
+    onSubmit: (values) => {
+      setLoading(true)
+
+      commit({
+        variables: {
+          input: {
+            name: values.name,
+            location: {
+              city: values.location?.city,
+              state: values.location?.state,
+              country: values.location?.country,
+            },
+            profession: values.profession,
+            otherRelevantPositions: values.otherRelevantPositions,
+          },
+        },
+        onCompleted: () => {
+          trackEvent(tracks.editedUserProfile())
+          setLoading(false)
+          onClose()
+        },
+        onError: () => {
+          // TODO: display an error message to user
+          console.log("Error updating user profile")
+          setLoading(false)
+        },
+      })
+    },
+    validationSchema: userProfileYupSchema,
+  })
+
+  const { handleSubmit, isValid } = formikBag
+  return (
+    <Box p={2} testID="my-profile-edit-modal-content">
+      <Text>{message}</Text>
+      <FormikProvider value={formikBag}>
+        <UserProfileFields useBottomSheetInputs />
+        <Button block mt={2} onPress={handleSubmit} disabled={!isValid} loading={loading}>
+          Save and Continue
+        </Button>
+      </FormikProvider>
+    </Box>
+  )
+}
+
+const MyProfileEditModalSkeleton = () => {
+  return (
+    <Skeleton>
+      <Box p={2}>
+        <Spacer y={0.5} />
+        <SkeletonText>
+          Tell us a few more details about yourself to complete your profile.
+        </SkeletonText>
+        <Spacer y={2} />
+        <SkeletonBox width="100%" height={60} borderRadius={4}>
+          {/* Full name */}
+        </SkeletonBox>
+        <Spacer y={4} />
+        <SkeletonBox width="100%" height={60} borderRadius={4}>
+          {/* Primary location */}
+        </SkeletonBox>
+        <Spacer y={4} />
+        <SkeletonBox width="100%" height={60} borderRadius={4}>
+          {/* Profession */}
+        </SkeletonBox>
+        <Spacer y={4} />
+        <SkeletonBox width="100%" height={60} borderRadius={4}>
+          {/* Other Relevant Positions */}
+        </SkeletonBox>
+        <Spacer y={2} />
+        <SkeletonBox width="100%" height={50} borderRadius={50}>
+          {/* Save and Continue */}
+        </SkeletonBox>
+      </Box>
+    </Skeleton>
+  )
+}

--- a/src/app/Scenes/MyProfile/useUpdateUserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/useUpdateUserProfileFields.tsx
@@ -1,0 +1,15 @@
+import { useUpdateUserProfileFieldsMutation } from "__generated__/useUpdateUserProfileFieldsMutation.graphql"
+import { graphql, useMutation } from "react-relay"
+
+export const useUpdateUserProfileFields = () => {
+  return useMutation<useUpdateUserProfileFieldsMutation>(graphql`
+    mutation useUpdateUserProfileFieldsMutation($input: UpdateMyProfileInput!) {
+      updateMyUserProfile(input: $input) {
+        me {
+          ...MyProfileHeader_me
+          ...MyProfileEditForm_me
+        }
+      }
+    }
+  `)
+}


### PR DESCRIPTION
This PR resolves [DIA-695]

### Description

This PR adds a new `MyEditProfileModal` component that we can use to prompt collector's to complete their profile. It uses the same profile fields as the `MyEditProfileScreen` component, so it includes some refactoring work to extract those fields.

| iOS | Android |
|-----|---------|
| ![ios](https://github.com/artsy/eigen/assets/44589599/6882dffa-606d-4a89-bdc5-f19cbdf73918) | ![android](https://github.com/artsy/eigen/assets/44589599/0f3debae-1113-41d5-8b64-86213268fa33) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- The user profile address can be erased with one tap.

#### Dev changes

- A new `MyProfileEditModal` component is available.

</details>

[DIA-695]: https://artsyproduct.atlassian.net/browse/DIA-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ