### PR TITLE
chore: Remove sub-copy from Artwork Saved tooltip for auction lots

### DIFF
--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tests.tsx
@@ -473,6 +473,7 @@ const preselectedArtworkLists = {
 const artworkEntity: ArtworkEntity = {
   id: "artwork-id",
   internalID: "artwork-internal-id",
+  isInAuction: false,
   title: "Artwork Title",
   year: "2023",
   artistNames: "Banksy",

--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
@@ -169,6 +169,7 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
     if (result.action === ResultAction.SavedToDefaultArtworkList) {
       toast.savedToDefaultArtworkList({
         onToastPress: () => openSelectArtworkListsForArtworkView(result.artwork as ArtworkEntity),
+        isInAuction: !!result.artwork.isInAuction,
       })
       return
     }

--- a/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkInfo.tests.tsx
@@ -61,10 +61,11 @@ describe("ArtworkInfo", () => {
 })
 
 const artworkEntity: ArtworkEntity = {
-  id: "artwork-id",
-  internalID: "artwork-internal-id",
   artistNames: "Banksy",
+  id: "artwork-id",
+  imageURL: null,
+  internalID: "artwork-internal-id",
+  isInAuction: false,
   title: "Artwork Title",
   year: "2023",
-  imageURL: null,
 }

--- a/src/app/Components/ArtworkLists/types.ts
+++ b/src/app/Components/ArtworkLists/types.ts
@@ -19,6 +19,7 @@ export interface ArtworkEntity {
   year: string | null | undefined
   artistNames: string | null | undefined
   imageURL: string | null | undefined
+  isInAuction: boolean | null | undefined
 }
 
 export type SaveResult = {

--- a/src/app/Components/ArtworkLists/useArtworkListsToast.ts
+++ b/src/app/Components/ArtworkLists/useArtworkListsToast.ts
@@ -12,6 +12,7 @@ interface Options {
 
 type SavedToDefaultArtworkListOptions = {
   onToastPress: () => void
+  isInAuction: boolean
 }
 
 type MultipleArtworkListsOptions = Options & {
@@ -33,15 +34,16 @@ export const useArtworkListToast = (bottomPadding?: number | null) => {
     })
   }
   const savedToDefaultArtworkList = (options: SavedToDefaultArtworkListOptions) => {
-    const { onToastPress } = options
+    const { onToastPress, isInAuction } = options
 
     showToast("Artwork saved", {
       cta: "Add to a List",
       onPress: onToastPress,
       backgroundColor: "green100",
-      description: isPartnerOfferEnabled
-        ? "Saving an artwork signals interest to galleries."
-        : null,
+      description:
+        isPartnerOfferEnabled && !isInAuction
+          ? "Saving an artwork signals interest to galleries."
+          : null,
     })
   }
 

--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -25,6 +25,7 @@ export const useSaveArtworkToArtworkLists = (options: Options) => {
     year: artwork.date,
     artistNames: artwork.artistNames,
     imageURL: artwork.preview?.url ?? null,
+    isInAuction: !!artwork.isInAuction,
   }
   let isSaved = artwork.isSaved
 
@@ -105,6 +106,7 @@ const ArtworkFragment = graphql`
   fragment useSaveArtworkToArtworkLists_artwork on Artwork {
     id
     internalID
+    isInAuction
     isSaved
     slug
     title

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView.tests.tsx
@@ -172,10 +172,11 @@ describe("CreateNewArtworkListView", () => {
 })
 
 const artworkEntity: ArtworkEntity = {
+  artistNames: "Banksy",
   id: "artwork-id",
+  imageURL: null,
   internalID: "artwork-internal-id",
+  isInAuction: false,
   title: "Artwork Title",
   year: "2023",
-  artistNames: "Banksy",
-  imageURL: null,
 }


### PR DESCRIPTION
This PR resolves https://artsyproduct.atlassian.net/browse/EMI-1976 

My first PR in Eigen so please excuse my mistakes here. Figuring out this Eigen flow!

### Description
Ideally we would have the auction saves(watches) go into a different list type but that is not done this way now. We are relying on checking if the artwork is in the auction for handling those saves in several places. So for now just reading this attribute from artwork and basing the sub-copy on that parameter.

Before:
<img width="456" alt="Screen Shot 2024-07-18 at 11 53 15 AM" src="https://github.com/user-attachments/assets/953c735a-42bf-49d5-95e5-6307f5b46450">

After:
<img width="378" alt="Screen Shot 2024-07-18 at 11 53 00 AM" src="https://github.com/user-attachments/assets/bab8ab7e-b460-42a4-a590-6b5f7a134b49">

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Removed misleading sub-note after auction artwork save - oxaudo

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1976]: https://artsyproduct.atlassian.net/browse/EMI-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ