### PR TITLE
fix: use me properties instead of collectorProfile

### DIFF
--- a/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteMyProfileSteps.tests.tsx
+++ b/src/app/Scenes/CompleteMyProfile/hooks/__tests__/useCompleteMyProfileSteps.tests.tsx
@@ -16,12 +16,10 @@ describe("useCompleteMyProfileSteps", () => {
     env.mock.queueOperationResolver((operation) =>
       MockPayloadGenerator.generate(operation, {
         Me: () => ({
-          collectorProfile: {
-            location: { display: "New York, NY" },
-            profession: null,
-            icon: null,
-            isIdentityVerified: false,
-          },
+          location: { display: "New York, NY" },
+          profession: null,
+          icon: null,
+          isIdentityVerified: false,
         }),
       })
     )
@@ -40,11 +38,7 @@ describe("useCompleteMyProfileSteps", () => {
   it("returns only 2 steps given only 1 field missing", () => {
     env.mock.queueOperationResolver((operation) =>
       MockPayloadGenerator.generate(operation, {
-        Me: () => ({
-          collectorProfile: {
-            isIdentityVerified: false,
-          },
-        }),
+        Me: () => ({ isIdentityVerified: false }),
       })
     )
 

--- a/src/app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps.ts
+++ b/src/app/Scenes/CompleteMyProfile/hooks/useCompleteMyProfileSteps.ts
@@ -26,29 +26,25 @@ const fragment = graphql`
     ...ImageSelector_me
     ...IdentityVerificationStep_me
 
-    collectorProfile @required(action: NONE) {
-      icon {
-        url(version: "thumbnail")
-      }
-      profession
-      location {
-        display
-      }
-      isIdentityVerified
+    icon {
+      url(version: "thumbnail")
     }
+    profession
+    location {
+      display
+    }
+    isIdentityVerified
   }
 `
 
 export type StepsResult = "loading" | Routes[]
 
 const getSteps = (data?: useCompleteMyProfileSteps_me$data | null): StepsResult => {
-  if (!data?.collectorProfile) {
+  if (!data) {
     return "loading"
   }
 
-  const {
-    collectorProfile: { icon, isIdentityVerified, location, profession },
-  } = data
+  const { icon, isIdentityVerified, location, profession } = data
 
   const steps: Routes[] = []
 


### PR DESCRIPTION
### Description

Fixes the bug when updating the user avatar during "Complete My Profile" would keep the avatar step in the flow showing that the user has no image uploaded.
We have a updater to the store that changes `me.icon.url` and the hook was using `me.collectorProfile.icon` data, this PR switches to use `me.fields` instead and keep it simple.

https://github.com/user-attachments/assets/52b50265-d601-4496-8689-fa04637a7024


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: complete my profile avatar step asking for an image given the collector has one - araujobarret

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
