### PR TITLE
fix: Sell flow "Save and Exit" button error handling

### DIFF
--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission.ts
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission.ts
@@ -25,9 +25,10 @@ export const createOrUpdateSubmission = async (
   externalID: string | null
 ) => {
   const isRarityLimitedEdition = values.attributionClass === limitedEditionValue
-  type NewType = ConsignmentAttributionClass
 
-  const attributionClass = values?.attributionClass?.replace(" ", "_").toUpperCase() as NewType
+  const attributionClass = values?.attributionClass
+    ?.replace(" ", "_")
+    .toUpperCase() as ConsignmentAttributionClass
 
   const submissionValues: SubmissionInput = {
     artistID: values.artistId,


### PR DESCRIPTION
This PR resolves https://artsy.slack.com/archives/C05EQL4R5N0/p1726128004361939

### Description

This fixes the "Condition is not in list" Sell flow "Save & Exit" bug and improves the error handling. Instead of failing when the artwork cannot be updated, we now catch the error and show a warning toast. This should be okay because creating/updating the submission does not fail in this case. Only updating the related My Collection artwork.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: Sell flow Save and Exit button error handling when submitting a MyC artwork - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
