### PR TITLE
fix(EMI-2053): Hide register by signal on auction screen

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tests.tsx
@@ -37,6 +37,27 @@ describe("ArtworkAuctionTimer", () => {
     expect(screen.getByText(`Register by ${registerDate.toFormat("MMM d")}`)).toBeOnTheScreen()
   })
 
+  it('hides "Register by" when hideRegisterBySignal is true', () => {
+    const registerDate = DateTime.fromMillis(Date.now()).plus({ days: 1 })
+
+    renderWithRelay(
+      {
+        Artwork: () => ({
+          collectorSignals: {
+            auction: {
+              registrationEndsAt: registerDate.toISO(),
+            },
+          },
+        }),
+      },
+      { hideRegisterBySignal: true }
+    )
+
+    expect(
+      screen.queryByText(`Register by ${registerDate.toFormat("MMM d")}`)
+    ).not.toBeOnTheScreen()
+  })
+
   it("shows the time left to bid", () => {
     renderWithRelay({
       Artwork: () => ({

--- a/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
@@ -7,11 +7,13 @@ import { graphql, useFragment } from "react-relay"
 
 interface ArtworkAuctionTimerProps {
   collectorSignals: ArtworkAuctionTimer_collectorSignals$key
+  hideRegisterBySignal?: boolean
   inRailCard?: boolean
 }
 
 export const ArtworkAuctionTimer: React.FC<ArtworkAuctionTimerProps> = ({
   collectorSignals,
+  hideRegisterBySignal,
   inRailCard,
 }) => {
   const lineHeight = inRailCard ? "20px" : "18px"
@@ -25,6 +27,10 @@ export const ArtworkAuctionTimer: React.FC<ArtworkAuctionTimerProps> = ({
 
   if (registrationEndsAt && DateTime.fromISO(registrationEndsAt).diffNow().as("seconds") > 0) {
     const formattedRegistrationEndsAt = DateTime.fromISO(registrationEndsAt).toFormat("MMM d")
+
+    if (hideRegisterBySignal) {
+      return null
+    }
 
     return (
       <Text lineHeight={lineHeight} variant="xs" numberOfLines={1} color="black100">

--- a/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
@@ -25,12 +25,12 @@ export const ArtworkAuctionTimer: React.FC<ArtworkAuctionTimerProps> = ({
 
   const { lotClosesAt, onlineBiddingExtended, registrationEndsAt } = data.auction
 
-  if (registrationEndsAt && DateTime.fromISO(registrationEndsAt).diffNow().as("seconds") > 0) {
+  if (
+    registrationEndsAt &&
+    DateTime.fromISO(registrationEndsAt).diffNow().as("seconds") > 0 &&
+    !hideRegisterBySignal
+  ) {
     const formattedRegistrationEndsAt = DateTime.fromISO(registrationEndsAt).toFormat("MMM d")
-
-    if (hideRegisterBySignal) {
-      return null
-    }
 
     return (
       <Text lineHeight={lineHeight} variant="xs" numberOfLines={1} color="black100">

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -58,8 +58,11 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   disableArtworksListPrompt?: boolean
   /** Hide sale info */
   height?: number
+  hideCuratorsPickSignal?: boolean
+  hideIncreasedInterestSignal?: boolean
   /** Hide partner name */
   hidePartner?: boolean
+  hideRegisterBySignal?: boolean
   hideSaleInfo?: boolean
   hideSaveIcon?: boolean
   /** Hide urgency tags (3 Days left, 1 hour left) */
@@ -81,8 +84,6 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   /** allows for artwork to be added to recent searches */
   updateRecentSearchesOnTap?: boolean
   urgencyTagTextStyle?: TextProps
-  hideIncreasedInterestSignal?: boolean
-  hideCuratorsPickSignal?: boolean
 }
 
 export const Artwork: React.FC<ArtworkProps> = ({
@@ -97,7 +98,10 @@ export const Artwork: React.FC<ArtworkProps> = ({
   contextScreenQuery,
   disableArtworksListPrompt = false,
   height,
+  hideCuratorsPickSignal = false,
+  hideIncreasedInterestSignal = false,
   hidePartner = false,
+  hideRegisterBySignal = false,
   hideSaleInfo = false,
   hideSaveIcon = false,
   hideUrgencyTags = false,
@@ -113,8 +117,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
   trackTap,
   updateRecentSearchesOnTap = false,
   urgencyTagTextStyle,
-  hideIncreasedInterestSignal = false,
-  hideCuratorsPickSignal = false,
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
@@ -472,7 +474,10 @@ export const Artwork: React.FC<ArtworkProps> = ({
                 )}
 
                 {!!displayAuctionSignal && !!collectorSignals && (
-                  <ArtworkAuctionTimer collectorSignals={collectorSignals} />
+                  <ArtworkAuctionTimer
+                    collectorSignals={collectorSignals}
+                    hideRegisterBySignal={hideRegisterBySignal}
+                  />
                 )}
               </Flex>
               {!hideSaveIcon && (

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -122,6 +122,8 @@ export interface Props extends ArtworkActionTrackingProps {
   hideIncreasedInterest?: boolean
 
   hideCuratorsPick?: boolean
+
+  hideRegisterBySignal?: boolean
 }
 
 interface PrivateProps {
@@ -182,7 +184,10 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   FooterComponent,
   hasMore,
   HeaderComponent,
+  hideCuratorsPick,
+  hideIncreasedInterest,
   hidePartner = false,
+  hideRegisterBySignal,
   hideSaveIcon = false,
   hideUrgencyTags,
   isLoading,
@@ -204,8 +209,6 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   updateRecentSearchesOnTap = false,
   useParentAwareScrollView = Platform.OS === "android",
   width,
-  hideIncreasedInterest,
-  hideCuratorsPick,
 }) => {
   const artworks = extractNodes(connection)
 
@@ -359,6 +362,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
             displayToolTip={displayToolTip}
             hideIncreasedInterestSignal={hideIncreasedInterest}
             hideCuratorsPickSignal={hideCuratorsPick}
+            hideRegisterBySignal={hideRegisterBySignal}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/app/Scenes/Sale/Components/SaleLotsList.tsx
+++ b/src/app/Scenes/Sale/Components/SaleLotsList.tsx
@@ -154,7 +154,7 @@ export const SaleLotsList: React.FC<Props> = ({
 
       {viewAsFilter?.paramValue === ViewAsValues.List ? (
         <SaleArtworkListContainer
-          connection={saleArtworksConnection.saleArtworksConnection!}
+          connection={saleArtworksConnection.saleArtworksConnection}
           hasMore={relay.hasMore}
           loadMore={relay.loadMore}
           isLoading={relay.isLoading}
@@ -165,7 +165,7 @@ export const SaleLotsList: React.FC<Props> = ({
       ) : (
         <Flex px={2}>
           <InfiniteScrollArtworksGridContainer
-            connection={saleArtworksConnection.saleArtworksConnection!}
+            connection={saleArtworksConnection.saleArtworksConnection}
             contextScreenOwnerType={OwnerType.sale}
             contextScreenOwnerId={saleID}
             contextScreenOwnerSlug={saleSlug}
@@ -175,6 +175,7 @@ export const SaleLotsList: React.FC<Props> = ({
             showLotLabel
             hidePartner
             hideUrgencyTags
+            hideRegisterBySignal
           />
         </Flex>
       )}


### PR DESCRIPTION
This PR resolves [EMI-2053] <!-- eg [PROJECT-XXXX] -->

### Description
This PR hides the Register By signal on the auction screen
it also fixes an issue with the data where some auctions have `undefined` as a price in rails

### Screenshots
#### Register By signal fix
| | Before | After |
|---|---|---|
| Android | ![image](https://github.com/user-attachments/assets/fe781426-8a7a-4377-989f-e10d214a77a0) | ![image](https://github.com/user-attachments/assets/4c006941-9ceb-4cf3-b822-f8512439ae21) |
| iOS | ![image](https://github.com/user-attachments/assets/8b257463-9d71-4419-b9fc-fd350662ad89) | ![image](https://github.com/user-attachments/assets/962de22e-3c71-4b7a-ae4b-7be54428c2eb) |

### `undefined` issue
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/de3fef3a-3f1f-49c3-a53c-a9e03a4638a1) | ![image](https://github.com/user-attachments/assets/bae8c848-cd9c-4b37-bd28-baff8569afbf) |	



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- hide Register By signal on Auction screen + fix undefined on auction artwork rail cards - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2053]: https://artsyproduct.atlassian.net/browse/EMI-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ