### PR TITLE
fix: artworks screen loading skeleton

### DIFF
--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
@@ -1,7 +1,7 @@
 import { ScreenOwnerType } from "@artsy/cohesion"
 import { Flex, Screen, SimpleMessage, Text } from "@artsy/palette-mobile"
-import { HomeViewSectionScreenArtworksQuery } from "__generated__/HomeViewSectionScreenArtworksQuery.graphql"
 import { HomeViewSectionScreenArtworks_section$key } from "__generated__/HomeViewSectionScreenArtworks_section.graphql"
+import { HomeViewSectionScreenQuery } from "__generated__/HomeViewSectionScreenQuery.graphql"
 import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -21,10 +21,10 @@ export const HomeViewSectionScreenArtworks: React.FC<ArtworksScreenHomeSection> 
     loadNext,
     refetch,
     hasNext,
-  } = usePaginationFragment<
-    HomeViewSectionScreenArtworksQuery,
-    HomeViewSectionScreenArtworks_section$key
-  >(artworksFragment, props.section)
+  } = usePaginationFragment<HomeViewSectionScreenQuery, HomeViewSectionScreenArtworks_section$key>(
+    artworksFragment,
+    props.section
+  )
 
   const artworks = extractNodes(section?.artworksConnection)
 
@@ -86,16 +86,6 @@ export const artworksFragment = graphql`
           }
           ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
         }
-      }
-    }
-  }
-`
-
-export const artworksQuery = graphql`
-  query HomeViewSectionScreenArtworksQuery($id: String!) {
-    homeView {
-      section(id: $id) @principalField {
-        ...HomeViewSectionScreenArtworks_section
       }
     }
   }

--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenPlaceholder.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenPlaceholder.tsx
@@ -6,7 +6,7 @@ export const HomeViewSectionScreenPlaceholderContent: React.FC<{
   sectionType: string
 }> = ({ sectionType }) => {
   switch (sectionType) {
-    case "ArtworksRailHomeViewSection":
+    case "HomeViewSectionArtworks":
       return <HomeViewSectionScreenArtworksPlaceholder />
     default:
       return (


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/Would-be-nice-if-artwork-rails-used-skeleton-loaders-rather-than-spinners-when-viewing-all-10ecab0764a080509f0cc5ebf7701c03?pvs=4] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the loading skeleton on the artworks section screen.


https://github.com/user-attachments/assets/0b0bd471-c588-4a9a-807f-9b38784b14a4


https://github.com/user-attachments/assets/ca96603d-3546-4661-a09e-aabf5e4f15df



#nochangelog