### PR TITLE
fix: Do not allow editing a submissions artist

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription.tsx
@@ -1,7 +1,11 @@
 import { Button, Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { ArtworkSubmissionStatusDescription_artwork$key } from "__generated__/ArtworkSubmissionStatusDescription_artwork.graphql"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
-import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import {
+  INITIAL_EDIT_STEP,
+  INITIAL_POST_APPROVAL_STEP,
+  SubmitArtworkProps,
+} from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
@@ -62,7 +66,7 @@ export const ArtworkSubmissionStatusDescription: React.FC<
     }
 
     const passProps: SubmitArtworkProps = {
-      initialStep: state === "APPROVED" ? "ShippingLocation" : "AddPhotos",
+      initialStep: state === "APPROVED" ? INITIAL_POST_APPROVAL_STEP : INITIAL_EDIT_STEP,
       hasStartedFlowFromMyCollection: true,
       initialValues: {},
     }

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -184,7 +184,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
       <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
         <Flex flexDirection="row" alignItems="center">
           {/* Hide the "Back" button in the Title step when editing a submission to disallow updating the artist. */}
-          {!!values.submissionId && currentStep !== INITIAL_EDIT_STEP && (
+          {(!values.submissionId || currentStep !== INITIAL_EDIT_STEP) && (
             <Touchable onPress={handleBackPress}>
               <Text underline>Back</Text>
             </Touchable>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -179,12 +179,14 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
     )
   }
 
+  // Hide the "Back" button in the Title step when editing a submission to disallow updating the artist.
+  const displayBackButton = !(values.submissionId && currentStep === INITIAL_EDIT_STEP)
+
   return (
     <Wrapper>
       <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
         <Flex flexDirection="row" alignItems="center">
-          {/* Hide the "Back" button in the Title step when editing a submission to disallow updating the artist. */}
-          {(!values.submissionId || currentStep !== INITIAL_EDIT_STEP) && (
+          {!!displayBackButton && (
             <Touchable onPress={handleBackPress}>
               <Text underline>Back</Text>
             </Touchable>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -183,6 +183,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
     <Wrapper>
       <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
         <Flex flexDirection="row" alignItems="center">
+          {/* Hide the "Back" button in the Title step when editing a submission to disallow updating the artist. */}
           {!!values.submissionId && currentStep !== INITIAL_EDIT_STEP && (
             <Touchable onPress={handleBackPress}>
               <Text underline>Back</Text>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -1,7 +1,10 @@
 import { Button, Flex, Spacer, Text, Touchable, useSpace } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import { SubmitArtworkFormStore } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFormStore"
-import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
+import {
+  INITIAL_EDIT_STEP,
+  SubmitArtworkStackNavigation,
+} from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { useSubmissionContext } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext"
 import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
@@ -180,9 +183,11 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
     <Wrapper>
       <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
         <Flex flexDirection="row" alignItems="center">
-          <Touchable onPress={handleBackPress}>
-            <Text underline>Back</Text>
-          </Touchable>
+          {currentStep !== INITIAL_EDIT_STEP && (
+            <Touchable onPress={handleBackPress}>
+              <Text underline>Back</Text>
+            </Touchable>
+          )}
         </Flex>
         <Button
           onPress={handleNextPress}

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkBottomNavigation.tsx
@@ -183,7 +183,7 @@ export const SubmitArtworkBottomNavigation: React.FC<{}> = () => {
     <Wrapper>
       <Flex flexDirection="row" justifyContent="space-between" backgroundColor="white100">
         <Flex flexDirection="row" alignItems="center">
-          {currentStep !== INITIAL_EDIT_STEP && (
+          {!!values.submissionId && currentStep !== INITIAL_EDIT_STEP && (
             <Touchable onPress={handleBackPress}>
               <Text underline>Back</Text>
             </Touchable>

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkBottomNavigation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkBottomNavigation.tests.tsx
@@ -140,21 +140,34 @@ describe("SubmitArtworkBottomNavigation", () => {
       expect(emit).toHaveBeenCalledWith(NAVIGATE_TO_NEXT_STEP_EVENT)
     })
 
-    it("Shows a functional back button", () => {
-      renderWithSubmitArtworkWrapper({
-        includeBottomNavigation: false,
-        component: <SubmitArtworkBottomNavigation />,
-        props: { currentStep: "AddTitle" },
-        injectedFormikProps: { title: "Some title" },
+    describe("when the current step is AddTitle", () => {
+      it("does not show a back button", () => {
+        renderWithSubmitArtworkWrapper({
+          includeBottomNavigation: false,
+          component: <SubmitArtworkBottomNavigation />,
+          props: { currentStep: "ArtistRejected" },
+        })
+
+        expect(screen.queryByText("Back")).toBeNull()
       })
+    })
+    describe("when the current step is not AddTitle", () => {
+      it("shows a functional back button", () => {
+        renderWithSubmitArtworkWrapper({
+          includeBottomNavigation: false,
+          component: <SubmitArtworkBottomNavigation />,
+          props: { currentStep: "AddPhotos" },
+          injectedFormikProps: { title: "Some title" },
+        })
 
-      const backButton = screen.getByText("Back")
-      expect(backButton).toBeOnTheScreen()
+        const backButton = screen.getByText("Back")
+        expect(backButton).toBeOnTheScreen()
 
-      const emit = jest.spyOn(SubmitArtworkFormEvents, "emit")
-      fireEvent(backButton, "onPress")
+        const emit = jest.spyOn(SubmitArtworkFormEvents, "emit")
+        fireEvent(backButton, "onPress")
 
-      expect(emit).toHaveBeenCalledWith(NAVIGATE_TO_PREVIOUS_STEP_EVENT)
+        expect(emit).toHaveBeenCalledWith(NAVIGATE_TO_PREVIOUS_STEP_EVENT)
+      })
     })
   })
 })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -30,9 +30,9 @@ import {
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import { getInitialNavigationState } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialNavigationState"
 import {
+  getCurrentValidationSchema,
   SubmissionModel,
   submissionModelInitialValues,
-  getCurrentValidationSchema,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { fetchUserContactInformation } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/fetchUserContactInformation"
@@ -71,6 +71,9 @@ export interface SubmitArtworkProps {
   submissionID?: string
   hasStartedFlowFromMyCollection?: boolean
 }
+
+export const INITIAL_EDIT_STEP: keyof SubmitArtworkStackNavigation = "AddTitle"
+export const INITIAL_POST_APPROVAL_STEP: keyof SubmitArtworkStackNavigation = "ShippingLocation"
 
 export const SubmitArtworkForm: React.FC<SubmitArtworkProps> = (props) => {
   const initialScreen: SubmitArtworkScreen = props.initialStep || "StartFlow"

--- a/src/app/Scenes/SellWithArtsy/Components/Header.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/Header.tsx
@@ -8,6 +8,10 @@ import {
   Touchable,
 } from "@artsy/palette-mobile"
 import { Header_submission$key } from "__generated__/Header_submission.graphql"
+import {
+  INITIAL_EDIT_STEP,
+  SubmitArtworkStackNavigation,
+} from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
@@ -29,6 +33,8 @@ export const Header: React.FC<HeaderProps> = (props) => {
 
   const artist = submission?.artist
 
+  const previousStep: keyof SubmitArtworkStackNavigation = draft?.currentStep || INITIAL_EDIT_STEP
+
   return (
     <Flex>
       <Image
@@ -44,10 +50,8 @@ export const Header: React.FC<HeaderProps> = (props) => {
           <Box mb={0.5}>
             <Touchable
               onPress={() => {
-                trackTappedContinueSubmission(draft.submissionID, draft.currentStep)
-                navigate(
-                  `/sell/submissions/${draft.submissionID}/edit?initialStep=${draft.currentStep}`
-                )
+                trackTappedContinueSubmission(draft.submissionID, previousStep)
+                navigate(`/sell/submissions/${draft.submissionID}/edit?initialStep=${previousStep}`)
               }}
               onLongPress={() => {
                 Alert.alert(

--- a/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
+++ b/src/app/Scenes/SellWithArtsy/utils/submissionModelState.tsx
@@ -1,3 +1,4 @@
+import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import {
   artworkDetailsEmptyInitialValues,
   ArtworkDetailsFormModel,
@@ -35,7 +36,7 @@ export interface ArtworkSubmissionModel {
 export interface SubmissionModel {
   draft: {
     submissionID: string
-    currentStep: string
+    currentStep: keyof SubmitArtworkStackNavigation | undefined
   } | null
   submission: ArtworkSubmissionModel
   setDraft: Action<this, this["draft"]>


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

Resolves https://www.notion.so/artsy/App-the-user-can-go-back-to-the-title-step-of-a-non-draft-submission-We-should-not-allow-the-user--06df9d217c3d45f7ab985276ed8a3b53?pvs=4

- Related Force PR: https://github.com/artsy/force/pull/14323

### Description

With this change, we link to the Title step instead of the Artist step when editing a submission and remove the "Back" button on the Title step. This approach prevents/discourages users from updating the artist of an already existing submission.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Do not allow updating the artist from an already created submission in the Sell flow (behind ff) - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
