### PR TITLE
fix: fix some unable to loads

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -36,7 +36,7 @@ import { SavedArtworks } from "app/Scenes/SavedArtworks/SavedArtworks"
 import { AlertArtworks } from "app/Scenes/SavedSearchAlert/AlertArtworks"
 import { SearchScreen, SearchScreenQuery } from "app/Scenes/Search/Search"
 import { SubmitArtworkForm } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
-import { SubmitArtworkFormEdit } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit"
+import { SubmitArtworkFormEditContainer } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit"
 import { SimilarToRecentlyViewedScreen } from "app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed"
 import { ArtsyKeyboardAvoidingViewContext } from "app/utils/ArtsyKeyboardAvoidingView"
 import { SafeAreaInsets, useScreenDimensions } from "app/utils/hooks"
@@ -686,7 +686,7 @@ export const modules = defineModules({
       gestureEnabled: false,
     },
   }),
-  SubmitArtworkEdit: reactModule(SubmitArtworkFormEdit, {
+  SubmitArtworkEdit: reactModule(SubmitArtworkFormEditContainer, {
     hidesBackButton: true,
     alwaysPresentModally: true,
     modalPresentationStyle: "fullScreen",

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -26,6 +26,8 @@ interface LoadFailureViewProps {
   justifyContent?: JustifyContentValue
   trackErrorBoundary?: boolean
   showBackButton?: boolean
+  showCloseButton?: boolean
+  useSafeArea?: boolean
 }
 
 const HEADER_HEIGHT = 50
@@ -35,6 +37,8 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   onRetry,
   trackErrorBoundary = true,
   showBackButton = false,
+  showCloseButton = false,
+  useSafeArea = true,
   ...restProps
 }) => {
   const color = useColor()
@@ -43,7 +47,8 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   const userId = GlobalStore.useAppState((state) => state.auth.userID)
   const activeTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
   const showErrorInLoadFailureViewToggle = useDevToggle("DTShowErrorInLoadFailureView")
-  const topInsets = useSafeAreaInsets().top
+  const safeAreaInset = useSafeAreaInsets()
+  const topInsets = useSafeArea ? safeAreaInset.top : 0
 
   const isStaging = useIsStaging()
 
@@ -78,13 +83,16 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
     ).start()
   }
 
+  const showTopButton = !!showBackButton || !!showCloseButton
+
   return (
     <>
-      {!!showBackButton && (
+      {!!showTopButton && (
         <Flex pt={`${topInsets}px`} mx={2} mb={2} height={HEADER_HEIGHT}>
           <Flex flexDirection="row" justifyContent="space-between" height={30} mb={1}>
             <BackButton
               onPress={goBack}
+              showX={showCloseButton}
               hitSlop={{
                 top: space(2),
                 left: space(2),

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -24,7 +24,7 @@ interface LoadFailureViewProps {
   error?: Error
   onRetry?: (() => void) | null
   justifyContent?: JustifyContentValue
-  appWideErrorBoundary?: boolean
+  trackErrorBoundary?: boolean
   showBackButton?: boolean
 }
 
@@ -33,7 +33,7 @@ const HEADER_HEIGHT = 50
 export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   error,
   onRetry,
-  appWideErrorBoundary = false,
+  trackErrorBoundary = true,
   showBackButton = false,
   ...restProps
 }) => {
@@ -50,7 +50,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   const showErrorMessage = __DEV__ || isStaging || showErrorInLoadFailureViewToggle
 
   const trackLoadFailureView = (error: Error | undefined) => {
-    const shouldTrackError = !__DEV__ && !isStaging && appWideErrorBoundary
+    const shouldTrackError = !__DEV__ && !isStaging && trackErrorBoundary
     if (shouldTrackError) {
       Sentry.withScope((scope) => {
         scope.setExtra("user-id", userId)
@@ -147,7 +147,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
             <Text>Error: {error?.message}</Text>
           </Flex>
         )}
-        {!!(appWideErrorBoundary && __DEV__) && (
+        {!!(trackErrorBoundary && __DEV__) && (
           <Flex m={2}>
             <Text color="red">
               This is the app wide error boundary. This should be avoided, please add local error

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   Touchable,
   BackButton,
+  DEFAULT_HIT_SLOP,
 } from "@artsy/palette-mobile"
 import * as Sentry from "@sentry/react-native"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -17,7 +18,7 @@ import { debounce } from "lodash"
 import { useEffect, useRef, useState } from "react"
 import { Animated, Easing } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
-import { space } from "styled-system"
+
 import { JustifyContentValue } from "./Bidding/Elements/types"
 
 interface LoadFailureViewProps {
@@ -90,16 +91,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
       {!!showTopButton && (
         <Flex pt={`${topInsets}px`} mx={2} mb={2} height={HEADER_HEIGHT}>
           <Flex flexDirection="row" justifyContent="space-between" height={30} mb={1}>
-            <BackButton
-              onPress={goBack}
-              showX={showCloseButton}
-              hitSlop={{
-                top: space(2),
-                left: space(2),
-                right: space(2),
-                bottom: space(2),
-              }}
-            />
+            <BackButton onPress={goBack} showX={showCloseButton} hitSlop={DEFAULT_HIT_SLOP} />
           </Flex>
         </Flex>
       )}

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -150,8 +150,10 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
         {!!(trackErrorBoundary && __DEV__) && (
           <Flex m={2}>
             <Text color="red">
-              This is the app wide error boundary. This should be avoided, please add local error
-              handling to the originating screen.
+              This is marked as a tracked major error boundary. If this is being handled correctly
+              pass trackErrorBoundary=false to the LoadFailureView. Handled correctly means: 1)
+              local to the screen 2) navigation is accessible. If not, please add error handling to
+              originating screen.
             </Text>
           </Flex>
         )}

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -68,6 +68,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
         Please try again
       </Text>
       {!!isStaging && <Box mb={1} border={2} width={200} borderColor="devpurple" />}
+
       {!!onRetry && (
         <Touchable
           onPress={debounce(() => {
@@ -111,6 +112,14 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
       {!!showErrorMessage && (
         <Flex m={2}>
           <Text>Error: {error?.message}</Text>
+        </Flex>
+      )}
+      {!!(appWideErrorBoundary && __DEV__) && (
+        <Flex m={2}>
+          <Text color="red">
+            This is the app wide error boundary. This should be avoided, please add local error
+            handling to the originating screen.
+          </Text>
         </Flex>
       )}
     </Flex>

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -22,7 +22,7 @@ import { JustifyContentValue } from "./Bidding/Elements/types"
 
 interface LoadFailureViewProps {
   error?: Error
-  onRetry?: () => void
+  onRetry?: (() => void) | null
   justifyContent?: JustifyContentValue
   appWideErrorBoundary?: boolean
   showBackButton?: boolean

--- a/src/app/Components/LoadFailureView.tsx
+++ b/src/app/Components/LoadFailureView.tsx
@@ -12,11 +12,13 @@ interface LoadFailureViewProps {
   error?: Error
   onRetry?: () => void
   justifyContent?: JustifyContentValue
+  appWideErrorBoundary?: boolean
 }
 
 export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   error,
   onRetry,
+  appWideErrorBoundary = false,
   ...restProps
 }) => {
   const color = useColor()
@@ -31,7 +33,7 @@ export const LoadFailureView: React.FC<LoadFailureViewProps & BoxProps> = ({
   const showErrorMessage = __DEV__ || isStaging || showErrorInLoadFailureViewToggle
 
   const trackLoadFailureView = (error: Error | undefined) => {
-    const shouldTrackError = !__DEV__ && !isStaging
+    const shouldTrackError = !__DEV__ && !isStaging && appWideErrorBoundary
     if (shouldTrackError) {
       Sentry.withScope((scope) => {
         scope.setExtra("user-id", userId)

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -35,8 +35,14 @@ export class RetryErrorBoundary extends Component<
   }
 
   render() {
-    const { children, failureView, notFoundTitle, notFoundText, notFoundBackButtonText } =
-      this.props
+    const {
+      children,
+      failureView,
+      notFoundTitle,
+      notFoundText,
+      notFoundBackButtonText,
+      appWideErrorBoundary,
+    } = this.props
     const { error } = this.state
 
     if (error) {
@@ -63,7 +69,7 @@ export class RetryErrorBoundary extends Component<
         <LoadFailureView
           error={error}
           onRetry={this._retry}
-          appWideErrorBoundary={this.props.appWideErrorBoundary}
+          appWideErrorBoundary={appWideErrorBoundary}
         />
       )
     }

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -11,6 +11,7 @@ interface RetryErrorBoundaryProps {
   notFoundOnBackPress?: () => void
   children?: React.ReactNode
   appWideErrorBoundary?: boolean
+  showBackButton?: boolean
 }
 interface RetryErrorBoundaryState {
   error: Error | null
@@ -22,6 +23,7 @@ export class RetryErrorBoundary extends Component<
 > {
   static defaultProps = {
     appWideErrorBoundary: false,
+    showBackButton: false,
   }
 
   static getDerivedStateFromError(error: Error | null): RetryErrorBoundaryState {
@@ -42,6 +44,7 @@ export class RetryErrorBoundary extends Component<
       notFoundText,
       notFoundBackButtonText,
       appWideErrorBoundary,
+      showBackButton,
     } = this.props
     const { error } = this.state
 
@@ -69,6 +72,7 @@ export class RetryErrorBoundary extends Component<
         <LoadFailureView
           error={error}
           onRetry={this._retry}
+          showBackButton={showBackButton}
           appWideErrorBoundary={appWideErrorBoundary}
         />
       )

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -21,7 +21,7 @@ export class RetryErrorBoundary extends Component<
   RetryErrorBoundaryState
 > {
   static defaultProps = {
-    shouldTrackError: false,
+    appWideErrorBoundary: false,
   }
 
   static getDerivedStateFromError(error: Error | null): RetryErrorBoundaryState {
@@ -74,7 +74,7 @@ export class RetryErrorBoundary extends Component<
 
 export const AppWideErrorBoundary: React.FC<RetryErrorBoundaryProps> = ({ children, ...props }) => {
   return (
-    <RetryErrorBoundary {...props} shouldTrackError={true}>
+    <RetryErrorBoundary {...props} appWideErrorBoundary={true}>
       {children}
     </RetryErrorBoundary>
   )

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -12,7 +12,10 @@ interface RetryErrorBoundaryProps {
   children?: React.ReactNode
   trackErrorBoundary?: boolean
   showBackButton?: boolean
+  showCloseButton?: boolean
+  useSafeArea?: boolean
 }
+
 interface RetryErrorBoundaryState {
   error: Error | null
 }
@@ -24,6 +27,8 @@ export class RetryErrorBoundary extends Component<
   static defaultProps = {
     trackErrorBoundary: true,
     showBackButton: false,
+    showCloseButton: false,
+    useSafeArea: true,
   }
 
   static getDerivedStateFromError(error: Error | null): RetryErrorBoundaryState {
@@ -45,6 +50,8 @@ export class RetryErrorBoundary extends Component<
       notFoundBackButtonText,
       trackErrorBoundary,
       showBackButton,
+      showCloseButton,
+      useSafeArea,
     } = this.props
     const { error } = this.state
 
@@ -73,7 +80,9 @@ export class RetryErrorBoundary extends Component<
           error={error}
           onRetry={this._retry}
           showBackButton={showBackButton}
+          showCloseButton={showCloseButton}
           trackErrorBoundary={trackErrorBoundary}
+          useSafeArea={useSafeArea}
         />
       )
     }

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -9,7 +9,8 @@ interface RetryErrorBoundaryProps {
   notFoundText?: string
   notFoundBackButtonText?: string
   notFoundOnBackPress?: () => void
-  children: React.ReactNode
+  children?: React.ReactNode
+  appWideErrorBoundary?: boolean
 }
 interface RetryErrorBoundaryState {
   error: Error | null
@@ -19,6 +20,10 @@ export class RetryErrorBoundary extends Component<
   RetryErrorBoundaryProps,
   RetryErrorBoundaryState
 > {
+  static defaultProps = {
+    shouldTrackError: false,
+  }
+
   static getDerivedStateFromError(error: Error | null): RetryErrorBoundaryState {
     return { error }
   }
@@ -54,11 +59,25 @@ export class RetryErrorBoundary extends Component<
         )
       }
 
-      return <LoadFailureView error={error} onRetry={this._retry} />
+      return (
+        <LoadFailureView
+          error={error}
+          onRetry={this._retry}
+          appWideErrorBoundary={this.props.appWideErrorBoundary}
+        />
+      )
     }
 
     return children
   }
+}
+
+export const AppWideErrorBoundary: React.FC<RetryErrorBoundaryProps> = ({ children, ...props }) => {
+  return (
+    <RetryErrorBoundary {...props} shouldTrackError={true}>
+      {children}
+    </RetryErrorBoundary>
+  )
 }
 
 export const getNotFoundRoute = (error: any) => {

--- a/src/app/Components/RetryErrorBoundary.tsx
+++ b/src/app/Components/RetryErrorBoundary.tsx
@@ -10,7 +10,7 @@ interface RetryErrorBoundaryProps {
   notFoundBackButtonText?: string
   notFoundOnBackPress?: () => void
   children?: React.ReactNode
-  appWideErrorBoundary?: boolean
+  trackErrorBoundary?: boolean
   showBackButton?: boolean
 }
 interface RetryErrorBoundaryState {
@@ -22,7 +22,7 @@ export class RetryErrorBoundary extends Component<
   RetryErrorBoundaryState
 > {
   static defaultProps = {
-    appWideErrorBoundary: false,
+    trackErrorBoundary: true,
     showBackButton: false,
   }
 
@@ -43,7 +43,7 @@ export class RetryErrorBoundary extends Component<
       notFoundTitle,
       notFoundText,
       notFoundBackButtonText,
-      appWideErrorBoundary,
+      trackErrorBoundary,
       showBackButton,
     } = this.props
     const { error } = this.state
@@ -73,7 +73,7 @@ export class RetryErrorBoundary extends Component<
           error={error}
           onRetry={this._retry}
           showBackButton={showBackButton}
-          appWideErrorBoundary={appWideErrorBoundary}
+          trackErrorBoundary={trackErrorBoundary}
         />
       )
     }
@@ -84,7 +84,7 @@ export class RetryErrorBoundary extends Component<
 
 export const AppWideErrorBoundary: React.FC<RetryErrorBoundaryProps> = ({ children, ...props }) => {
   return (
-    <RetryErrorBoundary {...props} appWideErrorBoundary={true}>
+    <RetryErrorBoundary {...props} trackErrorBoundary={true}>
       {children}
     </RetryErrorBoundary>
   )

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -11,7 +11,7 @@ import { SafeAreaProvider } from "react-native-safe-area-context"
 import { RelayEnvironmentProvider } from "react-relay"
 import { _FancyModalPageWrapper } from "./Components/FancyModal/FancyModalContext"
 import { PopoverMessageProvider } from "./Components/PopoverMessage/PopoverMessageProvider"
-import { RetryErrorBoundary } from "./Components/RetryErrorBoundary"
+import { AppWideErrorBoundary } from "./Components/RetryErrorBoundary"
 import { ToastProvider } from "./Components/Toast/toastHook"
 import { GlobalStore, GlobalStoreProvider } from "./store/GlobalStore"
 import { GravityWebsocketContextProvider } from "./utils/Websockets/GravityWebsocketContext"
@@ -36,7 +36,7 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       ThemeWithDarkModeSupport, // uses: GlobalStoreProvider
       // TODO: rename to ScreenContextProvider
       Screen.ScreenScrollContextProvider,
-      RetryErrorBoundary,
+      AppWideErrorBoundary,
       SuspenseProvider,
       ActionSheetProvider,
       PopoverMessageProvider,

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -295,7 +295,9 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = (props) =
                 variables: { artistID },
               }}
               cacheConfig={{ force: false }}
-              fallback={({ error }) => <LoadFailureView showBackButton error={error} />}
+              fallback={({ error }) => (
+                <LoadFailureView showBackButton error={error} trackErrorBoundary={false} />
+              )}
               render={{
                 renderPlaceholder: () => <ArtistSkeleton />,
                 renderComponent: ({ above, below }) => {

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -32,6 +32,7 @@ import { DEFAULT_ARTWORK_SORT } from "app/Components/ArtworkFilter/Filters/SortO
 import { getOnlyFilledSearchCriteriaValues } from "app/Components/ArtworkFilter/SavedSearch/searchCriteriaHelpers"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
 import { SearchCriteriaQueryRenderer } from "app/Scenes/Artist/SearchCriteria"
@@ -294,6 +295,7 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = (props) =
                 variables: { artistID },
               }}
               cacheConfig={{ force: false }}
+              fallback={() => <LoadFailureView showBackButton />}
               render={{
                 renderPlaceholder: () => <ArtistSkeleton />,
                 renderComponent: ({ above, below }) => {

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -295,7 +295,7 @@ export const ArtistQueryRenderer: React.FC<ArtistQueryRendererProps> = (props) =
                 variables: { artistID },
               }}
               cacheConfig={{ force: false }}
-              fallback={() => <LoadFailureView showBackButton />}
+              fallback={({ error }) => <LoadFailureView showBackButton error={error} />}
               render={{
                 renderPlaceholder: () => <ArtistSkeleton />,
                 renderComponent: ({ above, below }) => {

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -846,6 +846,7 @@ export const ArtworkQueryRenderer: React.FC<ArtworkScreenProps> = ({
         `,
         variables: { artworkID },
       }}
+      fallback={() => <ArtworkErrorScreen />}
       render={{
         renderPlaceholder: () => <AboveTheFoldPlaceholder artworkID={artworkID} />,
         renderComponent: ({ above, below }) => {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -28,6 +28,7 @@ import { AboveTheFoldFlatList } from "app/Components/AboveTheFoldFlatList"
 import { ArtworkRailPlaceholder } from "app/Components/ArtworkRail/ArtworkRail"
 import { ArtistRailFragmentContainer } from "app/Components/Home/ArtistRails/ArtistRail"
 import { RecommendedArtistsRailFragmentContainer } from "app/Components/Home/ArtistRails/RecommendedArtistsRail"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { useDismissSavedArtwork } from "app/Components/ProgressiveOnboarding/useDismissSavedArtwork"
 import { useEnableProgressiveOnboarding } from "app/Components/ProgressiveOnboarding/useEnableProgressiveOnboarding"
 import { ArticlesCards } from "app/Scenes/Articles/News/ArticlesCards"
@@ -827,6 +828,7 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
             `,
             variables: {},
           }}
+          fallback={() => <LoadFailureView />}
           render={{
             renderComponent: ({ above, below }) => {
               if (!above) {

--- a/src/app/Scenes/Home/Home.tsx
+++ b/src/app/Scenes/Home/Home.tsx
@@ -828,7 +828,7 @@ export const HomeQueryRenderer: React.FC<HomeQRProps> = ({ environment }) => {
             `,
             variables: {},
           }}
-          fallback={() => <LoadFailureView />}
+          fallback={({ error }) => <LoadFailureView error={error} trackErrorBoundary={false} />}
           render={{
             renderComponent: ({ above, below }) => {
               if (!above) {

--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -350,9 +350,11 @@ export const MyCollectionQueryRenderer: React.FC = () => {
             render={renderWithPlaceholder({
               Container: MyCollectionContainer,
               renderPlaceholder: () => <MyCollectionPlaceholder />,
-              renderFallback: ({ retry }) => (
+              renderFallback: ({ retry, error }) => (
                 // align at the end with bottom margin to prevent the header to overlap the unable to load screen.
                 <LoadFailureView
+                  error={error}
+                  trackErrorBoundary={false}
                   onRetry={retry || (() => {})}
                   justifyContent="flex-end"
                   mb="100px"

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggestResults.tsx
@@ -213,7 +213,9 @@ export const ArtworkAutosuggestResultsQueryRenderer: React.FC<{
           onPress,
           setShowSkipAheadToAddArtworkLink,
         },
-        renderFallback: ({ retry }) => <LoadFailureView onRetry={retry || (() => {})} />,
+        renderFallback: ({ retry, error }) => (
+          <LoadFailureView error={error} onRetry={retry || (() => {})} trackErrorBoundary={false} />
+        ),
       })}
       variables={{ count: 20, keyword, input: { artistIDs: [artistSlug] } }}
       cacheConfig={{ force: true }}

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -500,7 +500,7 @@ export const SaleQueryRenderer: React.FC<{
           } else {
             captureMessage(`SaleQueryRenderer ${error.message}`)
           }
-          return <LoadFailureView />
+          return <LoadFailureView error={error} />
         }
         if (!props?.above.me || !props.above.sale) {
           return <SalePlaceholder />

--- a/src/app/Scenes/Sale/Sale.tsx
+++ b/src/app/Scenes/Sale/Sale.tsx
@@ -500,7 +500,7 @@ export const SaleQueryRenderer: React.FC<{
           } else {
             captureMessage(`SaleQueryRenderer ${error.message}`)
           }
-          return <LoadFailureView error={error} />
+          return <LoadFailureView error={error} trackErrorBoundary={false} />
         }
         if (!props?.above.me || !props.above.sale) {
           return <SalePlaceholder />

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkFormEdit.tsx
@@ -1,5 +1,5 @@
 import { SubmitArtworkFormEditQuery } from "__generated__/SubmitArtworkFormEditQuery.graphql"
-import { LoadFailureView } from "app/Components/LoadFailureView"
+import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import {
   SubmitArtworkForm,
   SubmitArtworkProps,
@@ -17,20 +17,28 @@ export const SubmitArtworkFormEdit: React.FC<SubmitArtworkProps> = withSuspense(
     { fetchPolicy: "network-only" }
   )
 
-  if (!data?.submission) {
-    return <LoadFailureView />
-  }
-
   return (
-    <SubmitArtworkForm
-      externalID={props.externalID}
-      initialValues={getInitialSubmissionValues(data.submission, data?.me)}
-      initialStep={props.initialStep}
-      navigationState={props.navigationState}
-      hasStartedFlowFromMyCollection={props.hasStartedFlowFromMyCollection}
-    />
+    <>
+      {!!data?.submission && (
+        <SubmitArtworkForm
+          externalID={props.externalID}
+          initialValues={getInitialSubmissionValues(data.submission, data?.me)}
+          initialStep={props.initialStep}
+          navigationState={props.navigationState}
+          hasStartedFlowFromMyCollection={props.hasStartedFlowFromMyCollection}
+        />
+      )}
+    </>
   )
 })
+
+export const SubmitArtworkFormEditContainer: React.FC<SubmitArtworkProps> = (props) => {
+  return (
+    <RetryErrorBoundary showCloseButton={true} trackErrorBoundary={false} useSafeArea={false}>
+      <SubmitArtworkFormEdit {...props} />
+    </RetryErrorBoundary>
+  )
+}
 
 const submitArtworkFormEditQuery = graphql`
   query SubmitArtworkFormEditQuery($id: ID) {

--- a/src/app/utils/AboveTheFoldQueryRenderer.tsx
+++ b/src/app/utils/AboveTheFoldQueryRenderer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react"
 import { QueryRenderer, Environment, GraphQLTaggedNode } from "react-relay"
 import { CacheConfig, FetchPolicy, OperationType } from "relay-runtime"
 import { MockEnvironment } from "relay-test-utils"
-import { renderWithPlaceholder } from "./renderWithPlaceholder"
+import { FallbackRenderer, renderWithPlaceholder } from "./renderWithPlaceholder"
 
 interface AboveTheFoldQueryRendererProps<
   AboveQuery extends OperationType,
@@ -29,6 +29,7 @@ interface AboveTheFoldQueryRendererProps<
         }) => React.ReactChild
         renderPlaceholder: () => React.ReactChild
       }
+  fallback?: FallbackRenderer
   cacheConfig?: CacheConfig | null
   fetchPolicy?: FetchPolicy
   /** Fire below-the-fold query after the given timeout or when the above-the-fold query returns. */
@@ -75,11 +76,14 @@ export function AboveTheFoldQueryRenderer<
         : renderWithPlaceholder({
             renderPlaceholder: props.render.renderPlaceholder,
             render: props.render.renderComponent,
+            renderFallback: ({ retry }) =>
+              props.fallback ? <props.fallback retry={retry} /> : null,
           }),
     [props.render]
   )
 
   const error = aboveArgs?.error || belowArgs?.error || null
+
   const retry = () => {
     aboveArgs?.retry?.()
     belowArgs?.retry?.()

--- a/src/app/utils/AboveTheFoldQueryRenderer.tsx
+++ b/src/app/utils/AboveTheFoldQueryRenderer.tsx
@@ -77,7 +77,7 @@ export function AboveTheFoldQueryRenderer<
             renderPlaceholder: props.render.renderPlaceholder,
             render: props.render.renderComponent,
             renderFallback: ({ retry }) =>
-              props.fallback ? <props.fallback retry={retry} /> : null,
+              props.fallback ? <props.fallback retry={retry} error={error ?? undefined} /> : null,
           }),
     [props.render]
   )

--- a/src/app/utils/renderWithPlaceholder.tsx
+++ b/src/app/utils/renderWithPlaceholder.tsx
@@ -7,7 +7,7 @@ import { ProvidePlaceholderContext } from "./placeholders"
 type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
 
 export type FallbackRenderer = (args: {
-  retry: null | (() => void)
+  retry?: (() => void) | null
   error?: Error
 }) => React.ReactElement | null
 
@@ -77,15 +77,15 @@ export function renderWithPlaceholder<Props>({
         return <LoadFailureView error={error} />
       } else {
         retrying = true
-        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
         return <LoadFailureView onRetry={retry} error={error} />
       }
     } else if (props) {
       if (render) {
         return <>{render({ ...initialProps, ...(props as any) })}</>
-      } else {
-        // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
+      } else if (Container) {
         return <Container {...initialProps} {...(props as any)} />
+      } else {
+        return null
       }
     } else {
       return (

--- a/src/app/utils/renderWithPlaceholder.tsx
+++ b/src/app/utils/renderWithPlaceholder.tsx
@@ -6,7 +6,10 @@ import { ProvidePlaceholderContext } from "./placeholders"
 
 type ReadyState = Parameters<React.ComponentProps<typeof QueryRenderer>["render"]>[0]
 
-export type FallbackRenderer = (args: { retry: null | (() => void) }) => React.ReactElement | null
+export type FallbackRenderer = (args: {
+  retry: null | (() => void)
+  error?: Error
+}) => React.ReactElement | null
 
 export function renderWithPlaceholder<Props>({
   Container,
@@ -63,7 +66,7 @@ export function renderWithPlaceholder<Props>({
       }
 
       if (renderFallback) {
-        return renderFallback({ retry })
+        return renderFallback({ retry, error })
       } else if (retrying) {
         retrying = false
         // TODO: Even though this code path is reached, the retry button keeps spinning. iirc it _should_ disappear when
@@ -71,11 +74,11 @@ export function renderWithPlaceholder<Props>({
         //
         // This will re-use the native view first created in the renderFailure callback, which means it can
         // continue its ‘retry’ animation.
-        return <LoadFailureView />
+        return <LoadFailureView error={error} />
       } else {
         retrying = true
         // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-        return <LoadFailureView onRetry={retry} />
+        return <LoadFailureView onRetry={retry} error={error} />
       }
     } else if (props) {
       if (render) {

--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -39,7 +39,9 @@ export function useDeepLinks() {
         targetURL = await fetch(url)
       } catch (error) {
         if (__DEV__) {
-          console.warn(error)
+          console.warn(
+            `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`
+          )
         } else {
           captureMessage(
             `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`,


### PR DESCRIPTION
This PR resolves [PHIRE-1196] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- Updates a few error screens that were either dead ends (no nav) or not showing error messages.
- Stop tracking a few screens that are showing errors correctly
- Add an error message for devs in any error screen still being tracked


| Screen | Before | After |
|--------|--------|--------|
| SubmitArtworkEditForm | ![submit-artwork-edit-before](https://github.com/user-attachments/assets/6490f689-c874-4663-ab5c-500434973586)|![SubmitArtworkEditAfter](https://github.com/user-attachments/assets/8c8c011b-f7ca-4edc-b211-89ddd914f381)|
| Artist | ![artist-before](https://github.com/user-attachments/assets/fd20723c-d45c-48f2-be43-193d9a26c47d)| ![ArtistErrorAfter](https://github.com/user-attachments/assets/fd7f656b-fd36-40d5-979a-62d1f4847dfa)|
| Artwork |![artwork-before](https://github.com/user-attachments/assets/e818ea8b-266a-4cfe-b793-e85d32bbecaa)|![ArtworkAfter](https://github.com/user-attachments/assets/09ce0362-f6ba-45a8-84d5-af417695f7e5)|
| Home (Legacy)  | ![home-before](https://github.com/user-attachments/assets/684161ec-79ce-4e6f-ab6d-6aa60d9dde27)|![homeAfter](https://github.com/user-attachments/assets/dc20bcf0-2a25-4c2c-b9f8-776c876cf92e)|
| My Collection |![my-collection-before](https://github.com/user-attachments/assets/e917a5ab-01c1-4f17-9f0f-b0fa1445f481)|![mycollection-after](https://github.com/user-attachments/assets/e72a542f-4369-46f0-82f5-5fbbb171aaba)| 
| ArtworkAutosuggestResults  | ![artwork-autosuggest-before](https://github.com/user-attachments/assets/70050689-1418-41a1-ba35-8fc88b55a16b)| ![artwork-autosuggest-results-after](https://github.com/user-attachments/assets/d541b7e3-0143-4529-9f0b-4eec1d1e0151)| 
| Sale  | ![sale-before](https://github.com/user-attachments/assets/11467550-4f99-4494-b64f-820e99410453) |![sale-after](https://github.com/user-attachments/assets/0c33abf1-16fd-42e3-ab5f-b8693d6653e3)| 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- handle some unable to load errors and improve error reporting - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1196]: https://artsyproduct.atlassian.net/browse/PHIRE-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ