### PR TITLE
feat(onyx-1278): restore prompt for app store review for new home view

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import {
   Flex,
   Screen,
@@ -13,6 +14,7 @@ import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { extractNodes } from "app/utils/extractNodes"
+import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
 import { Suspense, useState } from "react"
 import { RefreshControl } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
@@ -32,6 +34,8 @@ export const HomeView: React.FC = () => {
   >(sectionsFragment, queryData.viewer)
 
   const flatlistRef = useBottomTabsScrollToTop("home")
+
+  useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
 
   const sections = extractNodes(data?.homeView.sectionsConnection)
 


### PR DESCRIPTION
This PR resolves [ONYX-1278]

### Description

<img src="https://github.com/user-attachments/assets/9ba72017-e3c7-4a4a-93cc-2130dfe5eb9d" width="300px" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1278]: https://artsyproduct.atlassian.net/browse/ONYX-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ