### PR TITLE
feat(onyx-1190): add Curators' Picks: Emerging home view section

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -66,11 +66,15 @@ const sectionsFragment = graphql`
             __typename
             ... on GenericHomeViewSection {
               internalID
+              component {
+                type
+              }
               ...GenericHomeViewSection_section
             }
             ... on ArtworksRailHomeViewSection {
               internalID
               ...ArtworksRailHomeViewSection_section
+              ...FeaturedCollectionHomeViewSection_section
             }
             ... on ArtistsRailHomeViewSection {
               internalID

--- a/src/app/Scenes/HomeView/Sections/FeaturedCollectionHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/FeaturedCollectionHomeViewSection.tsx
@@ -1,0 +1,80 @@
+import { Flex, Image, Spacer, Text } from "@artsy/palette-mobile"
+import { FeaturedCollectionHomeViewSection_section$key } from "__generated__/FeaturedCollectionHomeViewSection_section.graphql"
+import { LargeArtworkRail } from "app/Components/ArtworkRail/LargeArtworkRail"
+import { navigate } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { TouchableOpacity, useWindowDimensions } from "react-native"
+import { graphql, useFragment } from "react-relay"
+
+interface FeaturedCollectionHomeViewSectionProps {
+  section: FeaturedCollectionHomeViewSection_section$key
+}
+
+export const FeaturedCollectionHomeViewSection: React.FC<
+  FeaturedCollectionHomeViewSectionProps
+> = ({ section }) => {
+  const { width } = useWindowDimensions()
+  const data = useFragment(fragment, section)
+  const component = data.component
+
+  if (!component) return null
+
+  const artworks = extractNodes(data.artworksConnection)
+  if (!artworks || artworks.length === 0) return null
+
+  const handlePress = () => {
+    navigate(component.href as string)
+  }
+
+  const handleOnArtworkPress = (artwork: any, _position: any) => {
+    navigate(artwork.href)
+  }
+
+  return (
+    <Flex pb={2} backgroundColor="black100">
+      <TouchableOpacity onPress={handlePress} activeOpacity={0.7}>
+        {!!component.backgroundImageURL && (
+          <Image width={width} height={80} resizeMode="cover" src={component.backgroundImageURL} />
+        )}
+        <Flex mx={2} mt={2}>
+          <Text color="white100" variant="lg-display" mb={0.5}>
+            {component.title}
+          </Text>
+          <Text color="white100" variant="xs">
+            {component.description}
+          </Text>
+        </Flex>
+      </TouchableOpacity>
+
+      <Spacer y={4} />
+
+      <LargeArtworkRail
+        dark
+        showPartnerName
+        artworks={artworks}
+        showSaveIcon
+        onPress={handleOnArtworkPress}
+        onMorePress={handlePress}
+      />
+    </Flex>
+  )
+}
+
+const fragment = graphql`
+  fragment FeaturedCollectionHomeViewSection_section on ArtworksRailHomeViewSection {
+    component {
+      title
+      description
+      backgroundImageURL
+      href
+    }
+
+    artworksConnection(first: 10) {
+      edges {
+        node {
+          ...LargeArtworkRail_artworks
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -2,6 +2,7 @@ import { Flex, Text } from "@artsy/palette-mobile"
 import { HomeViewSectionsConnection_viewer$data } from "__generated__/HomeViewSectionsConnection_viewer.graphql"
 import { ArtistsRailHomeViewSectionPaginationContainer } from "app/Scenes/HomeView/Sections/ArtistsRailHomeViewSection"
 import { ArtworksRailHomeViewSection } from "app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection"
+import { FeaturedCollectionHomeViewSection } from "app/Scenes/HomeView/Sections/FeaturedCollectionHomeViewSection"
 import { GenericHomeViewSection } from "app/Scenes/HomeView/Sections/GenericHomeViewSection"
 import { HeroUnitsRailHomeViewSection } from "app/Scenes/HomeView/Sections/HeroUnitsRailHomeViewSection"
 import { ExtractNodeType } from "app/utils/relayHelpers"
@@ -14,6 +15,11 @@ type SectionT = ExtractNodeType<SectionsConnection>
 
 export const Section: React.FC<{ section: SectionT }> = (props) => {
   const { section } = props
+
+  switch (section.component?.type) {
+    case "FeaturedCollection":
+      return <FeaturedCollectionHomeViewSection section={section} />
+  }
 
   switch (section.__typename) {
     case "ArtworksRailHomeViewSection":


### PR DESCRIPTION
This PR resolves [ONYX-1190]

### Description

Adds Curators' Picks: Emerging section to the new home view. Blocked by https://github.com/artsy/metaphysics/pull/5916.

See a discussion why we came up with some of implementation decisions [in Slack](https://artsy.slack.com/archives/C05EQL4R5N0/p1723746300946949).
 
<img src="https://github.com/user-attachments/assets/9e5717f4-8bbb-4737-9cd1-12dd44f38a13" width="300px" />


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1190]: https://artsyproduct.atlassian.net/browse/ONYX-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ