### PR TITLE
fix: draft submissions displayed incorrectly

### DIFF
--- a/src/app/Scenes/MyCollection/Components/SubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Components/SubmissionStatus.tsx
@@ -19,9 +19,11 @@ export const SubmissionStatus: React.FC<SubmissionStatusProps> = ({ artwork }) =
 
   return (
     <Flex flexDirection="column" testID="Submission-status-component">
-      <Text variant="xs" fontWeight="bold" color={stateLabelColor ?? "black100"}>
-        {artworkData.isListed ? "Listed" : stateLabel}
-      </Text>
+      {!!(stateLabel || isListed) && (
+        <Text variant="xs" fontWeight="bold" color={stateLabelColor ?? "black100"}>
+          {artworkData.isListed ? "Listed" : stateLabel}
+        </Text>
+      )}
 
       {!!actionLabel && !isListed && (
         <Flex flexDirection="row" alignItems="center" testID="action-label">

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
@@ -177,5 +177,31 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
         },
       })
     })
+
+    it("navigatess to submission flow ShippingLocation when action label is pressed and Tier 2", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            isListed: false,
+            internalID: "artwork-id",
+            submissionId: "submission-id",
+            consignmentSubmission: {
+              state: "DRAFT",
+              actionLabel: "Complete Submission",
+            },
+          }
+        },
+      })
+
+      expect(screen.queryAllByText("Complete Submission")).toHaveLength(2)
+      fireEvent.press(screen.getByTestId("action-label"))
+      expect(navigate).toHaveBeenCalledWith("/sell/submissions/submission-id/edit", {
+        passProps: {
+          hasStartedFlowFromMyCollection: true,
+          initialStep: "AddTitle",
+          initialValues: {},
+        },
+      })
+    })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tsx
@@ -5,6 +5,7 @@ import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { ArtworkSubmissionStatusFAQ } from "app/Scenes/MyCollection/Screens/Artwork/ArtworkSubmissionStatusFAQ"
 import { ArtworkSubmissionStatusDescription } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkSubmissionStatusDescription"
 import {
+  INITIAL_EDIT_STEP,
   INITIAL_POST_APPROVAL_STEP,
   SubmitArtworkProps,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
@@ -49,10 +50,11 @@ export const MyCollectionArtworkSubmissionStatus: React.FC<
 
   const navigateToTheSubmissionFlow = () => {
     const passProps: SubmitArtworkProps = {
-      initialStep: INITIAL_POST_APPROVAL_STEP,
+      initialStep: state === "APPROVED" ? INITIAL_POST_APPROVAL_STEP : INITIAL_EDIT_STEP,
       hasStartedFlowFromMyCollection: true,
       initialValues: {},
     }
+
     navigate(`/sell/submissions/${submissionId}/edit`, { passProps })
   }
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
Addresses [Notion card](https://www.notion.so/artsy/App-draft-submissions-displayed-incorrectly-submission-staus-is-mission-on-the-artwork-grid-the--970bdad2662d4895bb9a5acc8d5295b5?pvs=4): [App] draft submissions displayed incorrectly - submission status is mission on the artwork grid, the action label take the user to the wrong screen 
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix draft submissions displayed incorrectly -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
