### PR TITLE
test(flushPromiseQueue): deprecate flushPromiseQueue and give some examples

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateSavedSearchModal.tests.tsx
@@ -13,7 +13,6 @@ import {
   SavedSearchStoreProvider,
   savedSearchModel,
 } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -141,11 +140,12 @@ describe("CreateSavedSearchModal", () => {
     expect(screen.getByTestId("save-alert-button")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByTestId("save-alert-button"))
-    await flushPromiseQueue()
 
-    expect(mockNavigate).toHaveBeenCalledWith("ConfirmationScreen", {
-      alertID: "new-alert-4242",
-      searchCriteriaID: "criteria-id",
-    })
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith("ConfirmationScreen", {
+        alertID: "new-alert-4242",
+        searchCriteriaID: "criteria-id",
+      })
+    )
   })
 })

--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -19,7 +19,6 @@ import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import NavigatorIOS, {
   NavigatorIOSPushArgs,
 } from "app/utils/__legacy_do_not_use__navigator-ios-shim"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { merge } from "lodash"
 import { TouchableWithoutFeedback } from "react-native"
@@ -916,9 +915,7 @@ describe("ConfirmBid", () => {
         fireEvent.press(screen.UNSAFE_getByType(Checkbox))
         fireEvent.press(screen.getByTestId("bid-button"))
 
-        await flushPromiseQueue()
-
-        expect(relay.commitMutation).toHaveBeenCalled()
+        await waitFor(() => expect(relay.commitMutation).toHaveBeenCalled())
         expect(relay.commitMutation).toHaveBeenCalledWith(
           expect.any(Object),
           expect.objectContaining({

--- a/src/app/Components/LocationAutocomplete.tests.tsx
+++ b/src/app/Components/LocationAutocomplete.tests.tsx
@@ -1,6 +1,5 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { getLocationDetails, getLocationPredictions } from "app/utils/googleMaps"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { buildLocationDisplay, LocationAutocomplete } from "./LocationAutocomplete"
 
@@ -13,22 +12,24 @@ const mockOnChange = jest.fn()
 
 describe("LocationAutocomplete", () => {
   it("pre-fills the input with the initialLocation", () => {
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <LocationAutocomplete initialLocation={initialLocation} onChange={mockOnChange} />
     )
 
-    expect(getByTestId("autocomplete-location-input").props.value).toBe("Berlin, Germany")
+    expect(screen.getByTestId("autocomplete-location-input").props.value).toBe("Berlin, Germany")
   })
 
   it("pre-fills the input with the displayLocation", () => {
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <LocationAutocomplete
         displayLocation={buildLocationDisplay(initialLocation)}
         onChange={mockOnChange}
       />
     )
 
-    expect(getByTestId("autocomplete-location-input").props.value).toBe("Berlin, Berlin, Germany")
+    expect(screen.getByTestId("autocomplete-location-input").props.value).toBe(
+      "Berlin, Berlin, Germany"
+    )
   })
 
   describe("when selecting a location", () => {
@@ -38,11 +39,9 @@ describe("LocationAutocomplete", () => {
     })
 
     it("queries google when the user types 3 or more characters", async () => {
-      const { getByTestId, getByText } = renderWithWrappers(
-        <LocationAutocomplete onChange={mockOnChange} />
-      )
+      renderWithWrappers(<LocationAutocomplete onChange={mockOnChange} />)
 
-      const input = getByTestId("autocomplete-location-input")
+      const input = screen.getByTestId("autocomplete-location-input")
 
       fireEvent(input, "focus")
 
@@ -55,35 +54,34 @@ describe("LocationAutocomplete", () => {
       fireEvent(input, "changeText", "foo")
       expect(getLocationPredictions).toHaveBeenCalled()
 
-      await flushPromiseQueue()
+      await waitFor(() =>
+        // TOFIX: fix children direct access
+        // eslint-disable-next-line testing-library/no-node-access
+        expect(screen.getByTestId("autocomplete-location-predictions").children.length).not.toEqual(
+          0
+        )
+      )
 
-      expect(getByTestId("autocomplete-location-predictions").children.length).not.toEqual(0)
-
-      expect(getByText("Busytown, USA")).toBeTruthy()
-      expect(getByText("Hello, USA")).toBeTruthy()
+      expect(screen.getByText("Busytown, USA")).toBeTruthy()
+      expect(screen.getByText("Hello, USA")).toBeTruthy()
     })
 
     it("calls the onChange with the correct location and clears the predictions when the user selects a location", async () => {
-      const { getByTestId } = renderWithWrappers(<LocationAutocomplete onChange={mockOnChange} />)
+      renderWithWrappers(<LocationAutocomplete onChange={mockOnChange} />)
 
-      const input = getByTestId("autocomplete-location-input")
+      const input = screen.getByTestId("autocomplete-location-input")
 
       fireEvent(input, "focus")
       fireEvent(input, "changeText", "foo")
 
       expect(getLocationPredictions).toHaveBeenCalled()
 
-      await flushPromiseQueue()
-
-      const result = getByTestId("autocomplete-location-prediction-a")
-
+      const result = await screen.findByTestId("autocomplete-location-prediction-a")
       fireEvent.press(result)
 
       expect(getLocationDetails).toHaveBeenCalled()
 
-      await flushPromiseQueue()
-
-      expect(mockOnChange).toHaveBeenCalledWith(locationDetails)
+      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith(locationDetails))
     })
   })
 
@@ -94,20 +92,16 @@ describe("LocationAutocomplete", () => {
     })
 
     it("calls onChange with a custom location", async () => {
-      const { getByTestId } = renderWithWrappers(
-        <LocationAutocomplete allowCustomLocation onChange={mockOnChange} />
-      )
+      renderWithWrappers(<LocationAutocomplete allowCustomLocation onChange={mockOnChange} />)
 
-      const input = getByTestId("autocomplete-location-input")
+      const input = screen.getByTestId("autocomplete-location-input")
 
       fireEvent(input, "focus")
       fireEvent(input, "changeText", "A custom location")
 
       fireEvent(input, "blur")
 
-      await flushPromiseQueue()
-
-      expect(mockOnChange).toHaveBeenCalledWith({ city: "A custom location" })
+      await waitFor(() => expect(mockOnChange).toHaveBeenCalledWith({ city: "A custom location" }))
     })
   })
 
@@ -117,20 +111,21 @@ describe("LocationAutocomplete", () => {
     })
 
     it("shows a message", async () => {
-      const { getByText, getByTestId } = renderWithWrappers(
-        <LocationAutocomplete showError onChange={mockOnChange} />
-      )
+      renderWithWrappers(<LocationAutocomplete showError onChange={mockOnChange} />)
 
-      expect(() => getByText("Please try searching again with a different spelling.")).toThrow(
+      expect(() =>
+        screen.getByText("Please try searching again with a different spelling.")
+      ).toThrow(
         "Unable to find an element with text: Please try searching again with a different spelling."
       )
 
-      const input = getByTestId("autocomplete-location-input")
+      const input = screen.getByTestId("autocomplete-location-input")
       fireEvent.changeText(input, "there is no such a location")
 
-      await flushPromiseQueue()
-
-      expect(getByText("Please try searching again with a different spelling.")).toBeTruthy()
+      await (() =>
+        expect(
+          screen.getByText("Please try searching again with a different spelling.")
+        ).toBeTruthy())
     })
   })
 })

--- a/src/app/Scenes/Activity/Activity.tests.tsx
+++ b/src/app/Scenes/Activity/Activity.tests.tsx
@@ -1,5 +1,4 @@
-import { screen } from "@testing-library/react-native"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import { screen, waitFor } from "@testing-library/react-native"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Suspense } from "react"
 import { ActivityScreen } from "./ActivityScreen"
@@ -18,10 +17,8 @@ describe("ActivityScreen", () => {
       NotificationConnection: () => notifications,
     })
 
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Notification One")).toBeTruthy()
-    expect(screen.getByText("Notification Two")).toBeTruthy()
+    await screen.findByText("Notification One")
+    expect(screen.getByText("Notification Two")).toBeOnTheScreen()
   })
 
   describe("notification type filter pills", () => {
@@ -33,12 +30,10 @@ describe("ActivityScreen", () => {
         NotificationConnection: () => ({ totalCount: 1 }),
       })
 
-      await flushPromiseQueue()
-
-      expect(screen.getByText("All")).toBeTruthy()
-      expect(screen.getByText("Offers")).toBeTruthy()
-      expect(screen.getByText("Alerts")).toBeTruthy()
-      expect(screen.getByText("Follows")).toBeTruthy()
+      await screen.findByText("All")
+      expect(screen.getByText("Offers")).toBeOnTheScreen()
+      expect(screen.getByText("Alerts")).toBeOnTheScreen()
+      expect(screen.getByText("Follows")).toBeOnTheScreen()
     })
 
     it("does not render 'Offers' filter pill when there are no offers available", async () => {
@@ -49,13 +44,11 @@ describe("ActivityScreen", () => {
         NotificationConnection: () => ({ totalCount: 0 }),
       })
 
-      await flushPromiseQueue()
+      await waitFor(() => expect(screen.queryByText("Offers")).not.toBeOnTheScreen())
 
-      expect(screen.queryByText("Offers")).toBeFalsy()
-
-      expect(screen.getByText("All")).toBeTruthy()
-      expect(screen.getByText("Alerts")).toBeTruthy()
-      expect(screen.getByText("Follows")).toBeTruthy()
+      expect(screen.getByText("All")).toBeOnTheScreen()
+      expect(screen.getByText("Alerts")).toBeOnTheScreen()
+      expect(screen.getByText("Follows")).toBeOnTheScreen()
     })
   })
 
@@ -66,9 +59,7 @@ describe("ActivityScreen", () => {
       }),
     })
 
-    await flushPromiseQueue()
-
-    expect(screen.getByLabelText("Activities are empty")).toBeTruthy()
+    await screen.findByLabelText("Activities are empty")
   })
 
   it("hides notifications with 0 artworks", async () => {
@@ -89,11 +80,9 @@ describe("ActivityScreen", () => {
       }),
     })
 
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Notification One")).toBeTruthy()
-    expect(screen.getByText("Notification Two")).toBeTruthy()
-    expect(screen.queryByText("Notification Three")).toBeNull()
+    await screen.findByText("Notification One")
+    expect(screen.getByText("Notification Two")).toBeOnTheScreen()
+    expect(screen.queryByText("Notification Three")).not.toBeOnTheScreen()
   })
 })
 

--- a/src/app/Scenes/Activity/components/__tests__/AlertNotification.tests.tsx
+++ b/src/app/Scenes/Activity/components/__tests__/AlertNotification.tests.tsx
@@ -1,8 +1,7 @@
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { AlertNotification_Test_Query } from "__generated__/AlertNotification_Test_Query.graphql"
 import { AlertNotification } from "app/Scenes/Activity/components/AlertNotification"
 import { navigate } from "app/system/navigation/navigate"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Suspense } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -44,14 +43,12 @@ describe("AlertNotification", () => {
       }),
     })
 
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Alerts")).toBeTruthy()
-    expect(screen.getByText("2 New Works by Banksy")).toBeTruthy()
-    expect(screen.getByText("Street Art")).toBeTruthy()
-    expect(screen.getByText("Edit")).toBeTruthy()
-    expect(screen.getByText("Edit Alert")).toBeTruthy()
-    expect(screen.getByText("View all works by Banksy")).toBeTruthy()
+    await screen.findByText("Alerts")
+    expect(screen.getByText("2 New Works by Banksy")).toBeOnTheScreen()
+    expect(screen.getByText("Street Art")).toBeOnTheScreen()
+    expect(screen.getByText("Edit")).toBeOnTheScreen()
+    expect(screen.getByText("Edit Alert")).toBeOnTheScreen()
+    expect(screen.getByText("View all works by Banksy")).toBeOnTheScreen()
   })
 
   describe("Edit Alert Button in the header", () => {
@@ -62,15 +59,13 @@ describe("AlertNotification", () => {
         }),
       })
 
-      await flushPromiseQueue()
-
-      const editAlertButton = screen.getByTestId("edit-alert-header-link")
+      const editAlertButton = await screen.findByTestId("edit-alert-header-link")
 
       fireEvent.press(editAlertButton)
 
-      await flushPromiseQueue()
-
-      expect(navigate).toHaveBeenCalledWith("/settings/alerts/internal-alert-id/edit")
+      await waitFor(() =>
+        expect(navigate).toHaveBeenCalledWith("/settings/alerts/internal-alert-id/edit")
+      )
     })
   })
 
@@ -82,15 +77,13 @@ describe("AlertNotification", () => {
         }),
       })
 
-      await flushPromiseQueue()
-
-      const editAlertButton = screen.getByTestId("edit-alert-CTA")
+      const editAlertButton = await screen.findByTestId("edit-alert-CTA")
 
       fireEvent.press(editAlertButton)
 
-      await flushPromiseQueue()
-
-      expect(navigate).toHaveBeenCalledWith("/settings/alerts/internal-alert-id/edit")
+      await waitFor(() =>
+        expect(navigate).toHaveBeenCalledWith("/settings/alerts/internal-alert-id/edit")
+      )
     })
   })
 
@@ -102,15 +95,11 @@ describe("AlertNotification", () => {
         }),
       })
 
-      await flushPromiseQueue()
-
-      const viewAllWorksByLink = screen.getByText("View all works by Banksy")
+      const viewAllWorksByLink = await screen.findByText("View all works by Banksy")
 
       fireEvent.press(viewAllWorksByLink)
 
-      await flushPromiseQueue()
-
-      expect(navigate).toHaveBeenCalledWith("/artist/banksy/works-for-sale")
+      await waitFor(() => expect(navigate).toHaveBeenCalledWith("/artist/banksy/works-for-sale"))
     })
   })
 })

--- a/src/app/utils/tests/flushPromiseQueue.ts
+++ b/src/app/utils/tests/flushPromiseQueue.ts
@@ -1,5 +1,9 @@
 /**
- * test utility to wait for all promises to be resolved
+ * @deprecated consider instead:
+ *   - waiting an element to appear with `await screen.findBy`
+ *   - waiting an element to disappear with `await waitForElementToBeRemoved(() => screen.getByTestId("test"))`
+ *   - resolving any pending relay operations with `mockMostRecentOperation`
+ *   - spreading any missing component dependent fragment in the test query
  */
 export const flushPromiseQueue = () =>
   new Promise((r) => setTimeout(() => requestAnimationFrame(r), 0))

--- a/src/app/utils/tests/flushPromiseQueue.ts
+++ b/src/app/utils/tests/flushPromiseQueue.ts
@@ -1,5 +1,6 @@
 /**
  * @deprecated consider instead:
+ *   - await waitFor(() => { ... })
  *   - waiting an element to appear with `await screen.findBy`
  *   - waiting an element to disappear with `await waitForElementToBeRemoved(() => screen.getByTestId("test"))`
  *   - resolving any pending relay operations with `mockMostRecentOperation`


### PR DESCRIPTION
This PR deprecates flushPromiseQueue and shows some examples how to proper handle these cases within some test scenarios.

#noChangelog

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
