### PR TITLE
fix: show edit artwork button

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -396,14 +396,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 624
+        "line_number": 625
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 710
+        "line_number": 711
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1134,5 +1134,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-07T08:22:24Z"
+  "generated_at": "2024-08-21T08:03:56Z"
 }

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -23,21 +23,6 @@ describe("My Collection Artwork", () => {
   })
 
   describe("Edit button", () => {
-    it("should not be visible when consignmentSubmission is not available", () => {
-      renderWithHookWrappersTL(
-        <MyCollectionArtworkScreen
-          artworkId="random-id"
-          artistInternalID="internal-id"
-          medium="medium"
-          category="medium"
-        />,
-        mockEnvironment
-      )
-
-      resolveMostRecentRelayOperation(mockEnvironment)
-      expect(screen.getByText("Edit")).toBeOnTheScreen()
-    })
-
     it("should be visible when consignmentSubmission is available", () => {
       renderWithHookWrappersTL(
         <MyCollectionArtworkScreen
@@ -50,8 +35,29 @@ describe("My Collection Artwork", () => {
       )
 
       resolveMostRecentRelayOperation(mockEnvironment, {
-        ArtworkConsignmentSubmission: () => ({
-          state: "RESUBMITTED",
+        Artwork: () => ({
+          consignmentSubmission: {
+            internalID: "submission-id",
+          },
+        }),
+      })
+      expect(screen.getByText("Edit")).toBeOnTheScreen()
+    })
+
+    it("should be visible when consignmentSubmission is not available", () => {
+      renderWithHookWrappersTL(
+        <MyCollectionArtworkScreen
+          artworkId="random-id"
+          artistInternalID="internal-id"
+          medium="medium"
+          category="medium"
+        />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        Artwork: () => ({
+          consignmentSubmission: null,
         }),
       })
       expect(() => screen.getByText("Edit")).toThrow()

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -1,3 +1,4 @@
+import { screen } from "@testing-library/react-native"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
@@ -7,7 +8,7 @@ const mockEnvironment = getMockRelayEnvironment()
 
 describe("My Collection Artwork", () => {
   it("show new artwork screen ", () => {
-    const { getByTestId } = renderWithHookWrappersTL(
+    renderWithHookWrappersTL(
       <MyCollectionArtworkScreen
         artworkId="random-id"
         artistInternalID="internal-id"
@@ -18,6 +19,42 @@ describe("My Collection Artwork", () => {
     )
 
     resolveMostRecentRelayOperation(mockEnvironment)
-    expect(() => getByTestId("my-collection-artwork")).toBeTruthy()
+    expect(() => screen.getByTestId("my-collection-artwork")).toBeTruthy()
+  })
+
+  describe("Edit button", () => {
+    it("should not be visible when consignmentSubmission is not available", () => {
+      renderWithHookWrappersTL(
+        <MyCollectionArtworkScreen
+          artworkId="random-id"
+          artistInternalID="internal-id"
+          medium="medium"
+          category="medium"
+        />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment)
+      expect(screen.getByText("Edit")).toBeOnTheScreen()
+    })
+
+    it("should be visible when consignmentSubmission is available", () => {
+      renderWithHookWrappersTL(
+        <MyCollectionArtworkScreen
+          artworkId="random-id"
+          artistInternalID="internal-id"
+          medium="medium"
+          category="medium"
+        />,
+        mockEnvironment
+      )
+
+      resolveMostRecentRelayOperation(mockEnvironment, {
+        ArtworkConsignmentSubmission: () => ({
+          state: "RESUBMITTED",
+        }),
+      })
+      expect(() => screen.getByText("Edit")).toThrow()
+    })
   })
 })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -87,7 +87,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const articles = extractNodes(artwork.artist?.articles)
 
-  const isEditable = artwork.consignmentSubmission?.state !== "RESUBMITTED"
+  const isEditable = !!artwork.consignmentSubmission?.internalID
 
   return (
     <Screen>
@@ -273,8 +273,8 @@ export const ArtworkMetaProps = graphql`
     # needed to show the banner inside the edit artwork view
     # TODO: move logic to the edit artwork view https://artsyproduct.atlassian.net/browse/CX-2846
     consignmentSubmission @optionalField {
+      internalID
       displayText
-      state
     }
     pricePaid {
       display

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -87,12 +87,14 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const articles = extractNodes(artwork.artist?.articles)
 
+  const isEditable = artwork.consignmentSubmission?.state !== "RESUBMITTED"
+
   return (
     <Screen>
       <Screen.Header
         onBack={goBack}
-        rightElements={() =>
-          !artwork.consignmentSubmission && (
+        rightElements={
+          !!isEditable && (
             <TouchableOpacity onPress={handleEdit} hitSlop={DEFAULT_HIT_SLOP}>
               <Text>Edit</Text>
             </TouchableOpacity>
@@ -272,6 +274,7 @@ export const ArtworkMetaProps = graphql`
     # TODO: move logic to the edit artwork view https://artsyproduct.atlassian.net/browse/CX-2846
     consignmentSubmission @optionalField {
       displayText
+      state
     }
     pricePaid {
       display

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -481,7 +481,7 @@ describe("MyCollectionArtworkForm", () => {
                   confidentialNotes: "some-notes",
                   consignmentSubmission: {
                     displayText: "In progress",
-                    state: "SUBMITTED",
+                    internalID: "submission-id",
                   },
                   dimensions: {
                     in: "23",

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -481,6 +481,7 @@ describe("MyCollectionArtworkForm", () => {
                   confidentialNotes: "some-notes",
                   consignmentSubmission: {
                     displayText: "In progress",
+                    state: "SUBMITTED",
                   },
                   dimensions: {
                     in: "23",


### PR DESCRIPTION
This PR resolves [ONYX-1209]

### Description

This PR fixes the missing edit button on my collection artwork screen. I also added a bunch of tests to avoid the same regression in the future
| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/8b24fad1-c1e0-43f5-8150-158181ad5161" /> | <img src="https://github.com/user-attachments/assets/32b2f106-0243-43d5-abad-7734e2ac11bb" /> |



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- show edit artwork button - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1209]: https://artsyproduct.atlassian.net/browse/ONYX-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ