### PR TITLE
fix: show collection prompt before profile prompt

### DIFF
--- a/src/app/Scenes/Artwork/hooks/__tests__/useSendInquiry.tests.tsx
+++ b/src/app/Scenes/Artwork/hooks/__tests__/useSendInquiry.tests.tsx
@@ -193,7 +193,7 @@ describe("useSendInquiry", () => {
 
       await waitFor(() =>
         expect(dispatch).toHaveBeenCalledWith({
-          type: "setProfilePromptVisible",
+          type: "setCollectionPromptVisible",
           payload: true,
         })
       )

--- a/src/app/Scenes/Artwork/hooks/__tests__/useSendInquiry.tests.tsx
+++ b/src/app/Scenes/Artwork/hooks/__tests__/useSendInquiry.tests.tsx
@@ -176,6 +176,7 @@ describe("useSendInquiry", () => {
           location: { display: null },
           collectorProfile: { lastUpdatePromptAt: null },
           myCollectionInfo: { artistsCount: 0, artworksCount: 0 },
+          userInterestsConnection: { totalCount: 0 },
         }),
       })
 

--- a/src/app/Scenes/Artwork/hooks/useSendInquiry.ts
+++ b/src/app/Scenes/Artwork/hooks/useSendInquiry.ts
@@ -101,13 +101,6 @@ export const useSendInquiry = ({
         }
 
         if (
-          userShouldBePromptedToCompleteProfile({ locationDisplay, profession, lastUpdatePromptAt })
-        ) {
-          dispatch({ type: "setProfilePromptVisible", payload: true })
-          return
-        }
-
-        if (
           userShouldBePromptedToAddArtistsToCollection({
             lastUpdatePromptAt,
             artworksCount,
@@ -115,6 +108,13 @@ export const useSendInquiry = ({
           })
         ) {
           dispatch({ type: "setCollectionPromptVisible", payload: true })
+          return
+        }
+
+        if (
+          userShouldBePromptedToCompleteProfile({ locationDisplay, profession, lastUpdatePromptAt })
+        ) {
+          dispatch({ type: "setProfilePromptVisible", payload: true })
           return
         }
 


### PR DESCRIPTION
### Description

This PR changes the order of prompts. Previously we showed a profile prompt before the collector prompt, but this PR swaps that so that the collector prompt is shown first.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Show collection prompt before profile prompt

</details>
