### PR TITLE
fix(EMI-1897): Update Contact Gallery requirement to send messages

### DIFF
--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -89,6 +89,9 @@ describe("inquiry modal", () => {
   it("enables the 'send' button when an inquiry question is selected", async () => {
     renderWithRelay({ Artwork: () => mockArtwork })
 
+    // clearing the input field
+    fireEvent.changeText(screen.getByLabelText("Add message"), "")
+
     expect(screen.getByText("Send")).toBeDisabled()
 
     fireEvent.press(screen.getByText("Question"))

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -109,7 +109,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork: _artwork, m
           leftButtonText="Cancel"
           onLeftButtonPress={handleDismiss}
           rightButtonText="Send"
-          rightButtonDisabled={state.inquiryQuestions.length === 0}
+          rightButtonDisabled={state.inquiryQuestions.length === 0 && message === ""}
           onRightButtonPress={() => sendInquiry(message)}
         >
           Contact Gallery


### PR DESCRIPTION
This PR resolves [EMI-1897] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the requirement for the Contact Gallery modal form to allow users to send messages without the need to have any of the checkboxes selected but it still requires a message to be able to send to a gallery


### Videos
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/fc89ed9d-3763-4d18-adab-e09b2972d2d7" /> | <video src="https://github.com/user-attachments/assets/1549ece5-5687-4398-a385-5febdcc11a12" /> |
| iOS | <video src="https://github.com/user-attachments/assets/7a131e01-b9e0-4ecc-87c0-ef7cd9b163ff" /> | <video src="https://github.com/user-attachments/assets/4b494ef7-e467-49b9-a58b-fb1b619d5252" /> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update Contact Gallery requirement to send with only a message (to not require a checkbox) - mrsltun

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-1897]: https://artsyproduct.atlassian.net/browse/EMI-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ