### PR TITLE
feat(DIA-764): navigate back instead of popping the navigation stack from add artist to my collection

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tests.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { AutosuggestResultsQuery } from "__generated__/AutosuggestResultsQuery.graphql"
 import { MyCollectionAddCollectedArtistsScreen } from "app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists"
-import { dismissModal, navigate, popToRoot } from "app/system/navigation/navigate"
+import { dismissModal, navigate, goBack } from "app/system/navigation/navigate"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -14,7 +14,7 @@ describe("MyCollectionAddCollectedArtists", () => {
   it("renders MyCollectionAddCollectedArtists", async () => {
     renderWithRelay()
 
-    expect(screen.queryByText("Add Artists You Collect")).toBeOnTheScreen()
+    expect(screen.getByText("Add Artists You Collect")).toBeOnTheScreen()
   })
 
   it("adds collected artists by creating user interests", async () => {
@@ -58,7 +58,7 @@ describe("MyCollectionAddCollectedArtists", () => {
     await flushPromiseQueue()
 
     expect(dismissModal).toHaveBeenCalledWith()
-    expect(popToRoot).toHaveBeenCalledWith()
+    expect(goBack).toHaveBeenCalledWith()
   })
 
   it("creates custom artists", async () => {

--- a/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tsx
+++ b/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tsx
@@ -11,7 +11,7 @@ import { MyCollectionAddCollectedArtistsAutosuggest } from "app/Scenes/MyCollect
 import { MyCollectionAddCollectedArtistsStore } from "app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtistsStore"
 import { createArtist } from "app/Scenes/MyCollection/mutations/createArtist"
 import { createUserInterests } from "app/Scenes/MyCollection/mutations/createUserInterests"
-import { dismissModal, popToRoot } from "app/system/navigation/navigate"
+import { dismissModal, goBack } from "app/system/navigation/navigate"
 import { pluralize } from "app/utils/pluralize"
 import { refreshMyCollection } from "app/utils/refreshHelpers"
 import { Suspense, useState } from "react"
@@ -109,7 +109,7 @@ export const MyCollectionAddCollectedArtists: React.FC<{}> = () => {
       refreshMyCollection()
       toast.show("Saved.", "bottom", { backgroundColor: "green100" })
       dismissModal()
-      popToRoot()
+      goBack()
     }
   }
 


### PR DESCRIPTION
This PR resolves [DIA-764]

### Description

Use `goBack` instead of `popToRoot` when submitting artists from `MyCollectionAddCollectedArtists` screen.
This fixes the bug when linking the flow to Complete My Profile where we need to navigate back after the submission instead of going back to the root.

I've checked the existing flow and nothing breaks, tagged onyx folks because you have more context of something that might be off with this change or not 👍 


https://github.com/user-attachments/assets/54ab85f3-6556-4627-a1c1-01b51932c012



### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-764]: https://artsyproduct.atlassian.net/browse/DIA-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ