### PR TITLE
feat(EMI-2112): failed payment order history

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsHeader.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsHeader.tsx
@@ -39,21 +39,23 @@ export const OrderDetailsHeader: React.FC<Props> = ({ info }) => {
         </Text>
       </Flex>
 
-      <Flex flexDirection="row" justifyContent="space-between">
-        <Text variant="sm" mb={1}>
-          Status
-        </Text>
+      {!!orderStatus && (
+        <Flex flexDirection="row" justifyContent="space-between">
+          <Text variant="sm" mb={1}>
+            Status
+          </Text>
 
-        <Text
-          testID="status"
-          color="black60"
-          variant="sm"
-          mb={1}
-          style={{ textTransform: "capitalize" }}
-        >
-          {orderStatus}
-        </Text>
-      </Flex>
+          <Text
+            testID="status"
+            color="black60"
+            variant="sm"
+            mb={1}
+            style={{ textTransform: "capitalize" }}
+          >
+            {orderStatus}
+          </Text>
+        </Flex>
+      )}
 
       <Flex flexDirection="row" justifyContent="space-between">
         <Text variant="sm" mb={1}>

--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/TrackOrderSection.tsx
@@ -27,9 +27,11 @@ export const TrackOrderSection: React.FC<Props> = ({ section }) => {
   return (
     <Flex flexDirection="row" justifyContent="space-between">
       <Flex>
-        <Text testID="orderStatus" variant="sm" style={{ textTransform: "capitalize" }}>
-          {orderStatus}
-        </Text>
+        {!!orderStatus && (
+          <Text testID="orderStatus" variant="sm" style={{ textTransform: "capitalize" }}>
+            {orderStatus}
+          </Text>
+        )}
         {!!shipment?.trackingNumber && (
           <Text testID="trackingNumber" variant="sm" color="black60">
             Tracking:&nbsp;

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -54,7 +54,7 @@ describe("OrderHistoryRow", () => {
   it("displays the artist name", () => {
     renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(screen.getByTestId("artist-names")).toHaveTextContent("Torbjørn Rødland")
+    expect(screen.getByText("Torbjørn Rødland")).toBeOnTheScreen()
   })
 
   it("displays the partner name", () => {
@@ -66,19 +66,19 @@ describe("OrderHistoryRow", () => {
   it("displays the order creation date", () => {
     renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(screen.queryByTestId("date")).toHaveTextContent("5/18/2021")
+    expect(screen.getByText("5/18/2021")).toBeOnTheScreen()
   })
 
   it("displays the price", () => {
     renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(screen.getByTestId("price")).toHaveTextContent("11,200")
+    expect(screen.getByText("11,200")).toBeOnTheScreen()
   })
 
   it("displays the display state", () => {
     renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(screen.getByTestId("order-status")).toHaveTextContent("pending")
+    expect(screen.getByText("pending")).toBeOnTheScreen()
   })
 
   describe("artwork image", () => {

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -220,7 +220,7 @@ describe("OrderHistoryRow", () => {
 
       expect(navigate).toHaveBeenCalledWith("/orders/internal-id/payment/new", {
         modal: true,
-        passProps: { orderID: "internal-id", title: "Update Payment Method" },
+        passProps: { orderID: "internal-id", title: "Update Payment Details" },
       })
     })
     it("is not visible when the displayState is not PAYMENT_FAILED", () => {

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -60,7 +60,7 @@ describe("OrderHistoryRow", () => {
   it("displays the partner name", () => {
     renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(screen.getByTestId("partner-name")).toHaveTextContent("Andrea Festa Fine Art")
+    expect(screen.getByText("Andrea Festa Fine Art")).toBeOnTheScreen()
   })
 
   it("displays the order creation date", () => {

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { OrderHistoryRowTestsQuery } from "__generated__/OrderHistoryRowTestsQuery.graphql"
 import { navigate } from "app/system/navigation/navigate"
 import { extractText } from "app/utils/tests/extractText"
@@ -52,44 +52,44 @@ describe("OrderHistoryRow", () => {
   })
 
   it("displays the artist name", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+    renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(tree.queryByTestId("artist-names")?.children[0]).toBe("Torbjørn Rødland")
+    expect(screen.getByTestId("artist-names")).toHaveTextContent("Torbjørn Rødland")
   })
 
   it("displays the partner name", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+    renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(tree.queryByTestId("partner-name")?.children[0]).toBe("Andrea Festa Fine Art")
+    expect(screen.getByTestId("partner-name")).toHaveTextContent("Andrea Festa Fine Art")
   })
 
   it("displays the order creation date", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+    renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(tree.queryByTestId("date")?.children[0]).toBe("5/18/2021")
+    expect(screen.queryByTestId("date")).toHaveTextContent("5/18/2021")
   })
 
   it("displays the price", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+    renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(tree.queryByTestId("price")?.children[0]).toBe("11,200")
+    expect(screen.getByTestId("price")).toHaveTextContent("11,200")
   })
 
   it("displays the display state", () => {
-    const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+    renderWithRelay({ CommerceOrder: () => mockOrder })
 
-    expect(tree.queryByTestId("order-status")?.children[0]).toBe("pending")
+    expect(screen.getByTestId("order-status")).toHaveTextContent("pending")
   })
 
   describe("artwork image", () => {
     it("displays the image", () => {
-      const tree = renderWithRelay({ CommerceOrder: () => mockOrder })
+      renderWithRelay({ CommerceOrder: () => mockOrder })
 
-      expect(tree.queryByTestId("image")).toBeTruthy()
+      expect(screen.getByTestId("image")).toBeTruthy()
     })
 
     it("displays a gray box unless there is an image", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           lineItems: {
@@ -111,13 +111,13 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(tree.queryByTestId("image-box")).toBeTruthy()
+      expect(screen.getByTestId("image-box")).toBeTruthy()
     })
   })
 
   describe("track package button", () => {
     it("is visible when a tracking URL is provided", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           lineItems: {
@@ -134,11 +134,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeTruthy()
     })
 
     it("is visible when a tracking number is provided", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           lineItems: {
@@ -155,11 +155,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeTruthy()
     })
 
     it("is visible when a tracking ID is provided", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           lineItems: {
@@ -176,11 +176,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(tree.queryByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeTruthy()
     })
 
     it("is not visible unless tracking information is provided", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           lineItems: {
@@ -197,46 +197,82 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(tree.queryByTestId("track-package-button")).toBeNull()
+      expect(screen.queryByTestId("track-package-button")).toBeNull()
+    })
+  })
+
+  describe("update payment method button", () => {
+    it("is includes a message and button go fix payment when the displayState is PAYMENT_FAILED", () => {
+      renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          internalID: "internal-id",
+          displayState: "PAYMENT_FAILED",
+        }),
+      })
+
+      screen.getByText("payment failed")
+
+      const button = screen.getByTestId("update-payment-button")
+      expect(button).toBeVisible()
+
+      fireEvent.press(button!)
+
+      expect(navigate).toHaveBeenCalledWith("/orders/internal-id/payment/new", {
+        modal: true,
+        passProps: { orderID: "internal-id", title: "Update Payment Method" },
+      })
+    })
+    it("is not visible when the displayState is not PAYMENT_FAILED", () => {
+      renderWithRelay({
+        CommerceOrder: () => ({
+          ...mockOrder,
+          internalID: "internal-id",
+          displayState: "SUBMITTED",
+        }),
+      })
+
+      const button = screen.queryByTestId("update-payment-button")
+      expect(button).toBeNull()
     })
   })
 
   describe("view order button", () => {
     it("is visible when the order is submitted", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "SUBMITTED",
         }),
       })
 
-      expect(tree.queryByTestId("view-order-button")).toBeTruthy()
+      expect(screen.getByTestId("view-order-button")).toBeTruthy()
     })
 
     it("is not visible when the order is canceled", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "CANCELED",
         }),
       })
 
-      expect(tree.queryByTestId("view-order-button")).toBeNull()
+      expect(screen.queryByTestId("view-order-button")).toBeNull()
     })
 
     it("is not visible when the order is refunded", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "REFUNDED",
         }),
       })
 
-      expect(tree.queryByTestId("view-order-button")).toBeNull()
+      expect(screen.queryByTestId("view-order-button")).toBeNull()
     })
 
     it("shows 'view order' when the order is submitted", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "SUBMITTED",
@@ -244,11 +280,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Order")
+      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Order")
     })
 
     it("shows 'view offer' when the order has a submitted offer", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "SUBMITTED",
@@ -256,11 +292,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Offer")
+      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Offer")
     })
 
     it("shows 'view order' when the order has an approved offer", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           displayState: "APPROVED",
@@ -268,11 +304,11 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(tree.getByTestId("view-order-button"))).toContain("View Order")
+      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Order")
     })
 
     it("navigates to the counteroffer when the order has a submitted offer", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           internalID: "internal-id",
@@ -280,7 +316,7 @@ describe("OrderHistoryRow", () => {
           mode: "OFFER",
         }),
       })
-      const button = tree.UNSAFE_getByProps({ testID: "view-order-button" })
+      const button = screen.UNSAFE_getByProps({ testID: "view-order-button" })
 
       fireEvent.press(button)
 
@@ -291,7 +327,7 @@ describe("OrderHistoryRow", () => {
     })
 
     it("navigates to the purchase summary when the order has a processing offer", () => {
-      const tree = renderWithRelay({
+      renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
           internalID: "internal-id",
@@ -300,7 +336,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      const button = tree.getByTestId("view-order-button")
+      const button = screen.getByTestId("view-order-button")
       fireEvent.press(button)
       expect(navigate).toHaveBeenCalledWith("/user/purchases/internal-id")
     })

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -122,7 +122,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             onPress={() =>
               navigate(`/orders/${order.internalID}/payment/new`, {
                 modal: true,
-                passProps: { orderID: order.internalID, title: "Update Payment Method" },
+                passProps: { orderID: order.internalID, title: "Update Payment Details" },
               })
             }
             testID="update-payment-button"

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -20,15 +20,13 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const trackingUrl = getTrackingUrl(lineItem)
 
   const orderStatus = getOrderStatus(order.displayState)
-  const orderStatusColor = ["canceled", "payment failed"].includes(orderStatus)
+  const orderStatusColor = ["canceled", "payment failed"].includes(orderStatus as string)
     ? "red100"
     : "black60"
 
-  const hasFailedPayment = orderStatus === "payment failed"
-  const isActive =
-    !hasFailedPayment &&
-    orderStatus &&
-    !(["canceled", "refunded"] as string[]).includes(orderStatus)
+  const showFixPayment = orderStatus === "payment failed"
+  const showViewOrder =
+    !showFixPayment && orderStatus && !(["canceled", "refunded"] as string[]).includes(orderStatus)
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
   const artworkImageUrl = artworkVersion?.image?.resized?.url
@@ -97,7 +95,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             Track Package
           </Button>
         )}
-        {!!isActive && (
+        {!!showViewOrder && (
           <Button
             block
             variant="fillGray"
@@ -115,7 +113,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             {isViewOffer ? "View Offer" : "View Order"}
           </Button>
         )}
-        {!!hasFailedPayment && (
+        {!!showFixPayment && (
           <Button
             block
             variant="fillDark"

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -20,7 +20,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const trackingUrl = getTrackingUrl(lineItem)
 
   const orderStatus = getOrderStatus(order.displayState)
-  const orderStatusColor = ["canceled", "payment failed"].includes(orderStatus as string)
+  const orderStatusColor = ["canceled", "payment failed"].includes(orderStatus)
     ? "red100"
     : "black60"
 

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -18,8 +18,17 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
   const { artwork, artworkVersion } = lineItem || {}
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const trackingUrl = getTrackingUrl(lineItem)
+
   const orderStatus = getOrderStatus(order.displayState)
-  const orderIsInactive = orderStatus === "canceled" || orderStatus === "refunded"
+  const orderStatusColor = ["canceled", "payment failed"].includes(orderStatus)
+    ? "red100"
+    : "black60"
+
+  const hasFailedPayment = orderStatus === "payment failed"
+  const isActive =
+    !hasFailedPayment &&
+    orderStatus &&
+    !(["canceled", "refunded"] as string[]).includes(orderStatus)
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
   const artworkImageUrl = artworkVersion?.image?.resized?.url
@@ -62,15 +71,17 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             <Text textAlign="right" variant="sm" testID="price">
               {order.buyerTotal}
             </Text>
-            <Text
-              textAlign="right"
-              variant="xs"
-              color={orderStatus === "canceled" ? "red100" : "black60"}
-              style={{ textTransform: "capitalize" }}
-              testID="order-status"
-            >
-              {orderStatus}
-            </Text>
+            {!!orderStatus && (
+              <Text
+                textAlign="right"
+                variant="xs"
+                color={orderStatusColor}
+                style={{ textTransform: "capitalize" }}
+                testID="order-status"
+              >
+                {orderStatus}
+              </Text>
+            )}
           </Flex>
         </Flex>
       </Flex>
@@ -86,7 +97,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             Track Package
           </Button>
         )}
-        {!orderIsInactive && (
+        {!!isActive && (
           <Button
             block
             variant="fillGray"
@@ -102,6 +113,21 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
             testID="view-order-button"
           >
             {isViewOffer ? "View Offer" : "View Order"}
+          </Button>
+        )}
+        {!!hasFailedPayment && (
+          <Button
+            block
+            variant="fillDark"
+            onPress={() =>
+              navigate(`/orders/${order.internalID}/payment/new`, {
+                modal: true,
+                passProps: { orderID: order.internalID, title: "Update Payment Method" },
+              })
+            }
+            testID="update-payment-button"
+          >
+            Update Payment Method
           </Button>
         )}
       </Box>

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -26,7 +26,7 @@ export const OrderHistoryRow: React.FC<OrderHistoryRowProps> = ({ order }) => {
 
   const showFixPayment = orderStatus === "payment failed"
   const showViewOrder =
-    !showFixPayment && orderStatus && !(["canceled", "refunded"] as string[]).includes(orderStatus)
+    !showFixPayment && orderStatus && !["canceled", "refunded"].includes(orderStatus)
   const isViewOffer = orderStatus === "pending" && order?.mode === "OFFER"
 
   const artworkImageUrl = artworkVersion?.image?.resized?.url

--- a/src/app/utils/getOrderStatus.tests.ts
+++ b/src/app/utils/getOrderStatus.tests.ts
@@ -11,9 +11,10 @@ describe(getOrderStatus, () => {
     expect(getOrderStatus("PROCESSING_APPROVAL")).toBe("payment processing")
     expect(getOrderStatus("IN_TRANSIT")).toBe("in transit")
     expect(getOrderStatus("CANCELED")).toBe("canceled")
+    expect(getOrderStatus("PAYMENT_FAILED")).toBe("payment failed")
   })
-  it("returns 'unknown' for order states that are not displayed", () => {
-    expect(getOrderStatus("ABANDONED")).toBe("unknown")
-    expect(getOrderStatus("PENDING")).toBe("unknown")
+  it("returns empty string ('') for order states that are not displayed", () => {
+    expect(getOrderStatus("ABANDONED")).toBe("")
+    expect(getOrderStatus("PENDING")).toBe("")
   })
 })

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,6 +1,6 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
-export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum) {
+export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string {
   switch (displayState) {
     case "SUBMITTED":
       return "pending"
@@ -13,11 +13,13 @@ export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum) {
     case "PROCESSING":
       return "processing"
     case "PROCESSING_APPROVAL":
-      return "payment processing"
+      return "processing approval"
     case "IN_TRANSIT":
       return "in transit"
     case "CANCELED":
       return "canceled"
+    case "PAYMENT_FAILED":
+      return "payment failed"
     default:
       return "unknown"
   }

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,6 +1,6 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
-export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string | "" {
+export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string {
   switch (displayState) {
     case "SUBMITTED":
       return "pending"

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,6 +1,6 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
-export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string {
+export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string | null {
   switch (displayState) {
     case "SUBMITTED":
       return "pending"
@@ -21,6 +21,6 @@ export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): str
     case "PAYMENT_FAILED":
       return "payment failed"
     default:
-      return "unknown"
+      return null
   }
 }

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,6 +1,6 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
 
-export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string | null {
+export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string | "" {
   switch (displayState) {
     case "SUBMITTED":
       return "pending"
@@ -13,7 +13,7 @@ export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): str
     case "PROCESSING":
       return "processing"
     case "PROCESSING_APPROVAL":
-      return "processing approval"
+      return "payment processing"
     case "IN_TRANSIT":
       return "in transit"
     case "CANCELED":
@@ -21,6 +21,6 @@ export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): str
     case "PAYMENT_FAILED":
       return "payment failed"
     default:
-      return null
+      return ""
   }
 }


### PR DESCRIPTION
This PR resolves [EMI-2112]
### Description

This PR adds a `payment failed` state to the order history along with a CTA to fix the failed payment. The work to expose that new payment failed state is still in progress, so there are no user-facing changes yet.

The `getOrderStatus()` method now returns a `string | null` rather than the string `'unknown'`. Unhandled (null) values are not rendered in the app - this should never happen.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>📱Order history (failed payment state simulated)</summary>
<p>

![Simulator Screenshot - iPhone 15 Pro - 2024-09-24 at 13 48 20](https://github.com/user-attachments/assets/6b8d0154-b8e6-4438-a5ae-4bdb11ee5370)

![image](https://github.com/user-attachments/assets/3d07dc22-1c6d-43f4-be46-11d79ac3fe6a)

</p>
</details> 

<details><summary>📱After clicking CTA</summary>
<p>

![Simulator Screenshot - iPhone 15 Pro - 2024-09-24 at 13 48 16](https://github.com/user-attachments/assets/9e7bc338-46ba-4e31-b580-ae39e2adb1c0)

<img width="463" alt="image" src="https://github.com/user-attachments/assets/60bc8f65-3f5e-4804-921d-cadea1219ddf">


</p>
</details> 


### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Enhancements to the order history screen when an order has a failed payment

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2112]: https://artsyproduct.atlassian.net/browse/EMI-2112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ