### PR TITLE
fix: fix Alerts nested navigation issue

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -488,6 +488,7 @@ export const modules = defineModules({
     hidesBackButton: true,
   }),
   Home: reactModule(HomeContainer, {
+    isRootViewForTabName: "home",
     fullBleed: unsafe_getFeatureFlag("ARUseNewHomeView") ? true : false,
   }),
   HomeView: reactModule(HomeViewScreen, { hidesBackButton: true }),

--- a/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
@@ -10,7 +10,7 @@ import {
   ArtworkIcon,
 } from "@artsy/palette-mobile"
 import SearchIcon from "app/Components/Icons/SearchIcon"
-import { switchTab } from "app/system/navigation/navigate"
+import { navigate } from "app/system/navigation/navigate"
 import { ScrollView } from "react-native"
 
 interface InfoSectionProps {
@@ -77,7 +77,7 @@ export const EmptyMessage: React.FC = () => {
           <InfoSection title={t.match.title} body={t.match.body} icon={<ArtworkIcon />} />
         </Join>
         <Spacer y={4} />
-        <Button block variant="outline" onPress={() => switchTab("home")}>
+        <Button block variant="outline" onPress={() => navigate("/")}>
           {t.button.label}
         </Button>
       </Box>

--- a/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
@@ -10,7 +10,7 @@ import {
   ArtworkIcon,
 } from "@artsy/palette-mobile"
 import SearchIcon from "app/Components/Icons/SearchIcon"
-import { navigate } from "app/system/navigation/navigate"
+import { switchTab } from "app/system/navigation/navigate"
 import { ScrollView } from "react-native"
 
 interface InfoSectionProps {
@@ -77,7 +77,7 @@ export const EmptyMessage: React.FC = () => {
           <InfoSection title={t.match.title} body={t.match.body} icon={<ArtworkIcon />} />
         </Join>
         <Spacer y={4} />
-        <Button block variant="outline" onPress={() => navigate("/")}>
+        <Button block variant="outline" onPress={() => switchTab("home")}>
           {t.button.label}
         </Button>
       </Box>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
This PR updates the navigation from the empty state of the Alerts screen in the new collector profile

### Demos

| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/d44a3e81-f32f-4cd7-b723-4b9430b91d25" /> | <video src="https://github.com/user-attachments/assets/f4f892d3-e430-4529-919b-f808b29956df" /> |
| iOS | <video src="https://github.com/user-attachments/assets/c7d80ba8-74b1-4ca6-84b3-85c5b28b776c" /> | <video src="https://github.com/user-attachments/assets/cc664cab-f659-4f5f-bb48-35f7ed521621" /> |	


### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix navigation to home in Alerts empty state - mrsltun

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
