### PR TITLE
fix: Update view saves button issue

### DIFF
--- a/src/app/Components/ArtworkLists/useArtworkListsToast.ts
+++ b/src/app/Components/ArtworkLists/useArtworkListsToast.ts
@@ -64,7 +64,7 @@ export const useArtworkListToast = (bottomPadding?: number | null) => {
     showToast(message, {
       cta: "View List",
       onPress: () => {
-        navigate(`/artwork-list/${artworkList.internalID}`)
+        navigate(`/settings/saves/${artworkList.internalID}`)
       },
       backgroundColor: "green100",
     })
@@ -77,7 +77,7 @@ export const useArtworkListToast = (bottomPadding?: number | null) => {
     showToast(message, {
       cta: "View Saves",
       onPress: () => {
-        navigate("/artwork-lists")
+        navigate("/settings/saves")
       },
       backgroundColor: "green100",
     })

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -257,6 +257,7 @@ function getDomainMap(): Record<string, RouteMatcher[] | null> {
     addRoute("/settings/alerts/:savedSearchAlertId/edit", "EditSavedSearchAlert"),
     addRoute("/settings/alerts/:alertId/artworks", "AlertArtworks"),
     addRoute("/settings/saves", "SavedArtworks"),
+    addRoute("/settings/saves/:listID", "ArtworkList"),
     addRoute("/settings/dark-mode", "DarkModeSettings"),
     addRoute("/show/:showID", "Show"),
     addRoute("/show/:showID/info", "ShowMoreInfo"),


### PR DESCRIPTION
This PR resolves [APPL-1069] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue with the View Saves button showing an empty screen after saving an artwork

### Demos
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/1e34fd46-ea43-49de-b54f-72fa76a848e2" /> | <video src="https://github.com/user-attachments/assets/cbebb581-2493-449a-8347-489fa38da470" /> |
| iOS | <video src="https://github.com/user-attachments/assets/cd1ddbde-626c-486d-b629-7d998510b1af" /> | <video src="https://github.com/user-attachments/assets/14d28979-94c9-4971-bf48-3c81c28f4105" /> |	

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix the issue with View Saves link navigating the user to an empty screen - sultan, brian, carlos

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[APPL-1069]: https://artsyproduct.atlassian.net/browse/APPL-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ