### PR TITLE
fix: generalize and animate AnimatedMasonryListFooterComponent

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -32,6 +32,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -75,6 +76,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     relay,
     aggregations: artist.aggregations?.aggregations,
     componentPath: "ArtistArtworks/ArtistArtworks",
+    pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions(
@@ -139,7 +141,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
-      relay.loadMore(10, () => {
+      relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)
       })
     }

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -140,6 +140,9 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
+      // IMPORTANT: this is a workaround to show the spinner concistently between refetches of pages
+      // and it is not needed for grids that use relay hooks since isLoadingNext works better than the
+      // legacy container API. See FairArtworks.tsx for an example of how to use with relay hooks.
       setIsLoading(true)
       relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -30,12 +30,12 @@ import { Props as InfiniteScrollGridProps } from "app/Components/ArtworkGrids/In
 import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { RelayPaginationProp, createPaginationContainer, graphql } from "react-relay"
@@ -252,7 +252,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
             iconPosition="right"
           />
         )}
-        <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+        <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
       </>
     )
   }

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -5,7 +5,6 @@ import { PriceOfferMessage } from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { MasonryArtworkGridItem } from "app/Components/ArtworkGrids/MasonryArtworkGridItem"
 import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   MasonryArtworkItem,
@@ -13,6 +12,7 @@ import {
   ON_END_REACHED_THRESHOLD_MASONRY,
   masonryRenderItemProps,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { useCallback } from "react"
 import Animated from "react-native-reanimated"
 
@@ -140,7 +140,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
       refreshControl={refreshControl}
       renderItem={renderItem}
       ListFooterComponent={
-        <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+        <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
       }
       onScroll={rest.onScroll}
     />

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -6,9 +6,9 @@ import { MasonryArtworkGridItem } from "app/Components/ArtworkGrids/MasonryArtwo
 import { PAGE_SIZE } from "app/Components/constants"
 import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import {
+  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MasonryArtworkItem,
-  MasonryListFooterComponent,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
   masonryRenderItemProps,
@@ -140,7 +140,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
       refreshControl={refreshControl}
       renderItem={renderItem}
       ListFooterComponent={
-        <MasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+        <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
       }
       onScroll={rest.onScroll}
     />

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -3,11 +3,11 @@ import { useSpace } from "@artsy/palette-mobile"
 import { MasonryFlashList, MasonryFlashListProps } from "@shopify/flash-list"
 import { PriceOfferMessage } from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { MasonryArtworkGridItem } from "app/Components/ArtworkGrids/MasonryArtworkGridItem"
-import { PAGE_SIZE } from "app/Components/constants"
 import { PartnerOffer } from "app/Scenes/Activity/components/NotificationArtworkList"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   MasonryArtworkItem,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
@@ -62,7 +62,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   ListHeaderComponent,
   loadMore,
   onPress,
-  pageSize = PAGE_SIZE,
+  pageSize = MASONRY_LIST_PAGE_SIZE,
   partnerOffer,
   priceOfferMessage,
   refreshControl,

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -16,12 +16,12 @@ import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/Filter
 import { GeneArtworksFilterHeader } from "app/Components/Gene/GeneArtworksFilterHeader"
 import { extractNodes } from "app/utils/extractNodes"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -128,7 +128,7 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={
-          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
         }
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -71,6 +71,9 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
+      // IMPORTANT: this is a workaround to show the spinner concistently between refetches of pages
+      // and it is not needed for grids that use relay hooks since isLoadingNext works better than the
+      // legacy container API. See FairArtworks.tsx for an example of how to use with relay hooks.
       setIsLoading(true)
       relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -14,11 +14,11 @@ import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilter
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { GeneArtworksFilterHeader } from "app/Components/Gene/GeneArtworksFilterHeader"
-import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -49,6 +49,7 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
     relay,
     aggregations: gene.artworks?.aggregations,
     componentPath: "Gene/GeneArtworks",
+    pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
   const trackClear = () => {
@@ -71,7 +72,7 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
-      relay.loadMore(PAGE_SIZE, () => {
+      relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)
       })
     }

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -11,12 +11,12 @@ import { HeaderArtworksFilterWithTotalArtworks } from "app/Components/HeaderArtw
 import { extractNodes } from "app/utils/extractNodes"
 import { get } from "app/utils/get"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -152,7 +152,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
           </Tabs.SubTabBar>
         }
         ListFooterComponent={
-          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
         }
       />
       <ArtworkFilterNavigator

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -67,6 +67,9 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
 
   const loadMore = () => {
     if (relay.hasMore() && !relay.isLoading()) {
+      // IMPORTANT: this is a workaround to show the spinner concistently between refetches of pages
+      // and it is not needed for grids that use relay hooks since isLoadingNext works better than the
+      // legacy container API. See FairArtworks.tsx for an example of how to use with relay hooks.
       setIsLoading(true)
       relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -13,6 +13,7 @@ import { get } from "app/utils/get"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -50,6 +51,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
     relay,
     aggregations: collection?.collectionArtworks?.aggregations,
     componentPath: "Collection/CollectionArtworks",
+    pageSize: MASONRY_LIST_PAGE_SIZE,
     type: "sort",
     onApply: () => scrollToTop(),
   })
@@ -66,7 +68,7 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
   const loadMore = () => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
-      relay.loadMore(10, () => {
+      relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)
       })
     }

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -19,6 +19,7 @@ import { useScreenDimensions } from "app/utils/hooks"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -230,7 +231,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
     refetch,
     aggregations: dispatchAggregations,
     componentPath: "Fair/FairArtworks",
-    pageSize: FAIR2_ARTWORKS_PAGE_SIZE,
+    pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
   useEffect(() => {
@@ -249,7 +250,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
 
   const handleOnEndReached = () => {
     if (!isLoadingNext && hasNext) {
-      loadNext(FAIR2_ARTWORKS_PAGE_SIZE, {
+      loadNext(MASONRY_LIST_PAGE_SIZE, {
         onComplete: (error) => {
           if (error) {
             console.error("FairArtworks.tsx", error.message)
@@ -342,7 +343,7 @@ const fragment = graphql`
   fragment FairArtworks_fair on Fair
   @refetchable(queryName: "FairArtworksPaginationQuery")
   @argumentDefinitions(
-    count: { type: "Int", defaultValue: 30 }
+    count: { type: "Int", defaultValue: 10 }
     cursor: { type: "String" }
     input: { type: "FilterArtworksInput" }
   ) {

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -17,6 +17,7 @@ import { FAIR2_ARTWORKS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
 import {
+  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
@@ -174,11 +175,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
           </>
         }
         ListFooterComponent={
-          !!isLoadingNext ? (
-            <Flex my={4} flexDirection="row" justifyContent="center">
-              <Spinner />
-            </Flex>
-          ) : null
+          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={isLoadingNext} />
         }
         onEndReached={handleOnEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -17,12 +17,12 @@ import { FAIR2_ARTWORKS_PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { pluralize } from "app/utils/pluralize"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useEffect, useState } from "react"
@@ -175,9 +175,7 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
             )}:`}</Text>
           </>
         }
-        ListFooterComponent={
-          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={isLoadingNext} />
-        }
+        ListFooterComponent={<AnimatedMasonryListFooter shouldDisplaySpinner={isLoadingNext} />}
         onEndReached={handleOnEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         renderItem={renderItem}

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -14,6 +14,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -33,7 +34,7 @@ export const PartnerArtwork: React.FC<{
     relay,
     aggregations: partner.artworks?.aggregations,
     componentPath: "PartnerArtwork/PartnerArtwork",
-    pageSize: 30,
+    pageSize: MASONRY_LIST_PAGE_SIZE,
   })
   const appliedFiltersCount = useSelectedFiltersCount()
 
@@ -42,7 +43,7 @@ export const PartnerArtwork: React.FC<{
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
-      relay.loadMore(10, () => {
+      relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)
       })
     }

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Box, Flex, Spinner, Tabs, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
+import { Box, Flex, Tabs, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { PartnerArtwork_partner$data } from "__generated__/PartnerArtwork_partner.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
 import {
@@ -12,6 +12,7 @@ import { TabEmptyState } from "app/Components/TabEmptyState"
 import { extractNodes } from "app/utils/extractNodes"
 
 import {
+  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
@@ -24,7 +25,7 @@ export const PartnerArtwork: React.FC<{
   relay: RelayPaginationProp
 }> = ({ partner, relay }) => {
   const [isFilterArtworksModalVisible, setIsFilterArtworksModalVisible] = useState(false)
-
+  const [isLoading, setIsLoading] = useState(false)
   const space = useSpace()
   const { width } = useScreenDimensions()
 
@@ -40,11 +41,15 @@ export const PartnerArtwork: React.FC<{
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
-      relay.loadMore(10)
+      setIsLoading(true)
+      relay.loadMore(10, () => {
+        setIsLoading(false)
+      })
     }
   }, [relay.hasMore(), relay.isLoading()])
 
-  const shouldDisplaySpinner = !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
+  const shouldDisplaySpinner =
+    !!isLoading && !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
 
   const emptyText =
     "There are no matching works from this gallery.\nTry changing your search filters"
@@ -88,11 +93,7 @@ export const PartnerArtwork: React.FC<{
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={
-          shouldDisplaySpinner ? (
-            <Flex my={4} flexDirection="row" justifyContent="center">
-              <Spinner />
-            </Flex>
-          ) : null
+          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
         }
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -12,12 +12,12 @@ import { TabEmptyState } from "app/Components/TabEmptyState"
 import { extractNodes } from "app/utils/extractNodes"
 
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import React, { useCallback, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
@@ -97,7 +97,7 @@ export const PartnerArtwork: React.FC<{
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={
-          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
         }
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -42,6 +42,9 @@ export const PartnerArtwork: React.FC<{
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
+      // IMPORTANT: this is a workaround to show the spinner concistently between refetches of pages
+      // and it is not needed for grids that use relay hooks since isLoadingNext works better than the
+      // legacy container API. See FairArtworks.tsx for an example of how to use with relay hooks.
       setIsLoading(true)
       relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -17,12 +17,12 @@ import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/Filter
 import { TagArtworksFilterHeader } from "app/Scenes/Tag/TagArtworksFilterHeader"
 import { extractNodes } from "app/utils/extractNodes"
 import {
-  AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
   MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -134,7 +134,7 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={
-          <AnimatedMasonryListFooterComponent shouldDisplaySpinner={shouldDisplaySpinner} />
+          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
         }
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -14,12 +14,12 @@ import { FilterModalMode } from "app/Components/ArtworkFilter/ArtworkFilterOptio
 import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
-import { PAGE_SIZE } from "app/Components/constants"
 import { TagArtworksFilterHeader } from "app/Scenes/Tag/TagArtworksFilterHeader"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   AnimatedMasonryListFooterComponent,
   ESTIMATED_MASONRY_ITEM_SIZE,
+  MASONRY_LIST_PAGE_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
@@ -55,6 +55,7 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
     relay,
     aggregations: tag?.artworks?.aggregations,
     componentPath: "Tag/TagArtworks",
+    pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
   const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
@@ -77,7 +78,7 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
-      relay.loadMore(PAGE_SIZE, () => {
+      relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)
       })
     }

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -77,6 +77,9 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
+      // IMPORTANT: this is a workaround to show the spinner concistently between refetches of pages
+      // and it is not needed for grids that use relay hooks since isLoadingNext works better than the
+      // legacy container API. See FairArtworks.tsx for an example of how to use with relay hooks.
       setIsLoading(true)
       relay.loadMore(MASONRY_LIST_PAGE_SIZE, () => {
         setIsLoading(false)

--- a/src/app/utils/masonryHelpers/AnimatedMasonryListFooter.tsx
+++ b/src/app/utils/masonryHelpers/AnimatedMasonryListFooter.tsx
@@ -1,0 +1,23 @@
+import { Flex, Spinner } from "@artsy/palette-mobile"
+import { motify } from "moti"
+
+interface MasonryListFooterComponentProps {
+  shouldDisplaySpinner: boolean
+}
+
+const MotiFlex = motify(Flex)()
+
+export const AnimatedMasonryListFooter: React.FC<MasonryListFooterComponentProps> = ({
+  shouldDisplaySpinner,
+}) => {
+  return (
+    <MotiFlex
+      my={4}
+      flexDirection="row"
+      justifyContent="center"
+      from={{ opacity: shouldDisplaySpinner ? 1 : 0 }}
+    >
+      <Spinner />
+    </MotiFlex>
+  )
+}

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -10,6 +10,8 @@ export const NUM_COLUMNS_MASONRY = isTablet() ? 3 : 2
 
 export const ON_END_REACHED_THRESHOLD_MASONRY = 0.3
 
+export const MASONRY_LIST_PAGE_SIZE = 10
+
 export interface masonryRenderItemProps {
   item: MasonryArtworkItem
   index: number

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -1,5 +1,5 @@
-import { Flex } from "@artsy/palette-mobile"
-import { ActivityIndicator, Platform } from "react-native"
+import { Flex, Spinner } from "@artsy/palette-mobile"
+import { motify } from "moti"
 import { isTablet } from "react-native-device-info"
 import { FragmentRefs } from "relay-runtime"
 
@@ -32,13 +32,19 @@ interface MasonryListFooterComponentProps {
   shouldDisplaySpinner: boolean
 }
 
-export const MasonryListFooterComponent: React.FC<MasonryListFooterComponentProps> = ({
+const MotiFlex = motify(Flex)()
+
+export const AnimatedMasonryListFooterComponent: React.FC<MasonryListFooterComponentProps> = ({
   shouldDisplaySpinner,
-}) =>
-  shouldDisplaySpinner ? (
-    <Flex width="100%" position="absolute">
-      <Flex mt={2}>
-        <ActivityIndicator color={Platform.OS === "android" ? "black" : undefined} />
-      </Flex>
-    </Flex>
-  ) : null
+}) => {
+  return (
+    <MotiFlex
+      my={4}
+      flexDirection="row"
+      justifyContent="center"
+      from={{ opacity: shouldDisplaySpinner ? 1 : 0 }}
+    >
+      <Spinner />
+    </MotiFlex>
+  )
+}

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -1,5 +1,3 @@
-import { Flex, Spinner } from "@artsy/palette-mobile"
-import { motify } from "moti"
 import { isTablet } from "react-native-device-info"
 import { FragmentRefs } from "relay-runtime"
 
@@ -28,25 +26,4 @@ export interface MasonryArtworkItem {
     | undefined
   readonly slug: string
   readonly " $fragmentSpreads": FragmentRefs<"ArtworkGridItem_artwork">
-}
-
-interface MasonryListFooterComponentProps {
-  shouldDisplaySpinner: boolean
-}
-
-const MotiFlex = motify(Flex)()
-
-export const AnimatedMasonryListFooterComponent: React.FC<MasonryListFooterComponentProps> = ({
-  shouldDisplaySpinner,
-}) => {
-  return (
-    <MotiFlex
-      my={4}
-      flexDirection="row"
-      justifyContent="center"
-      from={{ opacity: shouldDisplaySpinner ? 1 : 0 }}
-    >
-      <Spinner />
-    </MotiFlex>
-  )
 }


### PR DESCRIPTION
This PR resolves [PHIRE-1124] <!-- eg [PROJECT-XXXX] -->

### Description

During the mobile QA we noticed that when doing infinite scroll in any `Tabs.Masonry` surface the spinner was never displayed for the `first` refetch. 

This PR fixes that. Note that in order to do it we had to introduce a boolean state variable on the artworkGrids that use the legacy relay containers.

In surfaces where we use the hooks (i.e. Fairs), it is **not needed** since the `isLoadingNext` is working as expected.

Unified also the page size for all surfaces and the spinner and **bonus** fix was that with the new `AnimatedMasonryListFooterComponent` the content is no longer jumpy after the next page is rendered ⭐ .

Tested on all surfaces on both Android and iOS - Attaching before and after videos for `CollectionArtworks` and `ArtistArtworks`

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/68a780e3-0285-4cf4-9323-40e9a7b2d006" width="400" />|<video src="https://github.com/user-attachments/assets/c2abc4c7-78b4-48eb-b206-06d6426390ca" width="400" />|
|<video src="https://github.com/user-attachments/assets/ecc09c86-cc6e-45c1-a124-92cbfa9fa44c" width="400" />|<video src="https://github.com/user-attachments/assets/ff9b229d-f8be-4a88-b0be-cbfc34909961" width="400" />|












<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix spinner not being displayed for first refetch on Tabbed Masonry - gkartalis

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1124]: https://artsyproduct.atlassian.net/browse/PHIRE-1124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ