### PR TITLE
chore: remove last named inline spread from top-level home view query

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -95,7 +95,7 @@ export const HomeView: React.FC = () => {
         <FlashList
           ref={flashlistRef}
           data={sections}
-          keyExtractor={(item) => `${item.internalID || ""}`}
+          keyExtractor={(item) => item.internalID}
           renderItem={({ item }) => {
             return <Section section={item} />
           }}
@@ -151,13 +151,12 @@ const sectionsFragment = graphql`
         edges {
           node {
             __typename
-            ... on HomeViewSectionGeneric {
-              internalID
-              component {
-                type
-              }
-              ...HomeViewSectionGeneric_section
+            internalID
+            component {
+              title
+              type
             }
+            ...HomeViewSectionGeneric_section
           }
         }
       }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionGeneric.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionGeneric.tsx
@@ -30,8 +30,11 @@ export const HomeViewSectionGeneric: React.FC<{ section: any }> = (props) => {
 
 const genericSectionFragment = graphql`
   fragment HomeViewSectionGeneric_section on HomeViewSectionGeneric {
+    __typename
+    internalID
     component {
       title
+      type
     }
   }
 `

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -1,5 +1,5 @@
 import { Flex, Text } from "@artsy/palette-mobile"
-import { HomeViewSectionsConnection_viewer$data } from "__generated__/HomeViewSectionsConnection_viewer.graphql"
+import { HomeViewSectionGeneric_section$data } from "__generated__/HomeViewSectionGeneric_section.graphql"
 import { HomeViewSectionActivityQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionActivity"
 import { HomeViewSectionArticlesQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionArticles"
 import { HomeViewSectionArticlesCardsQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards"
@@ -15,15 +15,11 @@ import { HomeViewSectionMarketingCollectionsQueryRenderer } from "app/Scenes/Hom
 import { HomeViewSectionSalesQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionSales"
 import { HomeViewSectionShowsQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionShows"
 import { HomeViewSectionViewingRoomsQueryRenderer } from "app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms"
-import { ExtractNodeType } from "app/utils/relayHelpers"
+import { CleanRelayFragment } from "app/utils/relayHelpers"
 
-type SectionsConnection = NonNullable<
-  HomeViewSectionsConnection_viewer$data["homeView"]["sectionsConnection"]
->
-
-type SectionT = ExtractNodeType<SectionsConnection>
-
-export const Section: React.FC<{ section: SectionT }> = (props) => {
+export const Section: React.FC<{
+  section: CleanRelayFragment<HomeViewSectionGeneric_section$data>
+}> = (props) => {
   const { section } = props
 
   if (!section.internalID) {

--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreen.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreen.tsx
@@ -33,16 +33,13 @@ const HOME_SECTION_SCREEN_QUERY = graphql`
     homeView {
       section(id: $id) {
         __typename
-        ... on HomeViewSectionGeneric {
-          component {
-            title
-          }
+        internalID
+
+        component {
+          title
         }
+
         ... on HomeViewSectionArtworks {
-          internalID
-          component {
-            title
-          }
           ...HomeViewSectionScreenArtworks_section
         }
       }


### PR DESCRIPTION
### Description

Since switching sectionsConnection to be backed by an interface rather than a union, we can query for those standard attributes without the named inline spread.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- chore: remove last named inline spread from top-level home view query

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
