### PR TITLE
feat(onyx-1279): prefetch tabs from new home view screen

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -2,14 +2,17 @@ import { Flex, Screen, Spinner, Text } from "@artsy/palette-mobile"
 import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
 import { HomeViewSectionsConnection_viewer$key } from "__generated__/HomeViewSectionsConnection_viewer.graphql"
 import { HomeView_me$key } from "__generated__/HomeView_me.graphql"
+import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { useDismissSavedArtwork } from "app/Components/ProgressiveOnboarding/useDismissSavedArtwork"
 import { useEnableProgressiveOnboarding } from "app/Components/ProgressiveOnboarding/useEnableProgressiveOnboarding"
 import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
 import { Section } from "app/Scenes/HomeView/Sections/Section"
+import { searchQueryDefaultVariables } from "app/Scenes/Search/Search"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { extractNodes } from "app/utils/extractNodes"
-import { Suspense, useState } from "react"
+import { usePrefetch } from "app/utils/queryPrefetching"
+import { Suspense, useEffect, useState } from "react"
 import { RefreshControl } from "react-native"
 import {
   fetchQuery,
@@ -41,8 +44,16 @@ export const HomeView: React.FC = () => {
   const savedArtworksCount = meData?.counts?.savedArtworks ?? 0
   useDismissSavedArtwork(savedArtworksCount > 0)
   useEnableProgressiveOnboarding()
+  const prefetchUrl = usePrefetch()
 
   const sections = extractNodes(data?.homeView.sectionsConnection)
+
+  useEffect(() => {
+    prefetchUrl<SearchQuery>("search", searchQueryDefaultVariables)
+    prefetchUrl("my-profile")
+    prefetchUrl("inbox")
+    prefetchUrl("sell")
+  }, [])
 
   const handleRefresh = () => {
     if (isRefreshing) return


### PR DESCRIPTION
This PR resolves [ONYX-1279]

### Description

Prefetch tabs just like how "old" home screen does it: https://github.com/artsy/eigen/blob/f179a02295479892cac6f0f379ae246711c5188d/src/app/Scenes/Home/Home.tsx#L145-L150

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1279]: https://artsyproduct.atlassian.net/browse/ONYX-1279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ