### PR TITLE
feat(onyx-1259): home view sections use use behaviors.viewAll.href field for navigation

### DIFF
--- a/src/app/Scenes/Home/Components/ArticlesRail.tsx
+++ b/src/app/Scenes/Home/Components/ArticlesRail.tsx
@@ -14,9 +14,14 @@ import { useTracking } from "react-tracking"
 interface ArticlesRailProps {
   title: string
   articlesConnection: ArticlesRail_articlesConnection$data
+  onSectionTitlePress?: () => void
 }
 
-export const ArticlesRail: React.FC<ArticlesRailProps> = ({ title, articlesConnection }) => {
+export const ArticlesRail: React.FC<ArticlesRailProps> = ({
+  title,
+  articlesConnection,
+  onSectionTitlePress,
+}) => {
   const articles = extractNodes(articlesConnection)
   const tracking = useTracking()
 
@@ -24,16 +29,19 @@ export const ArticlesRail: React.FC<ArticlesRailProps> = ({ title, articlesConne
     return null
   }
 
+  const onTitlePress = () => {
+    if (onSectionTitlePress) {
+      onSectionTitlePress()
+    } else {
+      tracking.trackEvent(HomeAnalytics.articlesHeaderTapEvent())
+      navigate("/articles")
+    }
+  }
+
   return (
     <Flex>
       <Flex mx={2}>
-        <SectionTitle
-          title={title}
-          onPress={() => {
-            tracking.trackEvent(HomeAnalytics.articlesHeaderTapEvent())
-            navigate("/articles")
-          }}
-        />
+        <SectionTitle title={title} onPress={onTitlePress} />
       </Flex>
       <Flex>
         <FlatList

--- a/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ActivityRailHomeViewSection.tsx
@@ -18,7 +18,7 @@ export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionPr
 }) => {
   const data = useFragment(sectionFragment, section)
   const component = data.component
-  const componentHref = "/notifications" // TODO: this should be in the schema
+  const componentHref = component?.behaviors?.viewAll?.href
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
@@ -33,9 +33,13 @@ export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionPr
       <Flex px={2}>
         <SectionTitle
           title={component?.title || "Activity"}
-          onPress={() => {
-            navigate(componentHref)
-          }}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
         />
       </Flex>
 
@@ -43,13 +47,17 @@ export const ActivityRailHomeViewSection: React.FC<ActivityRailHomeViewSectionPr
         horizontal
         showsHorizontalScrollIndicator={false}
         ListHeaderComponent={() => <Spacer x={2} />}
-        ListFooterComponent={() => (
-          <SeeAllCard
-            onPress={() => {
-              navigate(componentHref)
-            }}
-          />
-        )}
+        ListFooterComponent={
+          componentHref
+            ? () => (
+                <SeeAllCard
+                  onPress={() => {
+                    navigate(componentHref)
+                  }}
+                />
+              )
+            : undefined
+        }
         ItemSeparatorComponent={() => <Spacer x={2} />}
         data={notifications}
         initialNumToRender={3}
@@ -66,6 +74,11 @@ const sectionFragment = graphql`
   fragment ActivityRailHomeViewSection_section on ActivityRailHomeViewSection {
     component {
       title
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
     notificationsConnection(first: 10) {
       edges {

--- a/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tests.tsx
@@ -29,6 +29,12 @@ describe("ArticlesCardsHomeViewSection", () => {
     renderWithRelay({
       HomeViewComponent: () => ({
         title: "Some news items",
+        behaviors: {
+          viewAll: {
+            href: "/articles",
+            buttonText: "All the news",
+          },
+        },
       }),
       ArticleConnection: () => ({
         edges: [
@@ -58,5 +64,6 @@ describe("ArticlesCardsHomeViewSection", () => {
     expect(screen.getByText(/The first news item/)).toBeOnTheScreen()
     expect(screen.getByText(/The second news item/)).toBeOnTheScreen()
     expect(screen.getByText(/The third news item/)).toBeOnTheScreen()
+    expect(screen.getByText(/All the news/)).toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tsx
@@ -15,12 +15,14 @@ export const ArticlesCardsHomeViewSection: React.FC<ArticlesCardsHomeViewSection
   const data = useFragment(fragment, section)
   const articles = extractNodes(data.cardArticlesConnection)
   const title = data.component?.title ?? "News"
-  const viewAllHref = data.component?.href ?? "/news" // TODO: update to use new behaviors
+  const componentHref = data.component?.behaviors?.viewAll?.href
 
   const space = useSpace()
 
-  const handleOnPress = (href: string) => {
-    navigate(href)
+  const handleOnPress = () => {
+    if (componentHref) {
+      navigate(componentHref)
+    }
   }
 
   return (
@@ -31,7 +33,7 @@ export const ArticlesCardsHomeViewSection: React.FC<ArticlesCardsHomeViewSection
       </Flex>
       {articles.map((article, index) => (
         <Flex key={index} gap={space(2)}>
-          <Touchable onPress={() => handleOnPress(article.href ?? "")}>
+          <Touchable onPress={handleOnPress}>
             <Flex flexDirection="row" alignItems="center">
               <Text variant="sm-display" numberOfLines={3}>
                 {article.title}
@@ -41,14 +43,13 @@ export const ArticlesCardsHomeViewSection: React.FC<ArticlesCardsHomeViewSection
           {index !== articles.length - 1 && <Separator />}
         </Flex>
       ))}
-      <Touchable onPress={() => navigate(viewAllHref)}>
-        <Flex flexDirection="row" justifyContent="flex-end">
-          <Text variant="sm-display">
-            {/* TODO: get this text from new behavior */}
-            More in News
-          </Text>
-        </Flex>
-      </Touchable>
+      {!!componentHref && (
+        <Touchable onPress={() => navigate(componentHref)}>
+          <Flex flexDirection="row" justifyContent="flex-end">
+            <Text variant="sm-display">More in News</Text>
+          </Flex>
+        </Touchable>
+      )}
     </Flex>
   )
 }
@@ -63,7 +64,11 @@ const fragment = graphql`
   fragment ArticlesCardsHomeViewSection_section on ArticlesRailHomeViewSection {
     component {
       title
-      href
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
 
     cardArticlesConnection: articlesConnection(first: 3) {

--- a/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArticlesCardsHomeViewSection.tsx
@@ -16,6 +16,7 @@ export const ArticlesCardsHomeViewSection: React.FC<ArticlesCardsHomeViewSection
   const articles = extractNodes(data.cardArticlesConnection)
   const title = data.component?.title ?? "News"
   const componentHref = data.component?.behaviors?.viewAll?.href
+  const componentButtonText = data.component?.behaviors?.viewAll?.buttonText
 
   const space = useSpace()
 
@@ -46,7 +47,7 @@ export const ArticlesCardsHomeViewSection: React.FC<ArticlesCardsHomeViewSection
       {!!componentHref && (
         <Touchable onPress={() => navigate(componentHref)}>
           <Flex flexDirection="row" justifyContent="flex-end">
-            <Text variant="sm-display">More in News</Text>
+            <Text variant="sm-display">{componentButtonText}</Text>
           </Flex>
         </Touchable>
       )}
@@ -67,6 +68,7 @@ const fragment = graphql`
       behaviors {
         viewAll {
           href
+          buttonText
         }
       }
     }

--- a/src/app/Scenes/HomeView/Sections/ArticlesRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArticlesRailHomeViewSection.tsx
@@ -1,5 +1,6 @@
 import { ArticlesRailHomeViewSection_section$key } from "__generated__/ArticlesRailHomeViewSection_section.graphql"
 import { ArticlesRailFragmentContainer } from "app/Scenes/Home/Components/ArticlesRail"
+import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
 interface ArticlesRailHomeViewSectionProps {
@@ -13,10 +14,19 @@ export const ArticlesRailHomeViewSection: React.FC<ArticlesRailHomeViewSectionPr
     return null
   }
 
+  const componentHref = section.component?.behaviors?.viewAll?.href
+
   return (
     <ArticlesRailFragmentContainer
       title={section.component?.title ?? ""}
       articlesConnection={section.articlesConnection}
+      onSectionTitlePress={
+        componentHref
+          ? () => {
+              navigate(componentHref)
+            }
+          : undefined
+      }
     />
   )
 }
@@ -25,6 +35,11 @@ const sectionFragment = graphql`
   fragment ArticlesRailHomeViewSection_section on ArticlesRailHomeViewSection {
     component {
       title
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
     articlesConnection(first: 10) {
       ...ArticlesRail_articlesConnection

--- a/src/app/Scenes/HomeView/Sections/ArtistsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArtistsRailHomeViewSection.tsx
@@ -7,6 +7,7 @@ import {
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { PAGE_SIZE } from "app/Components/constants"
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
@@ -24,6 +25,7 @@ export const ArtistsRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionPro
   const { hasMore, isLoading, loadMore } = relay
 
   const title = section.component?.title
+  const componentHref = section.component?.behaviors?.viewAll?.href
 
   const onEndReached = () => {
     if (!hasMore() && !isLoading()) {
@@ -46,7 +48,16 @@ export const ArtistsRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionPro
   return (
     <Flex>
       <Flex px={2}>
-        <SectionTitle title={title} />
+        <SectionTitle
+          title={title}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
+        />
       </Flex>
       <CardRailFlatList<Artist>
         data={artists}
@@ -87,6 +98,11 @@ export const ArtistsRailHomeViewSectionPaginationContainer = createPaginationCon
         internalID
         component {
           title
+          behaviors {
+            viewAll {
+              href
+            }
+          }
         }
         artistsConnection(after: $cursor, first: $count)
           @connection(key: "ArtistsRailHomeViewSection_artistsConnection") {

--- a/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ArtworksRailHomeViewSection.tsx
@@ -17,7 +17,7 @@ export const ArtworksRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionPr
   const data = useFragment(fragment, section)
   const title = data.component?.title
   const artworks = extractNodes(data.artworksConnection)
-  const componentHref = "" // TODO: should be in schema
+  const componentHref = data.component?.behaviors?.viewAll?.href
 
   if (!artworks || artworks.length === 0) return null
 
@@ -31,18 +31,26 @@ export const ArtworksRailHomeViewSection: React.FC<ArtworksRailHomeViewSectionPr
         <Flex pl={2} pr={2}>
           <SectionTitle
             title={title}
-            onPress={() => {
-              navigate(componentHref)
-            }}
+            onPress={
+              componentHref
+                ? () => {
+                    navigate(componentHref)
+                  }
+                : undefined
+            }
           />
         </Flex>
         <LargeArtworkRail
           artworks={artworks}
           onPress={handleOnArtworkPress}
           showSaveIcon
-          onMorePress={() => {
-            navigate(componentHref)
-          }}
+          onMorePress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
         />
       </View>
     </Flex>
@@ -53,6 +61,11 @@ const fragment = graphql`
   fragment ArtworksRailHomeViewSection_section on ArtworksRailHomeViewSection {
     component {
       title
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
 
     artworksConnection(first: 10) {

--- a/src/app/Scenes/HomeView/Sections/AuctionResultsRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/AuctionResultsRailHomeViewSection.tests.tsx
@@ -30,7 +30,6 @@ describe("AuctionResultsRailHomeViewSection", () => {
     const { toJSON } = renderWithRelay({
       HomeViewComponent: () => ({
         title: "Latest Auction Results",
-        href: "/auction-results-for-artists-you-follow",
       }),
       AuctionResultConnection: () => ({
         totalCount: 0,
@@ -45,10 +44,8 @@ describe("AuctionResultsRailHomeViewSection", () => {
     renderWithRelay({
       HomeViewComponent: () => ({
         title: "Latest Auction Results",
-        href: "/auction-results-for-artists-you-follow-href",
         behaviors: {
           viewAll: {
-            buttonText: "View All",
             href: "/auction-results-for-artists-you-follow-view-all-href",
           },
         },
@@ -73,8 +70,8 @@ describe("AuctionResultsRailHomeViewSection", () => {
     expect(screen.getByText(/Auction result 1/)).toBeOnTheScreen()
     expect(screen.getByText(/Auction result 2/)).toBeOnTheScreen()
 
-    expect(screen.getByText("View All")).toBeOnTheScreen()
-    fireEvent.press(screen.getByText("View All"))
+    expect(screen.getByText("Browse All Results")).toBeOnTheScreen()
+    fireEvent.press(screen.getByText("Browse All Results"))
 
     expect(navigate).toHaveBeenCalledWith("/auction-results-for-artists-you-follow-view-all-href")
   })

--- a/src/app/Scenes/HomeView/Sections/AuctionResultsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/AuctionResultsRailHomeViewSection.tsx
@@ -23,15 +23,14 @@ export const AuctionResultsRailHomeViewSection: React.FC<AuctionResultsRailHomeV
   }
 
   const auctionResults = extractNodes(section.auctionResultsConnection)
+  const componentHref = section.component?.behaviors?.viewAll?.href
 
   return (
     <Flex>
       <Flex px={2}>
         <SectionTitle
           title={section.component?.title ?? "Auction Results"}
-          {...(section.component?.href
-            ? { onPress: () => navigate(section.component?.href as string) }
-            : {})}
+          onPress={componentHref ? () => navigate(componentHref) : undefined}
         />
       </Flex>
       <FlatList
@@ -47,18 +46,16 @@ export const AuctionResultsRailHomeViewSection: React.FC<AuctionResultsRailHomeV
           />
         )}
         keyExtractor={(item) => item.internalID}
-        {...(section.component?.behaviors?.viewAll?.href
-          ? {
-              ListFooterComponent: (
-                <BrowseMoreRailCard
-                  onPress={() => {
-                    navigate(section.component?.behaviors?.viewAll?.href as string)
-                  }}
-                  text={section.component?.behaviors?.viewAll?.buttonText ?? "Browse All Results"}
-                />
-              ),
-            }
-          : {})}
+        ListFooterComponent={
+          componentHref ? (
+            <BrowseMoreRailCard
+              onPress={() => {
+                navigate(componentHref)
+              }}
+              text="Browse All Results"
+            />
+          ) : undefined
+        }
       />
     </Flex>
   )
@@ -68,10 +65,8 @@ const sectionFragment = graphql`
   fragment AuctionResultsRailHomeViewSection_section on AuctionResultsRailHomeViewSection {
     component {
       title
-      href
       behaviors {
         viewAll {
-          buttonText
           href
         }
       }

--- a/src/app/Scenes/HomeView/Sections/FairsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/FairsRailHomeViewSection.tsx
@@ -3,6 +3,7 @@ import { FairsRailHomeViewSection_section$key } from "__generated__/FairsRailHom
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { FairRailItem } from "app/Scenes/HomeView/Sections/FairRailItem"
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { graphql, useFragment } from "react-relay"
 
@@ -13,6 +14,7 @@ interface FairsRailHomeViewSectionProps {
 export const FairsRailHomeViewSection: React.FC<FairsRailHomeViewSectionProps> = ({ section }) => {
   const data = useFragment(fragment, section)
   const component = data.component
+  const componentHref = component?.behaviors?.viewAll?.href
 
   if (!component) return null
 
@@ -22,7 +24,17 @@ export const FairsRailHomeViewSection: React.FC<FairsRailHomeViewSectionProps> =
   return (
     <Flex>
       <Flex pl={2} pr={2}>
-        <SectionTitle title={component.title} subtitle={component.description} />
+        <SectionTitle
+          title={component.title}
+          subtitle={component.description}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
+        />
       </Flex>
 
       <CardRailFlatList<any>
@@ -41,6 +53,11 @@ const fragment = graphql`
     component {
       title
       description
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
 
     fairsConnection(first: 10) {

--- a/src/app/Scenes/HomeView/Sections/FeaturedCollectionHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/FeaturedCollectionHomeViewSection.tsx
@@ -16,6 +16,7 @@ export const FeaturedCollectionHomeViewSection: React.FC<
   const { width } = useWindowDimensions()
   const data = useFragment(fragment, section)
   const component = data.component
+  const componentHref = component?.behaviors?.viewAll?.href
 
   if (!component) return null
 
@@ -23,7 +24,9 @@ export const FeaturedCollectionHomeViewSection: React.FC<
   if (!artworks || artworks.length === 0) return null
 
   const handlePress = () => {
-    navigate(component.href as string)
+    if (componentHref) {
+      navigate(componentHref)
+    }
   }
 
   const handleOnArtworkPress = (artwork: any, _position: any) => {
@@ -54,7 +57,7 @@ export const FeaturedCollectionHomeViewSection: React.FC<
         artworks={artworks}
         showSaveIcon
         onPress={handleOnArtworkPress}
-        onMorePress={handlePress}
+        onMorePress={componentHref ? handlePress : undefined}
       />
     </Flex>
   )
@@ -66,7 +69,11 @@ const fragment = graphql`
       title
       description
       backgroundImageURL
-      href
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
 
     artworksConnection(first: 10) {

--- a/src/app/Scenes/HomeView/Sections/GalleriesHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/GalleriesHomeViewSection.tests.tsx
@@ -27,13 +27,11 @@ describe("GalleriesHomeViewSection", () => {
     renderWithRelay({
       HomeViewComponent: () => ({
         title: "Galleries Near You",
-        href: "/galleries-for-you",
         backgroundImageURL: "https://url.com/image.jpg",
         description: "Follow these local galleries for updates on artists you love.",
         behaviors: {
           viewAll: {
             href: "/galleries-for-you",
-            buttonText: "Explore",
           },
         },
       }),

--- a/src/app/Scenes/HomeView/Sections/GalleriesHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/GalleriesHomeViewSection.tsx
@@ -23,8 +23,7 @@ export const GalleriesHomeViewSection: React.FC<GalleriesHomeViewSectionProps> =
   const hasImage = !!section.component.backgroundImageURL
   const textColor = hasImage ? "white100" : "black100"
 
-  const componentHref = section.component?.href
-  const viewAllHref = section.component?.behaviors?.viewAll?.href
+  const componentHref = section.component?.behaviors?.viewAll?.href
 
   return (
     <Flex>
@@ -69,16 +68,16 @@ export const GalleriesHomeViewSection: React.FC<GalleriesHomeViewSectionProps> =
               </Text>
             </Flex>
 
-            {!!viewAllHref && (
+            {!!componentHref && (
               <Flex mt={0.5} maxWidth={150}>
                 <Button
                   variant={hasImage ? "outlineLight" : "fillDark"}
                   size="small"
                   onPress={() => {
-                    navigate(viewAllHref)
+                    navigate(componentHref)
                   }}
                 >
-                  {section.component.behaviors?.viewAll?.buttonText}
+                  Explore
                 </Button>
               </Flex>
             )}
@@ -95,11 +94,9 @@ const GalleriesHomeViewSectionFragment = graphql`
       title
       backgroundImageURL
       description
-      href
       behaviors {
         viewAll {
           href
-          buttonText
         }
       }
     }

--- a/src/app/Scenes/HomeView/Sections/MarketingCollectionsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/MarketingCollectionsRailHomeViewSection.tsx
@@ -6,6 +6,7 @@ import {
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { MarketingCollectionRailItem } from "app/Scenes/HomeView/Sections/MarketingCollectionRailItem"
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { graphql, useFragment } from "react-relay"
@@ -19,6 +20,7 @@ export const MarketingCollectionsRailHomeViewSection: React.FC<
 > = ({ section }) => {
   const data = useFragment(fragment, section)
   const component = data.component
+  const componentHref = component?.behaviors?.viewAll?.href
 
   if (!component) return null
 
@@ -28,7 +30,16 @@ export const MarketingCollectionsRailHomeViewSection: React.FC<
   return (
     <Flex>
       <Flex pl={2} pr={2}>
-        <SectionTitle title={component.title} />
+        <SectionTitle
+          title={component.title}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
+        />
       </Flex>
 
       <CardRailFlatList<
@@ -50,6 +61,11 @@ const fragment = graphql`
   fragment MarketingCollectionsRailHomeViewSection_section on MarketingCollectionsRailHomeViewSection {
     component {
       title
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
 
     marketingCollectionsConnection(first: 10) {

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tests.tsx
@@ -33,7 +33,6 @@ describe("SalesRailHomeViewSection", () => {
           behaviors: {
             viewAll: {
               href: "/auctions",
-              buttonText: "Browse All Auctions",
             },
           },
         },

--- a/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/SalesRailHomeViewSection.tsx
@@ -18,6 +18,7 @@ export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> =
   const listRef = useRef<FlatList<any>>()
   const data = useFragment(fragment, section)
   const component = data.component
+  const componentHref = component?.behaviors?.viewAll?.href
   const sales = extractNodes(data.salesConnection)
 
   const { width } = useScreenDimensions()
@@ -32,9 +33,13 @@ export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> =
       <Flex px={2}>
         <SectionTitle
           title={component?.title}
-          onPress={() => {
-            navigate(component?.behaviors?.viewAll?.href || "/auctions")
-          }}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
         />
       </Flex>
       <CardRailFlatList
@@ -47,12 +52,14 @@ export const SalesRailHomeViewSection: React.FC<SalesRailHomeViewSectionProps> =
           return <SalesRailItem sale={item} />
         }}
         ListFooterComponent={
-          <BrowseMoreRailCard
-            onPress={() => {
-              navigate(component?.behaviors?.viewAll?.href || "/auctions")
-            }}
-            text={component?.behaviors?.viewAll?.buttonText || "Browse All Auctions"}
-          />
+          componentHref ? (
+            <BrowseMoreRailCard
+              onPress={() => {
+                navigate(componentHref)
+              }}
+              text="Browse All Auctions"
+            />
+          ) : undefined
         }
       />
     </Flex>
@@ -66,7 +73,6 @@ const fragment = graphql`
       behaviors {
         viewAll {
           href
-          buttonText
         }
       }
     }

--- a/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tsx
@@ -5,6 +5,7 @@ import {
   ViewingRoomsHomeRail as LegacyViewingRoomsHomeRail,
   ViewingRoomsRailPlaceholder,
 } from "app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail"
+import { navigate } from "app/system/navigation/navigate"
 import { Suspense } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -12,11 +13,21 @@ export const ViewingRoomsRailHomeViewSection: React.FC<{
   section: ViewingRoomsRailHomeViewSection_section$key
 }> = ({ section }) => {
   const data = useFragment(viewingRoomsFragment, section)
+  const componentHref = data.component?.behaviors?.viewAll?.href
 
   return (
     <Flex>
       <Flex px={2}>
-        <SectionTitle title={data.component?.title} />
+        <SectionTitle
+          title={data.component?.title}
+          onPress={
+            componentHref
+              ? () => {
+                  navigate(componentHref)
+                }
+              : undefined
+          }
+        />
       </Flex>
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
         <LegacyViewingRoomsHomeRail />
@@ -29,6 +40,11 @@ const viewingRoomsFragment = graphql`
   fragment ViewingRoomsRailHomeViewSection_section on ViewingRoomsRailHomeViewSection {
     component {
       title
+      behaviors {
+        viewAll {
+          href
+        }
+      }
     }
   }
 `


### PR DESCRIPTION
This PR resolves [ONYX-1259]

### Description

Follow-up for https://github.com/artsy/metaphysics/pull/5963. Adds navigation links (from MP) to new home view sections.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1259]: https://artsyproduct.atlassian.net/browse/ONYX-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ