### PR TITLE
fix: SWA transition animation between AdditionalDocuments and Condition

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm.tsx
@@ -165,11 +165,12 @@ const SubmitArtworkFormContent: React.FC<SubmitArtworkProps> = ({
                 : SUBMIT_ARTWORK_DRAFT_SUBMISSION_STEPS,
           })}
         >
+          <SubmitArtworkTopNavigation />
           <Stack.Navigator
             // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
             detachInactiveScreens={false}
             screenOptions={{
-              header: () => <SubmitArtworkTopNavigation />,
+              headerShown: false,
               cardStyle: {
                 backgroundColor: "white",
                 ...(isTablet


### PR DESCRIPTION
This PR is a follow-up on https://github.com/artsy/eigen/pull/10625

### Description
This PR fixes the issue related to the progress bar transition between the additional documents and condition screens. The root cause for the issue resides inside react-navigation header prop which keeps on rendering. 

https://github.com/user-attachments/assets/7dfe1c42-4ac4-46df-b727-eb9c9d8d74c2



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix SWA transition animation between AdditionalDocuments and Condition - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
