### PR TITLE
chore: improve home view query performance

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tests.tsx
@@ -2,9 +2,11 @@ import { HomeViewSectionArtworksTestsQuery } from "__generated__/HomeViewSection
 import * as dismissSavedArtworkModule from "app/Components/ProgressiveOnboarding/useDismissSavedArtwork"
 import { HomeViewScreen } from "app/Scenes/HomeView/HomeView"
 import * as requestPushNotificationsPermissionModule from "app/utils/requestPushNotificationsPermission"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
+import { act } from "react-test-renderer"
 
 const useDismissSavedArtworkSpy = jest.spyOn(dismissSavedArtworkModule, "useDismissSavedArtwork")
 const requestPushNotificationsPermissionSpy = jest.spyOn(
@@ -19,10 +21,6 @@ describe("HomeView", () => {
     },
     query: graphql`
       query HomeViewTestsQuery($count: Int!, $cursor: String) @relay_test_operation {
-        me {
-          ...HomeView_me
-        }
-
         viewer {
           ...HomeViewSectionsConnection_viewer @arguments(count: $count, cursor: $cursor)
         }
@@ -31,14 +29,20 @@ describe("HomeView", () => {
   })
 
   describe("progressive onboarding setup", () => {
-    it("dismisses 'save-artwork' onboarding flow when user has saves", () => {
-      renderWithRelay({
-        Me: () => ({
-          counts: {
-            savedArtworks: 1,
-          },
-        }),
+    it("dismisses 'save-artwork' onboarding flow when user has saves", async () => {
+      const { mockResolveLastOperation } = renderWithRelay()
+
+      act(() => {
+        mockResolveLastOperation({
+          Me: () => ({
+            counts: {
+              savedArtworks: 1,
+            },
+          }),
+        })
       })
+
+      await flushPromiseQueue()
 
       expect(useDismissSavedArtworkSpy).toHaveBeenCalledWith(true)
     })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

In this PR, I added support of `cacheable` to Eigen. It is however not possible to use that at the home view query because it is using `Me`. In this PR, I am fixing that by moving that `Me` query to be a standalone query. 
This has actually led to more performance gains! **167ms less** **or 37% faster**

| Before | After |
|--------|--------|
| <img width="578" alt="Screenshot 2024-09-25 at 15 43 02" src="https://github.com/user-attachments/assets/2cb39c88-b64d-4c41-b97b-6c35ff6cfe6e"> | <img width="681" alt="Screenshot 2024-09-25 at 15 54 27" src="https://github.com/user-attachments/assets/01e9dd59-b457-4da9-8347-36d12e30c0be"> |
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- improve home view query performance - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
