### PR TITLE
feat(EMI-2027): Add Curators' Pick and Increased Interest signals

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -644,6 +644,54 @@ describe("ArtworkGridItem", () => {
         expect(screen.getByText("$3,700 (7 bids)")).toBeOnTheScreen()
       })
     })
+
+    describe("social signal", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableCuratorsPicksAndInterestSignals: true,
+        })
+      })
+
+      it("renders the increased interest signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: true,
+              curatorsPick: false,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+      })
+
+      it("renders the increased interest signal even when there's a curator's pick signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: true,
+              curatorsPick: true,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+        expect(screen.queryByText("Curators’ Pick")).not.toBeOnTheScreen()
+      })
+
+      it("renders the curators pick signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: false,
+              curatorsPick: true,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Curators’ Pick")).toBeOnTheScreen()
+      })
+    })
   })
 })
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -19,6 +19,7 @@ import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/Cr
 import { filterArtworksParams } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
+import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { ContextMenuArtwork } from "app/Components/ContextMenu/ContextMenuArtwork"
 import { DurationProvider } from "app/Components/Countdown"
@@ -80,6 +81,8 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   /** allows for artwork to be added to recent searches */
   updateRecentSearchesOnTap?: boolean
   urgencyTagTextStyle?: TextProps
+  hideIncreasedInterestSignal?: boolean
+  hideCuratorsPickSignal?: boolean
 }
 
 export const Artwork: React.FC<ArtworkProps> = ({
@@ -110,6 +113,8 @@ export const Artwork: React.FC<ArtworkProps> = ({
   trackTap,
   updateRecentSearchesOnTap = false,
   urgencyTagTextStyle,
+  hideIncreasedInterestSignal = false,
+  hideCuratorsPickSignal = false,
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
@@ -355,6 +360,13 @@ export const Artwork: React.FC<ArtworkProps> = ({
                     </Text>
                   </Box>
                 )}
+                {!isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals && (
+                  <ArtworkSocialSignal
+                    collectorSignals={collectorSignals}
+                    hideCuratorsPick={hideCuratorsPickSignal}
+                    hideIncreasedInterest={hideIncreasedInterestSignal}
+                  />
+                )}
                 {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
                   <>
                     <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
@@ -592,6 +604,7 @@ export default createFragmentContainer(Artwork, {
           lotClosesAt
         }
         ...ArtworkAuctionTimer_collectorSignals
+        ...ArtworkSocialSignal_collectorSignals
       }
       ...useSaveArtworkToArtworkLists_artwork
     }

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -123,6 +123,9 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const AREnablePartnerOfferSignals = useFeatureFlag("AREnablePartnerOfferSignals")
   const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
+  const AREnableCuratorsPicksAndInterestSignals = useFeatureFlag(
+    "AREnableCuratorsPicksAndInterestSignals"
+  )
 
   let filterParams: any = undefined
 
@@ -360,13 +363,16 @@ export const Artwork: React.FC<ArtworkProps> = ({
                     </Text>
                   </Box>
                 )}
-                {!isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals && (
-                  <ArtworkSocialSignal
-                    collectorSignals={collectorSignals}
-                    hideCuratorsPick={hideCuratorsPickSignal}
-                    hideIncreasedInterest={hideIncreasedInterestSignal}
-                  />
-                )}
+                {!isAuction &&
+                  !displayLimitedTimeOfferSignal &&
+                  !!collectorSignals &&
+                  !!AREnableCuratorsPicksAndInterestSignals && (
+                    <ArtworkSocialSignal
+                      collectorSignals={collectorSignals}
+                      hideCuratorsPick={hideCuratorsPickSignal}
+                      hideIncreasedInterest={hideIncreasedInterestSignal}
+                    />
+                  )}
                 {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
                   <>
                     <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>

--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tests.tsx
@@ -1,0 +1,97 @@
+import { screen } from "@testing-library/react-native"
+import { ArtworkSocialSignalTestsQuery } from "__generated__/ArtworkSocialSignalTestsQuery.graphql"
+import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("ArtworkSocialSignal", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkSocialSignalTestsQuery>({
+    Component: (props) => (
+      <ArtworkSocialSignal collectorSignals={props.artwork?.collectorSignals} {...(props as any)} />
+    ),
+    query: graphql`
+      query ArtworkSocialSignalTestsQuery @relay_test_operation {
+        artwork(id: "example") {
+          collectorSignals {
+            ...ArtworkSocialSignal_collectorSignals
+          }
+        }
+      }
+    `,
+  })
+
+  describe("increased interest signal", () => {
+    it("renders the increased interest signal", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          collectorSignals: {
+            increasedInterest: true,
+            curatorsPick: false,
+          },
+        }),
+      })
+
+      expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+    })
+
+    it("does not render the increased interest signal when it is hidden", () => {
+      renderWithRelay(
+        {
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: true,
+              curatorsPick: false,
+            },
+          }),
+        },
+        { hideIncreasedInterest: true }
+      )
+
+      expect(screen.queryByText("Increased Interest")).not.toBeOnTheScreen()
+    })
+
+    it("renders the increased interest signal even if with curator's pick singal available", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          collectorSignals: {
+            increasedInterest: true,
+            curatorsPick: true,
+          },
+        }),
+      })
+
+      expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+    })
+  })
+
+  describe("curator's pick signal", () => {
+    it("renders the curator's pick signal", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          collectorSignals: {
+            increasedInterest: false,
+            curatorsPick: true,
+          },
+        }),
+      })
+
+      expect(screen.getByText("Curators’ Pick")).toBeOnTheScreen()
+    })
+
+    it("does not render the curators pick signal when it is hidden", () => {
+      renderWithRelay(
+        {
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: false,
+              curatorsPick: true,
+            },
+          }),
+        },
+        { hideCuratorsPick: true }
+      )
+
+      expect(screen.queryByText("Curators’ Pick")).not.toBeOnTheScreen()
+    })
+  })
+})

--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
@@ -16,10 +16,6 @@ export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
 }) => {
   const { curatorsPick, increasedInterest } = useFragment(fragment, collectorSignals)
 
-  if ((hideIncreasedInterest && hideCuratorsPick) || (!curatorsPick && !increasedInterest)) {
-    return null
-  }
-
   const primaryColor = dark ? "white100" : "black100"
 
   switch (true) {

--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
@@ -1,0 +1,70 @@
+import { Box, Text } from "@artsy/palette-mobile"
+import { ArtworkSocialSignal_collectorSignals$key } from "__generated__/ArtworkSocialSignal_collectorSignals.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface ArtworkSocialSignalProps {
+  collectorSignals: ArtworkSocialSignal_collectorSignals$key
+  hideIncreasedInterest?: boolean
+  hideCuratorsPick?: boolean
+  dark?: boolean
+}
+export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
+  collectorSignals,
+  hideCuratorsPick,
+  hideIncreasedInterest,
+  dark = false,
+}) => {
+  const { curatorsPick, increasedInterest } = useFragment(fragment, collectorSignals)
+
+  if ((hideIncreasedInterest && hideCuratorsPick) || (!curatorsPick && !increasedInterest)) {
+    return null
+  }
+
+  const primaryColor = dark ? "white100" : "black100"
+
+  switch (true) {
+    case increasedInterest && !hideIncreasedInterest:
+      return (
+        <Box
+          px={0.5}
+          pb="2px"
+          alignSelf="flex-start"
+          borderRadius={3}
+          borderWidth={1}
+          borderColor={primaryColor}
+          mb={0.5}
+        >
+          <Text color={primaryColor} variant="xxs">
+            Increased Interest
+          </Text>
+        </Box>
+      )
+
+    case curatorsPick && !hideCuratorsPick:
+      return (
+        <Box
+          px={0.5}
+          pb="2px"
+          alignSelf="flex-start"
+          borderRadius={3}
+          borderWidth={1}
+          borderColor={primaryColor}
+          mb={0.5}
+        >
+          <Text color={primaryColor} variant="xxs">
+            Curators’ Pick
+          </Text>
+        </Box>
+      )
+
+    default:
+      return null
+  }
+}
+
+const fragment = graphql`
+  fragment ArtworkSocialSignal_collectorSignals on CollectorSignals {
+    increasedInterest
+    curatorsPick
+  }
+`

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -118,6 +118,10 @@ export interface Props extends ArtworkActionTrackingProps {
     RefreshControlProps,
     string | React.JSXElementConstructor<any>
   >
+
+  hideIncreasedInterest?: boolean
+
+  hideCuratorsPick?: boolean
 }
 
 interface PrivateProps {
@@ -200,6 +204,8 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   updateRecentSearchesOnTap = false,
   useParentAwareScrollView = Platform.OS === "android",
   width,
+  hideIncreasedInterest,
+  hideCuratorsPick,
 }) => {
   const artworks = extractNodes(connection)
 
@@ -351,6 +357,8 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
             height={imgHeight}
             {...componentSpecificProps}
             displayToolTip={displayToolTip}
+            hideIncreasedInterestSignal={hideIncreasedInterest}
+            hideCuratorsPickSignal={hideCuratorsPick}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -30,6 +30,8 @@ interface CommonArtworkRailProps {
   onMorePress?: () => void
   viewabilityConfig?: ViewabilityConfig | undefined
   onViewableItemsChanged?: (info: { viewableItems: any[]; changed: any[] }) => void
+  hideIncreasedInterestSignal?: boolean
+  hideCuratorsPickSignal?: boolean
 }
 
 export interface ArtworkRailProps extends CommonArtworkRailProps, ArtworkActionTrackingProps {
@@ -56,6 +58,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
   viewabilityConfig,
   onViewableItemsChanged,
   onMorePress,
+  hideIncreasedInterestSignal,
+  hideCuratorsPickSignal,
   ...otherProps
 }) => {
   const trackingProps = extractArtworkActionTrackingProps(otherProps)
@@ -109,6 +113,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
                 onSupressArtwork={() => {
                   handleSupress(item)
                 }}
+                hideIncreasedInterestSignal={hideIncreasedInterestSignal}
+                hideCuratorsPickSignal={hideCuratorsPickSignal}
               />
             </Box>
           </Disappearable>

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
@@ -307,6 +307,54 @@ describe("ArtworkRailCard", () => {
         expect(screen.getByText("$3,700 (7 bids)")).toBeOnTheScreen()
       })
     })
+
+    describe("social signal", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableCuratorsPicksAndInterestSignals: true,
+        })
+      })
+
+      it("renders the increased interest signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: true,
+              curatorsPick: false,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+      })
+
+      it("renders the increased interest signal even when there's a curator's pick signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: true,
+              curatorsPick: true,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+        expect(screen.queryByText("Curators’ Pick")).not.toBeOnTheScreen()
+      })
+
+      it("renders the curators pick signal", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            collectorSignals: {
+              increasedInterest: false,
+              curatorsPick: true,
+            },
+          }),
+        })
+
+        expect(screen.getByText("Curators’ Pick")).toBeOnTheScreen()
+      })
+    })
   })
 })
 

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -103,6 +103,9 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
 
   const AREnablePartnerOfferSignals = useFeatureFlag("AREnablePartnerOfferSignals")
   const AREnableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
+  const AREnableCuratorsPicksAndInterestSignals = useFeatureFlag(
+    "AREnableCuratorsPicksAndInterestSignals"
+  )
 
   const {
     artistNames,
@@ -306,14 +309,17 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                     </Text>
                   </Box>
                 )}
-                {!sale?.isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals && (
-                  <ArtworkSocialSignal
-                    collectorSignals={collectorSignals}
-                    hideCuratorsPick={hideCuratorsPickSignal}
-                    hideIncreasedInterest={hideIncreasedInterestSignal}
-                    dark={dark}
-                  />
-                )}
+                {!sale?.isAuction &&
+                  !displayLimitedTimeOfferSignal &&
+                  !!collectorSignals &&
+                  !!AREnableCuratorsPicksAndInterestSignals && (
+                    <ArtworkSocialSignal
+                      collectorSignals={collectorSignals}
+                      hideCuratorsPick={hideCuratorsPickSignal}
+                      hideIncreasedInterest={hideIncreasedInterestSignal}
+                      dark={dark}
+                    />
+                  )}
                 {!!lotLabel && (
                   <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1}>
                     Lot {lotLabel}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -15,6 +15,7 @@ import {
 } from "__generated__/ArtworkRailCard_artwork.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
+import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useExtraLargeWidth } from "app/Components/ArtworkRail/useExtraLargeWidth"
 import { ContextMenuArtwork } from "app/Components/ContextMenu/ContextMenuArtwork"
@@ -68,6 +69,8 @@ export interface ArtworkRailCardProps extends ArtworkActionTrackingProps {
   showSaveIcon?: boolean
   size: ArtworkCardSize
   testID?: string
+  hideIncreasedInterestSignal?: boolean
+  hideCuratorsPickSignal?: boolean
 }
 
 export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
@@ -86,6 +89,8 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   showSaveIcon = false,
   size,
   testID,
+  hideIncreasedInterestSignal = false,
+  hideCuratorsPickSignal = false,
   ...restProps
 }) => {
   const EXTRALARGE_RAIL_CARD_IMAGE_WIDTH = useExtraLargeWidth()
@@ -300,6 +305,14 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                       Limited-Time Offer
                     </Text>
                   </Box>
+                )}
+                {!sale?.isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals && (
+                  <ArtworkSocialSignal
+                    collectorSignals={collectorSignals}
+                    hideCuratorsPick={hideCuratorsPickSignal}
+                    hideIncreasedInterest={hideIncreasedInterestSignal}
+                    dark={dark}
+                  />
                 )}
                 {!!lotLabel && (
                   <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1}>
@@ -669,6 +682,7 @@ const artworkFragment = graphql`
         lotClosesAt
       }
       ...ArtworkAuctionTimer_collectorSignals
+      ...ArtworkSocialSignal_collectorSignals
     }
     ...useSaveArtworkToArtworkLists_artwork
   }

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -10,6 +10,7 @@ import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsCo
 import { AuctionTimerState, currentTimerState } from "app/Components/Bidding/Components/Timer"
 import { ArtistSeriesMoreSeriesFragmentContainer as ArtistSeriesMoreSeries } from "app/Scenes/ArtistSeries/ArtistSeriesMoreSeries"
 import { ArtworkAuctionCreateAlertHeader } from "app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader"
+import { ArtworkCuratorsPickIncreasedInterestCollectorSignal } from "app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal"
 import { ArtworkDimensionsClassificationAndAuthenticityFragmentContainer } from "app/Scenes/Artwork/Components/ArtworkDimensionsClassificationAndAuthenticity/ArtworkDimensionsClassificationAndAuthenticity"
 import { ArtworkErrorScreen } from "app/Scenes/Artwork/Components/ArtworkError"
 import { ArtworkPartnerOfferNote } from "app/Scenes/Artwork/Components/ArtworkPartnerOfferNote"
@@ -297,6 +298,15 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
           />
         ),
         excludePadding: true,
+        excludeSeparator: true,
+        excludeVerticalMargin: true,
+      })
+
+      sections.push({
+        key: "artworkCuratorsPickIncreasedInterestCollectorSignal",
+        element: (
+          <ArtworkCuratorsPickIncreasedInterestCollectorSignal artwork={artworkAboveTheFold} />
+        ),
         excludeSeparator: true,
         excludeVerticalMargin: true,
       })
@@ -672,6 +682,7 @@ export const ArtworkContainer = createRefetchContainer(
         ...ArtworkPartnerOfferNote_artwork
         ...ArtworkPrice_artwork
         ...ArtworkDimensionsClassificationAndAuthenticity_artwork
+        ...ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork
         slug
         internalID
         isAcquireable

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -108,6 +108,9 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
   const allowExpiredPartnerOffers = useFeatureFlag("AREnableExpiredPartnerOffers")
   const enableAuctionHeaderAlertCTA = useFeatureFlag("AREnableAuctionHeaderAlertCTA")
   const enablePartnerOfferOnArtworkScreen = useFeatureFlag("AREnablePartnerOfferOnArtworkScreen")
+  const enableCuratorsPicksAndInterestSignals = useFeatureFlag(
+    "AREnableCuratorsPicksAndInterestSignals"
+  )
 
   const expectedPartnerOfferId = !!props.partner_offer_id && enablePartnerOfferOnArtworkScreen
 
@@ -302,14 +305,16 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         excludeVerticalMargin: true,
       })
 
-      sections.push({
-        key: "artworkCuratorsPickIncreasedInterestCollectorSignal",
-        element: (
-          <ArtworkCuratorsPickIncreasedInterestCollectorSignal artwork={artworkAboveTheFold} />
-        ),
-        excludeSeparator: true,
-        excludeVerticalMargin: true,
-      })
+      if (enableCuratorsPicksAndInterestSignals) {
+        sections.push({
+          key: "artworkCuratorsPickIncreasedInterestCollectorSignal",
+          element: (
+            <ArtworkCuratorsPickIncreasedInterestCollectorSignal artwork={artworkAboveTheFold} />
+          ),
+          excludeSeparator: true,
+          excludeVerticalMargin: true,
+        })
+      }
 
       sections.push({
         key: "dimensionsClassificationAndAuthenticity",

--- a/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tests.tsx
@@ -1,0 +1,79 @@
+import { screen } from "@testing-library/react-native"
+import { ArtworkCuratorsPickIncreasedInterestCollectorSignal } from "app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("ArtworkCuratorsPickIncreasedInterestCollectorSignal", () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: ArtworkCuratorsPickIncreasedInterestCollectorSignal,
+    query: graphql`
+      query ArtworkCuratorsPickIncreasedInterestCollectorSignalTestsQuery @relay_test_operation {
+        artwork(id: "example") {
+          ...ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork
+        }
+      }
+    `,
+  })
+
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCuratorsPicksAndInterestSignals: true })
+  })
+
+  it("renders the increased interest signal", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        collectorSignals: {
+          increasedInterest: true,
+          curatorsPick: false,
+        },
+      }),
+    })
+
+    expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+    expect(screen.getByText("Based on collector activity in the past 14 days")).toBeOnTheScreen()
+  })
+
+  it("renders the increased interest signal even when there's a curator's pick signal", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        collectorSignals: {
+          increasedInterest: true,
+          curatorsPick: true,
+        },
+      }),
+    })
+
+    expect(screen.getByText("Increased Interest")).toBeOnTheScreen()
+    expect(screen.getByText("Based on collector activity in the past 14 days")).toBeOnTheScreen()
+    expect(screen.queryByText("Curators’ Pick")).not.toBeOnTheScreen()
+  })
+
+  it("renders the curators pick signal", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        collectorSignals: {
+          increasedInterest: false,
+          curatorsPick: true,
+        },
+      }),
+    })
+
+    expect(screen.getByText("Curators’ Pick")).toBeOnTheScreen()
+    expect(screen.getByText("Hand selected by Artsy curators this week")).toBeOnTheScreen()
+  })
+
+  it("doesn't render if there are no signals", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        collectorSignals: {
+          increasedInterest: false,
+          curatorsPick: false,
+        },
+      }),
+    })
+
+    expect(screen.queryByText("Increased Interest")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Curators’ Pick")).not.toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tsx
@@ -1,0 +1,58 @@
+import { Flex, Text, TrendingIcon, VerifiedIcon } from "@artsy/palette-mobile"
+import { ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork$key } from "__generated__/ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface Props {
+  artwork: ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork$key
+}
+
+export const ArtworkCuratorsPickIncreasedInterestCollectorSignal: React.FC<Props> = ({
+  artwork,
+}) => {
+  const { collectorSignals } = useFragment(fragment, artwork)
+
+  if (!collectorSignals) {
+    return null
+  }
+
+  const { increasedInterest, curatorsPick } = collectorSignals
+
+  if (!increasedInterest && !curatorsPick) {
+    return null
+  }
+
+  let singalTitle = "Curators’ Pick"
+  let signalDescription = "Hand selected by Artsy curators this week"
+  let SignalIcon = VerifiedIcon
+
+  if (increasedInterest) {
+    singalTitle = "Increased Interest"
+    signalDescription = "Based on collector activity in the past 14 days"
+    SignalIcon = TrendingIcon
+  }
+
+  return (
+    <Flex flexDirection="row" mt={4} mb={2}>
+      <SignalIcon mr={0.5} mt="2px" />
+
+      <Flex flexDirection="column">
+        <Text variant="sm-display" color="black100">
+          {singalTitle}
+        </Text>
+
+        <Text variant="sm" color="black60">
+          {signalDescription}
+        </Text>
+      </Flex>
+    </Flex>
+  )
+}
+
+const fragment = graphql`
+  fragment ArtworkCuratorsPickIncreasedInterestCollectorSignal_artwork on Artwork {
+    collectorSignals {
+      increasedInterest
+      curatorsPick
+    }
+  }
+`

--- a/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCuratorsPickIncreasedInterestCollectorSignal.tsx
@@ -11,15 +11,14 @@ export const ArtworkCuratorsPickIncreasedInterestCollectorSignal: React.FC<Props
 }) => {
   const { collectorSignals } = useFragment(fragment, artwork)
 
-  if (!collectorSignals) {
+  if (
+    !collectorSignals ||
+    (!collectorSignals.increasedInterest && !collectorSignals.curatorsPick)
+  ) {
     return null
   }
 
-  const { increasedInterest, curatorsPick } = collectorSignals
-
-  if (!increasedInterest && !curatorsPick) {
-    return null
-  }
+  const { increasedInterest } = collectorSignals
 
   let singalTitle = "Curators’ Pick"
   let signalDescription = "Hand selected by Artsy curators this week"
@@ -32,7 +31,7 @@ export const ArtworkCuratorsPickIncreasedInterestCollectorSignal: React.FC<Props
   }
 
   return (
-    <Flex flexDirection="row" mt={4} mb={2}>
+    <Flex flexDirection="row" pt={4} pb={2}>
       <SignalIcon mr={0.5} mt="2px" />
 
       <Flex flexDirection="column">

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -27,6 +27,8 @@ interface CollectionArtworksProps {
   relay: RelayPaginationProp
 }
 
+const CURATORS_PICKS_SLUGS = ["curators-picks-emerging-artists", "curators-picks-blue-chip-artists"]
+
 export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collection, relay }) => {
   const { width } = useScreenDimensions()
   const space = useSpace()
@@ -104,6 +106,8 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
     const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
     const imgHeight = imgWidth / imgAspectRatio
 
+    const hideSignals = CURATORS_PICKS_SLUGS.includes(collection.slug)
+
     return (
       <Flex
         pl={columnIndex === 0 ? 0 : 1}
@@ -117,6 +121,8 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
           contextScreenOwnerSlug={collection.slug}
           artwork={item}
           height={imgHeight}
+          hideCuratorsPickSignal={hideSignals}
+          hideIncreasedInterestSignal={hideSignals}
         />
       </Flex>
     )

--- a/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
+++ b/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
@@ -108,6 +108,8 @@ export const MarketingCollectionRail: React.FC<MarketingCollectionRailProps> = m
           dark
           showPartnerName
           onMorePress={handleMorePress}
+          hideCuratorsPickSignal
+          hideIncreasedInterestSignal
         />
       </Flex>
     )

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
@@ -54,6 +54,8 @@ const OnboardingMarketingCollection: React.FC<OnboardingMarketingCollectionProps
           connection={marketingCollection?.artworks}
           shouldAddPadding
           disableArtworksListPrompt
+          hideCuratorsPick={slug === "curators-picks-emerging"}
+          hideIncreasedInterest={slug === "curators-picks-emerging"}
         />
         <Flex p={2} backgroundColor="white">
           <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -277,6 +277,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableCollectionsWithoutHeaderImage",
   },
+  AREnableCuratorsPicksAndInterestSignals: {
+    description: "Enable Curators' Picks and Increased Interest signals",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableCuratorsPicksAndInterestSignals",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [EMI-2027] <!-- eg [PROJECT-XXXX] -->

> [!NOTE]
> This work is hidden behind `AREnableCuratorsPicksAndInterestSignals` feature flag

### Description
This PR adds the new Increased Interest and Curator's Pick signals on artwork rail cards, grid items, and artwork details page

### Screenshots
| | Android | iOS |
|---|---|---|
| Artwork screen - increased interest | <img width="468" alt="image" src="https://github.com/user-attachments/assets/ca040f09-bffd-4af9-924c-5de0513f2898"> | ![image](https://github.com/user-attachments/assets/dc7fbb22-2d47-4af4-8b2f-e4318681a286) |
| Artwork screen - curator's pick | <img width="466" alt="image" src="https://github.com/user-attachments/assets/1ba5c450-f8da-435b-91c8-1ac61d8ae569"> | ![image](https://github.com/user-attachments/assets/926562ee-dad2-416f-8c27-244224ac2120) |
| Artwork rail - increased interest | <img width="467" alt="image" src="https://github.com/user-attachments/assets/145d9af5-68b5-4c31-b2c3-0da2f28053f9"> | ![image](https://github.com/user-attachments/assets/d959ac97-8a6c-42c3-b9a4-39d0a616b374) |
| Artwork rail - curator's pick | <img width="466" alt="image" src="https://github.com/user-attachments/assets/6ef09768-5ea6-4357-9265-03f6204cef3d"> | ![image](https://github.com/user-attachments/assets/59f477f6-7b48-44b3-9496-6f254a778085) |
| Artwork grid - increased interest | <img width="467" alt="image" src="https://github.com/user-attachments/assets/8f93d49d-9e0d-4abc-961f-c028afbe279c"> | ![image](https://github.com/user-attachments/assets/d79627be-cd9c-4f2f-92e5-2f1f484667d3) |
| Artwork grid - curator's pick | <img width="465" alt="image" src="https://github.com/user-attachments/assets/3c0828cc-f657-411c-90de-e9f0f616f6be"> | ![image](https://github.com/user-attachments/assets/887238c3-9755-4e0d-8013-5b81253814ce) |



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add new Increased Interest and Curator's Pick signals (hidden behind FF) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->


cc @artsy/emerald-devs 

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2027]: https://artsyproduct.atlassian.net/browse/EMI-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ