### PR TITLE
fix: missing inquiry modal title

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -583,7 +583,6 @@ describe("ArtworkCommercialButtons", () => {
 
 const state: ArtworkInquiryContextState = {
   shippingLocation: null,
-  inquiryType: null,
   message: null,
   inquiryQuestions: [],
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -14,7 +14,6 @@ const mockDispatch = jest.fn()
 
 const initialState = {
   shippingLocation: null,
-  inquiryType: null,
   message: null,
   inquiryQuestions: [],
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -308,7 +308,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork, ...props })
         rightButtonDisabled={state.inquiryQuestions.length === 0}
         onRightButtonPress={sendInquiry}
       >
-        {state.inquiryType}
+        Contact Gallery
       </FancyModalHeader>
       {!!mutationError && (
         <ErrorMessageFlex bg="red100" py={1} alignItems="center">

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tests.tsx
@@ -14,7 +14,6 @@ describe("selectInquiryQuestion", () => {
   it("when a question is checked it pushes that question into the inquiryQuestions array", () => {
     inquiryState = {
       shippingLocation: null,
-      inquiryType: null,
       inquiryQuestions: [],
       message: null,
     }
@@ -32,7 +31,6 @@ describe("selectInquiryQuestion", () => {
 
     expect(r).toEqual({
       shippingLocation: null,
-      inquiryType: null,
       inquiryQuestions: [{ questionID: "condition_and_provenance", details: null }],
       message: null,
     })
@@ -41,7 +39,6 @@ describe("selectInquiryQuestion", () => {
   it("when a question is deselected it gets removed from the inquiryQuestions array", () => {
     inquiryState = {
       shippingLocation: null,
-      inquiryType: "Inquire to purchase",
       inquiryQuestions: [
         {
           questionID: "shipping_quote",
@@ -68,7 +65,6 @@ describe("selectInquiryQuestion", () => {
 
     expect(r).toEqual({
       shippingLocation: null,
-      inquiryType: "Inquire to purchase",
       inquiryQuestions: [{ questionID: "shipping_quote", details: null }],
       message: null,
     })

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -8,7 +8,6 @@ import { createContext, Reducer, useReducer } from "react"
 
 const initialArtworkInquiryState: ArtworkInquiryContextState = {
   shippingLocation: null,
-  inquiryType: null,
   inquiryQuestions: [],
   message: null,
 }

--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryTypes.ts
@@ -10,7 +10,6 @@ export interface ArtworkInquiryContextProps {
 }
 
 export interface ArtworkInquiryContextState {
-  readonly inquiryType: InquiryTypes | null
   readonly shippingLocation: LocationWithDetails | null
   readonly inquiryQuestions: InquiryQuestionInput[]
   readonly message: string | null


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes a bug I introduced in #10491 by not setting the `inquiryType` state variable that defines what label should be used for the "Contact Gallery" button. I stopped using it because we never used any of the other 2 options, but I forgot that the inquiry modal's header also uses that state variable to display "Contact Gallery" as the title.

| Screenshot |
| ------------|
| ![Screenshot_1721403894](https://github.com/user-attachments/assets/1d63ad18-bda2-483e-891b-7486c91b565d) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fixes a bug introduced mid-release that made the inquiry modal title disappear.

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
