### PR TITLE
fix(ONYX-1287): broken spacing between home view sections

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,11 +1,4 @@
-import {
-  Flex,
-  Screen,
-  Spacer,
-  SpacingUnitDSValueNumber,
-  Spinner,
-  Text,
-} from "@artsy/palette-mobile"
+import { Flex, Screen, Spinner, Text } from "@artsy/palette-mobile"
 import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
 import { HomeViewSectionsConnection_viewer$key } from "__generated__/HomeViewSectionsConnection_viewer.graphql"
 import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
@@ -17,8 +10,10 @@ import { Suspense, useState } from "react"
 import { RefreshControl } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
-const SECTION_SEPARATOR_HEIGHT: SpacingUnitDSValueNumber = 6
 const NUMBER_OF_SECTIONS_TO_LOAD = 10
+// Hard coding the value here because 30px is not a valid value for the spacing unit
+// and we need it to be consistent with 60px spacing between sections
+export const HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT = "30px"
 
 export const HomeView: React.FC = () => {
   const queryData = useLazyLoadQuery<HomeViewQuery>(homeViewScreenQuery, {
@@ -63,7 +58,6 @@ export const HomeView: React.FC = () => {
           renderItem={({ item }) => {
             return <Section section={item} />
           }}
-          ItemSeparatorComponent={SectionSeparator}
           onEndReached={() => loadNext(10)}
           ListHeaderComponent={<HomeHeader />}
           ListFooterComponent={
@@ -79,8 +73,6 @@ export const HomeView: React.FC = () => {
     </Screen>
   )
 }
-
-const SectionSeparator = () => <Spacer y={SECTION_SEPARATOR_HEIGHT} />
 
 export const HomeViewScreen: React.FC = () => (
   <Suspense

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
@@ -4,6 +4,7 @@ import { SectionTitle } from "app/Components/SectionTitle"
 import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { SeeAllCard } from "app/Scenes/Home/Components/ActivityRail"
 import { ActivityRailItem } from "app/Scenes/Home/Components/ActivityRailItem"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -30,7 +31,7 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
   }
 
   return (
-    <Flex pt={2}>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex px={2}>
         <SectionTitle
           title={component?.title || "Activity"}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticles.tsx
@@ -1,5 +1,7 @@
+import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionArticles_section$key } from "__generated__/HomeViewSectionArticles_section.graphql"
 import { ArticlesRailFragmentContainer } from "app/Scenes/Home/Components/ArticlesRail"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
@@ -19,20 +21,22 @@ export const HomeViewSectionArticles: React.FC<HomeViewSectionArticlesProps> = (
   const componentHref = section.component?.behaviors?.viewAll?.href
 
   return (
-    <ArticlesRailFragmentContainer
-      title={section.component?.title ?? ""}
-      articlesConnection={section.articlesConnection}
-      onTrack={(article, index) => {
-        tracking.tappedArticleGroup(article.internalID, article.slug, section.internalID, index)
-      }}
-      onSectionTitlePress={
-        componentHref
-          ? () => {
-              navigate(componentHref)
-            }
-          : undefined
-      }
-    />
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
+      <ArticlesRailFragmentContainer
+        title={section.component?.title ?? ""}
+        articlesConnection={section.articlesConnection}
+        onTrack={(article, index) => {
+          tracking.tappedArticleGroup(article.internalID, article.slug, section.internalID, index)
+        }}
+        onSectionTitlePress={
+          componentHref
+            ? () => {
+                navigate(componentHref)
+              }
+            : undefined
+        }
+      />
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
@@ -1,5 +1,6 @@
 import { Flex, Separator, Text, Touchable, useSpace } from "@artsy/palette-mobile"
 import { HomeViewSectionArticlesCards_section$key } from "__generated__/HomeViewSectionArticlesCards_section.graphql"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { graphql, useFragment } from "react-relay"
@@ -27,7 +28,14 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
   }
 
   return (
-    <Flex m={2} p={2} border="1px solid" borderColor="black30" gap={space(2)}>
+    <Flex
+      my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}
+      mx={2}
+      p={2}
+      border="1px solid"
+      borderColor="black30"
+      gap={space(2)}
+    >
       <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
         <Text variant="lg-display">{title}</Text>
         <Text variant="lg-display">{date()}</Text>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtists.tsx
@@ -7,6 +7,7 @@ import {
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { PAGE_SIZE } from "app/Components/constants"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -48,7 +49,7 @@ export const HomeViewSectionArtists: React.FC<HomeViewSectionArtworksProps> = ({
   const artists = extractNodes(section.artistsConnection)
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex px={2}>
         <SectionTitle
           title={title}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -4,6 +4,7 @@ import { LargeArtworkRail_artworks$data } from "__generated__/LargeArtworkRail_a
 import { SmallArtworkRail_artworks$data } from "__generated__/SmallArtworkRail_artworks.graphql"
 import { LargeArtworkRail } from "app/Components/ArtworkRail/LargeArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { getSectionHref } from "app/Scenes/HomeView/helpers/getSectionHref"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
@@ -45,7 +46,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
   }
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <View>
         <Flex pl={2} pr={2}>
           <SectionTitle

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
@@ -3,6 +3,7 @@ import { HomeViewSectionAuctionResults_section$key } from "__generated__/HomeVie
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -28,7 +29,7 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
   const componentHref = section.component?.behaviors?.viewAll?.href
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex px={2}>
         <SectionTitle
           title={section.component?.title ?? "Auction Results"}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
@@ -2,6 +2,7 @@ import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionFairs_section$key } from "__generated__/HomeViewSectionFairs_section.graphql"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { HomeViewSectionFairsFairItem } from "app/Scenes/HomeView/Sections/HomeViewSectionFairsFairItem"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
@@ -25,7 +26,7 @@ export const HomeViewSectionFairs: React.FC<HomeViewSectionFairsProps> = ({ sect
   if (!fairs || fairs.length === 0) return null
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex pl={2} pr={2}>
         <SectionTitle
           title={component.title}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -1,6 +1,7 @@
 import { Flex, Image, Spacer, Text } from "@artsy/palette-mobile"
 import { HomeViewSectionFeaturedCollection_section$key } from "__generated__/HomeViewSectionFeaturedCollection_section.graphql"
 import { LargeArtworkRail } from "app/Components/ArtworkRail/LargeArtworkRail"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { TouchableOpacity, useWindowDimensions } from "react-native"
@@ -34,7 +35,7 @@ export const HomeViewSectionFeaturedCollection: React.FC<
   }
 
   return (
-    <Flex pb={2} backgroundColor="black100">
+    <Flex pb={2} backgroundColor="black100" my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <TouchableOpacity onPress={handlePress} activeOpacity={0.7}>
         {!!component.backgroundImageURL && (
           <Image width={width} height={80} resizeMode="cover" src={component.backgroundImageURL} />

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGalleries.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { HomeViewSectionGalleries_section$key } from "__generated__/HomeViewSectionGalleries_section.graphql"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { isTablet } from "react-native-device-info"
@@ -36,7 +37,7 @@ export const HomeViewSectionGalleries: React.FC<HomeViewSectionGalleriesProps> =
   }
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Touchable onPress={handleOnPress} haptic="impactLight">
         {!!hasImage && (
           <Flex position="absolute">

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGeneric.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGeneric.tsx
@@ -1,4 +1,5 @@
 import { Flex, Text } from "@artsy/palette-mobile"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { graphql, useFragment } from "react-relay"
 
 export const HomeViewSectionGeneric: React.FC<{ section: any }> = (props) => {
@@ -8,7 +9,7 @@ export const HomeViewSectionGeneric: React.FC<{ section: any }> = (props) => {
   const title = data.component?.title
 
   return (
-    <Flex bg="black5" alignItems="center">
+    <Flex bg="black5" alignItems="center" my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Text color="black60" p={2}>
         Need to render the{" "}
         <Text color="black100" fontSize="80%">

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -1,7 +1,8 @@
-import { Spacer } from "@artsy/palette-mobile"
+import { Flex, Spacer } from "@artsy/palette-mobile"
 import { HomeViewSectionHeroUnits_section$key } from "__generated__/HomeViewSectionHeroUnits_section.graphql"
 import { PaginationDots } from "app/Components/PaginationDots"
 import { HeroUnit } from "app/Scenes/Home/Components/HeroUnitsRail"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
@@ -37,7 +38,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
   const { width } = useScreenDimensions()
 
   return (
-    <>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <FlatList
         data={heroUnits}
         decelerationRate="fast"
@@ -57,7 +58,7 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
       />
       <Spacer y={2} />
       <PaginationDots currentIndex={currentIndex} length={heroUnits.length} />
-    </>
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
@@ -5,6 +5,7 @@ import {
 } from "__generated__/HomeViewSectionMarketingCollections_section.graphql"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { HomeViewSectionMarketingCollectionsItem } from "app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
@@ -31,7 +32,7 @@ export const HomeViewSectionMarketingCollections: React.FC<
   if (!marketingCollections || marketingCollections.length === 0) return null
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex pl={2} pr={2}>
         <SectionTitle
           title={component.title}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionSales.tsx
@@ -3,6 +3,7 @@ import { HomeViewSectionSales_section$key } from "__generated__/HomeViewSectionS
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { CardRailFlatList } from "app/Components/Home/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { HomeViewSectionSalesItem } from "app/Scenes/HomeView/Sections/HomeViewSectionSalesItem"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
@@ -32,7 +33,7 @@ export const HomeViewSectionSales: React.FC<HomeViewSectionSalesProps> = ({ sect
   }
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex px={2}>
         <SectionTitle
           title={component?.title}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
@@ -1,5 +1,7 @@
+import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionShows_section$key } from "__generated__/HomeViewSectionShows_section.graphql"
 import { ShowsRailContainer } from "app/Scenes/Home/Components/ShowsRail"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
@@ -15,13 +17,15 @@ export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({ sect
   const tracking = useHomeViewTracking()
 
   return (
-    <ShowsRailContainer
-      title={component?.title || "Shows"}
-      disableLocation={!enableShowsForYouLocation}
-      onTrack={(show, index) => {
-        tracking.tappedShowGroup(show.internalID, show.slug, data.internalID, index)
-      }}
-    />
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
+      <ShowsRailContainer
+        title={component?.title || "Shows"}
+        disableLocation={!enableShowsForYouLocation}
+        onTrack={(show, index) => {
+          tracking.tappedShowGroup(show.internalID, show.slug, data.internalID, index)
+        }}
+      />
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms.tsx
@@ -1,6 +1,7 @@
 import { Flex } from "@artsy/palette-mobile"
 import { HomeViewSectionViewingRooms_section$key } from "__generated__/HomeViewSectionViewingRooms_section.graphql"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT } from "app/Scenes/HomeView/HomeView"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import {
   ViewingRoomsHomeRail as LegacyViewingRoomsHomeRail,
@@ -18,7 +19,7 @@ export const HomeViewSectionViewingRooms: React.FC<{
   const componentHref = data.component?.behaviors?.viewAll?.href
 
   return (
-    <Flex>
+    <Flex my={HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT}>
       <Flex px={2}>
         <SectionTitle
           title={data.component?.title}


### PR DESCRIPTION
This PR resolves [ONYX-1287]

### Description

This PR is an attempt to fix the broken spacings between home view sections. Here I am attempting a fix using the first approach suggested below in the thread👇.

<details><summary>Full Context from Slack Pasted Below</summary>
<p>

I noticed an extra margin between some rails in the home view - this is mainly because we define an ItemSeparatorComponent on the HomeView level. This is fine in the case where all sections are defined, however in our case, some sections might be missing and that will lead  to additional spaces representing missing section. 

If we want reliable margins, I see two possible approaches:
- Move the spacings one level below to the individual sections level. 
   - Pros: easy to implement
   - Cons: we need to make sure all new sections include the same spacing logic (I guess this will be easier done than said)
- Have some logic within the HomeView component to check if an item is empty or not. 
For example: In the case of auction results, a function like isSectionEmpty()  that checks the count of auction results count of a section in case its typeName is HomeViewSectionAuctionResults 
   - Pros: We can stick to the ItemSeparatorComponent API
   - Cons: more or less complex to implement and will require us to unmask the sections relay fragments or something similar to check if the section is empty or not
- Any other thoughts?

</p>
</details> 

 

https://github.com/user-attachments/assets/ce8e35df-fac4-4e0f-b1b0-82df7fa43e88


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix broken padding between home view sections - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1287]: https://artsyproduct.atlassian.net/browse/ONYX-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ