### PR TITLE
chore(analytics): implement missing analytics in new home view sections

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tests.tsx
@@ -2,6 +2,7 @@ import { HomeViewSectionArtworksTestsQuery } from "__generated__/HomeViewSection
 import * as dismissSavedArtworkModule from "app/Components/ProgressiveOnboarding/useDismissSavedArtwork"
 import { HomeViewScreen } from "app/Scenes/HomeView/HomeView"
 import * as requestPushNotificationsPermissionModule from "app/utils/requestPushNotificationsPermission"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -59,5 +60,14 @@ describe("HomeView", () => {
     renderWithRelay({})
 
     expect(requestPushNotificationsPermissionSpy).toHaveBeenCalled()
+  })
+
+  it("fires a screen view event", () => {
+    renderWithRelay({})
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "screen",
+      context_screen_owner_type: "home",
+    })
   })
 })

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -11,6 +11,7 @@ import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { Section } from "app/Scenes/HomeView/Sections/Section"
+import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { searchQueryDefaultVariables } from "app/Scenes/Search/Search"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
@@ -57,6 +58,7 @@ export const HomeView: React.FC = () => {
   useDismissSavedArtwork(savedArtworksCount > 0)
   useEnableProgressiveOnboarding()
   const prefetchUrl = usePrefetch()
+  const tracking = useHomeViewTracking()
 
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
 
@@ -71,6 +73,10 @@ export const HomeView: React.FC = () => {
 
   useEffect(() => {
     requestPushNotificationsPermission()
+  }, [])
+
+  useEffect(() => {
+    tracking.screen(OwnerType.home)
   }, [])
 
   const handleRefresh = () => {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
@@ -47,8 +47,15 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
 
   const space = useSpace()
 
-  const onItemPress = (article: ArticleType) => {
+  const onItemPress = (article: ArticleType, index: number) => {
     if (article.href) {
+      tracking.tappedArticleGroup(
+        article.internalID,
+        article.slug,
+        section.contextModule as ContextModule,
+        index
+      )
+
       navigate(article.href)
     }
   }
@@ -73,7 +80,7 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
         </Flex>
         {articles.map((article, index) => (
           <Flex key={index} gap={space(2)}>
-            <Touchable onPress={() => onItemPress(article)}>
+            <Touchable onPress={() => onItemPress(article, index)}>
               <Flex flexDirection="row" alignItems="center">
                 <Text variant="sm-display" numberOfLines={3}>
                   {article.title}
@@ -124,8 +131,10 @@ const fragment = graphql`
     cardArticlesConnection: articlesConnection(first: 3) {
       edges {
         node {
-          title
           href
+          internalID
+          slug
+          title
         }
       }
     }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -10,6 +10,7 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette-mobile"
+import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.graphql"
 import { HomeViewSectionFeaturedCollectionQuery } from "__generated__/HomeViewSectionFeaturedCollectionQuery.graphql"
 import { HomeViewSectionFeaturedCollection_section$key } from "__generated__/HomeViewSectionFeaturedCollection_section.graphql"
 import { ARTWORK_RAIL_IMAGE_WIDTH, ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
@@ -66,8 +67,18 @@ export const HomeViewSectionFeaturedCollection: React.FC<
     }
   }
 
-  const handleOnArtworkPress = (artwork: any, _position: any) => {
-    navigate(artwork.href)
+  const handleOnArtworkPress = (artwork: ArtworkRail_artworks$data[0], index: number) => {
+    if (artwork.href) {
+      tracking.tappedArtworkGroup(
+        artwork.internalID,
+        artwork.slug,
+        artwork.collectorSignals,
+        section.contextModule as ContextModule,
+        index
+      )
+
+      navigate(artwork.href)
+    }
   }
 
   return (


### PR DESCRIPTION
### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- chore(analytics): add tappedArticleGroup for Home View > ArticlesCards
- chore(analytics): add tappedArtworkGroup for Home View > FeaturedCollection
- chore(analytics): add screen analytics event for new Home View screen

This PR resolves [ONYX-1317](https://artsyproduct.atlassian.net/browse/ONYX-1317), [ONYX-1319](https://artsyproduct.atlassian.net/browse/ONYX-1319), and [ONYX-1323](https://artsyproduct.atlassian.net/browse/ONYX-1323).

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- chore(analytics): add tappedArticleGroup for Home View > ArticlesCards
- chore(analytics): add tappedArtworkGroup for Home View > FeaturedCollection
- chore(analytics): add screen analytics event for new Home View screen

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1317]: https://artsyproduct.atlassian.net/browse/ONYX-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1319]: https://artsyproduct.atlassian.net/browse/ONYX-1319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ONYX-1323]: https://artsyproduct.atlassian.net/browse/ONYX-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ