### PR TITLE
feat(DIA-695): show profile prompt after sending an inquiry

### DIFF
--- a/src/app/Components/FancyModal/FancyModalHeader.tsx
+++ b/src/app/Components/FancyModal/FancyModalHeader.tsx
@@ -93,6 +93,7 @@ export const FancyModalHeader: React.FC<FancyModalHeaderProps> = ({
                   variant="sm"
                   color={rightButtonDisabled ? "black30" : "black100"}
                   testID={rightButtonTestId}
+                  disabled={rightButtonDisabled}
                 >
                   {rightButtonText}
                 </Text>

--- a/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
+++ b/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
@@ -2,10 +2,12 @@ import { ActionType, ContextModule, OwnerType, TappedViewWork } from "@artsy/coh
 import { Button, Flex, useSpace, Join, Spacer } from "@artsy/palette-mobile"
 import { BuyNowButton_artwork$key } from "__generated__/BuyNowButton_artwork.graphql"
 import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
+import { ContactGalleryButton_me$key } from "__generated__/ContactGalleryButton_me.graphql"
 import { CreateArtworkAlertModal_artwork$key } from "__generated__/CreateArtworkAlertModal_artwork.graphql"
 import { MakeOfferButton_artwork$key } from "__generated__/MakeOfferButton_artwork.graphql"
 import { NotificationCommercialButtonsQuery } from "__generated__/NotificationCommercialButtonsQuery.graphql"
 import { NotificationCommercialButtons_artwork$key } from "__generated__/NotificationCommercialButtons_artwork.graphql"
+import { NotificationCommercialButtons_me$key } from "__generated__/NotificationCommercialButtons_me.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import { BuyNowButton } from "app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton"
@@ -65,10 +67,12 @@ export const CommercialButtons: React.FC<{
     | BuyNowButton_artwork$key
     | MakeOfferButton_artwork$key
     | ContactGalleryButton_artwork$key
+  me: NotificationCommercialButtons_me$key
   partnerOffer?: PartnerOffer
   artworkID: string
-}> = ({ artwork, partnerOffer, artworkID }) => {
+}> = ({ artwork, me, partnerOffer, artworkID }) => {
   const artworkData = useFragment(artworkFragment, artwork)
+  const meData = useFragment(meFragment, me)
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
   const space = useSpace()
 
@@ -89,6 +93,7 @@ export const CommercialButtons: React.FC<{
           />
           <ContactGalleryButton
             artwork={artworkData as ContactGalleryButton_artwork$key}
+            me={meData as ContactGalleryButton_me$key}
             block
             variant="outline"
           />
@@ -177,6 +182,12 @@ const artworkFragment = graphql`
     ...BuyNowButton_artwork
     ...ContactGalleryButton_artwork
     ...CreateArtworkAlertModal_artwork
+  }
+`
+
+const meFragment = graphql`
+  fragment NotificationCommercialButtons_me on Me {
+    ...ContactGalleryButton_me
   }
 `
 

--- a/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
+++ b/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
@@ -1,13 +1,9 @@
 import { ActionType, ContextModule, OwnerType, TappedViewWork } from "@artsy/cohesion"
 import { Button, Flex, useSpace, Join, Spacer } from "@artsy/palette-mobile"
 import { BuyNowButton_artwork$key } from "__generated__/BuyNowButton_artwork.graphql"
-import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
 import { ContactGalleryButton_me$key } from "__generated__/ContactGalleryButton_me.graphql"
-import { CreateArtworkAlertModal_artwork$key } from "__generated__/CreateArtworkAlertModal_artwork.graphql"
-import { MakeOfferButton_artwork$key } from "__generated__/MakeOfferButton_artwork.graphql"
 import { NotificationCommercialButtonsQuery } from "__generated__/NotificationCommercialButtonsQuery.graphql"
 import { NotificationCommercialButtons_artwork$key } from "__generated__/NotificationCommercialButtons_artwork.graphql"
-import { NotificationCommercialButtons_me$key } from "__generated__/NotificationCommercialButtons_me.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import { BuyNowButton } from "app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton"
@@ -61,18 +57,13 @@ const RowContainer: React.FC = ({ children }) => {
 }
 
 export const CommercialButtons: React.FC<{
-  artwork:
-    | NotificationCommercialButtons_artwork$key
-    | CreateArtworkAlertModal_artwork$key
-    | BuyNowButton_artwork$key
-    | MakeOfferButton_artwork$key
-    | ContactGalleryButton_artwork$key
-  me: NotificationCommercialButtons_me$key
+  artwork: NotificationCommercialButtons_artwork$key
+  me: ContactGalleryButton_me$key
   partnerOffer?: PartnerOffer
   artworkID: string
 }> = ({ artwork, me, partnerOffer, artworkID }) => {
   const artworkData = useFragment(artworkFragment, artwork)
-  const meData = useFragment(meFragment, me)
+
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
   const space = useSpace()
 
@@ -87,16 +78,8 @@ export const CommercialButtons: React.FC<{
     if (!enablePartnerOfferOnArtworkScreen) {
       renderComponent = (
         <>
-          <MakeOfferButtonFragmentContainer
-            artwork={artworkData as MakeOfferButton_artwork$key}
-            editionSetID={null}
-          />
-          <ContactGalleryButton
-            artwork={artworkData as ContactGalleryButton_artwork$key}
-            me={meData as ContactGalleryButton_me$key}
-            block
-            variant="outline"
-          />
+          <MakeOfferButtonFragmentContainer artwork={artworkData} editionSetID={null} />
+          <ContactGalleryButton artwork={artworkData} me={me} block variant="outline" />
         </>
       )
     } else {
@@ -118,7 +101,7 @@ export const CommercialButtons: React.FC<{
     if (!enablePartnerOfferOnArtworkScreen) {
       renderComponent = (
         <BuyNowButton
-          artwork={artworkData as BuyNowButton_artwork$key}
+          artwork={artworkData}
           partnerOffer={partnerOffer}
           editionSetID={null}
           buttonText="Continue to Purchase"
@@ -161,7 +144,7 @@ export const CommercialButtons: React.FC<{
         </Button>
 
         <CreateArtworkAlertModal
-          artwork={artwork as CreateArtworkAlertModal_artwork$key}
+          artwork={artworkData}
           onClose={() => setShowCreateArtworkAlertModal(false)}
           visible={showCreateArtworkAlertModal}
         />
@@ -182,12 +165,6 @@ const artworkFragment = graphql`
     ...BuyNowButton_artwork
     ...ContactGalleryButton_artwork
     ...CreateArtworkAlertModal_artwork
-  }
-`
-
-const meFragment = graphql`
-  fragment NotificationCommercialButtons_me on Me {
-    ...ContactGalleryButton_me
   }
 `
 

--- a/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
+++ b/src/app/Scenes/Activity/components/NotificationCommercialButtons.tsx
@@ -1,7 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedViewWork } from "@artsy/cohesion"
 import { Button, Flex, useSpace, Join, Spacer } from "@artsy/palette-mobile"
 import { BuyNowButton_artwork$key } from "__generated__/BuyNowButton_artwork.graphql"
-import { ContactGalleryButton_me$key } from "__generated__/ContactGalleryButton_me.graphql"
+import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { NotificationCommercialButtonsQuery } from "__generated__/NotificationCommercialButtonsQuery.graphql"
 import { NotificationCommercialButtons_artwork$key } from "__generated__/NotificationCommercialButtons_artwork.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
@@ -58,7 +58,7 @@ const RowContainer: React.FC = ({ children }) => {
 
 export const CommercialButtons: React.FC<{
   artwork: NotificationCommercialButtons_artwork$key
-  me: ContactGalleryButton_me$key
+  me: InquiryModal_me$key
   partnerOffer?: PartnerOffer
   artworkID: string
 }> = ({ artwork, me, partnerOffer, artworkID }) => {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -765,8 +765,8 @@ export const ArtworkContainer = createRefetchContainer(
     `,
     me: graphql`
       fragment Artwork_me on Me @argumentDefinitions(artworkID: { type: "String!" }) {
-        ...ArtworkStickyBottomContent_me
-        ...PartnerCard_me
+        ...ArtworkCommercialButtons_me
+        ...InquiryModal_me
         partnerOffersConnection(artworkID: $artworkID, first: 1) {
           edges {
             node {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -69,7 +69,7 @@ import { ShippingAndTaxesFragmentContainer } from "./Components/ShippingAndTaxes
 interface ArtworkProps {
   artworkAboveTheFold: Artwork_artworkAboveTheFold$data | null | undefined
   artworkBelowTheFold: Artwork_artworkBelowTheFold$data | null | undefined
-  me: Artwork_me$data | null | undefined
+  me: Artwork_me$data
   isVisible: boolean
   onLoad: (artworkProps: ArtworkProps) => void
   relay: RelayRefetchProp
@@ -375,6 +375,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
           element: (
             <PartnerCard
               artwork={artworkBelowTheFold}
+              me={me}
               showShortContactGallery={
                 !!artworkAboveTheFold?.isUnlisted && !!artworkBelowTheFold.partner?.isInquireable
               }
@@ -463,6 +464,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
           <PartnerCard
             shouldShowQuestions={!!artworkBelowTheFold.partner?.isInquireable}
             artwork={artworkBelowTheFold}
+            me={me}
             showShortContactGallery={
               !!artworkAboveTheFold?.isUnlisted && !!artworkBelowTheFold.partner?.isInquireable
             }
@@ -764,6 +766,7 @@ export const ArtworkContainer = createRefetchContainer(
     me: graphql`
       fragment Artwork_me on Me @argumentDefinitions(artworkID: { type: "String!" }) {
         ...ArtworkStickyBottomContent_me
+        ...PartnerCard_me
         partnerOffersConnection(artworkID: $artworkID, first: 1) {
           edges {
             node {
@@ -828,7 +831,8 @@ export const ArtworkQueryRenderer: React.FC<ArtworkScreenProps> = ({
         renderComponent: ({ above, below }) => {
           if (
             // Make sure that the artwork exists
-            above.artworkResult?.__typename === "Artwork"
+            above.artworkResult?.__typename === "Artwork" &&
+            above.me
           ) {
             return (
               <ArtworkContainer

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -5,8 +5,10 @@ import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { ArtworkInquiryContextState } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import {
+  ArtworkInquiryContext,
+  initialArtworkInquiryState,
+} from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -25,7 +27,7 @@ describe("ArtworkCommercialButtons", () => {
       return (
         <ArtworkInquiryContext.Provider
           value={{
-            state,
+            state: initialArtworkInquiryState,
             dispatch: jest.fn(),
           }}
         >
@@ -580,12 +582,6 @@ describe("ArtworkCommercialButtons", () => {
     })
   })
 })
-
-const state: ArtworkInquiryContextState = {
-  shippingLocation: null,
-  message: null,
-  inquiryQuestions: [],
-}
 
 const meFixture = {
   id: "id",

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -5,10 +5,7 @@ import { ArtworkStoreProvider } from "app/Scenes/Artwork/ArtworkStore"
 import { ArtworkFixture } from "app/__fixtures__/ArtworkFixture"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
-import {
-  ArtworkInquiryContext,
-  initialArtworkInquiryState,
-} from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { ArtworkInquiryStateProvider } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { extractNodes } from "app/utils/extractNodes"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -25,12 +22,7 @@ describe("ArtworkCommercialButtons", () => {
       const partnerOffer = extractNodes(props.me!.partnerOffersConnection)[0]
 
       return (
-        <ArtworkInquiryContext.Provider
-          value={{
-            state: initialArtworkInquiryState,
-            dispatch: jest.fn(),
-          }}
-        >
+        <ArtworkInquiryStateProvider>
           <ArtworkStoreProvider>
             <ArtworkCommercialButtons
               partnerOffer={partnerOffer}
@@ -38,7 +30,7 @@ describe("ArtworkCommercialButtons", () => {
               me={props.me!}
             />
           </ArtworkStoreProvider>
-        </ArtworkInquiryContext.Provider>
+        </ArtworkInquiryStateProvider>
       )
     },
     query: graphql`

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -121,7 +121,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
     if (hasActivePartnerOffer) {
       return (
         <RowContainer>
-          <ContactGalleryButton artwork={artworkData} variant="outline" block />
+          <ContactGalleryButton artwork={artworkData} me={meData} variant="outline" block />
           <BuyNowButton
             partnerOffer={partnerOfferData}
             artwork={artworkData}
@@ -133,7 +133,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
 
     return (
       <RowContainer>
-        <ContactGalleryButton artwork={artworkData} variant="outline" block />
+        <ContactGalleryButton artwork={artworkData} me={meData} variant="outline" block />
         <MakeOfferButtonFragmentContainer artwork={artworkData} editionSetID={selectedEditionId} />
       </RowContainer>
     )
@@ -167,7 +167,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
     if (hasActivePartnerOffer) {
       return (
         <RowContainer>
-          <ContactGalleryButton artwork={artworkData} variant="outline" block />
+          <ContactGalleryButton artwork={artworkData} me={meData} variant="outline" block />
           <BuyNowButton
             partnerOffer={partnerOfferData}
             artwork={artworkData}
@@ -177,7 +177,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
       )
     }
 
-    return <ContactGalleryButton artwork={artworkData} block />
+    return <ContactGalleryButton artwork={artworkData} me={meData} block />
   }
 
   return null
@@ -206,6 +206,7 @@ const artworkFragment = graphql`
 const meFragment = graphql`
   fragment ArtworkCommercialButtons_me on Me {
     ...BidButton_me
+    ...ContactGalleryButton_me
   }
 `
 

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -206,7 +206,7 @@ const artworkFragment = graphql`
 const meFragment = graphql`
   fragment ArtworkCommercialButtons_me on Me {
     ...BidButton_me
-    ...ContactGalleryButton_me
+    ...InquiryModal_me
   }
 `
 

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tests.tsx
@@ -37,7 +37,7 @@ describe("ArtworkStickyBottomContent", () => {
           ...ArtworkStickyBottomContent_artwork
         }
         me {
-          ...ArtworkStickyBottomContent_me
+          ...ArtworkCommercialButtons_me
           partnerOffersConnection(artworkID: "artworkID", first: 1) {
             edges {
               node {

--- a/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkStickyBottomContent.tsx
@@ -1,6 +1,6 @@
 import { Box, Separator } from "@artsy/palette-mobile"
+import { ArtworkCommercialButtons_me$key } from "__generated__/ArtworkCommercialButtons_me.graphql"
 import { ArtworkStickyBottomContent_artwork$key } from "__generated__/ArtworkStickyBottomContent_artwork.graphql"
-import { ArtworkStickyBottomContent_me$key } from "__generated__/ArtworkStickyBottomContent_me.graphql"
 import { ArtworkStickyBottomContent_partnerOffer$key } from "__generated__/ArtworkStickyBottomContent_partnerOffer.graphql"
 import { useArtworkListsContext } from "app/Components/ArtworkLists/ArtworkListsContext"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
@@ -14,7 +14,7 @@ import { ArtworkPrice } from "./ArtworkPrice"
 
 interface ArtworkStickyBottomContentProps {
   artwork: ArtworkStickyBottomContent_artwork$key
-  me: ArtworkStickyBottomContent_me$key
+  me: ArtworkCommercialButtons_me$key
   partnerOffer: ArtworkStickyBottomContent_partnerOffer$key
 }
 
@@ -25,7 +25,6 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
 }) => {
   const { safeAreaInsets } = useScreenDimensions()
   const artworkData = useFragment(artworkFragment, artwork)
-  const meData = useFragment(meFragment, me)
   const partnerOfferData = useFragment(partnerOfferFragment, partnerOffer)
   const auctionState = ArtworkStore.useStoreState((state) => state.auctionState)
 
@@ -77,11 +76,7 @@ export const ArtworkStickyBottomContent: React.FC<ArtworkStickyBottomContentProp
       <Separator />
       <Box px={2} py={1}>
         <ArtworkPrice artwork={artworkData} partnerOffer={partnerOfferData} mb={1} />
-        <ArtworkCommercialButtons
-          artwork={artworkData}
-          partnerOffer={partnerOfferData}
-          me={meData}
-        />
+        <ArtworkCommercialButtons artwork={artworkData} partnerOffer={partnerOfferData} me={me} />
       </Box>
     </Box>
   )
@@ -97,12 +92,6 @@ const artworkFragment = graphql`
     }
     ...ArtworkPrice_artwork
     ...ArtworkCommercialButtons_artwork
-  }
-`
-
-const meFragment = graphql`
-  fragment ArtworkStickyBottomContent_me on Me {
-    ...ArtworkCommercialButtons_me
   }
 `
 

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -16,7 +16,7 @@ export interface CollapsibleArtworkDetailsProps {
 const artworkDetailItems = (artwork: CollapsibleArtworkDetails_artwork$data) => {
   const items = [
     { title: "Price", value: artwork.saleMessage },
-    { title: "Medium", value: artwork.category },
+    { title: "Medium", value: artwork.mediumType?.name },
     { title: "Manufacturer", value: artwork.manufacturer },
     { title: "Publisher", value: artwork.publisher },
     { title: "Materials", value: artwork.medium },
@@ -26,7 +26,7 @@ const artworkDetailItems = (artwork: CollapsibleArtworkDetails_artwork$data) => 
       value: [artwork.dimensions?.in, artwork.dimensions?.cm].filter((d) => d).join("\n"),
     },
     { title: "Signature", value: artwork.signatureInfo?.details },
-    { title: "Frame", value: artwork.framed?.details },
+    { title: "Frame", value: artwork.isFramed ? "Included" : "Not included" },
     { title: "Certificate of Authenticity", value: artwork.certificateOfAuthenticity?.details },
     { title: "Condition", value: artwork.conditionDescription?.details },
   ]
@@ -106,7 +106,9 @@ export const CollapsibleArtworkDetailsFragmentContainer = createFragmentContaine
         attributionClass {
           name
         }
-        category
+        mediumType {
+          name
+        }
         manufacturer
         publisher
         medium
@@ -116,9 +118,7 @@ export const CollapsibleArtworkDetailsFragmentContainer = createFragmentContaine
         certificateOfAuthenticity {
           details
         }
-        framed {
-          details
-        }
+        isFramed
         dimensions {
           in
           cm

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -49,7 +49,10 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
 
   return artwork ? (
     <>
-      <TouchableOpacity onPress={() => toggleExpanded()} testID="toggle-artwork-details-button">
+      <TouchableOpacity
+        accessibilityLabel={isExpanded ? "Hide artwork details" : "Show artwork details"}
+        onPress={() => toggleExpanded()}
+      >
         <Flex flexDirection="row" padding={2} alignItems="center">
           {!!artwork.image && (
             <Image

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails.tsx
@@ -1,7 +1,6 @@
-import { Collapse, Spacer, Flex, Box, Text, Separator, Join } from "@artsy/palette-mobile"
+import { Collapse, Spacer, Flex, Box, Text, Separator, Join, Image } from "@artsy/palette-mobile"
 import { CollapsibleArtworkDetails_artwork$data } from "__generated__/CollapsibleArtworkDetails_artwork.graphql"
 import ChevronIcon from "app/Components/Icons/ChevronIcon"
-import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { ArtworkDetailsRow } from "app/Scenes/Artwork/Components/ArtworkDetailsRow"
 import React, { useState } from "react"
 import { LayoutAnimation, ScrollView, TouchableOpacity } from "react-native"
@@ -53,10 +52,11 @@ export const CollapsibleArtworkDetails: React.FC<CollapsibleArtworkDetailsProps>
       <TouchableOpacity onPress={() => toggleExpanded()} testID="toggle-artwork-details-button">
         <Flex flexDirection="row" padding={2} alignItems="center">
           {!!artwork.image && (
-            <OpaqueImageView
+            <Image
+              accessibilityLabel={`Image of ${artwork.title}`}
               height={40}
               aspectRatio={(artwork.image.width || 1) / (artwork.image.height || 1)}
-              imageURL={artwork.image.url}
+              src={artwork.image?.url || ""}
               width={40}
               style={{ alignSelf: "center" }}
             />

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
@@ -1,4 +1,5 @@
 import { CompleteProfilePrompt_artwork$key } from "__generated__/CompleteProfilePrompt_artwork.graphql"
+import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { MyProfileEditModal } from "app/Scenes/MyProfile/MyProfileEditModal"
 import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { useContext } from "react"
@@ -6,14 +7,16 @@ import { graphql, useFragment } from "react-relay"
 
 interface CompleteProfilePromptProps {
   artwork: CompleteProfilePrompt_artwork$key
+  me: MyProfileEditModal_me$key
 }
 
-export const CompleteProfilePrompt: React.FC<CompleteProfilePromptProps> = ({ artwork }) => {
+export const CompleteProfilePrompt: React.FC<CompleteProfilePromptProps> = ({ artwork, me }) => {
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const artworkData = useFragment(artworkFragment, artwork)
 
   return (
     <MyProfileEditModal
+      me={me}
       visible={state.profilePromptVisible}
       message={`Inquiry sent! Tell ${artworkData.partner?.name || ""} more about yourself.`}
       onClose={() => dispatch({ type: "setProfilePromptVisible", payload: false })}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
@@ -4,11 +4,11 @@ import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquirySt
 import { useContext } from "react"
 import { graphql, useFragment } from "react-relay"
 
-interface Props {
+interface CompleteProfilePromptProps {
   artwork: CompleteProfilePrompt_artwork$key
 }
 
-export const CompleteProfilePrompt: React.FC<Props> = ({ artwork }) => {
+export const CompleteProfilePrompt: React.FC<CompleteProfilePromptProps> = ({ artwork }) => {
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const artworkData = useFragment(artworkFragment, artwork)
 

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
@@ -1,8 +1,7 @@
 import { CompleteProfilePrompt_artwork$key } from "__generated__/CompleteProfilePrompt_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { MyProfileEditModal } from "app/Scenes/MyProfile/MyProfileEditModal"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { useContext } from "react"
+import { useArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { graphql, useFragment } from "react-relay"
 
 interface CompleteProfilePromptProps {
@@ -11,7 +10,7 @@ interface CompleteProfilePromptProps {
 }
 
 export const CompleteProfilePrompt: React.FC<CompleteProfilePromptProps> = ({ artwork, me }) => {
-  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const { state, dispatch } = useArtworkInquiryContext()
   const artworkData = useFragment(artworkFragment, artwork)
 
   return (

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt.tsx
@@ -1,0 +1,30 @@
+import { CompleteProfilePrompt_artwork$key } from "__generated__/CompleteProfilePrompt_artwork.graphql"
+import { MyProfileEditModal } from "app/Scenes/MyProfile/MyProfileEditModal"
+import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { useContext } from "react"
+import { graphql, useFragment } from "react-relay"
+
+interface Props {
+  artwork: CompleteProfilePrompt_artwork$key
+}
+
+export const CompleteProfilePrompt: React.FC<Props> = ({ artwork }) => {
+  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const artworkData = useFragment(artworkFragment, artwork)
+
+  return (
+    <MyProfileEditModal
+      visible={state.profilePromptVisible}
+      message={`Inquiry sent! Tell ${artworkData.partner?.name || ""} more about yourself.`}
+      onClose={() => dispatch({ type: "setProfilePromptVisible", payload: false })}
+    />
+  )
+}
+
+const artworkFragment = graphql`
+  fragment CompleteProfilePrompt_artwork on Artwork {
+    partner {
+      name
+    }
+  }
+`

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
@@ -20,7 +20,7 @@ describe("ContactGalleryButton", () => {
     `,
   })
 
-  it("makes the inquiry modal visible when the contact gallery button is pressed", async () => {
+  it("opens the inquiry modal when the contact gallery button is pressed", async () => {
     renderWithRelay()
 
     fireEvent.press(screen.getByText("Contact Gallery"))

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
@@ -6,21 +6,7 @@ import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
 describe("ContactGalleryButton", () => {
-  const { renderWithRelay } = setupTestWrapper<ContactGalleryButtonTestsQuery>({
-    Component: ({ artwork, me }) => <ContactGalleryButton artwork={artwork} me={me} />,
-    query: graphql`
-      query ContactGalleryButtonTestsQuery @relay_test_operation {
-        artwork(id: "artwork-id") @required(action: NONE) {
-          ...ContactGalleryButton_artwork
-        }
-        me @required(action: NONE) {
-          ...InquiryModal_me
-        }
-      }
-    `,
-  })
-
-  it("opens the inquiry modal when the contact gallery button is pressed", async () => {
+  it("opens the inquiry modal when the 'contact gallery' button is pressed", async () => {
     renderWithRelay()
 
     fireEvent.press(screen.getByText("Contact Gallery"))
@@ -30,7 +16,7 @@ describe("ContactGalleryButton", () => {
     })
   })
 
-  it("tracks an event when the contact gallery button is pressed", async () => {
+  it("tracks an event when the 'contact gallery' button is pressed", async () => {
     renderWithRelay({
       Artwork: () => ({
         internalID: "artwork-id",
@@ -49,4 +35,18 @@ describe("ContactGalleryButton", () => {
       })
     })
   })
+})
+
+const { renderWithRelay } = setupTestWrapper<ContactGalleryButtonTestsQuery>({
+  Component: ({ artwork, me }) => <ContactGalleryButton artwork={artwork} me={me} />,
+  query: graphql`
+    query ContactGalleryButtonTestsQuery @relay_test_operation {
+      artwork(id: "artwork-id") @required(action: NONE) {
+        ...ContactGalleryButton_artwork
+      }
+      me @required(action: NONE) {
+        ...InquiryModal_me
+      }
+    }
+  `,
 })

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
@@ -1,33 +1,52 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ContactGalleryButtonTestsQuery } from "__generated__/ContactGalleryButtonTestsQuery.graphql"
 import { ContactGalleryButton } from "app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
 describe("ContactGalleryButton", () => {
-  beforeEach(() => {
-    jest.useFakeTimers({
-      legacyFakeTimers: true,
-    })
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
-  setupTestWrapper<ContactGalleryButtonTestsQuery>({
-    Component: ({ artwork, me }) => <ContactGalleryButton artwork={artwork!} me={me!} />,
+  const { renderWithRelay } = setupTestWrapper<ContactGalleryButtonTestsQuery>({
+    Component: ({ artwork, me }) => <ContactGalleryButton artwork={artwork} me={me} />,
     query: graphql`
       query ContactGalleryButtonTestsQuery @relay_test_operation {
-        artwork(id: "great-artttt") {
+        artwork(id: "artwork-id") @required(action: NONE) {
           ...ContactGalleryButton_artwork
         }
-        me {
+        me @required(action: NONE) {
           ...InquiryModal_me
         }
       }
     `,
   })
 
-  test.todo("renders the message sent notification and clears the message after 2000 ms")
-  test.todo("navigates to the inbox route when notifcation tapped")
+  it("makes the inquiry modal visible when the contact gallery button is pressed", async () => {
+    renderWithRelay()
+
+    fireEvent.press(screen.getByText("Contact Gallery"))
+
+    await waitFor(() => {
+      expect(screen.getByText("What information are you looking for?")).toBeVisible()
+    })
+  })
+
+  it("tracks an event when the contact gallery button is pressed", async () => {
+    renderWithRelay({
+      Artwork: () => ({
+        internalID: "artwork-id",
+        slug: "artwork-slug",
+      }),
+    })
+
+    fireEvent.press(screen.getByText("Contact Gallery"))
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "tappedContactGallery",
+        context_owner_id: "artwork-id",
+        context_owner_slug: "artwork-slug",
+        context_owner_type: "artwork",
+      })
+    })
+  })
 })

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
@@ -1,24 +1,7 @@
-import { fireEvent, screen } from "@testing-library/react-native"
 import { ContactGalleryButtonTestsQuery } from "__generated__/ContactGalleryButtonTestsQuery.graphql"
 import { ContactGalleryButton } from "app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton"
-import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
-import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
-import { TouchableOpacity } from "react-native"
 import { graphql } from "react-relay"
-
-jest.mock("app/Scenes/Artwork/Components/CommercialButtons/InquiryModal", () => {
-  return {
-    InquiryModal: ({ onMutationSuccessful }: any) => {
-      mockSuccessfulMutation.mockImplementation((mockState) => {
-        onMutationSuccessful(mockState)
-      })
-      return null
-    },
-  }
-})
-
-const mockSuccessfulMutation = jest.fn()
 
 describe("ContactGalleryButton", () => {
   beforeEach(() => {
@@ -31,34 +14,20 @@ describe("ContactGalleryButton", () => {
     jest.clearAllMocks()
   })
 
-  const { renderWithRelay } = setupTestWrapper<ContactGalleryButtonTestsQuery>({
-    Component: ({ artwork }) => <ContactGalleryButton artwork={artwork!} />,
+  setupTestWrapper<ContactGalleryButtonTestsQuery>({
+    Component: ({ artwork, me }) => <ContactGalleryButton artwork={artwork!} me={me!} />,
     query: graphql`
       query ContactGalleryButtonTestsQuery @relay_test_operation {
         artwork(id: "great-artttt") {
           ...ContactGalleryButton_artwork
         }
+        me {
+          ...ContactGalleryButton_me
+        }
       }
     `,
   })
 
-  it("renders the message sent notification and clears the message after 2000 ms", () => {
-    renderWithRelay()
-    mockSuccessfulMutation(true)
-
-    expect(screen.UNSAFE_getByType(InquirySuccessNotification)).toHaveProp("modalVisible", true)
-
-    jest.advanceTimersByTime(2001)
-    jest.runAllTicks()
-    expect(screen.UNSAFE_getByType(InquirySuccessNotification)).toHaveProp("modalVisible", false)
-  })
-
-  it("navigates to the inbox route when notifcation tapped", () => {
-    renderWithRelay()
-    mockSuccessfulMutation(true)
-
-    fireEvent.press(screen.UNSAFE_getByType(TouchableOpacity))
-
-    expect(navigate).toHaveBeenCalledWith("inbox")
-  })
+  test.todo("renders the message sent notification and clears the message after 2000 ms")
+  test.todo("navigates to the inbox route when notifcation tapped")
 })

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tests.tsx
@@ -22,7 +22,7 @@ describe("ContactGalleryButton", () => {
           ...ContactGalleryButton_artwork
         }
         me {
-          ...ContactGalleryButton_me
+          ...InquiryModal_me
         }
       }
     `,

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -33,7 +33,7 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
       <InquirySuccessNotification />
       <Button
         onPress={() => {
-          trackEvent(tracks.trackTappedContactGallery(artworkData.slug, artworkData.internalID))
+          trackEvent(tracks.trackTappedContactGallery(artworkData.internalID, artworkData.slug))
           setModalVisibility(true)
         }}
         haptic
@@ -53,38 +53,18 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
 }
 
 const tracks = {
-  trackTappedContactGallery: (slug: string, internalID: string): TappedContactGallery => ({
+  trackTappedContactGallery: (artworkId: string, artworkSlug: string): TappedContactGallery => ({
     action: ActionType.tappedContactGallery,
     context_owner_type: OwnerType.artwork,
-    context_owner_slug: slug,
-    context_owner_id: internalID,
+    context_owner_id: artworkId,
+    context_owner_slug: artworkSlug,
   }),
 }
 
 const artworkFragment = graphql`
   fragment ContactGalleryButton_artwork on Artwork {
-    image {
-      url
-      width
-      height
-    }
-    slug
     internalID
-    isPriceHidden
-    title
-    date
-    medium
-    dimensions {
-      in
-      cm
-    }
-    editionOf
-    signatureInfo {
-      details
-    }
-    artist {
-      name
-    }
+    slug
     ...InquiryModal_artwork
     ...CompleteProfilePrompt_artwork
   }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -2,13 +2,11 @@ import { ActionType, OwnerType, TappedContactGallery } from "@artsy/cohesion"
 import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
 import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
-import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import {
   ArtworkInquiryContext,
   ArtworkInquiryStateProvider,
 } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import React from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -23,8 +21,6 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
   me,
   ...rest
 }) => {
-  const profilePromptIsEnabled = useFeatureFlag("AREnableCollectorProfilePrompts")
-
   const artworkData = useFragment(artworkFragment, artwork)
 
   const { trackEvent } = useTracking()
@@ -46,7 +42,6 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
         )}
       </ArtworkInquiryContext.Consumer>
       <InquiryModal artwork={artworkData} me={me} />
-      {!!profilePromptIsEnabled && <CompleteProfilePrompt artwork={artworkData} />}
     </ArtworkInquiryStateProvider>
   )
 }
@@ -65,6 +60,5 @@ const artworkFragment = graphql`
     internalID
     slug
     ...InquiryModal_artwork
-    ...CompleteProfilePrompt_artwork
   }
 `

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -1,7 +1,7 @@
 import { ActionType, OwnerType, TappedContactGallery } from "@artsy/cohesion"
 import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
-import { ContactGalleryButton_me$key } from "__generated__/ContactGalleryButton_me.graphql"
+import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
@@ -13,7 +13,7 @@ import { useTracking } from "react-tracking"
 
 type ContactGalleryButtonProps = Omit<ButtonProps, "children"> & {
   artwork: ContactGalleryButton_artwork$key
-  me: ContactGalleryButton_me$key
+  me: InquiryModal_me$key
 }
 
 export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
@@ -24,7 +24,6 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
   const profilePromptIsEnabled = useFeatureFlag("AREnableCollectorProfilePrompts")
 
   const artworkData = useFragment(artworkFragment, artwork)
-  const meData = useFragment(meFragment, me)
 
   const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
@@ -44,7 +43,7 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
       </Button>
       <InquiryModal
         artwork={artworkData}
-        me={meData}
+        me={me}
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}
       />
@@ -88,11 +87,5 @@ const artworkFragment = graphql`
     }
     ...InquiryModal_artwork
     ...CompleteProfilePrompt_artwork
-  }
-`
-
-const meFragment = graphql`
-  fragment ContactGalleryButton_me on Me {
-    ...InquiryModal_me
   }
 `

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -6,6 +6,7 @@ import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialB
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import { ArtworkInquiryStateProvider } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import React, { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -20,8 +21,11 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
   me,
   ...rest
 }) => {
+  const profilePromptIsEnabled = useFeatureFlag("AREnableCollectorProfilePrompts")
+
   const artworkData = useFragment(artworkFragment, artwork)
   const meData = useFragment(meFragment, me)
+
   const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
 
@@ -44,7 +48,7 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}
       />
-      <CompleteProfilePrompt artwork={artworkData} />
+      {!!profilePromptIsEnabled && <CompleteProfilePrompt artwork={artworkData} />}
     </ArtworkInquiryStateProvider>
   )
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -1,6 +1,8 @@
 import { ActionType, OwnerType, TappedContactGallery } from "@artsy/cohesion"
 import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
+import { ContactGalleryButton_me$key } from "__generated__/ContactGalleryButton_me.graphql"
+import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import { ArtworkInquiryStateProvider } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
@@ -10,20 +12,22 @@ import { useTracking } from "react-tracking"
 
 type ContactGalleryButtonProps = Omit<ButtonProps, "children"> & {
   artwork: ContactGalleryButton_artwork$key
+  me: ContactGalleryButton_me$key
 }
 
-export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({ artwork, ...rest }) => {
+export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
+  artwork,
+  me,
+  ...rest
+}) => {
   const artworkData = useFragment(artworkFragment, artwork)
+  const meData = useFragment(meFragment, me)
   const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
-  const [notificationVisibility, setNotificationVisibility] = useState(false)
 
   return (
     <ArtworkInquiryStateProvider>
-      <InquirySuccessNotification
-        modalVisible={notificationVisibility}
-        toggleNotification={(state: boolean) => setNotificationVisibility(state)}
-      />
+      <InquirySuccessNotification />
       <Button
         onPress={() => {
           trackEvent(tracks.trackTappedContactGallery(artworkData.slug, artworkData.internalID))
@@ -36,10 +40,11 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({ artw
       </Button>
       <InquiryModal
         artwork={artworkData}
+        me={meData}
         modalIsVisible={modalVisibility}
         toggleVisibility={() => setModalVisibility(!modalVisibility)}
-        onMutationSuccessful={(state: boolean) => setNotificationVisibility(state)}
       />
+      <CompleteProfilePrompt artwork={artworkData} />
     </ArtworkInquiryStateProvider>
   )
 }
@@ -78,5 +83,12 @@ const artworkFragment = graphql`
       name
     }
     ...InquiryModal_artwork
+    ...CompleteProfilePrompt_artwork
+  }
+`
+
+const meFragment = graphql`
+  fragment ContactGalleryButton_me on Me {
+    ...InquiryModal_me
   }
 `

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -4,7 +4,6 @@ import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryBu
 import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
-import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import {
   ArtworkInquiryContext,
   ArtworkInquiryStateProvider,
@@ -32,7 +31,6 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
 
   return (
     <ArtworkInquiryStateProvider>
-      <InquirySuccessNotification />
       <ArtworkInquiryContext.Consumer>
         {({ dispatch }) => (
           <Button

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -5,9 +5,12 @@ import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
-import { ArtworkInquiryStateProvider } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import {
+  ArtworkInquiryContext,
+  ArtworkInquiryStateProvider,
+} from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import React, { useState } from "react"
+import React from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -25,28 +28,26 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
 
   const artworkData = useFragment(artworkFragment, artwork)
 
-  const [modalVisibility, setModalVisibility] = useState(false)
   const { trackEvent } = useTracking()
 
   return (
     <ArtworkInquiryStateProvider>
       <InquirySuccessNotification />
-      <Button
-        onPress={() => {
-          trackEvent(tracks.trackTappedContactGallery(artworkData.internalID, artworkData.slug))
-          setModalVisibility(true)
-        }}
-        haptic
-        {...rest}
-      >
-        Contact Gallery
-      </Button>
-      <InquiryModal
-        artwork={artworkData}
-        me={me}
-        modalIsVisible={modalVisibility}
-        toggleVisibility={() => setModalVisibility(!modalVisibility)}
-      />
+      <ArtworkInquiryContext.Consumer>
+        {({ dispatch }) => (
+          <Button
+            onPress={() => {
+              trackEvent(tracks.trackTappedContactGallery(artworkData.internalID, artworkData.slug))
+              dispatch({ type: "setInquiryModalVisible", payload: true })
+            }}
+            haptic
+            {...rest}
+          >
+            Contact Gallery
+          </Button>
+        )}
+      </ArtworkInquiryContext.Consumer>
+      <InquiryModal artwork={artworkData} me={me} />
       {!!profilePromptIsEnabled && <CompleteProfilePrompt artwork={artworkData} />}
     </ArtworkInquiryStateProvider>
   )

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -309,7 +309,7 @@ describe("inquiry modal", () => {
         mockUseSubmitInquiryRequest.mockRestore()
       })
 
-      it("tracks an event when the inquiry fails to send", async () => {
+      it("tracks two events before and after the inquiry fails to send", async () => {
         renderWithRelay({
           Artwork: () => mockArtwork,
         })

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -149,11 +149,19 @@ describe("inquiry modal", () => {
         await waitFor(() => {
           expect(mockTrackEvent).toHaveBeenCalledWith({
             action_type: "tap",
-            action_name: "inquiryCancel",
+            action_name: "inquirySend",
             owner_type: "Artwork",
             owner_id: "artwork-id",
             owner_slug: "artwork-slug",
           })
+        })
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          action_type: "success",
+          action_name: "inquirySend",
+          owner_type: "Artwork",
+          owner_id: "artwork-id",
+          owner_slug: "artwork-slug",
         })
       })
 
@@ -301,7 +309,37 @@ describe("inquiry modal", () => {
         mockUseSubmitInquiryRequest.mockRestore()
       })
 
-      test.todo("tracks an event when the inquiry fails to send")
+      it("tracks an event when the inquiry fails to send", async () => {
+        renderWithRelay({
+          Artwork: () => mockArtwork,
+        })
+
+        fireEvent.press(screen.getByText("Question"))
+
+        await waitFor(() => {
+          expect(screen.getByText("Send")).toBeEnabled()
+        })
+
+        fireEvent.press(screen.getByText("Send"))
+
+        await waitFor(() => {
+          expect(mockTrackEvent).toHaveBeenCalledWith({
+            action_type: "tap",
+            action_name: "inquirySend",
+            owner_type: "Artwork",
+            owner_id: "artwork-id",
+            owner_slug: "artwork-slug",
+          })
+        })
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          action_type: "fail",
+          action_name: "inquirySend",
+          owner_type: "Artwork",
+          owner_id: "artwork-id",
+          owner_slug: "artwork-slug",
+        })
+      })
 
       it("displays an error message", async () => {
         renderWithRelay({

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -28,10 +28,10 @@ const { renderWithRelay } = setupTestWrapper<InquiryModalTestsQuery>({
   },
   query: graphql`
     query InquiryModalTestsQuery @relay_test_operation {
-      artwork(id: "pumpkins") {
+      artwork(id: "pumpkins") @required(action: NONE) {
         ...InquiryModal_artwork
       }
-      me {
+      me @required(action: NONE) {
         ...InquiryModal_me
       }
     }
@@ -50,8 +50,8 @@ const FakeApp = (props: InquiryModalTestsQuery["response"]) => {
 
   return (
     <InquiryModal
-      artwork={props!.artwork!}
-      me={props!.me!}
+      artwork={props!.artwork}
+      me={props!.me}
       modalIsVisible={modalProps.modalIsVisible}
       toggleVisibility={modalProps.toggleVisibility}
     />

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -1,7 +1,10 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { InquiryModalTestsQuery } from "__generated__/InquiryModalTestsQuery.graphql"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import {
+  ArtworkInquiryContext,
+  initialArtworkInquiryState,
+} from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { rejectMostRecentRelayOperation } from "app/utils/tests/rejectMostRecentRelayOperation"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -12,17 +15,11 @@ const toggleVisibility = jest.fn()
 const onMutationSuccessful = jest.fn()
 const mockDispatch = jest.fn()
 
-const initialState = {
-  shippingLocation: null,
-  message: null,
-  inquiryQuestions: [],
-}
-
 const { renderWithRelay } = setupTestWrapper<InquiryModalTestsQuery>({
   Component: (props) => {
     return (
       <ArtworkInquiryContext.Provider
-        value={{ state: initialState, dispatch: mockDispatch }}
+        value={{ state: initialArtworkInquiryState, dispatch: mockDispatch }}
         {...props}
       >
         <FakeApp {...props} />
@@ -33,6 +30,9 @@ const { renderWithRelay } = setupTestWrapper<InquiryModalTestsQuery>({
     query InquiryModalTestsQuery @relay_test_operation {
       artwork(id: "pumpkins") {
         ...InquiryModal_artwork
+      }
+      me {
+        ...InquiryModal_me
       }
     }
   `,
@@ -51,9 +51,9 @@ const FakeApp = (props: InquiryModalTestsQuery["response"]) => {
   return (
     <InquiryModal
       artwork={props!.artwork!}
+      me={props!.me!}
       modalIsVisible={modalProps.modalIsVisible}
       toggleVisibility={modalProps.toggleVisibility}
-      onMutationSuccessful={modalProps.onMutationSuccessful}
     />
   )
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { InquiryModalTestsQuery } from "__generated__/InquiryModalTestsQuery.graphql"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
+import { AUTOMATED_MESSAGES } from "app/Scenes/Artwork/Components/CommercialButtons/constants"
 import {
   ArtworkInquiryContext,
   initialArtworkInquiryState,
@@ -102,7 +103,11 @@ describe("InquiryModal", () => {
     })
   })
 
-  test.todo("displays a hand-picked message")
+  it("displays a random automated message", () => {
+    renderWithRelay()
+
+    expect(AUTOMATED_MESSAGES).toContain(screen.getByLabelText("Add message").props.value)
+  })
 
   test.todo("displays a success message when the inquiry is sent")
   test.todo("displays an error message when the inquiry fails to send")

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -14,6 +14,7 @@ import {
   InquiryQuestionIDs,
 } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { daysInCooldownPeriod } from "app/utils/collectorPromptHelpers"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Reducer, useReducer } from "react"
 import { graphql } from "react-relay"
@@ -93,12 +94,26 @@ describe("inquiry modal", () => {
     })
   })
 
-  test.todo("tracks an event when the inquiry modal is closed")
+  it("tracks an event when the inquiry modal is closed", async () => {
+    renderWithRelay({
+      Artwork: () => mockArtwork,
+    })
+
+    fireEvent.press(screen.getByText("Cancel"))
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action_type: "tap",
+        action_name: "inquiryCancel",
+        owner_type: "Artwork",
+        owner_id: "artwork-id",
+        owner_slug: "artwork-slug",
+      })
+    })
+  })
 
   describe("sending the inquiry", () => {
     let mockUseSubmitInquiryRequest: jest.SpyInstance
-
-    test.todo("tracks an event before sending the inquiry")
 
     describe("when the inquiry is successfully sent", () => {
       beforeAll(() => {
@@ -118,7 +133,29 @@ describe("inquiry modal", () => {
         mockUseSubmitInquiryRequest.mockRestore()
       })
 
-      test.todo("tracks an event when the inquiry is successfully sent")
+      it("tracks two events before and after the inquiry is successfully sent", async () => {
+        renderWithRelay({
+          Artwork: () => mockArtwork,
+        })
+
+        fireEvent.press(screen.getByText("Question"))
+
+        await waitFor(() => {
+          expect(screen.getByText("Send")).toBeEnabled()
+        })
+
+        fireEvent.press(screen.getByText("Send"))
+
+        await waitFor(() => {
+          expect(mockTrackEvent).toHaveBeenCalledWith({
+            action_type: "tap",
+            action_name: "inquiryCancel",
+            owner_type: "Artwork",
+            owner_id: "artwork-id",
+            owner_slug: "artwork-slug",
+          })
+        })
+      })
 
       it("displays a success message ", async () => {
         renderWithRelay({
@@ -290,6 +327,8 @@ describe("inquiry modal", () => {
 })
 
 const mockArtwork = {
+  internalID: "artwork-id",
+  slug: "artwork-slug",
   title: "Title",
   date: "Date",
   artistNames: "Artist Name",

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { InquiryModalTestsQuery } from "__generated__/InquiryModalTestsQuery.graphql"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { AUTOMATED_MESSAGES } from "app/Scenes/Artwork/Components/CommercialButtons/constants"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import {
   ArtworkInquiryContext,
   initialArtworkInquiryState,
@@ -12,77 +13,40 @@ import {
   ArtworkInquiryContextState,
   InquiryQuestionIDs,
 } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import { daysInCooldownPeriod } from "app/utils/collectorPromptHelpers"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Reducer, useReducer } from "react"
 import { graphql } from "react-relay"
 
-describe("InquiryModal", () => {
+describe("inquiry modal", () => {
   it("displays artwork metadata", () => {
     renderWithRelay({
-      Artwork: () => ({
-        title: "Artwork Title",
-        date: "2021",
-        artistNames: "Artist Name",
-        image: {
-          url: "https://example.com/image.jpg",
-        },
-      }),
+      Artwork: () => mockArtwork,
     })
 
     expect(screen.getByText("Artist Name")).toBeVisible()
-    expect(screen.getByText("Artwork Title, 2021")).toBeVisible()
-    expect(screen.getByLabelText("Image of Artwork Title")).toBeVisible()
-  })
-
-  it("closes when the 'cancel' button is pressed", async () => {
-    renderWithRelay()
-
-    fireEvent.press(screen.getByText("Cancel"))
-
-    await waitFor(() => {
-      expect(screen.queryByText("What information are you looking for?")).toBeNull()
-    })
+    expect(screen.getByText("Title, Date")).toBeVisible()
+    expect(screen.getByLabelText("Image of Title")).toBeVisible()
   })
 
   it("displays inquiry questions", () => {
     renderWithRelay({
-      Artwork: () => ({
-        inquiryQuestions: [
-          {
-            internalID: "question-id",
-            question: "Question",
-          },
-        ],
-      }),
+      Artwork: () => mockArtwork,
     })
 
     expect(screen.getByText("Question")).toBeVisible()
   })
 
-  it("enables the 'send' button when an inquiry question is selected", async () => {
-    renderWithRelay({
-      Artwork: () => ({
-        inquiryQuestions: [
-          {
-            internalID: "question-id",
-            question: "Question",
-          },
-        ],
-      }),
-    })
+  it("displays a random automated message", () => {
+    renderWithRelay()
 
-    expect(screen.getByText("Send")).toBeDisabled()
-
-    fireEvent.press(screen.getByText("Question"))
-
-    await waitFor(() => {
-      expect(screen.getByText("Send")).toBeEnabled()
-    })
+    expect(AUTOMATED_MESSAGES).toContain(screen.getByLabelText("Add message").props.value)
   })
 
   it("opens the shipping modal when the 'add your location' field is pressed", async () => {
     renderWithRelay({
       Artwork: () => ({
+        ...mockArtwork,
         inquiryQuestions: [
           {
             internalID: InquiryQuestionIDs.Shipping,
@@ -105,99 +69,243 @@ describe("InquiryModal", () => {
     })
   })
 
-  it("displays a random automated message", () => {
+  it("enables the 'send' button when an inquiry question is selected", async () => {
+    renderWithRelay({
+      Artwork: () => mockArtwork,
+    })
+
+    expect(screen.getByText("Send")).toBeDisabled()
+
+    fireEvent.press(screen.getByText("Question"))
+
+    await waitFor(() => {
+      expect(screen.getByText("Send")).toBeEnabled()
+    })
+  })
+
+  it("closes when the 'cancel' button is pressed", async () => {
     renderWithRelay()
 
-    expect(AUTOMATED_MESSAGES).toContain(screen.getByLabelText("Add message").props.value)
+    fireEvent.press(screen.getByText("Cancel"))
+
+    await waitFor(() => {
+      expect(screen.queryByText("What information are you looking for?")).toBeNull()
+    })
   })
-
-  it("displays a success message when the inquiry is sent", async () => {
-    const mockUseSubmitInquiryRequest = jest
-      .spyOn(
-        require("app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"),
-        "useSubmitInquiryRequest"
-      )
-      .mockImplementation(() => [
-        jest.fn(({ onCompleted }) => {
-          onCompleted()
-        }),
-      ])
-
-    renderWithRelay({
-      Artwork: () => ({
-        inquiryQuestions: [
-          {
-            internalID: "question-id",
-            question: "Question",
-          },
-        ],
-      }),
-    })
-
-    fireEvent.press(screen.getByText("Question"))
-
-    await waitFor(() => {
-      expect(screen.getByText("Send")).toBeEnabled()
-    })
-
-    fireEvent.press(screen.getByText("Send"))
-
-    await waitFor(() => {
-      expect(screen.getByText("Message Sent")).toBeVisible()
-    })
-
-    mockUseSubmitInquiryRequest.mockRestore()
-  })
-
-  it("displays an error message when the inquiry fails to send", async () => {
-    const mockUseSubmitInquiryRequest = jest
-      .spyOn(
-        require("app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"),
-        "useSubmitInquiryRequest"
-      )
-      .mockImplementation(() => [
-        jest.fn(({ onError }) => {
-          onError()
-        }),
-      ])
-
-    renderWithRelay({
-      Artwork: () => ({
-        inquiryQuestions: [
-          {
-            internalID: "question-id",
-            question: "Question",
-          },
-        ],
-      }),
-    })
-
-    fireEvent.press(screen.getByText("Question"))
-
-    await waitFor(() => {
-      expect(screen.getByText("Send")).toBeEnabled()
-    })
-
-    fireEvent.press(screen.getByText("Send"))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Sorry, we were unable to send this message. Please try again.")
-      ).toBeVisible()
-    })
-
-    mockUseSubmitInquiryRequest.mockRestore()
-  })
-
-  test.todo(
-    "displays a profile prompt after the inquiry is sent if the user has not completed their profile"
-  )
 
   test.todo("tracks an event when the inquiry modal is closed")
-  test.todo("tracks an event before sending the inquiry")
-  test.todo("tracks an event when the inquiry is successfully sent")
-  test.todo("tracks an event when the inquiry fails to send")
+
+  describe("sending the inquiry", () => {
+    let mockUseSubmitInquiryRequest: jest.SpyInstance
+
+    test.todo("tracks an event before sending the inquiry")
+
+    describe("when the inquiry is successfully sent", () => {
+      beforeAll(() => {
+        mockUseSubmitInquiryRequest = jest
+          .spyOn(
+            require("app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"),
+            "useSubmitInquiryRequest"
+          )
+          .mockImplementation(() => [
+            jest.fn(({ onCompleted }) => {
+              onCompleted()
+            }),
+          ])
+      })
+
+      afterAll(() => {
+        mockUseSubmitInquiryRequest.mockRestore()
+      })
+
+      test.todo("tracks an event when the inquiry is successfully sent")
+
+      it("displays a success message ", async () => {
+        renderWithRelay({
+          Artwork: () => mockArtwork,
+        })
+
+        fireEvent.press(screen.getByText("Question"))
+
+        await waitFor(() => {
+          expect(screen.getByText("Send")).toBeEnabled()
+        })
+
+        fireEvent.press(screen.getByText("Send"))
+
+        await waitFor(() => {
+          expect(screen.getByText("Message Sent")).toBeVisible()
+        })
+      })
+
+      describe("and the profile prompt feature flag is enabled", () => {
+        beforeEach(() => {
+          __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCollectorProfilePrompts: true })
+        })
+
+        it("displays a profile prompt if the user has not completed their profile and never been prompted", async () => {
+          renderWithRelay({
+            Artwork: () => mockArtwork,
+            Me: () => ({
+              location: {
+                city: null,
+              },
+              profession: null,
+              collectorProfile: {
+                lastUpdatePromptAt: null,
+              },
+            }),
+          })
+
+          expect(
+            screen.queryByText("Inquiry sent! Tell Partner Name more about yourself.")
+          ).toBeNull()
+
+          fireEvent.press(screen.getByText("Question"))
+
+          await waitFor(() => {
+            expect(screen.getByText("Send")).toBeEnabled()
+          })
+
+          fireEvent.press(screen.getByText("Send"))
+
+          await waitFor(() => {
+            expect(
+              screen.getByText("Inquiry sent! Tell Partner Name more about yourself.")
+            ).toBeVisible()
+          })
+        })
+
+        it("displays a profile prompt if the user has not completed their profile and has not been prompted since the cooldown period", async () => {
+          renderWithRelay({
+            Artwork: () => mockArtwork,
+            Me: () => ({
+              location: {
+                city: null,
+              },
+              profession: null,
+              collectorProfile: {
+                lastUpdatePromptAt: new Date(
+                  Date.now() - (daysInCooldownPeriod + 1) * 24 * 60 * 60 * 1000
+                ).toISOString(),
+              },
+            }),
+          })
+
+          expect(
+            screen.queryByText("Inquiry sent! Tell Partner Name more about yourself.")
+          ).toBeNull()
+
+          fireEvent.press(screen.getByText("Question"))
+
+          await waitFor(() => {
+            expect(screen.getByText("Send")).toBeEnabled()
+          })
+
+          fireEvent.press(screen.getByText("Send"))
+
+          await waitFor(() => {
+            expect(
+              screen.getByText("Inquiry sent! Tell Partner Name more about yourself.")
+            ).toBeVisible()
+          })
+        })
+
+        it("does not display a profile prompt if the user has not completed their profile and has been prompted within the cooldown period", async () => {
+          renderWithRelay({
+            Artwork: () => mockArtwork,
+            Me: () => ({
+              location: {
+                city: null,
+              },
+              profession: null,
+              collectorProfile: {
+                lastUpdatePromptAt: new Date(
+                  Date.now() - (daysInCooldownPeriod - 10) * 24 * 60 * 60 * 1000
+                ).toISOString(),
+              },
+            }),
+          })
+
+          fireEvent.press(screen.getByText("Question"))
+
+          await waitFor(() => {
+            expect(screen.getByText("Send")).toBeEnabled()
+          })
+
+          fireEvent.press(screen.getByText("Send"))
+
+          await waitFor(() => {
+            expect(screen.getByText("Message Sent")).toBeVisible()
+          })
+
+          expect(
+            screen.queryByText("Inquiry sent! Tell Partner Name more about yourself.")
+          ).toBeNull()
+        })
+      })
+    })
+
+    describe("when the inquiry fails to send", () => {
+      beforeAll(() => {
+        mockUseSubmitInquiryRequest = jest
+          .spyOn(
+            require("app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"),
+            "useSubmitInquiryRequest"
+          )
+          .mockImplementation(() => [
+            jest.fn(({ onError }) => {
+              onError()
+            }),
+          ])
+      })
+
+      afterAll(() => {
+        mockUseSubmitInquiryRequest.mockRestore()
+      })
+
+      test.todo("tracks an event when the inquiry fails to send")
+
+      it("displays an error message", async () => {
+        renderWithRelay({
+          Artwork: () => mockArtwork,
+        })
+
+        fireEvent.press(screen.getByText("Question"))
+
+        await waitFor(() => {
+          expect(screen.getByText("Send")).toBeEnabled()
+        })
+
+        fireEvent.press(screen.getByText("Send"))
+
+        await waitFor(() => {
+          expect(
+            screen.getByText("Sorry, we were unable to send this message. Please try again.")
+          ).toBeVisible()
+        })
+      })
+    })
+  })
 })
+
+const mockArtwork = {
+  title: "Title",
+  date: "Date",
+  artistNames: "Artist Name",
+  image: {
+    url: "https://example.com/image.jpg",
+  },
+  inquiryQuestions: [
+    {
+      internalID: "question-id",
+      question: "Question",
+    },
+  ],
+  partner: {
+    name: "Partner Name",
+  },
+}
 
 const { renderWithRelay } = setupTestWrapper<InquiryModalTestsQuery>({
   Component: ({ artwork, me }) => (

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -155,13 +155,13 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({
         if (
           profilePromptIsEnabled &&
           userHasAnEmptyCollection() &&
-          userHasNotBeenPromptedIn30Days()
+          userHasNotBeenPromptedInThirtyDays()
         ) {
           dispatch({ type: "setCollectionPromptVisible", payload: true })
         } else if (
           profilePromptIsEnabled &&
           userHasAnIncompleteProfile() &&
-          userHasNotBeenPromptedIn30Days()
+          userHasNotBeenPromptedInThirtyDays()
         ) {
           dispatch({ type: "setProfilePromptVisible", payload: true })
         } else {
@@ -183,17 +183,21 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({
   }
 
   const userHasAnIncompleteProfile = () => {
-    return !!meData.profession && !!meData.location?.city
+    return !meData.profession || !meData.location?.city
   }
 
-  const userHasNotBeenPromptedIn30Days = () => {
+  const userHasNotBeenPromptedInThirtyDays = () => {
     const lastTimeUserWasPrompted = meData.collectorProfile?.lastUpdatePromptAt
 
     if (lastTimeUserWasPrompted == null) {
       return true
     }
 
-    return new Date(lastTimeUserWasPrompted).getTime() > Date.now() - 30 * 24 * 60 * 60
+    const millisecondsSinceLastTimeUserWasPrompted =
+      new Date().getTime() - new Date(lastTimeUserWasPrompted).getTime()
+    const millisecondsInThirtyDays = 30 * 24 * 60 * 60 * 1000
+
+    return millisecondsSinceLastTimeUserWasPrompted > millisecondsInThirtyDays
   }
 
   return (

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -5,6 +5,7 @@ import { InquiryQuestionInput } from "__generated__/useSubmitInquiryRequestMutat
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { InquiryQuestionOption } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption"
+import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
 import { randomAutomatedMessage } from "app/Scenes/Artwork/Components/CommercialButtons/constants"
 import { useSubmitInquiryRequest } from "app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"
 import { navigate } from "app/system/navigation/navigate"
@@ -164,93 +165,95 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, me }) => {
   }
 
   return (
-    <FancyModal visible={state.inquiryModalVisible} onBackgroundPressed={handleDismiss}>
-      <FancyModalHeader
-        leftButtonText="Cancel"
-        onLeftButtonPress={handleDismiss}
-        rightButtonText="Send"
-        rightButtonDisabled={state.inquiryQuestions.length === 0}
-        onRightButtonPress={sendInquiry}
-      >
-        Contact Gallery
-      </FancyModalHeader>
-      {!!mutationError && (
-        <Flex
-          bg="red100"
-          py={1}
-          alignItems="center"
-          position="absolute"
-          top={6}
-          width={1}
-          zIndex={5}
+    <>
+      <FancyModal visible={state.inquiryModalVisible} onBackgroundPressed={handleDismiss}>
+        <FancyModalHeader
+          leftButtonText="Cancel"
+          onLeftButtonPress={handleDismiss}
+          rightButtonText="Send"
+          rightButtonDisabled={state.inquiryQuestions.length === 0}
+          onRightButtonPress={sendInquiry}
         >
-          <Text variant="xs" color="white">
-            Sorry, we were unable to send this message. Please try again.
-          </Text>
-        </Flex>
-      )}
-      <ScrollView ref={scrollViewRef}>
-        <CollapsibleArtworkDetailsFragmentContainer artwork={artworkData} />
-        <Box px={2}>
-          <Box my={2}>
-            <Text variant="sm">What information are you looking for?</Text>
-            {questions?.map((inquiryQuestion) => {
-              if (!inquiryQuestion) {
-                return false
-              }
-              const { internalID: id, question } = inquiryQuestion
-              return id === InquiryQuestionIDs.Shipping ? (
-                <InquiryQuestionOption
-                  key={id}
-                  id={id}
-                  question={question}
-                  setShippingModalVisibility={setShippingModalVisibility}
-                />
-              ) : (
-                <InquiryQuestionOption key={id} id={id} question={question} />
-              )
-            })}
-          </Box>
-          <Box
-            mb={4}
-            onLayout={({ nativeEvent }) => {
-              setAddMessageYCoordinate(nativeEvent.layout.y)
-            }}
+          Contact Gallery
+        </FancyModalHeader>
+        {!!mutationError && (
+          <Flex
+            bg="red100"
+            py={1}
+            alignItems="center"
+            position="absolute"
+            top={6}
+            width={1}
+            zIndex={5}
           >
-            <Input
-              multiline
-              placeholder="Add a custom note..."
-              title="Add message"
-              accessibilityLabel="Add message"
-              value={message ? message : ""}
-              onChangeText={setMessage}
-              onFocus={scrollToInput}
-              style={{ justifyContent: "flex-start" }}
-            />
-          </Box>
-          <Box flexDirection="row">
-            <InfoCircleIcon mr={0.5} style={{ marginTop: 2 }} />
-            <Box flex={1}>
-              <Text variant="xs" color="black60">
-                By clicking send, we will share your profile with {partnerName}. Update your profile
-                at any time in{" "}
-                <Text variant="xs" onPress={handleSettingsPress}>
-                  Settings
+            <Text variant="xs" color="white">
+              Sorry, we were unable to send this message. Please try again.
+            </Text>
+          </Flex>
+        )}
+        <ScrollView ref={scrollViewRef}>
+          <CollapsibleArtworkDetailsFragmentContainer artwork={artworkData} />
+          <Box px={2}>
+            <Box my={2}>
+              <Text variant="sm">What information are you looking for?</Text>
+              {questions?.map((inquiryQuestion) => {
+                if (!inquiryQuestion) {
+                  return false
+                }
+                const { internalID: id, question } = inquiryQuestion
+                return id === InquiryQuestionIDs.Shipping ? (
+                  <InquiryQuestionOption
+                    key={id}
+                    id={id}
+                    question={question}
+                    setShippingModalVisibility={setShippingModalVisibility}
+                  />
+                ) : (
+                  <InquiryQuestionOption key={id} id={id} question={question} />
+                )
+              })}
+            </Box>
+            <Box
+              mb={4}
+              onLayout={({ nativeEvent }) => {
+                setAddMessageYCoordinate(nativeEvent.layout.y)
+              }}
+            >
+              <Input
+                multiline
+                placeholder="Add a custom note..."
+                title="Add message"
+                accessibilityLabel="Add message"
+                value={message ? message : ""}
+                onChangeText={setMessage}
+                onFocus={scrollToInput}
+                style={{ justifyContent: "flex-start" }}
+              />
+            </Box>
+            <Box flexDirection="row">
+              <InfoCircleIcon mr={0.5} style={{ marginTop: 2 }} />
+              <Box flex={1}>
+                <Text variant="xs" color="black60">
+                  By clicking send, we will share your profile with {partnerName}. Update your
+                  profile at any time in{" "}
+                  <Text variant="xs" onPress={handleSettingsPress}>
+                    Settings
+                  </Text>
+                  .
                 </Text>
-                .
-              </Text>
+              </Box>
             </Box>
           </Box>
-        </Box>
-      </ScrollView>
-
-      <ShippingModal
-        toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
-        modalIsVisible={shippingModalVisibility}
-        setLocation={selectShippingLocation}
-        location={state.shippingLocation}
-      />
-    </FancyModal>
+        </ScrollView>
+        <ShippingModal
+          toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
+          modalIsVisible={shippingModalVisibility}
+          setLocation={selectShippingLocation}
+          location={state.shippingLocation}
+        />
+      </FancyModal>
+      <InquirySuccessNotification />
+    </>
   )
 }
 

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -221,6 +221,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, me }) => {
               multiline
               placeholder="Add a custom note..."
               title="Add message"
+              accessibilityLabel="Add message"
               value={message ? message : ""}
               onChangeText={setMessage}
               onFocus={scrollToInput}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -10,7 +10,7 @@ import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/Commer
 import { randomAutomatedMessage } from "app/Scenes/Artwork/Components/CommercialButtons/constants"
 import { useSubmitInquiryRequest } from "app/Scenes/Artwork/Components/CommercialButtons/useSubmitInquiryRequest"
 import { navigate } from "app/system/navigation/navigate"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { useArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import {
   userShouldBePromptedToAddArtistsToCollection,
@@ -19,7 +19,7 @@ import {
 import { LocationWithDetails } from "app/utils/googleMaps"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { ScrollView } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -32,7 +32,7 @@ interface InquiryModalProps {
 }
 
 export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, me }) => {
-  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const { state, dispatch } = useArtworkInquiryContext()
   const profilePromptIsEnabled = useFeatureFlag("AREnableCollectorProfilePrompts")
   const scrollViewRef = useRef<ScrollView>(null)
   const [commit] = useSubmitInquiryRequest()

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -11,6 +11,7 @@ import { navigate } from "app/system/navigation/navigate"
 import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { LocationWithDetails } from "app/utils/googleMaps"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react"
 import { ScrollView } from "react-native"
@@ -46,6 +47,8 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({
   const [shippingModalVisibility, setShippingModalVisibility] = useState(false)
   const [mutationError, setMutationError] = useState(false)
   const [loading, setLoading] = useState(false)
+
+  const profilePromptIsEnabled = useFeatureFlag("AREnableCollectorProfilePrompts")
 
   const selectShippingLocation = (locationDetails: LocationWithDetails) =>
     dispatch({ type: "selectShippingLocation", payload: locationDetails })
@@ -149,9 +152,17 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({
           owner_slug: artworkData.slug,
         })
 
-        if (userHasAnEmptyCollection() && userHasNotBeenPromptedIn30Days()) {
+        if (
+          profilePromptIsEnabled &&
+          userHasAnEmptyCollection() &&
+          userHasNotBeenPromptedIn30Days()
+        ) {
           dispatch({ type: "setCollectionPromptVisible", payload: true })
-        } else if (userHasAnIncompleteProfile() && userHasNotBeenPromptedIn30Days()) {
+        } else if (
+          profilePromptIsEnabled &&
+          userHasAnIncompleteProfile() &&
+          userHasNotBeenPromptedIn30Days()
+        ) {
           dispatch({ type: "setProfilePromptVisible", payload: true })
         } else {
           setTimeout(() => {

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -57,6 +57,14 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, me }) => {
     }
   }, [mutationError])
 
+  const scrollToInput = useCallback(() => {
+    scrollViewRef.current?.scrollTo({ y: addMessageYCoordinate })
+  }, [addMessageYCoordinate])
+
+  if (!artworkData || !meData) {
+    return null
+  }
+
   const artworkId = artworkData.internalID
   const artworkSlug = artworkData.slug
   const questions = artworkData?.inquiryQuestions
@@ -70,10 +78,6 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, me }) => {
     dispatch({ type: "resetForm", payload: null })
     dispatch({ type: "setInquiryModalVisible", payload: false })
   }
-
-  const scrollToInput = useCallback(() => {
-    scrollViewRef.current?.scrollTo({ y: addMessageYCoordinate })
-  }, [addMessageYCoordinate])
 
   const sendInquiry = () => {
     if (loading) {
@@ -276,7 +280,7 @@ const meFragment = graphql`
       city
     }
     profession
-    collectorProfile {
+    collectorProfile @required(action: NONE) {
       lastUpdatePromptAt
     }
   }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
@@ -14,11 +14,17 @@ import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes
 import React, { useContext } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
 
-export const InquiryQuestionOption: React.FC<{
+interface InquiryQuestionOptionProps {
   id: string
   question: string
   setShippingModalVisibility?: (isVisible: boolean) => void
-}> = ({ id, question, setShippingModalVisibility }) => {
+}
+
+export const InquiryQuestionOption: React.FC<InquiryQuestionOptionProps> = ({
+  id,
+  question,
+  setShippingModalVisibility,
+}) => {
   const { color, space } = useTheme()
   const { state, dispatch } = useContext(ArtworkInquiryContext)
   const isShipping = id === InquiryQuestionIDs.Shipping

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
@@ -1,0 +1,120 @@
+import {
+  Box,
+  Checkbox,
+  ChevronIcon,
+  Flex,
+  Join,
+  Separator,
+  Spacer,
+  Text,
+  useTheme,
+} from "@artsy/palette-mobile"
+import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
+import React, { useContext } from "react"
+import { LayoutAnimation, TouchableOpacity } from "react-native"
+
+export const InquiryQuestionOption: React.FC<{
+  id: string
+  question: string
+  setShippingModalVisibility?: (isVisible: boolean) => void
+}> = ({ id, question, setShippingModalVisibility }) => {
+  const { color, space } = useTheme()
+  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const isShipping = id === InquiryQuestionIDs.Shipping
+
+  const questionSelected = Boolean(
+    state.inquiryQuestions.find((iq) => {
+      return iq.questionID === id
+    })
+  )
+
+  const maybeRegisterAnimation = () => {
+    if (isShipping) {
+      LayoutAnimation.configureNext({
+        ...LayoutAnimation.Presets.linear,
+        duration: 200,
+      })
+    }
+  }
+
+  React.useLayoutEffect(maybeRegisterAnimation, [questionSelected])
+
+  const setSelection = () => {
+    dispatch({
+      type: "selectInquiryQuestion",
+      payload: {
+        questionID: id,
+        details: isShipping ? state.shippingLocation?.name : null,
+        isChecked: !questionSelected,
+      },
+    })
+  }
+
+  return (
+    <React.Fragment>
+      <TouchableOpacity onPress={setSelection}>
+        <Flex
+          style={{
+            borderColor: questionSelected ? color("black100") : color("black10"),
+            borderWidth: 1,
+            borderRadius: 5,
+            flexDirection: "column",
+            marginTop: space(1),
+            padding: space(2),
+          }}
+        >
+          <Flex flexDirection="row" justifyContent="space-between">
+            <Flex flexDirection="row">
+              <Join separator={<Spacer x={4} />}>
+                <Checkbox
+                  testID={`checkbox-${id}`}
+                  checked={questionSelected}
+                  onPress={setSelection}
+                />
+                <Text variant="sm">{question}</Text>
+              </Join>
+            </Flex>
+          </Flex>
+
+          {!!isShipping && !!questionSelected && (
+            <>
+              <Separator my={2} />
+
+              <TouchableOpacity
+                testID="toggle-shipping-modal"
+                onPress={() => {
+                  if (typeof setShippingModalVisibility === "function") {
+                    setShippingModalVisibility(true)
+                  }
+                }}
+              >
+                <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+                  {!state.shippingLocation ? (
+                    <>
+                      <Text variant="sm" color="black60">
+                        Add your location
+                      </Text>
+                      <Box>
+                        <ChevronIcon color="black60" />
+                      </Box>
+                    </>
+                  ) : (
+                    <>
+                      <Text variant="sm" color="black100" style={{ width: "70%" }}>
+                        {state.shippingLocation.name}
+                      </Text>
+                      <Text variant="sm" color="blue100">
+                        Edit
+                      </Text>
+                    </>
+                  )}
+                </Flex>
+              </TouchableOpacity>
+            </>
+          )}
+        </Flex>
+      </TouchableOpacity>
+    </React.Fragment>
+  )
+}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption.tsx
@@ -9,9 +9,9 @@ import {
   Text,
   useTheme,
 } from "@artsy/palette-mobile"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { useArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { InquiryQuestionIDs } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
-import React, { useContext } from "react"
+import React, { useLayoutEffect } from "react"
 import { LayoutAnimation, TouchableOpacity } from "react-native"
 
 interface InquiryQuestionOptionProps {
@@ -26,7 +26,7 @@ export const InquiryQuestionOption: React.FC<InquiryQuestionOptionProps> = ({
   setShippingModalVisibility,
 }) => {
   const { color, space } = useTheme()
-  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const { state, dispatch } = useArtworkInquiryContext()
   const isShipping = id === InquiryQuestionIDs.Shipping
 
   const questionSelected = Boolean(
@@ -35,16 +35,14 @@ export const InquiryQuestionOption: React.FC<InquiryQuestionOptionProps> = ({
     })
   )
 
-  const maybeRegisterAnimation = () => {
+  useLayoutEffect(() => {
     if (isShipping) {
       LayoutAnimation.configureNext({
         ...LayoutAnimation.Presets.linear,
         duration: 200,
       })
     }
-  }
-
-  React.useLayoutEffect(maybeRegisterAnimation, [questionSelected])
+  }, [questionSelected])
 
   const setSelection = () => {
     dispatch({
@@ -58,7 +56,7 @@ export const InquiryQuestionOption: React.FC<InquiryQuestionOptionProps> = ({
   }
 
   return (
-    <React.Fragment>
+    <>
       <TouchableOpacity onPress={setSelection}>
         <Flex
           style={{
@@ -121,6 +119,6 @@ export const InquiryQuestionOption: React.FC<InquiryQuestionOptionProps> = ({
           )}
         </Flex>
       </TouchableOpacity>
-    </React.Fragment>
+    </>
   )
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
@@ -1,9 +1,9 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import { navigate } from "app/system/navigation/navigate"
-import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { useArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { useScreenDimensions } from "app/utils/hooks"
-import React, { useContext, useEffect } from "react"
+import React, { useEffect } from "react"
 import { Animated, Modal, TouchableOpacity } from "react-native"
 import styled from "styled-components/native"
 
@@ -11,15 +11,19 @@ import styled from "styled-components/native"
 // See https://artsy.slack.com/archives/C02BAQ5K7/p1623332112279700
 
 export const InquirySuccessNotification: React.FC = () => {
-  const { state, dispatch } = useContext(ArtworkInquiryContext)
+  const { state, dispatch } = useArtworkInquiryContext()
 
   // auto-hide the success notification after 2 seconds
   useEffect(() => {
+    let timeout: number
+
     if (state.successNotificationVisible) {
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         dispatch({ type: "setSuccessNotificationVisible", payload: false })
       }, 2000)
     }
+
+    return () => clearTimeout(timeout)
   }, [state.successNotificationVisible])
 
   const navigateToConversation = () => {

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification.tsx
@@ -1,41 +1,40 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import { navigate } from "app/system/navigation/navigate"
+import { ArtworkInquiryContext } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { useScreenDimensions } from "app/utils/hooks"
-import React, { useEffect } from "react"
+import React, { useContext, useEffect } from "react"
 import { Animated, Modal, TouchableOpacity } from "react-native"
 import styled from "styled-components/native"
 
-interface InquirySuccessNotificationProps {
-  modalVisible: boolean
-  toggleNotification: (state: boolean) => void
-}
-
 // TODO: Replace by usePopoverMessage when the floating back button is removed from the design
 // See https://artsy.slack.com/archives/C02BAQ5K7/p1623332112279700
-export const InquirySuccessNotification: React.FC<InquirySuccessNotificationProps> = ({
-  modalVisible,
-  toggleNotification,
-}) => {
-  let delayNotification: NodeJS.Timeout | any
+
+export const InquirySuccessNotification: React.FC = () => {
+  const { state, dispatch } = useContext(ArtworkInquiryContext)
+
+  // auto-hide the success notification after 2 seconds
+  useEffect(() => {
+    if (state.successNotificationVisible) {
+      setTimeout(() => {
+        dispatch({ type: "setSuccessNotificationVisible", payload: false })
+      }, 2000)
+    }
+  }, [state.successNotificationVisible])
+
   const navigateToConversation = () => {
-    toggleNotification(false)
+    dispatch({ type: "setSuccessNotificationVisible", payload: false })
     navigate("inbox")
   }
 
-  useEffect(() => {
-    delayNotification = setTimeout(() => {
-      toggleNotification(false)
-    }, 2000)
-    return () => {
-      clearTimeout(delayNotification)
-    }
-  }, [modalVisible])
+  const handleRequestClose = () => {
+    dispatch({ type: "setSuccessNotificationVisible", payload: false })
+  }
 
   return (
     <Modal
-      visible={modalVisible}
-      onRequestClose={() => toggleNotification(false)}
+      visible={state.successNotificationVisible}
+      onRequestClose={handleRequestClose}
       animationType="fade"
       transparent
     >

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/constants.ts
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/constants.ts
@@ -1,3 +1,7 @@
+export const randomAutomatedMessage = (): string => {
+  return AUTOMATED_MESSAGES[Math.floor(Math.random() * AUTOMATED_MESSAGES.length)]
+}
+
 export const AUTOMATED_MESSAGES = [
   "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?",
   "Hello, I'm interested in this artwork. Could you provide more details about it?",

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { PartnerCardTestsQuery } from "__generated__/PartnerCardTestsQuery.graphql"
 import { PartnerCard_artwork$data } from "__generated__/PartnerCard_artwork.graphql"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -6,45 +7,44 @@ import { PartnerCardFragmentContainer } from "./PartnerCard"
 
 describe("PartnerCard", () => {
   const { renderWithRelay } = setupTestWrapper<PartnerCardTestsQuery>({
-    Component: (props) => {
-      if (props?.artwork) {
-        return <PartnerCardFragmentContainer artwork={props.artwork} />
-      }
-
-      return null
+    Component: ({ artwork, me }) => {
+      return <PartnerCardFragmentContainer artwork={artwork} me={me} />
     },
     query: graphql`
       query PartnerCardTestsQuery @relay_test_operation @raw_response_type {
-        artwork(id: "artworkID") {
+        artwork(id: "artworkID") @required(action: NONE) {
           ...PartnerCard_artwork
+        }
+        me @required(action: NONE) {
+          ...PartnerCard_me
         }
       }
     `,
   })
 
   it("renders partner name correctly", () => {
-    const { getByText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtwork,
     })
 
-    expect(getByText("Test Gallery")).toBeTruthy()
+    expect(screen.getByText("Test Gallery")).toBeTruthy()
   })
 
   it("renders partner image", () => {
-    const { queryByLabelText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtwork,
     })
 
-    expect(queryByLabelText("AvatarImage")).toBeOnTheScreen()
-    expect(queryByLabelText("Avatar")).not.toBeOnTheScreen()
+    expect(screen.getByLabelText("AvatarImage")).toBeOnTheScreen()
+    expect(screen.queryByLabelText("Avatar")).not.toBeOnTheScreen()
   })
 
   it("renders partner type", () => {
-    const { getByText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtwork,
     })
 
-    expect(getByText("Gallery")).toBeTruthy()
+    expect(screen.getByText("Gallery")).toBeTruthy()
   })
 
   it("renders partner type correctly for institutional sellers", () => {
@@ -56,11 +56,11 @@ describe("PartnerCard", () => {
       },
     }
 
-    const { getByText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtworkInstitutionalSeller,
     })
 
-    expect(getByText("Institution")).toBeTruthy()
+    expect(screen.getByText("Institution")).toBeTruthy()
   })
 
   it("doesn't render partner type for partners that aren't institutions or galleries", () => {
@@ -71,12 +71,12 @@ describe("PartnerCard", () => {
         type: "Some Other Partner Type",
       },
     }
-    const { queryByText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtworkOtherType,
     })
 
-    expect(queryByText("At institution")).toBeFalsy()
-    expect(queryByText("At gallery")).toBeFalsy()
+    expect(screen.queryByText("At institution")).toBeFalsy()
+    expect(screen.queryByText("At gallery")).toBeFalsy()
   })
 
   it("renders partner initials when no image is present", () => {
@@ -87,21 +87,21 @@ describe("PartnerCard", () => {
         profile: null,
       },
     }
-    const { getByText, queryByLabelText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtworkWithoutImage,
     })
 
-    expect(getByText("TG")).toBeTruthy()
-    expect(queryByLabelText("AvatarImage")).not.toBeOnTheScreen()
-    expect(queryByLabelText("Avatar")).toBeOnTheScreen()
+    expect(screen.getByText("TG")).toBeTruthy()
+    expect(screen.queryByLabelText("AvatarImage")).not.toBeOnTheScreen()
+    expect(screen.getByLabelText("Avatar")).toBeOnTheScreen()
   })
 
   it("truncates partner locations correctly", () => {
-    const { getByText } = renderWithRelay({
+    renderWithRelay({
       Artwork: () => PartnerCardArtwork,
     })
 
-    expect(getByText("Miami, New York, +3 more")).toBeTruthy()
+    expect(screen.getByText("Miami, New York, +3 more")).toBeTruthy()
   })
 
   it("does not render when the partner is an auction house", () => {

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tests.tsx
@@ -16,7 +16,7 @@ describe("PartnerCard", () => {
           ...PartnerCard_artwork
         }
         me @required(action: NONE) {
-          ...PartnerCard_me
+          ...InquiryModal_me
         }
       }
     `,

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tsx
@@ -1,6 +1,6 @@
 import { Spacer, Flex, Text, EntityHeader } from "@artsy/palette-mobile"
+import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { PartnerCard_artwork$data } from "__generated__/PartnerCard_artwork.graphql"
-import { PartnerCard_me$data } from "__generated__/PartnerCard_me.graphql"
 import { ShortContactGallery } from "app/Scenes/Artwork/Components/ShortContactGallery"
 import { navigateToPartner } from "app/system/navigation/navigate"
 import { limitWithCount } from "app/utils/limitWithCount"
@@ -12,7 +12,7 @@ import { Questions } from "./Questions"
 
 interface PartnerCardProps {
   artwork: PartnerCard_artwork$data
-  me: PartnerCard_me$data
+  me: InquiryModal_me$key
   relay: RelayProp
   shouldShowQuestions?: boolean
   showShortContactGallery?: boolean
@@ -119,12 +119,6 @@ export const PartnerCardFragmentContainer = createFragmentContainer(PartnerCard,
           }
         }
       }
-    }
-  `,
-  me: graphql`
-    fragment PartnerCard_me on Me {
-      ...Questions_me
-      ...ShortContactGallery_me
     }
   `,
 })

--- a/src/app/Scenes/Artwork/Components/PartnerCard.tsx
+++ b/src/app/Scenes/Artwork/Components/PartnerCard.tsx
@@ -1,5 +1,6 @@
 import { Spacer, Flex, Text, EntityHeader } from "@artsy/palette-mobile"
 import { PartnerCard_artwork$data } from "__generated__/PartnerCard_artwork.graphql"
+import { PartnerCard_me$data } from "__generated__/PartnerCard_me.graphql"
 import { ShortContactGallery } from "app/Scenes/Artwork/Components/ShortContactGallery"
 import { navigateToPartner } from "app/system/navigation/navigate"
 import { limitWithCount } from "app/utils/limitWithCount"
@@ -11,6 +12,7 @@ import { Questions } from "./Questions"
 
 interface PartnerCardProps {
   artwork: PartnerCard_artwork$data
+  me: PartnerCard_me$data
   relay: RelayProp
   shouldShowQuestions?: boolean
   showShortContactGallery?: boolean
@@ -18,6 +20,7 @@ interface PartnerCardProps {
 
 export const PartnerCard: React.FC<PartnerCardProps> = ({
   artwork,
+  me,
   shouldShowQuestions,
   showShortContactGallery,
 }) => {
@@ -53,6 +56,7 @@ export const PartnerCard: React.FC<PartnerCardProps> = ({
     return (
       <ShortContactGallery
         artwork={artwork}
+        me={me}
         showPartnerType={showPartnerType}
         partnerName={partner.name}
         partnerHref={partner.href ?? undefined}
@@ -84,7 +88,7 @@ export const PartnerCard: React.FC<PartnerCardProps> = ({
         />
       </TouchableWithoutFeedback>
       <Spacer y={2} />
-      {!!shouldShowQuestions && <Questions artwork={artwork} />}
+      {!!shouldShowQuestions && <Questions artwork={artwork} me={me} />}
     </Flex>
   )
 }
@@ -115,6 +119,12 @@ export const PartnerCardFragmentContainer = createFragmentContainer(PartnerCard,
           }
         }
       }
+    }
+  `,
+  me: graphql`
+    fragment PartnerCard_me on Me {
+      ...Questions_me
+      ...ShortContactGallery_me
     }
   `,
 })

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { Questions_Test_Query } from "__generated__/Questions_Test_Query.graphql"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
@@ -16,18 +17,21 @@ describe("Questions", () => {
           artwork(id: "test-id") {
             ...Questions_artwork
           }
+          me {
+            ...Questions_me
+          }
         }
       `,
       {}
     )
-    return <Questions artwork={data.artwork!} />
+    return <Questions artwork={data.artwork!} me={data.me!} />
   }
 
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
   beforeEach(() => (mockEnvironment = createMockEnvironment()))
 
   it("renders", async () => {
-    const { getByText } = renderWithWrappers(
+    renderWithWrappers(
       <RelayEnvironmentProvider environment={mockEnvironment}>
         <Suspense fallback={<Text>SusLoading</Text>}>
           <TestRenderer />
@@ -35,11 +39,11 @@ describe("Questions", () => {
       </RelayEnvironmentProvider>
     )
     resolveMostRecentRelayOperation(mockEnvironment, { Artwork: () => ({}) })
-    expect(getByText("SusLoading")).toBeDefined()
+    expect(screen.getByText("SusLoading")).toBeDefined()
 
     await flushPromiseQueue()
 
-    expect(getByText("Questions about this piece?")).toBeDefined()
-    expect(getByText("Contact Gallery")).toBeDefined()
+    expect(screen.getByText("Questions about this piece?")).toBeDefined()
+    expect(screen.getByText("Contact Gallery")).toBeDefined()
   })
 })

--- a/src/app/Scenes/Artwork/Components/Questions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tests.tsx
@@ -18,7 +18,7 @@ describe("Questions", () => {
             ...Questions_artwork
           }
           me {
-            ...Questions_me
+            ...InquiryModal_me
           }
         }
       `,

--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -1,14 +1,17 @@
 import { EnvelopeIcon, Flex, Text } from "@artsy/palette-mobile"
 import { Questions_artwork$key } from "__generated__/Questions_artwork.graphql"
+import { Questions_me$key } from "__generated__/Questions_me.graphql"
 import { graphql, useFragment } from "react-relay"
 import { ContactGalleryButton } from "./CommercialButtons/ContactGalleryButton"
 
 interface QuestionsProps {
   artwork: Questions_artwork$key
+  me: Questions_me$key
 }
 
 export const Questions: React.FC<QuestionsProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
+  const meData = useFragment(meFragment, props.me)
 
   return (
     <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" alignItems="center">
@@ -19,6 +22,7 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
       <Flex flex={1} alignItems="flex-end">
         <ContactGalleryButton
           artwork={artworkData}
+          me={meData}
           variant="outline"
           size="small"
           icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
@@ -31,5 +35,11 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
 const artworkFragment = graphql`
   fragment Questions_artwork on Artwork {
     ...ContactGalleryButton_artwork
+  }
+`
+
+const meFragment = graphql`
+  fragment Questions_me on Me {
+    ...ContactGalleryButton_me
   }
 `

--- a/src/app/Scenes/Artwork/Components/Questions.tsx
+++ b/src/app/Scenes/Artwork/Components/Questions.tsx
@@ -1,17 +1,16 @@
 import { EnvelopeIcon, Flex, Text } from "@artsy/palette-mobile"
+import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { Questions_artwork$key } from "__generated__/Questions_artwork.graphql"
-import { Questions_me$key } from "__generated__/Questions_me.graphql"
 import { graphql, useFragment } from "react-relay"
 import { ContactGalleryButton } from "./CommercialButtons/ContactGalleryButton"
 
 interface QuestionsProps {
   artwork: Questions_artwork$key
-  me: Questions_me$key
+  me: InquiryModal_me$key
 }
 
 export const Questions: React.FC<QuestionsProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
-  const meData = useFragment(meFragment, props.me)
 
   return (
     <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" alignItems="center">
@@ -22,7 +21,7 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
       <Flex flex={1} alignItems="flex-end">
         <ContactGalleryButton
           artwork={artworkData}
-          me={meData}
+          me={props.me}
           variant="outline"
           size="small"
           icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
@@ -35,11 +34,5 @@ export const Questions: React.FC<QuestionsProps> = (props) => {
 const artworkFragment = graphql`
   fragment Questions_artwork on Artwork {
     ...ContactGalleryButton_artwork
-  }
-`
-
-const meFragment = graphql`
-  fragment Questions_me on Me {
-    ...ContactGalleryButton_me
   }
 `

--- a/src/app/Scenes/Artwork/Components/ShortContactGallery.tsx
+++ b/src/app/Scenes/Artwork/Components/ShortContactGallery.tsx
@@ -1,5 +1,6 @@
 import { EntityHeader, EnvelopeIcon, Flex } from "@artsy/palette-mobile"
 import { ShortContactGallery_artwork$key } from "__generated__/ShortContactGallery_artwork.graphql"
+import { ShortContactGallery_me$key } from "__generated__/ShortContactGallery_me.graphql"
 import { navigateToPartner } from "app/system/navigation/navigate"
 import { TouchableWithoutFeedback } from "react-native"
 import { graphql, useFragment } from "react-relay"
@@ -7,6 +8,7 @@ import { ContactGalleryButton } from "./CommercialButtons/ContactGalleryButton"
 
 interface ShortContactGalleryProps {
   artwork: ShortContactGallery_artwork$key
+  me: ShortContactGallery_me$key
   partnerHref?: string
   partnerName?: string | null
   locationNames?: string | null
@@ -15,6 +17,7 @@ interface ShortContactGalleryProps {
 
 export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
+  const meData = useFragment(meFragment, props.me)
 
   return (
     <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" alignItems="center">
@@ -33,6 +36,7 @@ export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) =
       </TouchableWithoutFeedback>
       <ContactGalleryButton
         artwork={artworkData}
+        me={meData}
         variant="outline"
         size="small"
         icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
@@ -44,5 +48,11 @@ export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) =
 const artworkFragment = graphql`
   fragment ShortContactGallery_artwork on Artwork {
     ...ContactGalleryButton_artwork
+  }
+`
+
+const meFragment = graphql`
+  fragment ShortContactGallery_me on Me {
+    ...ContactGalleryButton_me
   }
 `

--- a/src/app/Scenes/Artwork/Components/ShortContactGallery.tsx
+++ b/src/app/Scenes/Artwork/Components/ShortContactGallery.tsx
@@ -1,6 +1,6 @@
 import { EntityHeader, EnvelopeIcon, Flex } from "@artsy/palette-mobile"
+import { InquiryModal_me$key } from "__generated__/InquiryModal_me.graphql"
 import { ShortContactGallery_artwork$key } from "__generated__/ShortContactGallery_artwork.graphql"
-import { ShortContactGallery_me$key } from "__generated__/ShortContactGallery_me.graphql"
 import { navigateToPartner } from "app/system/navigation/navigate"
 import { TouchableWithoutFeedback } from "react-native"
 import { graphql, useFragment } from "react-relay"
@@ -8,7 +8,7 @@ import { ContactGalleryButton } from "./CommercialButtons/ContactGalleryButton"
 
 interface ShortContactGalleryProps {
   artwork: ShortContactGallery_artwork$key
-  me: ShortContactGallery_me$key
+  me: InquiryModal_me$key
   partnerHref?: string
   partnerName?: string | null
   locationNames?: string | null
@@ -17,7 +17,6 @@ interface ShortContactGalleryProps {
 
 export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) => {
   const artworkData = useFragment(artworkFragment, props.artwork)
-  const meData = useFragment(meFragment, props.me)
 
   return (
     <Flex flexDirection="row" flexWrap="wrap" justifyContent="space-between" alignItems="center">
@@ -36,7 +35,7 @@ export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) =
       </TouchableWithoutFeedback>
       <ContactGalleryButton
         artwork={artworkData}
-        me={meData}
+        me={props.me}
         variant="outline"
         size="small"
         icon={<EnvelopeIcon fill="black100" width="16px" height="16px" />}
@@ -48,11 +47,5 @@ export const ShortContactGallery: React.FC<ShortContactGalleryProps> = (props) =
 const artworkFragment = graphql`
   fragment ShortContactGallery_artwork on Artwork {
     ...ContactGalleryButton_artwork
-  }
-`
-
-const meFragment = graphql`
-  fragment ShortContactGallery_me on Me {
-    ...ContactGalleryButton_me
   }
 `

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -43,6 +43,8 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   onClose,
   visible,
 }) => {
+  console.log("🐢", { visible })
+
   /**
    * TODO: On Android
    *
@@ -54,7 +56,7 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
    */
 
   return (
-    <AutomountedBottomSheetModal visible={visible} enableDynamicSizing>
+    <AutomountedBottomSheetModal visible={visible} onDismiss={onClose} enableDynamicSizing>
       <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <MyProfileEditModalWithSuspense onClose={onClose} message={message} />
       </BottomSheetScrollView>
@@ -128,6 +130,7 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
           },
         },
         onCompleted: () => {
+          console.log("🐇")
           trackEvent(tracks.editedUserProfile())
           setLoading(false)
           onClose()
@@ -148,7 +151,7 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
       <Text>{message}</Text>
       <FormikProvider value={formikBag}>
         <UserProfileFields bottomSheetInput />
-        <Button block mt={2} onPress={handleSubmit} disabled={!isValid} loading={loading}>
+        <Button block mt={2} mb={4} onPress={handleSubmit} disabled={!isValid} loading={loading}>
           Save and Continue
         </Button>
       </FormikProvider>

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -82,9 +82,8 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
           setLoading(false)
           onClose()
         },
-        onError: () => {
-          // TODO: display an error message to user
-          console.log("Error updating user profile")
+        onError: (error) => {
+          console.error("[MyProfileEditModal] Error updating user profile", error)
           setLoading(false)
         },
       })
@@ -104,9 +103,8 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
       onCompleted: () => {
         onClose()
       },
-      onError: () => {
-        // TODO: display an error message to user
-        console.log("Error updating user profile")
+      onError: (error) => {
+        console.error("[MyProfileEditModal] Error updating last prompt timestamp", error)
       },
     })
   }

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -52,9 +52,27 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
    * 3. The primary location field title is behind the outline
    *   - This does not happen in the settings screen (on the feature branch)
    */
+  const [commit] = useUpdateUserProfileFields()
+
+  const handleDismiss = () => {
+    commit({
+      variables: {
+        input: {
+          promptedForUpdate: true,
+        },
+      },
+      onCompleted: () => {
+        onClose()
+      },
+      onError: () => {
+        // TODO: display an error message to user
+        console.log("Error updating user profile")
+      },
+    })
+  }
 
   return (
-    <AutomountedBottomSheetModal visible={visible} onDismiss={onClose} enableDynamicSizing>
+    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
       <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <MyProfileEditModalWithSuspense onClose={onClose} message={message} />
       </BottomSheetScrollView>
@@ -94,8 +112,7 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
   const [loading, setLoading] = useState<boolean>(false)
   const { trackEvent } = useTracking()
 
-  // TODO: what am I suposed to do with inProgress?
-  const [commit, _inProgress] = useUpdateUserProfileFields()
+  const [commit] = useUpdateUserProfileFields()
 
   const formikBag = useFormik<UserProfileFormikSchema>({
     enableReinitialize: true,
@@ -125,6 +142,7 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
             },
             profession: values.profession,
             otherRelevantPositions: values.otherRelevantPositions,
+            promptedForUpdate: true,
           },
         },
         onCompleted: () => {

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -29,13 +29,12 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   visible,
 }) => {
   /**
-   * TODO: On Android
+   * TODO: I have observed the following issues with this modal in the Android emulator:
    *
-   * 1. The modal glitches during autocompletion
-   * 2. The submit button doesn't work after selecting a location
-   *   - This also happens on the settings screen (on the main branch)
-   * 3. The primary location field title is behind the outline
-   *   - This does not happen in the settings screen (on the feature branch)
+   * 1. The modal flickers during autocompletion
+   * 2. The submit button doesn't respond after selecting a new location
+   * 3. The title of the location field is rendered behind its outline
+   * 4. The modal overlay doesn't disappear after closing the modal
    */
 
   const data = useFragment(meFragmentQuery, me)

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -43,8 +43,6 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   onClose,
   visible,
 }) => {
-  console.log("🐢", { visible })
-
   /**
    * TODO: On Android
    *
@@ -130,7 +128,6 @@ const MyProfileEditModalContent: React.FC<MyProfileEditModalContentProps> = ({
           },
         },
         onCompleted: () => {
-          console.log("🐇")
           trackEvent(tracks.editedUserProfile())
           setLoading(false)
           onClose()

--- a/src/app/Scenes/MyProfile/useUpdateUserProfileFields.tsx
+++ b/src/app/Scenes/MyProfile/useUpdateUserProfileFields.tsx
@@ -8,6 +8,7 @@ export const useUpdateUserProfileFields = () => {
         me {
           ...MyProfileHeader_me
           ...MyProfileEditForm_me
+          ...InquiryModal_me
         }
       }
     }

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
@@ -1,24 +1,9 @@
-import { reducer } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
-import {
-  ArtworkInquiryActions,
-  ArtworkInquiryContextState,
-} from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
-
-let inquiryState: ArtworkInquiryContextState
-let inquiryAction: ArtworkInquiryActions
-
-// TODO: Add tests for location reducer
-// describe("selectShippingLocation", () => {})
+import { initialArtworkInquiryState, reducer } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import { ArtworkInquiryActions } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 
 describe("selectInquiryQuestion", () => {
   it("when a question is checked it pushes that question into the inquiryQuestions array", () => {
-    inquiryState = {
-      shippingLocation: null,
-      inquiryQuestions: [],
-      message: null,
-    }
-
-    inquiryAction = {
+    const inquiryAction: ArtworkInquiryActions = {
       type: "selectInquiryQuestion",
       payload: {
         questionID: "condition_and_provenance",
@@ -27,18 +12,17 @@ describe("selectInquiryQuestion", () => {
       },
     }
 
-    const r = reducer(inquiryState, inquiryAction)
+    const r = reducer(initialArtworkInquiryState, inquiryAction)
 
     expect(r).toEqual({
-      shippingLocation: null,
+      ...initialArtworkInquiryState,
       inquiryQuestions: [{ questionID: "condition_and_provenance", details: null }],
-      message: null,
     })
   })
 
   it("when a question is deselected it gets removed from the inquiryQuestions array", () => {
-    inquiryState = {
-      shippingLocation: null,
+    const modifiedArtworkInquiryState = {
+      ...initialArtworkInquiryState,
       inquiryQuestions: [
         {
           questionID: "shipping_quote",
@@ -49,10 +33,9 @@ describe("selectInquiryQuestion", () => {
           details: null,
         },
       ],
-      message: null,
     }
 
-    inquiryAction = {
+    const inquiryAction: ArtworkInquiryActions = {
       type: "selectInquiryQuestion",
       payload: {
         questionID: "condition_and_provenance",
@@ -61,12 +44,11 @@ describe("selectInquiryQuestion", () => {
       },
     }
 
-    const r = reducer(inquiryState, inquiryAction)
+    const r = reducer(modifiedArtworkInquiryState, inquiryAction)
 
     expect(r).toEqual({
-      shippingLocation: null,
+      ...modifiedArtworkInquiryState,
       inquiryQuestions: [{ questionID: "shipping_quote", details: null }],
-      message: null,
     })
   })
 })

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
@@ -1,4 +1,7 @@
-import { initialArtworkInquiryState, reducer } from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
+import {
+  initialArtworkInquiryState,
+  artworkInquiryStateReducer,
+} from "app/utils/ArtworkInquiry/ArtworkInquiryStore"
 import { ArtworkInquiryActions } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 
 describe("selectInquiryQuestion", () => {
@@ -12,7 +15,7 @@ describe("selectInquiryQuestion", () => {
       },
     }
 
-    const r = reducer(initialArtworkInquiryState, inquiryAction)
+    const r = artworkInquiryStateReducer(initialArtworkInquiryState, inquiryAction)
 
     expect(r).toEqual({
       ...initialArtworkInquiryState,
@@ -44,7 +47,7 @@ describe("selectInquiryQuestion", () => {
       },
     }
 
-    const r = reducer(modifiedArtworkInquiryState, inquiryAction)
+    const r = artworkInquiryStateReducer(modifiedArtworkInquiryState, inquiryAction)
 
     expect(r).toEqual({
       ...modifiedArtworkInquiryState,

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -10,12 +10,13 @@ export const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
   inquiryQuestions: [],
   message: null,
+  inquiryModalVisible: false,
   successNotificationVisible: false,
   collectionPromptVisible: false,
   profilePromptVisible: false,
 }
 
-export const reducer = (
+export const artworkInquiryStateReducer = (
   inquiryState: ArtworkInquiryContextState,
   action: ArtworkInquiryActions
 ): ArtworkInquiryContextState => {
@@ -46,6 +47,11 @@ export const reducer = (
         ...inquiryState,
         message: action.payload,
       }
+    case "setInquiryModalVisible":
+      return {
+        ...inquiryState,
+        inquiryModalVisible: action.payload,
+      }
     case "setSuccessNotificationVisible":
       return {
         ...inquiryState,
@@ -68,9 +74,10 @@ export const ArtworkInquiryContext = createContext<ArtworkInquiryContextProps>(n
 
 export const ArtworkInquiryStateProvider = ({ children }: any) => {
   const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(
-    reducer,
+    artworkInquiryStateReducer,
     initialArtworkInquiryState
   )
+
   return (
     <ArtworkInquiryContext.Provider value={{ state, dispatch }}>
       {children}

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -57,7 +57,6 @@ export const reducer = (
         collectionPromptVisible: action.payload,
       }
     case "setProfilePromptVisible":
-      console.log("🦃", action.payload)
       return {
         ...inquiryState,
         profilePromptVisible: action.payload,

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -9,7 +9,6 @@ import { createContext, Reducer, useReducer } from "react"
 export const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
   inquiryQuestions: [],
-  message: null,
   inquiryModalVisible: false,
   successNotificationVisible: false,
   collectionPromptVisible: false,
@@ -42,11 +41,6 @@ export const artworkInquiryStateReducer = (
         inquiryQuestions: newSelection,
       }
     }
-    case "setMessage":
-      return {
-        ...inquiryState,
-        message: action.payload,
-      }
     case "setInquiryModalVisible":
       return {
         ...inquiryState,

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -4,7 +4,7 @@ import {
   ArtworkInquiryContextProps,
   ArtworkInquiryContextState,
 } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
-import { createContext, Reducer, useReducer } from "react"
+import { createContext, Reducer, useContext, useReducer } from "react"
 
 export const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
@@ -65,6 +65,8 @@ export const artworkInquiryStateReducer = (
 }
 
 export const ArtworkInquiryContext = createContext<ArtworkInquiryContextProps>(null as any)
+
+export const useArtworkInquiryContext = () => useContext(ArtworkInquiryContext)
 
 export const ArtworkInquiryStateProvider = ({ children }: any) => {
   const [state, dispatch] = useReducer<Reducer<ArtworkInquiryContextState, ArtworkInquiryActions>>(

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -6,10 +6,13 @@ import {
 } from "app/utils/ArtworkInquiry/ArtworkInquiryTypes"
 import { createContext, Reducer, useReducer } from "react"
 
-const initialArtworkInquiryState: ArtworkInquiryContextState = {
+export const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
   inquiryQuestions: [],
   message: null,
+  successNotificationVisible: false,
+  collectionPromptVisible: false,
+  profilePromptVisible: false,
 }
 
 export const reducer = (
@@ -42,6 +45,22 @@ export const reducer = (
       return {
         ...inquiryState,
         message: action.payload,
+      }
+    case "setSuccessNotificationVisible":
+      return {
+        ...inquiryState,
+        successNotificationVisible: action.payload,
+      }
+    case "setCollectionPromptVisible":
+      return {
+        ...inquiryState,
+        collectionPromptVisible: action.payload,
+      }
+    case "setProfilePromptVisible":
+      console.log("🦃", action.payload)
+      return {
+        ...inquiryState,
+        profilePromptVisible: action.payload,
       }
   }
 }

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -5,7 +5,6 @@ import { Dispatch } from "react"
 export type ArtworkInquiryActions =
   | SelectLocation
   | SelectInquiryQuestion
-  | SetMessage
   | ResetForm
   | SetInquiryModalVisible
   | SetSuccessNotificationVisible
@@ -20,7 +19,6 @@ export interface ArtworkInquiryContextProps {
 export interface ArtworkInquiryContextState {
   readonly shippingLocation: LocationWithDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
-  readonly message: string | null
   readonly inquiryModalVisible: boolean
   readonly successNotificationVisible: boolean
   readonly collectionPromptVisible: boolean
@@ -35,11 +33,6 @@ interface ResetForm {
 interface SelectLocation {
   type: "selectShippingLocation"
   payload: LocationWithDetails
-}
-
-interface SetMessage {
-  type: "setMessage"
-  payload: string
 }
 
 interface SelectInquiryQuestion {

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -7,6 +7,7 @@ export type ArtworkInquiryActions =
   | SelectInquiryQuestion
   | SetMessage
   | ResetForm
+  | SetInquiryModalVisible
   | SetSuccessNotificationVisible
   | SetCollectionPromptVisible
   | SetProfilePromptVisible
@@ -20,6 +21,7 @@ export interface ArtworkInquiryContextState {
   readonly shippingLocation: LocationWithDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
   readonly message: string | null
+  readonly inquiryModalVisible: boolean
   readonly successNotificationVisible: boolean
   readonly collectionPromptVisible: boolean
   readonly profilePromptVisible: boolean
@@ -43,6 +45,11 @@ interface SetMessage {
 interface SelectInquiryQuestion {
   type: "selectInquiryQuestion"
   payload: InquiryQuestionInput & { isChecked: boolean }
+}
+
+interface SetInquiryModalVisible {
+  type: "setInquiryModalVisible"
+  payload: boolean
 }
 
 interface SetSuccessNotificationVisible {

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -2,7 +2,14 @@ import { InquiryQuestionInput } from "__generated__/useSubmitInquiryRequestMutat
 import { LocationWithDetails } from "app/utils/googleMaps"
 import { Dispatch } from "react"
 
-export type ArtworkInquiryActions = SelectLocation | SelectInquiryQuestion | SetMessage | ResetForm
+export type ArtworkInquiryActions =
+  | SelectLocation
+  | SelectInquiryQuestion
+  | SetMessage
+  | ResetForm
+  | SetSuccessNotificationVisible
+  | SetCollectionPromptVisible
+  | SetProfilePromptVisible
 
 export interface ArtworkInquiryContextProps {
   state: ArtworkInquiryContextState
@@ -13,9 +20,10 @@ export interface ArtworkInquiryContextState {
   readonly shippingLocation: LocationWithDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
   readonly message: string | null
+  readonly successNotificationVisible: boolean
+  readonly collectionPromptVisible: boolean
+  readonly profilePromptVisible: boolean
 }
-
-export type InquiryTypes = "Inquire on price" | "Contact Gallery" | "Inquire to purchase"
 
 interface ResetForm {
   type: "resetForm"
@@ -35,6 +43,21 @@ interface SetMessage {
 interface SelectInquiryQuestion {
   type: "selectInquiryQuestion"
   payload: InquiryQuestionInput & { isChecked: boolean }
+}
+
+interface SetSuccessNotificationVisible {
+  type: "setSuccessNotificationVisible"
+  payload: boolean
+}
+
+interface SetCollectionPromptVisible {
+  type: "setCollectionPromptVisible"
+  payload: boolean
+}
+
+interface SetProfilePromptVisible {
+  type: "setProfilePromptVisible"
+  payload: boolean
 }
 
 /**

--- a/src/app/utils/collectorPromptHelpers.ts
+++ b/src/app/utils/collectorPromptHelpers.ts
@@ -1,0 +1,41 @@
+type NullableString = string | null | undefined
+
+interface userShouldBePromptedToCompleteProfileParams {
+  city: NullableString
+  lastPromptAt: NullableString
+  profession: NullableString
+}
+
+export const userShouldBePromptedToCompleteProfile = ({
+  city,
+  lastPromptAt,
+  profession,
+}: userShouldBePromptedToCompleteProfileParams) => {
+  const userHasAnIncompleteProfile = !profession || !city
+  return userHasAnIncompleteProfile && userHasNotBeenPromptedWithinCooldownPeriod(lastPromptAt)
+}
+
+interface userShouldBePromptedToAddArtistsToCollectionParams {
+  lastPromptAt: NullableString
+}
+
+export const userShouldBePromptedToAddArtistsToCollection = ({
+  lastPromptAt,
+}: userShouldBePromptedToAddArtistsToCollectionParams) => {
+  const userHasAnEmptyCollection = undefined
+  return userHasAnEmptyCollection && userHasNotBeenPromptedWithinCooldownPeriod(lastPromptAt)
+}
+
+const userHasNotBeenPromptedWithinCooldownPeriod = (lastPromptAt: NullableString) => {
+  if (lastPromptAt == null) {
+    return true
+  }
+
+  const millisecondsSinceLastTimeUserWasPrompted =
+    new Date().getTime() - new Date(lastPromptAt).getTime()
+  const millisecondsInCooldownPeriod = daysInCooldownPeriod * 24 * 60 * 60 * 1000
+
+  return millisecondsSinceLastTimeUserWasPrompted > millisecondsInCooldownPeriod
+}
+
+export const daysInCooldownPeriod = 30

--- a/src/app/utils/collectorPromptHelpers.ts
+++ b/src/app/utils/collectorPromptHelpers.ts
@@ -1,9 +1,11 @@
-type NullableString = string | null | undefined
+import { InquiryModal_me$data } from "__generated__/InquiryModal_me.graphql"
+
+type InquiryModalData = NonNullable<InquiryModal_me$data>
 
 interface userShouldBePromptedToCompleteProfileParams {
-  city: NullableString
-  lastPromptAt: NullableString
-  profession: NullableString
+  city?: NonNullable<InquiryModalData["location"]>["city"]
+  lastPromptAt?: InquiryModalData["collectorProfile"]["lastUpdatePromptAt"]
+  profession?: InquiryModalData["profession"]
 }
 
 export const userShouldBePromptedToCompleteProfile = ({
@@ -16,7 +18,7 @@ export const userShouldBePromptedToCompleteProfile = ({
 }
 
 interface userShouldBePromptedToAddArtistsToCollectionParams {
-  lastPromptAt: NullableString
+  lastPromptAt?: InquiryModalData["collectorProfile"]["lastUpdatePromptAt"]
 }
 
 export const userShouldBePromptedToAddArtistsToCollection = ({
@@ -26,7 +28,9 @@ export const userShouldBePromptedToAddArtistsToCollection = ({
   return userHasAnEmptyCollection && userHasNotBeenPromptedWithinCooldownPeriod(lastPromptAt)
 }
 
-const userHasNotBeenPromptedWithinCooldownPeriod = (lastPromptAt: NullableString) => {
+const userHasNotBeenPromptedWithinCooldownPeriod = (
+  lastPromptAt?: InquiryModalData["collectorProfile"]["lastUpdatePromptAt"]
+) => {
   if (lastPromptAt == null) {
     return true
   }

--- a/src/app/utils/tests/collectorPromptHelpers.tests.ts
+++ b/src/app/utils/tests/collectorPromptHelpers.tests.ts
@@ -1,0 +1,108 @@
+import {
+  daysInCooldownPeriod,
+  userShouldBePromptedToCompleteProfile,
+} from "app/utils/collectorPromptHelpers"
+
+describe("userShouldBePromptedToCompleteProfile", () => {
+  it("returns true if city is null and user has never been prompted", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: null,
+        profession: "Profession",
+        lastPromptAt: null,
+      })
+    ).toEqual(true)
+  })
+
+  it("returns true if profession is null and user has never been prompted", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: null,
+        profession: "Profession",
+        lastPromptAt: null,
+      })
+    ).toEqual(true)
+  })
+
+  it("returns true if city is null and user has not been prompted in 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: null,
+        profession: "Profession",
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod + 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(true)
+  })
+
+  it("returns true if profession is null and user has not been prompted in 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: null,
+        profession: "Profession",
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod + 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(true)
+  })
+
+  it("returns false if city is null and user has been prompted in the last 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: null,
+        profession: "Profession",
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod - 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(false)
+  })
+
+  it("returns false if profession is null and user has been prompted in the last 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: "City",
+        profession: null,
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod - 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(false)
+  })
+
+  it("returns false if city and profession are not null and user has never been prompted", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: "City",
+        profession: "Profession",
+        lastPromptAt: null,
+      })
+    ).toEqual(false)
+  })
+
+  it("return false if city and profession are not null and user has not been prompted in 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: "City",
+        profession: "Profession",
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod + 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(false)
+  })
+
+  it("returns false if city and profession are not null and user has been prompted in the last 30 days", () => {
+    expect(
+      userShouldBePromptedToCompleteProfile({
+        city: "City",
+        profession: "Profession",
+        lastPromptAt: new Date(
+          Date.now() - (daysInCooldownPeriod - 1) * 24 * 60 * 60 * 1000
+        ).toISOString(),
+      })
+    ).toEqual(false)
+  })
+})


### PR DESCRIPTION
This PR resolves [DIA-695]

### Description

This PR updates the inquiry modal to prompt users to complete their profile after an inquiry is sent, if their profile is incomplete and they have not been prompted in 30 days.

I have observed a few issues with the Android implementation, which can be merged without impacting users since this is behind a feature flag:

1. The modal flickers during autocompletion
2. The submit button doesn't respond after selecting a new location
3. The title of the location field is rendered behind its outline
4. The modal overlay doesn't disappear after closing the modal

| iOS | Android |
|-----|---------|
| ![ios](https://github.com/user-attachments/assets/57114eaf-7c4e-454c-960c-4aee1c0ae53e) | ![android](https://github.com/user-attachments/assets/82347092-ad24-47a7-8f77-b240590de69c) |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Refactored inquiry modal to allow profile completion prompt
- Added profile completion prompt behind a feature flag

<!-- end_changelog_updates -->

</details>

[DIA-695]: https://artsyproduct.atlassian.net/browse/DIA-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ