### PR TITLE
fix: user agents in webviews

### DIFF
--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -165,7 +165,7 @@ describe("ArtsyWebViewPage", () => {
     it("on Android", () => {
       Platform.OS = "android"
       const tree = render()
-      const source = webViewProps(tree).source
+      const source = webViewProps(tree).source as any
       expect(source).toHaveProperty("headers")
       expect(source?.headers["User-Agent"]).toBe(
         `Artsy-Mobile android Artsy-Mobile/${appJson().version} Eigen/some-build-number/${

--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -7,6 +7,7 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import mockFetch from "jest-fetch-mock"
 import { debounce } from "lodash"
 import { stringify } from "query-string"
+import { Platform } from "react-native"
 import Share from "react-native-share"
 import WebView, { WebViewProps } from "react-native-webview"
 import { WebViewNavigation } from "react-native-webview/lib/WebViewTypes"
@@ -73,6 +74,7 @@ describe("ArtsyWebViewPage", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     ;(debounce as jest.Mock).mockImplementation((func) => func)
+    Platform.OS = "ios"
   })
 
   const render = (props: Partial<React.ComponentProps<typeof ArtsyWebViewPage>> = {}) =>
@@ -150,13 +152,27 @@ describe("ArtsyWebViewPage", () => {
     })
   })
 
-  it("sets the user agent correctly", () => {
-    const tree = render()
-    expect(webViewProps(tree).applicationNameForUserAgent).toBe(
-      `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
-        appJson().version
-      }`
-    )
+  describe("sets the user agent correctly", () => {
+    it("on iOS", () => {
+      const tree = render()
+      expect(webViewProps(tree).userAgent).toBe(
+        `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
+          appJson().version
+        }`
+      )
+    })
+
+    it("on Android", () => {
+      Platform.OS = "android"
+      const tree = render()
+      const source = webViewProps(tree).source
+      expect(source).toHaveProperty("headers")
+      expect(source?.headers["User-Agent"]).toBe(
+        `Artsy-Mobile android Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
+          appJson().version
+        }`
+      )
+    })
   })
 
   it("receives messages from the browser", () => {

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -268,9 +268,18 @@ export const ArtsyWebView = forwardRef<
           // on android it works without it
           sharedCookiesEnabled
           decelerationRate="normal"
-          source={{ uri }}
+          source={{
+            uri,
+            // Workaround for user agent breaking back behavior on Android
+            // see: https://github.com/react-native-webview/react-native-webview/pull/3133
+            ...(Platform.OS === "android" && {
+              headers: {
+                "User-Agent": userAgent,
+              },
+            }),
+          }}
           style={{ flex: 1 }}
-          applicationNameForUserAgent={userAgent}
+          userAgent={Platform.OS === "ios" ? userAgent : undefined}
           onMessage={({ nativeEvent }) => {
             const data = nativeEvent.data
             try {
@@ -280,6 +289,12 @@ export const ArtsyWebView = forwardRef<
               console.log("error parsing webview message data", e, data)
             }
           }}
+          injectedJavaScript={`
+            const div = document.createElement('div');
+            div.innerHTML = navigator.userAgent;
+            document.body.appendChild(div);
+            true;
+        `}
           onNavigationStateChange={onNavigationStateChange}
         />
         {!!showDevToggleIndicator && (

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -289,12 +289,6 @@ export const ArtsyWebView = forwardRef<
               console.log("error parsing webview message data", e, data)
             }
           }}
-          injectedJavaScript={`
-            const div = document.createElement('div');
-            div.innerHTML = navigator.userAgent;
-            document.body.appendChild(div);
-            true;
-        `}
           onNavigationStateChange={onNavigationStateChange}
         />
         {!!showDevToggleIndicator && (


### PR DESCRIPTION
This PR resolves [PHIRE-1081] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

A while back we fixed a bug in our android webviews by changing the way we pass user agent: 
https://github.com/artsy/eigen/pull/9354 
This was due to a bug in the react-native-webview dependency:
https://github.com/react-native-webview/react-native-webview/issues/2949

This unfortunately also changed the format of our user agent to append our custom user agent to the browser user agent:
e.g: `Mozilla/5.0 (Linux; Android 14; Pixel 7 Pro Build/AP2A.240705.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/126.0.6478.134 Mobile Safari/537.36 Mozilla/5.0 (Linux; Android 14; Pixel 7 Pro Build/AP2A.240705.004; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/126.0.6478.134 Mobile Safari/537.36 Artsy-Mobile/8.44.0 Eigen/1674645751/8.44.0`  vs just `Artsy-Mobile/8.44.0 Eigen/1674645751/8.44.0` 

And this broke analytics reporting for webview actions like checkout on Android (possibly impacted iOS to a lesser extent? 🤔 ) 

This pr applies workaround recommended here: 
https://github.com/react-native-webview/react-native-webview/pull/3133

which will hopefully get our user agent back to the old format and keep the back button bug fixed.

### Before


<details>

<summary>
iOS user agent
</summary>

<img width="1218" alt="ios-user-agent-before-short" src="https://github.com/user-attachments/assets/1c64ce99-f71a-47fd-8ca7-09c701a2d19b">


</details>

<details>

<summary>
Android user agent
</summary>

<img width="952" alt="android-user-agent-before" src="https://github.com/user-attachments/assets/4d54f502-b534-4cc9-9e36-1b5ff5251c24">


</details>

### After 

<details>
<summary>
iOS user agent
</summary>

<img width="519" alt="ios-user-agent-after" src="https://github.com/user-attachments/assets/d249ab17-d2e9-4858-8e00-0d3e4bbc99a1">

</details>

<details>
<summary>
Android user agent
</summary>

<img width="463" alt="android-user-agent-after" src="https://github.com/user-attachments/assets/64dce487-6558-49c7-a157-ea0efcd0e6a7">

</details>


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix user agent in webviews - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1081]: https://artsyproduct.atlassian.net/browse/PHIRE-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ