### PR TITLE
chore(analytics): add useHomeViewTracking hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "braces": "in the resolutions - needed to resolve a security dependency issue - need to remove this when the issue is resolved and packages are updated"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.203.0",
+    "@artsy/cohesion": "4.204.0",
     "@artsy/palette-mobile": "13.2.29",
     "@artsy/to-title-case": "1.1.0",
     "@braze/react-native-sdk": "5.2.0",

--- a/src/app/Components/Lists/AuctionResultListItem.tsx
+++ b/src/app/Components/Lists/AuctionResultListItem.tsx
@@ -24,6 +24,7 @@ interface Props {
   auctionResult: AuctionResultListItem_auctionResult$data
   first?: boolean
   onPress?: () => void
+  onTrack?: () => void
   showArtistName?: boolean
   trackingEventPayload?: {}
   width?: number
@@ -38,6 +39,7 @@ const AuctionResultListItem: React.FC<Props> = ({
   onPress,
   showArtistName,
   trackingEventPayload,
+  onTrack,
   width,
   withHorizontalPadding = true,
 }) => {
@@ -58,9 +60,12 @@ const AuctionResultListItem: React.FC<Props> = ({
       return
     }
 
-    if (trackingEventPayload) {
+    if (onTrack) {
+      onTrack()
+    } else if (trackingEventPayload) {
       tracking.trackEvent(trackingEventPayload)
     }
+
     // For upcoming auction results that are happening in Artsy we want to navigate to the lot page
     if (auctionResult.isUpcoming && auctionResult.isInArtsyAuction && auctionResult.externalURL) {
       navigate(auctionResult.externalURL)

--- a/src/app/Scenes/Home/Components/ArticlesRail.tsx
+++ b/src/app/Scenes/Home/Components/ArticlesRail.tsx
@@ -1,4 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer } from "@artsy/palette-mobile"
 import { ArticlesRail_articlesConnection$data } from "__generated__/ArticlesRail_articlesConnection.graphql"
 import { ArticleCardContainer } from "app/Components/ArticleCard"
@@ -6,6 +5,7 @@ import { SectionTitle } from "app/Components/SectionTitle"
 import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { ExtractNodeType } from "app/utils/relayHelpers"
 import { memo } from "react"
 import { FlatList } from "react-native"
 import { isTablet } from "react-native-device-info"
@@ -14,14 +14,14 @@ import { useTracking } from "react-tracking"
 
 interface ArticlesRailProps {
   articlesConnection: ArticlesRail_articlesConnection$data
-  contextModule?: ContextModule
+  onTrack?: (article: ExtractNodeType<ArticlesRail_articlesConnection$data>, index: number) => void
   onSectionTitlePress?: () => void
   title: string
 }
 
 export const ArticlesRail: React.FC<ArticlesRailProps> = ({
   articlesConnection,
-  contextModule,
+  onTrack,
   onSectionTitlePress,
   title,
 }) => {
@@ -59,11 +59,14 @@ export const ArticlesRail: React.FC<ArticlesRailProps> = ({
           renderItem={({ item, index }) => (
             <ArticleCardContainer
               onPress={() => {
+                if (onTrack) {
+                  return onTrack(item, index)
+                }
+
                 const tapEvent = HomeAnalytics.articleThumbnailTapEvent(
                   item.internalID,
                   item.slug || "",
-                  index,
-                  contextModule
+                  index
                 )
                 tracking.trackEvent(tapEvent)
               }}

--- a/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
+++ b/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
@@ -11,7 +11,7 @@ import { useRef, useState } from "react"
 import { FlatList, PixelRatio, ViewabilityConfig } from "react-native"
 import { useFragment, graphql } from "react-relay"
 
-export type HeroUnit = NonNullable<
+type HeroUnit = NonNullable<
   NonNullable<NonNullable<HeroUnitsRail_heroUnitsConnection$data["edges"]>[number]>["node"]
 >
 interface HeroUnitProps {

--- a/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
+++ b/src/app/Scenes/Home/Components/HeroUnitsRail.tsx
@@ -11,7 +11,7 @@ import { useRef, useState } from "react"
 import { FlatList, PixelRatio, ViewabilityConfig } from "react-native"
 import { useFragment, graphql } from "react-relay"
 
-type HeroUnit = NonNullable<
+export type HeroUnit = NonNullable<
   NonNullable<NonNullable<HeroUnitsRail_heroUnitsConnection$data["edges"]>[number]>["node"]
 >
 interface HeroUnitProps {

--- a/src/app/Scenes/Home/Components/ShowsRail.tsx
+++ b/src/app/Scenes/Home/Components/ShowsRail.tsx
@@ -1,13 +1,17 @@
 import { ActionType, ContextModule, OwnerType, TappedShowGroup } from "@artsy/cohesion"
 import { Flex, Spacer, Text } from "@artsy/palette-mobile"
 import { ShowsRailQuery } from "__generated__/ShowsRailQuery.graphql"
-import { ShowsRail_showsConnection$key } from "__generated__/ShowsRail_showsConnection.graphql"
+import {
+  ShowsRail_showsConnection$data,
+  ShowsRail_showsConnection$key,
+} from "__generated__/ShowsRail_showsConnection.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { ShowCardContainer } from "app/Components/ShowCard"
 import { extractNodes } from "app/utils/extractNodes"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { Location, useLocation } from "app/utils/hooks/useLocation"
 import { PlaceholderBox, RandomWidthPlaceholderText } from "app/utils/placeholders"
+import { ExtractNodeType } from "app/utils/relayHelpers"
 import { times } from "lodash"
 import { Suspense, memo } from "react"
 import { FlatList } from "react-native"
@@ -18,6 +22,7 @@ interface ShowsRailProps {
   disableLocation: boolean
   location?: Location | null
   contextModule?: ContextModule
+  onTrack?: (show: ExtractNodeType<ShowsRail_showsConnection$data>, index: number) => void
   title: string
 }
 
@@ -25,7 +30,7 @@ interface ShowsRailProps {
 const NUMBER_OF_SHOWS = 10
 
 export const ShowsRail: React.FC<ShowsRailProps> = memo(
-  ({ disableLocation, location, contextModule, title }) => {
+  ({ disableLocation, location, contextModule, onTrack, title }) => {
     const tracking = useTracking()
 
     const queryVariables = location
@@ -66,6 +71,10 @@ export const ShowsRail: React.FC<ShowsRailProps> = memo(
               <ShowCardContainer
                 show={item}
                 onPress={() => {
+                  if (onTrack) {
+                    return onTrack(item, index)
+                  }
+
                   tracking.trackEvent(
                     tracks.tappedThumbnail(item.internalID, item.slug || "", index, contextModule)
                   )
@@ -135,11 +144,13 @@ interface ShowsRailContainerProps {
   title: string
   disableLocation?: boolean
   contextModule?: ContextModule
+  onTrack?: (show: ExtractNodeType<ShowsRail_showsConnection$data>, index: number) => void
 }
 
 export const ShowsRailContainer: React.FC<ShowsRailContainerProps> = ({
   disableLocation = false,
   contextModule,
+  onTrack,
   ...restProps
 }) => {
   const visualizeLocation = useDevToggle("DTLocationDetectionVisialiser")
@@ -166,6 +177,7 @@ export const ShowsRailContainer: React.FC<ShowsRailContainerProps> = ({
         location={location}
         disableLocation={disableLocation}
         contextModule={contextModule}
+        onTrack={onTrack}
       />
     </Suspense>
   )

--- a/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
@@ -1,20 +1,18 @@
-import { ActionType } from "@artsy/cohesion"
-import { ClickedNotificationsBell } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
 import { BellIcon, Box, DEFAULT_HIT_SLOP, VisualClueDot } from "@artsy/palette-mobile"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { TouchableOpacity } from "react-native"
-import { useTracking } from "react-tracking"
 
 interface ActivityIndicatorProps {
   hasUnseenNotifications: boolean
 }
 
 export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasUnseenNotifications }) => {
-  const tracking = useTracking()
+  const { clickedNotificationBell } = useHomeViewTracking()
 
   const navigateToActivityPanel = () => {
+    clickedNotificationBell()
     navigate("/notifications")
-    tracking.trackEvent(tracks.clickedNotificationsBell())
   }
 
   return (
@@ -39,10 +37,4 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasUnseenN
       </TouchableOpacity>
     </Box>
   )
-}
-
-const tracks = {
-  clickedNotificationsBell: (): ClickedNotificationsBell => ({
-    action: ActionType.clickedNotificationsBell,
-  }),
 }

--- a/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
@@ -8,10 +8,10 @@ interface ActivityIndicatorProps {
 }
 
 export const ActivityIndicator: React.FC<ActivityIndicatorProps> = ({ hasUnseenNotifications }) => {
-  const { clickedNotificationBell } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const navigateToActivityPanel = () => {
-    clickedNotificationBell()
+    tracking.clickedNotificationBell()
     navigate("/notifications")
   }
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tests.tsx
@@ -53,6 +53,7 @@ describe("HomeViewSectionActivity", () => {
                 internalID: "id-1",
                 notificationType: "ARTWORK_ALERT",
                 headline: "artwork alert",
+                targetHref: "/artwork-room/id-1",
               },
             },
             {
@@ -60,6 +61,7 @@ describe("HomeViewSectionActivity", () => {
                 internalID: "id-2",
                 notificationType: "VIEWING_ROOM_PUBLISHED",
                 headline: "viewing room published",
+                targetHref: "/viewing-room/id-2",
               },
             },
           ],
@@ -76,9 +78,9 @@ describe("HomeViewSectionActivity", () => {
         [
           {
             "action": "tappedActivityGroup",
-            "context_module": "home-view-section-latest-activity",
+            "context_module": "latestActivityRail",
             "context_screen_owner_type": "home",
-            "destination_screen_owner_type": "vanityurlentity",
+            "destination_path": "/viewing-room/id-2",
             "horizontal_slide_position": 1,
             "module_height": "single",
             "type": "thumbnail",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tests.tsx
@@ -78,7 +78,7 @@ describe("HomeViewSectionActivity", () => {
         [
           {
             "action": "tappedActivityGroup",
-            "context_module": "latestActivityRail",
+            "context_module": "latestActivity",
             "context_screen_owner_type": "home",
             "destination_path": "/viewing-room/id-2",
             "horizontal_slide_position": 1,

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
@@ -1,24 +1,21 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer } from "@artsy/palette-mobile"
 import { HomeViewSectionActivity_section$key } from "__generated__/HomeViewSectionActivity_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { SeeAllCard } from "app/Scenes/Home/Components/ActivityRail"
 import { ActivityRailItem } from "app/Scenes/Home/Components/ActivityRailItem"
-import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
-import { matchRoute } from "app/routes"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { FlatList } from "react-native"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionActivityProps {
   section: HomeViewSectionActivity_section$key
 }
 
 export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = ({ section }) => {
-  const tracking = useTracking()
+  const { tappedActivityGroup } = useHomeViewTracking()
 
   const data = useFragment(sectionFragment, section)
   const component = data.component
@@ -71,17 +68,7 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
             <ActivityRailItem
               item={item}
               onPress={() => {
-                const destinationRoute = matchRoute(item.targetHref)
-                const destinationModule =
-                  destinationRoute.type === "match" ? destinationRoute?.module : ""
-
-                tracking.trackEvent(
-                  HomeAnalytics.activityThumbnailTapEvent(
-                    index,
-                    destinationModule,
-                    data.internalID as ContextModule
-                  )
-                )
+                tappedActivityGroup(item.targetHref, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
@@ -15,7 +15,7 @@ interface HomeViewSectionActivityProps {
 }
 
 export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = ({ section }) => {
-  const { tappedActivityGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const data = useFragment(sectionFragment, section)
   const component = data.component
@@ -68,7 +68,7 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
             <ActivityRailItem
               item={item}
               onPress={() => {
-                tappedActivityGroup(item.targetHref, data.internalID, index)
+                tracking.tappedActivityGroup(item.targetHref, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tests.tsx
@@ -63,7 +63,7 @@ describe("HomeViewSectionArticles", () => {
         [
           {
             "action": "tappedArticleGroup",
-            "context_module": "latestArticlesRail",
+            "context_module": "latestArticles",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "article-2-id",
             "destination_screen_owner_slug": "article-2",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tests.tsx
@@ -63,9 +63,7 @@ describe("HomeViewSectionArticles", () => {
         [
           {
             "action": "tappedArticleGroup",
-            "context_module": "home-view-section-latest-articles",
-            "context_screen_owner_id": undefined,
-            "context_screen_owner_slug": undefined,
+            "context_module": "latestArticlesRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "article-2-id",
             "destination_screen_owner_slug": "article-2",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
@@ -10,7 +10,7 @@ interface HomeViewSectionArticlesProps {
 
 export const HomeViewSectionArticles: React.FC<HomeViewSectionArticlesProps> = (props) => {
   const section = useFragment(sectionFragment, props.section)
-  const { tappedArticleGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   if (!section.articlesConnection) {
     return null
@@ -23,7 +23,7 @@ export const HomeViewSectionArticles: React.FC<HomeViewSectionArticlesProps> = (
       title={section.component?.title ?? ""}
       articlesConnection={section.articlesConnection}
       onTrack={(article, index) => {
-        tappedArticleGroup(article.internalID, article.slug, section.internalID, index)
+        tracking.tappedArticleGroup(article.internalID, article.slug, section.internalID, index)
       }}
       onSectionTitlePress={
         componentHref

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
@@ -1,6 +1,6 @@
-import { ContextModule } from "@artsy/cohesion"
 import { HomeViewSectionArticles_section$key } from "__generated__/HomeViewSectionArticles_section.graphql"
 import { ArticlesRailFragmentContainer } from "app/Scenes/Home/Components/ArticlesRail"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
@@ -10,6 +10,7 @@ interface HomeViewSectionArticlesProps {
 
 export const HomeViewSectionArticles: React.FC<HomeViewSectionArticlesProps> = (props) => {
   const section = useFragment(sectionFragment, props.section)
+  const { tappedArticleGroup } = useHomeViewTracking()
 
   if (!section.articlesConnection) {
     return null
@@ -21,7 +22,9 @@ export const HomeViewSectionArticles: React.FC<HomeViewSectionArticlesProps> = (
     <ArticlesRailFragmentContainer
       title={section.component?.title ?? ""}
       articlesConnection={section.articlesConnection}
-      contextModule={section.internalID as ContextModule}
+      onTrack={(article, index) => {
+        tappedArticleGroup(article.internalID, article.slug, section.internalID, index)
+      }}
       onSectionTitlePress={
         componentHref
           ? () => {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tests.tsx
@@ -82,7 +82,7 @@ describe("HomeViewSectionArtists", () => {
         [
           {
             "action": "tappedArtistGroup",
-            "context_module": "recommendedArtistsRail",
+            "context_module": "recommendedArtists",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "artist-2-id",
             "destination_screen_owner_slug": "artist-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tests.tsx
@@ -82,9 +82,7 @@ describe("HomeViewSectionArtists", () => {
         [
           {
             "action": "tappedArtistGroup",
-            "context_module": "home-view-section-recommended-artists",
-            "context_screen_owner_id": undefined,
-            "context_screen_owner_slug": undefined,
+            "context_module": "recommendedArtistsRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "artist-2-id",
             "destination_screen_owner_slug": "artist-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
@@ -1,4 +1,3 @@
-import { ContextModule, OwnerType, tappedEntityGroup } from "@artsy/cohesion"
 import { Flex, Spacer, Spinner } from "@artsy/palette-mobile"
 import { HomeViewSectionArtists_section$data } from "__generated__/HomeViewSectionArtists_section.graphql"
 import {
@@ -8,11 +7,11 @@ import {
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { PAGE_SIZE } from "app/Components/constants"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionArtworksProps {
   section: HomeViewSectionArtists_section$data
@@ -25,7 +24,7 @@ export const HomeViewSectionArtists: React.FC<HomeViewSectionArtworksProps> = ({
   relay,
 }) => {
   const { hasMore, isLoading, loadMore } = relay
-  const tracking = useTracking()
+  const { tappedArtistGroup } = useHomeViewTracking()
 
   const title = section.component?.title
   const componentHref = section.component?.behaviors?.viewAll?.href
@@ -89,14 +88,7 @@ export const HomeViewSectionArtists: React.FC<HomeViewSectionArtworksProps> = ({
               artist={artist}
               showDefaultFollowButton
               onPress={() => {
-                tracking.trackEvent(
-                  tracks.tapArtistCard({
-                    artistID: artist.internalID,
-                    artistSlug: artist.slug,
-                    index,
-                    sectionID: section.internalID,
-                  })
-                )
+                tappedArtistGroup(artist.internalID, artist.slug, section.internalID, index)
               }}
             />
           )
@@ -165,28 +157,3 @@ export const HomeViewSectionArtistsPaginationContainer = createPaginationContain
     `,
   }
 )
-
-export const tracks = {
-  tapArtistCard: ({
-    artistID,
-    artistSlug,
-    index,
-    sectionID,
-  }: {
-    artistID: string
-    artistSlug: string
-    index: number
-    sectionID: string
-  }) => {
-    return tappedEntityGroup({
-      contextModule: sectionID as ContextModule,
-      contextScreenOwnerType: OwnerType.home,
-      destinationScreenOwnerType: OwnerType.artist,
-      destinationScreenOwnerId: artistID,
-      destinationScreenOwnerSlug: artistSlug,
-      horizontalSlidePosition: index,
-      moduleHeight: "double",
-      type: "thumbnail",
-    })
-  },
-}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
@@ -24,7 +24,7 @@ export const HomeViewSectionArtists: React.FC<HomeViewSectionArtworksProps> = ({
   relay,
 }) => {
   const { hasMore, isLoading, loadMore } = relay
-  const { tappedArtistGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const title = section.component?.title
   const componentHref = section.component?.behaviors?.viewAll?.href
@@ -88,7 +88,12 @@ export const HomeViewSectionArtists: React.FC<HomeViewSectionArtworksProps> = ({
               artist={artist}
               showDefaultFollowButton
               onPress={() => {
-                tappedArtistGroup(artist.internalID, artist.slug, section.internalID, index)
+                tracking.tappedArtistGroup(
+                  artist.internalID,
+                  artist.slug,
+                  section.internalID,
+                  index
+                )
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
@@ -88,6 +88,9 @@ describe("HomeViewSectionArtworks", () => {
             "destination_screen_owner_type": "artwork",
             "horizontal_slide_position": 1,
             "module_height": "single",
+            "signal_bid_count": 42,
+            "signal_label": "Limited-Time Offer",
+            "signal_lot_watcher_count": 42,
             "type": "thumbnail",
           },
         ]

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
@@ -81,7 +81,7 @@ describe("HomeViewSectionArtworks", () => {
         [
           {
             "action": "tappedArtworkGroup",
-            "context_module": "newWorksForYouRail",
+            "context_module": "newWorksForYou",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "artwork-2-id",
             "destination_screen_owner_slug": "artwork-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tests.tsx
@@ -81,7 +81,7 @@ describe("HomeViewSectionArtworks", () => {
         [
           {
             "action": "tappedArtworkGroup",
-            "context_module": "home-view-section-new-works-for-you",
+            "context_module": "newWorksForYouRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "artwork-2-id",
             "destination_screen_owner_slug": "artwork-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -1,22 +1,25 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSectionArtworks_section.graphql"
+import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
+import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
 import { LargeArtworkRail } from "app/Components/ArtworkRail/LargeArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
-import LegacyHomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { getSectionHref } from "app/Scenes/HomeView/helpers/getSectionHref"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { View } from "react-native"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionArtworksProps {
   section: HomeViewSectionArtworks_section$key
 }
 
-export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({ section }) => {
-  const tracking = useTracking()
+export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({
+  section,
+}) => {
+  const { tappedArtworkGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const title = data.component?.title
@@ -27,18 +30,13 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     return null
   }
 
-  const handleOnArtworkPress = (artwork: any, position: number) => {
-    tracking.trackEvent(
-      LegacyHomeAnalytics.artworkThumbnailTapEvent(
-        data.internalID as ContextModule,
-        artwork.slug,
-        artwork.internalID,
-        position,
-        "single"
-      )
-    )
+  const handleOnArtworkPress = (
+    artwork: LargeArtworkRail_artworks$data[0] | SmallArtworkRail_artworks$data[0],
+    position: number
+  ) => {
+    tappedArtworkGroup(artwork, data.internalID as ContextModule, position)
 
-    navigate(artwork.href)
+    navigate(artwork.href as string)
   }
 
   return (

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -1,4 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSectionArtworks_section.graphql"
 import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
@@ -16,9 +15,7 @@ interface HomeViewSectionArtworksProps {
   section: HomeViewSectionArtworks_section$key
 }
 
-export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({
-  section,
-}) => {
+export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({ section }) => {
   const { tappedArtworkGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
@@ -34,9 +31,17 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     artwork: LargeArtworkRail_artworks$data[0] | SmallArtworkRail_artworks$data[0],
     position: number
   ) => {
-    tappedArtworkGroup(artwork, data.internalID as ContextModule, position)
+    tappedArtworkGroup(
+      artwork.internalID,
+      artwork.slug,
+      artwork.collectorSignals,
+      data.internalID,
+      position
+    )
 
-    navigate(artwork.href as string)
+    if (artwork.href) {
+      navigate(artwork.href)
+    }
   }
 
   return (

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -16,7 +16,7 @@ interface HomeViewSectionArtworksProps {
 }
 
 export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({ section }) => {
-  const { tappedArtworkGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const title = data.component?.title
@@ -31,7 +31,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     artwork: LargeArtworkRail_artworks$data[0] | SmallArtworkRail_artworks$data[0],
     position: number
   ) => {
-    tappedArtworkGroup(
+    tracking.tappedArtworkGroup(
       artwork.internalID,
       artwork.slug,
       artwork.collectorSignals,

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
@@ -82,7 +82,7 @@ describe("HomeViewSectionAuctionResults", () => {
         [
           {
             "action": "tappedAuctionResultGroup",
-            "context_module": "latestAuctionResultsRail",
+            "context_module": "latestAuctionResults",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "auction-result-2-id",
             "destination_screen_owner_slug": "auction-result-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
@@ -82,7 +82,7 @@ describe("HomeViewSectionAuctionResults", () => {
         [
           {
             "action": "tappedAuctionResultGroup",
-            "context_module": "home-view-section-latest-auction-results",
+            "context_module": "latestAuctionResultsRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "auction-result-2-id",
             "destination_screen_owner_slug": "auction-result-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
@@ -18,7 +18,7 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
 ) => {
   const section = useFragment(sectionFragment, props.section)
   const { width: screenWidth } = useScreenDimensions()
-  const { tappedAuctionResultGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   if (!section || !section.auctionResultsConnection?.totalCount) {
     return null
@@ -47,7 +47,12 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
               auctionResult={item}
               width={screenWidth * 0.9}
               onTrack={() => {
-                tappedAuctionResultGroup(item.internalID, item.slug, section.internalID, index)
+                tracking.tappedAuctionResultGroup(
+                  item.internalID,
+                  item.slug,
+                  section.internalID,
+                  index
+                )
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
@@ -1,9 +1,9 @@
-import { ActionType, ContextModule, OwnerType, TappedEntityGroup } from "@artsy/cohesion"
 import { Flex, useScreenDimensions } from "@artsy/palette-mobile"
 import { HomeViewSectionAuctionResults_section$key } from "__generated__/HomeViewSectionAuctionResults_section.graphql"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { FlatList } from "react-native"
@@ -18,6 +18,7 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
 ) => {
   const section = useFragment(sectionFragment, props.section)
   const { width: screenWidth } = useScreenDimensions()
+  const { tappedAuctionResultGroup } = useHomeViewTracking()
 
   if (!section || !section.auctionResultsConnection?.totalCount) {
     return null
@@ -45,12 +46,9 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
               showArtistName
               auctionResult={item}
               width={screenWidth * 0.9}
-              trackingEventPayload={tracks.tappedAuctionResultGroup({
-                auctionResultID: item.internalID,
-                auctionResultSlug: item.slug ?? "",
-                index,
-                sectionID: section.internalID,
-              })}
+              onTrack={() => {
+                tappedAuctionResultGroup(item.internalID, item.slug, section.internalID, index)
+              }}
             />
           )
         }}
@@ -93,28 +91,3 @@ const sectionFragment = graphql`
     }
   }
 `
-
-const tracks = {
-  tappedAuctionResultGroup: ({
-    auctionResultID,
-    auctionResultSlug,
-    index,
-    sectionID,
-  }: {
-    auctionResultID: string
-    auctionResultSlug: string
-    index: number
-    sectionID: string
-  }): TappedEntityGroup => {
-    return {
-      action: ActionType.tappedAuctionResultGroup,
-      context_module: sectionID as ContextModule,
-      context_screen_owner_type: OwnerType.home,
-      destination_screen_owner_id: auctionResultID,
-      destination_screen_owner_slug: auctionResultSlug,
-      destination_screen_owner_type: OwnerType.auctionResult,
-      horizontal_slide_position: index,
-      type: "thumbnail",
-    }
-  },
-}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tests.tsx
@@ -107,9 +107,7 @@ describe("HomeViewSectionFairs", () => {
         [
           {
             "action": "tappedFairGroup",
-            "context_module": "home-view-section-fairs-for-you",
-            "context_screen_owner_id": undefined,
-            "context_screen_owner_slug": undefined,
+            "context_module": "fairsForYouRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "fair-2-id",
             "destination_screen_owner_slug": "fair-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tests.tsx
@@ -107,7 +107,7 @@ describe("HomeViewSectionFairs", () => {
         [
           {
             "action": "tappedFairGroup",
-            "context_module": "fairsForYouRail",
+            "context_module": "fairsForYou",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "fair-2-id",
             "destination_screen_owner_slug": "fair-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
@@ -1,21 +1,19 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionFairs_section$key } from "__generated__/HomeViewSectionFairs_section.graphql"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
-import LegacyHomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { HomeViewSectionFairsFairItem } from "app/Scenes/HomeView/Sections/HomeViewSectionFairsFairItem"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionFairsProps {
   section: HomeViewSectionFairs_section$key
 }
 
 export const HomeViewSectionFairs: React.FC<HomeViewSectionFairsProps> = ({ section }) => {
-  const tracking = useTracking()
+  const { tappedFairGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const component = data.component
@@ -51,14 +49,7 @@ export const HomeViewSectionFairs: React.FC<HomeViewSectionFairsProps> = ({ sect
               key={item.internalID}
               fair={item}
               onPress={(fair) => {
-                tracking.trackEvent(
-                  LegacyHomeAnalytics.fairThumbnailTapEvent(
-                    fair.internalID,
-                    fair.slug,
-                    index,
-                    data.internalID as ContextModule
-                  )
-                )
+                tappedFairGroup(fair.internalID, fair.slug, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
@@ -13,7 +13,7 @@ interface HomeViewSectionFairsProps {
 }
 
 export const HomeViewSectionFairs: React.FC<HomeViewSectionFairsProps> = ({ section }) => {
-  const { tappedFairGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const component = data.component
@@ -49,7 +49,7 @@ export const HomeViewSectionFairs: React.FC<HomeViewSectionFairsProps> = ({ sect
               key={item.internalID}
               fair={item}
               onPress={(fair) => {
-                tappedFairGroup(fair.internalID, fair.slug, data.internalID, index)
+                tracking.tappedFairGroup(fair.internalID, fair.slug, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tests.tsx
@@ -48,9 +48,9 @@ describe("HomeViewSectionGalleries", () => {
       [
         {
           "action": "tappedShowMore",
-          "context_module": "home-view-section-galleries-near-you",
+          "context_module": "galleriesNearYouRail",
           "context_screen_owner_type": "home",
-          "destination_screen_owner_type": "galleriesForYou",
+          "subject": "Explore",
         },
       ]
     `)

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tests.tsx
@@ -48,7 +48,7 @@ describe("HomeViewSectionGalleries", () => {
       [
         {
           "action": "tappedShowMore",
-          "context_module": "galleriesNearYouRail",
+          "context_module": "galleriesNearYou",
           "context_screen_owner_type": "home",
           "subject": "Explore",
         },

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
@@ -11,7 +11,7 @@ interface HomeViewSectionGalleriesProps {
   section: HomeViewSectionGalleries_section$key
 }
 export const HomeViewSectionGalleries: React.FC<HomeViewSectionGalleriesProps> = (props) => {
-  const { tappedShowMore } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const { width, height } = useScreenDimensions()
   const section = useFragment(HomeViewSectionGalleriesFragment, props.section)
@@ -28,7 +28,7 @@ export const HomeViewSectionGalleries: React.FC<HomeViewSectionGalleriesProps> =
   const componentHref = section.component?.behaviors?.viewAll?.href
 
   const handleOnPress = () => {
-    tappedShowMore("Explore", section.internalID)
+    tracking.tappedShowMore("Explore", section.internalID)
 
     if (componentHref) {
       navigate(componentHref)

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
@@ -1,18 +1,17 @@
-import { ActionType, OwnerType } from "@artsy/cohesion"
 import { Button, Flex, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { HomeViewSectionGalleries_section$key } from "__generated__/HomeViewSectionGalleries_section.graphql"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { isTablet } from "react-native-device-info"
 import FastImage from "react-native-fast-image"
 import LinearGradient from "react-native-linear-gradient"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionGalleriesProps {
   section: HomeViewSectionGalleries_section$key
 }
 export const HomeViewSectionGalleries: React.FC<HomeViewSectionGalleriesProps> = (props) => {
-  const tracking = useTracking()
+  const { tappedShowMore } = useHomeViewTracking()
 
   const { width, height } = useScreenDimensions()
   const section = useFragment(HomeViewSectionGalleriesFragment, props.section)
@@ -29,9 +28,9 @@ export const HomeViewSectionGalleries: React.FC<HomeViewSectionGalleriesProps> =
   const componentHref = section.component?.behaviors?.viewAll?.href
 
   const handleOnPress = () => {
-    if (componentHref) {
-      tracking.trackEvent(tracks.tappedSection({ sectionID: section.internalID }))
+    tappedShowMore("Explore", section.internalID)
 
+    if (componentHref) {
       navigate(componentHref)
     }
   }
@@ -105,12 +104,3 @@ const HomeViewSectionGalleriesFragment = graphql`
     }
   }
 `
-
-export const tracks = {
-  tappedSection: ({ sectionID }: { sectionID: string }) => ({
-    action: ActionType.tappedShowMore,
-    context_module: sectionID,
-    context_screen_owner_type: OwnerType.home,
-    destination_screen_owner_type: OwnerType.galleriesForYou,
-  }),
-}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
@@ -95,11 +95,9 @@ describe("HomeViewSectionHeroUnits", () => {
      [
        {
          "action": "tappedHeroUnitsGroup",
-         "context_module": "home-view-section-hero-units",
+         "context_module": "heroUnitsRail",
          "context_screen_owner_type": "home",
-         "destination_screen_owner_id": "hero-unit-1-id",
-         "destination_screen_owner_type": "Collection",
-         "destination_screen_owner_url": "/collection/collection-1",
+         "destination_path": "/collection/collection-1",
          "type": "header",
        },
      ]

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
@@ -95,7 +95,7 @@ describe("HomeViewSectionHeroUnits", () => {
      [
        {
          "action": "tappedHeroUnitGroup",
-         "context_module": "heroUnitsRail",
+         "context_module": "heroUnits",
          "context_screen_owner_type": "home",
          "destination_path": "/collection/collection-1",
          "horizontal_slide_position": 1,

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
@@ -94,7 +94,7 @@ describe("HomeViewSectionHeroUnits", () => {
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
      [
        {
-         "action": "tappedHeroUnitsGroup",
+         "action": "tappedHeroUnitGroup",
          "context_module": "heroUnitsRail",
          "context_screen_owner_type": "home",
          "destination_path": "/collection/collection-1",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tests.tsx
@@ -98,6 +98,7 @@ describe("HomeViewSectionHeroUnits", () => {
          "context_module": "heroUnitsRail",
          "context_screen_owner_type": "home",
          "destination_path": "/collection/collection-1",
+         "horizontal_slide_position": 1,
          "type": "header",
        },
      ]

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -43,11 +43,11 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
         decelerationRate="fast"
         horizontal
         keyExtractor={(item) => item.internalID}
-        renderItem={({ item }) => (
+        renderItem={({ item, index }) => (
           <HeroUnit
             item={item}
             onPress={() => {
-              tappedHeroUnitsGroup(item.link.url, data.internalID)
+              tappedHeroUnitsGroup(item.link.url, data.internalID, index)
             }}
           />
         )}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -1,4 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Spacer } from "@artsy/palette-mobile"
 import { HomeViewSectionHeroUnits_section$key } from "__generated__/HomeViewSectionHeroUnits_section.graphql"
 import { PaginationDots } from "app/Components/PaginationDots"
@@ -14,9 +13,7 @@ interface HomeViewSectionHeroUnitsProps {
   section: HomeViewSectionHeroUnits_section$key
 }
 
-export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({
-  section,
-}) => {
+export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({ section }) => {
   const { tappedHeroUnitsGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
@@ -50,7 +47,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
           <HeroUnit
             item={item}
             onPress={() => {
-              tappedHeroUnitsGroup(item, data.internalID as ContextModule)
+              tappedHeroUnitsGroup(item.link.url, data.internalID)
             }}
           />
         )}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -14,7 +14,7 @@ interface HomeViewSectionHeroUnitsProps {
 }
 
 export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({ section }) => {
-  const { tappedHeroUnitsGroup } = useHomeViewTracking()
+  const { tappedHeroUnitGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const heroUnits = extractNodes(data.heroUnitsConnection)
@@ -47,7 +47,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
           <HeroUnit
             item={item}
             onPress={() => {
-              tappedHeroUnitsGroup(item.link.url, data.internalID, index)
+              tappedHeroUnitGroup(item.link.url, data.internalID, index)
             }}
           />
         )}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -14,7 +14,7 @@ interface HomeViewSectionHeroUnitsProps {
 }
 
 export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({ section }) => {
-  const { tappedHeroUnitGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const heroUnits = extractNodes(data.heroUnitsConnection)
@@ -47,7 +47,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
           <HeroUnit
             item={item}
             onPress={() => {
-              tappedHeroUnitGroup(item.link.url, data.internalID, index)
+              tracking.tappedHeroUnitGroup(item.link.url, data.internalID, index)
             }}
           />
         )}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -1,28 +1,23 @@
-import {
-  ActionType,
-  ContextModule,
-  OwnerType,
-  TappedEntityDestinationType,
-  TappedHeroUnitsGroup,
-} from "@artsy/cohesion"
+import { ContextModule } from "@artsy/cohesion"
 import { Spacer } from "@artsy/palette-mobile"
 import { HomeViewSectionHeroUnits_section$key } from "__generated__/HomeViewSectionHeroUnits_section.graphql"
 import { PaginationDots } from "app/Components/PaginationDots"
 import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
-import { matchRoute } from "app/routes"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
 import { useRef, useState } from "react"
 import { FlatList, ViewabilityConfig, ViewToken } from "react-native"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionHeroUnitsProps {
   section: HomeViewSectionHeroUnits_section$key
 }
 
-export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({ section }) => {
-  const tracking = useTracking()
+export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> = ({
+  section,
+}) => {
+  const { tappedHeroUnitsGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const heroUnits = extractNodes(data.heroUnitsConnection)
@@ -55,13 +50,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
           <HeroUnit
             item={item}
             onPress={() => {
-              tracking.trackEvent(
-                tracks.tappedHeroUnitsGroup({
-                  sectionID: data.internalID,
-                  heroUnitID: item.internalID,
-                  heroUnitURL: item.link.url,
-                })
-              )
+              tappedHeroUnitsGroup(item, data.internalID as ContextModule)
             }}
           />
         )}
@@ -98,33 +87,3 @@ const fragment = graphql`
     }
   }
 `
-
-const tracks = {
-  tappedHeroUnitsGroup: ({
-    sectionID,
-    heroUnitID,
-    heroUnitURL,
-  }: {
-    sectionID: string
-    heroUnitID: string
-    heroUnitURL: string
-  }): TappedHeroUnitsGroup => {
-    let destinationScreenOwnerType = "WebView"
-
-    const routeSpecs = matchRoute(heroUnitURL)
-
-    if (routeSpecs.type === "match") {
-      destinationScreenOwnerType = routeSpecs.module
-    }
-
-    return {
-      action: ActionType.tappedHeroUnitsGroup,
-      context_module: sectionID as ContextModule,
-      context_screen_owner_type: OwnerType.home,
-      destination_screen_owner_id: heroUnitID,
-      destination_screen_owner_type: destinationScreenOwnerType as TappedEntityDestinationType,
-      destination_screen_owner_url: heroUnitURL,
-      type: "header",
-    }
-  },
-}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tests.tsx
@@ -43,7 +43,7 @@ describe("HomeViewSectionMarketingCollections", () => {
         title: "Marketing Collections",
         behaviors: {
           viewAll: {
-            href: "/marketing-collections-view-all-href",
+            href: "/collections",
           },
         },
       }),
@@ -69,18 +69,18 @@ describe("HomeViewSectionMarketingCollections", () => {
 
     fireEvent.press(screen.getByText("Marketing Collections"))
 
-    expect(navigate).toHaveBeenCalledWith("/marketing-collections-view-all-href")
+    expect(navigate).toHaveBeenCalledWith("/collections")
   })
 
   it("navigates and tracks clicks on an individual collection", () => {
     renderWithRelay({
       HomeViewSectionMarketingCollections: () => ({
-        internalID: "home-view-section-latest-auction-results",
+        internalID: "home-view-section-marketing-collections",
         component: {
           title: "Marketing Collections",
           behaviors: {
             viewAll: {
-              href: "/marketing-collections-view-all-href",
+              href: "/collections",
             },
           },
         },
@@ -112,11 +112,9 @@ describe("HomeViewSectionMarketingCollections", () => {
       [
         {
           "action": "tappedCollectionGroup",
-          "context_module": "home-view-section-latest-auction-results",
-          "context_screen_owner_id": undefined,
-          "context_screen_owner_slug": undefined,
+          "context_module": "marketingCollectionsRail",
           "context_screen_owner_type": "home",
-          "destination_screen_owner_id": undefined,
+          "destination_screen_owner_id": "marketing-collection-id-2",
           "destination_screen_owner_slug": "marketing-collection-slug-2",
           "destination_screen_owner_type": "collection",
           "horizontal_slide_position": 1,

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tests.tsx
@@ -112,7 +112,7 @@ describe("HomeViewSectionMarketingCollections", () => {
       [
         {
           "action": "tappedCollectionGroup",
-          "context_module": "marketingCollectionsRail",
+          "context_module": "marketingCollections",
           "context_screen_owner_type": "home",
           "destination_screen_owner_id": "marketing-collection-id-2",
           "destination_screen_owner_slug": "marketing-collection-slug-2",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
@@ -19,7 +19,7 @@ interface HomeViewSectionMarketingCollectionsProps {
 export const HomeViewSectionMarketingCollections: React.FC<
   HomeViewSectionMarketingCollectionsProps
 > = ({ section }) => {
-  const { tappedMarketingCollectionGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const component = data.component
@@ -58,7 +58,7 @@ export const HomeViewSectionMarketingCollections: React.FC<
               key={item.internalID}
               marketingCollection={item}
               onPress={(collection) => {
-                tappedMarketingCollectionGroup(
+                tracking.tappedMarketingCollectionGroup(
                   collection.internalID,
                   collection.slug,
                   data.internalID,

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
@@ -1,4 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import {
   HomeViewSectionMarketingCollections_section$data,
@@ -6,13 +5,12 @@ import {
 } from "__generated__/HomeViewSectionMarketingCollections_section.graphql"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
-import LegacyHomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { HomeViewSectionMarketingCollectionsItem } from "app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionMarketingCollectionsProps {
   section: HomeViewSectionMarketingCollections_section$key
@@ -21,7 +19,7 @@ interface HomeViewSectionMarketingCollectionsProps {
 export const HomeViewSectionMarketingCollections: React.FC<
   HomeViewSectionMarketingCollectionsProps
 > = ({ section }) => {
-  const tracking = useTracking()
+  const { tappedMarketingCollectionGroup } = useHomeViewTracking()
 
   const data = useFragment(fragment, section)
   const component = data.component
@@ -59,15 +57,13 @@ export const HomeViewSectionMarketingCollections: React.FC<
             <HomeViewSectionMarketingCollectionsItem
               key={item.internalID}
               marketingCollection={item}
-              onPress={(marketCollection) => {
-                const tapEvent = LegacyHomeAnalytics.collectionThumbnailTapEvent(
-                  marketCollection.slug,
-                  index,
-                  data.internalID as ContextModule
+              onPress={(collection) => {
+                tappedMarketingCollectionGroup(
+                  collection.internalID,
+                  collection.slug,
+                  data.internalID,
+                  index
                 )
-                if (tapEvent) {
-                  tracking.trackEvent(tapEvent)
-                }
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem.tsx
@@ -69,6 +69,7 @@ export const HomeViewSectionMarketingCollectionsItem: FC<
 
 const fragment = graphql`
   fragment HomeViewSectionMarketingCollectionsItem_marketingCollection on MarketingCollection {
+    internalID
     title
     slug
     artworksConnection(first: 5, sort: "-decayed_merch") {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tests.tsx
@@ -105,9 +105,7 @@ describe("HomeViewSectionSales", () => {
         [
           {
             "action": "tappedAuctionGroup",
-            "context_module": "home-view-section-sales",
-            "context_screen_owner_id": undefined,
-            "context_screen_owner_slug": undefined,
+            "context_module": "salesRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "sale-2-id",
             "destination_screen_owner_slug": "sale-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tests.tsx
@@ -105,7 +105,7 @@ describe("HomeViewSectionSales", () => {
         [
           {
             "action": "tappedAuctionGroup",
-            "context_module": "salesRail",
+            "context_module": "sales",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "sale-2-id",
             "destination_screen_owner_slug": "sale-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
@@ -16,7 +16,7 @@ interface HomeViewSectionSalesProps {
 }
 
 export const HomeViewSectionSales: React.FC<HomeViewSectionSalesProps> = ({ section }) => {
-  const { tappedAuctionGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   const listRef = useRef<FlatList<any>>()
   const data = useFragment(fragment, section)
@@ -56,7 +56,7 @@ export const HomeViewSectionSales: React.FC<HomeViewSectionSalesProps> = ({ sect
             <HomeViewSectionSalesItem
               sale={item}
               onPress={(sale) => {
-                tappedAuctionGroup(sale.internalID, sale.slug, data.internalID, index)
+                tracking.tappedAuctionGroup(sale.internalID, sale.slug, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
@@ -1,24 +1,22 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex, useScreenDimensions } from "@artsy/palette-mobile"
 import { HomeViewSectionSales_section$key } from "__generated__/HomeViewSectionSales_section.graphql"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
-import HomeAnalytics from "app/Scenes/Home/homeAnalytics"
 import { HomeViewSectionSalesItem } from "app/Scenes/HomeView/Sections/HomeViewSectionSalesItem"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useRef } from "react"
 import { FlatList } from "react-native-gesture-handler"
 import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 
 interface HomeViewSectionSalesProps {
   section: HomeViewSectionSales_section$key
 }
 
 export const HomeViewSectionSales: React.FC<HomeViewSectionSalesProps> = ({ section }) => {
-  const tracking = useTracking()
+  const { tappedAuctionGroup } = useHomeViewTracking()
 
   const listRef = useRef<FlatList<any>>()
   const data = useFragment(fragment, section)
@@ -58,14 +56,7 @@ export const HomeViewSectionSales: React.FC<HomeViewSectionSalesProps> = ({ sect
             <HomeViewSectionSalesItem
               sale={item}
               onPress={(sale) => {
-                tracking.trackEvent(
-                  HomeAnalytics.auctionThumbnailTapEvent(
-                    sale?.internalID,
-                    sale?.slug,
-                    index,
-                    data.internalID as ContextModule
-                  )
-                )
+                tappedAuctionGroup(sale.internalID, sale.slug, data.internalID, index)
               }}
             />
           )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tests.tsx
@@ -105,7 +105,7 @@ describe("HomeViewSectionShows", () => {
         [
           {
             "action": "tappedShowGroup",
-            "context_module": "showsForYouRail",
+            "context_module": "showsForYou",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "show-2-id",
             "destination_screen_owner_slug": "show-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tests.tsx
@@ -105,7 +105,7 @@ describe("HomeViewSectionShows", () => {
         [
           {
             "action": "tappedShowGroup",
-            "context_module": "home-view-section-shows-for-you",
+            "context_module": "showsForYouRail",
             "context_screen_owner_type": "home",
             "destination_screen_owner_id": "show-2-id",
             "destination_screen_owner_slug": "show-2-slug",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
@@ -12,14 +12,14 @@ export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({ sect
   const enableShowsForYouLocation = useFeatureFlag("AREnableShowsForYouLocation")
   const data = useFragment(fragment, section)
   const component = data.component
-  const { tappedShowGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
 
   return (
     <ShowsRailContainer
       title={component?.title || "Shows"}
       disableLocation={!enableShowsForYouLocation}
       onTrack={(show, index) => {
-        tappedShowGroup(show.internalID, show.slug, data.internalID, index)
+        tracking.tappedShowGroup(show.internalID, show.slug, data.internalID, index)
       }}
     />
   )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
@@ -1,6 +1,6 @@
-import { ContextModule } from "@artsy/cohesion"
 import { HomeViewSectionShows_section$key } from "__generated__/HomeViewSectionShows_section.graphql"
 import { ShowsRailContainer } from "app/Scenes/Home/Components/ShowsRail"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
 
@@ -12,12 +12,15 @@ export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({ sect
   const enableShowsForYouLocation = useFeatureFlag("AREnableShowsForYouLocation")
   const data = useFragment(fragment, section)
   const component = data.component
+  const { tappedShowGroup } = useHomeViewTracking()
 
   return (
     <ShowsRailContainer
       title={component?.title || "Shows"}
       disableLocation={!enableShowsForYouLocation}
-      contextModule={data.internalID as ContextModule}
+      onTrack={(show, index) => {
+        tappedShowGroup(show.internalID, show.slug, data.internalID, index)
+      }}
     />
   )
 }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
@@ -118,6 +118,7 @@ describe("HomeViewSectionViewingRooms", () => {
           "destination_screen_owner_id": "one",
           "destination_screen_owner_slug": "alessandro-pessoli-ardente-primavera-number-1",
           "destination_screen_owner_type": "viewingRoom",
+          "horizontal_slide_position": 0,
           "type": "thumbnail",
         },
       ]

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
@@ -113,7 +113,7 @@ describe("HomeViewSectionViewingRooms", () => {
       [
         {
           "action": "tappedViewingRoomGroup",
-          "context_module": "home-view-section-viewing-rooms",
+          "context_module": "viewingRoomsRail",
           "context_screen_owner_type": "home",
           "destination_screen_owner_id": "one",
           "destination_screen_owner_slug": "alessandro-pessoli-ardente-primavera-number-1",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
@@ -114,11 +114,10 @@ describe("HomeViewSectionViewingRooms", () => {
         {
           "action": "tappedViewingRoomGroup",
           "context_module": "home-view-section-viewing-rooms",
-          "context_screen": "home",
           "context_screen_owner_type": "home",
           "destination_screen_owner_id": "one",
           "destination_screen_owner_slug": "alessandro-pessoli-ardente-primavera-number-1",
-          "destination_screen_owner_type": "ViewingRoom",
+          "destination_screen_owner_type": "viewingRoom",
           "type": "thumbnail",
         },
       ]

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tests.tsx
@@ -113,7 +113,7 @@ describe("HomeViewSectionViewingRooms", () => {
       [
         {
           "action": "tappedViewingRoomGroup",
-          "context_module": "viewingRoomsRail",
+          "context_module": "viewingRooms",
           "context_screen_owner_type": "home",
           "destination_screen_owner_id": "one",
           "destination_screen_owner_slug": "alessandro-pessoli-ardente-primavera-number-1",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
@@ -1,7 +1,8 @@
-import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionViewingRooms_section$key } from "__generated__/HomeViewSectionViewingRooms_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import {
   ViewingRoomsHomeRail as LegacyViewingRoomsHomeRail,
   ViewingRoomsRailPlaceholder,
@@ -14,6 +15,7 @@ export const HomeViewSectionViewingRooms: React.FC<{
   section: HomeViewSectionViewingRooms_section$key
 }> = ({ section }) => {
   const data = useFragment(viewingRoomsFragment, section)
+  const { tappedViewingRoomGroup } = useHomeViewTracking()
   const componentHref = data.component?.behaviors?.viewAll?.href
 
   return (
@@ -32,10 +34,10 @@ export const HomeViewSectionViewingRooms: React.FC<{
       </Flex>
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
         <LegacyViewingRoomsHomeRail
-          trackInfo={{
-            screen: OwnerType.home,
-            ownerType: OwnerType.home,
-            contextModule: data.internalID as ContextModule,
+          onPress={(viewingRoom) => {
+            tappedViewingRoomGroup(viewingRoom, data.internalID as ContextModule)
+
+            navigate(`/viewing-room/${viewingRoom.slug}`)
           }}
         />
       </Suspense>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
@@ -33,8 +33,8 @@ export const HomeViewSectionViewingRooms: React.FC<{
       </Flex>
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
         <LegacyViewingRoomsHomeRail
-          onPress={(viewingRoom) => {
-            tappedViewingRoomGroup(viewingRoom.internalID, viewingRoom.slug, data.internalID)
+          onPress={(viewingRoom, index) => {
+            tappedViewingRoomGroup(viewingRoom.internalID, viewingRoom.slug, data.internalID, index)
 
             navigate(`/viewing-room/${viewingRoom.slug}`)
           }}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
@@ -14,7 +14,7 @@ export const HomeViewSectionViewingRooms: React.FC<{
   section: HomeViewSectionViewingRooms_section$key
 }> = ({ section }) => {
   const data = useFragment(viewingRoomsFragment, section)
-  const { tappedViewingRoomGroup } = useHomeViewTracking()
+  const tracking = useHomeViewTracking()
   const componentHref = data.component?.behaviors?.viewAll?.href
 
   return (
@@ -34,7 +34,12 @@ export const HomeViewSectionViewingRooms: React.FC<{
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
         <LegacyViewingRoomsHomeRail
           onPress={(viewingRoom, index) => {
-            tappedViewingRoomGroup(viewingRoom.internalID, viewingRoom.slug, data.internalID, index)
+            tracking.tappedViewingRoomGroup(
+              viewingRoom.internalID,
+              viewingRoom.slug,
+              data.internalID,
+              index
+            )
 
             navigate(`/viewing-room/${viewingRoom.slug}`)
           }}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
@@ -1,4 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionViewingRooms_section$key } from "__generated__/HomeViewSectionViewingRooms_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
@@ -35,7 +34,7 @@ export const HomeViewSectionViewingRooms: React.FC<{
       <Suspense fallback={<ViewingRoomsRailPlaceholder />}>
         <LegacyViewingRoomsHomeRail
           onPress={(viewingRoom) => {
-            tappedViewingRoomGroup(viewingRoom, data.internalID as ContextModule)
+            tappedViewingRoomGroup(viewingRoom.internalID, viewingRoom.slug, data.internalID)
 
             navigate(`/viewing-room/${viewingRoom.slug}`)
           }}

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -2,6 +2,7 @@ import {
   ActionType,
   ContextModule,
   OwnerType,
+  TappedArticleGroup,
   TappedArtworkGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
@@ -46,6 +47,34 @@ export const useHomeViewTracking = () => {
 
       trackEvent(payload)
     },
+
+    tappedArticleGroup: (
+      articleID: string,
+      articleSlug: string | undefined | null,
+      sectionID: string,
+      index: number
+    ) => {
+      let payload: TappedArticleGroup = {
+        action: ActionType.tappedArticleGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_id: articleID,
+        destination_screen_owner_type: OwnerType.article,
+        horizontal_slide_position: index,
+        module_height: "double",
+        type: "thumbnail",
+      }
+
+      if (articleSlug) {
+        payload = {
+          ...payload,
+          destination_screen_owner_slug: articleSlug,
+        }
+      }
+
+      trackEvent(payload)
+    },
+
     tappedArtworkGroup: (
       artworkID: string,
       artworkSlug: string,

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -162,13 +162,14 @@ export const useHomeViewTracking = () => {
       trackEvent(payload)
     },
 
-    tappedHeroUnitsGroup: (destinationPath: string, sectionID: string) => {
+    tappedHeroUnitsGroup: (destinationPath: string, sectionID: string, index: number) => {
       // TODO: Type as TappedHeroUnitsGroup once artsy/cohesion is updated
       const payload = {
         action: ActionType.tappedHeroUnitsGroup,
         context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
         destination_path: destinationPath,
+        horizontal_slide_position: index,
         type: "header",
       }
 

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -1,0 +1,39 @@
+import { ActionType, ContextModule, OwnerType, TappedArtworkGroup, TappedEntityDestinationType, TappedHeroUnitsGroup } from "@artsy/cohesion"
+import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
+import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
+import { matchRoute } from "app/routes"
+import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
+import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useTracking } from "react-tracking"
+
+export const useHomeViewTracking = () => {
+  const { trackEvent } = useTracking()
+  const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
+
+  return {
+    tappedArtworkGroup: (
+      artwork: LargeArtworkRail_artworks$data[0] | SmallArtworkRail_artworks$data[0],
+      contextModule: ContextModule,
+      index: number
+    ) => {
+      const payload: TappedArtworkGroup = {
+        action: ActionType.tappedArtworkGroup,
+        context_module: contextModule,
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.artwork,
+        destination_screen_owner_slug: artwork.slug,
+        destination_screen_owner_id: artwork.internalID,
+        horizontal_slide_position: index,
+        module_height: "single",
+        type: "thumbnail",
+        ...getArtworkSignalTrackingFields(
+          artwork.collectorSignals,
+          AREnableAuctionImprovementsSignals
+        ),
+      }
+
+      trackEvent(payload)
+    },
+  }
+}

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -6,6 +6,7 @@ import {
   TappedArtistGroup,
   TappedArtworkGroup,
   TappedAuctionResultGroup,
+  TappedCollectionGroup,
   TappedFairGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
@@ -171,6 +172,27 @@ export const useHomeViewTracking = () => {
         destination_path: destinationPath,
         horizontal_slide_position: index,
         type: "header",
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedMarketingCollectionGroup: (
+      collectionID: string,
+      collectionSlug: string,
+      sectionID: string,
+      index: number
+    ) => {
+      const payload: TappedCollectionGroup = {
+        action: ActionType.tappedCollectionGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.collection,
+        destination_screen_owner_id: collectionID,
+        destination_screen_owner_slug: collectionSlug,
+        horizontal_slide_position: index,
+        module_height: "double",
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -6,6 +6,7 @@ import {
   TappedArtistGroup,
   TappedArtworkGroup,
   TappedAuctionResultGroup,
+  TappedFairGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
@@ -140,6 +141,22 @@ export const useHomeViewTracking = () => {
           ...payload,
           destination_screen_owner_slug: auctionResultSlug,
         }
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedFairGroup: (fairID: string, fairSlug: string, sectionID: string, index: number) => {
+      const payload: TappedFairGroup = {
+        action: ActionType.tappedFairGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.fair,
+        destination_screen_owner_id: fairID,
+        destination_screen_owner_slug: fairSlug,
+        horizontal_slide_position: index,
+        module_height: "double",
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -2,8 +2,6 @@ import {
   ActionType,
   ContextModule,
   OwnerType,
-  ScreenOwnerType,
-  TappedActivityGroup,
   TappedArtworkGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
@@ -34,12 +32,15 @@ export const useHomeViewTracking = () => {
   const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
 
   return {
-    tappedActivityGroup: (sectionID: string) => {
-      const payload: TappedActivityGroup = {
+    tappedActivityGroup: (destinationPath: string, sectionID: string, index: number) => {
+      // TODO: Type as TappedActivityGroup once artsy/cohesion is updated
+      const payload = {
         action: ActionType.tappedActivityGroup,
         context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
-        destination_screen_owner_type: "" as ScreenOwnerType,
+        destination_path: destinationPath,
+        horizontal_slide_position: index,
+        module_height: "single",
         type: "thumbnail",
       }
 

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -5,6 +5,7 @@ import {
   TappedArticleGroup,
   TappedArtistGroup,
   TappedArtworkGroup,
+  TappedAuctionGroup,
   TappedAuctionResultGroup,
   TappedCollectionGroup,
   TappedFairGroup,
@@ -116,6 +117,22 @@ export const useHomeViewTracking = () => {
           artworkCollectorSignals,
           AREnableAuctionImprovementsSignals
         ),
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedAuctionGroup: (saleID: string, saleSlug: string, sectionID: string, index: number) => {
+      const payload: TappedAuctionGroup = {
+        action: ActionType.tappedAuctionGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.sale,
+        destination_screen_owner_id: saleID,
+        destination_screen_owner_slug: saleSlug,
+        horizontal_slide_position: index,
+        module_height: "double",
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -27,12 +27,11 @@ import { useTracking } from "react-tracking"
 
  Examples
  - home-view-section-artist-rail -> artistRail
- - home-view-section-new-works-for-you -> newWorksForYouRail
+ - home-view-section-new-works-for-you -> newWorksForYou
 
 */
 const formatSectionIDAsContextModule = (sectionID: string) => {
   let contextModule = sectionID.replace(/^home-view-section-/, "")
-  contextModule = contextModule.replace(/(-rail)?$/, "-rail")
   contextModule = camelCase(contextModule)
 
   return contextModule as ContextModule

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -5,6 +5,7 @@ import {
   TappedArticleGroup,
   TappedArtistGroup,
   TappedArtworkGroup,
+  TappedAuctionResultGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
@@ -113,6 +114,32 @@ export const useHomeViewTracking = () => {
           artworkCollectorSignals,
           AREnableAuctionImprovementsSignals
         ),
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedAuctionResultGroup: (
+      auctionResultID: string,
+      auctionResultSlug: string | null | undefined,
+      sectionID: string,
+      index: number
+    ) => {
+      let payload: TappedAuctionResultGroup = {
+        action: ActionType.tappedAuctionResultGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_id: auctionResultID,
+        destination_screen_owner_type: OwnerType.auctionResult,
+        horizontal_slide_position: index,
+        type: "thumbnail",
+      }
+
+      if (auctionResultSlug) {
+        payload = {
+          ...payload,
+          destination_screen_owner_slug: auctionResultSlug,
+        }
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -2,42 +2,68 @@ import {
   ActionType,
   ContextModule,
   OwnerType,
+  ScreenOwnerType,
+  TappedActivityGroup,
   TappedArtworkGroup,
-  TappedEntityDestinationType,
-  TappedHeroUnitsGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
-import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
-import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
-import { ViewingRoomsHomeRail_viewingRoom$data } from "__generated__/ViewingRoomsHomeRail_viewingRoom.graphql"
-import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
-import { matchRoute } from "app/routes"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { camelCase } from "lodash"
 import { useTracking } from "react-tracking"
+
+/**
+
+ Convert section ID to requested ContextModule format
+
+ Examples
+ - home-view-section-artist-rail -> artistRail
+ - home-view-section-new-works-for-you -> newWorksForYouRail
+
+*/
+const formatSectionIDAsContextModule = (sectionID: string) => {
+  let contextModule = sectionID.replace(/^home-view-section-/, "")
+  contextModule = contextModule.replace(/(-rail)?$/, "-rail")
+  contextModule = camelCase(contextModule)
+
+  return contextModule as ContextModule
+}
 
 export const useHomeViewTracking = () => {
   const { trackEvent } = useTracking()
   const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
 
   return {
+    tappedActivityGroup: (sectionID: string) => {
+      const payload: TappedActivityGroup = {
+        action: ActionType.tappedActivityGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: "" as ScreenOwnerType,
+        type: "thumbnail",
+      }
+
+      trackEvent(payload)
+    },
     tappedArtworkGroup: (
-      artwork: LargeArtworkRail_artworks$data[0] | SmallArtworkRail_artworks$data[0],
-      contextModule: ContextModule,
+      artworkID: string,
+      artworkSlug: string,
+      artworkCollectorSignals: any,
+      sectionID: string,
       index: number
     ) => {
       const payload: TappedArtworkGroup = {
         action: ActionType.tappedArtworkGroup,
-        context_module: contextModule,
+        context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_id: artworkID,
+        destination_screen_owner_slug: artworkSlug,
         destination_screen_owner_type: OwnerType.artwork,
-        destination_screen_owner_slug: artwork.slug,
-        destination_screen_owner_id: artwork.internalID,
         horizontal_slide_position: index,
         module_height: "single",
         type: "thumbnail",
         ...getArtworkSignalTrackingFields(
-          artwork.collectorSignals,
+          artworkCollectorSignals,
           AREnableAuctionImprovementsSignals
         ),
       }
@@ -45,39 +71,27 @@ export const useHomeViewTracking = () => {
       trackEvent(payload)
     },
 
-    tappedHeroUnitsGroup: (item: HeroUnit, contextModule: ContextModule) => {
-      let destinationScreenOwnerType = "WebView"
-
-      const routeSpecs = matchRoute(item.link.url)
-
-      if (routeSpecs.type === "match") {
-        destinationScreenOwnerType = routeSpecs.module
-      }
-
-      const payload: TappedHeroUnitsGroup = {
+    tappedHeroUnitsGroup: (destinationPath: string, sectionID: string) => {
+      // TODO: Type as TappedHeroUnitsGroup once artsy/cohesion is updated
+      const payload = {
         action: ActionType.tappedHeroUnitsGroup,
-        context_module: contextModule,
+        context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
-        destination_screen_owner_type: destinationScreenOwnerType as TappedEntityDestinationType,
-        destination_screen_owner_id: item.internalID,
-        destination_screen_owner_url: item.link.url,
+        destination_path: destinationPath,
         type: "header",
       }
 
       trackEvent(payload)
     },
 
-    tappedViewingRoomGroup: (
-      viewingRoom: ViewingRoomsHomeRail_viewingRoom$data,
-      contextModule: ContextModule
-    ) => {
+    tappedViewingRoomGroup: (viewingRoomID: string, viewingRoomSlug: string, sectionID: string) => {
       const payload: TappedViewingRoomGroup = {
         action: ActionType.tappedViewingRoomGroup,
-        context_module: contextModule,
+        context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
         destination_screen_owner_type: OwnerType.viewingRoom,
-        destination_screen_owner_id: viewingRoom.internalID,
-        destination_screen_owner_slug: viewingRoom.slug,
+        destination_screen_owner_id: viewingRoomID,
+        destination_screen_owner_slug: viewingRoomSlug,
         type: "thumbnail",
       }
 

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -1,8 +1,15 @@
-import { ActionType, ContextModule, OwnerType, TappedArtworkGroup, TappedEntityDestinationType, TappedHeroUnitsGroup } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  TappedArtworkGroup,
+  TappedEntityDestinationType,
+  TappedHeroUnitsGroup,
+} from "@artsy/cohesion"
 import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
 import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
-import { matchRoute } from "app/routes"
 import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
+import { matchRoute } from "app/routes"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useTracking } from "react-tracking"
@@ -31,6 +38,28 @@ export const useHomeViewTracking = () => {
           artwork.collectorSignals,
           AREnableAuctionImprovementsSignals
         ),
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedHeroUnitsGroup: (item: HeroUnit, contextModule: ContextModule) => {
+      let destinationScreenOwnerType = "WebView"
+
+      const routeSpecs = matchRoute(item.link.url)
+
+      if (routeSpecs.type === "match") {
+        destinationScreenOwnerType = routeSpecs.module
+      }
+
+      const payload: TappedHeroUnitsGroup = {
+        action: ActionType.tappedHeroUnitsGroup,
+        context_module: contextModule,
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: destinationScreenOwnerType as TappedEntityDestinationType,
+        destination_screen_owner_id: item.internalID,
+        destination_screen_owner_url: item.link.url,
+        type: "header",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -2,6 +2,7 @@ import {
   ActionType,
   ContextModule,
   OwnerType,
+  TappedActivityGroup,
   TappedArticleGroup,
   TappedArtistGroup,
   TappedArtworkGroup,
@@ -9,6 +10,7 @@ import {
   TappedAuctionResultGroup,
   TappedCollectionGroup,
   TappedFairGroup,
+  TappedHeroUnitGroup,
   TappedShowGroup,
   TappedShowMore,
   TappedViewingRoomGroup,
@@ -51,8 +53,7 @@ export const useHomeViewTracking = () => {
     },
 
     tappedActivityGroup: (destinationPath: string, sectionID: string, index: number) => {
-      // TODO: Type as TappedActivityGroup once artsy/cohesion is updated
-      const payload = {
+      const payload: TappedActivityGroup = {
         action: ActionType.tappedActivityGroup,
         context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
@@ -192,10 +193,9 @@ export const useHomeViewTracking = () => {
       trackEvent(payload)
     },
 
-    tappedHeroUnitsGroup: (destinationPath: string, sectionID: string, index: number) => {
-      // TODO: Type as TappedHeroUnitsGroup once artsy/cohesion is updated
-      const payload = {
-        action: ActionType.tappedHeroUnitsGroup,
+    tappedHeroUnitGroup: (destinationPath: string, sectionID: string, index: number) => {
+      const payload: TappedHeroUnitGroup = {
+        action: ActionType.tappedHeroUnitGroup,
         context_module: formatSectionIDAsContextModule(sectionID),
         context_screen_owner_type: OwnerType.home,
         destination_path: destinationPath,

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -9,6 +9,7 @@ import {
   TappedAuctionResultGroup,
   TappedCollectionGroup,
   TappedFairGroup,
+  TappedShowGroup,
   TappedShowMore,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
@@ -210,6 +211,21 @@ export const useHomeViewTracking = () => {
         destination_screen_owner_slug: collectionSlug,
         horizontal_slide_position: index,
         module_height: "double",
+        type: "thumbnail",
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedShowGroup: (showID: string, showSlug: string, sectionID: string, index: number) => {
+      const payload: TappedShowGroup = {
+        action: ActionType.tappedShowGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.show,
+        destination_screen_owner_id: showID,
+        destination_screen_owner_slug: showSlug,
+        horizontal_slide_position: index,
         type: "thumbnail",
       }
 

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -13,6 +13,7 @@ import {
   TappedShowMore,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
+import { ClickedNotificationsBell } from "@artsy/cohesion/dist/Schema/Events/ActivityPanel"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { camelCase } from "lodash"
@@ -40,6 +41,15 @@ export const useHomeViewTracking = () => {
   const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
 
   return {
+    // TODO: Shouldn't this be tappedNotificationBell?
+    clickedNotificationBell: () => {
+      const payload: ClickedNotificationsBell = {
+        action: ActionType.clickedNotificationsBell,
+      }
+
+      trackEvent(payload)
+    },
+
     tappedActivityGroup: (destinationPath: string, sectionID: string, index: number) => {
       // TODO: Type as TappedActivityGroup once artsy/cohesion is updated
       const payload = {

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -5,9 +5,11 @@ import {
   TappedArtworkGroup,
   TappedEntityDestinationType,
   TappedHeroUnitsGroup,
+  TappedViewingRoomGroup,
 } from "@artsy/cohesion"
 import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_artworks.graphql"
 import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
+import { ViewingRoomsHomeRail_viewingRoom$data } from "__generated__/ViewingRoomsHomeRail_viewingRoom.graphql"
 import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
 import { matchRoute } from "app/routes"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
@@ -60,6 +62,23 @@ export const useHomeViewTracking = () => {
         destination_screen_owner_id: item.internalID,
         destination_screen_owner_url: item.link.url,
         type: "header",
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedViewingRoomGroup: (
+      viewingRoom: ViewingRoomsHomeRail_viewingRoom$data,
+      contextModule: ContextModule
+    ) => {
+      const payload: TappedViewingRoomGroup = {
+        action: ActionType.tappedViewingRoomGroup,
+        context_module: contextModule,
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.viewingRoom,
+        destination_screen_owner_id: viewingRoom.internalID,
+        destination_screen_owner_slug: viewingRoom.slug,
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -9,6 +9,7 @@ import {
   TappedAuctionResultGroup,
   TappedCollectionGroup,
   TappedFairGroup,
+  TappedShowMore,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
@@ -210,6 +211,17 @@ export const useHomeViewTracking = () => {
         horizontal_slide_position: index,
         module_height: "double",
         type: "thumbnail",
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedShowMore: (subject: string, sectionID: string) => {
+      const payload: TappedShowMore = {
+        action: ActionType.tappedShowMore,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        subject: subject,
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -3,6 +3,7 @@ import {
   ContextModule,
   OwnerType,
   TappedArticleGroup,
+  TappedArtistGroup,
   TappedArtworkGroup,
   TappedViewingRoomGroup,
 } from "@artsy/cohesion"
@@ -70,6 +71,22 @@ export const useHomeViewTracking = () => {
           ...payload,
           destination_screen_owner_slug: articleSlug,
         }
+      }
+
+      trackEvent(payload)
+    },
+
+    tappedArtistGroup: (artistID: string, artistSlug: string, sectionID: string, index: number) => {
+      const payload: TappedArtistGroup = {
+        action: ActionType.tappedArtistGroup,
+        context_module: formatSectionIDAsContextModule(sectionID),
+        context_screen_owner_type: OwnerType.home,
+        destination_screen_owner_type: OwnerType.artist,
+        destination_screen_owner_id: artistID,
+        destination_screen_owner_slug: artistSlug,
+        horizontal_slide_position: index,
+        module_height: "double",
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/app/Scenes/HomeView/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewTracking.ts
@@ -253,7 +253,12 @@ export const useHomeViewTracking = () => {
       trackEvent(payload)
     },
 
-    tappedViewingRoomGroup: (viewingRoomID: string, viewingRoomSlug: string, sectionID: string) => {
+    tappedViewingRoomGroup: (
+      viewingRoomID: string,
+      viewingRoomSlug: string,
+      sectionID: string,
+      index: number
+    ) => {
       const payload: TappedViewingRoomGroup = {
         action: ActionType.tappedViewingRoomGroup,
         context_module: formatSectionIDAsContextModule(sectionID),
@@ -261,6 +266,7 @@ export const useHomeViewTracking = () => {
         destination_screen_owner_type: OwnerType.viewingRoom,
         destination_screen_owner_id: viewingRoomID,
         destination_screen_owner_slug: viewingRoomSlug,
+        horizontal_slide_position: index,
         type: "thumbnail",
       }
 

--- a/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -1,6 +1,7 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer, Touchable } from "@artsy/palette-mobile"
 import { ViewingRoomsHomeRailQuery } from "__generated__/ViewingRoomsHomeRailQuery.graphql"
+import { ViewingRoomsHomeRail_viewingRoom$data } from "__generated__/ViewingRoomsHomeRail_viewingRoom.graphql"
 import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
 import { MediumCard } from "app/Components/Cards"
 import { SectionTitle } from "app/Components/SectionTitle"
@@ -75,9 +76,13 @@ export const ViewingRoomsRailPlaceholder = () => (
 
 interface ViewingRoomsHomeRailProps {
   trackInfo?: { screen: string; ownerType: string; contextModule?: ContextModule }
+  onPress?: (viewingRoom: ViewingRoomsHomeRail_viewingRoom$data) => void
 }
 
-export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({ trackInfo }) => {
+export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({
+  trackInfo,
+  onPress,
+}) => {
   const queryData = useLazyLoadQuery<ViewingRoomsHomeRailQuery>(ViewingRoomsHomeRailMainQuery, {})
   const regular = extractNodes(queryData.viewingRooms)
   const { trackEvent } = useTracking()
@@ -96,6 +101,10 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({ trac
           return (
             <Touchable
               onPress={() => {
+                if (onPress) {
+                  return onPress(item as any)
+                }
+
                 if (!!item.slug) {
                   trackEvent(
                     trackInfo
@@ -127,11 +136,19 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({ trac
   )
 }
 
+graphql`
+  fragment ViewingRoomsHomeRail_viewingRoom on ViewingRoom {
+    internalID
+    slug
+  }
+`
+
 const ViewingRoomsHomeRailMainQuery = graphql`
   query ViewingRoomsHomeRailQuery {
     viewingRooms(first: 10) {
       edges {
         node {
+          ...ViewingRoomsHomeRail_viewingRoom
           internalID
           title
           slug

--- a/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
+++ b/src/app/Scenes/ViewingRoom/Components/ViewingRoomsHomeRail.tsx
@@ -1,13 +1,16 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Flex, Spacer, Touchable } from "@artsy/palette-mobile"
-import { ViewingRoomsHomeRailQuery } from "__generated__/ViewingRoomsHomeRailQuery.graphql"
-import { ViewingRoomsHomeRail_viewingRoom$data } from "__generated__/ViewingRoomsHomeRail_viewingRoom.graphql"
+import {
+  ViewingRoomsHomeRailQuery,
+  ViewingRoomsHomeRailQuery$data,
+} from "__generated__/ViewingRoomsHomeRailQuery.graphql"
 import { ViewingRoomsListFeatured_featured$key } from "__generated__/ViewingRoomsListFeatured_featured.graphql"
 import { MediumCard } from "app/Components/Cards"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { PlaceholderBox, ProvidePlaceholderContext } from "app/utils/placeholders"
+import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Schema } from "app/utils/track"
 import { times } from "lodash"
 import React, { memo, Suspense } from "react"
@@ -76,7 +79,10 @@ export const ViewingRoomsRailPlaceholder = () => (
 
 interface ViewingRoomsHomeRailProps {
   trackInfo?: { screen: string; ownerType: string; contextModule?: ContextModule }
-  onPress?: (viewingRoom: ViewingRoomsHomeRail_viewingRoom$data) => void
+  onPress?: (
+    viewingRoom: ExtractNodeType<ViewingRoomsHomeRailQuery$data["viewingRooms"]>,
+    index: number
+  ) => void
 }
 
 export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({
@@ -96,13 +102,13 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({
         data={regular}
         initialNumToRender={isTablet() ? 10 : 5}
         keyExtractor={(item) => `${item.internalID}`}
-        renderItem={({ item }) => {
+        renderItem={({ item, index }) => {
           const tag = tagForStatus(item.status, item.distanceToOpen, item.distanceToClose)
           return (
             <Touchable
               onPress={() => {
                 if (onPress) {
-                  return onPress(item as any)
+                  return onPress(item, index)
                 }
 
                 if (!!item.slug) {
@@ -136,19 +142,11 @@ export const ViewingRoomsHomeRail: React.FC<ViewingRoomsHomeRailProps> = ({
   )
 }
 
-graphql`
-  fragment ViewingRoomsHomeRail_viewingRoom on ViewingRoom {
-    internalID
-    slug
-  }
-`
-
 const ViewingRoomsHomeRailMainQuery = graphql`
   query ViewingRoomsHomeRailQuery {
     viewingRooms(first: 10) {
       edges {
         node {
-          ...ViewingRoomsHomeRail_viewingRoom
           internalID
           title
           slug

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@artsy/cohesion@4.203.0":
-  version "4.203.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.203.0.tgz#3de943028459e5a7a2f672bc93bca3954aa3e4cd"
-  integrity sha512-ifSyvELlUdpp8a4OnCLf7TPK3tAjyBU7HtnrVccpV8p6lDM/QcikG71pIB+L/qwRsAquensLAN1W4D7zrK236A==
+"@artsy/cohesion@4.204.0":
+  version "4.204.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.204.0.tgz#8882f00ba0bce7b0d2ac6e9d7ee9cda7e6f6c99a"
+  integrity sha512-oR+ucWA93SUvERuksReQSYCjSiOpIqu/BHYtE8gmEfwV4JMJVVWhE/TeE3Xv2dv4OATwUat7Zg0VePxe6aJ02g==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
### Description

Similar to the pattern used in Force, this introduces a useHomeViewTracking hook to consolidate event definitions/payloads and keep component triggering logic simple.

- https://github.com/artsy/force/blob/main/src/Apps/Article/useArticleTracking.ts
- https://github.com/artsy/force/blob/main/src/Apps/Auction/Hooks/useAuctionTracking.ts
- https://github.com/artsy/force/blob/main/src/Apps/MyCollection/Routes/Hooks/useMyCollectionTracking.tsx

cc/ @gkartalis @MrSltun 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- chore(analytics): add useHomeViewTracking hook

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
