### PR TITLE
feat: add ArtworksRailHomeViewSection tracking

### DIFF
--- a/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tests.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { ArtworksRailHomeViewSectionTestsQuery } from "__generated__/ArtworksRailHomeViewSectionTestsQuery.graphql"
+import { ArtworksRailHomeViewSection } from "app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection"
+import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("ArtworksRailHomeViewSection", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworksRailHomeViewSectionTestsQuery>({
+    Component: (props) => {
+      if (!props.homeView.section) {
+        return null
+      }
+      return <ArtworksRailHomeViewSection section={props.homeView.section} />
+    },
+    query: graphql`
+      query ArtworksRailHomeViewSectionTestsQuery @relay_test_operation {
+        homeView {
+          section(id: "home-view-section-new-works-for-you") {
+            ... on ArtworksRailHomeViewSection {
+              ...ArtworksRailHomeViewSection_section
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders nothing when no artworks", () => {
+    const { toJSON } = renderWithRelay({
+      HomeViewComponent: () => ({
+        title: "New Works for You",
+      }),
+      ArtworkConnection: () => ({
+        totalCount: 0,
+        edges: [],
+      }),
+    })
+
+    expect(toJSON()).toBeNull()
+  })
+
+  it("renders a list of artworks", () => {
+    renderWithRelay({
+      ArtworksRailHomeViewSection: () => ({
+        internalID: "home-view-section-new-works-for-you",
+        component: {
+          title: "New Works for You",
+        },
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "artwork-1-id",
+                slug: "artwork-1-slug",
+                title: "Artwork 1",
+                href: "/artwork-1-href",
+              },
+            },
+            {
+              node: {
+                internalID: "artwork-2-id",
+                slug: "artwork-2-slug",
+                title: "Artwork 2",
+                href: "/artwork-2-href",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("New Works for You")).toBeOnTheScreen()
+    expect(screen.getByText(/Artwork 1/)).toBeOnTheScreen()
+    expect(screen.getByText(/Artwork 2/)).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText(/Artwork 2/))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "action": "tappedArtworkGroup",
+            "context_module": "home-view-section-new-works-for-you",
+            "context_screen_owner_type": "home",
+            "destination_screen_owner_id": "artwork-2-id",
+            "destination_screen_owner_slug": "artwork-2-slug",
+            "destination_screen_owner_type": "artwork",
+            "horizontal_slide_position": 1,
+            "module_height": "single",
+            "type": "thumbnail",
+          },
+        ]
+      `)
+
+    expect(navigate).toHaveBeenCalledWith("/artwork-2-href")
+  })
+})

--- a/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tsx
@@ -1,11 +1,14 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { ArtworksRailHomeViewSection_section$key } from "__generated__/ArtworksRailHomeViewSection_section.graphql"
 import { LargeArtworkRail } from "app/Components/ArtworkRail/LargeArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
+import LegacyHomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { View } from "react-native"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface ArtworksRailHomeViewSectionProps {
   section: ArtworksRailHomeViewSection_section$key
@@ -14,14 +17,28 @@ interface ArtworksRailHomeViewSectionProps {
 export const ArtworksRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionProps> = ({
   section,
 }) => {
+  const tracking = useTracking()
+
   const data = useFragment(fragment, section)
   const title = data.component?.title
   const artworks = extractNodes(data.artworksConnection)
   const componentHref = data.component?.behaviors?.viewAll?.href
 
-  if (!artworks || artworks.length === 0) return null
+  if (!artworks || artworks.length === 0) {
+    return null
+  }
 
-  const handleOnArtworkPress = (artwork: any, _position: any) => {
+  const handleOnArtworkPress = (artwork: any, position: number) => {
+    tracking.trackEvent(
+      LegacyHomeAnalytics.artworkThumbnailTapEvent(
+        data.internalID as ContextModule,
+        artwork.slug,
+        artwork.internalID,
+        position,
+        "single"
+      )
+    )
+
     navigate(artwork.href)
   }
 
@@ -59,6 +76,7 @@ export const ArtworksRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionPr
 
 const fragment = graphql`
   fragment ArtworksRailHomeViewSection_section on ArtworksRailHomeViewSection {
+    internalID
     component {
       title
       behaviors {


### PR DESCRIPTION
This PR resolves [ONYX-1255] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds legacy tracking events to artworks' rail sections.


https://github.com/user-attachments/assets/732d4a8b-4131-460c-89a8-d19cb7799e74



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1255]: https://artsyproduct.atlassian.net/browse/ONYX-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ