### PR TITLE
fix: Filter out null notifications in Activity panel

### DIFF
--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -1,9 +1,6 @@
 import { Flex, LazyFlatlist, Screen, Separator, Spinner } from "@artsy/palette-mobile"
 import { ActivityList_viewer$key } from "__generated__/ActivityList_viewer.graphql"
-import {
-  shouldDisplayNotification,
-  Notification,
-} from "app/Scenes/Activity/utils/shouldDisplayNotification"
+import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { extractNodes } from "app/utils/extractNodes"
 import { useState } from "react"
 import { RefreshControl } from "react-native"
@@ -27,9 +24,7 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type }) => {
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter((notification) =>
-    shouldDisplayNotification(notification as Notification)
-  )
+  const notifications = notificationsNodes.filter(shouldDisplayNotification)
 
   const handleLoadMore = () => {
     if (!hasNext || isLoadingNext) {

--- a/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
@@ -6,24 +6,28 @@ describe("shouldDisplayNotification", () => {
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result).toEqual(true)
 
     const result2 = shouldDisplayNotification({
       notificationType: "ARTWORK_PUBLISHED",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result2).toEqual(true)
 
     const result3 = shouldDisplayNotification({
       notificationType: "PARTNER_OFFER_CREATED",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result3).toEqual(true)
 
     // viewing room notification has viewing rooms
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
+      artworks: undefined,
       item: { viewingRoomsConnection: { totalCount: 1 } },
     })
     expect(result4).toEqual(true)
@@ -31,7 +35,8 @@ describe("shouldDisplayNotification", () => {
     // editorial notification has article
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
-      item: { article: { internalID: 1 } },
+      artworks: undefined,
+      item: { article: { internalID: "1" } },
     })
     expect(result5).toEqual(true)
   })
@@ -41,24 +46,28 @@ describe("shouldDisplayNotification", () => {
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result).toEqual(false)
 
     const result2 = shouldDisplayNotification({
       notificationType: "ARTWORK_PUBLISHED",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result2).toEqual(false)
 
     const result3 = shouldDisplayNotification({
       notificationType: "PARTNER_OFFER_CREATED",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result3).toEqual(false)
 
     // viewing room notification has no viewing rooms
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
+      artworks: undefined,
       item: { viewingRoomsConnection: { totalCount: 0 } },
     })
     expect(result4).toEqual(false)
@@ -66,6 +75,7 @@ describe("shouldDisplayNotification", () => {
     // editorial notification has no article
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
+      artworks: undefined,
       item: {},
     })
     expect(result5).toEqual(false)

--- a/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
+++ b/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
@@ -1,15 +1,20 @@
+import { ActivityList_viewer$data } from "__generated__/ActivityList_viewer.graphql"
 import { isArtworksBasedNotification } from "app/Scenes/Activity/utils/isArtworksBasedNotification"
 
-export interface Notification {
-  notificationType?: string | null
-  artworks?: { totalCount?: number | null } | null
-  item?: {
-    viewingRoomsConnection?: { totalCount?: number | null } | null
-    article?: { internalID?: number | null } | null
-  } | null
-}
+export type NotificationNode = NonNullable<
+  NonNullable<NonNullable<ActivityList_viewer$data["notificationsConnection"]>["edges"]>[0]
+>["node"]
 
-export const shouldDisplayNotification = (notification: Notification) => {
+export const shouldDisplayNotification = (
+  notification:
+    | Pick<NonNullable<NotificationNode>, "notificationType" | "artworks" | "item">
+    | null
+    | undefined
+) => {
+  if (!notification) {
+    return false
+  }
+
   if (isArtworksBasedNotification(notification?.notificationType ?? "")) {
     const artworksCount = notification.artworks?.totalCount ?? 0
     return artworksCount > 0

--- a/src/app/Scenes/Home/Components/ActivityRail.tsx
+++ b/src/app/Scenes/Home/Components/ActivityRail.tsx
@@ -1,10 +1,7 @@
 import { Flex, Spacer, Text, useTheme } from "@artsy/palette-mobile"
 import { ActivityRail_notificationsConnection$key } from "__generated__/ActivityRail_notificationsConnection.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
-import {
-  shouldDisplayNotification,
-  Notification,
-} from "app/Scenes/Activity/utils/shouldDisplayNotification"
+import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { ActivityRailItem } from "app/Scenes/Home/Components/ActivityRailItem"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { matchRoute } from "app/routes"
@@ -26,9 +23,7 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, notifications
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter((notification) =>
-    shouldDisplayNotification(notification as Notification)
-  )
+  const notifications = notificationsNodes.filter(shouldDisplayNotification)
 
   if (notifications.length === 0) {
     return null


### PR DESCRIPTION
The type of this PR is: **Fix**

* Related Force PR: The type of this PR is: https://github.com/artsy/force/pull/14205

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://artsy.slack.com/archives/C05EQL4R5N0/p1721034091096429

### Description

We should filter out `null` notifications in the Activity panel. This PR fixes the types of `shouldDisplayNotification` and adds a check that filters out `null` notifications to avoid the following error:

![screenshot_2024-07-15_at_11 56 03_480](https://github.com/user-attachments/assets/a77511d7-f682-4616-a10f-1bbc42d0bbc2)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://artsy.slack.com/archives/C05EQL4R5N0/p1721034091096429

### Description

We should filter out `null` notifications in the Activity panel. This PR fixes the types of `shouldDisplayNotification` and adds a check that filters out `null` notifications to avoid the following error:

![screenshot_2024-07-15_at_11 56 03_480](https://github.com/user-attachments/assets/a77511d7-f682-4616-a10f-1bbc42d0bbc2)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ