### PR TITLE
chore: Simplify Previously Sold on Artsy artworks rail

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -3,7 +3,6 @@ import {
   ArtworkRail_artworks$data,
   ArtworkRail_artworks$key,
 } from "__generated__/ArtworkRail_artworks.graphql"
-import { SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$data } from "__generated__/SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection.graphql"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
   ArtworkRailCard,
@@ -28,26 +27,23 @@ import { graphql, useFragment } from "react-relay"
 const MAX_NUMBER_OF_ARTWORKS = 30
 export const ARTWORK_RAIL_IMAGE_WIDTH = 295
 
-interface CommonArtworkRailProps {
+export interface ArtworkRailProps extends ArtworkActionTrackingProps {
+  artworks: ArtworkRail_artworks$key
+  onPress?: (artwork: ArtworkRail_artworks$data[0], index: number) => void
   dark?: boolean
   hideArtistName?: boolean
+  hideCuratorsPickSignal?: boolean
+  hideIncreasedInterestSignal?: boolean
   showPartnerName?: boolean
   ListFooterComponent?: ReactElement | null
   ListHeaderComponent?: ReactElement | null
   listRef?: React.RefObject<FlatList<any>>
   onEndReached?: () => void
   onEndReachedThreshold?: number
-  showSaveIcon?: boolean
   onMorePress?: () => void
-  viewabilityConfig?: ViewabilityConfig | undefined
   onViewableItemsChanged?: (info: { viewableItems: any[]; changed: any[] }) => void
-  hideIncreasedInterestSignal?: boolean
-  hideCuratorsPickSignal?: boolean
-}
-
-export interface ArtworkRailProps extends CommonArtworkRailProps, ArtworkActionTrackingProps {
-  artworks: ArtworkRail_artworks$key
-  onPress?: (artwork: ArtworkRail_artworks$data[0], index: number) => void
+  showSaveIcon?: boolean
+  viewabilityConfig?: ViewabilityConfig | undefined
 }
 
 export const ArtworkRail: React.FC<ArtworkRailProps> = ({
@@ -55,8 +51,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
   onPress,
   onEndReached,
   onEndReachedThreshold,
-  ListHeaderComponent = SpacerComponent,
-  ListFooterComponent = SpacerComponent,
+  ListHeaderComponent = <Spacer x={2} />,
+  ListFooterComponent = <Spacer x={2} />,
   hideArtistName = false,
   showPartnerName = true,
   dark = false,
@@ -137,67 +133,6 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
   )
 }
 
-type RecentlySoldArtwork = NonNullable<
-  NonNullable<SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$data["edges"]>[0]
->["node"]
-
-export interface RecentlySoldArtworksRailProps extends CommonArtworkRailProps {
-  recentlySoldArtworks: RecentlySoldArtwork[]
-  onPress?: (recentlySoldArtwork: RecentlySoldArtwork, index: number) => void
-}
-
-export const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
-  listRef,
-  onPress,
-  onEndReached,
-  onEndReachedThreshold,
-  ListHeaderComponent = SpacerComponent,
-  ListFooterComponent = SpacerComponent,
-  hideArtistName = false,
-  recentlySoldArtworks,
-  showPartnerName = true,
-}) => {
-  return (
-    <PrefetchFlatList
-      onEndReached={onEndReached}
-      onEndReachedThreshold={onEndReachedThreshold}
-      prefetchUrlExtractor={(item) => item?.artwork?.href || undefined}
-      listRef={listRef}
-      horizontal
-      ListHeaderComponent={ListHeaderComponent}
-      ListFooterComponent={ListFooterComponent}
-      ItemSeparatorComponent={() => <Spacer x="15px" />}
-      showsHorizontalScrollIndicator={false}
-      // We need to set the maximum number of artworks to not cause layout shifts
-      data={recentlySoldArtworks.slice(0, MAX_NUMBER_OF_ARTWORKS)}
-      initialNumToRender={MAX_NUMBER_OF_ARTWORKS}
-      contentContainerStyle={{ alignItems: "flex-end" }}
-      renderItem={({ item, index }) => {
-        if (!item?.artwork) {
-          return null
-        }
-
-        return (
-          <ArtworkRailCard
-            artwork={item.artwork}
-            onPress={() => {
-              onPress?.(item, index)
-            }}
-            priceRealizedDisplay={item?.priceRealized?.display || ""}
-            lowEstimateDisplay={item?.lowEstimate?.display || ""}
-            highEstimateDisplay={item?.highEstimate?.display || ""}
-            performanceDisplay={item?.performance?.mid ?? undefined}
-            showPartnerName={showPartnerName}
-            isRecentlySoldArtwork
-            hideArtistName={hideArtistName}
-          />
-        )
-      }}
-      keyExtractor={(item, index) => String(item?.artwork?.slug || index)}
-    />
-  )
-}
-
 const artworksFragment = graphql`
   fragment ArtworkRail_artworks on Artwork @relay(plural: true) {
     ...ArtworkRailCard_artwork @arguments(width: 590)
@@ -213,8 +148,6 @@ const artworksFragment = graphql`
     }
   }
 `
-
-const SpacerComponent = () => <Spacer x={2} />
 
 export const ArtworkRailPlaceholder: React.FC = () => (
   <Join separator={<Spacer x="15px" />}>

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -23,15 +23,7 @@ interface ContextAction extends Omit<ContextMenuAction, "subtitle"> {
 
 export type ArtworkDisplayProps = Pick<
   ArtworkRailCardProps,
-  | "dark"
-  | "hideArtistName"
-  | "showPartnerName"
-  | "isRecentlySoldArtwork"
-  | "lotLabel"
-  | "lowEstimateDisplay"
-  | "highEstimateDisplay"
-  | "performanceDisplay"
-  | "priceRealizedDisplay"
+  "dark" | "hideArtistName" | "showPartnerName" | "lotLabel" | "SalePriceComponent"
 >
 
 interface ContextMenuArtworkProps {

--- a/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
@@ -139,7 +139,6 @@ export interface ContextMenuArtworkPreviewCardImageProps {
   image: ArtworkRailCard_artwork$data["image"]
   urgencyTag?: string | null
   containerWidth?: number
-  displayRealizedPrice?: boolean
   /** imageHeightExtra is an optional padding value you might want to add to image height
    * When using large width like with RecentlySold, image appears cropped
    * TODO: - Investigate why
@@ -149,9 +148,8 @@ export interface ContextMenuArtworkPreviewCardImageProps {
 
 export const ContextMenuArtworkPreviewCardImage: React.FC<
   ContextMenuArtworkPreviewCardImageProps
-> = ({ image, urgencyTag = null, containerWidth, displayRealizedPrice, imageHeightExtra = 0 }) => {
+> = ({ image, urgencyTag = null, containerWidth, imageHeightExtra = 0 }) => {
   const color = useColor()
-  const FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH = useFullWidth()
 
   const { width, height, src } = image?.resized || {}
 
@@ -172,9 +170,7 @@ export const ContextMenuArtworkPreviewCardImage: React.FC<
       height: height ?? 0,
     },
     {
-      width: displayRealizedPrice
-        ? FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH
-        : ARTWORK_LARGE_RAIL_CARD_IMAGE_WIDTH,
+      width: ARTWORK_LARGE_RAIL_CARD_IMAGE_WIDTH,
       height: ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
     }
   )

--- a/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
@@ -1,7 +1,6 @@
 import { Flex, Text, useColor, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { ArtworkGridItem_artwork$data } from "__generated__/ArtworkGridItem_artwork.graphql"
 import { ArtworkRailCard_artwork$data } from "__generated__/ArtworkRailCard_artwork.graphql"
-import { RecentlySoldCardSection } from "app/Components/ArtworkRail/ArtworkRailCard"
 import { ArtworkDisplayProps } from "app/Components/ContextMenu/ContextMenuArtwork"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { saleMessageOrBidInfo as defaultSaleMessageOrBidInfo } from "app/utils/getSaleMessgeOrBidInfo"
@@ -34,15 +33,11 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
   artworkDisplayProps,
 }) => {
   const {
+    SalePriceComponent,
     dark = false,
     hideArtistName = false,
     showPartnerName = true,
-    isRecentlySoldArtwork = false,
     lotLabel,
-    lowEstimateDisplay,
-    highEstimateDisplay,
-    performanceDisplay,
-    priceRealizedDisplay,
   } = artworkDisplayProps ?? {}
 
   const FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH = useFullWidth()
@@ -63,11 +58,10 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
   const backgroundColor = dark ? "black100" : "white100"
 
   const getTextHeight = () => {
-    return ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + (isRecentlySoldArtwork ? 50 : 0)
+    return ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT
   }
 
   const containerWidth = FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH
-  const displayForRecentlySoldArtwork = !!isRecentlySoldArtwork
 
   return (
     <Flex backgroundColor={backgroundColor} m={1}>
@@ -75,11 +69,6 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
         containerWidth={containerWidth}
         image={image}
         urgencyTag={urgencyTag}
-        imageHeightExtra={
-          displayForRecentlySoldArtwork
-            ? getTextHeight() - ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT
-            : undefined
-        }
       />
       <Flex
         my={1}
@@ -100,31 +89,21 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
             </Text>
           )}
           {!hideArtistName && !!artistNames && (
-            <Text
-              color={primaryTextColor}
-              numberOfLines={1}
-              lineHeight={displayForRecentlySoldArtwork ? undefined : "20px"}
-              variant={displayForRecentlySoldArtwork ? "md" : "xs"}
-            >
+            <Text color={primaryTextColor} numberOfLines={1} lineHeight="20px" variant="xs">
               {artistNames}
             </Text>
           )}
           {!!title && (
             <Text
-              lineHeight={displayForRecentlySoldArtwork ? undefined : "20px"}
-              color={displayForRecentlySoldArtwork ? undefined : secondaryTextColor}
+              lineHeight="20px"
+              color={secondaryTextColor}
               numberOfLines={1}
               variant="xs"
-              fontStyle={displayForRecentlySoldArtwork ? undefined : "italic"}
+              fontStyle="italic"
             >
               {title}
               {!!date && (
-                <Text
-                  lineHeight={displayForRecentlySoldArtwork ? undefined : "20px"}
-                  color={displayForRecentlySoldArtwork ? undefined : secondaryTextColor}
-                  numberOfLines={1}
-                  variant="xs"
-                >
+                <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1} variant="xs">
                   {title && date ? ", " : ""}
                   {date}
                 </Text>
@@ -137,27 +116,19 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
               {partner?.name}
             </Text>
           )}
-          {!!isRecentlySoldArtwork && (
-            <RecentlySoldCardSection
-              priceRealizedDisplay={priceRealizedDisplay}
-              lowEstimateDisplay={lowEstimateDisplay}
-              highEstimateDisplay={highEstimateDisplay}
-              performanceDisplay={performanceDisplay}
-              secondaryTextColor={secondaryTextColor}
-            />
-          )}
-
-          {!!saleMessage && !isRecentlySoldArtwork && (
-            <Text
-              lineHeight="20px"
-              variant="xs"
-              color={primaryTextColor}
-              numberOfLines={1}
-              fontWeight={500}
-            >
-              {saleMessage}
-            </Text>
-          )}
+          {SalePriceComponent
+            ? SalePriceComponent
+            : !!saleMessage && (
+                <Text
+                  lineHeight="20px"
+                  variant="xs"
+                  color={primaryTextColor}
+                  numberOfLines={1}
+                  fontWeight={500}
+                >
+                  {saleMessage}
+                </Text>
+              )}
         </Flex>
       </Flex>
     </Flex>
@@ -168,7 +139,7 @@ export interface ContextMenuArtworkPreviewCardImageProps {
   image: ArtworkRailCard_artwork$data["image"]
   urgencyTag?: string | null
   containerWidth?: number
-  isRecentlySoldArtwork?: boolean
+  displayRealizedPrice?: boolean
   /** imageHeightExtra is an optional padding value you might want to add to image height
    * When using large width like with RecentlySold, image appears cropped
    * TODO: - Investigate why
@@ -178,7 +149,7 @@ export interface ContextMenuArtworkPreviewCardImageProps {
 
 export const ContextMenuArtworkPreviewCardImage: React.FC<
   ContextMenuArtworkPreviewCardImageProps
-> = ({ image, urgencyTag = null, containerWidth, isRecentlySoldArtwork, imageHeightExtra = 0 }) => {
+> = ({ image, urgencyTag = null, containerWidth, displayRealizedPrice, imageHeightExtra = 0 }) => {
   const color = useColor()
   const FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH = useFullWidth()
 
@@ -201,7 +172,7 @@ export const ContextMenuArtworkPreviewCardImage: React.FC<
       height: height ?? 0,
     },
     {
-      width: isRecentlySoldArtwork
+      width: displayRealizedPrice
         ? FULL_WIDTH_RAIL_CARD_IMAGE_WIDTH
         : ARTWORK_LARGE_RAIL_CARD_IMAGE_WIDTH,
       height: ARTWORK_RAIL_CARD_IMAGE_HEIGHT,

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -88,11 +88,6 @@ export const SellWithArtsyHome: React.FC = () => {
   }
 
   const data = compact([
-    // TODO: Remove this
-    !!recentlySoldArtworks && {
-      key: "recently-sold-artworks",
-      content: <SellWithArtsyRecentlySold recentlySoldArtworks={recentlySoldArtworks} />,
-    },
     {
       key: "header",
       content: <Header submission={submission || null} />,

--- a/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
+++ b/src/app/Scenes/SellWithArtsy/SellWithArtsyHome.tsx
@@ -88,6 +88,11 @@ export const SellWithArtsyHome: React.FC = () => {
   }
 
   const data = compact([
+    // TODO: Remove this
+    !!recentlySoldArtworks && {
+      key: "recently-sold-artworks",
+      content: <SellWithArtsyRecentlySold recentlySoldArtworks={recentlySoldArtworks} />,
+    },
     {
       key: "header",
       content: <Header submission={submission || null} />,


### PR DESCRIPTION
This PR resolves [ONYX-1290] <!-- eg [PROJECT-XXXX] -->

### Description

This PR simplifies the code of the "Previously Sold on Artsy" rail on the `Sell` screen, which is a preparation for the Artwork Rail redesign. 

While these changes will lead to some design modifications, I believe this is acceptable since we will redesign and unify all artwork rails across the app in the upcoming weeks.

| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Pro Max (17 2) - 2024-09-18 at 11 02 49](https://github.com/user-attachments/assets/7787d160-6abd-4ea3-902c-7287885ba13a) | ![Simulator Screenshot - iPhone 15 Pro Max (17 2) - 2024-09-18 at 11 02 18](https://github.com/user-attachments/assets/1d56f968-547d-42c8-94d9-ec5541a9280e)|

### PR Checklist




- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Simplify "Previously Sold on Artsy" artworks rail code - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1290]: https://artsyproduct.atlassian.net/browse/ONYX-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ