### PR TITLE
feat(DIA-763): Move complete my profile lazyLoadQuery to fragment

### DIFF
--- a/src/app/Scenes/CompleteMyProfile/CompleteMyProfile.tsx
+++ b/src/app/Scenes/CompleteMyProfile/CompleteMyProfile.tsx
@@ -1,5 +1,6 @@
 import { NavigationContainer, NavigationProp } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
+import { useCompleteMyProfileSteps_me$key } from "__generated__/useCompleteMyProfileSteps_me.graphql"
 import { AvatarStep } from "app/Scenes/CompleteMyProfile/AvatarStep"
 import { ChangesSummary } from "app/Scenes/CompleteMyProfile/ChangesSummary"
 import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
@@ -77,9 +78,9 @@ const CompleteMyProfileNavigator: FC = () => {
   )
 }
 
-export const CompleteMyProfile = () => {
+export const CompleteMyProfile: FC<{ meKey: useCompleteMyProfileSteps_me$key }> = ({ meKey }) => {
   return (
-    <CompleteMyProfileStore.Provider>
+    <CompleteMyProfileStore.Provider runtimeModel={{ meKey }}>
       <CompleteMyProfileNavigator />
     </CompleteMyProfileStore.Provider>
   )

--- a/src/app/Scenes/CompleteMyProfile/CompleteMyProfile.tsx
+++ b/src/app/Scenes/CompleteMyProfile/CompleteMyProfile.tsx
@@ -78,7 +78,11 @@ const CompleteMyProfileNavigator: FC = () => {
   )
 }
 
-export const CompleteMyProfile: FC<{ meKey: useCompleteMyProfileSteps_me$key }> = ({ meKey }) => {
+interface CompleteMyProfileProps {
+  meKey: useCompleteMyProfileSteps_me$key
+}
+
+export const CompleteMyProfile: FC<CompleteMyProfileProps> = ({ meKey }) => {
   return (
     <CompleteMyProfileStore.Provider runtimeModel={{ meKey }}>
       <CompleteMyProfileNavigator />

--- a/src/app/Scenes/CompleteMyProfile/CompleteMyProfileProvider.tsx
+++ b/src/app/Scenes/CompleteMyProfile/CompleteMyProfileProvider.tsx
@@ -1,3 +1,4 @@
+import { useCompleteMyProfileSteps_me$key } from "__generated__/useCompleteMyProfileSteps_me.graphql"
 import { Routes } from "app/Scenes/CompleteMyProfile/CompleteMyProfile"
 import { StepsResult } from "app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps"
 import { LocationWithDetails } from "app/utils/googleMaps"
@@ -20,6 +21,7 @@ export const ROUTE_ACTION_TYPES: Record<Exclude<Routes, "ChangesSummary">, keyof
 }
 
 export interface CompleteMyProfileStoreModel {
+  meKey: useCompleteMyProfileSteps_me$key | null
   steps: StepsResult
   progressState: ProgressState
   isLoading: boolean
@@ -31,6 +33,7 @@ export interface CompleteMyProfileStoreModel {
 
 export const model: CompleteMyProfileStoreModel = {
   steps: "loading",
+  meKey: null,
   isLoading: false,
   progressState: {},
   setSteps: action((state, steps) => {
@@ -49,4 +52,9 @@ export const model: CompleteMyProfileStoreModel = {
   }),
 }
 
-export const CompleteMyProfileStore = createContextStore(model)
+export const CompleteMyProfileStore = createContextStore((runtimeModel) => {
+  return {
+    ...model,
+    ...runtimeModel,
+  }
+})

--- a/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteMyProfileSteps.tests.tsx
+++ b/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteMyProfileSteps.tests.tsx
@@ -1,6 +1,8 @@
 import { renderHook } from "@testing-library/react-hooks"
+import { useCompleteMyProfileStepsTestQuery } from "__generated__/useCompleteMyProfileStepsTestQuery.graphql"
+import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { useCompleteMyProfileSteps } from "app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps"
-import { RelayEnvironmentProvider } from "react-relay/hooks"
+import { graphql, RelayEnvironmentProvider, useLazyLoadQuery } from "react-relay"
 import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
 
 const env = createMockEnvironment()
@@ -10,7 +12,7 @@ describe("useCompleteMyProfileSteps", () => {
     env.mockClear()
   })
 
-  it("returns the next route and steps", async () => {
+  it("returns the next route and steps", () => {
     env.mock.queueOperationResolver((operation) =>
       MockPayloadGenerator.generate(operation, {
         Me: () => ({
@@ -54,5 +56,26 @@ describe("useCompleteMyProfileSteps", () => {
 })
 
 const wrapper = ({ children }: any) => (
-  <RelayEnvironmentProvider environment={env}>{children}</RelayEnvironmentProvider>
+  <RelayEnvironmentProvider environment={env}>
+    <StoreWrapper>{children}</StoreWrapper>
+  </RelayEnvironmentProvider>
 )
+
+const StoreWrapper = ({ children }: any) => {
+  const data = useLazyLoadQuery<useCompleteMyProfileStepsTestQuery>(
+    graphql`
+      query useCompleteMyProfileStepsTestQuery {
+        me @required(action: NONE) {
+          ...useCompleteMyProfileSteps_me
+        }
+      }
+    `,
+    {}
+  )
+
+  return (
+    <CompleteMyProfileStore.Provider runtimeModel={{ meKey: data?.me }}>
+      {children}
+    </CompleteMyProfileStore.Provider>
+  )
+}

--- a/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteProfile.tests.tsx
+++ b/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteProfile.tests.tsx
@@ -1,18 +1,17 @@
-// useCompleteProfile.test.js
 import { useNavigation, useRoute } from "@react-navigation/native"
 import { renderHook, act } from "@testing-library/react-hooks"
 import { useToast } from "app/Components/Toast/toastHook"
 import { CompleteMyProfileStore } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { useCompleteProfile } from "app/Scenes/CompleteMyProfile/hooks/useCompleteProfile"
-import { useUpdateMyProfile } from "app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile"
 import { navigate as artsyNavigate } from "app/system/navigation/navigate"
+import { useUpdateMyProfile } from "app/utils/mutations/useUpdateMyProfile"
 
 jest.mock("@react-navigation/native", () => ({
   useNavigation: jest.fn(),
   useRoute: jest.fn(),
 }))
 
-jest.mock("app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile", () => ({
+jest.mock("app/utils/mutations/useUpdateMyProfile", () => ({
   useUpdateMyProfile: jest.fn(),
 }))
 
@@ -67,7 +66,7 @@ describe("useCompleteProfile", () => {
 
   it("should not navigate to next route if loading", () => {
     jest
-      .spyOn(require("app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile"), "useUpdateMyProfile")
+      .spyOn(require("app/utils/mutations/useUpdateMyProfile"), "useUpdateMyProfile")
       .mockReturnValue([jest.fn(), true])
     jest
       .spyOn(CompleteMyProfileStore, "useStoreState")
@@ -182,7 +181,7 @@ describe("useCompleteProfile", () => {
       onError(new Error("Test error"))
     })
     jest
-      .spyOn(require("app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile"), "useUpdateMyProfile")
+      .spyOn(require("app/utils/mutations/useUpdateMyProfile"), "useUpdateMyProfile")
       .mockReturnValue([updateProfileMock, false])
 
     const { result } = renderHook(() => useCompleteProfile())

--- a/src/app/Scenes/CompleteMyProfile/hooks/useCompleteProfile.ts
+++ b/src/app/Scenes/CompleteMyProfile/hooks/useCompleteProfile.ts
@@ -11,8 +11,8 @@ import {
   CompleteMyProfileStore,
 } from "app/Scenes/CompleteMyProfile/CompleteMyProfileProvider"
 import { getNextRoute } from "app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps"
-import { useUpdateMyProfile } from "app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile"
 import { navigate as artsyNavigate } from "app/system/navigation/navigate"
+import { useUpdateMyProfile } from "app/utils/mutations/useUpdateMyProfile"
 import { useMemo } from "react"
 
 // Hook responsible for navigating between the steps of the profile completion process
@@ -75,13 +75,11 @@ export const useCompleteProfile = () => {
     }
 
     updateProfile({
-      variables: {
-        input,
-      },
+      variables: { input },
       onCompleted: (_, errors) => {
         if (errors) {
           show("An error occurred", "bottom")
-          console.log("error", errors)
+          console.error("error", errors)
           setIsLoading(false)
           return
         }
@@ -100,7 +98,7 @@ export const useCompleteProfile = () => {
       },
       onError: (error) => {
         show("An error occurred", "bottom")
-        console.log("error", error)
+        console.error("error", error)
         setIsLoading(false)
       },
     })

--- a/src/app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile.tsx
+++ b/src/app/Scenes/CompleteMyProfile/hooks/useUpdateMyProfile.tsx
@@ -8,6 +8,7 @@ const mutation = graphql`
   mutation useUpdateMyProfileMutation($input: UpdateMyProfileInput!) @raw_response_type {
     updateMyUserProfile(input: $input) {
       me @required(action: NONE) {
+        ...useCompleteMyProfileSteps_me
         ...MyProfileHeader_me
         ...MyProfileEditModal_me
         ...MyProfileEditForm_me

--- a/src/app/Scenes/MyProfile/MyProfile.tsx
+++ b/src/app/Scenes/MyProfile/MyProfile.tsx
@@ -3,30 +3,27 @@ import { createStackNavigator } from "@react-navigation/stack"
 import { MyCollectionArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
 import { MyProfileEditFormScreen } from "./MyProfileEditForm"
 import { MyProfileHeaderMyCollectionAndSavedWorksQueryRenderer } from "./MyProfileHeaderMyCollectionAndSavedWorks"
-import { MyProfileProvider } from "./MyProfileProvider"
 
 const Stack = createStackNavigator()
 
 export const MyProfile = () => {
   return (
-    <MyProfileProvider>
-      <NavigationContainer independent>
-        <Stack.Navigator
-          // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
-          detachInactiveScreens={false}
-          screenOptions={{
-            headerShown: false,
-            cardStyle: { backgroundColor: "white" },
-          }}
-        >
-          <Stack.Screen
-            name="MyProfileHeaderMyCollectionAndSavedWorks"
-            component={MyProfileHeaderMyCollectionAndSavedWorksQueryRenderer}
-          />
-          <Stack.Screen name="MyCollectionArtworkForm" component={MyCollectionArtworkForm} />
-          <Stack.Screen name="MyProfileEditForm" component={MyProfileEditFormScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </MyProfileProvider>
+    <NavigationContainer independent>
+      <Stack.Navigator
+        // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
+        detachInactiveScreens={false}
+        screenOptions={{
+          headerShown: false,
+          cardStyle: { backgroundColor: "white" },
+        }}
+      >
+        <Stack.Screen
+          name="MyProfileHeaderMyCollectionAndSavedWorks"
+          component={MyProfileHeaderMyCollectionAndSavedWorksQueryRenderer}
+        />
+        <Stack.Screen name="MyCollectionArtworkForm" component={MyCollectionArtworkForm} />
+        <Stack.Screen name="MyProfileEditForm" component={MyProfileEditFormScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
   )
 }

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -242,7 +242,7 @@ export const MyProfileHeader: React.FC<MyProfileHeaderProps> = ({ meProp }) => {
                 size="small"
                 onPress={() => {
                   tracks.tappedCompleteMyProfile({ id: me.internalID })
-                  navigate("/complete-my-profile")
+                  navigate("/complete-my-profile", { passProps: { meKey: me } })
                 }}
               >
                 Complete My Profile
@@ -389,6 +389,8 @@ const MyProfileHeaderPlaceholder: React.FC<{}> = () => {
 
 const myProfileHeaderFragment = graphql`
   fragment MyProfileHeader_me on Me {
+    ...useCompleteMyProfileSteps_me
+
     internalID
     name
     bio

--- a/src/app/Scenes/MyProfile/hooks/useEditProfile.ts
+++ b/src/app/Scenes/MyProfile/hooks/useEditProfile.ts
@@ -1,0 +1,54 @@
+import { updateMyUserProfileMutation$variables } from "__generated__/updateMyUserProfileMutation.graphql"
+import { useUpdateMyProfile } from "app/utils/mutations/useUpdateMyProfile"
+import { useState } from "react"
+
+export const useEditProfile = () => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [commit, isMutationLoading] = useUpdateMyProfile()
+
+  const updateProfile = async (
+    input: updateMyUserProfileMutation$variables["input"],
+    iconLocalPath?: string
+  ) => {
+    commit({
+      variables: { input },
+
+      updater: (store) => {
+        if (iconLocalPath) {
+          store
+            .getRoot()
+            ?.getLinkedRecord("me")
+            ?.getOrCreateLinkedRecord("icon", "Image")
+            ?.setValue(iconLocalPath, `url(version:"thumbnail")`)
+        }
+      },
+      onError: (e) => {
+        try {
+          const message = JSON.parse(JSON.stringify(e))?.res?.json?.errors?.[0]?.message ?? ""
+          // should be like "https://api.artsy.net/api/v1/me?email=david@artsymail.com - {"error": "User-facing error message"}"
+          if (typeof message === "string") {
+            const jsonString = message.match(/http.* (\{.*)$/)?.[1]
+            if (jsonString) {
+              const json = JSON.parse(jsonString)
+              if (typeof json?.error === "string") {
+                console.error(ERROR_MESSAGE, json.error)
+                return
+              }
+              if (typeof json?.message === "string") {
+                console.error(ERROR_MESSAGE, json.message)
+                return
+              }
+            }
+          }
+        } catch (e) {
+          console.error(ERROR_MESSAGE, e)
+        }
+        console.error(ERROR_MESSAGE, e)
+      },
+    })
+  }
+
+  return { updateProfile, isLoading: isLoading || isMutationLoading, setIsLoading }
+}
+
+const ERROR_MESSAGE = "[useEditProfile updateProfile] error:"

--- a/src/app/utils/mutations/useUpdateMyProfile.tsx
+++ b/src/app/utils/mutations/useUpdateMyProfile.tsx
@@ -1,7 +1,8 @@
+import { updateMyUserProfileMutation } from "__generated__/updateMyUserProfileMutation.graphql"
 import { graphql, useMutation } from "react-relay"
 
 export const useUpdateMyProfile = () => {
-  return useMutation(mutation)
+  return useMutation<updateMyUserProfileMutation>(mutation)
 }
 
 const mutation = graphql`


### PR DESCRIPTION
This PR resolves [DIA-763] <!-- eg [PROJECT-XXXX] -->

### Description

This PR changes the Complete My Profile query into a fragment resulting in a more solid flow between the Edit form when changing the data.
This work also removes the localStorage approach with the avatar and the context around MyProfile in favor of the relay store manipulation

LazyLoad to Fragment change: 178d57b47987f8e1bbfc6800f3268aa6d2294de7
Avatar removed from local storage and manipulated directly on Relay store: c35f4bb78c01090c139d4473e33774474a6b36bd
Tests refactor: 6ed96c1a5414d551a9720295fbc6151997d1329f

https://github.com/user-attachments/assets/96f7585d-bff7-4b39-bf18-a0cef0b393bc


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: complete my profile query changed to fragment - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-763]: https://artsyproduct.atlassian.net/browse/DIA-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ