### PR TITLE
refactor(perf): boost performance by wrapping renderitem usecallback

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -162,6 +162,30 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     )
   }
 
+  const renderItem = useCallback(({ item, index, columnIndex }) => {
+    const imgAspectRatio = item.image?.aspectRatio ?? 1
+    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+    const imgHeight = imgWidth / imgAspectRatio
+
+    return (
+      <Flex
+        pl={columnIndex === 0 ? 0 : 1}
+        pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+        mt={2}
+      >
+        <ArtworkGridItem
+          {...props}
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.artist}
+          contextScreenOwnerId={artist.internalID}
+          contextScreenOwnerSlug={artist.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      </Flex>
+    )
+  }, [])
+
   if (!artist.statuses?.artworks) {
     return (
       <Tabs.ScrollView>
@@ -249,29 +273,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
           </Box>
         }
         keyExtractor={(item) => item.id}
-        renderItem={({ item, index, columnIndex }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <Flex
-              pl={columnIndex === 0 ? 0 : 1}
-              pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
-              mt={2}
-            >
-              <ArtworkGridItem
-                {...props}
-                itemIndex={index}
-                contextScreenOwnerType={OwnerType.artist}
-                contextScreenOwnerId={artist.internalID}
-                contextScreenOwnerSlug={artist.slug}
-                artwork={item}
-                height={imgHeight}
-              />
-            </Flex>
-          )
-        }}
+        renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -78,30 +78,33 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
     }
   }, [hasMore, isLoading])
 
-  const renderItem = ({ item, index, columnIndex }: masonryRenderItemProps) => (
-    <MasonryArtworkGridItem
-      index={index}
-      item={item}
-      columnIndex={columnIndex}
-      contextModule={contextModule}
-      contextScreenOwnerType={contextScreenOwnerType}
-      contextScreen={contextScreen}
-      contextScreenOwnerId={contextScreenOwnerId}
-      contextScreenOwnerSlug={contextScreenOwnerSlug}
-      numColumns={rest.numColumns}
-      artworkMetaStyle={{
-        // Since the grid is full width,
-        // we need to add padding to the artwork meta to make sure its readable
-        paddingHorizontal: rest.numColumns !== 1 ? 0 : space(2),
-        // Extra space between items for one column artwork grids
-        paddingBottom: rest.numColumns !== 1 ? 0 : artworks.length === 1 ? space(2) : space(4),
-      }}
-      partnerOffer={partnerOffer}
-      priceOfferMessage={priceOfferMessage}
-      onPress={onPress}
-      hideSaleInfo={hideSaleInfo}
-      hideSaveIcon={hideSaveIcon}
-    />
+  const renderItem = useCallback(
+    ({ item, index, columnIndex }: masonryRenderItemProps) => (
+      <MasonryArtworkGridItem
+        index={index}
+        item={item}
+        columnIndex={columnIndex}
+        contextModule={contextModule}
+        contextScreenOwnerType={contextScreenOwnerType}
+        contextScreen={contextScreen}
+        contextScreenOwnerId={contextScreenOwnerId}
+        contextScreenOwnerSlug={contextScreenOwnerSlug}
+        numColumns={rest.numColumns}
+        artworkMetaStyle={{
+          // Since the grid is full width,
+          // we need to add padding to the artwork meta to make sure its readable
+          paddingHorizontal: rest.numColumns !== 1 ? 0 : space(2),
+          // Extra space between items for one column artwork grids
+          paddingBottom: rest.numColumns !== 1 ? 0 : artworks.length === 1 ? space(2) : space(4),
+        }}
+        partnerOffer={partnerOffer}
+        priceOfferMessage={priceOfferMessage}
+        onPress={onPress}
+        hideSaleInfo={hideSaleInfo}
+        hideSaveIcon={hideSaveIcon}
+      />
+    ),
+    []
   )
 
   const FlashlistComponent = animated ? AnimatedMasonryFlashList : MasonryFlashList

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -72,6 +72,28 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
     }
   }, [relay.hasMore(), relay.isLoading()])
 
+  const renderItem = useCallback(({ item, columnIndex }) => {
+    const imgAspectRatio = item.image?.aspectRatio ?? 1
+    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+    const imgHeight = imgWidth / imgAspectRatio
+
+    return (
+      <Flex
+        pl={columnIndex === 0 ? 0 : 1}
+        pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+        mt={2}
+      >
+        <ArtworkGridItem
+          contextScreenOwnerType={OwnerType.gene}
+          contextScreenOwnerId={gene.internalID}
+          contextScreenOwnerSlug={gene.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      </Flex>
+    )
+  }, [])
+
   return (
     <>
       <Tabs.Masonry
@@ -93,27 +115,7 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
           )
         }
         keyExtractor={(item) => item.id}
-        renderItem={({ item, columnIndex }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <Flex
-              pl={columnIndex === 0 ? 0 : 1}
-              pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
-              mt={2}
-            >
-              <ArtworkGridItem
-                contextScreenOwnerType={OwnerType.gene}
-                contextScreenOwnerId={gene.internalID}
-                contextScreenOwnerSlug={gene.slug}
-                artwork={item}
-                height={imgHeight}
-              />
-            </Flex>
-          )
-        }}
+        renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -23,7 +23,7 @@ import {
 } from "app/utils/masonryHelpers"
 import { pluralize } from "app/utils/pluralize"
 import { Schema } from "app/utils/track"
-import React, { useEffect, useState } from "react"
+import React, { useCallback, useEffect, useState } from "react"
 import { graphql, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -80,6 +80,29 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   useEffect(() => {
     setFiltersCountAction({ ...counts, total: artworksTotal })
   }, [artworksTotal])
+
+  const renderItem = useCallback(({ item, index, columnIndex }) => {
+    const imgAspectRatio = item.image?.aspectRatio ?? 1
+    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+    const imgHeight = imgWidth / imgAspectRatio
+
+    return (
+      <Flex
+        pl={columnIndex === 0 ? 0 : 1}
+        pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+        mt={2}
+      >
+        <ArtworkGridItem
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.fair}
+          contextScreenOwnerId={data.internalID}
+          contextScreenOwnerSlug={data.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      </Flex>
+    )
+  }, [])
 
   if (!data) {
     return null
@@ -159,28 +182,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
         }
         onEndReached={handleOnEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        renderItem={({ item, index, columnIndex }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <Flex
-              pl={columnIndex === 0 ? 0 : 1}
-              pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
-              mt={2}
-            >
-              <ArtworkGridItem
-                itemIndex={index}
-                contextScreenOwnerType={OwnerType.fair}
-                contextScreenOwnerId={data.internalID}
-                contextScreenOwnerSlug={data.slug}
-                artwork={item}
-                height={imgHeight}
-              />
-            </Flex>
-          )
-        }}
+        renderItem={renderItem}
       />
       <ArtworkFilterNavigator
         visible={isFilterArtworksModalVisible}

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -49,6 +49,28 @@ export const PartnerArtwork: React.FC<{
   const emptyText =
     "There are no matching works from this gallery.\nTry changing your search filters"
 
+  const renderItem = useCallback(({ item, columnIndex }) => {
+    const imgAspectRatio = item.image?.aspectRatio ?? 1
+    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+    const imgHeight = imgWidth / imgAspectRatio
+
+    return (
+      <Flex
+        pl={columnIndex === 0 ? 0 : 1}
+        pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+        mt={2}
+      >
+        <ArtworkGridItem
+          contextScreenOwnerType={OwnerType.partner}
+          contextScreenOwnerId={partner.internalID}
+          contextScreenOwnerSlug={partner.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      </Flex>
+    )
+  }, [])
+
   return (
     <>
       <Tabs.Masonry
@@ -62,27 +84,7 @@ export const PartnerArtwork: React.FC<{
           </Box>
         }
         keyExtractor={(item) => item.id}
-        renderItem={({ item, columnIndex }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <Flex
-              pl={columnIndex === 0 ? 0 : 1}
-              pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
-              mt={2}
-            >
-              <ArtworkGridItem
-                contextScreenOwnerType={OwnerType.partner}
-                contextScreenOwnerId={partner.internalID}
-                contextScreenOwnerSlug={partner.slug}
-                artwork={item}
-                height={imgHeight}
-              />
-            </Flex>
-          )
-        }}
+        renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -78,6 +78,28 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
     }
   }, [relay.hasMore(), relay.isLoading()])
 
+  const renderItem = useCallback(({ item, columnIndex }) => {
+    const imgAspectRatio = item.image?.aspectRatio ?? 1
+    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+    const imgHeight = imgWidth / imgAspectRatio
+
+    return (
+      <Flex
+        pl={columnIndex === 0 ? 0 : 1}
+        pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
+        mt={2}
+      >
+        <ArtworkGridItem
+          contextScreenOwnerType={OwnerType.tag}
+          contextScreenOwnerId={tag?.internalID}
+          contextScreenOwnerSlug={tag?.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      </Flex>
+    )
+  }, [])
+
   return (
     <>
       <Tabs.Masonry
@@ -99,27 +121,7 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
           )
         }
         keyExtractor={(item) => item.id}
-        renderItem={({ item, columnIndex }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <Flex
-              pl={columnIndex === 0 ? 0 : 1}
-              pr={NUM_COLUMNS_MASONRY - (columnIndex + 1) === 0 ? 0 : 1}
-              mt={2}
-            >
-              <ArtworkGridItem
-                contextScreenOwnerType={OwnerType.tag}
-                contextScreenOwnerId={tag?.internalID}
-                contextScreenOwnerSlug={tag?.slug}
-                artwork={item}
-                height={imgHeight}
-              />
-            </Flex>
-          )
-        }}
+        renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Moved all the renderItem from `Tabs.Masonry` to a `useCallback` in order to take advantage of slightly improved performance.

Read more [here](https://www.mukesh-jangid.com/post/optimize-flatlist-with-the-power-of-usememo-and-usecallback)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- boost tabs.masonry performance by wrapping renderitem in usecallback - gkartalis

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
