### PR TITLE
feat(onyx-1277): enable context menu for new works for you rail on new home screen

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -66,6 +66,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
           />
         </Flex>
         <LargeArtworkRail
+          contextModule={data.contextModule as ContextModule}
           artworks={artworks}
           onPress={handleOnArtworkPress}
           showSaveIcon


### PR DESCRIPTION
This PR resolves [ONYX-1277]

### Description

One more PR to achieve [parity](https://www.notion.so/artsy/Home-View-Features-Migration-Milestone-2-fa79161107e948078d2f32b4b9a282aa) between new and old home screens. [This condition](https://github.com/artsy/eigen/blob/main/src/app/Components/ContextMenu/ContextMenuArtwork.tsx#L60) (`contextModule == "newWorksForYouRail"`) enables the feature only for newWorksForYouRail. `contextModule` was missing before.

During refinement session we've discussed opportunity to enable context menu for all home screen rails, I've created a ticket to not forget to do it: [jira](https://artsyproduct.atlassian.net/browse/ONYX-1295).

<img src="https://github.com/user-attachments/assets/c198bc51-23c5-40cc-a97b-329c0c419bd3" width="300px" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1277]: https://artsyproduct.atlassian.net/browse/ONYX-1277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ