### PR TITLE
chore: update commit message to use conventional commits

### DIFF
--- a/scripts/update-metaphysics.js
+++ b/scripts/update-metaphysics.js
@@ -9,9 +9,9 @@ async function main() {
     await updateRepo({
       repo: { owner: "artsy", repo: "metaphysics" },
       branch: "update-eigen-query-map",
-      title: "Update eigen query map",
+      title: "chore: update eigen query map",
       targetBranch: "main",
-      commitMessage: "Update eigen query map",
+      commitMessage: "chore: update eigen query map",
       body: "Greetings human :robot: this PR was automatically created as part of eigen's deploy process",
       assignees: ["artsyit"],
       labels: ["Merge On Green"],


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Our query map updates in metaphysics were failing because they did not adhere to conventional commit format 🙃 
This just updates the message to conform. 

https://github.com/artsy/metaphysics/pull/5827

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update query map pr to use conventional commits - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
