### PR TITLE
refactor: make collections release ready

### DIFF
--- a/src/app/Scenes/Collection/Collection.tsx
+++ b/src/app/Scenes/Collection/Collection.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Flex,
   Screen,
   Separator,
@@ -19,8 +20,10 @@ import { CollectionOverview } from "app/Scenes/Collection/CollectionOverview"
 import { CollectionArtworksFragmentContainer as CollectionArtworks } from "app/Scenes/Collection/Screens/CollectionArtworks"
 import { CollectionHeader } from "app/Scenes/Collection/Screens/CollectionHeader"
 import { goBack } from "app/system/navigation/navigate"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { PlaceholderGrid } from "app/utils/placeholderGrid"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
+import { isEmpty } from "lodash"
 import { Suspense, useCallback } from "react"
 import { TouchableOpacity } from "react-native"
 import RNShare from "react-native-share"
@@ -47,10 +50,9 @@ export const CollectionContent: React.FC<CollectionProps> = ({ collection }) => 
     return null
   }
 
-  const { slug, id, title, linkedCollections, showFeaturedArtists, descriptionMarkdown } = data
+  const { slug, id, title, linkedCollections, showFeaturedArtists } = data
 
-  const shouldRenderOverviewTab =
-    !!descriptionMarkdown || !!showFeaturedArtists || !!linkedCollections
+  const shouldRenderOverviewTab = !!showFeaturedArtists || !isEmpty(linkedCollections)
 
   const trackingInfo: Schema.PageView = {
     context_screen: Schema.PageNames.Collection,
@@ -81,7 +83,7 @@ export const CollectionContent: React.FC<CollectionProps> = ({ collection }) => 
     <ProvideScreenTracking info={trackingInfo}>
       <ArtworkFiltersStoreProvider>
         <Tabs.TabsWithHeader
-          initialTabName={shouldRenderOverviewTab ? "Overview" : "Artworks"}
+          initialTabName="Artworks"
           title={`${title}`}
           showLargeHeaderText={false}
           BelowTitleHeaderComponent={renderBelowTheHeaderComponent}
@@ -98,6 +100,11 @@ export const CollectionContent: React.FC<CollectionProps> = ({ collection }) => 
             ),
           }}
         >
+          <Tabs.Tab name="Artworks" label="Artworks">
+            <Tabs.Lazy>
+              <CollectionArtworks collection={data} />
+            </Tabs.Lazy>
+          </Tabs.Tab>
           {!!shouldRenderOverviewTab ? (
             <Tabs.Tab name="Overview" label="Overview">
               <Tabs.Lazy>
@@ -105,11 +112,6 @@ export const CollectionContent: React.FC<CollectionProps> = ({ collection }) => 
               </Tabs.Lazy>
             </Tabs.Tab>
           ) : null}
-          <Tabs.Tab name="Artworks" label="Artworks">
-            <Tabs.Lazy>
-              <CollectionArtworks collection={data} />
-            </Tabs.Lazy>
-          </Tabs.Tab>
         </Tabs.TabsWithHeader>
       </ArtworkFiltersStoreProvider>
     </ProvideScreenTracking>
@@ -136,24 +138,32 @@ export const CollectionScreen: React.FC<CollectionScreenProps> = ({ collectionID
 
 const CollectionPlaceholder: React.FC = () => {
   const { width } = useScreenDimensions()
+  const shouldRenderCollectionImage = useFeatureFlag("AREnableCollectionsWithoutHeaderImage")
 
   return (
     <Screen>
-      <Screen.Header rightElements={<ShareIcon width={23} height={23} />} />
+      <Screen.Header onBack={goBack} rightElements={<ShareIcon width={23} height={23} />} />
       <Screen.Body fullwidth>
         <Skeleton>
-          <SkeletonBox width={width} height={250} />
+          {!!shouldRenderCollectionImage && <SkeletonBox width={width} height={250} />}
           <Spacer y={2} />
           <Flex px={2}>
             <SkeletonText variant="lg">Collection Name</SkeletonText>
           </Flex>
+          <Spacer y={2} />
+
+          {!shouldRenderCollectionImage && (
+            <Box px={2}>
+              <SkeletonBox width={width - 40} height={100} />
+            </Box>
+          )}
 
           <Spacer y={4} />
 
           {/* Tabs */}
           <Flex justifyContent="space-around" flexDirection="row" px={2}>
-            <SkeletonText variant="xs">Overview</SkeletonText>
             <SkeletonText variant="xs">Artworks</SkeletonText>
+            <SkeletonText variant="xs">Overview</SkeletonText>
           </Flex>
         </Skeleton>
 
@@ -181,7 +191,6 @@ export const fragment = graphql`
     title
     isDepartment
     showFeaturedArtists
-    descriptionMarkdown
     ...CollectionHeader_collection
     ...CollectionArtworks_collection @arguments(input: { sort: "-decayed_merch" })
     ...CollectionArtworksFilter_collection

--- a/src/app/Scenes/Collection/Collection.tsx
+++ b/src/app/Scenes/Collection/Collection.tsx
@@ -152,11 +152,9 @@ const CollectionPlaceholder: React.FC = () => {
           </Flex>
           <Spacer y={2} />
 
-          {!shouldRenderCollectionImage && (
-            <Box px={2}>
-              <SkeletonBox width={width - 40} height={100} />
-            </Box>
-          )}
+          <Box px={2}>
+            <SkeletonBox width={width - 40} height={100} />
+          </Box>
 
           <Spacer y={4} />
 

--- a/src/app/Scenes/Collection/CollectionOverview.tsx
+++ b/src/app/Scenes/Collection/CollectionOverview.tsx
@@ -1,8 +1,6 @@
 import { Box, Tabs, useSpace } from "@artsy/palette-mobile"
 import { CollectionOverview_collection$key } from "__generated__/CollectionOverview_collection.graphql"
-import { ReadMore } from "app/Components/ReadMore"
-import { Schema } from "app/utils/track"
-import { isTablet } from "react-native-device-info"
+import { isEmpty } from "lodash"
 import { graphql, useFragment } from "react-relay"
 import { CollectionsHubRailsContainer as CollectionHubsRails } from "./Components/CollectionHubsRails/index"
 import { CollectionFeaturedArtistsContainer as CollectionFeaturedArtists } from "./Components/FeaturedArtists"
@@ -21,23 +19,12 @@ export const CollectionOverview: React.FC<CollectionProps> = ({ collection }) =>
 
   return (
     <Tabs.ScrollView style={{ paddingTop: space(2) }}>
-      {!!data.collectionDescription && (
-        <Box mb={4} mt={0.5} accessibilityLabel="Read more">
-          <ReadMore
-            content={data.collectionDescription}
-            maxChars={isTablet() ? 300 : 250} // truncate at 300 characters on iPads and 250 on all other devices
-            contextModule={Schema.ContextModules.CollectionDescription}
-            trackingFlow={Schema.Flow.AboutTheCollection}
-            textStyle="sans"
-          />
-        </Box>
-      )}
       {!!data.showFeaturedArtists && (
         <Box>
           <CollectionFeaturedArtists collection={data} />
         </Box>
       )}
-      {!!data.linkedCollections && (
+      {!isEmpty(data.linkedCollections) && (
         <Box>
           <CollectionHubsRails linkedCollections={data.linkedCollections} collection={data} />
         </Box>
@@ -49,8 +36,6 @@ export const CollectionOverview: React.FC<CollectionProps> = ({ collection }) =>
 const fragment = graphql`
   fragment CollectionOverview_collection on MarketingCollection {
     showFeaturedArtists
-    isDepartment
-    collectionDescription: descriptionMarkdown
     ...FeaturedArtists_collection
     ...CollectionHubsRails_collection
     linkedCollections {

--- a/src/app/Scenes/Collection/Screens/CollectionHeader.tests.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionHeader.tests.tsx
@@ -2,6 +2,7 @@ import { screen } from "@testing-library/react-native"
 import { CollectionHeaderTestsQuery } from "__generated__/CollectionHeaderTestsQuery.graphql"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
 import { CollectionFixture } from "app/Scenes/Collection/Components/__fixtures__/CollectionFixture"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 import { CollectionHeader } from "./CollectionHeader"
@@ -18,34 +19,67 @@ describe("collection header", () => {
     `,
   })
 
-  it("passes the collection header image url to collection header", () => {
-    renderWithRelay({ MarketingCollection: () => CollectionFixture })
+  describe("when the feature flag is enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableCollectionsWithoutHeaderImage: true,
+      })
+    })
 
-    expect(screen.UNSAFE_queryByType(OpaqueImageView)).toBeTruthy()
-    expect(screen.UNSAFE_getByType(OpaqueImageView)).toHaveProp(
-      "imageURL",
-      "http://imageuploadedbymarketingteam.jpg"
-    )
+    it("passes the collection header image url to collection header", () => {
+      renderWithRelay({ MarketingCollection: () => CollectionFixture })
+
+      expect(screen.UNSAFE_queryByType(OpaqueImageView)).not.toBeTruthy()
+    })
+
+    it("passes the url of the most marketable artwork in the collection to the collection header when there is no headerImage value present", () => {
+      renderWithRelay({
+        MarketingCollection: () => ({
+          ...CollectionFixture,
+          headerImage: null,
+        }),
+      })
+
+      expect(screen.UNSAFE_queryByType(OpaqueImageView)).not.toBeOnTheScreen()
+    })
+  })
+
+  describe("when the feature flag is disabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableCollectionsWithoutHeaderImage: false,
+      })
+    })
+
+    it("passes the collection header image url to collection header", () => {
+      renderWithRelay({ MarketingCollection: () => CollectionFixture })
+
+      expect(screen.UNSAFE_queryByType(OpaqueImageView)).toBeTruthy()
+      expect(screen.UNSAFE_getByType(OpaqueImageView)).toHaveProp(
+        "imageURL",
+        "http://imageuploadedbymarketingteam.jpg"
+      )
+    })
+
+    it("passes the url of the most marketable artwork in the collection to the collection header when there is no headerImage value present", () => {
+      renderWithRelay({
+        MarketingCollection: () => ({
+          ...CollectionFixture,
+          headerImage: null,
+        }),
+      })
+
+      expect(screen.UNSAFE_queryByType(OpaqueImageView)).toBeOnTheScreen()
+      expect(screen.UNSAFE_getByType(OpaqueImageView)).toHaveProp(
+        "imageURL",
+        "https://defaultmostmarketableartworkincollectionimage.jpg"
+      )
+    })
   })
 
   it("passes the collection header title to collection header", () => {
     renderWithRelay({ MarketingCollection: () => CollectionFixture })
 
     expect(screen.getByText("Street Art Now")).toBeOnTheScreen()
-  })
-
-  it("passes the url of the most marketable artwork in the collection to the collection header when there is no headerImage value present", () => {
-    renderWithRelay({
-      MarketingCollection: () => ({
-        ...CollectionFixture,
-        headerImage: null,
-      }),
-    })
-
-    expect(screen.UNSAFE_queryByType(OpaqueImageView)).toBeOnTheScreen()
-    expect(screen.UNSAFE_getByType(OpaqueImageView)).toHaveProp(
-      "imageURL",
-      "https://defaultmostmarketableartworkincollectionimage.jpg"
-    )
   })
 })

--- a/src/app/Scenes/Collection/Screens/CollectionHeader.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionHeader.tsx
@@ -1,7 +1,11 @@
 import { Box, Text } from "@artsy/palette-mobile"
 import { CollectionHeader_collection$key } from "__generated__/CollectionHeader_collection.graphql"
 import OpaqueImageView from "app/Components/OpaqueImageView/OpaqueImageView"
+import { ReadMore } from "app/Components/ReadMore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { Schema } from "app/utils/track"
 import { Dimensions } from "react-native"
+import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
 interface CollectionHeaderProps {
@@ -13,21 +17,35 @@ const HEADER_IMAGE_HEIGHT = 204
 export const CollectionHeader: React.FC<CollectionHeaderProps> = ({ collection }) => {
   const data = useFragment(fragment, collection)
 
-  const { title, image, headerImage } = data
+  const shouldHideHeaderImage = useFeatureFlag("AREnableCollectionsWithoutHeaderImage")
+  const { title, image, headerImage, descriptionMarkdown } = data
   const defaultHeaderUrl = image?.edges?.[0]?.node?.image?.url || ""
   const url = headerImage ? headerImage : defaultHeaderUrl
   const { width: screenWidth } = Dimensions.get("window")
 
   return (
     <>
-      <Box mb={2} pointerEvents="none">
-        <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} />
-      </Box>
+      {!shouldHideHeaderImage && (
+        <Box mb={2} pointerEvents="none">
+          <OpaqueImageView imageURL={url} height={HEADER_IMAGE_HEIGHT} width={screenWidth} />
+        </Box>
+      )}
       <Box mb={2} pointerEvents="none">
         <Text variant="lg-display" mx={2}>
           {title}
         </Text>
       </Box>
+      {!!descriptionMarkdown && (
+        <Box mx={2} my={0.5} accessibilityLabel="Read more">
+          <ReadMore
+            content={descriptionMarkdown}
+            maxChars={isTablet() ? 300 : 250} // truncate at 300 characters on iPads and 250 on all other devices
+            contextModule={Schema.ContextModules.CollectionDescription}
+            trackingFlow={Schema.Flow.AboutTheCollection}
+            textStyle="sans"
+          />
+        </Box>
+      )}
     </>
   )
 }
@@ -36,6 +54,7 @@ const fragment = graphql`
   fragment CollectionHeader_collection on MarketingCollection {
     title
     headerImage
+    descriptionMarkdown
     image: artworksConnection(sort: "-decayed_merch", first: 1) {
       edges {
         node {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -293,6 +293,11 @@ export const features = {
     readyForRelease: false,
     showInDevMenu: true,
   },
+  AREnableCollectionsWithoutHeaderImage: {
+    description: "Remove the header image from collections",
+    readyForRelease: false,
+    showInDevMenu: true,
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Makes collection ready for release.

After checking in with Jordan Huelskamp we decided to remove the header image from the collection header to avoid duplication (change hidden behind a FF) and to move description back to the header.

Now artworks is the default tab.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- make collections release ready - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
