### PR TITLE
fix: broken search artworks container test

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -462,7 +462,7 @@ describe("ArtworkCommercialButtons", () => {
             "context_owner_id": "5b2b745e9c18db204fc32e11",
             "context_owner_slug": "andreas-rod-prinzknecht",
             "context_owner_type": "artwork",
-            "signal_label": undefined,
+            "signal_label": "Limited-Time Offer",
           },
         ]
       `)
@@ -494,7 +494,7 @@ describe("ArtworkCommercialButtons", () => {
             "context_owner_id": "5b2b745e9c18db204fc32e11",
             "context_owner_slug": "andreas-rod-prinzknecht",
             "context_owner_type": "artwork",
-            "signal_label": undefined,
+            "signal_label": "Limited-Time Offer",
           },
         ]
       `)

--- a/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tests.tsx
@@ -79,6 +79,7 @@ describe("SearchArtworks", () => {
           "destination_screen_owner_type": "artwork",
           "position": 0,
           "query": "keyword",
+          "signal_label": "Limited-Time Offer",
           "sort": "-decayed_merch",
           "type": "thumbnail",
         },


### PR DESCRIPTION
### Description

This PR fixes tests after they broke due to enabling [this](https://github.com/artsy/echo/pull/668) feature flag

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
