### PR TITLE
feat(onyx-1230): add Auctions home view section

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -113,6 +113,10 @@ const sectionsFragment = graphql`
               internalID
               ...ViewingRoomsRailHomeViewSection_section
             }
+            ... on SalesRailHomeViewSection {
+              internalID
+              ...SalesRailHomeViewSection_section
+            }
           }
         }
       }

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tests.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react-native"
+import { SalesRailHomeViewSectionTestsQuery } from "__generated__/SalesRailHomeViewSectionTestsQuery.graphql"
+import { SalesRailHomeViewSection } from "app/Scenes/HomeView/Sections/SalesRailHomeViewSection"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("SalesRailHomeViewSection", () => {
+  const { renderWithRelay } = setupTestWrapper<SalesRailHomeViewSectionTestsQuery>({
+    Component: (props) => {
+      if (!props.homeView.section) {
+        return null
+      }
+      return <SalesRailHomeViewSection section={props.homeView.section} />
+    },
+    query: graphql`
+      query SalesRailHomeViewSectionTestsQuery @relay_test_operation {
+        homeView {
+          section(id: "home-view-section-auctions") {
+            ... on SalesRailHomeViewSection {
+              ...SalesRailHomeViewSection_section
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders the section properly", async () => {
+    renderWithRelay({
+      SalesRailHomeViewSection: () => ({
+        component: {
+          title: "Auctions",
+          behaviors: {
+            viewAll: {
+              href: "/auctions",
+              buttonText: "Browse All Auctions",
+            },
+          },
+        },
+        salesConnection: {
+          edges: [
+            {
+              node: {
+                name: "sale 1",
+              },
+            },
+            {
+              node: {
+                name: "sale 2",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("Auctions")).toBeOnTheScreen()
+    expect(screen.getByText("Browse All Auctions")).toBeOnTheScreen()
+    expect(screen.getByText("sale 1")).toBeOnTheScreen()
+    expect(screen.getByText("sale 2")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
@@ -22,7 +22,9 @@ export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> =
 
   const { width } = useScreenDimensions()
   const isTablet = width > 700
-
+if (sales.length === 0) {
+  return null
+}
   return (
     <Flex>
       <Flex px={2}>

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
@@ -22,9 +22,11 @@ export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> =
 
   const { width } = useScreenDimensions()
   const isTablet = width > 700
-if (sales.length === 0) {
-  return null
-}
+
+  if (sales.length === 0) {
+    return null
+  }
+
   return (
     <Flex>
       <Flex px={2}>

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
@@ -1,0 +1,80 @@
+import { Flex, useScreenDimensions } from "@artsy/palette-mobile"
+import { SalesRailHomeViewSection_section$key } from "__generated__/SalesRailHomeViewSection_section.graphql"
+import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
+import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
+import { SectionTitle } from "app/Components/SectionTitle"
+import { SalesRailItem } from "app/Scenes/HomeView/Sections/SalesRailItem"
+import { navigate } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { useRef } from "react"
+import { FlatList } from "react-native-gesture-handler"
+import { graphql, useFragment } from "react-relay"
+
+interface SalesRailHomeViewSectionProps {
+  section: SalesRailHomeViewSection_section$key
+}
+
+export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> = ({ section }) => {
+  const listRef = useRef<FlatList<any>>()
+  const data = useFragment(fragment, section)
+  const component = data.component
+  const sales = extractNodes(data.salesConnection)
+
+  const { width } = useScreenDimensions()
+  const isTablet = width > 700
+
+  return (
+    <Flex>
+      <Flex px={2}>
+        <SectionTitle
+          title={component?.title}
+          onPress={() => {
+            navigate(component?.behaviors?.viewAll?.href || "/auctions")
+          }}
+        />
+      </Flex>
+      <CardRailFlatList
+        prefetchUrlExtractor={(item) => item?.href}
+        prefetchVariablesExtractor={(item) => ({ saleSlug: item?.slug })}
+        listRef={listRef}
+        data={sales}
+        initialNumToRender={isTablet ? 10 : 5}
+        renderItem={({ item }) => {
+          return <SalesRailItem sale={item} />
+        }}
+        ListFooterComponent={
+          <BrowseMoreRailCard
+            onPress={() => {
+              navigate(component?.behaviors?.viewAll?.href || "/auctions")
+            }}
+            text={component?.behaviors?.viewAll?.buttonText || "Browse All Auctions"}
+          />
+        }
+      />
+    </Flex>
+  )
+}
+
+const fragment = graphql`
+  fragment SalesRailHomeViewSection_section on SalesRailHomeViewSection {
+    component {
+      title
+      behaviors {
+        viewAll {
+          href
+          buttonText
+        }
+      }
+    }
+
+    salesConnection(first: 10) {
+      edges {
+        node {
+          href
+          slug
+          ...SalesRailItem_sale
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/HomeView/Sections/SalesRailItem.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailItem.tsx
@@ -1,0 +1,95 @@
+import { Text } from "@artsy/palette-mobile"
+import { SalesRailItem_sale$key } from "__generated__/SalesRailItem_sale.graphql"
+import {
+  CardRailCard,
+  CardRailMetadataContainer as MetadataContainer,
+} from "app/Components/Home/CardRailCard"
+import { ThreeUpImageLayout } from "app/Components/ThreeUpImageLayout"
+import { navigate } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { compact } from "lodash"
+import { FC } from "react"
+import { View } from "react-native"
+import { graphql, useFragment } from "react-relay"
+
+interface SalesRailItemProps {
+  sale: SalesRailItem_sale$key
+}
+
+export const SalesRailItem: FC<SalesRailItemProps> = ({ sale: saleProp }) => {
+  const isArtworksConnectionEnabled = useFeatureFlag("AREnableArtworksConnectionForAuction")
+  const sale = useFragment(fragment, saleProp)
+
+  let imageURLs
+
+  if (isArtworksConnectionEnabled) {
+    imageURLs = extractNodes(sale.artworksConnection, (artwork) => artwork.image?.url)
+  } else {
+    imageURLs = extractNodes(sale.saleArtworksConnection, (artwork) => artwork.artwork?.image?.url)
+  }
+
+  // Sales are expected to always have >= 2 artworks, but we should
+  // still be cautious to avoid crashes if this assumption is broken.
+  const availableArtworkImageURLs = compact(imageURLs)
+
+  return (
+    <CardRailCard
+      key={sale.href}
+      onPress={() => {
+        const url = sale.liveURLIfOpen ?? sale.href
+
+        if (url) {
+          navigate(url)
+        }
+      }}
+    >
+      <View>
+        <ThreeUpImageLayout imageURLs={availableArtworkImageURLs} />
+        <MetadataContainer>
+          <Text numberOfLines={2} lineHeight="20px" variant="sm">
+            {sale.name}
+          </Text>
+          <Text
+            numberOfLines={1}
+            lineHeight="20px"
+            color="black60"
+            variant="sm"
+            ellipsizeMode="middle"
+          >
+            {sale.formattedStartDateTime}
+          </Text>
+        </MetadataContainer>
+      </View>
+    </CardRailCard>
+  )
+}
+
+const fragment = graphql`
+  fragment SalesRailItem_sale on Sale {
+    href
+    name
+    liveURLIfOpen
+    formattedStartDateTime
+    saleArtworksConnection(first: 3) {
+      edges {
+        node {
+          artwork {
+            image {
+              url(version: "large")
+            }
+          }
+        }
+      }
+    }
+    artworksConnection(first: 3) {
+      edges {
+        node {
+          image {
+            url(version: "large")
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -11,6 +11,7 @@ import { FeaturedCollectionHomeViewSection } from "app/Scenes/HomeView/Sections/
 import { GenericHomeViewSection } from "app/Scenes/HomeView/Sections/GenericHomeViewSection"
 import { HeroUnitsRailHomeViewSection } from "app/Scenes/HomeView/Sections/HeroUnitsRailHomeViewSection"
 import { MarketingCollectionsRailHomeViewSection } from "app/Scenes/HomeView/Sections/MarketingCollectionsRailHomeViewSection"
+import { SalesRailHomeViewSection } from "app/Scenes/HomeView/Sections/SalesRailHomeViewSection"
 import { ShowsRailHomeViewSection } from "app/Scenes/HomeView/Sections/ShowsRailHomeViewSection"
 import { ViewingRoomsRailHomeViewSection } from "app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection"
 import { ExtractNodeType } from "app/utils/relayHelpers"
@@ -54,6 +55,8 @@ export const Section: React.FC<{ section: SectionT }> = (props) => {
       return <ShowsRailHomeViewSection section={section} />
     case "ViewingRoomsRailHomeViewSection":
       return <ViewingRoomsRailHomeViewSection section={section} />
+    case "SalesRailHomeViewSection":
+      return <SalesRailHomeViewSection section={section} />
     default:
       if (__DEV__) {
         return (


### PR DESCRIPTION
This PR resolves [ONYX-1230]

### Description

Add Auctions home view section:

<img src="https://github.com/user-attachments/assets/4eae993b-ee18-4a59-b765-64fd506983f5" width="300px" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1230]: https://artsyproduct.atlassian.net/browse/ONYX-1230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ