### PR TITLE
fix: layout shifts for artwork rails

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -3,11 +3,13 @@ import {
   ArtworkRail_artworks$data,
   ArtworkRail_artworks$key,
 } from "__generated__/ArtworkRail_artworks.graphql"
-import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
+import {
+  ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
+  ArtworkRailCard,
+} from "app/Components/ArtworkRail/ArtworkRailCard"
 import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
-import { PrefetchFlatList } from "app/Components/PrefetchFlatList"
-import { HORIZONTAL_FLATLIST_WINDOW_SIZE } from "app/Scenes/HomeView/helpers/constants"
+import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
 import { RandomWidthPlaceholderText, useMemoizedRandom } from "app/utils/placeholders"
 import {
   ArtworkActionTrackingProps,
@@ -62,13 +64,11 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
   const artworks = useFragment(artworksFragment, otherProps.artworks)
 
   return (
-    <PrefetchFlatList
-      onEndReached={onEndReached}
-      onEndReachedThreshold={onEndReachedThreshold}
-      prefetchUrlExtractor={(item) => item?.href || undefined}
-      listRef={listRef}
+    <PrefetchFlashList
+      data={artworks}
+      estimatedItemSize={ARTWORK_RAIL_CARD_MINIMUM_WIDTH}
       horizontal
-      ListHeaderComponent={ListHeaderComponent}
+      keyExtractor={(item) => item.internalID}
       ListFooterComponent={
         <>
           {!!onMorePress && (
@@ -77,11 +77,12 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
           {ListFooterComponent}
         </>
       }
-      showsHorizontalScrollIndicator={false}
-      data={artworks}
-      initialNumToRender={INITIAL_NUM_TO_RENDER}
-      windowSize={HORIZONTAL_FLATLIST_WINDOW_SIZE}
-      contentContainerStyle={{ alignItems: "flex-end" }}
+      ListHeaderComponent={ListHeaderComponent}
+      listRef={listRef}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={onEndReachedThreshold}
+      onViewableItemsChanged={onViewableItemsChanged}
+      prefetchUrlExtractor={(item) => item?.href || undefined}
       renderItem={({ item, index }) => {
         return (
           <Box pr={2}>
@@ -102,9 +103,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
           </Box>
         )
       }}
-      keyExtractor={(item) => item.internalID}
+      showsHorizontalScrollIndicator={false}
       viewabilityConfig={viewabilityConfig}
-      onViewableItemsChanged={onViewableItemsChanged}
     />
   )
 }

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, Join, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
+import { ListRenderItem } from "@shopify/flash-list"
 import {
   ArtworkRail_artworks$data,
   ArtworkRail_artworks$key,
@@ -16,13 +17,15 @@ import {
   extractArtworkActionTrackingProps,
 } from "app/utils/track/ArtworkActions"
 import { times } from "lodash"
-import React, { ReactElement } from "react"
+import React, { ReactElement, useCallback } from "react"
 import { FlatList, ViewabilityConfig } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
 export const INITIAL_NUM_TO_RENDER = isTablet() ? 10 : 5
 export const ARTWORK_RAIL_IMAGE_WIDTH = 295
+
+type Artwork = ArtworkRail_artworks$data[0]
 
 export interface ArtworkRailProps extends ArtworkActionTrackingProps {
   artworks: ArtworkRail_artworks$key
@@ -63,6 +66,29 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
 }) => {
   const artworks = useFragment(artworksFragment, otherProps.artworks)
 
+  const renderItem: ListRenderItem<Artwork> = useCallback(
+    ({ item, index }) => {
+      return (
+        <Box pr={2}>
+          <ArtworkRailCard
+            testID={`artwork-${item.slug}`}
+            artwork={item}
+            showPartnerName={showPartnerName}
+            hideArtistName={hideArtistName}
+            dark={dark}
+            onPress={() => {
+              onPress?.(item, index)
+            }}
+            showSaveIcon={showSaveIcon}
+            hideIncreasedInterestSignal={hideIncreasedInterestSignal}
+            hideCuratorsPickSignal={hideCuratorsPickSignal}
+            {...extractArtworkActionTrackingProps(otherProps)}
+          />
+        </Box>
+      )
+    },
+    [hideArtistName, onPress, showPartnerName]
+  )
   return (
     <PrefetchFlashList
       data={artworks}
@@ -83,26 +109,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
       onEndReachedThreshold={onEndReachedThreshold}
       onViewableItemsChanged={onViewableItemsChanged}
       prefetchUrlExtractor={(item) => item?.href || undefined}
-      renderItem={({ item, index }) => {
-        return (
-          <Box pr={2}>
-            <ArtworkRailCard
-              testID={`artwork-${item.slug}`}
-              artwork={item}
-              showPartnerName={showPartnerName}
-              hideArtistName={hideArtistName}
-              dark={dark}
-              onPress={() => {
-                onPress?.(item, index)
-              }}
-              showSaveIcon={showSaveIcon}
-              hideIncreasedInterestSignal={hideIncreasedInterestSignal}
-              hideCuratorsPickSignal={hideCuratorsPickSignal}
-              {...extractArtworkActionTrackingProps(otherProps)}
-            />
-          </Box>
-        )
-      }}
+      renderItem={renderItem}
       showsHorizontalScrollIndicator={false}
       viewabilityConfig={viewabilityConfig}
     />

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -6,17 +6,21 @@ import {
   ArtworkRailCardCommonProps,
   ArtworkRailCardMeta,
 } from "app/Components/ArtworkRail/ArtworkRailCardMeta"
-import { LegacyArtworkRailCardImage } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
+import {
+  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  LegacyArtworkRailCardImage,
+} from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { ContextMenuArtwork } from "app/Components/ContextMenu/ContextMenuArtwork"
 import { Disappearable, DissapearableArtwork } from "app/Components/Disappearable"
 import { AnalyticsContextProvider } from "app/system/analytics/AnalyticsContext"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ArtworkActionTrackingProps } from "app/utils/track/ArtworkActions"
 import { useState } from "react"
-import { GestureResponderEvent, TouchableHighlight } from "react-native"
+import { GestureResponderEvent, PixelRatio, TouchableHighlight } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
-export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = 90
+export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = PixelRatio.getFontScale() * 90
+export const ARTWORK_RAIL_CARD_MINIMUM_WIDTH = 140
 
 export interface ArtworkRailCardProps
   extends ArtworkActionTrackingProps,
@@ -86,7 +90,10 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
             onPress={onPress}
             testID={testID}
           >
-            <Flex backgroundColor={backgroundColor}>
+            <Flex
+              height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT + ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT}
+              justifyContent="flex-end"
+            >
               {enableArtworkRailRedesignImageAspectRatio ? (
                 <ArtworkRailCardImage artwork={artwork} />
               ) : (

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -13,7 +13,6 @@ import {
   ArtworkActionTrackingProps,
   tracks as artworkActionTracks,
 } from "app/utils/track/ArtworkActions"
-import { PixelRatio } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -61,8 +60,6 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
   showSaveIcon = false,
 }) => {
   const { trackEvent } = useTracking()
-  const fontScale = PixelRatio.getFontScale()
-
   const enablePartnerOfferSignals = useFeatureFlag("AREnablePartnerOfferSignals")
   const enableAuctionImprovementsSignals = useFeatureFlag("AREnableAuctionImprovementsSignals")
   const enableCuratorsPicksAndInterestSignals = useFeatureFlag(
@@ -139,7 +136,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
     <Flex
       my={1}
       style={{
-        height: fontScale * ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT,
+        height: ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT,
         ...metaContainerStyles,
       }}
       backgroundColor={backgroundColor}

--- a/src/app/Components/PrefetchFlashList.tsx
+++ b/src/app/Components/PrefetchFlashList.tsx
@@ -1,0 +1,74 @@
+import { FlashList, FlashListProps, ViewToken } from "@shopify/flash-list"
+import { usePrefetch } from "app/utils/queryPrefetching"
+import { Ref, useCallback, useReducer, useRef } from "react"
+
+const DEFAULT_VIEWABILITY_CONFIG = {
+  waitForInteraction: true,
+  itemVisiblePercentThreshold: 0,
+}
+
+export type PrefetchFlashListProps<ItemType> = {
+  prefetchUrlExtractor?: (item?: ItemType) => string | undefined | null
+  prefetchVariablesExtractor?: (item?: ItemType) => object | undefined
+  listRef?: Ref<FlashList<ItemType | any> | any>
+} & FlashListProps<ItemType>
+
+/**
+ * Wraps `FlashList` and prefetches items when they are about to be rendered if `prefetchUrlExtractor` is provided.
+ * An item will be prefetched as soon as the item is visible to the user and the user has interacted with the FlashList.
+ * @param prefetchUrlExtractor - A function that extracts the prefetch URL from an item.
+ * @param prefetchVariablesExtractor - A function that extracts the variables to pass to the prefetch query.
+ */
+export function PrefetchFlashList<ItemType>({
+  onViewableItemsChanged,
+  viewabilityConfig,
+  prefetchUrlExtractor,
+  prefetchVariablesExtractor,
+  listRef,
+  ...restProps
+}: PrefetchFlashListProps<ItemType>) {
+  const prefetchUrl = usePrefetch()
+
+  const [viewedUrls, addViewedUrl] = useReducer(
+    (state: { [key: string]: boolean }, url: string) => {
+      state[url] = true
+      return state
+    },
+    {}
+  )
+
+  const viewabilityConfigRef = useRef(viewabilityConfig || DEFAULT_VIEWABILITY_CONFIG)
+
+  const handleOnViewableItemsChanged = useCallback(
+    ({ changed, viewableItems }: { viewableItems: ViewToken[]; changed: ViewToken[] }) => {
+      onViewableItemsChanged?.({ changed, viewableItems })
+
+      if (!prefetchUrlExtractor) {
+        return
+      }
+
+      // Prefetch all changed items that have not yet been prefetched
+      changed.forEach((item) => {
+        const url = prefetchUrlExtractor?.(item.item)
+        const variables = prefetchVariablesExtractor?.(item.item)
+
+        if (!url || viewedUrls[url]) {
+          return
+        }
+
+        addViewedUrl(url)
+        prefetchUrl(url, variables)
+      })
+    },
+    []
+  )
+
+  return (
+    <FlashList<ItemType>
+      {...restProps}
+      onViewableItemsChanged={handleOnViewableItemsChanged}
+      viewabilityConfig={viewabilityConfigRef.current}
+      ref={listRef}
+    />
+  )
+}

--- a/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
@@ -5,8 +5,11 @@ import {
   SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$key,
 } from "__generated__/SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection.graphql"
 import { ArtworkRailProps } from "app/Components/ArtworkRail/ArtworkRail"
-import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
-import { PrefetchFlatList } from "app/Components/PrefetchFlatList"
+import {
+  ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
+  ArtworkRailCard,
+} from "app/Components/ArtworkRail/ArtworkRailCard"
+import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
@@ -87,20 +90,19 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
   showPartnerName = true,
 }) => {
   return (
-    <PrefetchFlatList
+    <PrefetchFlashList
+      // We need to set the maximum number of artworks to not cause layout shifts
+      data={recentlySoldArtworks.slice(0, MAX_NUMBER_OF_ARTWORKS)}
+      estimatedItemSize={ARTWORK_RAIL_CARD_MINIMUM_WIDTH}
+      horizontal
+      keyExtractor={(item, index) => String(item?.artwork?.slug || index)}
+      ItemSeparatorComponent={() => <Spacer x="15px" />}
+      ListFooterComponent={ListFooterComponent}
+      ListHeaderComponent={ListHeaderComponent}
+      listRef={listRef}
       onEndReached={onEndReached}
       onEndReachedThreshold={onEndReachedThreshold}
       prefetchUrlExtractor={(item) => item?.artwork?.href || undefined}
-      listRef={listRef}
-      horizontal
-      ListHeaderComponent={ListHeaderComponent}
-      ListFooterComponent={ListFooterComponent}
-      ItemSeparatorComponent={() => <Spacer x="15px" />}
-      showsHorizontalScrollIndicator={false}
-      // We need to set the maximum number of artworks to not cause layout shifts
-      data={recentlySoldArtworks.slice(0, MAX_NUMBER_OF_ARTWORKS)}
-      initialNumToRender={MAX_NUMBER_OF_ARTWORKS}
-      contentContainerStyle={{ alignItems: "flex-end" }}
       renderItem={({ item, index }) => {
         if (!item?.artwork) {
           return null
@@ -112,6 +114,7 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
             onPress={() => {
               onPress?.(item, index)
             }}
+            metaContainerStyles={{ height: 100 }}
             showPartnerName={showPartnerName}
             SalePriceComponent={
               <RecentlySoldCardSection
@@ -125,7 +128,7 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
           />
         )
       }}
-      keyExtractor={(item, index) => String(item?.artwork?.slug || index)}
+      showsHorizontalScrollIndicator={false}
     />
   )
 }

--- a/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
@@ -1,5 +1,6 @@
 import { ContextModule, OwnerType, tappedEntityGroup, TappedEntityGroupArgs } from "@artsy/cohesion"
 import { Flex, Spacer, Text } from "@artsy/palette-mobile"
+import { ListRenderItem } from "@shopify/flash-list"
 import {
   SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$data,
   SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$key,
@@ -14,6 +15,7 @@ import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { compact } from "lodash"
+import { useCallback } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -89,6 +91,34 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
   recentlySoldArtworks,
   showPartnerName = true,
 }) => {
+  const renderItem: ListRenderItem<RecentlySoldArtwork> = useCallback(
+    ({ item, index }) => {
+      if (!item?.artwork) {
+        return null
+      }
+
+      return (
+        <ArtworkRailCard
+          artwork={item.artwork}
+          onPress={() => {
+            onPress?.(item, index)
+          }}
+          metaContainerStyles={{ height: 100 }}
+          showPartnerName={showPartnerName}
+          SalePriceComponent={
+            <RecentlySoldCardSection
+              priceRealizedDisplay={item?.priceRealized?.display || ""}
+              lowEstimateDisplay={item?.lowEstimate?.display || ""}
+              highEstimateDisplay={item?.highEstimate?.display || ""}
+              performanceDisplay={item?.performance?.mid ?? undefined}
+            />
+          }
+          hideArtistName={hideArtistName}
+        />
+      )
+    },
+    [hideArtistName, onPress, showPartnerName]
+  )
   return (
     <PrefetchFlashList
       // We need to set the maximum number of artworks to not cause layout shifts
@@ -103,31 +133,7 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
       onEndReached={onEndReached}
       onEndReachedThreshold={onEndReachedThreshold}
       prefetchUrlExtractor={(item) => item?.artwork?.href || undefined}
-      renderItem={({ item, index }) => {
-        if (!item?.artwork) {
-          return null
-        }
-
-        return (
-          <ArtworkRailCard
-            artwork={item.artwork}
-            onPress={() => {
-              onPress?.(item, index)
-            }}
-            metaContainerStyles={{ height: 100 }}
-            showPartnerName={showPartnerName}
-            SalePriceComponent={
-              <RecentlySoldCardSection
-                priceRealizedDisplay={item?.priceRealized?.display || ""}
-                lowEstimateDisplay={item?.lowEstimate?.display || ""}
-                highEstimateDisplay={item?.highEstimate?.display || ""}
-                performanceDisplay={item?.performance?.mid ?? undefined}
-              />
-            }
-            hideArtistName={hideArtistName}
-          />
-        )
-      }}
+      renderItem={renderItem}
       showsHorizontalScrollIndicator={false}
     />
   )


### PR DESCRIPTION
This PR resolves [ONYX-1322] <!-- eg [PROJECT-XXXX] -->

### Description

This PR comes as a fix for some issues after the past refactoring PRs to the artwork rails. 


__ Issue __

https://github.com/user-attachments/assets/0630c785-2ba2-474d-bfb0-b3c5a24ed6a2



__ After __

https://github.com/user-attachments/assets/727a6f7e-9e2f-42c2-823a-253b21dfab4f

**Rationale**
For some reason, `Flatlist` was struggling to calculate the width of the container in initial render and it led in some instances to the `RailCard` not covering the entire allowed area. Here I am setting the width and using `Flashlist` instead of `Flatlist` to take advantage of the performance improvements as well. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix layout shifts for artwork rails

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use Flashlist for artwork rails - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1322]: https://artsyproduct.atlassian.net/browse/ONYX-1322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ