### PR TITLE
fix: submit artwork from my collection

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
@@ -34,7 +34,7 @@ export const SubmitArtworkAddPhoneNumber = () => {
       try {
         setIsLoading(true)
 
-        const nextStep = values.state === "DRAFT" ? "ShippingLocation" : "CompleteYourSubmission"
+        const nextStep = values.state === "DRAFT" ? "CompleteYourSubmission" : "ShippingLocation"
         const newValues = {
           userPhone: values.userPhone,
           state: values.state === "DRAFT" ? "SUBMITTED" : undefined,

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddTitle.tsx
@@ -15,7 +15,7 @@ import { useFormikContext } from "formik"
 import { ScrollView } from "react-native"
 
 export const SubmitArtworkAddTitle = () => {
-  const { handleChange, values } = useFormikContext<ArtworkDetailsFormModel>()
+  const { handleChange, values, setFieldValue } = useFormikContext<ArtworkDetailsFormModel>()
 
   const { show: showToast } = useToast()
 
@@ -30,12 +30,20 @@ export const SubmitArtworkAddTitle = () => {
     onNextStep: async () => {
       try {
         setIsLoading(true)
+        let submissionId = values.submissionId
+
+        // If no submission is present, create one
+        // This is the case when the user is submitting an artwork from my collection
+        if (!submissionId) {
+          submissionId = (await createOrUpdateSubmission(values, null)) || null
+          setFieldValue("submissionId", submissionId)
+        }
 
         await createOrUpdateSubmission(
           {
             title: values.title,
           },
-          values.submissionId
+          submissionId
         )
 
         navigation.navigate("AddPhotos")


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR comes as a follow-up on https://github.com/artsy/eigen/pull/10466. 
- We need to navigate to complete your submission step on draft submissions instead of the shipping location
- When an artwork is submitted through my collection, we need to create a submission at the title step since it's not going to be there (because we skipped the creation that is supposed to happen at the artist step)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix submit artwork from my collection - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
