### PR TITLE
chore: register to bid ux/ui improvemnts

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -430,6 +430,10 @@ export const modules = defineModules({
     alwaysPresentModally: true,
     hasOwnModalCloseButton: true,
     fullBleed: true,
+    screenOptions: {
+      // Don't allow the screen to be swiped away by mistake
+      gestureEnabled: false,
+    },
   }),
   AuctionBidArtwork: reactModule(BidFlow, {
     alwaysPresentModally: true,

--- a/src/app/Components/Bidding/Components/BidInfoRow.tsx
+++ b/src/app/Components/Bidding/Components/BidInfoRow.tsx
@@ -18,7 +18,7 @@ export class BidInfoRow extends React.Component<BidInfoRowProps> {
       <TouchableWithoutFeedback onPress={onPress}>
         <Row p={2} pb="1" mb={1} {...props}>
           <Col>
-            <Text variant="xs">{label}</Text>
+            <Text variant="sm-display">{label}</Text>
           </Col>
 
           <Col alignItems="flex-end">{!!value && <Text numberOfLines={1}>{value}</Text>}</Col>

--- a/src/app/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/app/Components/Bidding/Screens/BillingAddress.tsx
@@ -106,11 +106,11 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
       </FancyModalHeader>
       <ScrollView
         ref={scrollViewRef}
-        contentContainerStyle={{ padding: 20, paddingBottom: 50 }}
+        contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 50 }}
         keyboardDismissMode="on-drag"
         keyboardShouldPersistTaps="handled"
       >
-        <Stack spacing={4}>
+        <Stack spacing={2}>
           <Input
             ref={fullNameRef}
             title="Full name"
@@ -122,6 +122,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.fullName}
             onChangeText={(e) => handleInputTextChange("fullName", e)}
             testID="input-full-name"
+            onSubmitEditing={() => addressLine1Ref.current?.focus()}
           />
 
           <Input
@@ -135,6 +136,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.addressLine1}
             onChangeText={(e) => handleInputTextChange("addressLine1", e)}
             testID="input-address-1"
+            onSubmitEditing={() => addressLine2Ref.current?.focus()}
           />
 
           <Input
@@ -152,6 +154,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.addressLine2}
             onChangeText={(e) => handleInputTextChange("addressLine2", e)}
             testID="input-address-2"
+            onSubmitEditing={() => cityRef.current?.focus()}
           />
 
           <Input
@@ -165,6 +168,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.city}
             onChangeText={(e) => handleInputTextChange("city", e)}
             testID="input-city"
+            onSubmitEditing={() => stateRef.current?.focus()}
           />
 
           <Input
@@ -178,6 +182,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.state}
             onChangeText={(e) => handleInputTextChange("state", e)}
             testID="input-state-province-region"
+            onSubmitEditing={() => postalCodeRef.current?.focus()}
           />
 
           <Input
@@ -191,6 +196,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
             value={address.postalCode}
             onChangeText={(e) => handleInputTextChange("postalCode", e)}
             testID="input-post-code"
+            onSubmitEditing={() => phoneRef.current?.focus()}
           />
 
           <Input
@@ -212,7 +218,7 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
               const countryError = checkFieldError("country")
 
               return (
-                <Flex mb={4}>
+                <Flex mb={4} mt={2}>
                   <CountrySelect
                     maxModalHeight={height * 0.95}
                     onSelectValue={(value: string) => handleCountrySelection(value)}

--- a/src/app/Components/Bidding/Screens/Registration.tests.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tests.tsx
@@ -12,8 +12,9 @@ import { Address } from "app/Components/Bidding/types"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { Linking, TouchableWithoutFeedback } from "react-native"
+import { TouchableWithoutFeedback } from "react-native"
 import relay from "react-relay"
 import { BillingAddress } from "./BillingAddress"
 import { CreditCardForm } from "./CreditCardForm"
@@ -662,8 +663,7 @@ it("navigates to the conditions of sale when the user taps the link", () => {
 
   fireEvent.press(screen.getByText("Conditions of Sale"))
 
-  expect(Linking.openURL).toHaveBeenCalledWith("https://www.artsy.net/conditions-of-sale")
-  // expect(navigation.navigate).toHaveBeenCalledWith("/conditions-of-sale")
+  expect(navigate).toHaveBeenCalledWith("/conditions-of-sale")
 })
 
 describe("when AREnableNewTermsAndConditions is enabled", () => {
@@ -691,7 +691,7 @@ describe("when AREnableNewTermsAndConditions is enabled", () => {
 
     fireEvent.press(screen.getByText("General Terms and Conditions of Sale"))
 
-    expect(Linking.openURL).toHaveBeenCalledWith("https://www.artsy.net/terms")
+    expect(navigate).toHaveBeenCalledWith("/terms")
   })
 })
 

--- a/src/app/Components/Bidding/Screens/Registration.tests.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tests.tsx
@@ -1,4 +1,4 @@
-import { Text, LinkText, Checkbox, Button } from "@artsy/palette-mobile"
+import { Button, Checkbox, LinkText, Text } from "@artsy/palette-mobile"
 import { createToken } from "@stripe/stripe-react-native"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Registration_me$data } from "__generated__/Registration_me.graphql"
@@ -12,9 +12,8 @@ import { Address } from "app/Components/Bidding/types"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import * as navigation from "app/system/navigation/navigate"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { TouchableWithoutFeedback } from "react-native"
+import { Linking, TouchableWithoutFeedback } from "react-native"
 import relay from "react-relay"
 import { BillingAddress } from "./BillingAddress"
 import { CreditCardForm } from "./CreditCardForm"
@@ -663,7 +662,8 @@ it("navigates to the conditions of sale when the user taps the link", () => {
 
   fireEvent.press(screen.getByText("Conditions of Sale"))
 
-  expect(navigation.navigate).toHaveBeenCalledWith("/conditions-of-sale")
+  expect(Linking.openURL).toHaveBeenCalledWith("https://www.artsy.net/conditions-of-sale")
+  // expect(navigation.navigate).toHaveBeenCalledWith("/conditions-of-sale")
 })
 
 describe("when AREnableNewTermsAndConditions is enabled", () => {
@@ -691,7 +691,7 @@ describe("when AREnableNewTermsAndConditions is enabled", () => {
 
     fireEvent.press(screen.getByText("General Terms and Conditions of Sale"))
 
-    expect(navigation.navigate).toHaveBeenCalledWith("/terms")
+    expect(Linking.openURL).toHaveBeenCalledWith("https://www.artsy.net/terms")
   })
 })
 

--- a/src/app/Components/Bidding/Screens/Registration.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tsx
@@ -17,7 +17,7 @@ import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { unsafe_getFeatureFlag } from "app/store/GlobalStore"
-import { dismissModal } from "app/system/navigation/navigate"
+import { dismissModal, navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import { bidderNeedsIdentityVerification } from "app/utils/auction/bidderNeedsIdentityVerification"
@@ -26,7 +26,7 @@ import { saleTime } from "app/utils/saleTime"
 import { Schema, screenTrack } from "app/utils/track"
 import { get, isEmpty } from "lodash"
 import React from "react"
-import { Alert, Linking, ScrollView, View, ViewProps } from "react-native"
+import { Alert, ScrollView, View, ViewProps } from "react-native"
 import {
   QueryRenderer,
   RelayProp,
@@ -116,11 +116,11 @@ export class Registration extends React.Component<RegistrationProps, Registratio
   }
 
   onPressGeneralTermsAndConditionsOfSale = () => {
-    Linking.openURL("https://www.artsy.net/terms")
+    navigate("/terms")
   }
 
   onPressConditionsOfSale = () => {
-    Linking.openURL("https://www.artsy.net/conditions-of-sale")
+    navigate("/conditions-of-sale")
   }
 
   onCreditCardAdded(token: Token.Result, params: PaymentCardTextFieldParams) {

--- a/src/app/Components/Containers/RegistrationFlow.tsx
+++ b/src/app/Components/Containers/RegistrationFlow.tsx
@@ -1,20 +1,16 @@
 import { TimeOffsetProvider } from "app/Components/Bidding/Context/TimeOffsetProvider"
 import { RegistrationQueryRenderer } from "app/Components/Bidding/Screens/Registration"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
-import { useScreenDimensions } from "app/utils/hooks"
-import { View } from "react-native"
 
 export const RegistrationFlow: React.FC<{ saleID: string }> = (props) => {
   return (
     <TimeOffsetProvider>
-      <View style={{ flex: 1, paddingTop: useScreenDimensions().safeAreaInsets.top }}>
-        <NavigatorIOS
-          initialRoute={{
-            component: RegistrationQueryRenderer,
-            passProps: props,
-          }}
-        />
-      </View>
+      <NavigatorIOS
+        initialRoute={{
+          component: RegistrationQueryRenderer,
+          passProps: props,
+        }}
+      />
     </TimeOffsetProvider>
   )
 }


### PR DESCRIPTION
[Future Friday]

### Description

This PR makes the following changes:

- Users were able to quit the flow directly without warning - now they will be warned about it
If you swipe down, the modal will close and you will use your progress
- we probably don't want that to happen accidentally, I made the modal sheet not dismissible by swiping down, it will only be dismissed by click the X button
If you press on Conditions of sale, we used top open it in a WebView where you could easily get lost
- now, we don't distract you from registering and open that externally so you are right where you left - just like we do in the SWA flow
- Use the new credit card input component
- The font sizes were a mess, custom line heights, custom font sizes etc.. I updated them to look more or less like what we do in other surfaces
- The paddings were massive inside the billing address screen - I made them a bit smaller to match our spacings in other areas.
- I fixed the small extra padding missing in the country picker
Instead of manually going through the fields in billing address, you can simply use the keyboard "Next" to be navigated through them faster

### Before

https://github.com/user-attachments/assets/08dfb578-e941-42c2-8d75-39833493e371


___

### After

https://github.com/user-attachments/assets/7bb0e6a9-6bca-45ff-bb7a-abf58fc71606


https://github.com/user-attachments/assets/c6b0b60e-9e44-4528-b3b1-1763c369ddde


https://github.com/user-attachments/assets/6701d86e-f0b7-442f-84af-922e6cee9643


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- register to bid ux/ui improvements - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
