### PR TITLE
fix(EMI-2020): Stop limited-time offer badge from displaying twice in Activity Panel

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -366,6 +366,28 @@ describe("ArtworkGridItem", () => {
         expect(screen.queryByText("Limited-Time Offer")).not.toBeOnTheScreen()
         expect(screen.queryByText("Exp. 1d 12h")).not.toBeOnTheScreen()
       })
+
+      it("doesn't show the limited-time offer signal if priceOfferMessage is present", () => {
+        renderWithRelay(
+          {
+            Artwork: () => ({
+              ...artwork,
+              sale: { ...artwork.sale, isAuction: false },
+              realizedPrice: null,
+              collectorSignals,
+            }),
+          },
+          {
+            priceOfferMessage: {
+              priceListedMessage: "$12,500",
+              priceWithDiscountMessage: "$10,000",
+            },
+          }
+        )
+
+        expect(screen.queryByText("Limited-Time Offer")).not.toBeOnTheScreen()
+        expect(screen.queryByText("Exp. 1d 12h")).not.toBeOnTheScreen()
+      })
     })
   })
 })

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -250,7 +250,8 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const displayLimitedTimeOfferSignal =
     AREnablePartnerOfferSignals &&
     collectorSignals?.partnerOffer?.isAvailable &&
-    !artwork.sale?.isAuction
+    !artwork.sale?.isAuction &&
+    !displayPriceOfferMessage
 
   const handleSupress = async (item: DissapearableArtwork) => {
     await item._disappearable?.disappear()


### PR DESCRIPTION
This PR resolves [EMI-2020] <!-- eg [PROJECT-XXXX] -->

> [!NOTE]
> These changes are hidden behind the `AREnablePartnerOfferSignals` feature flag

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR stops the second Limited-Time Offer badge in the Activity Panel from rendering

### Screenshots
| | Before | After |
|---|---|---|
| Android | <img width="487" alt="image" src="https://github.com/user-attachments/assets/9450116f-370f-41b5-ae1a-40317a83862b"> | <img width="487" alt="image" src="https://github.com/user-attachments/assets/482ec3cc-93c0-43f0-bf7c-c46c3cdabd2b"> |
| iOS | ![image](https://github.com/user-attachments/assets/8c324a58-a36c-42d1-b4fe-f91a14fb8379) | ![image](https://github.com/user-attachments/assets/4e3647d9-ee5f-4916-9b9c-b5bc19457532) |

### PR Checklist
- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Hide second Limited-Time Offer badge in Activity Panel (hidden behind AREnablePartnerOfferSignals ff) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2020]: https://artsyproduct.atlassian.net/browse/EMI-2020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ