### PR TITLE
fix(EMI-2019): check that partner offer is active before rendering

### DIFF
--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -337,7 +337,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         })
       }
 
-      if (!!enablePartnerOfferOnArtworkScreen && !!partnerOffer?.note) {
+      if (!!enablePartnerOfferOnArtworkScreen && !!partnerOffer?.isActive && !!partnerOffer?.note) {
         sections.push({
           key: "partnerOfferNote",
           element: (
@@ -575,7 +575,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         <ArtworkStickyBottomContent
           artwork={artworkAboveTheFold}
           me={me}
-          partnerOffer={extractNodes(me.partnerOffersConnection)[0]}
+          partnerOffer={partnerOffer}
         />
       )}
 

--- a/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkPrice.tsx
@@ -49,7 +49,12 @@ export const ArtworkPrice: React.FC<ArtworkPriceProps> = ({
     message = artworkData.saleMessage
   }
 
-  if (!!AREnablePartnerOfferOnArtworkScreen && !!partnerOfferData && partnerOfferData.isAvailable) {
+  if (
+    !!AREnablePartnerOfferOnArtworkScreen &&
+    !!partnerOfferData &&
+    partnerOfferData.isAvailable &&
+    partnerOfferData.isActive
+  ) {
     const listPrice = artworkData.isPriceHidden ? "Not publicly listed" : message
 
     return (
@@ -111,6 +116,7 @@ const partnerOfferPriceFragment = graphql`
   fragment ArtworkPrice_partnerOffer on PartnerOfferToCollector {
     endAt
     isAvailable
+    isActive
     priceWithDiscount {
       display
     }


### PR DESCRIPTION
This PR resolves [EMI-2019] <!-- eg [PROJECT-XXXX] -->

### Description

Follow up for #10607 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Check that partner offer is active before rendering - leamotta

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2019]: https://artsyproduct.atlassian.net/browse/EMI-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ