### PR TITLE
feat(onyx-1282): error boundary around new home view screen

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -135,7 +135,7 @@ const HomeViewScreenPlaceholder: React.FC = () => {
 export const HomeViewScreen: React.FC = () => {
   return (
     <RetryErrorBoundary>
-      <Suspense fallback={HomeViewScreenPlaceholder}>
+      <Suspense fallback={<HomeViewScreenPlaceholder />}>
         <HomeView />
       </Suspense>
     </RetryErrorBoundary>

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -7,17 +7,18 @@ import { HomeView_me$key } from "__generated__/HomeView_me.graphql"
 import { SearchQuery } from "__generated__/SearchQuery.graphql"
 import { useDismissSavedArtwork } from "app/Components/ProgressiveOnboarding/useDismissSavedArtwork"
 import { useEnableProgressiveOnboarding } from "app/Components/ProgressiveOnboarding/useEnableProgressiveOnboarding"
+import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
 import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { searchQueryDefaultVariables } from "app/Scenes/Search/Search"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { extractNodes } from "app/utils/extractNodes"
-import { withSuspense } from "app/utils/hooks/withSuspense"
+import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import { requestPushNotificationsPermission } from "app/utils/requestPushNotificationsPermission"
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
-import { useEffect, useState } from "react"
+import { Suspense, useEffect, useState } from "react"
 import { RefreshControl } from "react-native"
 import {
   fetchQuery,
@@ -119,19 +120,27 @@ export const HomeView: React.FC = () => {
 
 const HomeViewScreenPlaceholder: React.FC = () => {
   return (
-    <Screen safeArea={false}>
-      <Screen.Body fullwidth>
-        <Flex testID="new-home-view-skeleton">
-          <HomeHeader />
-        </Flex>
-      </Screen.Body>
-    </Screen>
+    <ProvidePlaceholderContext>
+      <Screen safeArea={false}>
+        <Screen.Body fullwidth>
+          <Flex testID="new-home-view-skeleton">
+            <HomeHeader />
+          </Flex>
+        </Screen.Body>
+      </Screen>
+    </ProvidePlaceholderContext>
   )
 }
 
-export const HomeViewScreen: React.FC = withSuspense(() => {
-  return <HomeView />
-}, HomeViewScreenPlaceholder)
+export const HomeViewScreen: React.FC = () => {
+  return (
+    <RetryErrorBoundary>
+      <Suspense fallback={HomeViewScreenPlaceholder}>
+        <HomeView />
+      </Suspense>
+    </RetryErrorBoundary>
+  )
+}
 
 const meFragment = graphql`
   fragment HomeView_me on Me {


### PR DESCRIPTION
This PR resolves [ONYX-1282]

### Description

Errors in the new home screen offer a retry option. Before errors were bubbling up beyond the home screen, bottom tabs were not available.

Instead of using `withSuspense` I use `Suspense` component, because `ErrorBoundary` should be located higher than `Suspense` in the component tree. I've noticed that at some point we [had](https://github.com/artsy/eigen/blob/f6cf59181d3253e9d9bdfe742e5eb0f15a96ee13/src/app/utils/hooks/withSuspense.tsx#L20) `ErrorBoundary` integrated in `withSuspense`, but for some reason it is not there anymore.

<img src="https://github.com/user-attachments/assets/14456f2b-2efe-4d7a-ad8a-94a58d99569b" width="300px" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1282]: https://artsyproduct.atlassian.net/browse/ONYX-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ