### PR TITLE
chore: temporarily undo M1 while we make breaking changes

### DIFF
--- a/src/app/Scenes/Home/HomeContainer.tests.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tests.tsx
@@ -26,9 +26,14 @@ describe("conditional rendering of old vs new home screen", () => {
         () => __globalStoreTestUtils__?.injectFeatureFlags({ ARPreferLegacyHomeScreen: false })
       )
 
-      it("renders the NEW screen", () => {
+      xit("renders the NEW screen", () => {
         renderWithWrappers(<HomeContainer />)
         expect(screen.getByTestId("new-home-view-skeleton")).toBeOnTheScreen()
+      })
+
+      it("temporarily renders the old screen while we make breaking changes", () => {
+        renderWithWrappers(<HomeContainer />)
+        expect(screen.queryByTestId("new-home-view-skeleton")).not.toBeOnTheScreen()
       })
     })
 

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -5,7 +5,7 @@ import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+// import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useEffect } from "react"
 
 export const HomeContainer = () => {
@@ -13,7 +13,7 @@ export const HomeContainer = () => {
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const showPlayground = useDevToggle("DTShowPlayground")
 
-  const preferLegacyHomeScreen = useFeatureFlag("ARPreferLegacyHomeScreen")
+  const preferLegacyHomeScreen = true // useFeatureFlag("ARPreferLegacyHomeScreen")
 
   const shouldDisplayNewHomeView = ArtsyNativeModule.isBetaOrDev && !preferLegacyHomeScreen
 


### PR DESCRIPTION
### Description

The impending breaking changes from https://github.com/artsy/metaphysics/pull/5962 are going to be more disruptive than we anticipated, so we are temporary undoing M1.

For the time being, the legacy home screen will continue to be the default, so that devs / internal testers do not end up on a dead-end version of the new home screen.

**Follow-up**: revert this commit when we update Eigen to understand the new MP schema changes.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Temporarily undo M1 and serve the legacy home screen - Roop

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
