### PR TITLE
feat: add submit artwork condition screen

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
@@ -1,20 +1,27 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Flex, Spacer, Text } from "@artsy/palette-mobile"
+import { Flex, Input, Spacer, Text } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
+import { ArtworkConditionEnumType } from "__generated__/myCollectionCreateArtworkMutation.graphql"
+import { Select } from "app/Components/Select"
 import { useToast } from "app/Components/Toast/toastHook"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { useNavigationListeners } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/useNavigationListeners"
 import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { InfoModal } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/InfoModal/InfoModal"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { useFormikContext } from "formik"
+import { useState } from "react"
 import { ScrollView } from "react-native"
 
 export const SubmitArtworkCondition = () => {
   const { values } = useFormikContext<SubmissionModel>()
 
   const { show: showToast } = useToast()
+
+  const [condition, setCondition] = useState<ArtworkConditionEnumType | null>(null)
+  const [isModalVisible, setIsModalVisible] = useState(false)
 
   const setIsLoading = SubmitArtworkFormStore.useStoreActions((actions) => actions.setIsLoading)
   const setCurrentStep = SubmitArtworkFormStore.useStoreActions((actions) => actions.setCurrentStep)
@@ -61,9 +68,81 @@ export const SubmitArtworkCondition = () => {
             </Text>
 
             <Spacer y={2} />
+
+            <Select
+              testID="ConditionSelect"
+              options={[
+                { label: "Excellent", value: "EXCELLENT" },
+                { label: "Very Good", value: "VERY_GOOD" },
+                { label: "Good", value: "GOOD" },
+                { label: "Fair", value: "FAIR" },
+              ]}
+              value={condition}
+              title="Add Condition"
+              onSelectValue={(value) => {
+                setCondition(value as ArtworkConditionEnumType)
+              }}
+              tooltipText="Condition Definitions"
+              onTooltipPress={() => setIsModalVisible(true)}
+            />
+
+            <Spacer y={2} />
+
+            <Input
+              testID="ConditionInput"
+              title="Add Additional Condition Details"
+              optional
+              multiline
+            />
           </Flex>
         </ScrollView>
+        <InfoModal
+          visible={isModalVisible}
+          onDismiss={() => setIsModalVisible(false)}
+          buttonVariant="outline"
+          fullScreen
+        >
+          <ScrollView>
+            <Text variant="lg-display">Condition Definitions</Text>
+
+            <Spacer y={2} />
+
+            {CONDITION_DEFINITIONS.map((definition) => {
+              return (
+                <Flex key={definition.title} mb={2}>
+                  <Text variant="sm-display" fontWeight="bold" mb={0.5}>
+                    {definition.title}:
+                  </Text>
+                  <Text variant="sm-display">{definition.description}</Text>
+                </Flex>
+              )
+            })}
+          </ScrollView>
+        </InfoModal>
       </Flex>
     </ProvideScreenTrackingWithCohesionSchema>
   )
 }
+
+const CONDITION_DEFINITIONS = [
+  {
+    title: "Excellent Condition",
+    description:
+      "No signs of age or wear, undulation associated with hinging. Work may be unsealed in original packaging.",
+  },
+  {
+    title: "Very Good Condition",
+    description:
+      "Overall very good condition, minor signs of wear or age such as light handling creases, scuffing, foxing, discoloration, buckling, and pinholes. Also includes works that have been previously restored.",
+  },
+  {
+    title: "Good Condition",
+    description:
+      "Overall good condition but with noticeable wear or age such as hard creases, scratches, indentations, water damage (associated buckling), foxing, discoloration, attenuation, material loss and tearing. May require the attention of a conservator.",
+  },
+  {
+    title: "Fair Condition",
+    description:
+      "Overall fair condition with significant wear and age that requires the attention of a conservator.",
+  },
+]

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
@@ -1,6 +1,7 @@
 import { OwnerType } from "@artsy/cohesion"
 import { Flex, Input, Spacer, Text } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
+import { captureException } from "@sentry/react-native"
 import { myCollectionUpdateArtworkMutation } from "__generated__/myCollectionUpdateArtworkMutation.graphql"
 import { Select } from "app/Components/Select"
 import { useToast } from "app/Components/Toast/toastHook"
@@ -34,7 +35,11 @@ export const SubmitArtworkCondition = () => {
         setIsLoading(true)
 
         if (!values.artwork.internalID) {
-          throw new Error("Artwork ID is required")
+          captureException("Artwork ID is required")
+          showToast("Could not save your submission, please try again.", "bottom", {
+            backgroundColor: "red100",
+          })
+          return
         }
 
         // Make API call to update related My Collection artwork

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFrameInformation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFrameInformation.tsx
@@ -38,10 +38,10 @@ export const SubmitArtworkFrameInformation = () => {
 
         const newValues = {
           artworkId: values.artwork.internalID,
-          framedMetric: values.artwork.isFramed ? values.artwork.framedMetric : null,
-          framedWidth: values.artwork.isFramed ? values.artwork.framedWidth : null,
-          framedHeight: values.artwork.isFramed ? values.artwork.framedHeight : null,
-          framedDepth: values.artwork.isFramed ? values.artwork.framedDepth : null,
+          framedMetric: values.artwork.framedMetric,
+          framedWidth: values.artwork.framedWidth,
+          framedHeight: values.artwork.framedHeight,
+          framedDepth: values.artwork.framedDepth,
           isFramed: values.artwork.isFramed,
         }
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkTopNavigation.tsx
@@ -41,11 +41,13 @@ export const SubmitArtworkTopNavigation: React.FC<{}> = () => {
       if (values.artwork.internalID) {
         const newValues = {
           artworkId: values.artwork.internalID,
-          framedMetric: values.artwork.isFramed ? values.artwork.framedMetric : null,
-          framedWidth: values.artwork.isFramed ? values.artwork.framedWidth : null,
-          framedHeight: values.artwork.isFramed ? values.artwork.framedHeight : null,
-          framedDepth: values.artwork.isFramed ? values.artwork.framedDepth : null,
+          framedMetric: values.artwork.framedMetric,
+          framedWidth: values.artwork.framedWidth,
+          framedHeight: values.artwork.framedHeight,
+          framedDepth: values.artwork.framedDepth,
           isFramed: values.artwork.isFramed,
+          condition: values.artwork.condition,
+          conditionDescription: values.artwork.conditionDescription,
         }
         // Make API call to update my collection artwork
         await myCollectionUpdateArtwork(newValues)

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkCondition.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkCondition.tests.tsx
@@ -1,0 +1,113 @@
+import { useIsFocused, useNavigation } from "@react-navigation/native"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { SubmitArtworkCondition } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition"
+import { renderWithSubmitArtworkWrapper } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/testWrappers"
+import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import relay from "react-relay"
+
+const mockNavigate = jest.fn()
+const mockCommitMutation = (fn?: typeof relay.commitMutation) =>
+  jest.fn<typeof relay.commitMutation, Parameters<typeof relay.commitMutation>>(fn as any)
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: jest.fn(),
+  useIsFocused: jest.fn(),
+}))
+
+describe("SubmitArtworkCondition", () => {
+  const useNavigationMock = useNavigation as jest.Mock
+  const useIsFocusedMock = useIsFocused as jest.Mock
+
+  beforeEach(() => {
+    useIsFocusedMock.mockReturnValue(() => true)
+    useNavigationMock.mockReturnValue({
+      navigate: mockNavigate,
+    })
+  })
+
+  it("renders the default artwork condition properly", async () => {
+    renderWithSubmitArtworkWrapper({
+      props: { currentStep: "Condition" },
+      component: <SubmitArtworkCondition />,
+      injectedFormikProps: {
+        artwork: {
+          ...defaultArtworkFixutre,
+          condition: "FAIR",
+          conditionDescription: "Pretty fair",
+        },
+      },
+    })
+
+    expect(screen.getByText("Fair")).toBeOnTheScreen()
+    expect(screen.getByDisplayValue("Pretty fair")).toBeOnTheScreen()
+  })
+
+  it("calls the mutation with the new condition details", async () => {
+    relay.commitMutation = mockCommitMutation((_, { onCompleted }) => {
+      onCompleted!(
+        {
+          updateConsignmentSubmission: {
+            consignmentSubmission: {
+              internalID: "submission-id",
+            },
+          },
+        },
+        null
+      )
+      return { dispose: jest.fn() }
+    }) as any
+
+    renderWithSubmitArtworkWrapper({
+      props: { currentStep: "Condition" },
+      component: <SubmitArtworkCondition />,
+      injectedFormikProps: {
+        artwork: {
+          ...defaultArtworkFixutre,
+        },
+      },
+    })
+
+    const conditionSelect = screen.getByTestId("ConditionSelect")
+    fireEvent(conditionSelect, "onPress")
+
+    // Wait for the select modal to show up
+    await flushPromiseQueue()
+    fireEvent.press(screen.getByText("Fair"))
+
+    // Wait for the select modal to show up
+    await flushPromiseQueue()
+
+    // The value is going to be rendered twice because it's also available in the Select component
+    expect(screen.getAllByText("Fair")).toHaveLength(2)
+
+    fireEvent(screen.getByText("Add Additional Condition Details"), "onChangeText", "Pretty fair")
+
+    fireEvent(screen.getByText("Continue"), "onPress")
+
+    expect(relay.commitMutation).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        variables: {
+          input: { artworkId: "some-id", condition: "FAIR", conditionDescription: "Pretty fair" },
+        },
+      })
+    )
+
+    await flushPromiseQueue()
+
+    expect(mockNavigate).toHaveBeenCalledWith("CompleteYourSubmission")
+  })
+})
+
+const defaultArtworkFixutre: SubmissionModel["artwork"] = {
+  internalID: "some-id",
+  framedDepth: null,
+  framedHeight: null,
+  framedMetric: null,
+  framedWidth: null,
+  isFramed: null,
+  condition: null,
+  conditionDescription: null,
+}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFrameInformation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFrameInformation.tests.tsx
@@ -2,6 +2,7 @@ import { useIsFocused, useNavigation } from "@react-navigation/native"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { SubmitArtworkFrameInformation } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFrameInformation"
 import { renderWithSubmitArtworkWrapper } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/testWrappers"
+import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import relay from "react-relay"
 
@@ -33,6 +34,7 @@ describe("SubmitArtworkFrameInformation", () => {
         component: <SubmitArtworkFrameInformation />,
         injectedFormikProps: {
           artwork: {
+            ...defaultArtworkFixutre,
             internalID: "some-id",
             isFramed: false,
             framedMetric: null,
@@ -71,6 +73,7 @@ describe("SubmitArtworkFrameInformation", () => {
         component: <SubmitArtworkFrameInformation />,
         injectedFormikProps: {
           artwork: {
+            ...defaultArtworkFixutre,
             internalID: "some-id",
             isFramed: null,
             framedMetric: "cm",
@@ -92,11 +95,11 @@ describe("SubmitArtworkFrameInformation", () => {
           variables: {
             input: {
               artworkId: "some-id",
-              framedDepth: null,
+              isFramed: false,
               framedHeight: null,
               framedMetric: null,
               framedWidth: null,
-              isFramed: false,
+              framedDepth: null,
             },
           },
         })
@@ -115,6 +118,7 @@ describe("SubmitArtworkFrameInformation", () => {
         component: <SubmitArtworkFrameInformation />,
         injectedFormikProps: {
           artwork: {
+            ...defaultArtworkFixutre,
             internalID: "some-id",
             isFramed: null,
             framedMetric: "cm",
@@ -158,6 +162,7 @@ describe("SubmitArtworkFrameInformation", () => {
         component: <SubmitArtworkFrameInformation />,
         injectedFormikProps: {
           artwork: {
+            ...defaultArtworkFixutre,
             internalID: "some-id",
             isFramed: null,
             framedMetric: null,
@@ -202,3 +207,14 @@ describe("SubmitArtworkFrameInformation", () => {
     })
   })
 })
+
+const defaultArtworkFixutre: SubmissionModel["artwork"] = {
+  internalID: "some-id",
+  framedDepth: null,
+  framedHeight: null,
+  framedMetric: null,
+  framedWidth: null,
+  isFramed: null,
+  condition: null,
+  conditionDescription: null,
+}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFromMyCollection.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFromMyCollection.tests.tsx
@@ -102,4 +102,10 @@ const mockedFetchedArtwork: NonNullable<FetchArtworkInformationResult> = {
   framedWidth: "20",
   framedHeight: "30",
   framedDepth: "2",
+  condition: {
+    value: "FAIR",
+  },
+  conditionDescription: {
+    details: "Prett fair",
+  },
 }

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
@@ -60,6 +60,12 @@ const submitArtworkFormEditQuery = graphql`
         framedWidth
         framedHeight
         framedDepth
+        condition {
+          value
+        }
+        conditionDescription {
+          details
+        }
       }
       attributionClass
       editionNumber

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation.ts
@@ -51,6 +51,12 @@ export const fetchArtworkInformation = async (artworkID: string) => {
           framedWidth
           framedMetric
           framedDepth
+          condition {
+            value
+          }
+          conditionDescription {
+            details
+          }
         }
       }
     `,

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValues.ts
@@ -2,6 +2,7 @@ import {
   ConsignmentAttributionClass,
   SubmitArtworkFormEditQuery$data,
 } from "__generated__/SubmitArtworkFormEditQuery.graphql"
+import { ArtworkConditionEnumType } from "__generated__/myCollectionCreateArtworkMutation.graphql"
 import { COUNTRY_SELECT_OPTIONS } from "app/Components/CountrySelect"
 import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { acceptableCategoriesForSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
@@ -27,9 +28,6 @@ export const getInitialSubmissionValues = (
 
   const addresses = extractNodes(me?.addressConnection)
   const defaultAddress = addresses.find((address) => address.isDefault) ?? addresses?.[0]
-
-  console.log("====")
-  console.log(values.myCollectionArtwork)
 
   return {
     artist: values.artist?.name ?? "",
@@ -77,6 +75,8 @@ export const getInitialSubmissionValues = (
       framedWidth: values.myCollectionArtwork?.framedWidth ?? null,
       framedHeight: values.myCollectionArtwork?.framedHeight ?? null,
       framedDepth: values.myCollectionArtwork?.framedDepth ?? null,
+      condition: (values.myCollectionArtwork?.condition?.value as ArtworkConditionEnumType) ?? null,
+      conditionDescription: values.myCollectionArtwork?.conditionDescription?.details ?? null,
     },
   }
 }

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValuesFromArtwork.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValuesFromArtwork.ts
@@ -1,4 +1,5 @@
 import { ConsignmentAttributionClass } from "__generated__/createConsignSubmissionMutation.graphql"
+import { ArtworkConditionEnumType } from "__generated__/myCollectionCreateArtworkMutation.graphql"
 import { FetchArtworkInformationResult } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation"
 import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { acceptableCategoriesForSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/acceptableCategoriesForSubmission"
@@ -100,6 +101,8 @@ export const getInitialSubmissionFormValuesFromArtwork = (
       framedWidth: artwork.framedWidth,
       framedHeight: artwork.framedHeight,
       framedDepth: artwork.framedDepth,
+      condition: artwork.condition?.value as ArtworkConditionEnumType | null | undefined,
+      conditionDescription: artwork.conditionDescription?.details,
     },
   }
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -2,6 +2,7 @@ import {
   ConsignmentSubmissionCategoryAggregation,
   ConsignmentSubmissionSource,
 } from "__generated__/createConsignSubmissionMutation.graphql"
+import { ArtworkConditionEnumType } from "__generated__/myCollectionCreateArtworkMutation.graphql"
 import {
   ConsignmentAttributionClass,
   ConsignmentSubmissionStateAggregation,
@@ -36,10 +37,22 @@ export const getCurrentValidationSchema = (_injectedStep?: keyof SubmitArtworkSt
       return shippingLocationSchema
     case "FrameInformation":
       return frameInformationSchema
+    case "Condition":
+      return conditionSchema
     default:
       return Yup.object()
   }
 }
+
+const conditionSchema = Yup.object().shape({
+  condition: Yup.string()
+    .oneOf(
+      ["EXCELLENT", "FAIR", "GOOD", "VERY_GOOD"],
+      "Condition must be one of EXCELLENT, FAIR, GOOD, VERY_GOOD"
+    )
+    .nullable(),
+  conditionDescription: Yup.string().trim(),
+})
 
 const frameInformationSchema = Yup.object().shape({
   isFramed: Yup.boolean().nullable(),
@@ -150,6 +163,8 @@ export interface SubmissionModel {
     framedWidth: string | null | undefined
     framedHeight: string | null | undefined
     framedDepth: string | null | undefined
+    condition: ArtworkConditionEnumType | null | undefined
+    conditionDescription: string | null | undefined
   }
 }
 
@@ -202,5 +217,7 @@ export const submissionModelInitialValues: SubmissionModel = {
     framedWidth: null,
     framedHeight: null,
     framedDepth: null,
+    condition: null,
+    conditionDescription: null,
   },
 }


### PR DESCRIPTION
This PR resolves [ONYX-1118] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds **Artwork Condition** screen to the submission flow

| Test case | Screenshot/video |
|--------|--------|
| Condition Definitions | <img width="379" alt="Screenshot 2024-07-23 at 12 20 58" src="https://github.com/user-attachments/assets/0553c31e-50cd-40a0-bd01-8109485f7c48"> |
| Save & Exit | <Video src="https://github.com/user-attachments/assets/60c7ea85-a605-4fff-a562-ff3e1eb05c9c" /> |
| Trigger the mutation | <Video src="https://github.com/user-attachments/assets/e9c5b2d0-1626-4fa8-a7d1-81be934972f3" /> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add artwork condition screen to SWA flow - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1118]: https://artsyproduct.atlassian.net/browse/ONYX-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ