### PR TITLE
feat(DIA-797): remove breadcrumb label from saved artworks screen

### DIFF
--- a/src/app/Scenes/SavedArtworks/SavedArtworks.tsx
+++ b/src/app/Scenes/SavedArtworks/SavedArtworks.tsx
@@ -1,4 +1,4 @@
-import { BackButton, Flex, Screen, Text, useSpace } from "@artsy/palette-mobile"
+import { BackButton, Flex, Screen, useSpace } from "@artsy/palette-mobile"
 import { ArtworkLists } from "app/Scenes/ArtworkLists/ArtworkLists"
 import { goBack } from "app/system/navigation/navigate"
 
@@ -11,7 +11,6 @@ export const SavedArtworks = () => {
         leftElements={
           <Flex flexDirection="row" alignItems="center" gap={space(1)}>
             <BackButton onPress={goBack} />
-            <Text>Profile</Text>
           </Flex>
         }
         title="Saves"


### PR DESCRIPTION
This PR resolves [DIA-797]

### Description

There are some minor differences in how the navigation headers for the saves, follows, and alerts screens work that are more obvious now that those surfaces can be accessed easily from the redesigned profile screen.

This PR addresses the minor difference that the saves screen header has a "profile" breadcrumb next to the back nav button and the other two screens don't.

| Before | | After | |
|-|-|-|-|
| ![IOS BEFORE ONE](https://github.com/user-attachments/assets/ff938ad0-be50-41e7-ba4f-622590fa1f01) | ![IOS BEFORE TWO](https://github.com/user-attachments/assets/6d8b1916-fab1-44a0-8731-79e601308fe7) | ![IOS AFTER ONE](https://github.com/user-attachments/assets/e1d94c8a-00a2-4dff-a847-a584fcc2d199) | ![IOS AFTER TWO](https://github.com/user-attachments/assets/39d2a125-8678-4ab8-a297-bb64f195efc3) |
| ![ANDROID BEFORE ONE](https://github.com/user-attachments/assets/59d757d4-9d57-4f01-97c2-69e1a5a42946) | ![ANDROID BEFORE TWO](https://github.com/user-attachments/assets/91e719f0-3fc6-4f60-aab8-424eb507580e) | ![ANDROID AFTER ONE](https://github.com/user-attachments/assets/8b59203e-9585-4a33-9e60-9fba5a954d18) | ![ANDROID AFTER TWO](https://github.com/user-attachments/assets/75e1684d-5537-41c4-bbe0-4ac6338f50ef)|


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Removed back nav breadcrumb from saved artworks screen

</details>

[DIA-797]: https://artsyproduct.atlassian.net/browse/DIA-797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ