### PR TITLE
feat(EMI-1958): Display limited time offer badge on artworks with Partner Offers

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -3,7 +3,6 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkGridItemTestsQuery } from "__generated__/ArtworkGridItemTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { DateTime } from "luxon"
@@ -164,7 +163,7 @@ describe("ArtworkGridItem", () => {
         }),
       })
 
-      expect(screen.queryByText("Some Kind of Dinosaur")).toBeOnTheScreen()
+      expect(screen.getByText("Some Kind of Dinosaur")).toBeOnTheScreen()
     })
   })
 
@@ -180,7 +179,7 @@ describe("ArtworkGridItem", () => {
         }),
       })
 
-      expect(screen.queryByText("Some Kind of Dinosaur")).toBeOnTheScreen()
+      expect(screen.getByText("Some Kind of Dinosaur")).toBeOnTheScreen()
     })
 
     it("renders without throwing an error when an auction is about to open, but not closed or finished", () => {
@@ -201,7 +200,7 @@ describe("ArtworkGridItem", () => {
         }),
       })
 
-      expect(screen.queryByText("$200 (1 bid)")).toBeOnTheScreen()
+      expect(screen.getByText("$200 (1 bid)")).toBeOnTheScreen()
     })
 
     it("does not show the partner name if hidePartner is set to true", () => {
@@ -240,7 +239,7 @@ describe("ArtworkGridItem", () => {
         { hidePartner: false }
       )
 
-      expect(screen.queryByText("partner")).toBeOnTheScreen()
+      expect(screen.getByText("partner")).toBeOnTheScreen()
     })
   })
 
@@ -266,8 +265,8 @@ describe("ArtworkGridItem", () => {
         { showLotLabel: true }
       )
 
-      expect(screen.queryByText("Lot 1")).toBeOnTheScreen()
-      expect(screen.queryByTestId("lot-close-info")).toBeOnTheScreen()
+      expect(screen.getByText("Lot 1")).toBeOnTheScreen()
+      expect(screen.getByTestId("lot-close-info")).toBeOnTheScreen()
     })
 
     it("does not show the LotCloseInfo component when the sale does not have cascading end times", () => {
@@ -287,44 +286,42 @@ describe("ArtworkGridItem", () => {
         {}
       )
 
-      expect(screen.queryByTestId("lot-close-info")).toBeFalsy()
+      expect(screen.queryByTestId("lot-close-info")).not.toBeOnTheScreen()
     })
   })
 
   describe("save artworks", () => {
-    it("favourites works", async () => {
+    it("favourites works", () => {
       renderWithRelay({
         Artwork: () => artwork,
       })
 
-      await flushPromiseQueue()
-
-      expect(screen.queryByTestId("empty-heart-icon")).toBeTruthy()
-      expect(screen.queryByTestId("filled-heart-icon")).toBeNull()
+      expect(screen.getByTestId("empty-heart-icon")).toBeOnTheScreen()
+      expect(screen.queryByTestId("filled-heart-icon")).not.toBeOnTheScreen()
 
       fireEvent.press(screen.getByTestId("save-artwork-icon"))
 
-      expect(screen.queryByTestId("filled-heart-icon")).toBeTruthy()
-      expect(screen.queryByTestId("empty-heart-icon")).toBeNull()
+      expect(screen.getByTestId("filled-heart-icon")).toBeOnTheScreen()
+      expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
     })
 
     it("is not visible when hideSaveIcon prop is specified", () => {
       renderWithRelay({}, { hideSaveIcon: true })
 
-      expect(screen.queryByTestId("empty-heart-icon")).toBeNull()
-      expect(screen.queryByTestId("filled-heart-icon")).toBeNull()
+      expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
+      expect(screen.queryByTestId("filled-heart-icon")).not.toBeOnTheScreen()
     })
   })
 
   describe("unlisted artworks", () => {
-    it("shows exclusive access", async () => {
+    it("shows exclusive access", () => {
       renderWithRelay({
         Artwork: () => ({
           isUnlisted: true,
         }),
       })
 
-      expect(screen.getByText("Exclusive Access")).toBeTruthy()
+      expect(screen.getByText("Exclusive Access")).toBeOnTheScreen()
     })
   })
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -419,7 +419,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
                         color="blue100"
                         {...saleInfoTextStyle}
                       >
-                        {" "}
+                        {"  "}
                         Exp. {partnerOfferEndAt}
                       </Text>
                     )}

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -248,7 +248,9 @@ export const Artwork: React.FC<ArtworkProps> = ({
     !!priceOfferMessage.priceWithDiscountMessage
 
   const displayLimitedTimeOfferSignal =
-    !!AREnablePartnerOfferSignals && !!collectorSignals?.partnerOffer?.isAvailable
+    AREnablePartnerOfferSignals &&
+    collectorSignals?.partnerOffer?.isAvailable &&
+    !artwork.sale?.isAuction
 
   const handleSupress = async (item: DissapearableArtwork) => {
     await item._disappearable?.disappear()

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
@@ -1,0 +1,236 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { ArtworkRailCardTestsQuery } from "__generated__/ArtworkRailCardTestsQuery.graphql"
+import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { DateTime } from "luxon"
+import { graphql } from "react-relay"
+
+describe("ArtworkRailCard", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkRailCardTestsQuery>({
+    Component: (props) => (
+      <ArtworkRailCard {...props} artwork={props.artwork!} size={(props as any).size || "large"} />
+    ),
+    query: graphql`
+      query ArtworkRailCardTestsQuery @relay_test_operation {
+        artwork(id: "the-artwork") {
+          ...ArtworkRailCard_artwork
+        }
+      }
+    `,
+  })
+
+  describe("in an open sale", () => {
+    it("gracefully handles a missing sale_artwork", () => {
+      renderWithRelay({
+        Artwork: () => ({ saleArtwork: null, title: "Some Kind of Dinosaur", date: "2015" }),
+      })
+
+      expect(screen.getByText("Some Kind of Dinosaur, 2015")).toBeOnTheScreen()
+    })
+  })
+
+  describe("in a closed sale", () => {
+    it("renders without throwing an error without any price information", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          sale: { isClosed: true },
+          realizedPrice: null,
+          title: "Some Kind of Dinosaur",
+          date: "2015",
+        }),
+      })
+
+      expect(screen.getByText("Some Kind of Dinosaur, 2015")).toBeOnTheScreen()
+    })
+
+    it("renders without throwing an error when an auction is about to open, but not closed or finished", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          title: "Some Kind of Dinosaur",
+          sale: { isClosed: false, isAuction: true },
+          saleArtwork: { currentBid: { display: "$200" }, counts: { bidderPositions: 1 } },
+          realizedPrice: null,
+        }),
+      })
+
+      expect(screen.getByText("$200 (1 bid)")).toBeOnTheScreen()
+    })
+
+    it("shows the partner name if showPartnerName is set to true", () => {
+      renderWithRelay(
+        { Artwork: () => ({ partner: { name: "partner" } }) },
+        { showPartnerName: true }
+      )
+      expect(screen.getByText("partner")).toBeOnTheScreen()
+    })
+
+    it("does not show the partner name if showPartnerName is set to false", () => {
+      renderWithRelay(
+        {
+          Artwork: () => ({
+            saleArtwork: { currentBid: { display: "$200" } },
+            sale: { isClosed: false, isAuction: true },
+            partner: { name: "partner" },
+          }),
+        },
+        { showPartnerName: false }
+      )
+
+      expect(() => screen.getByText("partner")).toThrow()
+    })
+  })
+
+  describe("cascading end times", () => {
+    it("shows the UrgencyTag component when the sale has cascading end times", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          sale: {
+            isClosed: false,
+            isAuction: true,
+            endAt: "2020-08-23T11:10:09.000+00:00",
+          },
+          saleArtwork: {
+            extendedBiddingEndAt: "2020-08-23T13:13:09.000+00:00",
+            endAt: "2020-08-23T11:10:09.000+00:00",
+          },
+        }),
+      })
+
+      expect(screen.getByTestId("auction-urgency-tag")).toBeOnTheScreen()
+      expect(screen.getByText("3 days left")).toBeOnTheScreen()
+    })
+
+    it("does not show the UrgencyTag component when the sale does not have cascading end times", () => {
+      renderWithRelay({ Artwork: () => ({ sale: { isClosed: true, isAuction: true } }) })
+
+      expect(screen.queryByTestId("auction-urgency-tag")).not.toBeOnTheScreen()
+    })
+  })
+
+  describe("lot label", () => {
+    it("shows the lot number when provided", () => {
+      renderWithRelay(
+        { Artwork: () => ({ sale: { isClosed: false, isAuction: true } }) },
+        { lotLabel: "123" }
+      )
+
+      expect(screen.getByText("Lot 123")).toBeOnTheScreen()
+    })
+
+    it("does not show the lot number when not provided", () => {
+      renderWithRelay(
+        { Artwork: () => ({ sale: { isClosed: false, isAuction: true } }) },
+        { lotLabel: null }
+      )
+
+      expect(() => screen.getByText("Lot")).toThrow()
+    })
+  })
+
+  describe("save artworks", () => {
+    it("saving artworks works when showSaveIcon is set to true", () => {
+      renderWithRelay({ Artwork: () => artwork }, { showSaveIcon: true })
+
+      expect(screen.getByTestId("empty-heart-icon")).toBeOnTheScreen()
+      expect(screen.queryByTestId("filled-heart-icon")).not.toBeOnTheScreen()
+
+      fireEvent.press(screen.getByTestId("save-artwork-icon"))
+
+      expect(screen.getByTestId("filled-heart-icon")).toBeOnTheScreen()
+      expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
+    })
+
+    it("does not show heart icon when showSaveIcon is set to false", () => {
+      renderWithRelay({}, { showSaveIcon: false })
+
+      expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
+      expect(screen.queryByTestId("filled-heart-icon")).not.toBeOnTheScreen()
+    })
+  })
+
+  describe("unlisted artworks", () => {
+    it("shows exclusive access", () => {
+      renderWithRelay({ Artwork: () => ({ isUnlisted: true }) })
+
+      expect(screen.getByText("Exclusive Access")).toBeOnTheScreen()
+    })
+  })
+
+  describe("artwork signals", () => {
+    describe("partner offer signal", () => {
+      beforeEach(
+        () => __globalStoreTestUtils__?.injectFeatureFlags({ AREnablePartnerOfferSignals: true })
+      )
+
+      const futureDate = DateTime.fromMillis(Date.now())
+        .plus({ days: 1, hours: 12, minutes: 1 })
+        .toISO()
+
+      const collectorSignals = {
+        partnerOffer: {
+          isAvailable: true,
+          endAt: futureDate,
+          priceWithDiscount: { display: "$2,750" },
+        },
+      }
+
+      it("shows the limited-time offer signal for non-auction artworks", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            ...artwork,
+            sale: { ...artwork.sale, isAuction: false },
+            realizedPrice: null,
+            collectorSignals,
+          }),
+        })
+
+        expect(screen.getByText("Limited-Time Offer")).toBeOnTheScreen()
+        expect(screen.getByText("Exp. 1d 12h")).toBeOnTheScreen()
+      })
+
+      it("doesn't show the limited-time offer signal for auction artworks", () => {
+        renderWithRelay({
+          // artwork is by default an auction
+          Artwork: () => ({ ...artwork, realizedPrice: null, collectorSignals }),
+        })
+
+        expect(screen.queryByText("Limited-Time Offer")).not.toBeOnTheScreen()
+        expect(screen.queryByText("Exp. 1d 12h")).not.toBeOnTheScreen()
+      })
+    })
+  })
+})
+
+const artwork = {
+  title: "Some Kind of Dinosaur",
+  date: "2015",
+  saleMessage: "Price on request",
+  sale: {
+    isAuction: true,
+    isClosed: true,
+    endAt: "2020-08-26T02:50:09+00:00",
+    cascadingEndTimeIntervalMinutes: null,
+  },
+  isSaved: false,
+  isUnlisted: false,
+  saleArtwork: null,
+  image: {
+    url: "artsy.net/image-url",
+    aspectRatio: 0.74,
+  },
+  artistNames: "Mikael Olson",
+  partner: {
+    name: "partner",
+  },
+  id: "mikael-olson-some-kind-of-dinosaur",
+  href: "/artwork/mikael-olson-some-kind-of-dinosaur",
+  slug: "cool-artwork",
+  internalID: "abc1234",
+  preview: {
+    url: "artsy.net/image-url",
+  },
+  customArtworkLists: {
+    totalCount: 0,
+  },
+}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -223,7 +223,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
     !!isRecentlySoldArtwork && (size === "large" || size === "extraLarge")
 
   const displayLimitedTimeOfferSignal =
-    !!AREnablePartnerOfferSignals && !!collectorSignals?.partnerOffer?.isAvailable
+    AREnablePartnerOfferSignals && collectorSignals?.partnerOffer?.isAvailable && !sale?.isAuction
 
   return (
     <AnalyticsContextProvider

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -351,7 +351,6 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                     fontWeight="bold"
                   >
                     {saleMessage}
-
                     {!!displayLimitedTimeOfferSignal && (
                       <Text
                         lineHeight="20px"
@@ -360,7 +359,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                         color="blue100"
                         numberOfLines={1}
                       >
-                        {" "}
+                        {"  "}
                         Exp. {partnerOfferEndAt}
                       </Text>
                     )}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -1,12 +1,13 @@
 import {
+  Box,
   Flex,
   HeartFillIcon,
   HeartIcon,
-  Text,
-  useColor,
-  Touchable,
-  useScreenDimensions,
   Image,
+  Text,
+  Touchable,
+  useColor,
+  useScreenDimensions,
 } from "@artsy/palette-mobile"
 import {
   ArtworkRailCard_artwork$data,
@@ -17,7 +18,9 @@ import { saleMessageOrBidInfo as defaultSaleMessageOrBidInfo } from "app/Compone
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidth"
 import { ContextMenuArtwork } from "app/Components/ContextMenu/ContextMenuArtwork"
+import { formattedTimeLeft } from "app/Scenes/Activity/utils/formattedTimeLeft"
 import { AnalyticsContextProvider } from "app/system/analytics/AnalyticsContext"
+import { getTimer } from "app/utils/getTimer"
 import { getUrgencyTag } from "app/utils/getUrgencyTag"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import {
@@ -92,9 +95,29 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   const artwork = useFragment(artworkFragment, restProps.artwork)
   const { width: screenWidth } = useScreenDimensions()
 
-  const { artistNames, date, image, partner, title, sale, saleArtwork, isUnlisted } = artwork
+  const AREnablePartnerOfferSignals = useFeatureFlag("AREnablePartnerOfferSignals")
 
-  const saleMessage = defaultSaleMessageOrBidInfo({ artwork, isSmallTile: true })
+  const {
+    artistNames,
+    date,
+    image,
+    partner,
+    title,
+    sale,
+    saleArtwork,
+    isUnlisted,
+    collectorSignals,
+  } = artwork
+
+  const saleMessage = defaultSaleMessageOrBidInfo({
+    artwork,
+    isSmallTile: true,
+    collectorSignals: AREnablePartnerOfferSignals ? collectorSignals : null,
+  })
+
+  const partnerOfferEndAt = collectorSignals?.partnerOffer?.endAt
+    ? formattedTimeLeft(getTimer(collectorSignals.partnerOffer.endAt).time).timerCopy
+    : ""
 
   const extendedBiddingEndAt = saleArtwork?.extendedBiddingEndAt
   const lotEndAt = saleArtwork?.endAt
@@ -199,6 +222,9 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   const displayForRecentlySoldArtwork =
     !!isRecentlySoldArtwork && (size === "large" || size === "extraLarge")
 
+  const displayLimitedTimeOfferSignal =
+    !!AREnablePartnerOfferSignals && !!collectorSignals?.partnerOffer?.isAvailable
+
   return (
     <AnalyticsContextProvider
       contextScreenOwnerId={contextScreenOwnerId}
@@ -255,6 +281,13 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
               justifyContent="space-between"
             >
               <Flex flex={1} backgroundColor={backgroundColor}>
+                {!!displayLimitedTimeOfferSignal && (
+                  <Box backgroundColor="blue10" px={0.5} alignSelf="flex-start" borderRadius={3}>
+                    <Text lineHeight="20px" variant="xs" color="blue100">
+                      Limited-Time Offer
+                    </Text>
+                  </Box>
+                )}
                 {!!lotLabel && (
                   <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1}>
                     Lot {lotLabel}
@@ -318,6 +351,19 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                     fontWeight="bold"
                   >
                     {saleMessage}
+
+                    {!!displayLimitedTimeOfferSignal && (
+                      <Text
+                        lineHeight="20px"
+                        variant="xs"
+                        fontWeight="normal"
+                        color="blue100"
+                        numberOfLines={1}
+                      >
+                        {" "}
+                        Exp. {partnerOfferEndAt}
+                      </Text>
+                    )}
                   </Text>
                 )}
 
@@ -583,6 +629,15 @@ const artworkFragment = graphql`
     }
     title
     realizedPrice
+    collectorSignals {
+      partnerOffer {
+        isAvailable
+        endAt
+        priceWithDiscount {
+          display
+        }
+      }
+    }
     ...useSaveArtworkToArtworkLists_artwork
   }
 `

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -533,6 +533,7 @@ const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({
 
       {!!urgencyTag && (
         <Flex
+          testID="auction-urgency-tag"
           backgroundColor={color("white100")}
           position="absolute"
           px="5px"


### PR DESCRIPTION
This PR resolves [EMI-1958] <!-- eg [PROJECT-XXXX] -->

>[!NOTE]
> This change is hidden behind `AREnablePartnerOfferSignals` feature flag

### Description
This PR adds a new "Limited-Time Offer" signal for artwork rail card and artwork grid item with partner offer

### Some Screenshots
### Without a partner offer
| | Android | iOS |
|---|---|---|
| Recently viewed rail | <img width="487" alt="image" src="https://github.com/user-attachments/assets/c2e74880-6246-4ef4-b2d5-a8cb54733f49"> | ![image](https://github.com/user-attachments/assets/e0d125a7-28db-4a6f-9a81-6a9de658a3fd) |
| Recently viewed grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/74d9e44a-c01c-4a4a-ada7-9f55974142af"> | ![image](https://github.com/user-attachments/assets/35df8fb0-8091-4d7e-9616-026340d870ec) |
| Saves list grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/beda191f-4a73-4180-a7af-fae172e49350"> | ![image](https://github.com/user-attachments/assets/dc5f358b-2679-4a00-94f0-0dd9f2fd3311) |
| Search results grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/7524ab4c-0037-47a3-b5b9-8ebf3e9d540c"> | ![image](https://github.com/user-attachments/assets/8e926165-5ba1-4cfc-b10a-d07aa5e54ba4) |

### With a partner offer
| | Android | iOS |
|---|---|---|
| Recently viewed rail | <img width="487" alt="image" src="https://github.com/user-attachments/assets/325923b0-1e56-470d-a992-928650a78fd3"> | ![image](https://github.com/user-attachments/assets/77e9e165-ef17-47f3-8b35-a827794c412d) |
| Recently viewed grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/b95f824b-10b2-498f-b80b-bc9115657d06"> | ![image](https://github.com/user-attachments/assets/1e420ec1-287c-4876-97d2-1fd7b77e6e80) |
| Saves list grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/cc62ec41-d56d-43ea-a16e-083f66f416c4"> | ![image](https://github.com/user-attachments/assets/a61dab0c-cfbb-4d9f-a92d-7abdce388eb0) |
| Search results grid | <img width="487" alt="image" src="https://github.com/user-attachments/assets/846b3631-eaac-4e92-a645-c7d5220bcf50"> | ![image](https://github.com/user-attachments/assets/a7e6833f-8692-4d26-b723-91d716cfdc46) |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add Limited-Time Offer signal to artwork cards/items (hidden behind AREnablePartnerOfferSignals) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1958]: https://artsyproduct.atlassian.net/browse/EMI-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ