### PR TITLE
fix(ActivityItem): avoid navigating on CollectorProfileUpdatePromptNotificationItem

### DIFF
--- a/src/app/Scenes/Activity/ActivityItem.tests.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tests.tsx
@@ -98,6 +98,22 @@ describe("ActivityItem", () => {
     )
   })
 
+  it("does not navigate given a notificationItem of type 'PartnerOfferCreatedNotificationItem'", async () => {
+    renderWithRelay({
+      Notification: () => ({
+        ...notificationWithFF,
+        item: {
+          item: notificationWithFF.item,
+          __typename: "CollectorProfileUpdatePromptNotificationItem",
+        },
+      }),
+    })
+
+    fireEvent.press(await screen.findByText("Tell us a little bit more about you."))
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
   it("should NOT call `mark as read` mutation if the notification has already been read", async () => {
     renderWithRelay({
       Notification: () => notificationWithFF,

--- a/src/app/Scenes/Activity/ActivityItem.tsx
+++ b/src/app/Scenes/Activity/ActivityItem.tsx
@@ -39,6 +39,8 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
       isArtworksBasedNotification(notification.notificationType) && remainingArtworksCount > 0
     const isPartnerOffer = notification.notificationType === "PARTNER_OFFER_CREATED"
     const isEditorial = notification.notificationType === "ARTICLE_FEATURED_ARTIST"
+    const isCollectorProfileUpdate =
+      notification.item?.__typename === "CollectorProfileUpdatePromptNotificationItem"
 
     const handlePress = () => {
       tracking.trackEvent(tracks.tappedNotification(notification.notificationType))
@@ -47,7 +49,9 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
         markAsRead(notification)
       }
 
-      navigateToActivityItem(notification)
+      if (!isCollectorProfileUpdate) {
+        navigateToActivityItem(notification)
+      }
     }
 
     const showAsRow = isPartnerOffer
@@ -55,7 +59,7 @@ export const ActivityItem: React.FC<ActivityItemProps> = memo(
     return (
       <TouchableOpacity activeOpacity={0.65} onPress={handlePress}>
         <Flex flexDirection="row" alignItems="center" justifyContent="space-between" px={2}>
-          {notification.item?.__typename === "CollectorProfileUpdatePromptNotificationItem" ? (
+          {!!isCollectorProfileUpdate ? (
             <CollectorUpdateNotification notification={notification} item={notification.item} />
           ) : (
             <Flex flex={1} pr={2}>


### PR DESCRIPTION
### Description

Fix when navigating to the notification item of type _CollectorProfileUpdatePromptNotificationItem_, it should not navigate on this case, we open a prompt instead.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
