### PR TITLE
feat: add ActivityRailHomeViewSection tracking

### DIFF
--- a/src/app/Scenes/Home/homeAnalytics.ts
+++ b/src/app/Scenes/Home/homeAnalytics.ts
@@ -112,10 +112,14 @@ export default class HomeAnalytics {
     })
   }
 
-  static activityThumbnailTapEvent(index: number, destinationModule: string): TappedEntityGroup {
+  static activityThumbnailTapEvent(
+    index: number,
+    destinationModule: string,
+    contextModule?: ContextModule
+  ): TappedEntityGroup {
     return {
       action: ActionType.tappedActivityGroup,
-      context_module: ContextModule.activityRail,
+      context_module: contextModule || ContextModule.activityRail,
       context_screen_owner_type: OwnerType.home,
       destination_screen_owner_type: destinationModule.toLowerCase() as TappedEntityDestinationType,
       horizontal_slide_position: index,

--- a/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tests.tsx
@@ -1,6 +1,7 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { ActivityRailHomeViewSectionTestsQuery } from "__generated__/ActivityRailHomeViewSectionTestsQuery.graphql"
 import { ActivityRailHomeViewSection } from "app/Scenes/HomeView/Sections/ActivityRailHomeViewSection"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -40,30 +41,49 @@ describe("ActivityRailHomeViewSection", () => {
 
   it("renders a list of activities", () => {
     renderWithRelay({
-      HomeViewComponent: () => ({
-        title: "Latest Activity",
-      }),
-      NotificationConnection: () => ({
-        edges: [
-          {
-            node: {
-              internalID: "id-1",
-              notificationType: "ARTWORK_ALERT",
-              headline: "artwork alert",
+      ActivityRailHomeViewSection: () => ({
+        internalID: "home-view-section-latest-activity",
+        component: {
+          title: "Latest Activity",
+        },
+        notificationsConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "id-1",
+                notificationType: "ARTWORK_ALERT",
+                headline: "artwork alert",
+              },
             },
-          },
-          {
-            node: {
-              internalID: "id-2",
-              notificationType: "VIEWING_ROOM_PUBLISHED",
-              headline: "viewing room published",
+            {
+              node: {
+                internalID: "id-2",
+                notificationType: "VIEWING_ROOM_PUBLISHED",
+                headline: "viewing room published",
+              },
             },
-          },
-        ],
+          ],
+        },
       }),
     })
 
     expect(screen.getByText(/artwork alert/)).toBeOnTheScreen()
     expect(screen.getByText(/viewing room published/)).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText(/viewing room published/))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "action": "tappedActivityGroup",
+            "context_module": "home-view-section-latest-activity",
+            "context_screen_owner_type": "home",
+            "destination_screen_owner_type": "vanityurlentity",
+            "horizontal_slide_position": 1,
+            "module_height": "single",
+            "type": "thumbnail",
+          },
+        ]
+      `)
   })
 })

--- a/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tsx
@@ -1,13 +1,17 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer } from "@artsy/palette-mobile"
 import { ActivityRailHomeViewSection_section$key } from "__generated__/ActivityRailHomeViewSection_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { SeeAllCard } from "app/Scenes/Home/Components/ActivityRail"
 import { ActivityRailItem } from "app/Scenes/Home/Components/ActivityRailItem"
+import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
+import { matchRoute } from "app/routes"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { FlatList } from "react-native"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface ActivityRailHomeViewSectionProps {
   section: ActivityRailHomeViewSection_section$key
@@ -16,6 +20,8 @@ interface ActivityRailHomeViewSectionProps {
 export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionProps> = ({
   section,
 }) => {
+  const tracking = useTracking()
+
   const data = useFragment(sectionFragment, section)
   const component = data.component
   const componentHref = "/notifications" // TODO: this should be in the schema
@@ -54,8 +60,25 @@ export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionPr
         data={notifications}
         initialNumToRender={3}
         keyExtractor={(item) => item.internalID}
-        renderItem={({ item }) => {
-          return <ActivityRailItem item={item} />
+        renderItem={({ item, index }) => {
+          return (
+            <ActivityRailItem
+              item={item}
+              onPress={() => {
+                const destinationRoute = matchRoute(item.targetHref)
+                const destinationModule =
+                  destinationRoute.type === "match" ? destinationRoute?.module : ""
+
+                tracking.trackEvent(
+                  HomeAnalytics.activityThumbnailTapEvent(
+                    index,
+                    destinationModule,
+                    data.internalID as ContextModule
+                  )
+                )
+              }}
+            />
+          )
         }}
       />
     </Flex>
@@ -64,6 +87,7 @@ export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionPr
 
 const sectionFragment = graphql`
   fragment ActivityRailHomeViewSection_section on ActivityRailHomeViewSection {
+    internalID
     component {
       title
     }
@@ -75,6 +99,7 @@ const sectionFragment = graphql`
           artworks: artworksConnection {
             totalCount
           }
+          targetHref
           item {
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {


### PR DESCRIPTION
This PR resolves [ONYX-1257] <!-- eg [PROJECT-XXXX] -->

### Description
This PR adds legacy tracking to activity' rail sections.



https://github.com/user-attachments/assets/0d4e9fab-3e47-4278-b81f-ccea041e6e93



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add ActivityRailHomeViewSection tracking - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1257]: https://artsyproduct.atlassian.net/browse/ONYX-1257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ