### PR TITLE
feat: consume prototype schema for new home view sections

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -112,6 +112,7 @@
                 <data android:pathPrefix="/galleries-for-you" />
                 <data android:pathPrefix="/gallery" />
                 <data android:pathPrefix="/gene" />
+                <data android:pathPrefix="/home-view" />
                 <data android:pathPrefix="/identity-verification-faq" />
                 <data android:pathPrefix="/inbox" />
                 <data android:pathPrefix="/inquiry" />

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2288,7 +2288,7 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericHomeViewSection & Node {
+type ArtistsRailHomeViewSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
   component: HomeViewComponent
 
@@ -3151,7 +3151,7 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericHomeViewSection & Node {
+type ArtworksRailHomeViewSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
   component: HomeViewComponent
 
@@ -11358,7 +11358,7 @@ enum HomeViewComponentType {
   ARTWORKS_RAIL
 }
 
-union HomeViewSection = ArtistsRailSection | ArtworksRailSection
+union HomeViewSection = ArtistsRailHomeViewSection | ArtworksRailHomeViewSection
 
 # A connection to a list of items.
 type HomeViewSectionConnection {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2288,9 +2288,15 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericSection {
+type ArtistsRailSection implements GenericSection & Node {
   # The component that is prescribed for this section
   component: Component
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # A stable identifier for this section
   key: String!
@@ -3145,9 +3151,15 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericSection {
+type ArtworksRailSection implements GenericSection & Node {
   # The component that is prescribed for this section
   component: Component
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
 
   # A stable identifier for this section
   key: String!
@@ -10974,6 +10986,12 @@ interface GenericSection {
   # The component that is prescribed for this section
   component: Component
 
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+
   # A stable identifier for this section
   key: String!
 
@@ -11334,6 +11352,12 @@ type HomePageSalesModule {
 type HomeView {
   # A list of sections on the home view
   sections: [Section!]!
+  sectionsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): SectionConnection
 }
 
 type IdentityVerification {
@@ -18509,6 +18533,26 @@ enum SecondFactorKind {
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
 union Section = ArtistsRailSection | ArtworksRailSection
+
+# A connection to a list of items.
+type SectionConnection {
+  # A list of edges.
+  edges: [SectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type SectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Section
+}
 
 # A piece that can be sold
 interface Sellable {

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -99,7 +99,9 @@ type addOrderedSetItemMutationPayload {
   clientMutationId: String
 }
 
-union addOrderedSetItemResponseOrError = addOrderedSetItemFailure | addOrderedSetItemSuccess
+union addOrderedSetItemResponseOrError =
+    addOrderedSetItemFailure
+  | addOrderedSetItemSuccess
 
 type addOrderedSetItemSuccess {
   set: OrderedSet
@@ -267,7 +269,12 @@ type Alert {
   additionalGeneNames: [String]
   artistIDs: [String]
   artists: [Artist!]!
-  artistsConnection(after: String, before: String, first: Int, last: Int): ArtistConnection!
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection!
   artistSeriesIDs: [String]
 
   # Artworks Elastic Search results
@@ -406,7 +413,12 @@ type AlertEdge {
 
 type AlertNotificationItem {
   alert: Alert
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 }
 
 enum AlertsConnectionSortEnum {
@@ -488,11 +500,13 @@ type AlertsSummaryCounts {
 type Algolia {
   apiKey: String! @deprecated(reason: "Algolia search is no longer supported")
   appID: String! @deprecated(reason: "Algolia search is no longer supported")
-  indices: [AlgoliaIndex!]! @deprecated(reason: "Algolia search is no longer supported")
+  indices: [AlgoliaIndex!]!
+    @deprecated(reason: "Algolia search is no longer supported")
 }
 
 type AlgoliaIndex {
-  displayName: String! @deprecated(reason: "Algolia search is no longer supported")
+  displayName: String!
+    @deprecated(reason: "Algolia search is no longer supported")
   key: String! @deprecated(reason: "Algolia search is no longer supported")
   name: String! @deprecated(reason: "Algolia search is no longer supported")
 }
@@ -829,7 +843,9 @@ type AnalyticsPartnerInquiryStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner inquiry count time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerInquiryCountTimeSeriesStats!]
 }
 
 # Sales stats of a partner
@@ -842,7 +858,9 @@ type AnalyticsPartnerSalesStats {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner sales time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerSalesTimeSeriesStats!]
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerSalesTimeSeriesStats!]
   total(
     decimal: String = "."
     format: String = "%s%v"
@@ -871,11 +889,17 @@ type AnalyticsPartnerSalesTimeSeriesStats {
 # Partner Stats
 type AnalyticsPartnerStats {
   # Time series data on number of artworks published
-  artworkPublished(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerStatsArtworksPublished
+  artworkPublished(
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsPartnerStatsArtworksPublished
 
   # Time series data on number of artworks published
-  artworksPublished(period: AnalyticsQueryPeriodEnum!): AnalyticsArtworksPublishedStats
-    @deprecated(reason: "Use artworkPublished for refactored time series bucket code")
+  artworksPublished(
+    period: AnalyticsQueryPeriodEnum!
+  ): AnalyticsArtworksPublishedStats
+    @deprecated(
+      reason: "Use artworkPublished for refactored time series bucket code"
+    )
 
   # Audience stats
   audience(period: AnalyticsQueryPeriodEnum!): AnalyticsPartnerAudienceStats
@@ -942,7 +966,8 @@ type AnalyticsPartnerStats {
 
     # Returns the last _n_ elements from the list.
     last: Int
-  ): AnalyticsRankedStatsConnection @deprecated(reason: "Use rankedStats(objectType: ) instead")
+  ): AnalyticsRankedStatsConnection
+    @deprecated(reason: "Use rankedStats(objectType: ) instead")
 
   # Number of unique visitors
   uniqueVisitors(period: AnalyticsQueryPeriodEnum!): Int
@@ -956,7 +981,9 @@ type AnalyticsPartnerStatsArtworksPublished {
   period: AnalyticsQueryPeriodEnum!
 
   # Partner artworks published count time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerStatsArtworksPublishedTimeSeries!]!
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsArtworksPublishedTimeSeries!]!
   totalCount: Int!
 }
 
@@ -977,7 +1004,9 @@ type AnalyticsPartnerStatsPageviews {
   showViews: Int!
 
   # Pageviews time series
-  timeSeries(cumulative: Boolean = false): [AnalyticsPartnerStatsPageviewsTimeSeries!]
+  timeSeries(
+    cumulative: Boolean = false
+  ): [AnalyticsPartnerStatsPageviewsTimeSeries!]
   totalCount: Int!
   uniqueVisitors: Int!
 }
@@ -1236,7 +1265,8 @@ type Article implements Node {
     size: Int = 12
   ): [Article!]!
   channelID: String @deprecated(reason: "Use `channel` instead")
-  contributingAuthors: [Author] @deprecated(reason: "Use `byline` or `authors` instead")
+  contributingAuthors: [Author]
+    @deprecated(reason: "Use `byline` or `authors` instead")
   description: String
   hero: ArticleHero
   href: String
@@ -1320,7 +1350,12 @@ type ArticleEdge {
 
 type ArticleFeaturedArtistNotificationItem {
   article: Article
-  artistsConnection(after: String, before: String, first: Int, last: Int): ArtistConnection
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
 }
 
 type ArticleFeatureSection {
@@ -1877,7 +1912,12 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 }
 
 type ArtistArtworkGrid implements ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -1894,7 +1934,9 @@ type ArtistBlurb {
 
   # The partner id of the partner who submitted the featured bio.
   partnerID: String
-    @deprecated(reason: "No longer used as the partner field contains the partner.id")
+    @deprecated(
+      reason: "No longer used as the partner field contains the partner.id"
+    )
   text: String
 }
 
@@ -2245,6 +2287,18 @@ enum ArtistSorts {
   TRENDING_DESC
 }
 
+# An artists rail section in the home view
+type ArtistsRailSection implements GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
+}
+
 type ArtistStatuses {
   articles: Boolean
   artists: Boolean
@@ -2302,7 +2356,9 @@ enum ArtistTargetSupplyType {
 type Artwork implements Node & Searchable & Sellable {
   additionalInformation(format: Format): String
   artaShippingEnabled: Boolean
-    @deprecated(reason: "Prefer to use `processWithArtsyShippingDomestic`. [Will be removed in v2]")
+    @deprecated(
+      reason: "Prefer to use `processWithArtsyShippingDomestic`. [Will be removed in v2]"
+    )
   articles(size: Int): [Article]
   artist(
     # Use whatever is in the original response instead of making a request
@@ -2323,7 +2379,8 @@ type Artwork implements Node & Searchable & Sellable {
   artsyShippingInternational: Boolean
 
   # Represents the location of the artwork for "My Collection" artworks
-  artworkLocation: String @deprecated(reason: "Please use `collectorLocation` instead")
+  artworkLocation: String
+    @deprecated(reason: "Please use `collectorLocation` instead")
 
   # Represents the "**classification**" of an artwork, such as _limited edition_
   attributionClass: AttributionClass
@@ -2424,7 +2481,8 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Formatted artwork metadata, including artist, title, date and partner; e.g., 'Andy Warhol, Truck, 1980, Westward Gallery'.
   formattedMetadata: String
-  framed: ArtworkInfoRow @deprecated(reason: "Consider using isFramed field (boolean) instead")
+  framed: ArtworkInfoRow
+    @deprecated(reason: "Consider using isFramed field (boolean) instead")
   framedDepth: String
   framedHeight: String
   framedMetric: String
@@ -2560,7 +2618,12 @@ type Artwork implements Node & Searchable & Sellable {
   ): String
   layer(id: String): ArtworkLayer
   layers: [ArtworkLayer]
-  listedArtworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection!
+  listedArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection!
   listPrice: ListPrice
   literature(format: Format): String
 
@@ -2653,7 +2716,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Is this work available for shipping only within the Continental US?
   shipsToContinentalUSOnly: Boolean
-    @deprecated(reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]")
+    @deprecated(
+      reason: "Prefer to use `onlyShipsDomestically`. [Will be removed in v2]"
+    )
   show(active: Boolean, atAFair: Boolean, sort: ShowSorts): Show
   shows(active: Boolean, atAFair: Boolean, size: Int, sort: ShowSorts): [Show]
   signature(format: Format): String
@@ -2801,7 +2866,12 @@ union ArtworkContext = Fair | Sale | Show
 
 # A specific grid.
 interface ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -2878,7 +2948,12 @@ type ArtworkInquiryEdge {
 
 type ArtworkLayer {
   # A connection of artworks from a Layer.
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   cached: Int
   description: String
   href: String
@@ -2921,7 +2996,9 @@ type ArtworkMutationFailure {
   mutationError: GravityMutationError
 }
 
-union ArtworkMutationType = ArtworkMutationDeleteSuccess | ArtworkMutationFailure
+union ArtworkMutationType =
+    ArtworkMutationDeleteSuccess
+  | ArtworkMutationFailure
 
 union ArtworkOrEditionSetType = Artwork | EditionSet
 
@@ -2960,7 +3037,12 @@ type ArtworkPriceInsights {
 
 type ArtworkPublishedNotificationItem {
   artists: [Artist!]!
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 }
 
 union ArtworkResult = Artwork | ArtworkError
@@ -3062,6 +3144,18 @@ enum ArtworkSorts {
   TITLE_DESC
 }
 
+# An artwork rail section in the home view
+type ArtworksRailSection implements GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
+}
+
 type ArtworkVersion implements Node {
   # The names for the artists related to this Artwork Version
   artistNames: String
@@ -3149,7 +3243,12 @@ type AttributionClass {
 }
 
 type AuctionArtworkGrid implements ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -3753,7 +3852,9 @@ type BankAccountMutationSuccess {
   bankAccountEdge: BankAccountEdge
 }
 
-union BankAccountMutationType = BankAccountMutationFailure | BankAccountMutationSuccess
+union BankAccountMutationType =
+    BankAccountMutationFailure
+  | BankAccountMutationSuccess
 
 enum BankAccountTypes {
   SEPA_DEBIT
@@ -4219,7 +4320,9 @@ type CollectorProfileType implements Node {
   ): String
   email: String
   emailConfirmed: Boolean
-    @deprecated(reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead")
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   firstNameLastInitial: String
   followedArtistsCount: Int!
   icon: Image
@@ -4227,12 +4330,19 @@ type CollectorProfileType implements Node {
   # A globally unique ID.
   id: ID!
   identityVerified: Boolean
-    @deprecated(reason: "identityVerified is going to be removed, use isIdentityVerified instead")
+    @deprecated(
+      reason: "identityVerified is going to be removed, use isIdentityVerified instead"
+    )
   initials(length: Int = 3): String
   inquiryRequestsCount: Int!
   institutionalAffiliations: String
   intents: [String]
-  interestsConnection(after: String, before: String, first: Int, last: Int): UserInterestConnection
+  interestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -4343,7 +4453,9 @@ type CollectorResume {
 }
 
 # Represents either an action or a potential failure
-union CommerceActionOrFailureUnion = CommerceOrderRequiresAction | CommerceOrderWithMutationFailure
+union CommerceActionOrFailureUnion =
+    CommerceOrderRequiresAction
+  | CommerceOrderWithMutationFailure
 
 # Autogenerated input type of AddInitialOfferToOrder
 input CommerceAddInitialOfferToOrderInput {
@@ -5763,7 +5875,9 @@ type CommerceOrderEdge {
 }
 
 # Represents either a state change or new offer
-union CommerceOrderEventUnion = CommerceOfferSubmittedEvent | CommerceOrderStateChangedEvent
+union CommerceOrderEventUnion =
+    CommerceOfferSubmittedEvent
+  | CommerceOrderStateChangedEvent
 
 enum CommerceOrderFulfillmentTypeEnum {
   # fulfillment type is: pickup
@@ -5936,7 +6050,10 @@ type CommercePickup {
 }
 
 # Represents either a shipping information or pickup
-union CommerceRequestedFulfillmentUnion = CommercePickup | CommerceShip | CommerceShipArta
+union CommerceRequestedFulfillmentUnion =
+    CommercePickup
+  | CommerceShip
+  | CommerceShipArta
 
 # Autogenerated input type of SelectShippingOption
 input CommerceSelectShippingOptionInput {
@@ -6342,6 +6459,21 @@ type CommerceUpdateImpulseConversationIdPayload {
 
 type CommerceUser {
   id: String!
+}
+
+# A component specification
+type Component {
+  # Which component type to render
+  type: ComponentType
+}
+
+# Known component types for use in home view
+enum ComponentType {
+  # A standard rail of artists
+  ARTISTS_RAIL
+
+  # A standard rail of artworks
+  ARTWORKS_RAIL
 }
 
 type ConditionReportRequest {
@@ -7536,11 +7668,14 @@ type Conversation implements Node {
   fromLastViewedMessageID: String
 
   # The collector profile of the user who initiated the conversation
-  fromProfile: CollectorProfileType @deprecated(reason: "Use `collectorResume` instead")
+  fromProfile: CollectorProfileType
+    @deprecated(reason: "Use `collectorResume` instead")
 
   # The user who initiated the conversation
   fromUser: User
-    @deprecated(reason: "Will be inaccessible to partners in future versions. Prefer fromProfile.")
+    @deprecated(
+      reason: "Will be inaccessible to partners in future versions. Prefer fromProfile."
+    )
 
   # A globally unique ID.
   id: ID!
@@ -7582,8 +7717,13 @@ type Conversation implements Node {
     )
 
   # A connection for all messages in a single conversation
-  messages(after: String, before: String, first: Int, last: Int, sort: sort): MessageConnection
-    @deprecated(reason: "Prefer messagesConnection")
+  messages(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    sort: sort
+  ): MessageConnection @deprecated(reason: "Prefer messagesConnection")
 
   # A connection for all messages and events in a single conversation
   messagesAndConversationEventsConnection(
@@ -7934,7 +8074,9 @@ type createCollectionPayload {
   responseOrError: CreateCollectionResponseOrError
 }
 
-union CreateCollectionResponseOrError = CreateCollectionFailure | CreateCollectionSuccess
+union CreateCollectionResponseOrError =
+    CreateCollectionFailure
+  | CreateCollectionSuccess
 
 type CreateCollectionSuccess {
   collection: Collection
@@ -7978,7 +8120,9 @@ type CreateFeaturedLinkMutationPayload {
   featuredLinkOrError: CreateFeaturedLinkResponseOrError
 }
 
-union CreateFeaturedLinkResponseOrError = CreateFeaturedLinkFailure | CreateFeaturedLinkSuccess
+union CreateFeaturedLinkResponseOrError =
+    CreateFeaturedLinkFailure
+  | CreateFeaturedLinkSuccess
 
 type CreateFeaturedLinkSuccess {
   featuredLink: FeaturedLink
@@ -8061,7 +8205,9 @@ type CreateHeroUnitMutationPayload {
   heroUnitOrError: createHeroUnitResponseOrError
 }
 
-union createHeroUnitResponseOrError = createHeroUnitFailure | createHeroUnitSuccess
+union createHeroUnitResponseOrError =
+    createHeroUnitFailure
+  | createHeroUnitSuccess
 
 type createHeroUnitSuccess {
   heroUnit: HeroUnit
@@ -8186,7 +8332,9 @@ type CreateOrderedSetMutationPayload {
   orderedSetOrError: createOrderedSetResponseOrError
 }
 
-union createOrderedSetResponseOrError = createOrderedSetFailure | createOrderedSetSuccess
+union createOrderedSetResponseOrError =
+    createOrderedSetFailure
+  | createOrderedSetSuccess
 
 type createOrderedSetSuccess {
   set: OrderedSet
@@ -8232,7 +8380,9 @@ type createPartnerOfferMutationPayload {
   partnerOfferOrError: createPartnerOfferResponseOrError
 }
 
-union createPartnerOfferResponseOrError = createPartnerOfferFailure | createPartnerOfferSuccess
+union createPartnerOfferResponseOrError =
+    createPartnerOfferFailure
+  | createPartnerOfferSuccess
 
 type createPartnerOfferSuccess {
   partner: Partner
@@ -8258,7 +8408,9 @@ type CreateSaleAgreementMutationPayload {
   saleAgreementOrError: CreateSaleAgreementResponseOrError
 }
 
-union CreateSaleAgreementResponseOrError = CreateSaleAgreementFailure | CreateSaleAgreementSuccess
+union CreateSaleAgreementResponseOrError =
+    CreateSaleAgreementFailure
+  | CreateSaleAgreementSuccess
 
 type CreateSaleAgreementSuccess {
   saleAgreement: SaleAgreement
@@ -8388,7 +8540,9 @@ type createUserAdminNoteMutationPayload {
   clientMutationId: String
 }
 
-union createUserAdminNoteResponseOrError = createUserAdminNoteFailure | createUserAdminNoteSuccess
+union createUserAdminNoteResponseOrError =
+    createUserAdminNoteFailure
+  | createUserAdminNoteSuccess
 
 type createUserAdminNoteSuccess {
   adminNote: UserAdminNotes
@@ -8645,7 +8799,9 @@ type CreditCardMutationSuccess {
   creditCardEdge: CreditCardEdge
 }
 
-union CreditCardMutationType = CreditCardMutationFailure | CreditCardMutationSuccess
+union CreditCardMutationType =
+    CreditCardMutationFailure
+  | CreditCardMutationSuccess
 
 type CreditCardPayload {
   clientMutationId: String
@@ -8833,7 +8989,9 @@ type deleteCollectionPayload {
   responseOrError: DeleteCollectionResponseOrError
 }
 
-union DeleteCollectionResponseOrError = DeleteCollectionFailure | DeleteCollectionSuccess
+union DeleteCollectionResponseOrError =
+    DeleteCollectionFailure
+  | DeleteCollectionSuccess
 
 type DeleteCollectionSuccess {
   collection: Collection
@@ -8857,7 +9015,9 @@ type DeleteConversationMutationPayload {
   conversationOrError: DeleteConversationResponseOrError
 }
 
-union DeleteConversationResponseOrError = DeleteConversationFailure | DeleteConversationSuccess
+union DeleteConversationResponseOrError =
+    DeleteConversationFailure
+  | DeleteConversationSuccess
 
 type DeleteConversationSuccess {
   conversation: Conversation
@@ -8888,7 +9048,9 @@ type DeleteFeaturedLinkMutationPayload {
   featuredLinkOrError: DeleteFeaturedLinkResponseOrError
 }
 
-union DeleteFeaturedLinkResponseOrError = DeleteFeaturedLinkFailure | DeleteFeaturedLinkSuccess
+union DeleteFeaturedLinkResponseOrError =
+    DeleteFeaturedLinkFailure
+  | DeleteFeaturedLinkSuccess
 
 type DeleteFeaturedLinkSuccess {
   featuredLink: FeaturedLink
@@ -8930,7 +9092,9 @@ type deleteHeroUnitMutationPayload {
   heroUnitOrError: deleteHeroUnitResponseOrError
 }
 
-union deleteHeroUnitResponseOrError = deleteHeroUnitFailure | deleteHeroUnitSuccess
+union deleteHeroUnitResponseOrError =
+    deleteHeroUnitFailure
+  | deleteHeroUnitSuccess
 
 type deleteHeroUnitSuccess {
   heroUnit: HeroUnit
@@ -8978,7 +9142,9 @@ type deleteOrderedSetMutationPayload {
   orderedSetOrError: deleteOrderedSetResponseOrError
 }
 
-union deleteOrderedSetResponseOrError = deleteOrderedSetFailure | deleteOrderedSetSuccess
+union deleteOrderedSetResponseOrError =
+    deleteOrderedSetFailure
+  | deleteOrderedSetSuccess
 
 type deleteOrderedSetSuccess {
   set: OrderedSet
@@ -9035,7 +9201,9 @@ type deleteUserAdminNoteMutationPayload {
   clientMutationId: String
 }
 
-union deleteUserAdminNoteResponseOrError = deleteUserAdminNoteFailure | deleteUserAdminNoteSuccess
+union deleteUserAdminNoteResponseOrError =
+    deleteUserAdminNoteFailure
+  | deleteUserAdminNoteSuccess
 
 type deleteUserAdminNoteSuccess {
   adminNote: UserAdminNotes
@@ -9147,7 +9315,9 @@ type deleteUserRoleMutationPayload {
   userOrError: deleteUserRoleResponseOrError
 }
 
-union deleteUserRoleResponseOrError = deleteUserRoleFailure | deleteUserRoleSuccess
+union deleteUserRoleResponseOrError =
+    deleteUserRoleFailure
+  | deleteUserRoleSuccess
 
 type deleteUserRoleSuccess {
   user: User
@@ -10155,7 +10325,8 @@ type FilterArtworksConnection implements ArtworkConnectionInterface & Node {
   facet: ArtworkFilterFacet
 
   # Artwork results.
-  hits: [Artwork] @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
+  hits: [Artwork]
+    @deprecated(reason: "Prefer to use `edges`. [Will be removed in v2]")
 
   # The ID of the object.
   id: ID!
@@ -10338,7 +10509,12 @@ type FollowArtists {
 
 type FollowedArtistsArtworksGroup implements Node {
   artists: String
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   href: String
 
   # A globally unique ID.
@@ -10547,7 +10723,12 @@ type FollowsAndSaves {
   ): FollowedArtistsArtworksGroupConnection
 
   # A list of the current user’s currently followed fair profiles
-  fairsConnection(after: String, before: String, first: Int, last: Int): FollowedFairConnection
+  fairsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): FollowedFairConnection
 
   # A list of the current user’s currently followed gallery profiles
   galleriesConnection(
@@ -10626,7 +10807,12 @@ type GeminiEntry {
 }
 
 type Gene implements Node & Searchable {
-  artistsConnection(after: String, before: String, first: Int, last: Int): ArtistConnection
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   cached: Int
   description(format: Format): String
   displayLabel: String
@@ -10781,6 +10967,18 @@ type GeneFamilyEdge {
 # Meta tags for Gene pages
 type GeneMeta {
   description: String!
+}
+
+# Abstract interface shared by every kind of home view section
+interface GenericSection {
+  # The component that is prescribed for this section
+  component: Component
+
+  # A stable identifier for this section
+  key: String!
+
+  # A display title for this section
+  title: String!
 }
 
 type GravityMutationError {
@@ -11134,9 +11332,6 @@ type HomePageSalesModule {
 
 # Experimental schema for new home view
 type HomeView {
-  # Hello, world
-  hello: String!
-
   # A list of sections on the home view
   sections: [Section!]!
 }
@@ -11433,7 +11628,9 @@ type InquirerCollectorProfile {
   ): String
   email: String
   emailConfirmed: Boolean
-    @deprecated(reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead")
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   firstNameLastInitial: String
   followedArtistsCount: Int!
 
@@ -11444,12 +11641,19 @@ type InquirerCollectorProfile {
   # A globally unique ID.
   id: ID!
   identityVerified: Boolean
-    @deprecated(reason: "identityVerified is going to be removed, use isIdentityVerified instead")
+    @deprecated(
+      reason: "identityVerified is going to be removed, use isIdentityVerified instead"
+    )
   initials(length: Int = 3): String
   inquiryRequestsCount: Int!
   institutionalAffiliations: String
   intents: [String]
-  interestsConnection(after: String, before: String, first: Int, last: Int): UserInterestConnection
+  interestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -11972,7 +12176,10 @@ type MarketingCollection {
   # Show artworks rail in header. Defaults to true
   showHeaderArtworksRail: Boolean!
   slug: String!
-  thumbnail: String @deprecated(reason: "If querying via Metaphysics use thumbnailImage instead.")
+  thumbnail: String
+    @deprecated(
+      reason: "If querying via Metaphysics use thumbnailImage instead."
+    )
   thumbnailImage: Image
   title: String!
   updatedAt: ISO8601DateTime!
@@ -12158,7 +12365,12 @@ type MatchEdge {
 }
 
 type Me implements Node {
-  addressConnection(after: String, before: String, first: Int, last: Int): UserAddressConnection
+  addressConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserAddressConnection
   alert(id: String!): Alert
   alertsConnection(
     after: String
@@ -12328,7 +12540,12 @@ type Me implements Node {
   ): String
 
   # A list of the current user’s credit cards
-  creditCards(after: String, before: String, first: Int, last: Int): CreditCardConnection
+  creditCards(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): CreditCardConnection
 
   # Currency preference of the user
   currencyPreference: CurrencyPreference!
@@ -12336,7 +12553,9 @@ type Me implements Node {
 
   # User has confirmed their email address
   emailConfirmed: Boolean!
-    @deprecated(reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead")
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
 
   # Frequency of marketing emails.
   emailFrequency: String
@@ -12356,7 +12575,9 @@ type Me implements Node {
     id: String!
   ): IdentityVerification
   identityVerified: Boolean
-    @deprecated(reason: "identityVerified is going to be removed, use isIdentityVerified instead")
+    @deprecated(
+      reason: "identityVerified is going to be removed, use isIdentityVerified instead"
+    )
   initials(length: Int = 3): String
   inquiryIntroduction: String
 
@@ -12418,7 +12639,11 @@ type Me implements Node {
   ): SaleArtworksConnection
 
   # The current user's status relating to bids on artworks
-  lotStanding(artworkID: String, saleArtworkID: String, saleID: String): LotStanding
+  lotStanding(
+    artworkID: String
+    saleArtworkID: String
+    saleID: String
+  ): LotStanding
 
   # A list of the current user's auction standings for given lots
   lotStandings(
@@ -12530,7 +12755,8 @@ type Me implements Node {
   ): CommerceOrderConnectionWithTotalCount
 
   # Collector's position with relevant institutions
-  otherRelevantPosition: String @deprecated(reason: "Use `otherRelevantPositions` instead")
+  otherRelevantPosition: String
+    @deprecated(reason: "Use `otherRelevantPositions` instead")
 
   # Collector's position with relevant institutions
   otherRelevantPositions: String
@@ -12737,7 +12963,12 @@ type Me implements Node {
   ): UserInterestConnection
 
   # A list of lots a user is watching.
-  watchedLotConnection(after: String, before: String, first: Int, last: Int): LotConnection
+  watchedLotConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): LotConnection
 }
 
 type MeCounts {
@@ -12954,7 +13185,9 @@ type Mutation {
   ): AddAssetToConsignmentSubmissionPayload
 
   # adds an item to an ordered set.
-  addOrderedSetItem(input: addOrderedSetItemMutationInput!): addOrderedSetItemMutationPayload
+  addOrderedSetItem(
+    input: addOrderedSetItemMutationInput!
+  ): addOrderedSetItemMutationPayload
 
   # Add a role associated with a user
   addUserRole(input: addUserRoleMutationInput!): addUserRoleMutationPayload
@@ -12964,16 +13197,24 @@ type Mutation {
   ): AddUserToSubmissionMutationPayload
 
   # Creates a new feature flag
-  adminCreateFeatureFlag(input: AdminCreateFeatureFlagInput!): AdminCreateFeatureFlagPayload
+  adminCreateFeatureFlag(
+    input: AdminCreateFeatureFlagInput!
+  ): AdminCreateFeatureFlagPayload
 
   # Deletes a feature flag
-  adminDeleteFeatureFlag(input: AdminDeleteFeatureFlagInput!): AdminDeleteFeatureFlagPayload
+  adminDeleteFeatureFlag(
+    input: AdminDeleteFeatureFlagInput!
+  ): AdminDeleteFeatureFlagPayload
 
   # Toggles a feature flag on or off for a given environment
-  adminToggleFeatureFlag(input: AdminToggleFeatureFlagInput!): AdminToggleFeatureFlagPayload
+  adminToggleFeatureFlag(
+    input: AdminToggleFeatureFlagInput!
+  ): AdminToggleFeatureFlagPayload
 
   # Updates a feature flag
-  adminUpdateFeatureFlag(input: AdminUpdateFeatureFlagInput!): AdminUpdateFeatureFlagPayload
+  adminUpdateFeatureFlag(
+    input: AdminUpdateFeatureFlagInput!
+  ): AdminUpdateFeatureFlagPayload
 
   # Add / remove artworks to / from collections
   artworksCollectionsBatchUpdate(
@@ -13201,7 +13442,9 @@ type Mutation {
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
 
   # Creates Artist Career Highlight.
-  createCareerHighlight(input: CreateCareerHighlightInput!): CreateCareerHighlightPayload
+  createCareerHighlight(
+    input: CreateCareerHighlightInput!
+  ): CreateCareerHighlightPayload
 
   # Create a collection
   createCollection(input: createCollectionInput!): createCollectionPayload
@@ -13227,10 +13470,14 @@ type Mutation {
   createCreditCard(input: CreditCardInput!): CreditCardPayload
 
   # Creates a feature.
-  createFeature(input: CreateFeatureMutationInput!): CreateFeatureMutationPayload
+  createFeature(
+    input: CreateFeatureMutationInput!
+  ): CreateFeatureMutationPayload
 
   # Creates a featured link.
-  createFeaturedLink(input: CreateFeaturedLinkMutationInput!): CreateFeaturedLinkMutationPayload
+  createFeaturedLink(
+    input: CreateFeaturedLinkMutationInput!
+  ): CreateFeaturedLinkMutationPayload
 
   # Attach an gemini asset to a consignment submission
   createGeminiEntryForAsset(
@@ -13238,7 +13485,9 @@ type Mutation {
   ): CreateGeminiEntryForAssetPayload
 
   # Creates a hero unit.
-  createHeroUnit(input: CreateHeroUnitMutationInput!): CreateHeroUnitMutationPayload
+  createHeroUnit(
+    input: CreateHeroUnitMutationInput!
+  ): CreateHeroUnitMutationPayload
 
   # Create an identity verification override
   createIdentityVerificationOverride(
@@ -13258,16 +13507,22 @@ type Mutation {
   ): CommerceCreateInquiryOrderWithArtworkPayload
 
   # Creates an ordered set.
-  createOrderedSet(input: CreateOrderedSetMutationInput!): CreateOrderedSetMutationPayload
+  createOrderedSet(
+    input: CreateOrderedSetMutationInput!
+  ): CreateOrderedSetMutationPayload
 
   # Creates a static Markdown-backed page.
   createPage(input: CreatePageMutationInput!): CreatePageMutationPayload
 
   # Create a partner offer for the users
-  createPartnerOffer(input: createPartnerOfferMutationInput!): createPartnerOfferMutationPayload
+  createPartnerOffer(
+    input: createPartnerOfferMutationInput!
+  ): createPartnerOfferMutationPayload
 
   # Creates a static Markdown-backed sale agreement.
-  createSaleAgreement(input: CreateSaleAgreementMutationInput!): CreateSaleAgreementMutationPayload
+  createSaleAgreement(
+    input: CreateSaleAgreementMutationInput!
+  ): CreateSaleAgreementMutationPayload
   createSavedSearch(
     # Parameters for CreateSavedSearch
     input: CreateSavedSearchInput!
@@ -13282,10 +13537,14 @@ type Mutation {
   ): CreateUserAddressPayload
 
   # Create a admin note for the user
-  createUserAdminNote(input: createUserAdminNoteMutationInput!): createUserAdminNoteMutationPayload
+  createUserAdminNote(
+    input: createUserAdminNoteMutationInput!
+  ): createUserAdminNoteMutationPayload
 
   # Creates a UserInterest on the logged in User's CollectorProfile.
-  createUserInterest(input: CreateUserInterestMutationInput!): CreateUserInterestMutationPayload
+  createUserInterest(
+    input: CreateUserInterestMutationInput!
+  ): CreateUserInterestMutationPayload
 
   # Creates a UserInterest for a user.
   createUserInterestForUser(
@@ -13293,7 +13552,9 @@ type Mutation {
   ): CreateUserInterestForUserPayload
 
   # Collect Multiple Artists
-  createUserInterests(input: CreateUserInterestsMutationInput!): CreateUserInterestsMutationPayload
+  createUserInterests(
+    input: CreateUserInterestsMutationInput!
+  ): CreateUserInterestsMutationPayload
 
   # Create a sale profile for a user
   createUserSaleProfile(
@@ -13322,25 +13583,35 @@ type Mutation {
   deleteBankAccount(input: DeleteBankAccountInput!): DeleteBankAccountPayload
 
   # Delete an artist career highlight
-  deleteCareerHighlight(input: DeleteCareerHighlightInput!): DeleteCareerHighlightPayload
+  deleteCareerHighlight(
+    input: DeleteCareerHighlightInput!
+  ): DeleteCareerHighlightPayload
 
   # Delete a collection
   deleteCollection(input: deleteCollectionInput!): deleteCollectionPayload
 
   # Soft-delete a conversation.
-  deleteConversation(input: DeleteConversationMutationInput!): DeleteConversationMutationPayload
+  deleteConversation(
+    input: DeleteConversationMutationInput!
+  ): DeleteConversationMutationPayload
 
   # Remove a credit card
   deleteCreditCard(input: DeleteCreditCardInput!): DeleteCreditCardPayload
 
   # deletes a feature.
-  deleteFeature(input: DeleteFeatureMutationInput!): DeleteFeatureMutationPayload
+  deleteFeature(
+    input: DeleteFeatureMutationInput!
+  ): DeleteFeatureMutationPayload
 
   # deletes a featured link.
-  deleteFeaturedLink(input: DeleteFeaturedLinkMutationInput!): DeleteFeaturedLinkMutationPayload
+  deleteFeaturedLink(
+    input: DeleteFeaturedLinkMutationInput!
+  ): DeleteFeaturedLinkMutationPayload
 
   # deletes a hero unit.
-  deleteHeroUnit(input: deleteHeroUnitMutationInput!): deleteHeroUnitMutationPayload
+  deleteHeroUnit(
+    input: deleteHeroUnitMutationInput!
+  ): deleteHeroUnitMutationPayload
 
   # Delete User Artsy Account
   deleteMyAccountMutation(input: DeleteAccountInput!): DeleteAccountPayload
@@ -13349,7 +13620,9 @@ type Mutation {
   deleteMyUserProfileIcon(input: DeleteUserIconInput!): DeleteUserIconPayload
 
   # deletes an ordered set.
-  deleteOrderedSet(input: deleteOrderedSetMutationInput!): deleteOrderedSetMutationPayload
+  deleteOrderedSet(
+    input: deleteOrderedSetMutationInput!
+  ): deleteOrderedSetMutationPayload
 
   # deletes an item to an ordered set.
   deleteOrderedSetItem(
@@ -13367,10 +13640,14 @@ type Mutation {
   ): DeleteUserAddressPayload
 
   # delete an admin note for the user
-  deleteUserAdminNote(input: deleteUserAdminNoteMutationInput!): deleteUserAdminNoteMutationPayload
+  deleteUserAdminNote(
+    input: deleteUserAdminNoteMutationInput!
+  ): deleteUserAdminNoteMutationPayload
 
   # Deletes a UserInterest on the logged in User's CollectorProfile.
-  deleteUserInterest(input: DeleteUserInterestMutationInput!): DeleteUserInterestMutationPayload
+  deleteUserInterest(
+    input: DeleteUserInterestMutationInput!
+  ): DeleteUserInterestMutationPayload
 
   # Delete a UserInterest.
   deleteUserInterestForUser(
@@ -13378,10 +13655,14 @@ type Mutation {
   ): DeleteUserInterestForUserPayload
 
   # Deletes multiple UserInterests on the logged in User's CollectorProfile.
-  deleteUserInterests(input: DeleteUserInterestsMutationInput!): DeleteUserInterestsMutationPayload
+  deleteUserInterests(
+    input: DeleteUserInterestsMutationInput!
+  ): DeleteUserInterestsMutationPayload
 
   # Delete a role associated with a user
-  deleteUserRole(input: deleteUserRoleMutationInput!): deleteUserRoleMutationPayload
+  deleteUserRole(
+    input: deleteUserRoleMutationInput!
+  ): deleteUserRoleMutationPayload
 
   # Deletes a Verified Representative.
   deleteVerifiedRepresentative(
@@ -13431,7 +13712,9 @@ type Mutation {
   ): HoldInventoryPayload
 
   # Links a 3rd party account
-  linkAuthentication(input: LinkAuthenticationMutationInput!): LinkAuthenticationMutationPayload
+  linkAuthentication(
+    input: LinkAuthenticationMutationInput!
+  ): LinkAuthenticationMutationPayload
 
   # Mark all unread notifications as read
   markAllNotificationsAsRead(
@@ -13439,10 +13722,14 @@ type Mutation {
   ): MarkAllNotificationsAsReadPayload
 
   # Mark an unread notifications as read
-  markNotificationAsRead(input: MarkNotificationAsReadInput!): MarkNotificationAsReadPayload
+  markNotificationAsRead(
+    input: MarkNotificationAsReadInput!
+  ): MarkNotificationAsReadPayload
 
   # Mark notifications as seen
-  markNotificationsAsSeen(input: MarkNotificationsAsSeenInput!): MarkNotificationsAsSeenPayload
+  markNotificationsAsSeen(
+    input: MarkNotificationsAsSeenInput!
+  ): MarkNotificationsAsSeenPayload
 
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload
@@ -13484,7 +13771,9 @@ type Mutation {
   ): RequestCredentialsForAssetUploadPayload
 
   # Request price estimate of an artwork
-  requestPriceEstimate(input: RequestPriceEstimateInput!): RequestPriceEstimatePayload
+  requestPriceEstimate(
+    input: RequestPriceEstimateInput!
+  ): RequestPriceEstimatePayload
 
   # Save (or remove) an artwork to (from) a users default collection.
   saveArtwork(input: SaveArtworkInput!): SaveArtworkPayload
@@ -13549,10 +13838,14 @@ type Mutation {
   updateArtist(input: UpdateArtistMutationInput!): UpdateArtistMutationPayload
 
   # Updates an artwork.
-  updateArtwork(input: UpdateArtworkMutationInput!): UpdateArtworkMutationPayload
+  updateArtwork(
+    input: UpdateArtworkMutationInput!
+  ): UpdateArtworkMutationPayload
 
   # Updates Artist Career Highlight.
-  updateCareerHighlight(input: UpdateCareerHighlightInput!): UpdateCareerHighlightPayload
+  updateCareerHighlight(
+    input: UpdateCareerHighlightInput!
+  ): UpdateCareerHighlightPayload
 
   # Updates the flags on a partner.
   updateCMSLastAccessTimestamp(
@@ -13563,7 +13856,9 @@ type Mutation {
   updateCollection(input: updateCollectionInput!): updateCollectionPayload
 
   # Updating a collector profile (loyalty applicant status).
-  updateCollectorProfile(input: UpdateCollectorProfileInput!): UpdateCollectorProfilePayload
+  updateCollectorProfile(
+    input: UpdateCollectorProfileInput!
+  ): UpdateCollectorProfilePayload
 
   # Updating a collector profile (loyalty applicant status).
   updateCollectorProfileWithID(
@@ -13575,16 +13870,24 @@ type Mutation {
   ): UpdateSubmissionMutationPayload
 
   # Update a conversation.
-  updateConversation(input: UpdateConversationMutationInput!): UpdateConversationMutationPayload
+  updateConversation(
+    input: UpdateConversationMutationInput!
+  ): UpdateConversationMutationPayload
 
   # updates a feature.
-  updateFeature(input: UpdateFeatureMutationInput!): UpdateFeatureMutationPayload
+  updateFeature(
+    input: UpdateFeatureMutationInput!
+  ): UpdateFeatureMutationPayload
 
   # updates a featured link.
-  updateFeaturedLink(input: UpdateFeaturedLinkMutationInput!): UpdateFeaturedLinkMutationPayload
+  updateFeaturedLink(
+    input: UpdateFeaturedLinkMutationInput!
+  ): UpdateFeaturedLinkMutationPayload
 
   # updates a hero unit.
-  updateHeroUnit(input: UpdateHeroUnitMutationInput!): UpdateHeroUnitMutationPayload
+  updateHeroUnit(
+    input: UpdateHeroUnitMutationInput!
+  ): UpdateHeroUnitMutationPayload
 
   # Updates the user's collections in batch.
   updateMeCollectionsMutation(
@@ -13592,10 +13895,14 @@ type Mutation {
   ): updateMeCollectionsMutationPayload
 
   # Update a message.
-  updateMessage(input: UpdateMessageMutationInput!): UpdateMessageMutationPayload
+  updateMessage(
+    input: UpdateMessageMutationInput!
+  ): UpdateMessageMutationPayload
 
   # Updates the logged in user's password
-  updateMyPassword(input: UpdateMyPasswordMutationInput!): UpdateMyPasswordMutationPayload
+  updateMyPassword(
+    input: UpdateMyPasswordMutationInput!
+  ): UpdateMyPasswordMutationPayload
 
   # Update the current logged in user.
   updateMyUserProfile(input: UpdateMyProfileInput!): UpdateMyProfilePayload
@@ -13606,19 +13913,25 @@ type Mutation {
   ): updateNotificationPreferencesMutationPayload
 
   # updates an ordered set.
-  updateOrderedSet(input: UpdateOrderedSetMutationInput!): UpdateOrderedSetMutationPayload
+  updateOrderedSet(
+    input: UpdateOrderedSetMutationInput!
+  ): UpdateOrderedSetMutationPayload
 
   # Updates a page.
   updatePage(input: UpdatePageMutationInput!): UpdatePageMutationPayload
 
   # Updates a partner artist.
-  updatePartnerShow(input: UpdatePartnerShowMutationInput!): UpdatePartnerShowMutationPayload
+  updatePartnerShow(
+    input: UpdatePartnerShowMutationInput!
+  ): UpdatePartnerShowMutationPayload
 
   # Update a quiz artwork interacted_with flag
   updateQuiz(input: updateQuizMutationInput!): updateQuizMutationPayload
 
   # Updates a saleAgreement.
-  updateSaleAgreement(input: UpdateSaleAgreementMutationInput!): UpdateSaleAgreementMutationPayload
+  updateSaleAgreement(
+    input: UpdateSaleAgreementMutationInput!
+  ): UpdateSaleAgreementMutationPayload
   updateSavedSearch(
     # Parameters for UpdateSavedSearch
     input: UpdateSavedSearchInput!
@@ -13640,10 +13953,14 @@ type Mutation {
   ): UpdateUserDefaultAddressPayload
 
   # Updates a UserInterest on the logged in User's CollectorProfile.
-  updateUserInterest(input: UpdateUserInterestMutationInput!): UpdateUserInterestMutationPayload
+  updateUserInterest(
+    input: UpdateUserInterestMutationInput!
+  ): UpdateUserInterestMutationPayload
 
   # Update user interests for multiple artists
-  updateUserInterests(input: UpdateUserInterestsMutationInput!): UpdateUserInterestsMutationPayload
+  updateUserInterests(
+    input: UpdateUserInterestsMutationInput!
+  ): UpdateUserInterestsMutationPayload
 
   # Update the user sale profile
   updateUserSaleProfile(
@@ -13726,7 +14043,8 @@ type MyCollectionConnection {
     page: Int
     size: Int
     sort: ArtistSorts
-  ): ArtistConnection @deprecated(reason: "Please use `me.userInterestsConnection` instead")
+  ): ArtistConnection
+    @deprecated(reason: "Please use `me.userInterestsConnection` instead")
   default: Boolean!
   description: String!
 
@@ -13835,7 +14153,8 @@ type MyCollectionInfo {
     page: Int
     size: Int
     sort: ArtistSorts
-  ): ArtistConnection @deprecated(reason: "Please use `me.userInterestsConnection` instead")
+  ): ArtistConnection
+    @deprecated(reason: "Please use `me.userInterestsConnection` instead")
   default: Boolean!
   description: String!
   includesPurchasedArtworks: Boolean!
@@ -13926,7 +14245,12 @@ interface Node {
 }
 
 type Notification implements Node {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   createdAt(
     format: String
 
@@ -14079,7 +14403,12 @@ type OrderedSet {
   items: [OrderedSetItem]
 
   # Returns a connection of the items. Only Artwork supported right now.
-  itemsConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  itemsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
     @deprecated(reason: "Utilize `orderedItemsConnection` for union type")
   itemType: String
   key: String
@@ -14115,7 +14444,14 @@ type OrderedSetEdge {
   node: OrderedSet
 }
 
-union OrderedSetItem = Artist | Artwork | FeaturedLink | Gene | Profile | Sale | Show
+union OrderedSetItem =
+    Artist
+  | Artwork
+  | FeaturedLink
+  | Gene
+  | Profile
+  | Sale
+  | Show
 
 # A connection to a list of items.
 type OrderedSetItemConnection {
@@ -14464,7 +14800,8 @@ type Partner implements Node {
     tagID: String
     width: String
   ): FilterArtworksConnection
-  fullProfileEligible: Boolean @deprecated(reason: "Prefer displayFullPartnerPage")
+  fullProfileEligible: Boolean
+    @deprecated(reason: "Prefer displayFullPartnerPage")
   hasFairPartnership: Boolean
 
   # The url for a partner. May be `null` if partner is not eligible for page.
@@ -14494,7 +14831,9 @@ type Partner implements Node {
 
   # This field is deprecated and is being used in Eigen release predating the 6.0 release
   locations(size: Int = 25): [Location]
-    @deprecated(reason: "Prefer to use `locationsConnection`. [Will be removed in v2]")
+    @deprecated(
+      reason: "Prefer to use `locationsConnection`. [Will be removed in v2]"
+    )
 
   # A connection of locations from a Partner.
   locationsConnection(
@@ -14746,7 +15085,12 @@ type PartnerArtistEdge {
 }
 
 type PartnerArtworkGrid implements ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -15034,7 +15378,9 @@ type PartnerOffer implements Node {
     @deprecated(reason: "This field is deprecated. Use 'priceListed' instead.")
   priceWithDiscount: Money
   priceWithDiscountMessage: String
-    @deprecated(reason: "This field is deprecated. Use 'priceWithDiscount' instead.")
+    @deprecated(
+      reason: "This field is deprecated. Use 'priceWithDiscount' instead."
+    )
   source: PartnerOfferSourceEnum
   userIds: [String]
 }
@@ -15051,7 +15397,12 @@ type PartnerOfferConnection {
 }
 
 type PartnerOfferCreatedNotificationItem {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # Deprecated. Use `partnerOffer.isAvailable` instead.
   available: Boolean
@@ -15521,7 +15872,8 @@ type Profile {
   bio: String
   cached: Int
   counts: ProfileCounts
-  displayArtistsSection: Boolean @deprecated(reason: "Prefer displayArtistsSection in Partner type")
+  displayArtistsSection: Boolean
+    @deprecated(reason: "Prefer displayArtistsSection in Partner type")
   fullBio: String
   href: String
   icon: Image
@@ -15539,7 +15891,8 @@ type Profile {
   location: String
   name: String
   owner: ProfileOwnerType!
-  profileArtistsLayout: String @deprecated(reason: "Prefer profileArtistsLayout in Partner type")
+  profileArtistsLayout: String
+    @deprecated(reason: "Prefer profileArtistsLayout in Partner type")
 
   # A slug ID.
   slug: ID!
@@ -15643,7 +15996,10 @@ type Query {
   _unused_gravity_partners(ids: [ID!]!): [DoNotUseThisPartner!]
 
   # Find a saved search by ID or criteria
-  _unused_gravity_savedSearch(criteria: SearchCriteriaAttributes, id: ID): SearchCriteria
+  _unused_gravity_savedSearch(
+    criteria: SearchCriteriaAttributes
+    id: ID
+  ): SearchCriteria
 
   # List of user's saved searches
   _unused_gravity_savedSearchesConnection(
@@ -15667,7 +16023,9 @@ type Query {
   ): SearchCriteriaConnection
 
   # List enabled Two-Factor Authentication factors
-  _unused_gravity_secondFactors(kinds: [SecondFactorKind!] = [app, sms, backup]): [SecondFactor!]!
+  _unused_gravity_secondFactors(
+    kinds: [SecondFactorKind!] = [app, sms, backup]
+  ): [SecondFactor!]!
 
   # List of user's saved addresses
   _unused_gravity_userAddressConnection(
@@ -16080,10 +16438,16 @@ type Query {
   ): CommerceOrderConnectionWithTotalCount
 
   # Find balance of an account associated with a setup intent
-  commerceBankAccountBalance(bankAccountId: ID, setupIntentId: ID): CommerceBankAccountBalance
+  commerceBankAccountBalance(
+    bankAccountId: ID
+    setupIntentId: ID
+  ): CommerceBankAccountBalance
 
   # Buyer Activity Data for Collector Resume
-  commerceBuyerActivity(buyerId: String!, sellerId: String): CommerceBuyerActivity
+  commerceBuyerActivity(
+    buyerId: String!
+    sellerId: String
+  ): CommerceBuyerActivity
 
   # Find list of competing orders
   commerceCompetingOrders(
@@ -16214,7 +16578,12 @@ type Query {
   curatedMarketingCollections(size: Int): [MarketingCollection]
 
   # A list of trending artists. Inferred from a manually curated collection of trending artworks.
-  curatedTrendingArtists(after: String, before: String, first: Int, last: Int): ArtistConnection
+  curatedTrendingArtists(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   departments: [Department!]!
 
   # A namespace external partners (provided by Galaxy)
@@ -16345,7 +16714,12 @@ type Query {
   ): Gene
 
   # A list of Gene Families
-  geneFamiliesConnection(after: String, before: String, first: Int, last: Int): GeneFamilyConnection
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
 
   # A list of Genes
   genes(
@@ -16473,7 +16847,9 @@ type Query {
   ): Node
 
   # User's notification preferences
-  notificationPreferences(authenticationToken: String): [NotificationPreference!]!
+  notificationPreferences(
+    authenticationToken: String
+  ): [NotificationPreference!]!
 
   # A feed of notifications
   notificationsConnection(
@@ -16571,7 +16947,8 @@ type Query {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentConnection @deprecated(reason: "Prefer `partner.documentsConnection`")
+  ): PartnerArtistDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -16652,7 +17029,8 @@ type Query {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerShowDocumentConnection @deprecated(reason: "Prefer `partner.documentsConnection`")
+  ): PartnerShowDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
@@ -17062,7 +17440,12 @@ enum RelatedArtistsKind {
 }
 
 type RelatedArtworkGrid implements ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -18125,11 +18508,7 @@ enum SecondFactorKind {
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
 
-# A generic section in the home view
-type Section {
-  # The title of the section
-  title: String!
-}
+union Section = ArtistsRailSection | ArtworksRailSection
 
 # A piece that can be sold
 interface Sellable {
@@ -18236,7 +18615,9 @@ type SendFeedbackMutationSuccess {
   feedback: Feedback
 }
 
-union SendFeedbackMutationType = SendFeedbackMutationFailure | SendFeedbackMutationSuccess
+union SendFeedbackMutationType =
+    SendFeedbackMutationFailure
+  | SendFeedbackMutationSuccess
 
 input SendIdentityVerificationEmailMutationInput {
   clientMutationId: String
@@ -18532,7 +18913,12 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
 }
 
 type ShowArtworkGrid implements ArtworkContextGrid {
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
   ctaHref: String
   ctaTitle: String
   title: String
@@ -18625,7 +19011,12 @@ type ShowFollowArtistEdge {
 
 type ShowOpenedNotificationItem {
   partner: Partner
-  showsConnection(after: String, before: String, first: Int, last: Int): ShowConnection
+  showsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ShowConnection
 }
 
 enum ShowSorts {
@@ -18989,7 +19380,9 @@ type TransferMyCollectionSuccess {
 }
 
 # A transfer My Collection success or errors object
-union TransferMyCollectionSuccessOrErrorsUnion = Errors | TransferMyCollectionSuccess
+union TransferMyCollectionSuccessOrErrorsUnion =
+    Errors
+  | TransferMyCollectionSuccess
 
 type TrendingArtists {
   artists: [Artist]
@@ -19244,7 +19637,9 @@ type updateCollectionPayload {
   responseOrError: UpdateCollectionResponseOrError
 }
 
-union UpdateCollectionResponseOrError = UpdateCollectionFailure | UpdateCollectionSuccess
+union UpdateCollectionResponseOrError =
+    UpdateCollectionFailure
+  | UpdateCollectionSuccess
 
 type UpdateCollectionSuccess {
   collection: Collection
@@ -19299,7 +19694,9 @@ type UpdateCollectorProfilePayload {
   ): String
   email: String
   emailConfirmed: Boolean
-    @deprecated(reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead")
+    @deprecated(
+      reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
+    )
   firstNameLastInitial: String
   followedArtistsCount: Int!
   icon: Image
@@ -19307,12 +19704,19 @@ type UpdateCollectorProfilePayload {
   # A globally unique ID.
   id: ID!
   identityVerified: Boolean
-    @deprecated(reason: "identityVerified is going to be removed, use isIdentityVerified instead")
+    @deprecated(
+      reason: "identityVerified is going to be removed, use isIdentityVerified instead"
+    )
   initials(length: Int = 3): String
   inquiryRequestsCount: Int!
   institutionalAffiliations: String
   intents: [String]
-  interestsConnection(after: String, before: String, first: Int, last: Int): UserInterestConnection
+  interestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -19476,7 +19880,9 @@ type UpdateFeaturedLinkMutationPayload {
   featuredLinkOrError: UpdateFeaturedLinkResponseOrError
 }
 
-union UpdateFeaturedLinkResponseOrError = UpdateFeaturedLinkFailure | UpdateFeaturedLinkSuccess
+union UpdateFeaturedLinkResponseOrError =
+    UpdateFeaturedLinkFailure
+  | UpdateFeaturedLinkSuccess
 
 type UpdateFeaturedLinkSuccess {
   featuredLink: FeaturedLink
@@ -19542,7 +19948,9 @@ type UpdateHeroUnitMutationPayload {
   heroUnitOrError: updateHeroUnitResponseOrError
 }
 
-union updateHeroUnitResponseOrError = updateHeroUnitFailure | updateHeroUnitSuccess
+union updateHeroUnitResponseOrError =
+    updateHeroUnitFailure
+  | updateHeroUnitSuccess
 
 type updateHeroUnitSuccess {
   heroUnit: HeroUnit
@@ -19567,7 +19975,9 @@ type updateMeCollectionsMutationPayload {
   meCollectionsOrErrors: [UpdateMeCollectionsResponseOrError!]!
 }
 
-union UpdateMeCollectionsResponseOrError = UpdateMeCollectionsFailure | UpdateMeCollectionsSuccess
+union UpdateMeCollectionsResponseOrError =
+    UpdateMeCollectionsFailure
+  | UpdateMeCollectionsSuccess
 
 type UpdateMeCollectionsSuccess {
   collection: Collection
@@ -19722,7 +20132,9 @@ input UpdateMyProfileInput {
   shareFollows: Boolean
 }
 
-union UpdateMyProfileMutation = UpdateMyProfileMutationFailure | UpdateMyProfileMutationSuccess
+union UpdateMyProfileMutation =
+    UpdateMyProfileMutationFailure
+  | UpdateMyProfileMutationSuccess
 
 type UpdateMyProfileMutationFailure {
   mutationError: GravityMutationError
@@ -19749,7 +20161,9 @@ type updateNotificationPreferencesMutationPayload {
   clientMutationId: String
 
   # User's notification preferences
-  notificationPreferences(authenticationToken: String): [NotificationPreference!]!
+  notificationPreferences(
+    authenticationToken: String
+  ): [NotificationPreference!]!
 }
 
 type UpdateOrderedSetFailure {
@@ -19782,7 +20196,9 @@ type UpdateOrderedSetMutationPayload {
   orderedSetOrError: UpdateOrderedSetResponseOrError
 }
 
-union UpdateOrderedSetResponseOrError = UpdateOrderedSetFailure | UpdateOrderedSetSuccess
+union UpdateOrderedSetResponseOrError =
+    UpdateOrderedSetFailure
+  | UpdateOrderedSetSuccess
 
 type UpdateOrderedSetSuccess {
   feature: Feature
@@ -19838,7 +20254,9 @@ type UpdatePartnerShowMutationPayload {
   showOrError: UpdatePartnerShowResponseOrError
 }
 
-union UpdatePartnerShowResponseOrError = UpdatePartnerShowFailure | UpdatePartnerShowSuccess
+union UpdatePartnerShowResponseOrError =
+    UpdatePartnerShowFailure
+  | UpdatePartnerShowSuccess
 
 type UpdatePartnerShowSuccess {
   show: Show
@@ -19878,7 +20296,9 @@ type UpdateSaleAgreementMutationPayload {
   saleAgreementOrError: UpdateSaleAgreementResponseOrError
 }
 
-union UpdateSaleAgreementResponseOrError = UpdateSaleAgreementFailure | UpdateSaleAgreementSuccess
+union UpdateSaleAgreementResponseOrError =
+    UpdateSaleAgreementFailure
+  | UpdateSaleAgreementSuccess
 
 type UpdateSaleAgreementSuccess {
   saleAgreement: SaleAgreement
@@ -20027,7 +20447,9 @@ type UpdateUserInterestMutationPayload {
 
 union UpdateUserInterestOrError = UpdateUserInterestsFailure | UserInterest
 
-union UpdateUserInterestResponseOrError = UpdateUserInterestFailure | UpdateUserInterestSuccess
+union UpdateUserInterestResponseOrError =
+    UpdateUserInterestFailure
+  | UpdateUserInterestSuccess
 
 type UpdateUserInterestsFailure {
   mutationError: GravityMutationError
@@ -20192,7 +20614,12 @@ type User implements Node {
     first: Int
     last: Int
   ): UserInquiredArtworksConnection
-  interestsConnection(after: String, before: String, first: Int, last: Int): UserInterestConnection
+  interestsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): UserInterestConnection
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
@@ -20285,7 +20712,12 @@ type User implements Node {
 
   # The sale profile of the user.
   saleProfile: UserSaleProfile
-  savedArtworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  savedArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # If the user has enabled two-factor authentication on their account
   secondFactorEnabled: Boolean!
@@ -20481,8 +20913,18 @@ type UserEdge {
 }
 
 type UserFollows {
-  artistsConnection(after: String, before: String, first: Int, last: Int): ArtistConnection
-  genesConnection(after: String, before: String, first: Int, last: Int): GeneConnection
+  artistsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
+  genesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneConnection
 }
 
 type UserIconDeleteFailureType {
@@ -20494,7 +20936,9 @@ type UserIconDeleteSuccessType {
   success: Boolean
 }
 
-union UserIconDeletionMutationType = UserIconDeleteFailureType | UserIconDeleteSuccessType
+union UserIconDeletionMutationType =
+    UserIconDeleteFailureType
+  | UserIconDeleteSuccessType
 
 # A connection to a list of items.
 type UserInquiredArtworksConnection {
@@ -21118,7 +21562,12 @@ type Viewer {
   ): CreditCard
 
   # A list of trending artists. Inferred from a manually curated collection of trending artworks.
-  curatedTrendingArtists(after: String, before: String, first: Int, last: Int): ArtistConnection
+  curatedTrendingArtists(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtistConnection
   departments: [Department!]!
 
   # A namespace external partners (provided by Galaxy)
@@ -21249,7 +21698,12 @@ type Viewer {
   ): Gene
 
   # A list of Gene Families
-  geneFamiliesConnection(after: String, before: String, first: Int, last: Int): GeneFamilyConnection
+  geneFamiliesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): GeneFamilyConnection
 
   # A list of Genes
   genes(
@@ -21368,7 +21822,9 @@ type Viewer {
   ): Node
 
   # User's notification preferences
-  notificationPreferences(authenticationToken: String): [NotificationPreference!]!
+  notificationPreferences(
+    authenticationToken: String
+  ): [NotificationPreference!]!
 
   # A feed of notifications
   notificationsConnection(
@@ -21435,7 +21891,8 @@ type Viewer {
     # The slug or ID of the Partner
     partnerID: String!
     size: Int
-  ): PartnerArtistDocumentConnection @deprecated(reason: "Prefer `partner.documentsConnection`")
+  ): PartnerArtistDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # A list of Artworks for a partner
   partnerArtworks(
@@ -21516,7 +21973,8 @@ type Viewer {
     # The slug or ID of the Show
     showID: String!
     size: Int
-  ): PartnerShowDocumentConnection @deprecated(reason: "Prefer `partner.documentsConnection`")
+  ): PartnerShowDocumentConnection
+    @deprecated(reason: "Prefer `partner.documentsConnection`")
 
   # Phone number information
   phoneNumber(phoneNumber: String!, regionCode: String): PhoneNumberType
@@ -21741,7 +22199,12 @@ type Viewer {
 # An artwork viewing room
 type ViewingRoom {
   artworkIDs: [String!]!
-  artworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # Body copy
   body: String
@@ -21764,7 +22227,12 @@ type ViewingRoom {
   # Introductory paragraph
   introStatement: String
   partner: Partner
-  partnerArtworksConnection(after: String, before: String, first: Int, last: Int): ArtworkConnection
+  partnerArtworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): ArtworkConnection
 
   # ID of the partner associated with this viewing room
   partnerID: String!

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -11132,6 +11132,15 @@ type HomePageSalesModule {
   results: [Sale]!
 }
 
+# Experimental schema for new home view
+type HomeView {
+  # Hello, world
+  hello: String!
+
+  # A list of sections on the home view
+  sections: [Section!]!
+}
+
 type IdentityVerification {
   createdAt(
     format: String
@@ -16371,6 +16380,9 @@ type Query {
   # Home screen content
   homePage: HomePage
 
+  # Home view content
+  homeView: HomeView!
+
   # An identity verification that the user has access to
   identityVerification(
     # ID of the IdentityVerification
@@ -18112,6 +18124,12 @@ enum SecondFactorKind {
 
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
+
+# A generic section in the home view
+type Section {
+  # The title of the section
+  title: String!
+}
 
 # A piece that can be sold
 interface Sellable {
@@ -21265,6 +21283,9 @@ type Viewer {
 
   # Home screen content
   homePage: HomePage
+
+  # Home view content
+  homeView: HomeView!
 
   # An identity verification that the user has access to
   identityVerification(

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2288,9 +2288,9 @@ enum ArtistSorts {
 }
 
 # An artists rail section in the home view
-type ArtistsRailSection implements GenericSection & Node {
+type ArtistsRailSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -3151,9 +3151,9 @@ enum ArtworkSorts {
 }
 
 # An artwork rail section in the home view
-type ArtworksRailSection implements GenericSection & Node {
+type ArtworksRailSection implements GenericHomeViewSection & Node {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -6471,21 +6471,6 @@ type CommerceUpdateImpulseConversationIdPayload {
 
 type CommerceUser {
   id: String!
-}
-
-# A component specification
-type Component {
-  # Which component type to render
-  type: ComponentType
-}
-
-# Known component types for use in home view
-enum ComponentType {
-  # A standard rail of artists
-  ARTISTS_RAIL
-
-  # A standard rail of artworks
-  ARTWORKS_RAIL
 }
 
 type ConditionReportRequest {
@@ -10982,9 +10967,9 @@ type GeneMeta {
 }
 
 # Abstract interface shared by every kind of home view section
-interface GenericSection {
+interface GenericHomeViewSection {
   # The component that is prescribed for this section
-  component: Component
+  component: HomeViewComponent
 
   # A globally unique ID.
   id: ID!
@@ -11350,14 +11335,49 @@ type HomePageSalesModule {
 
 # Experimental schema for new home view
 type HomeView {
-  # A list of sections on the home view
-  sections: [Section!]!
   sectionsConnection(
     after: String
     before: String
     first: Int
     last: Int
-  ): SectionConnection
+  ): HomeViewSectionConnection
+}
+
+# A component specification
+type HomeViewComponent {
+  # Which component type to render
+  type: HomeViewComponentType
+}
+
+# Known component types for use in home view
+enum HomeViewComponentType {
+  # A standard rail of artists
+  ARTISTS_RAIL
+
+  # A standard rail of artworks
+  ARTWORKS_RAIL
+}
+
+union HomeViewSection = ArtistsRailSection | ArtworksRailSection
+
+# A connection to a list of items.
+type HomeViewSectionConnection {
+  # A list of edges.
+  edges: [HomeViewSectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type HomeViewSectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: HomeViewSection
 }
 
 type IdentityVerification {
@@ -18531,28 +18551,6 @@ enum SecondFactorKind {
 
 # A second factor or errors
 union SecondFactorOrErrorsUnion = AppSecondFactor | Errors | SmsSecondFactor
-
-union Section = ArtistsRailSection | ArtworksRailSection
-
-# A connection to a list of items.
-type SectionConnection {
-  # A list of edges.
-  edges: [SectionEdge]
-  pageCursors: PageCursors!
-
-  # Information to aid in pagination.
-  pageInfo: PageInfo!
-  totalCount: Int
-}
-
-# An edge in a connection.
-type SectionEdge {
-  # A cursor for use in pagination
-  cursor: String!
-
-  # The item at the end of the edge
-  node: Section
-}
 
 # A piece that can be sold
 interface Sellable {

--- a/docs/add_a_new_screen.md
+++ b/docs/add_a_new_screen.md
@@ -9,9 +9,9 @@ When adding a new screen to Eigen, make sure to use `Screen` components coming f
 ![screen-with-animated-header](./screenshots/screen-with-header.gif)
 
 ```typescript
-const App = () => {
-  import { Screen } from "@artsy/palette-mobile"
+import { Screen } from "@artsy/palette-mobile"
 
+const App = () => {
   return (
     <Screen>
       <Screen.AnimatedHeader onBack={goBack} title="Activity" />

--- a/docs/adding_a_new_route.md
+++ b/docs/adding_a_new_route.md
@@ -25,7 +25,7 @@ Example of situations where **you do need** to add a new route:
 
 #### How to add a global app route
 
-1. Add the new route to `routes.tsx`.
+1. Add the new route to `routes.ts`.
 
    ```typescript
    ...
@@ -58,7 +58,7 @@ Example of situations where **you do need** to add a new route:
         // Hide the close button inside the moda
         hasOwnModalCloseButton?: boolean
         hidesBackButton?: boolean
-        // Sepecify how you want the screen to show up
+        // Specify how you want the screen to show up
         // See https://developer.apple.com/documentation/uikit/uiviewcontroller/1621355-modalpresentationstyle?language=objc
         modalPresentationStyle?: "fullScreen" | "pageSheet" | "formSheet"
         // If this module should only be shown in one particular tab, add it here

--- a/docs/adding_new_components.md
+++ b/docs/adding_new_components.md
@@ -40,10 +40,10 @@ And add an entry to the `modules` object.
 Then add a route in `routes.tsx`
 
 ```diff
-  new RouteMatcher("/fair/:fairID/info", "FairMoreInfo"),
-+ new RouteMatcher("/my-new-component", "MyNewComponent"),
-  new RouteMatcher("/city/:citySlug/:section", "CitySectionList"),
-  new RouteMatcher("/city-fair/:citySlug", "CityFairList"),
+  addRoute("/fair/:fairID/info", "FairMoreInfo"),
++ addRoute("/my-new-component", "MyNewComponent"),
+  addRoute("/city/:citySlug/:section", "CitySectionList"),
+  addRoute("/city-fair/:citySlug", "CityFairList"),
 ```
 
 Any path parameters you declare in the route (using the `/foo/:paramName/bar` syntax) will be passed as props to your component.

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -20,7 +20,7 @@ import { ArtworkRecommendationsScreen } from "app/Scenes/ArtworkRecommendations/
 import { CompleteMyProfile } from "app/Scenes/CompleteMyProfile/CompleteMyProfile"
 import { GalleriesForYouScreen } from "app/Scenes/GalleriesForYou/GalleriesForYouScreen"
 import { HomeContainer } from "app/Scenes/Home/HomeContainer"
-import { HomeView } from "app/Scenes/HomeView/HomeView"
+import { HomeViewScreen } from "app/Scenes/HomeView/HomeView"
 import { AddMyCollectionArtist } from "app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist"
 import { MyCollectionArtworkEditQueryRenderer } from "app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkEdit"
 import { MyCollectionCollectedArtistsPrivacyQueryRenderer } from "app/Scenes/MyCollection/Screens/CollectedArtistsPrivacy/MyCollectionCollectedArtistsPrivacy"
@@ -498,7 +498,7 @@ export const modules = defineModules({
   Home: reactModule(HomeContainer, {
     isRootViewForTabName: "home",
   }),
-  HomeView: reactModule(HomeView, { hidesBackButton: true }),
+  HomeView: reactModule(HomeViewScreen, { hidesBackButton: true }),
   Inbox: reactModule(InboxQueryRenderer, { isRootViewForTabName: "inbox" }, [InboxScreenQuery]),
   Inquiry: reactModule(Inquiry, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   LiveAuction: reactModule(LiveAuctionView, {

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -20,6 +20,7 @@ import { ArtworkRecommendationsScreen } from "app/Scenes/ArtworkRecommendations/
 import { CompleteMyProfile } from "app/Scenes/CompleteMyProfile/CompleteMyProfile"
 import { GalleriesForYouScreen } from "app/Scenes/GalleriesForYou/GalleriesForYouScreen"
 import { HomeContainer } from "app/Scenes/Home/HomeContainer"
+import { HomeView } from "app/Scenes/HomeView/HomeView"
 import { AddMyCollectionArtist } from "app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist"
 import { MyCollectionArtworkEditQueryRenderer } from "app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkEdit"
 import { MyCollectionCollectedArtistsPrivacyQueryRenderer } from "app/Scenes/MyCollection/Screens/CollectedArtistsPrivacy/MyCollectionCollectedArtistsPrivacy"
@@ -497,6 +498,7 @@ export const modules = defineModules({
   Home: reactModule(HomeContainer, {
     isRootViewForTabName: "home",
   }),
+  HomeView: reactModule(HomeView, { hidesBackButton: true }),
   Inbox: reactModule(InboxQueryRenderer, { isRootViewForTabName: "inbox" }, [InboxScreenQuery]),
   Inquiry: reactModule(Inquiry, { alwaysPresentModally: true, hasOwnModalCloseButton: true }),
   LiveAuction: reactModule(LiveAuctionView, {

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,15 +1,14 @@
 import { Flex, Screen, Separator, Spacer, Text } from "@artsy/palette-mobile"
+import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
 import { goBack } from "app/system/navigation/navigate"
+import { Suspense } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
 
 const SCREEN_TITLE = "HomeView WIP"
 
-const dummyData = Array.from({ length: 10 }).map((_, i) => {
-  return {
-    index: i,
-  }
-})
-
 export const HomeView: React.FC = () => {
+  const queryData = useLazyLoadQuery<HomeViewQuery>(homeViewScreenQuery, {})
+
   return (
     <Screen>
       <Screen.AnimatedHeader onBack={goBack} title={SCREEN_TITLE} />
@@ -21,10 +20,10 @@ export const HomeView: React.FC = () => {
 
       <Screen.Body fullwidth>
         <Screen.FlatList
-          data={dummyData}
-          keyExtractor={(item) => `${item.index}`}
+          data={queryData.homeView.sections}
+          keyExtractor={(item) => `${item.title}`}
           renderItem={({ item }) => {
-            return <Placeholder item={item} />
+            return <Section section={item} />
           }}
           ItemSeparatorComponent={() => <Spacer y={1} />}
         />
@@ -33,13 +32,36 @@ export const HomeView: React.FC = () => {
   )
 }
 
-const Placeholder: React.FC<{ item: any }> = (props) => {
-  const { item } = props
+const Section: React.FC<{ section: any }> = (props) => {
+  const { section } = props
+
   return (
     <Flex bg="black10" alignItems="center">
       <Text color="black60" py={2}>
-        Section {item.index}
+        {section.title}
       </Text>
     </Flex>
   )
 }
+
+export const HomeViewScreen: React.FC = () => (
+  <Suspense
+    fallback={
+      <Flex flex={1} justifyContent="center" alignItems="center">
+        <Text>Loading home view…</Text>
+      </Flex>
+    }
+  >
+    <HomeView />
+  </Suspense>
+)
+
+export const homeViewScreenQuery = graphql`
+  query HomeViewQuery {
+    homeView {
+      sections {
+        title
+      }
+    }
+  }
+`

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -37,8 +37,19 @@ const Section: React.FC<{ section: any }> = (props) => {
 
   return (
     <Flex bg="black10" alignItems="center">
-      <Text color="black60" py={2}>
-        {section.title}
+      <Text color="black60" p={2}>
+        Need to render the{" "}
+        <Text color="black100" fontSize="80%">
+          {section.key}
+        </Text>{" "}
+        section as a{" "}
+        <Text color="blue100" fontSize="80%">
+          {section.component.type}
+        </Text>{" "}
+        component, titled{" "}
+        <Text color="black100" fontWeight="bold">
+          {section.title}
+        </Text>{" "}
       </Text>
     </Flex>
   )
@@ -60,7 +71,13 @@ export const homeViewScreenQuery = graphql`
   query HomeViewQuery {
     homeView {
       sections {
-        title
+        ... on GenericSection {
+          key
+          title
+          component {
+            type
+          }
+        }
       }
     }
   }

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,6 +1,7 @@
 import { Flex, Screen, Separator, Spacer, Text } from "@artsy/palette-mobile"
 import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
 import { goBack } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
 import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
@@ -8,6 +9,7 @@ const SCREEN_TITLE = "HomeView WIP"
 
 export const HomeView: React.FC = () => {
   const queryData = useLazyLoadQuery<HomeViewQuery>(homeViewScreenQuery, {})
+  const sections = extractNodes(queryData.homeView.sectionsConnection)
 
   return (
     <Screen>
@@ -20,7 +22,7 @@ export const HomeView: React.FC = () => {
 
       <Screen.Body fullwidth>
         <Screen.FlatList
-          data={queryData.homeView.sections}
+          data={sections}
           keyExtractor={(item) => `${item.title}`}
           renderItem={({ item }) => {
             return <Section section={item} />
@@ -70,12 +72,17 @@ export const HomeViewScreen: React.FC = () => (
 export const homeViewScreenQuery = graphql`
   query HomeViewQuery {
     homeView {
-      sections {
-        ... on GenericSection {
-          key
-          title
-          component {
-            type
+      sectionsConnection(first: 3) {
+        edges {
+          cursor
+          node {
+            ... on GenericSection {
+              key
+              title
+              component {
+                type
+              }
+            }
           }
         }
       }

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,0 +1,14 @@
+import { Box, Text } from "@artsy/palette-mobile"
+
+export const HomeView: React.FC = () => {
+  return (
+    <Box>
+      <Text>Home View</Text>
+      <Text my={1}>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto inventore dolor in porro
+        expedita sint molestias itaque, suscipit nulla ducimus nemo asperiores quisquam officia
+        veniam necessitatibus at rerum atque alias.
+      </Text>
+    </Box>
+  )
+}

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -76,7 +76,7 @@ export const homeViewScreenQuery = graphql`
         edges {
           cursor
           node {
-            ... on GenericSection {
+            ... on GenericHomeViewSection {
               key
               title
               component {

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,14 +1,45 @@
-import { Box, Text } from "@artsy/palette-mobile"
+import { Flex, Screen, Separator, Spacer, Text } from "@artsy/palette-mobile"
+import { goBack } from "app/system/navigation/navigate"
+
+const SCREEN_TITLE = "HomeView WIP"
+
+const dummyData = Array.from({ length: 10 }).map((_, i) => {
+  return {
+    index: i,
+  }
+})
 
 export const HomeView: React.FC = () => {
   return (
-    <Box>
-      <Text>Home View</Text>
-      <Text my={1}>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Architecto inventore dolor in porro
-        expedita sint molestias itaque, suscipit nulla ducimus nemo asperiores quisquam officia
-        veniam necessitatibus at rerum atque alias.
+    <Screen>
+      <Screen.AnimatedHeader onBack={goBack} title={SCREEN_TITLE} />
+
+      <Screen.StickySubHeader
+        title={SCREEN_TITLE}
+        separatorComponent={<Separator borderColor="black5" />}
+      />
+
+      <Screen.Body fullwidth>
+        <Screen.FlatList
+          data={dummyData}
+          keyExtractor={(item) => `${item.index}`}
+          renderItem={({ item }) => {
+            return <Placeholder item={item} />
+          }}
+          ItemSeparatorComponent={() => <Spacer y={1} />}
+        />
+      </Screen.Body>
+    </Screen>
+  )
+}
+
+const Placeholder: React.FC<{ item: any }> = (props) => {
+  const { item } = props
+  return (
+    <Flex bg="black10" alignItems="center">
+      <Text color="black60" py={2}>
+        Section {item.index}
       </Text>
-    </Box>
+    </Flex>
   )
 }

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -191,6 +191,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     addRoute("/feature/:slug", "Feature"),
     addRoute("/galleries-for-you", "GalleriesForYou"),
     addRoute("/gene/:geneID", "Gene"),
+    addRoute("/home-view", "HomeView"),
     addRoute("/inbox", "Inbox"),
     addRoute("/inquiry/:artworkID", "Inquiry"),
     addRoute("/local-discovery", "LocalDiscovery"),


### PR DESCRIPTION
This is the counterpart to https://github.com/artsy/metaphysics/pull/5848 — see that description for more details.

### Description

Stubs in a new `HomeView` screen at the `home-view` route, so that we can safely iterate on the proposed new schema without touching or being constrained by existing home feed logic.

As of now this just renders some placeholders. A next step would be to actually render some content based on the response coming from `homeView.sectionsConnection`

![skel](https://github.com/user-attachments/assets/828682c0-c728-4e18-ae49-a2afbec26657)

(I'm having trouble bring this up in an Android sim, hoping someone else can confirm — would require access to the new MP schema either locally or in staging)

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- A new sandbox screen at `home-view` route for iterating on the new dynamic home view schema - Roop

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
