### PR TITLE
fix: add Add Additional Information tracking

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
 import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
@@ -20,6 +21,8 @@ export const ArtworkSubmissionStatusDescription: React.FC<
     submissionId,
     internalID: artworkInternalID,
   } = useFragment(fragment, artworkData)
+
+  const { trackTappedEditSubmission } = useSubmitArtworkTracking()
 
   if (!consignmentSubmission || !submissionId) return null
 
@@ -66,6 +69,8 @@ export const ArtworkSubmissionStatusDescription: React.FC<
     navigate(`/sell/submissions/${submissionId}/edit`, { passProps })
   }
 
+  const displayButtonLabel = isListed ? "View Listing" : buttonLabel
+
   return (
     <Flex testID="ArtworkSubmissionStatusDescription-Container">
       <AutoHeightBottomSheet onDismiss={closeModal} visible={visible}>
@@ -93,10 +98,11 @@ export const ArtworkSubmissionStatusDescription: React.FC<
               haptic
               variant={buttonVariant}
               onPress={() => {
+                trackTappedEditSubmission(submissionId, displayButtonLabel, state)
                 navigateToTheSubmissionFlow()
               }}
             >
-              {isListed ? "View Listing" : buttonLabel}
+              {displayButtonLabel}
             </Button>
           )}
         </Flex>

--- a/src/app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking.ts
+++ b/src/app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking.ts
@@ -96,6 +96,21 @@ export const useSubmitArtworkTracking = () => {
     })
   }
 
+  const trackTappedEditSubmission = (
+    submission_id: string,
+    buttonLabel: string | null | undefined,
+    submission_state: string
+  ) => {
+    trackEvent({
+      action: "tappedEditSubmission",
+      context_module: ContextModule.sell,
+      context_owner_type: OwnerType.myCollectionArtwork,
+      submission_id,
+      submission_state,
+      subject: buttonLabel,
+    })
+  }
+
   return {
     trackTappedContinueSubmission,
     trackTappedNewSubmission,
@@ -106,6 +121,7 @@ export const useSubmitArtworkTracking = () => {
     trackTappedSubmitAnotherWork,
     trackTappedViewArtworkInMyCollection,
     trackTappedContactAdvisor,
+    trackTappedEditSubmission,
   }
 }
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR resolves [Notion card](https://www.notion.so/artsy/App-Missing-tracking-when-clicking-on-Add-Additional-Information-76c98f940c94485da4199cfab3e49c09?pvs=4): add Add Additional Information tracking
### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add Add Additional Information tracking -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
