### PR TITLE
chore(analytics): use useFocusEffect for screen event

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,5 +1,6 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Screen, Spinner } from "@artsy/palette-mobile"
+import { useFocusEffect } from "@react-navigation/native"
 import { FlashList } from "@shopify/flash-list"
 import { HomeViewFetchMeQuery } from "__generated__/HomeViewFetchMeQuery.graphql"
 import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
@@ -20,7 +21,7 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import { requestPushNotificationsPermission } from "app/utils/requestPushNotificationsPermission"
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
-import { Suspense, useEffect, useState } from "react"
+import { Suspense, useCallback, useEffect, useState } from "react"
 import { RefreshControl } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
@@ -74,9 +75,11 @@ export const HomeView: React.FC = () => {
     requestPushNotificationsPermission()
   }, [])
 
-  useEffect(() => {
-    tracking.screen(OwnerType.home)
-  }, [])
+  useFocusEffect(
+    useCallback(() => {
+      tracking.screen(OwnerType.home)
+    }, [])
+  )
 
   useEffect(() => {
     const fetchMe = async () => {

--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreen.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreen.tsx
@@ -1,5 +1,6 @@
 import { ScreenOwnerType } from "@artsy/cohesion"
 import { Screen, Text } from "@artsy/palette-mobile"
+import { useFocusEffect } from "@react-navigation/native"
 import {
   HomeViewSectionScreenQuery,
   HomeViewSectionScreenQuery$data,
@@ -9,7 +10,7 @@ import { HomeViewSectionScreenContent } from "app/Scenes/HomeViewSectionScreen/H
 import { HomeViewSectionScreenPlaceholder } from "app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenPlaceholder"
 import { goBack } from "app/system/navigation/navigate"
 import { withSuspense } from "app/utils/hooks/withSuspense"
-import { useEffect } from "react"
+import { useCallback } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
 interface HomeSectionScreenProps {
@@ -21,9 +22,11 @@ export const HomeViewSectionScreen: React.FC<HomeSectionScreenProps> = ({ sectio
   const title =
     section?.__typename === "ArtworksRailHomeViewSection" ? section.component?.title : ""
 
-  useEffect(() => {
-    tracking.screen(section.ownerType as ScreenOwnerType)
-  }, [])
+  useFocusEffect(
+    useCallback(() => {
+      tracking.screen(section.ownerType as ScreenOwnerType)
+    }, [])
+  )
 
   return (
     <Screen>

--- a/src/app/utils/Sentinel.tsx
+++ b/src/app/utils/Sentinel.tsx
@@ -9,7 +9,8 @@
  */
 
 import { Flex } from "@artsy/palette-mobile"
-import { FC, ReactNode, useEffect, useRef, useState } from "react"
+import { useFocusEffect } from "@react-navigation/native"
+import { FC, ReactNode, useCallback, useRef, useState } from "react"
 import { Dimensions, View } from "react-native"
 
 export interface IDimensionData {
@@ -38,12 +39,14 @@ export const Sentinel: FC<Props> = ({ children, onChange }) => {
 
   let interval: any = null
 
-  useEffect(() => {
-    setLastValue(false)
-    startWatching()
-    isInViewPort()
-    return stopWatching
-  }, [dimensions.rectTop, dimensions.rectBottom, dimensions.rectWidth])
+  useFocusEffect(
+    useCallback(() => {
+      setLastValue(false)
+      startWatching()
+      isInViewPort()
+      return stopWatching
+    }, [dimensions.rectTop, dimensions.rectBottom, dimensions.rectWidth])
+  )
 
   const startWatching = () => {
     if (interval) {


### PR DESCRIPTION
### Description

To ensure relevant UI is on screen before triggering analytics events, use `useFocusEffect`.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- chore(analytics): use ProvideScreenTrackingWithCohesionSchema for screen event

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
