### PR TITLE
fix: 'Frame not included' string showing on all lots

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tests.tsx
@@ -66,6 +66,17 @@ describe("ArtworkDimensionsClassificationAndAuthenticity", () => {
     expect(screen.getByText("Frame not included")).toBeTruthy()
   })
 
+  it("does not render a frame string when artwork is not unlisted", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        framed: { details: "not included" },
+        isUnlisted: false,
+      }),
+    })
+
+    expect(screen.queryByText("Frame not included")).toBeFalsy()
+  })
+
   it("renders 'Frame included' when the frame is included", () => {
     renderWithRelay({
       Artwork: () => ({ framed: { details: "Included" } }),

--- a/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity.tsx
@@ -11,14 +11,18 @@ interface ArtworkDimensionsClassificationAndAuthenticityProps {
 const ArtworkDimensionsClassificationAndAuthenticity: React.FC<
   ArtworkDimensionsClassificationAndAuthenticityProps
 > = ({ artwork }) => {
-  const { medium, dimensions, framed, editionOf, editionSets } = artwork
+  const { medium, dimensions, framed, editionOf, editionSets, isUnlisted } = artwork
 
   const dimensionsPresent = (dimensions: any) =>
     /\d/.test(dimensions?.in) || /\d/.test(dimensions?.cm)
 
-  const getFrameString = (frameDetails?: string | null) => {
+  const getFrameString = (frameDetails?: string | null, isUnlisted?: boolean) => {
     if (frameDetails !== "Included") {
-      return "Frame not included"
+      if (isUnlisted) {
+        return "Frame not included"
+      } else {
+        return
+      }
     }
 
     return `Frame ${frameDetails.toLowerCase()}`
@@ -33,9 +37,9 @@ const ArtworkDimensionsClassificationAndAuthenticity: React.FC<
       {!!dimensionsPresent(dimensions) && (editionSets?.length ?? 0) < 2 && (
         <Text color="black60" variant="sm">{`${dimensions?.in} | ${dimensions?.cm}`}</Text>
       )}
-      {!!getFrameString(framed?.details) && (
+      {!!getFrameString(framed?.details, isUnlisted) && (
         <Text color="black60" variant="sm">
-          {getFrameString(framed?.details)}
+          {getFrameString(framed?.details, isUnlisted)}
         </Text>
       )}
       {!!editionOf && (
@@ -68,6 +72,7 @@ export const ArtworkDimensionsClassificationAndAuthenticityFragmentContainer =
         }
         editionOf
         isEdition
+        isUnlisted
         editionSets {
           internalID
         }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Uses forces logic including unlisted to prevent "Frame not included" from showing up on auction lots when this value is not explicitly set.


<details>
<summary>
Before
</summary>

![before](https://github.com/user-attachments/assets/934b42f0-a2da-4be6-9e1f-5e500b131d39)

</details>


<details>
<summary>
After
</summary>

![after](https://github.com/user-attachments/assets/67cd8f0d-fd44-45bb-9edb-9dcb2133bbba)

</details>



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix 'Frame not included' bug in auction lots - brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
