### PR TITLE
fix(DIA-561): Complete My Profile broken save in middle of the flow and UI adjustments

### DIFF
--- a/src/app/Scenes/CompleteMyProfile/AvatarStep.tsx
+++ b/src/app/Scenes/CompleteMyProfile/AvatarStep.tsx
@@ -1,13 +1,16 @@
 import { Text, Screen, Spacer, Flex } from "@artsy/palette-mobile"
-import { ProgressState } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { Footer } from "app/Scenes/CompleteMyProfile/Footer"
 import { ImageSelector } from "app/Scenes/CompleteMyProfile/ImageSelector"
 import { useCompleteProfile } from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
 import { FC } from "react"
 
 export const AvatarStep: FC = () => {
-  const { goNext, isCurrentRouteDirty, setField, field } =
-    useCompleteProfile<ProgressState["iconUrl"]>()
+  const { goNext } = useCompleteProfile()
+  const iconUrl = CompleteMyProfileStore.useStoreState((state) => state.progressState.iconUrl)
+  const setProgressState = CompleteMyProfileStore.useStoreActions(
+    (actions) => actions.setProgressState
+  )
 
   const handleOnImageSelect = ({
     localPath,
@@ -16,14 +19,14 @@ export const AvatarStep: FC = () => {
     localPath: string
     geminiUrl: string
   }) => {
-    setField({ localPath, geminiUrl })
+    setProgressState({ type: "iconUrl", value: { localPath, geminiUrl } })
   }
 
   return (
-    <Screen>
-      <Screen.Body>
+    <Screen safeArea={false}>
+      <Screen.Body pt={2} fullwidth>
         <Flex justifyContent="space-between" height="100%">
-          <Flex>
+          <Flex px={2}>
             <Text variant="lg">Add a profile image</Text>
 
             <Spacer y={1} />
@@ -34,10 +37,10 @@ export const AvatarStep: FC = () => {
 
             <Spacer y={2} />
 
-            <ImageSelector onImageSelect={handleOnImageSelect} src={field} />
+            <ImageSelector onImageSelect={handleOnImageSelect} src={iconUrl} />
           </Flex>
 
-          <Footer isFormDirty={isCurrentRouteDirty} onGoNext={goNext} />
+          <Footer isFormDirty={!!iconUrl} onGoNext={goNext} />
         </Flex>
       </Screen.Body>
     </Screen>

--- a/src/app/Scenes/CompleteMyProfile/ChangesSummary.tsx
+++ b/src/app/Scenes/CompleteMyProfile/ChangesSummary.tsx
@@ -15,7 +15,8 @@ import { FC } from "react"
 
 export const ChangesSummary: FC = () => {
   const space = useSpace()
-  const { saveAndExit, isLoading } = useCompleteProfile()
+  const { saveAndExit } = useCompleteProfile()
+  const isLoading = CompleteMyProfileStore.useStoreState((state) => state.isLoading)
   const steps = CompleteMyProfileStore.useStoreState((state) => state.steps)
   const progressState = CompleteMyProfileStore.useStoreState((state) => state.progressState)
   const progressStateWithoutUndefined = CompleteMyProfileStore.useStoreState(
@@ -36,8 +37,8 @@ export const ChangesSummary: FC = () => {
   const hasIsIdentityVerified = !!progressState.isIdentityVerified
 
   return (
-    <Screen>
-      <Screen.Body>
+    <Screen safeArea={false}>
+      <Screen.Body pt={2}>
         <Flex py={2} gap={space(2)}>
           <Text variant="lg-display">
             {isCompleted ? "Thank you for completing your profile." : "You’re almost there!"}

--- a/src/app/Scenes/CompleteMyProfile/CompleteMyProfileProvider.tsx
+++ b/src/app/Scenes/CompleteMyProfile/CompleteMyProfileProvider.tsx
@@ -1,11 +1,11 @@
-import { EditableLocation } from "__generated__/useUpdateMyProfileMutation.graphql"
 import { Routes } from "app/Scenes/CompleteMyProfile/CompleteMyProfile"
 import { StepsResult } from "app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps"
+import { LocationWithDetails } from "app/utils/googleMaps"
 import { Action, Computed, action, computed, createContextStore } from "easy-peasy"
 
 export type ProgressState = {
   profession?: string
-  location?: Partial<EditableLocation>
+  location?: Partial<LocationWithDetails>
   iconUrl?: { localPath: string; geminiUrl: string }
   isIdentityVerified?: boolean
 }
@@ -22,19 +22,25 @@ export const ROUTE_ACTION_TYPES: Record<Exclude<Routes, "ChangesSummary">, keyof
 export interface CompleteMyProfileStoreModel {
   steps: StepsResult
   progressState: ProgressState
+  isLoading: boolean
   setSteps: Action<this, StepsResult>
   setProgressState: Action<this, ActionPayload>
+  setIsLoading: Action<this, boolean>
   progressStateWithoutUndefined: Computed<this, ProgressState>
 }
 
 export const model: CompleteMyProfileStoreModel = {
   steps: "loading",
+  isLoading: false,
   progressState: {},
   setSteps: action((state, steps) => {
     state.steps = steps
   }),
   setProgressState: action((state, action) => {
     state.progressState = { ...state.progressState, [action.type]: action.value }
+  }),
+  setIsLoading: action((state, isLoading) => {
+    state.isLoading = isLoading
   }),
   progressStateWithoutUndefined: computed((state) => {
     return Object.entries(state.progressState)

--- a/src/app/Scenes/CompleteMyProfile/Footer.tsx
+++ b/src/app/Scenes/CompleteMyProfile/Footer.tsx
@@ -1,4 +1,5 @@
 import { Button, Flex, Touchable, Text } from "@artsy/palette-mobile"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { useCompleteProfile } from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
 import { FC } from "react"
 import { Platform } from "react-native"
@@ -9,11 +10,21 @@ interface FooterProps {
 }
 
 export const Footer: FC<FooterProps> = ({ isFormDirty, onGoNext }) => {
-  const { goBack, isLoading } = useCompleteProfile()
+  const { goBack } = useCompleteProfile()
+  const isLoading = CompleteMyProfileStore.useStoreState((state) => state.isLoading)
 
   return (
-    <Flex pt={2} pb={Platform.OS === "ios" ? 4 : 2} justifyContent="flex-end">
-      <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+    <Flex justifyContent="flex-end" justifySelf="flex-end" pt={6} height="auto">
+      <Flex
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="center"
+        pt={2}
+        pb={Platform.OS === "ios" ? 4 : 2}
+        px={2}
+        borderTopWidth={1}
+        borderTopColor="black10"
+      >
         <Touchable onPress={goBack}>
           <Text underline>Back</Text>
         </Touchable>

--- a/src/app/Scenes/CompleteMyProfile/IdentityVerificationStep.tsx
+++ b/src/app/Scenes/CompleteMyProfile/IdentityVerificationStep.tsx
@@ -1,5 +1,6 @@
 import { Text, Screen, Button, Spacer, Flex, useSpace, CheckIcon } from "@artsy/palette-mobile"
 import { IdentityVerificationStep_me$key } from "__generated__/IdentityVerificationStep_me.graphql"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { Footer } from "app/Scenes/CompleteMyProfile/Footer"
 import { useCompleteMyProfileSteps } from "app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps"
 import { useCompleteProfile } from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
@@ -10,61 +11,70 @@ import { graphql, useFragment } from "react-relay"
 
 export const IdentityVerificationStep: FC = () => {
   const space = useSpace()
-  const { goNext, isCurrentRouteDirty, field, setField } = useCompleteProfile()
+  const { goNext } = useCompleteProfile()
   const { me } = useCompleteMyProfileSteps()
   const data = useFragment<IdentityVerificationStep_me$key>(fragment, me)
   const { handleVerification } = useHandleIDVerification(data?.internalID ?? "")
 
+  const isIdentityVerified = CompleteMyProfileStore.useStoreState(
+    (state) => state.progressState.isIdentityVerified
+  )
+  const setProgressState = CompleteMyProfileStore.useStoreActions(
+    (actions) => actions.setProgressState
+  )
+
   const handleSendVerification = () => {
     handleVerification()
-    setField(true)
+    setProgressState({ type: "isIdentityVerified", value: true })
   }
 
   return (
-    <Screen>
-      <Screen.Body>
-        <Flex flexGrow={100}>
-          <Text variant="lg-display">Verify your ID</Text>
+    <Screen safeArea={false}>
+      <Screen.Body pt={2} fullwidth>
+        <Flex flex={1} justifyContent="space-between">
+          <Flex flex={1} justifyContent="space-between" px={2}>
+            <Flex>
+              <Text variant="lg-display">Verify your ID</Text>
 
-          <Spacer y={1} />
+              <Spacer y={1} />
 
-          <Flex gap={space(2)}>
-            <Text color="black60">
-              Send an ID verification email and follow the link and instructions to verify your
-              account.
-            </Text>
+              <Flex gap={space(2)}>
+                <Text color="black60">
+                  Send an ID verification email and follow the link and instructions to verify your
+                  account.
+                </Text>
 
-            {!field ? (
-              <Button onPress={handleSendVerification}>Send verification Email</Button>
-            ) : (
-              <Button icon={<CheckIcon fill="white100" />} variant="fillSuccess">
-                Email sent
-              </Button>
-            )}
+                {!isIdentityVerified ? (
+                  <Button onPress={handleSendVerification}>Send verification Email</Button>
+                ) : (
+                  <Button icon={<CheckIcon fill="white100" />} variant="fillSuccess">
+                    Email sent
+                  </Button>
+                )}
 
-            <Text color="black60">
-              Identify Verification is required for some transactions. For more details, see our
-              <Text
-                style={{ textDecorationLine: "underline" }}
-                onPress={() => navigate(`https://www.artsy.net/identity-verification-faq`)}
-                suppressHighlighting
-              >
-                {` FAQs`}
-              </Text>
-              .
-            </Text>
-          </Flex>
+                <Text color="black60">
+                  Identify Verification is required for some transactions. For more details, see our
+                  <Text
+                    style={{ textDecorationLine: "underline" }}
+                    onPress={() => navigate(`https://www.artsy.net/identity-verification-faq`)}
+                    suppressHighlighting
+                  >
+                    {` FAQs`}
+                  </Text>
+                  .
+                </Text>
+              </Flex>
+            </Flex>
 
-          {!!field && (
-            <Flex flex={1} justifyContent="flex-end">
+            {!!isIdentityVerified && (
               <Text color="white100" backgroundColor="green100" py={1} px={2}>
                 ID verification email sent to {data?.email}.
               </Text>
-            </Flex>
-          )}
-        </Flex>
+            )}
+          </Flex>
 
-        <Footer isFormDirty={isCurrentRouteDirty} onGoNext={goNext} />
+          <Footer isFormDirty={!!isIdentityVerified} onGoNext={goNext} />
+        </Flex>
       </Screen.Body>
     </Screen>
   )

--- a/src/app/Scenes/CompleteMyProfile/ProfessionStep.tsx
+++ b/src/app/Scenes/CompleteMyProfile/ProfessionStep.tsx
@@ -1,45 +1,54 @@
 import { Text, Screen, Spacer, Input, Flex } from "@artsy/palette-mobile"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { Footer } from "app/Scenes/CompleteMyProfile/Footer"
 import { useCompleteProfile } from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
-import { FC } from "react"
+import { FC, useRef } from "react"
 import { KeyboardAvoidingView } from "react-native"
 
 export const ProfessionStep: FC = () => {
-  const { goNext, isCurrentRouteDirty, field, setField } = useCompleteProfile<string>()
+  const ref = useRef<Input>(null)
+  const { goNext } = useCompleteProfile()
+
+  const profession = CompleteMyProfileStore.useStoreState((state) => state.progressState.profession)
+  const setProgressState = CompleteMyProfileStore.useStoreActions(
+    (actions) => actions.setProgressState
+  )
 
   const handleOnChange = (text: string) => {
-    setField(text)
+    setProgressState({ type: "profession", value: text })
   }
 
   return (
     <Screen safeArea={false}>
-      <Screen.Body pt={2}>
-        <KeyboardAvoidingView behavior="padding">
-          <Flex justifyContent="space-between" height="100%">
-            <Flex>
-              <Text variant="lg-display">Add your profession</Text>
+      <Screen.Body pt={2} fullwidth>
+        <KeyboardAvoidingView
+          behavior="padding"
+          style={{ flex: 1, justifyContent: "space-between" }}
+        >
+          <Flex px={2} onLayout={() => ref.current?.focus()}>
+            <Text variant="lg-display">Add your profession</Text>
 
-              <Spacer y={1} />
+            <Spacer y={1} />
 
-              <Text color="black60">
-                Accelerate conversations with galleries by providing quick insights into your
-                background.
-              </Text>
+            <Text color="black60">
+              Accelerate conversations with galleries by providing quick insights into your
+              background.
+            </Text>
 
-              <Spacer y={2} />
+            <Spacer y={2} />
 
-              <Input
-                aria-label="Profession"
-                placeholder="Profession"
-                title="Profession"
-                autoFocus
-                value={field}
-                onChangeText={handleOnChange}
-              />
-            </Flex>
-
-            <Footer isFormDirty={isCurrentRouteDirty} onGoNext={goNext} />
+            <Input
+              aria-label="Profession"
+              placeholder="Profession"
+              title="Profession"
+              value={profession as string}
+              onChangeText={handleOnChange}
+              // Android keyboard doesn't work so great with autofocus prop, slower devices don't measure 100% right the layout
+              ref={ref}
+            />
           </Flex>
+
+          <Footer isFormDirty={!!profession} onGoNext={goNext} />
         </KeyboardAvoidingView>
       </Screen.Body>
     </Screen>

--- a/src/app/Scenes/CompleteMyProfile/__tests__/Footer.tests.tsx
+++ b/src/app/Scenes/CompleteMyProfile/__tests__/Footer.tests.tsx
@@ -1,13 +1,15 @@
 import { screen, fireEvent } from "@testing-library/react-native"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { Footer } from "app/Scenes/CompleteMyProfile/Footer"
 import * as useCompleteProfile from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("Footer", () => {
   const mockGoBack = jest.fn()
-
+  jest
+    .spyOn(CompleteMyProfileStore, "useStoreState")
+    .mockImplementation((callback) => callback({ isLoading: false } as any))
   ;(jest.spyOn(useCompleteProfile, "useCompleteProfile") as jest.SpyInstance<any>).mockReturnValue({
-    isLoading: false,
     goBack: mockGoBack,
   })
 

--- a/src/app/Scenes/CompleteMyProfile/__tests__/ProfessionStep.tests.tsx
+++ b/src/app/Scenes/CompleteMyProfile/__tests__/ProfessionStep.tests.tsx
@@ -1,19 +1,20 @@
 import { screen, fireEvent } from "@testing-library/react-native"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { ProfessionStep } from "app/Scenes/CompleteMyProfile/ProfessionStep"
 import * as useCompleteProfile from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("ProfessionStep", () => {
-  const mockSetField = jest.fn()
-
-  const useCompleteMyProfileSpy = (
-    jest.spyOn(useCompleteProfile, "useCompleteProfile") as jest.SpyInstance<any>
-  ).mockReturnValue({
+  const setProgressState = jest.fn()
+  ;(jest.spyOn(useCompleteProfile, "useCompleteProfile") as jest.SpyInstance<any>).mockReturnValue({
     goNext: jest.fn(),
-    isCurrentRouteDirty: false,
-    field: undefined,
-    setField: mockSetField,
   })
+  jest
+    .spyOn(CompleteMyProfileStore, "useStoreActions")
+    .mockImplementation((callback) => callback({ setProgressState } as any))
+  const stateSpy = jest
+    .spyOn(CompleteMyProfileStore, "useStoreState")
+    .mockImplementation((callback) => callback({ progressState: {} } as any))
 
   afterEach(() => {
     jest.clearAllMocks()
@@ -37,16 +38,13 @@ describe("ProfessionStep", () => {
     const input = screen.getByLabelText("Profession")
     fireEvent(input, "changeText", "Artist")
 
-    expect(mockSetField).toHaveBeenCalledWith("Artist")
+    expect(setProgressState).toHaveBeenCalledWith({ type: "profession", value: "Artist" })
   })
 
   it("shows the input value from field state", () => {
-    useCompleteMyProfileSpy.mockReturnValue({
-      goNext: jest.fn(),
-      isCurrentRouteDirty: false,
-      field: "Curator",
-      setField: mockSetField,
-    })
+    stateSpy.mockImplementation((callback) =>
+      callback({ progressState: { profession: "Curator" } } as any)
+    )
 
     renderWithWrappers(<ProfessionStep />)
 

--- a/src/app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps.ts
+++ b/src/app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps.ts
@@ -11,7 +11,8 @@ export const useCompleteMyProfileSteps = () => {
     query,
     {},
     {
-      fetchPolicy: "store-or-network",
+      fetchPolicy: "network-only",
+      networkCacheConfig: { force: true },
     }
   )
 

--- a/src/app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile.tsx
+++ b/src/app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile.tsx
@@ -9,6 +9,8 @@ const mutation = graphql`
     updateMyUserProfile(input: $input) {
       me @required(action: NONE) {
         ...MyProfileHeader_me
+        ...MyProfileEditModal_me
+        ...MyProfileEditForm_me
       }
     }
   }

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -205,7 +205,7 @@ export const MyProfileHeader: React.FC<MyProfileHeaderProps> = ({ meProp }) => {
         >
           {!!me?.icon?.url ? (
             <Flex overflow="hidden" borderRadius={35}>
-              <Image src={me.icon.url} height={70} width={70} />
+              <Image src={me.icon.url} height={70} width={70} performResize={false} />
             </Flex>
           ) : (
             <PersonIcon width={24} height={24} />


### PR DESCRIPTION
This PR relates to [DIA-561] <!-- eg [PROJECT-XXXX] -->

### Description

This PR mainly fixes a bug when saving from the middle of the flow, the current screen didn't save its field correctly so I removed more logic from `useCompleteProfile` to work directly with the newly created `store` from `easy-peasy` since its performance is enough to have a smooth flow within the UI.
Other relevant changes:
- updates the store directly when adding an avatar to the user to simulate an optimistic response in the fragments that listened to(optimisticResponse was too much since we have 3 spreads in the mutation and the return when using it requires to return all properties used by the fragments)
- UI corrections, spacing, missing border
- Android keyboard layout issue fixed when using `autoFocus` with the input

<details>
  <summary>Android</summary>

  https://github.com/user-attachments/assets/16290591-caab-45e6-88ab-a45aa23d589b

</details>

<details>
  <summary>iOS</summary>

  https://github.com/user-attachments/assets/de8e20c3-3767-4e50-b59d-1547aaa3771b

</details>

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: complete my profile save during the flow and UI adjusts - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-561]: https://artsyproduct.atlassian.net/browse/DIA-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ