### PR TITLE
fix: broken MyC spec after SWA release

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
@@ -50,6 +50,10 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
   })
 
   it("display Submission status and In Progress when submission is in progress", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableSubmitArtworkTier2Information: false,
+    })
+
     renderWithRelay({
       Artwork: () => {
         return {
@@ -67,6 +71,10 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
   })
 
   it("display Submission status and Evaluation Complete when submission has been evaluated", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableSubmitArtworkTier2Information: false,
+    })
+
     renderWithRelay({
       Artwork: () => {
         return {


### PR DESCRIPTION
### Description

There's a spec that's been failing on CI ever since we [toggled the `AREnableSubmitArtworkTier2Information` flag](https://github.com/artsy/echo/pull/685/files) as part of the [SWA Tier 2 release](https://www.notion.so/artsy/SWA-Tier-2-Launch-f353c144ff2e473b8ecb859f1d3ca804) earlier today.



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Update a MyC spec that fails after an Echo change - Roop

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
