### PR TITLE
chore: restructure submission status tests

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
@@ -18,77 +18,73 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
     `,
   })
 
-  it("Displays nothing when there is no submission", () => {
-    renderWithRelay({
-      Artwork: () => {
-        return {
-          consignmentSubmission: null,
-        }
-      },
+  describe("AREnableSubmitArtworkTier2Information feature flag is off", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableSubmitArtworkTier2Information: false,
+      })
     })
 
-    expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
-  })
+    it("Displays nothing when there is no submission", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            consignmentSubmission: null,
+          }
+        },
+      })
 
-  it("Displays nothing if state is DRAFT", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({
-      AREnableSubmitArtworkTier2Information: false,
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
     })
 
-    renderWithRelay({
-      Artwork: () => {
-        return {
-          consignmentSubmission: {
-            externalID: "some-external-id",
-            state: "DRAFT",
-          },
-        }
-      },
+    it("Displays nothing if state is DRAFT", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            consignmentSubmission: {
+              externalID: "some-external-id",
+              state: "DRAFT",
+            },
+          }
+        },
+      })
+
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
     })
 
-    expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
-  })
+    it("display Submission status and In Progress when submission is in progress", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            consignmentSubmission: {
+              externalID: "some-external-id",
+              state: "SUBMITTED",
+              stateLabel: "In Progress",
+            },
+          }
+        },
+      })
 
-  it("display Submission status and In Progress when submission is in progress", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({
-      AREnableSubmitArtworkTier2Information: false,
+      expect(screen.getByText("Submission Status")).toBeDefined()
+      expect(screen.getByText("In Progress")).toBeDefined()
     })
 
-    renderWithRelay({
-      Artwork: () => {
-        return {
-          consignmentSubmission: {
-            externalID: "some-external-id",
-            state: "SUBMITTED",
-            stateLabel: "In Progress",
-          },
-        }
-      },
+    it("display Submission status and Evaluation Complete when submission has been evaluated", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            consignmentSubmission: {
+              externalID: "some-external-id",
+              state: "REJECTED",
+              stateLabel: "Evaluation Complete",
+            },
+          }
+        },
+      })
+
+      expect(screen.getByText("Submission Status")).toBeDefined()
+      expect(screen.getByText("Evaluation Complete")).toBeDefined()
     })
-
-    expect(screen.getByText("Submission Status")).toBeDefined()
-    expect(screen.getByText("In Progress")).toBeDefined()
-  })
-
-  it("display Submission status and Evaluation Complete when submission has been evaluated", () => {
-    __globalStoreTestUtils__?.injectFeatureFlags({
-      AREnableSubmitArtworkTier2Information: false,
-    })
-
-    renderWithRelay({
-      Artwork: () => {
-        return {
-          consignmentSubmission: {
-            externalID: "some-external-id",
-            state: "REJECTED",
-            stateLabel: "Evaluation Complete",
-          },
-        }
-      },
-    })
-
-    expect(screen.getByText("Submission Status")).toBeDefined()
-    expect(screen.getByText("Evaluation Complete")).toBeDefined()
   })
 
   describe("AREnableSubmitArtworkTier2Information feature flag is on", () => {
@@ -96,6 +92,18 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
       __globalStoreTestUtils__?.injectFeatureFlags({
         AREnableSubmitArtworkTier2Information: true,
       })
+    })
+
+    it("Displays nothing when there is no submission", () => {
+      renderWithRelay({
+        Artwork: () => {
+          return {
+            consignmentSubmission: null,
+          }
+        },
+      })
+
+      expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).toBe(null)
     })
 
     it("displays submission status even if state is DRAFT", () => {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Restructure submission status tests
Follow up on https://github.com/artsy/eigen/pull/10733

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- restructure submission status tests -daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
