### PR TITLE
refactor: update InquiryModal to use latest Relay patterns

### DIFF
--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tests.tsx
@@ -9,7 +9,7 @@ import { graphql } from "react-relay"
 
 jest.mock("app/Scenes/Artwork/Components/CommercialButtons/InquiryModal", () => {
   return {
-    InquiryModalFragmentContainer: ({ onMutationSuccessful }: any) => {
+    InquiryModal: ({ onMutationSuccessful }: any) => {
       mockSuccessfulMutation.mockImplementation((mockState) => {
         onMutationSuccessful(mockState)
       })

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryButtons.tsx
@@ -1,6 +1,7 @@
 import { ActionType, OwnerType, TappedContactGallery } from "@artsy/cohesion"
 import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { InquiryButtons_artwork$data } from "__generated__/InquiryButtons_artwork.graphql"
+import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import {
   ArtworkInquiryContext,
@@ -10,7 +11,6 @@ import { InquiryTypes, InquiryOptions } from "app/utils/ArtworkInquiry/ArtworkIn
 import React, { useContext, useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import { InquiryModalFragmentContainer } from "./InquiryModal"
 export type InquiryButtonsProps = Omit<ButtonProps, "children"> & {
   artwork: InquiryButtons_artwork$data
 }
@@ -45,7 +45,7 @@ const InquiryButtons: React.FC<InquiryButtonsProps> = ({ artwork, ...rest }) => 
       >
         {InquiryOptions.ContactGallery}
       </Button>
-      <InquiryModalFragmentContainer
+      <InquiryModal
         artwork={artwork}
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -1,12 +1,12 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { InquiryModalTestsQuery } from "__generated__/InquiryModalTestsQuery.graphql"
+import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import React from "react"
 import { graphql } from "react-relay"
-import { InquiryModalFragmentContainer } from "./InquiryModal"
 
 const toggleVisibility = jest.fn()
 const onMutationSuccessful = jest.fn()
@@ -50,7 +50,7 @@ const FakeApp = (props: InquiryModalTestsQuery["response"]) => {
   }
 
   return (
-    <InquiryModalFragmentContainer
+    <InquiryModal
       artwork={props!.artwork!}
       modalIsVisible={modalProps.modalIsVisible}
       toggleVisibility={modalProps.toggleVisibility}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -20,7 +20,6 @@ import { useSubmitInquiryRequest } from "app/Scenes/Artwork/Components/Commercia
 import { navigate } from "app/system/navigation/navigate"
 import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
-import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import { LocationWithDetails } from "app/utils/googleMaps"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
@@ -33,10 +32,7 @@ import { ShippingModal } from "./ShippingModal"
 
 interface InquiryModalProps {
   artwork: InquiryModal_artwork$key
-  closeModal?: () => void
-  exitModal?: () => void
   toggleVisibility: () => void
-  navigator?: NavigatorIOS
   modalIsVisible: boolean
   onMutationSuccessful: (state: boolean) => void
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest.tsx
@@ -1,0 +1,23 @@
+import { useSubmitInquiryRequestMutation } from "__generated__/useSubmitInquiryRequestMutation.graphql"
+import { graphql, useMutation } from "react-relay"
+
+export const useSubmitInquiryRequest = () => {
+  return useMutation<useSubmitInquiryRequestMutation>(graphql`
+    mutation useSubmitInquiryRequestMutation($input: SubmitInquiryRequestMutationInput!) {
+      submitInquiryRequestMutation(input: $input) {
+        inquiryRequest {
+          inquireable {
+            __typename
+            ... on Artwork {
+              title
+              artists {
+                name
+                birthday
+              }
+            }
+          }
+        }
+      }
+    }
+  `)
+}


### PR DESCRIPTION
This PR refactors the `InquiryModal` component to fetch its data using a `useFragment` hook instead of `createFragmentContainer`. It also adds a `useMutation` hook (instead of `commitMutation`) to declare the mutation to submit an inquiry.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.
 
<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Inquiry modal uses a useFragment hook to populate artwork data
- Inquiry modal uses a useMutation hook to submit inquiries

<!-- end_changelog_updates -->

</details>