### PR TITLE
feat: add AREnableCollectorProfilePrompts

### DIFF
--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -283,6 +283,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableSaveAndContinueSubmission",
   },
+  AREnableCollectorProfilePrompts: {
+    readyForRelease: false,
+    description: "Enable prompts to update collector profile",
+    showInDevMenu: true,
+    echoFlagKey: "AREnableCollectorProfilePrompts",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [DIA-713]

### Description

This PR adds `AREnableCollectorProfilePrompts` which will be used to build prompts to the user that will encourage them to update their profile or add artists to their collection after they perform commercial actions.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Added feature flag AREnableCollectorProfilePrompts

<!-- end_changelog_updates -->

</details>

[DIA-713]: https://artsyproduct.atlassian.net/browse/DIA-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ