### PR TITLE
feat: add ViewingRoomsRailHomeViewSection tracking

### DIFF
--- a/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tests.tsx
@@ -1,6 +1,7 @@
-import { screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
 import { ViewingRoomsRailHomeViewSectionTestsQuery } from "__generated__/ViewingRoomsRailHomeViewSectionTestsQuery.graphql"
 import { ViewingRoomsRailHomeViewSection } from "app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -61,5 +62,66 @@ describe("ViewingRoomsRailHomeViewSection", () => {
 
     expect(screen.getByText("viewing room 1")).toBeOnTheScreen()
     expect(screen.getByText("viewing room 2")).toBeOnTheScreen()
+  })
+
+  it("navigates and tracks individual viewing room taps", async () => {
+    const { mockResolveLastOperation } = renderWithRelay({
+      ViewingRoomsRailHomeViewSection: () => ({
+        internalID: "home-view-section-viewing-rooms",
+        component: {
+          title: "Viewing Rooms",
+          behaviors: {
+            viewAll: {
+              href: "/viewing-rooms",
+              buttonText: "View All",
+            },
+          },
+        },
+      }),
+    })
+
+    expect(screen.getByText("Viewing Rooms")).toBeOnTheScreen()
+
+    mockResolveLastOperation({
+      ViewingRoomConnection: () => ({
+        edges: [
+          {
+            node: {
+              title: "viewing room 1",
+              href: "/viewing-room/zero-dot-dot-dot-alessandro-pessoli/alessandro-pessoli-ardente-primavera-number-1",
+              slug: "alessandro-pessoli-ardente-primavera-number-1",
+              internalID: "one",
+            },
+          },
+          {
+            node: {
+              title: "viewing room 2",
+              href: "/viewing-room/zero-dot-dot-dot-alessandro-pessoli/alessandro-pessoli-ardente-primavera-number-1",
+              slug: "alessand-pessoli-ardente-primavera-number-1",
+              internalID: "two",
+            },
+          },
+        ],
+      }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId("viewing-room-rail-placeholder"))
+
+    fireEvent.press(screen.getByText("viewing room 1"))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "action": "tappedViewingRoomGroup",
+          "context_module": "home-view-section-viewing-rooms",
+          "context_screen": "home",
+          "context_screen_owner_type": "home",
+          "destination_screen_owner_id": "one",
+          "destination_screen_owner_slug": "alessandro-pessoli-ardente-primavera-number-1",
+          "destination_screen_owner_type": "ViewingRoom",
+          "type": "thumbnail",
+        },
+      ]
+  `)
   })
 })

--- a/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tsx
+++ b/src/app/Scenes/HomeView/Sections/ViewingRoomsRailHomeViewSection.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { ViewingRoomsRailHomeViewSection_section$key } from "__generated__/ViewingRoomsRailHomeViewSection_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
@@ -30,7 +31,13 @@ export const ViewingRoomsRailHomeViewSection: React.FC<{
         />
       </Flex>
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
-        <LegacyViewingRoomsHomeRail />
+        <LegacyViewingRoomsHomeRail
+          trackInfo={{
+            screen: OwnerType.home,
+            ownerType: OwnerType.home,
+            contextModule: data.internalID as ContextModule,
+          }}
+        />
       </Suspense>
     </Flex>
   )
@@ -38,6 +45,7 @@ export const ViewingRoomsRailHomeViewSection: React.FC<{
 
 const viewingRoomsFragment = graphql`
   fragment ViewingRoomsRailHomeViewSection_section on ViewingRoomsRailHomeViewSection {
+    internalID
     component {
       title
       behaviors {

--- a/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer, Touchable } from "@artsy/palette-mobile"
 import { ViewingRoomsHomeRailQuery } from "__generated__/ViewingRoomsHomeRailQuery.graphql"
 import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
@@ -73,7 +74,7 @@ export const ViewingRoomsRailPlaceholder = () => (
 )
 
 interface ViewingRoomsHomeRailProps {
-  trackInfo?: { screen: string; ownerType: string }
+  trackInfo?: { screen: string; ownerType: string; contextModule?: ContextModule }
 }
 
 export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({ trackInfo }) => {
@@ -102,7 +103,8 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({ trac
                           item.internalID,
                           item.slug,
                           trackInfo.screen,
-                          trackInfo.ownerType
+                          trackInfo.ownerType,
+                          trackInfo.contextModule
                         )
                       : featuredTracks.tappedFeaturedViewingRoomRailItem(item.internalID, item.slug)
                   )

--- a/src/app/Scenes/ViewingRoom/Components/ViewingRoomsListFeatured.tsx
+++ b/src/app/Scenes/ViewingRoom/Components/ViewingRoomsListFeatured.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Spacer, Touchable } from "@artsy/palette-mobile"
 import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
 import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
@@ -112,10 +113,11 @@ export const tracks = {
     vrId: string,
     vrSlug: string,
     screen: string,
-    ownerType: string
+    ownerType: string,
+    contextModule?: ContextModule
   ) => ({
     action: Schema.ActionNames.TappedViewingRoomGroup,
-    context_module: Schema.ContextModules.FeaturedViewingRoomsRail,
+    context_module: contextModule || Schema.ContextModules.FeaturedViewingRoomsRail,
     context_screen: screen,
     context_screen_owner_type: ownerType,
     destination_screen_owner_type: Schema.OwnerEntityTypes.ViewingRoom,


### PR DESCRIPTION
This PR resolves [ONYX-1263] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds tracking to the home view viewing rooms rail section.


https://github.com/user-attachments/assets/a4c3b269-28f0-4848-a935-10c388313f75



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add ViewingRoomsRailHomeViewSection tracking - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1263]: https://artsyproduct.atlassian.net/browse/ONYX-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ