### PR TITLE
feat: add submission statuses to the MyC artwork screen

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ.tsx
@@ -5,10 +5,12 @@ import { sendEmailWithMailTo } from "app/utils/sendEmail"
 export const ArtworkSubmissionStatusFAQ: React.FC<{ closeModal: () => void }> = ({
   closeModal,
 }) => {
-  const article = "https://support.artsy.net/s/article/What-items-do-you-accept"
+  const handleLinkPress = () => {
+    navigate("https://support.artsy.net/s/article/What-items-do-you-accept")
+  }
 
   return (
-    <Flex p={2}>
+    <Flex px={2} pb={2}>
       <Text variant="lg-display" mb={4}>
         Submission Status
       </Text>
@@ -27,13 +29,14 @@ export const ArtworkSubmissionStatusFAQ: React.FC<{ closeModal: () => void }> = 
           </BulletedItem>
         </Join>
       </Flex>
+
       <Text caps variant="xs" mb={2}>
         find out more
       </Text>
       <Flex flexDirection="column" mb={4}>
         <Text mb={1}>
           For more information, see our Collector Help Center article{" "}
-          <Text style={{ textDecorationLine: "underline" }} onPress={() => navigate(article)}>
+          <Text style={{ textDecorationLine: "underline" }} onPress={handleLinkPress}>
             What items do you accept?
           </Text>
         </Text>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ.tsx
@@ -1,4 +1,4 @@
-import { BulletedItem, Spacer, Flex, Text, Join, Button } from "@artsy/palette-mobile"
+import { BulletedItem, Spacer, Flex, Text, Join, Button, LinkText } from "@artsy/palette-mobile"
 import { navigate } from "app/system/navigation/navigate"
 import { sendEmailWithMailTo } from "app/utils/sendEmail"
 
@@ -36,18 +36,13 @@ export const ArtworkSubmissionStatusFAQ: React.FC<{ closeModal: () => void }> = 
       <Flex flexDirection="column" mb={4}>
         <Text mb={1}>
           For more information, see our Collector Help Center article{" "}
-          <Text style={{ textDecorationLine: "underline" }} onPress={handleLinkPress}>
-            What items do you accept?
-          </Text>
+          <LinkText onPress={handleLinkPress}>What items do you accept?</LinkText>
         </Text>
         <Text>
           Or get in touch with one of our specialists at{" "}
-          <Text
-            style={{ textDecorationLine: "underline" }}
-            onPress={() => sendEmailWithMailTo("mailto:consign@artsymail.com")}
-          >
+          <LinkText onPress={() => sendEmailWithMailTo("mailto:consign@artsymail.com")}>
             sell@artsy.net
-          </Text>
+          </LinkText>
           .
         </Text>
       </Flex>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
@@ -1,0 +1,119 @@
+// ArtworkSubmissionStatusDescription
+
+import { fireEvent, screen } from "@testing-library/react-native"
+import { ArtworkSubmissionStatusDescriptionTestsQuery } from "__generated__/ArtworkSubmissionStatusDescriptionTestsQuery.graphql"
+import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"
+import { navigate } from "app/system/navigation/navigate"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+jest.mock("app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation", () => ({
+  fetchArtworkInformation: () => Promise.resolve(artworkWithoutSubmission),
+}))
+
+describe("ArtworkSubmissionStatusDescription", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkSubmissionStatusDescriptionTestsQuery>({
+    Component: (props) => {
+      if (props?.artwork) {
+        return (
+          <ArtworkSubmissionStatusDescription artworkData={props.artwork} closeModal={() => {}} />
+        )
+      } else {
+        return null
+      }
+    },
+    query: graphql`
+      query ArtworkSubmissionStatusDescriptionTestsQuery @relay_test_operation {
+        artwork(id: "artwork-id") {
+          ...ArtworkSubmissionStatusDescription_artwork
+        }
+      }
+    `,
+  })
+
+  describe("Artwork without submission ", () => {
+    it("doesn't render the component if submission doesn't exists", async () => {
+      renderWithRelay({
+        Artwork: () => artworkWithoutSubmission,
+      })
+
+      expect(screen.queryByTestId("ArtworkSubmissionStatusDescription-Container")).toBe(null)
+    })
+  })
+
+  describe("Artwork with submission ", () => {
+    it("APPROVED state (or any other)", () => {
+      renderWithRelay({
+        Artwork: () => approvedSubmission,
+      })
+
+      expect(screen.getByText("Approved")).toBeTruthy()
+      expect(screen.getByText("Approved Message")).toBeTruthy()
+      expect(screen.getByText("Approved Button Label")).toBeTruthy()
+      expect(screen.getByText("Approved Action Label")).toBeTruthy()
+    })
+
+    it("LISTED state", () => {
+      renderWithRelay({
+        Artwork: () => listedSubmission,
+      })
+
+      expect(screen.getByText("Listed")).toBeTruthy()
+      expect(screen.getByText("View Listing")).toBeTruthy()
+    })
+  })
+
+  it("REJECTED state", () => {
+    renderWithRelay({
+      Artwork: () => rejectedSubmission,
+    })
+
+    expect(screen.getByText("Rejected")).toBeTruthy()
+
+    // test that the stateHelpMessage is displayed correctly when part of it is coming from the server
+    // and some part is hardcoded
+    expect(screen.getByText("Rejected Message", { exact: false })).toBeTruthy()
+    expect(screen.getByText("Find out more about our", { exact: false })).toBeTruthy()
+
+    expect(screen.getByText("Rejected Button Label")).toBeTruthy()
+    expect(screen.getByText("Rejected Action Label")).toBeTruthy()
+
+    fireEvent.press(screen.getByText("submission criteria"))
+    expect(navigate).toHaveBeenCalledWith(
+      "https://support.artsy.net/s/article/What-items-do-you-accept"
+    )
+  })
+})
+
+const artworkWithoutSubmission = {
+  submissionId: null,
+  consignmentSubmission: null,
+}
+
+const approvedSubmission = {
+  submissionId: "someId",
+  consignmentSubmission: {
+    state: "APPROVED",
+    stateLabel: "Approved",
+    stateHelpMessage: "Approved Message",
+    buttonLabel: "Approved Button Label",
+    actionLabel: "Approved Action Label",
+  },
+}
+
+const rejectedSubmission = {
+  submissionId: "someId",
+  consignmentSubmission: {
+    state: "REJECTED",
+    stateLabel: "Rejected",
+    stateHelpMessage: "Rejected Message",
+    buttonLabel: "Rejected Button Label",
+    actionLabel: "Rejected Action Label",
+  },
+}
+
+const listedSubmission = {
+  submissionId: "someId",
+  isListed: true,
+  consignmentSubmission: {},
+}

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
@@ -14,7 +14,11 @@ describe("ArtworkSubmissionStatusDescription", () => {
     Component: (props) => {
       if (props?.artwork) {
         return (
-          <ArtworkSubmissionStatusDescription artworkData={props.artwork} closeModal={() => {}} />
+          <ArtworkSubmissionStatusDescription
+            artworkData={props.artwork}
+            closeModal={() => {}}
+            visible={true}
+          />
         )
       } else {
         return null

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
@@ -1,7 +1,6 @@
-import { fireEvent, screen } from "@testing-library/react-native"
+import { screen } from "@testing-library/react-native"
 import { ArtworkSubmissionStatusDescriptionTestsQuery } from "__generated__/ArtworkSubmissionStatusDescriptionTestsQuery.graphql"
 import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"
-import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -14,7 +13,11 @@ describe("ArtworkSubmissionStatusDescription", () => {
     Component: (props) => {
       if (props?.artwork) {
         return (
-          <ArtworkSubmissionStatusDescription artworkData={props.artwork} closeModal={() => {}} />
+          <ArtworkSubmissionStatusDescription
+            artworkData={props.artwork}
+            closeModal={() => {}}
+            visible={true}
+          />
         )
       } else {
         return null
@@ -67,19 +70,9 @@ describe("ArtworkSubmissionStatusDescription", () => {
     })
 
     expect(screen.getByText("Rejected")).toBeTruthy()
-
-    // test that the stateHelpMessage is displayed correctly when part of it is coming from the server
-    // and some part is hardcoded
-    expect(screen.getByText("Rejected Message", { exact: false })).toBeTruthy()
-    expect(screen.getByText("Find out more about our", { exact: false })).toBeTruthy()
-
+    expect(screen.getByText("Rejected Message")).toBeTruthy()
     expect(screen.getByText("Rejected Button Label")).toBeTruthy()
     expect(screen.getByText("Rejected Action Label")).toBeTruthy()
-
-    fireEvent.press(screen.getByText("submission criteria"))
-    expect(navigate).toHaveBeenCalledWith(
-      "https://support.artsy.net/s/article/What-items-do-you-accept"
-    )
   })
 })
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
@@ -1,6 +1,7 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkSubmissionStatusDescriptionTestsQuery } from "__generated__/ArtworkSubmissionStatusDescriptionTestsQuery.graphql"
 import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"
+import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -13,11 +14,7 @@ describe("ArtworkSubmissionStatusDescription", () => {
     Component: (props) => {
       if (props?.artwork) {
         return (
-          <ArtworkSubmissionStatusDescription
-            artworkData={props.artwork}
-            closeModal={() => {}}
-            visible={true}
-          />
+          <ArtworkSubmissionStatusDescription artworkData={props.artwork} closeModal={() => {}} />
         )
       } else {
         return null
@@ -70,9 +67,19 @@ describe("ArtworkSubmissionStatusDescription", () => {
     })
 
     expect(screen.getByText("Rejected")).toBeTruthy()
-    expect(screen.getByText("Rejected Message")).toBeTruthy()
+
+    // test that the stateHelpMessage is displayed correctly when part of it is coming from the server
+    // and some part is hardcoded
+    expect(screen.getByText("Rejected Message", { exact: false })).toBeTruthy()
+    expect(screen.getByText("Find out more about our", { exact: false })).toBeTruthy()
+
     expect(screen.getByText("Rejected Button Label")).toBeTruthy()
     expect(screen.getByText("Rejected Action Label")).toBeTruthy()
+
+    fireEvent.press(screen.getByText("submission criteria"))
+    expect(navigate).toHaveBeenCalledWith(
+      "https://support.artsy.net/s/article/What-items-do-you-accept"
+    )
   })
 })
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tests.tsx
@@ -1,5 +1,3 @@
-// ArtworkSubmissionStatusDescription
-
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkSubmissionStatusDescriptionTestsQuery } from "__generated__/ArtworkSubmissionStatusDescriptionTestsQuery.graphql"
 import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -1,7 +1,6 @@
-import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
+import { Button, Flex, Text } from "@artsy/palette-mobile"
 import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
-import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtworkSubmissionStatusDescriptionProps {
@@ -25,10 +24,6 @@ export const ArtworkSubmissionStatusDescription: React.FC<
 
   const buttonVariant = ["DRAFT", "APPROVED"].includes(state) ? "fillDark" : "outline"
 
-  const handleLinkPress = () => {
-    navigate("https://support.artsy.net/s/article/What-items-do-you-accept")
-  }
-
   return (
     <Flex p={2} testID="ArtworkSubmissionStatusDescription-Container">
       <AutoHeightBottomSheet onDismiss={closeModal} visible={visible}>
@@ -45,19 +40,9 @@ export const ArtworkSubmissionStatusDescription: React.FC<
             </Text>
           )}
 
-          {state === "REJECTED" ? (
-            <Text variant="sm-display" mt={1} color="black60">
-              {stateHelpMessage} Find out more about our{" "}
-              <LinkText onPress={handleLinkPress} color="black60">
-                submission criteria
-              </LinkText>
-              .
-            </Text>
-          ) : (
-            <Text variant="sm-display" mt={1} color="black60">
-              {stateHelpMessage}
-            </Text>
-          )}
+          <Text variant="sm-display" mt={1} color="black60">
+            {stateHelpMessage}
+          </Text>
 
           {(!!buttonLabel || !!isListed) && (
             <Button

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -1,6 +1,7 @@
-import { Button, Flex, Text } from "@artsy/palette-mobile"
+import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
+import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtworkSubmissionStatusDescriptionProps {
@@ -24,6 +25,10 @@ export const ArtworkSubmissionStatusDescription: React.FC<
 
   const buttonVariant = ["DRAFT", "APPROVED"].includes(state) ? "fillDark" : "outline"
 
+  const handleLinkPress = () => {
+    navigate("https://support.artsy.net/s/article/What-items-do-you-accept")
+  }
+
   return (
     <Flex p={2} testID="ArtworkSubmissionStatusDescription-Container">
       <AutoHeightBottomSheet onDismiss={closeModal} visible={visible}>
@@ -40,9 +45,19 @@ export const ArtworkSubmissionStatusDescription: React.FC<
             </Text>
           )}
 
-          <Text variant="sm-display" mt={1} color="black60">
-            {stateHelpMessage}
-          </Text>
+          {state === "REJECTED" ? (
+            <Text variant="sm-display" mt={1} color="black60">
+              {stateHelpMessage} Find out more about our{" "}
+              <LinkText onPress={handleLinkPress} color="black60">
+                submission criteria
+              </LinkText>
+              .
+            </Text>
+          ) : (
+            <Text variant="sm-display" mt={1} color="black60">
+              {stateHelpMessage}
+            </Text>
+          )}
 
           {(!!buttonLabel || !!isListed) && (
             <Button

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -1,0 +1,78 @@
+import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
+import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
+import { navigate } from "app/system/navigation/navigate"
+import { graphql, useFragment } from "react-relay"
+
+interface ArtworkSubmissionStatusDescriptionProps {
+  artworkData: ArtworkSubmissionStatusDescription_artwork$key
+  closeModal: () => void
+}
+
+export const ArtworkSubmissionStatusDescription: React.FC<
+  ArtworkSubmissionStatusDescriptionProps
+> = ({ artworkData, closeModal }) => {
+  const {
+    consignmentSubmission: submissionData,
+    isListed,
+    submissionId,
+  } = useFragment(fragment, artworkData)
+
+  if (!submissionData || !submissionId) return null
+
+  const { stateLabel, actionLabel, stateHelpMessage, state, buttonLabel } = submissionData
+
+  const buttonVariant = state === "DRAFT" || state === "APPROVED" ? "fillDark" : "outline"
+
+  const handleLinkPress = () => {
+    navigate("https://support.artsy.net/s/article/What-items-do-you-accept")
+  }
+
+  return (
+    <Flex p={2} /* flex={1} */ testID="ArtworkSubmissionStatusDescription-Container">
+      {/* <Flex flex={1}> */}
+
+      <Text variant="md">{isListed ? "Listed" : stateLabel}</Text>
+
+      {!!actionLabel && (
+        <Text variant="md" color="orange100">
+          {actionLabel}
+        </Text>
+      )}
+
+      {state === "REJECTED" ? (
+        <Text variant="sm-display" mt={1} color="black60">
+          {stateHelpMessage} Find out more about our{" "}
+          <LinkText onPress={handleLinkPress} color="black60">
+            submission criteria
+          </LinkText>
+          .
+        </Text>
+      ) : (
+        <Text variant="sm-display" mt={1} color="black60">
+          {stateHelpMessage}
+        </Text>
+      )}
+      {/* </Flex> */}
+
+      {(!!buttonLabel || !!isListed) && (
+        <Button mt={2} block haptic variant={buttonVariant} onPress={closeModal}>
+          {isListed ? "View Listing" : buttonLabel}
+        </Button>
+      )}
+    </Flex>
+  )
+}
+
+const fragment = graphql`
+  fragment ArtworkSubmissionStatusDescription_artwork on Artwork {
+    submissionId
+    consignmentSubmission {
+      state
+      stateLabel
+      stateHelpMessage
+      buttonLabel
+      actionLabel
+    }
+    isListed
+  }
+`

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -62,7 +62,7 @@ export const ArtworkSubmissionStatusDescription: React.FC<
       navigate(`/sell/submissions/${submissionId}/edit`, { passProps })
     } else if (["APPROVED"].includes(state)) {
       const passProps: SubmitArtworkProps = {
-        initialStep: "AdditionalDocuments",
+        initialStep: "ShippingLocation",
         hasStartedFlowFromMyCollection: true,
         initialValues: {},
       }

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -1,16 +1,18 @@
 import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
+import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtworkSubmissionStatusDescriptionProps {
   artworkData: ArtworkSubmissionStatusDescription_artwork$key
   closeModal: () => void
+  visible: boolean
 }
 
 export const ArtworkSubmissionStatusDescription: React.FC<
   ArtworkSubmissionStatusDescriptionProps
-> = ({ artworkData, closeModal }) => {
+> = ({ artworkData, closeModal, visible }) => {
   const {
     consignmentSubmission: submissionData,
     isListed,
@@ -21,44 +23,57 @@ export const ArtworkSubmissionStatusDescription: React.FC<
 
   const { stateLabel, actionLabel, stateHelpMessage, state, buttonLabel } = submissionData
 
-  const buttonVariant = state === "DRAFT" || state === "APPROVED" ? "fillDark" : "outline"
+  const buttonVariant = ["DRAFT", "APPROVED"].includes(state) ? "fillDark" : "outline"
 
   const handleLinkPress = () => {
     navigate("https://support.artsy.net/s/article/What-items-do-you-accept")
   }
 
   return (
-    <Flex p={2} /* flex={1} */ testID="ArtworkSubmissionStatusDescription-Container">
-      {/* <Flex flex={1}> */}
+    <Flex p={2} testID="ArtworkSubmissionStatusDescription-Container">
+      <AutoHeightBottomSheet onDismiss={closeModal} visible={visible}>
+        <Flex mx={2} mb={2} mt={1}>
+          <Text variant="sm-display">Submission Status</Text>
 
-      <Text variant="md">{isListed ? "Listed" : stateLabel}</Text>
+          <Text variant="md" mt={1}>
+            {isListed ? "Listed" : stateLabel}
+          </Text>
 
-      {!!actionLabel && (
-        <Text variant="md" color="orange100">
-          {actionLabel}
-        </Text>
-      )}
+          {!!actionLabel && (
+            <Text variant="md" color="orange100">
+              {actionLabel}
+            </Text>
+          )}
 
-      {state === "REJECTED" ? (
-        <Text variant="sm-display" mt={1} color="black60">
-          {stateHelpMessage} Find out more about our{" "}
-          <LinkText onPress={handleLinkPress} color="black60">
-            submission criteria
-          </LinkText>
-          .
-        </Text>
-      ) : (
-        <Text variant="sm-display" mt={1} color="black60">
-          {stateHelpMessage}
-        </Text>
-      )}
-      {/* </Flex> */}
+          {state === "REJECTED" ? (
+            <Text variant="sm-display" mt={1} color="black60">
+              {stateHelpMessage} Find out more about our{" "}
+              <LinkText onPress={handleLinkPress} color="black60">
+                submission criteria
+              </LinkText>
+              .
+            </Text>
+          ) : (
+            <Text variant="sm-display" mt={1} color="black60">
+              {stateHelpMessage}
+            </Text>
+          )}
 
-      {(!!buttonLabel || !!isListed) && (
-        <Button mt={2} block haptic variant={buttonVariant} onPress={closeModal}>
-          {isListed ? "View Listing" : buttonLabel}
-        </Button>
-      )}
+          {(!!buttonLabel || !!isListed) && (
+            <Button
+              mt={2}
+              block
+              haptic
+              variant={buttonVariant}
+              onPress={() => {
+                /* TODO: add action */
+              }}
+            >
+              {isListed ? "View Listing" : buttonLabel}
+            </Button>
+          )}
+        </Flex>
+      </AutoHeightBottomSheet>
     </Flex>
   )
 }

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -15,15 +15,15 @@ export const ArtworkSubmissionStatusDescription: React.FC<
   ArtworkSubmissionStatusDescriptionProps
 > = ({ artworkData, closeModal, visible }) => {
   const {
-    consignmentSubmission: submissionData,
+    consignmentSubmission,
     isListed,
     submissionId,
     internalID: artworkInternalID,
   } = useFragment(fragment, artworkData)
 
-  if (!submissionData || !submissionId) return null
+  if (!consignmentSubmission || !submissionId) return null
 
-  const { stateLabel, actionLabel, stateHelpMessage, state, buttonLabel } = submissionData
+  const { stateLabel, actionLabel, stateHelpMessage, state, buttonLabel } = consignmentSubmission
 
   const buttonVariant = ["DRAFT", "APPROVED"].includes(state) ? "fillDark" : "outline"
 
@@ -81,7 +81,7 @@ export const ArtworkSubmissionStatusDescription: React.FC<
   }
 
   return (
-    <Flex p={2} testID="ArtworkSubmissionStatusDescription-Container">
+    <Flex testID="ArtworkSubmissionStatusDescription-Container">
       <AutoHeightBottomSheet onDismiss={closeModal} visible={visible}>
         <Flex mx={2} mb={2} mt={1}>
           <Text variant="sm-display">Submission Status</Text>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tests.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, waitFor } from "@testing-library/react-native"
+import { fireEvent, waitFor, screen } from "@testing-library/react-native"
 import { MyCollectionArtworkHeaderTestQuery } from "__generated__/MyCollectionArtworkHeaderTestQuery.graphql"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -17,55 +18,100 @@ describe("MyCollectionArtworkHeader", () => {
     `,
   })
 
-  it("renders without throwing an error", () => {
-    const { getByText } = renderWithRelay({
-      Artwork: () => ({
-        artistNames: "some artist name",
-        date: "Jan 20th",
-        image: {
-          url: "some/url",
-        },
-        title: "some title",
-      }),
+  describe("AREnableSubmitArtworkTier2Information feature flag is off", () => {
+    it("renders without throwing an error", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artistNames: "some artist name",
+          date: "Jan 20th",
+          image: {
+            url: "some/url",
+          },
+          title: "some title",
+        }),
+      })
+
+      expect(screen.getByText("some artist name")).toBeTruthy()
+      expect(screen.getByText("some title, Jan 20th")).toBeTruthy()
     })
 
-    expect(getByText("some artist name")).toBeTruthy()
-    expect(getByText("some title, Jan 20th")).toBeTruthy()
+    it("fires the analytics tracking event when image is pressed", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "someInternalId",
+          slug: "someSlug",
+        }),
+      })
+
+      const carouselImage = screen.getByLabelText("Image with Loading State")
+      fireEvent(carouselImage, "Press")
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action_name: "artworkImageZoom",
+        action_type: "tap",
+        context_module: "ArtworkImage",
+      })
+    })
+
+    it("shows fallback view when images are null", async () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artistNames: "names",
+          date: new Date().toISOString(),
+          figures: null,
+          internalID: "internal-id",
+          title: "a title",
+          slug: "some-slug",
+        }),
+      })
+
+      await waitFor(() => {
+        const fallbackView = screen.getByTestId("MyCollectionArtworkHeaderFallback")
+        expect(fallbackView).toBeDefined()
+      })
+    })
   })
 
-  it("fires the analytics tracking event when image is pressed", () => {
-    const { getByLabelText } = renderWithRelay({
-      Artwork: () => ({
-        internalID: "someInternalId",
-        slug: "someSlug",
-      }),
+  describe("AREnableSubmitArtworkTier2Information feature flag is on", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableSubmitArtworkTier2Information: true,
+      })
     })
 
-    const carouselImage = getByLabelText("Image with Loading State")
-    fireEvent(carouselImage, "Press")
-    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
-    expect(mockTrackEvent).toHaveBeenCalledWith({
-      action_name: "artworkImageZoom",
-      action_type: "tap",
-      context_module: "ArtworkImage",
-    })
-  })
-
-  it("shows fallback view when images are null", async () => {
-    const { getByTestId } = renderWithRelay({
-      Artwork: () => ({
-        artistNames: "names",
-        date: new Date().toISOString(),
-        figures: null,
-        internalID: "internal-id",
-        title: "a title",
-        slug: "some-slug",
-      }),
+    it("renders submission component when submission is not in REJECTED state", async () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artistNames: "names",
+          date: new Date().toISOString(),
+          figures: null,
+          internalID: "internal-id",
+          title: "a title",
+          slug: "some-slug",
+          consignmentSubmission: {
+            state: "APPROVED",
+          },
+        }),
+      })
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
     })
 
-    await waitFor(() => {
-      const fallbackView = getByTestId("MyCollectionArtworkHeaderFallback")
-      expect(fallbackView).toBeDefined()
+    it("does not render the submission component when submission is in REJECTED state", async () => {
+      renderWithRelay({
+        Artwork: () => ({
+          artistNames: "names",
+          date: new Date().toISOString(),
+          figures: null,
+          internalID: "internal-id",
+          title: "a title",
+          slug: "some-slug",
+          consignmentSubmission: {
+            state: "REJECTED",
+          },
+        }),
+      })
+
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
     })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -4,6 +4,7 @@ import { MyCollectionArtworkHeader_artwork$key } from "__generated__/MyCollectio
 import { ImageCarouselFragmentContainer } from "app/Scenes/Artwork/Components/ImageCarousel/ImageCarousel"
 import { navigate } from "app/system/navigation/navigate"
 import { useScreenDimensions } from "app/utils/hooks"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { TouchableOpacity } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -16,6 +17,9 @@ interface MyCollectionArtworkHeaderProps {
 }
 
 export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps> = (props) => {
+  const enableSubmitArtworkTier2Information = useFeatureFlag(
+    "AREnableSubmitArtworkTier2Information"
+  )
   const artwork = useFragment(myCollectionArtworkHeaderFragment, props.artwork)
   const { artistNames, date, internalID, title, slug, consignmentSubmission } = artwork
 
@@ -28,6 +32,13 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
   const hasImages = artwork?.figures?.length > 0
   const displaySubmissionStateSection =
     consignmentSubmission?.state && consignmentSubmission?.state !== "DRAFT"
+
+  const displaySubmissionStateSectionTier2 =
+    consignmentSubmission?.state && consignmentSubmission?.state !== "REJECTED" // TODO: Add more states to aviod displaying submissions in unsupprted statusess
+
+  const displaySubmissionStateSectionInHeader = enableSubmitArtworkTier2Information
+    ? displaySubmissionStateSectionTier2
+    : displaySubmissionStateSection
 
   return (
     <Join separator={<Spacer y={2} />}>
@@ -73,7 +84,7 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
         </Text>
       </Flex>
 
-      {!!displaySubmissionStateSection && (
+      {!!displaySubmissionStateSectionInHeader && (
         <Flex px={2}>
           <MyCollectionArtworkSubmissionStatus artwork={artwork} />
         </Flex>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkHeader.tsx
@@ -30,15 +30,10 @@ export const MyCollectionArtworkHeader: React.FC<MyCollectionArtworkHeaderProps>
   const { trackEvent } = useTracking()
 
   const hasImages = artwork?.figures?.length > 0
-  const displaySubmissionStateSection =
-    consignmentSubmission?.state && consignmentSubmission?.state !== "DRAFT"
-
-  const displaySubmissionStateSectionTier2 =
-    consignmentSubmission?.state && consignmentSubmission?.state !== "REJECTED" // TODO: Add more states to aviod displaying submissions in unsupprted statusess
 
   const displaySubmissionStateSectionInHeader = enableSubmitArtworkTier2Information
-    ? displaySubmissionStateSectionTier2
-    : displaySubmissionStateSection
+    ? consignmentSubmission?.state && consignmentSubmission?.state !== "REJECTED"
+    : consignmentSubmission?.state && consignmentSubmission?.state !== "DRAFT"
 
   return (
     <Join separator={<Spacer y={2} />}>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
@@ -99,24 +99,23 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
       })
 
       expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
-      expect(screen.getByText("Complete Submission")).toBeDefined()
+      // using queryAllByText here and in the following tests because two components are rendedred:
+      // MyCollectionArtworkSubmissionStatus and ArtworkSubmissionStatusDescription
+      expect(screen.queryAllByText("Complete Submission")).toHaveLength(2)
     })
 
     it("displays submission status in LISTED state when the feature is live", () => {
-      __globalStoreTestUtils__?.injectFeatureFlags({
-        AREnableSubmitArtworkTier2Information: true,
-      })
-
       renderWithRelay({
         Artwork: () => {
           return {
             isListed: true,
+            internalID: "artwork-id",
           }
         },
       })
 
       expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
-      expect(screen.getByText("Listed")).toBeDefined()
+      expect(screen.queryAllByText("Listed")).toHaveLength(2)
     })
 
     it("display Submission status in REJECTED state ", () => {
@@ -131,8 +130,8 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
         },
       })
 
-      expect(screen.getByText("Submission Status")).toBeDefined()
-      expect(screen.getByText("Submission Unsuccessful")).toBeDefined()
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
+      expect(screen.queryAllByText("Submission Unsuccessful")).toHaveLength(2)
     })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -1,4 +1,11 @@
-import { Flex, Box, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
+import {
+  Flex,
+  Box,
+  Text,
+  Touchable,
+  useScreenDimensions,
+  ArrowRightIcon,
+} from "@artsy/palette-mobile"
 import { MyCollectionArtworkSubmissionStatus_submissionState$key } from "__generated__/MyCollectionArtworkSubmissionStatus_submissionState.graphql"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
@@ -82,10 +89,11 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
 
             {!!consignmentSubmission?.actionLabel && (
               <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
-                <Flex flexDirection="row" alignItems="center">
+                <Flex flexDirection="row" alignItems="center" alignContent="center">
                   <Text variant="sm-display" fontWeight="bold" color="orange100">
-                    {consignmentSubmission?.actionLabel}
+                    {consignmentSubmission?.actionLabel}&nbsp;
                   </Text>
+                  <ArrowRightIcon fill="orange100" height={16} width={16} />
                 </Flex>
               </Touchable>
             )}

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -1,10 +1,9 @@
-import { Flex, Box, Text, Touchable, Button, Spacer } from "@artsy/palette-mobile"
+import { Flex, Box, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { MyCollectionArtworkSubmissionStatus_submissionState$key } from "__generated__/MyCollectionArtworkSubmissionStatus_submissionState.graphql"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { ArtworkSubmissionStatusFAQ } from "app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ"
-import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
-import { navigate } from "app/system/navigation/navigate"
+import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState } from "react"
 import { useFragment, graphql } from "react-relay"
@@ -23,12 +22,19 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
     "AREnableSubmitArtworkTier2Information"
   )
 
-  const { consignmentSubmission, submissionId } = useFragment(submissionStateFragment, artwork)
-  if (!consignmentSubmission) return null
+  const { height: screenHeight } = useScreenDimensions()
+
+  const { consignmentSubmission, submissionId, isListed } = useFragment(
+    submissionStateFragment,
+    artwork
+  )
+  const artworkData = useFragment(submissionStateFragment, artwork)
+
+  if (!consignmentSubmission || !submissionId) return null
 
   const { state, stateLabel } = consignmentSubmission
   if (!state) return null
-  if (state === "DRAFT") return null
+  if (state === "DRAFT" && !enableSubmitArtworkTier2Information) return null
 
   let stateLabelColor = "yellow150"
   if (["APPROVED", "REJECTED", "CLOSED", "PUBLISHED"].includes(state)) stateLabelColor = "orange150"
@@ -36,53 +42,80 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
   return (
     <Box testID="MyCollectionArtworkSubmissionStatus-Container">
       <Flex>
-        <FancyModal fullScreen visible={isSubmissionStatusModalVisible}>
-          <FancyModalHeader
-            onLeftButtonPress={() => setIsSubmissionStatusModalVisible(false)}
-            hideBottomDivider
-          ></FancyModalHeader>
-          <ArtworkSubmissionStatusFAQ closeModal={() => setIsSubmissionStatusModalVisible(false)} />
-        </FancyModal>
-
-        <Flex justifyContent="space-between" flexDirection="row">
-          <Text variant="xs" color="black100">
-            Submission Status
-          </Text>
-          <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
-            <Text style={{ textDecorationLine: "underline" }} variant="xs" color="black60">
-              What's this?
-            </Text>
-          </Touchable>
-        </Flex>
-        <Text lineHeight="16px" mt={1} color={stateLabelColor}>
-          {stateLabel}
-        </Text>
-        {!!enableSubmitArtworkTier2Information && !!submissionId && state === "APPROVED" && (
-          <Flex mt={1}>
-            <Text variant="xs" color="black60">
-              Congratulations, your submission has been approved. Please provide additional
-              information so we can accurately price your work and list it on the Artsy platform.
-            </Text>
-
-            <Spacer y={2} />
-            <Button
-              onPress={() => {
-                const passProps: SubmitArtworkProps = {
-                  initialStep: "AddTitle",
-                  hasStartedFlowFromMyCollection: true,
-                  initialValues: {},
-                }
-
-                navigate(`/sell/submissions/${submissionId}/edit`, {
-                  passProps,
-                })
-              }}
-              variant="fillSuccess"
-              block
+        {enableSubmitArtworkTier2Information ? (
+          <>
+            <FancyModal
+              visible={isSubmissionStatusModalVisible}
+              maxHeight={screenHeight / 2}
+              onBackgroundPressed={() => setIsSubmissionStatusModalVisible(false)}
             >
-              Add Additional Information
-            </Button>
-          </Flex>
+              <FancyModalHeader
+                useXButton
+                onRightButtonPress={() => setIsSubmissionStatusModalVisible(false)}
+                rightCloseButton
+              >
+                Submission Status
+              </FancyModalHeader>
+
+              <ArtworkSubmissionStatusDescription
+                artworkData={artworkData}
+                closeModal={() => setIsSubmissionStatusModalVisible(false)}
+              />
+            </FancyModal>
+
+            <Flex justifyContent="space-between" flexDirection="row">
+              <Text variant="xs" color="black100">
+                Submission Status
+              </Text>
+              <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
+                <Text style={{ textDecorationLine: "underline" }} variant="xs" color="black60">
+                  What's this?
+                </Text>
+              </Touchable>
+            </Flex>
+
+            <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
+              <Text mt={0.5} variant="sm-display" color={consignmentSubmission.stateLabelColor}>
+                {isListed ? "Listed" : stateLabel}
+              </Text>
+            </Touchable>
+
+            {!!consignmentSubmission?.actionLabel && (
+              <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
+                <Flex flexDirection="row" alignItems="center">
+                  <Text variant="sm-display" fontWeight="bold" color="orange100">
+                    {consignmentSubmission?.actionLabel}
+                  </Text>
+                </Flex>
+              </Touchable>
+            )}
+          </>
+        ) : (
+          <>
+            <FancyModal fullScreen visible={isSubmissionStatusModalVisible}>
+              <FancyModalHeader
+                onLeftButtonPress={() => setIsSubmissionStatusModalVisible(false)}
+                hideBottomDivider
+              />
+              <ArtworkSubmissionStatusFAQ
+                closeModal={() => setIsSubmissionStatusModalVisible(false)}
+              />
+            </FancyModal>
+
+            <Flex justifyContent="space-between" flexDirection="row">
+              <Text variant="xs" color="black100">
+                Submission Status
+              </Text>
+              <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
+                <Text style={{ textDecorationLine: "underline" }} variant="xs" color="black60">
+                  What's this?
+                </Text>
+              </Touchable>
+            </Flex>
+            <Text lineHeight="16px" mt={1} color={stateLabelColor}>
+              {stateLabel}
+            </Text>
+          </>
         )}
       </Flex>
     </Box>
@@ -94,7 +127,46 @@ const submissionStateFragment = graphql`
     consignmentSubmission {
       state
       stateLabel
+      actionLabel
+      stateLabelColor
     }
     submissionId
+    isListed
+    ...ArtworkSubmissionStatusDescription_artwork
   }
 `
+
+/*
+                 <AutoHeightBottomSheet
+          visible={isSubmissionStatusModalVisible}
+          onDismiss={() => setIsSubmissionStatusModalVisible(false)}
+        >
+          <Flex mx={2} mb={2} mt={1}>
+            <Text variant="sm-display" textAlign="center">
+              Submission Status
+            </Text>
+
+            <Text variant="md" mt={2} color={consignmentSubmission.stateLabelColor}>
+              {isListed ? "Listed" : stateLabel}
+            </Text>
+            {!!consignmentSubmission?.actionLabel && (
+              <Text variant="md" color="orange100">
+                {consignmentSubmission?.actionLabel}
+              </Text>
+            )}
+            <Text variant="sm-display" mt={1} color="black60">
+              {consignmentSubmission.stateHelpMessage}
+            </Text>
+
+            <Button
+              mt={2}
+              block
+              haptic
+              variant={buttonVariant}
+              onPress={() => setIsSubmissionStatusModalVisible(false)}
+            >
+              {isListed ? "View Listing" : consignmentSubmission.buttonLabel}
+            </Button>
+          </Flex>
+        </AutoHeightBottomSheet>
+        */

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -30,9 +30,10 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
 
   if (!consignmentSubmission || !submissionId) return null
 
-  const { state, stateLabel } = consignmentSubmission
+  const { state, stateLabel, actionLabel } = consignmentSubmission
 
   if (!state) return null
+  if (!stateLabel && !actionLabel) return null
   if (state === "DRAFT" && !enableSubmitArtworkTier2Information) return null
 
   let stateLabelColor = "yellow150"
@@ -60,17 +61,19 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
               </Touchable>
             </Flex>
 
-            <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
-              <Text mt={0.5} variant="sm-display" color={consignmentSubmission.stateLabelColor}>
-                {isListed ? "Listed" : stateLabel}
-              </Text>
-            </Touchable>
+            {!!stateLabel && (
+              <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
+                <Text mt={0.5} variant="sm-display" color={consignmentSubmission.stateLabelColor}>
+                  {isListed ? "Listed" : stateLabel}
+                </Text>
+              </Touchable>
+            )}
 
-            {!!consignmentSubmission?.actionLabel && (
+            {!!actionLabel && (
               <Touchable onPress={() => setIsSubmissionStatusModalVisible(true)}>
                 <Flex flexDirection="row" alignItems="center" alignContent="center">
                   <Text variant="sm-display" fontWeight="bold" color="orange100">
-                    {consignmentSubmission?.actionLabel}&nbsp;
+                    {actionLabel}&nbsp;
                   </Text>
                   <ArrowRightIcon fill="orange100" height={16} width={16} />
                 </Flex>

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -31,6 +31,7 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
   if (!consignmentSubmission || !submissionId) return null
 
   const { state, stateLabel } = consignmentSubmission
+
   if (!state) return null
   if (state === "DRAFT" && !enableSubmitArtworkTier2Information) return null
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -1,11 +1,4 @@
-import {
-  Flex,
-  Box,
-  Text,
-  Touchable,
-  useScreenDimensions,
-  ArrowRightIcon,
-} from "@artsy/palette-mobile"
+import { Flex, Box, Text, Touchable, ArrowRightIcon } from "@artsy/palette-mobile"
 import { MyCollectionArtworkSubmissionStatus_submissionState$key } from "__generated__/MyCollectionArtworkSubmissionStatus_submissionState.graphql"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
@@ -29,8 +22,6 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
     "AREnableSubmitArtworkTier2Information"
   )
 
-  const { height: screenHeight } = useScreenDimensions()
-
   const { consignmentSubmission, submissionId, isListed } = useFragment(
     submissionStateFragment,
     artwork
@@ -51,24 +42,11 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
       <Flex>
         {enableSubmitArtworkTier2Information ? (
           <>
-            <FancyModal
+            <ArtworkSubmissionStatusDescription
               visible={isSubmissionStatusModalVisible}
-              maxHeight={screenHeight / 2}
-              onBackgroundPressed={() => setIsSubmissionStatusModalVisible(false)}
-            >
-              <FancyModalHeader
-                useXButton
-                onRightButtonPress={() => setIsSubmissionStatusModalVisible(false)}
-                rightCloseButton
-              >
-                Submission Status
-              </FancyModalHeader>
-
-              <ArtworkSubmissionStatusDescription
-                artworkData={artworkData}
-                closeModal={() => setIsSubmissionStatusModalVisible(false)}
-              />
-            </FancyModal>
+              artworkData={artworkData}
+              closeModal={() => setIsSubmissionStatusModalVisible(false)}
+            />
 
             <Flex justifyContent="space-between" flexDirection="row">
               <Text variant="xs" color="black100">
@@ -143,38 +121,3 @@ const submissionStateFragment = graphql`
     ...ArtworkSubmissionStatusDescription_artwork
   }
 `
-
-/*
-                 <AutoHeightBottomSheet
-          visible={isSubmissionStatusModalVisible}
-          onDismiss={() => setIsSubmissionStatusModalVisible(false)}
-        >
-          <Flex mx={2} mb={2} mt={1}>
-            <Text variant="sm-display" textAlign="center">
-              Submission Status
-            </Text>
-
-            <Text variant="md" mt={2} color={consignmentSubmission.stateLabelColor}>
-              {isListed ? "Listed" : stateLabel}
-            </Text>
-            {!!consignmentSubmission?.actionLabel && (
-              <Text variant="md" color="orange100">
-                {consignmentSubmission?.actionLabel}
-              </Text>
-            )}
-            <Text variant="sm-display" mt={1} color="black60">
-              {consignmentSubmission.stateHelpMessage}
-            </Text>
-
-            <Button
-              mt={2}
-              block
-              haptic
-              variant={buttonVariant}
-              onPress={() => setIsSubmissionStatusModalVisible(false)}
-            >
-              {isListed ? "View Listing" : consignmentSubmission.buttonLabel}
-            </Button>
-          </Flex>
-        </AutoHeightBottomSheet>
-        */

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -1,8 +1,10 @@
-import { Flex } from "@artsy/palette-mobile"
+import { Flex, Separator } from "@artsy/palette-mobile"
 import { MyCollectionArtworkInsights_artwork$key } from "__generated__/MyCollectionArtworkInsights_artwork.graphql"
 import { MyCollectionArtworkInsights_marketPriceInsights$key } from "__generated__/MyCollectionArtworkInsights_marketPriceInsights.graphql"
 import { MyCollectionArtworkInsights_me$key } from "__generated__/MyCollectionArtworkInsights_me.graphql"
 import { PriceEstimateRequested } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkInsights/RequestForPriceEstimate/PriceEstimateRequested"
+import { MyCollectionArtworkSubmissionStatus } from "app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
 import { MyCollectionArtworkArtistAuctionResults } from "./Components/ArtworkInsights/MyCollectionArtworkArtistAuctionResults"
 import { MyCollectionArtworkArtistMarket } from "./Components/ArtworkInsights/MyCollectionArtworkArtistMarket"
@@ -20,6 +22,10 @@ interface MyCollectionArtworkInsightsProps {
 export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsProps> = ({
   ...restProps
 }) => {
+  const enableSubmitArtworkTier2Information = useFeatureFlag(
+    "AREnableSubmitArtworkTier2Information"
+  )
+
   const artwork = useFragment(artworkFragment, restProps.artwork)
 
   const marketPriceInsights = useFragment(
@@ -29,6 +35,8 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
 
   const me = useFragment(meFragment, restProps.me)
 
+  const isSubmissionRejected = artwork?.consignmentSubmission?.state === "REJECTED"
+
   return (
     <Flex mt={2} px={2}>
       {!!artwork.marketPriceInsights && (
@@ -37,6 +45,15 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
             artwork={artwork}
             marketPriceInsights={artwork.marketPriceInsights}
           />
+        </>
+      )}
+
+      {!!enableSubmitArtworkTier2Information && !!isSubmissionRejected && (
+        <>
+          <Flex>
+            <MyCollectionArtworkSubmissionStatus artwork={artwork} />
+          </Flex>
+          <Separator my={4} borderColor="black10" />
         </>
       )}
 
@@ -86,6 +103,10 @@ const artworkFragment = graphql`
       ...MyCollectionArtworkArtistMarket_artworkPriceInsights
       ...MyCollectionArtworkDemandIndex_artworkPriceInsights
     }
+    consignmentSubmission {
+      state
+    }
+    ...MyCollectionArtworkSubmissionStatus_submissionState
   }
 `
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtworkInsights.tsx
@@ -50,9 +50,7 @@ export const MyCollectionArtworkInsights: React.FC<MyCollectionArtworkInsightsPr
 
       {!!enableSubmitArtworkTier2Information && !!isSubmissionRejected && (
         <>
-          <Flex>
-            <MyCollectionArtworkSubmissionStatus artwork={artwork} />
-          </Flex>
+          <MyCollectionArtworkSubmissionStatus artwork={artwork} />
           <Separator my={4} borderColor="black10" />
         </>
       )}

--- a/src/app/Scenes/MyCollection/mutations/myCollectionUpdateArtwork.ts
+++ b/src/app/Scenes/MyCollection/mutations/myCollectionUpdateArtwork.ts
@@ -14,7 +14,6 @@ export function myCollectionUpdateArtwork(
               ... on MyCollectionArtworkMutationSuccess {
                 artwork {
                   ...MyCollectionArtwork_sharedProps @relay(mask: false)
-                  ...MyCollectionArtwork_sharedProps @relay(mask: false)
                 }
               }
               ... on MyCollectionArtworkMutationFailure {

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkCondition.tsx
@@ -108,7 +108,6 @@ export const SubmitArtworkCondition = () => {
             <Input
               testID="ConditionInput"
               title="Add Additional Condition Details"
-              optional
               defaultValue={values.artwork.conditionDescription || ""}
               multiline
               onChangeText={handleChange("artwork.conditionDescription")}


### PR DESCRIPTION
This PR resolves [ONYX-1127] <!-- eg [] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
The changes are hidden behind `AREnableSubmitArtworkTier2Information` ff
Add submission statuses to the MyCollection artwork screen
[Figma](https://www.figma.com/design/E6rVm1tiSI4PW3EzibKKZw/Submission-%26-Pre-Consignment-Management?node-id=3128-39743&m=dev)

| Rejected | Submitted | Listed | Approved | 
| --- | --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/692d23f3-73cb-449d-934b-964a5794eacb) | ![image](https://github.com/user-attachments/assets/6619e7f7-889c-4e81-9c8b-f3b4497f3db6) | ![image](https://github.com/user-attachments/assets/0494b4a7-a149-4a14-8e9b-8c1583804c88) | ![image](https://github.com/user-attachments/assets/0bef7ce9-dc8f-4f93-80de-ea5bdba6ff8b) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add submission statuses to the MyC artwork screen (behind AREnableSubmitArtworkTier2Information ff) -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1127]: https://artsyproduct.atlassian.net/browse/ONYX-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ