### PR TITLE
fix: edit submission, adjust additional documents screen

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAddPhoneNumber.tsx
@@ -5,6 +5,7 @@ import { PhoneInput } from "app/Components/Input/PhoneInput"
 import { useToast } from "app/Components/Toast/toastHook"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
 import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { TIER_1_STATES } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import { updateMyCollectionArtwork } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/updateMyCollectionArtwork"
 import { useNavigationListeners } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/useNavigationListeners"
 import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext"
@@ -34,10 +35,13 @@ export const SubmitArtworkAddPhoneNumber = () => {
       try {
         setIsLoading(true)
 
-        const nextStep = values.state === "DRAFT" ? "CompleteYourSubmission" : "ShippingLocation"
+        const nextStep =
+          values.state && TIER_1_STATES.includes(values.state)
+            ? "CompleteYourSubmission"
+            : "ShippingLocation"
         const newValues = {
           userPhone: values.userPhone,
-          state: values.state === "DRAFT" ? "SUBMITTED" : undefined,
+          state: values.state && TIER_1_STATES.includes(values.state) ? "SUBMITTED" : undefined,
         } as const
 
         await createOrUpdateSubmission(newValues, values.submissionId)

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAdditionalDocuments.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkAdditionalDocuments.tsx
@@ -5,8 +5,8 @@ import {
   DocumentIcon,
   Flex,
   INPUT_BORDER_RADIUS,
+  Join,
   ProgressBar,
-  Separator,
   Spacer,
   Text,
   Touchable,
@@ -161,37 +161,37 @@ export const SubmitArtworkAdditionalDocuments = () => {
           showsVerticalScrollIndicator={false}
         >
           <Flex>
-            <Text variant="lg-display">Additional documents</Text>
+            <Join separator={<Spacer y={2} />}>
+              <Text variant="lg-display">Additional documents</Text>
 
-            <Spacer y={2} />
+              <Text color="black60" variant="xs">
+                Please add any of the follow if you have them: Proof of purchase, Certificate of
+                Authentication, Fact Sheet, Condition Report
+              </Text>
 
-            <Text color="black60" variant="xs">
-              Please add any of the follow if you have them: Proof of purchase, Certificate of
-              Authentication, Fact Sheet, Condition Report
-            </Text>
+              <Button block variant="outline" onPress={handleUpload}>
+                Add Documents
+              </Button>
 
-            <Spacer y={2} />
+              <Text color="black60" variant="xs">
+                Maximum size: 50 MB.
+              </Text>
 
-            <Button block variant="outline" onPress={handleUpload}>
-              Add Documents
-            </Button>
-
-            <Separator my={2} borderColor="black10" />
-
-            <Flex rowGap={space(2)}>
-              {values.additionalDocuments.map((document) => {
-                return (
-                  <UploadedFile
-                    key={document.id}
-                    document={document}
-                    progress={progress[document.id]}
-                    onRemove={() => {
-                      handleDelete(document)
-                    }}
-                  />
-                )
-              })}
-            </Flex>
+              <Flex rowGap={space(2)}>
+                {values.additionalDocuments.map((document) => {
+                  return (
+                    <UploadedFile
+                      key={document.id}
+                      document={document}
+                      progress={progress[document.id]}
+                      onRemove={() => {
+                        handleDelete(document)
+                      }}
+                    />
+                  )
+                })}
+              </Flex>
+            </Join>
           </Flex>
         </ScrollView>
       </Flex>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
@@ -9,6 +9,7 @@ import {
 import {
   ARTWORK_FORM_TIER_1_FINAL_STEP,
   ARTWORK_FORM_TIER_2_FINAL_STEP,
+  TIER_1_STATES,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import {
   SubmissionModel,
@@ -41,7 +42,7 @@ export const useSubmissionContext = () => {
   }, [currentStep, values])
 
   const isFinalStep =
-    values.state === "DRAFT"
+    values.state && TIER_1_STATES.includes(values.state)
       ? currentStep === ARTWORK_FORM_TIER_1_FINAL_STEP
       : currentStep === ARTWORK_FORM_TIER_2_FINAL_STEP
 

--- a/src/app/utils/showDocumentsAndPhotosActionSheet.ts
+++ b/src/app/utils/showDocumentsAndPhotosActionSheet.ts
@@ -52,6 +52,10 @@ export async function showDocumentsAndPhotosActionSheet(
             resolve(results)
           }
           if (buttonIndex === 1) {
+            photos = await requestPhotos(allowMultiple)
+            resolve(photos)
+          }
+          if (buttonIndex === 2) {
             if (Platform.OS === "android") {
               // We attempt to clear the cache due to an ImagePicker bug
               // See Hacks.md for more.
@@ -62,11 +66,6 @@ export async function showDocumentsAndPhotosActionSheet(
               mediaType: "photo",
             })
             photos = [photo]
-            resolve(photos)
-          }
-
-          if (buttonIndex === 2) {
-            photos = await requestPhotos(allowMultiple)
             resolve(photos)
           }
         } catch (error) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Resolve [Notion ticket](https://www.notion.so/artsy/Navigation-fails-after-navigating-from-phone-number-step-edit-submission-in-state-SUBMITTED-f6379608f1d940c79d157c057574846c?pvs=4) (Navigation fails after navigating from phone number step (edit submission in state SUBMITTED)
Adjust Additional documents screen 
<image width="250" src="https://github.com/user-attachments/assets/acce21f8-15d4-4e1d-a68e-b3f296a6993b" />

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- adjust navigation and additional documents screen on the submission flow -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
