### PR TITLE
fix(FairOverview): remove double empty state rendered and isActive logic(deprecated)

### DIFF
--- a/src/app/Scenes/Fair/FairOverview.tests.tsx
+++ b/src/app/Scenes/Fair/FairOverview.tests.tsx
@@ -54,25 +54,14 @@ describe("FairOverview", () => {
     expect(screen.getByText("A great place to buy art")).toBeOnTheScreen()
   })
 
-  it("renders fewer components when fair is inactive", () => {
+  it("renders empty state given no data", () => {
     renderWithRelay({
       Fair: () => ({
-        isActive: false,
-      }),
-    })
-
-    expect(screen.getByText("View all")).toBeOnTheScreen()
-    expect(screen.queryByText("collection-1")).not.toBeOnTheScreen()
-    expect(screen.queryByText("Works by Artists You Follow")).not.toBeOnTheScreen()
-  })
-
-  it("does not render components when there is no data for them", () => {
-    renderWithRelay({
-      Fair: () => ({
-        articles: {
-          edges: [],
-        },
+        summary: null,
+        about: null,
+        articles: { edges: [] },
         marketingCollections: [],
+        filterArtworksConnection: { edges: [] },
         counts: {
           artworks: 0,
           partnerShows: 0,

--- a/src/app/Scenes/Fair/FairOverview.tsx
+++ b/src/app/Scenes/Fair/FairOverview.tsx
@@ -26,10 +26,10 @@ export const FairOverview: FC<FairOverviewProps> = ({ fair }) => {
   const hasArticles = !!data.articlesConnection?.totalCount
   const hasCollections = !!data.marketingCollections.length
   const hasFollowedArtistArtworks = !!data.filterArtworksConnection?.edges?.length
-  const hasPreviewText = data.summary || data.about
+  const previewText = data.summary || data.about
   // TOFIX: Must be a better way to determine if there is more info to show
   const canShowMoreInfoLink =
-    !!data.about ||
+    !!previewText ||
     !!data.tagline ||
     !!data.location?.summary ||
     shouldShowLocationMap(data.location?.coordinates) ||
@@ -37,45 +37,34 @@ export const FairOverview: FC<FairOverviewProps> = ({ fair }) => {
     !!data.hours ||
     !!data.links ||
     !!data.contact ||
-    !!data.summary ||
     !!data.tickets
+  const isEmpty = !previewText && !hasArticles && !hasCollections && !hasFollowedArtistArtworks
 
   return (
     <Tabs.ScrollView style={{ paddingTop: space(2) }}>
-      <Flex gap={space(2)}>
-        {!!hasPreviewText && (
-          <ReadMore textStyle="new" content={hasPreviewText} maxChars={truncatedTextLimit()} />
-        )}
-        {!!canShowMoreInfoLink && (
-          <Touchable onPress={() => navigate(`/fair/${data.slug}/info`)}>
-            <Flex pt={2} flexDirection="row" justifyContent="flex-start" alignItems="center">
-              <Text variant="sm">More info</Text>
-              <ChevronIcon mr="-5px" mt="4px" />
-            </Flex>
-          </Touchable>
-        )}
+      {!isEmpty ? (
+        <Flex gap={space(2)}>
+          {!!previewText && (
+            <ReadMore textStyle="new" content={previewText} maxChars={truncatedTextLimit()} />
+          )}
+          {!!canShowMoreInfoLink && (
+            <Touchable onPress={() => navigate(`/fair/${data.slug}/info`)}>
+              <Flex pt={2} flexDirection="row" justifyContent="flex-start" alignItems="center">
+                <Text variant="sm">More info</Text>
+                <ChevronIcon mr="-5px" mt="4px" />
+              </Flex>
+            </Touchable>
+          )}
 
-        {!!data.isActive ? (
-          <>
-            {!!hasArticles && <FairEditorialFragmentContainer fair={data} />}
-            {!!hasCollections && <FairCollectionsFragmentContainer fair={data} />}
-            {!!hasFollowedArtistArtworks && (
-              <FairFollowedArtistsRailFragmentContainer fair={data} />
-            )}
-          </>
-        ) : (
-          <>
-            <FairEmptyStateFragmentContainer fair={data} />
-            {!!hasArticles ? (
-              <FairEditorialFragmentContainer fair={data} />
-            ) : (
-              <FairEmptyStateFragmentContainer fair={data} />
-            )}
-          </>
-        )}
-      </Flex>
+          {!!hasArticles && <FairEditorialFragmentContainer fair={data} />}
+          {!!hasCollections && <FairCollectionsFragmentContainer fair={data} />}
+          {!!hasFollowedArtistArtworks && <FairFollowedArtistsRailFragmentContainer fair={data} />}
 
-      <Spacer y={4} />
+          <Spacer y={4} />
+        </Flex>
+      ) : (
+        <FairEmptyStateFragmentContainer fair={data} />
+      )}
     </Tabs.ScrollView>
   )
 }


### PR DESCRIPTION
This PR also resolves [PHIRE-1083] <!-- eg [PROJECT-XXXX] -->

### Description

The component was rendered doubled the empty state for the example below, on top of that the `isActive` logic is no longer used, so removing it made sense to fix the bug and clean up the component as we display in Force. From the example below we can see the fair had elements to be shown but `isActive` logic was blocking it.

![Simulator Screenshot - iPhone 14 - 2024-08-08 at 08 21 13](https://github.com/user-attachments/assets/64b0372e-fd68-42a7-9c5a-1e6444d6007b)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: double empty state and isActive logic on FairOverview tab - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1083]: https://artsyproduct.atlassian.net/browse/PHIRE-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ