### PR TITLE
feat(ONYX-1285): change of the image size dimensions of an artwork rail card

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -28,7 +28,7 @@ import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
 export const INITIAL_NUM_TO_RENDER = isTablet() ? 10 : 5
-export const ARTWORK_RAIL_IMAGE_WIDTH = 295 // here
+export const ARTWORK_RAIL_IMAGE_WIDTH = 295
 
 type Artwork = ArtworkRail_artworks$data[0]
 

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -139,7 +139,7 @@ const artworksFragment = graphql`
 `
 
 export const ArtworkRailPlaceholder: React.FC = () => {
-  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+  const enableArtworkRailRedesignImageAspectRatio = useFeatureFlag(
     "AREnableArtworkRailRedesignImageAspectRatio"
   )
 

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -8,7 +8,7 @@ import {
   ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
   ArtworkRailCard,
 } from "app/Components/ArtworkRail/ArtworkRailCard"
-import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
+import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
 import { RandomWidthPlaceholderText, useMemoizedRandom } from "app/utils/placeholders"
@@ -23,7 +23,7 @@ import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
 export const INITIAL_NUM_TO_RENDER = isTablet() ? 10 : 5
-export const ARTWORK_RAIL_IMAGE_WIDTH = 295
+export const ARTWORK_RAIL_IMAGE_WIDTH = 295 // here
 
 type Artwork = ArtworkRail_artworks$data[0]
 
@@ -68,6 +68,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
 
   const renderItem: ListRenderItem<Artwork> = useCallback(
     ({ item, index }) => {
+      // remove <Box pr={2}> and add separator to flatlist
       return (
         <Box pr={2}>
           <ArtworkRailCard
@@ -134,10 +135,14 @@ const artworksFragment = graphql`
 `
 
 export const ArtworkRailPlaceholder: React.FC = () => (
+  // adjust placeholder
   <Join separator={<Spacer x="15px" />}>
     {times(3 + useMemoizedRandom() * 10).map((index) => (
       <Flex key={index}>
-        <SkeletonBox height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT} width={ARTWORK_RAIL_IMAGE_WIDTH} />
+        <SkeletonBox
+          height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+          width={ARTWORK_RAIL_IMAGE_WIDTH + 200}
+        />
         <Spacer y={2} />
         <SkeletonText>Artist</SkeletonText>
         <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -8,9 +8,14 @@ import {
   ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
   ArtworkRailCard,
 } from "app/Components/ArtworkRail/ArtworkRailCard"
+import {
+  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+} from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { RandomWidthPlaceholderText, useMemoizedRandom } from "app/utils/placeholders"
 import {
   ArtworkActionTrackingProps,
@@ -68,7 +73,6 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
 
   const renderItem: ListRenderItem<Artwork> = useCallback(
     ({ item, index }) => {
-      // remove <Box pr={2}> and add separator to flatlist
       return (
         <Box pr={2}>
           <ArtworkRailCard
@@ -134,19 +138,31 @@ const artworksFragment = graphql`
   }
 `
 
-export const ArtworkRailPlaceholder: React.FC = () => (
-  // adjust placeholder
-  <Join separator={<Spacer x="15px" />}>
-    {times(3 + useMemoizedRandom() * 10).map((index) => (
-      <Flex key={index}>
-        <SkeletonBox
-          height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-          width={ARTWORK_RAIL_IMAGE_WIDTH + 200}
-        />
-        <Spacer y={2} />
-        <SkeletonText>Artist</SkeletonText>
-        <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />
-      </Flex>
-    ))}
-  </Join>
-)
+export const ArtworkRailPlaceholder: React.FC = () => {
+  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+    "AREnableArtworkRailRedesignImageAspectRatio"
+  )
+
+  return (
+    <Join separator={<Spacer x="15px" />}>
+      {times(3 + useMemoizedRandom() * 10).map((index) => (
+        <Flex key={index}>
+          {enableArtworkRailRedesignImageAspectRatio ? (
+            <SkeletonBox
+              height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+              width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+            />
+          ) : (
+            <SkeletonBox
+              height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+              width={ARTWORK_RAIL_IMAGE_WIDTH}
+            />
+          )}
+          <Spacer y={2} />
+          <SkeletonText>Artist</SkeletonText>
+          <RandomWidthPlaceholderText minWidth={30} maxWidth={90} />
+        </Flex>
+      ))}
+    </Join>
+  )
+}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tests.tsx
@@ -135,6 +135,27 @@ describe("ArtworkRailCard", () => {
     })
   })
 
+  describe("artwork image", () => {
+    beforeEach(
+      () =>
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableArtworkRailRedesignImageAspectRatio: true,
+        })
+    )
+
+    it("renders the artwork image", () => {
+      renderWithRelay({ Artwork: () => artwork })
+
+      expect(screen.getByTestId("artwork-rail-card-image")).toBeOnTheScreen()
+    })
+
+    it("doesn't render an image if the url is not present", () => {
+      renderWithRelay({ Artwork: () => ({ ...artwork, image: { url: null } }) })
+
+      expect(screen.queryByTestId("artwork-rail-card-image")).not.toBeOnTheScreen()
+    })
+  })
+
   describe("unlisted artworks", () => {
     it("shows exclusive access", () => {
       renderWithRelay({ Artwork: () => ({ isUnlisted: true }) })

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -49,7 +49,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   testID,
   ...restProps
 }) => {
-  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+  const enableArtworkRailRedesignImageAspectRatio = useFeatureFlag(
     "AREnableArtworkRailRedesignImageAspectRatio"
   )
 

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -7,7 +7,7 @@ import {
   ArtworkRailCardMeta,
 } from "app/Components/ArtworkRail/ArtworkRailCardMeta"
 import {
-  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
   LegacyArtworkRailCardImage,
 } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { ContextMenuArtwork } from "app/Components/ContextMenu/ContextMenuArtwork"
@@ -49,7 +49,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
   testID,
   ...restProps
 }) => {
-  const enableArtworkRailRedesignImageAspectRatio = useFeatureFlag(
+  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
     "AREnableArtworkRailRedesignImageAspectRatio"
   )
 
@@ -91,7 +91,11 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
             testID={testID}
           >
             <Flex
-              height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT + ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT}
+              height={
+                enableArtworkRailRedesignImageAspectRatio
+                  ? "auto"
+                  : LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT + ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT
+              }
               justifyContent="flex-end"
             >
               {enableArtworkRailRedesignImageAspectRatio ? (

--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -18,11 +18,10 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
   const { image } = artwork
 
   const useImageDimentions = () => {
-    if (!image?.aspectRatio) {
-      return { containerWidth: 0 }
-    }
+    const imageAspectRatio =
+      image?.aspectRatio ?? (image?.width && image?.height ? image.width / image.height : 1)
 
-    const imageWidth = ARTWORK_RAIL_CARD_IMAGE_HEIGHT * image?.aspectRatio
+    const imageWidth = ARTWORK_RAIL_CARD_IMAGE_HEIGHT * imageAspectRatio
 
     let containerWidth = imageWidth
     let horizontalPadding = 0
@@ -50,7 +49,7 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           2 * horizontalPadding
 
     const displayImageHeight =
-      Math.min(displayImageWidth / image.aspectRatio, ARTWORK_RAIL_CARD_IMAGE_HEIGHT) -
+      Math.min(displayImageWidth / imageAspectRatio, ARTWORK_RAIL_CARD_IMAGE_HEIGHT) -
       2 * verticalPadding
 
     return { containerWidth, displayImageWidth, displayImageHeight }
@@ -75,6 +74,7 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           blurhash={showBlurhash ? image.blurhash : undefined}
           performResize={false}
           resizeMode="contain"
+          testID="artwork-rail-card-image"
         />
       )}
     </Flex>
@@ -87,6 +87,8 @@ const artworkFragment = graphql`
       blurhash
       url(version: "large")
       aspectRatio
+      width
+      height
     }
   }
 `

--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -1,17 +1,91 @@
-import { Text } from "@artsy/palette-mobile"
+import { Image, Flex, useColor } from "@artsy/palette-mobile"
 import { ArtworkRailCardImage_artwork$key } from "__generated__/ArtworkRailCardImage_artwork.graphql"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
 
 export interface ArtworkRailCardImageProps {
   artwork: ArtworkRailCardImage_artwork$key
 }
+export const CONTAINER_HEIGHT = 215
+export const MIN_IMAGE_WIDTH = 140
+export const MAX_IMAGE_WIDTH = 340
+const PADDING = 10
+
+// Take
+const tallImage = {
+  aspectRatio: 0.3,
+  height: 3000,
+  url: "https://d32dm0rphc51dk.cloudfront.net/IIPB-7WL_QaSV9sqORf0TQ/large.jpg",
+  width: 911,
+}
+
+const wideImage = {
+  aspectRatio: 2.81,
+  height: 356,
+  url: "https://d32dm0rphc51dk.cloudfront.net/nELDUsRuQl5DLM-WedfSMQ/large.jpg",
+  width: 1000,
+}
 
 export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...restProps }) => {
+  const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const artwork = useFragment(artworkFragment, restProps.artwork)
-  // TODO: Extract urgency tags (see LegacyArtworkRailCardImage)
-  // TODO: Implement new image component
+  const color = useColor()
+  //  const { image } = artwork
 
-  return <Text>{artwork?.image?.url}</Text>
+  const image = tallImage
+  if (!artwork?.image || !image?.url || !image?.aspectRatio) {
+    return (
+      <Flex
+        bg={color("black30")}
+        width={MIN_IMAGE_WIDTH}
+        height={CONTAINER_HEIGHT}
+        style={{ borderRadius: 2 }}
+      />
+    )
+  }
+
+  const imageWidth = CONTAINER_HEIGHT * image?.aspectRatio
+
+  let containerWidth = imageWidth
+  let horizontalPadding = 0
+  let verticalPadding = 0
+  let imageDisplayWidth = 0
+  let imageDisplayHeight = 0
+
+  if (imageWidth <= MIN_IMAGE_WIDTH) {
+    containerWidth = MIN_IMAGE_WIDTH
+    verticalPadding = PADDING
+    imageDisplayHeight = CONTAINER_HEIGHT - 2 * verticalPadding
+    imageDisplayWidth = imageDisplayHeight * image.aspectRatio
+  }
+
+  // Case when the image width is wider than the maximum width
+  if (imageWidth >= MAX_IMAGE_WIDTH) {
+    containerWidth = MAX_IMAGE_WIDTH
+    horizontalPadding = PADDING
+    imageDisplayWidth = MAX_IMAGE_WIDTH - 2 * horizontalPadding
+    imageDisplayHeight = imageDisplayWidth / image.aspectRatio
+  }
+
+  return (
+    <Flex
+      backgroundColor="black5"
+      justifyContent="center"
+      alignItems="center"
+      height={CONTAINER_HEIGHT}
+      width={containerWidth}
+    >
+      <Image
+        src={image.url}
+        width={imageDisplayWidth}
+        height={imageDisplayHeight}
+        aspectRatio={image.aspectRatio}
+        blurhash={showBlurhash ? image.blurhash : undefined}
+        performResize={false}
+        resizeMode="contain"
+      />
+    </Flex>
+  )
 }
 
 const artworkFragment = graphql`
@@ -19,6 +93,7 @@ const artworkFragment = graphql`
     image(includeAll: false) {
       blurhash
       url(version: "large")
+      aspectRatio
     }
   }
 `

--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -11,34 +11,11 @@ export const ARTWORK_RAIL_MIN_IMAGE_WIDTH = 140
 export const ARTWORK_RAIL_MAX_IMAGE_WIDTH = 340
 const PADDING = 10
 
-// Take
-const tallImage = {
-  aspectRatio: 0.3,
-  height: 3000,
-  url: "https://d32dm0rphc51dk.cloudfront.net/IIPB-7WL_QaSV9sqORf0TQ/large.jpg",
-  width: 911,
-}
-
-const wideImage = {
-  aspectRatio: 2.81,
-  height: 356,
-  url: "https://d32dm0rphc51dk.cloudfront.net/nELDUsRuQl5DLM-WedfSMQ/large.jpg",
-  width: 1000,
-}
-
-/* const wideImage = {
-  aspectRatio: 2.28,
-  height: 1768,
-  url: "https://d32dm0rphc51dk.cloudfront.net/3PjwqKQuAqp1ZcgEro4qbg/large.jpg",
-  width: 4030,
-} */
 export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...restProps }) => {
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const artwork = useFragment(artworkFragment, restProps.artwork)
 
   const { image } = artwork
-
-  // const image = wideImage
 
   const useImageDimentions = () => {
     if (!image?.aspectRatio) {

--- a/src/app/Components/ArtworkRail/LegacyArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/LegacyArtworkRailCardImage.tsx
@@ -9,16 +9,14 @@ import { sizeToFit } from "app/utils/useSizeToFit"
 import { useMemo } from "react"
 import { graphql, useFragment } from "react-relay"
 
-export const ARTWORK_RAIL_CARD_IMAGE_HEIGHT = 320
+export const LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT = 320
 export const ARTWORK_RAIL_CARD_IMAGE_WIDTH = 295
 
 export interface LegacyArtworkRailCardImageProps {
   artwork: LegacyArtworkRailCardImage_artwork$key
-  urgencyTag?: string | null
 }
 
 export const LegacyArtworkRailCardImage: React.FC<LegacyArtworkRailCardImageProps> = ({
-  urgencyTag = null,
   ...restProps
 }) => {
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
@@ -41,7 +39,7 @@ export const LegacyArtworkRailCardImage: React.FC<LegacyArtworkRailCardImageProp
       <Flex
         bg={color("black30")}
         width={width}
-        height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+        height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
         style={{ borderRadius: 2 }}
       />
     )
@@ -49,7 +47,7 @@ export const LegacyArtworkRailCardImage: React.FC<LegacyArtworkRailCardImageProp
 
   const containerDimensions = {
     width: ARTWORK_RAIL_CARD_IMAGE_WIDTH,
-    height: ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+    height: LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
   }
 
   const imageDimensions = sizeToFit(
@@ -60,7 +58,7 @@ export const LegacyArtworkRailCardImage: React.FC<LegacyArtworkRailCardImageProp
     containerDimensions
   )
 
-  const imageHeight = imageDimensions.height || ARTWORK_RAIL_CARD_IMAGE_HEIGHT
+  const imageHeight = imageDimensions.height || LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT
 
   return (
     <Flex>
@@ -98,7 +96,7 @@ export const getContainerWidth = (image: LegacyArtworkRailCardImage_artwork$data
     },
     {
       width: ARTWORK_RAIL_CARD_IMAGE_WIDTH,
-      height: ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+      height: LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
     }
   )
 

--- a/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCardImage.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCardImage.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text, useColor } from "@artsy/palette-mobile"
 import { ContextMenuArtworkPreviewCardImage_artwork$key } from "__generated__/ContextMenuArtworkPreviewCardImage_artwork.graphql"
 import {
-  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
   ARTWORK_RAIL_CARD_IMAGE_WIDTH,
 } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
@@ -42,7 +42,7 @@ export const ContextMenuArtworkPreviewCardImage: React.FC<
       <Flex
         bg={color("black30")}
         width={width}
-        height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+        height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
         style={{ borderRadius: 2 }}
       />
     )
@@ -55,7 +55,7 @@ export const ContextMenuArtworkPreviewCardImage: React.FC<
     },
     {
       width: ARTWORK_RAIL_CARD_IMAGE_WIDTH,
-      height: ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+      height: LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
     }
   )
 
@@ -63,9 +63,9 @@ export const ContextMenuArtworkPreviewCardImage: React.FC<
     <Flex>
       <Flex width={containerWidth}>
         <OpaqueImageView
-          style={{ maxHeight: ARTWORK_RAIL_CARD_IMAGE_HEIGHT }}
+          style={{ maxHeight: LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT }}
           imageURL={src}
-          height={imageDimensions.height || ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+          height={imageDimensions.height || LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
           width={containerWidth}
         />
       </Flex>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -12,7 +12,7 @@ import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.gr
 import { HomeViewSectionArtworksQuery } from "__generated__/HomeViewSectionArtworksQuery.graphql"
 import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSectionArtworks_section.graphql"
 import { ARTWORK_RAIL_IMAGE_WIDTH, ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
-import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
+import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
@@ -145,6 +145,7 @@ const homeViewSectionArtworksQuery = graphql`
 
 const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
   const randomValue = useMemoizedRandom()
+  // here adjust placeholder
   return (
     <Skeleton>
       <Flex {...flexProps}>
@@ -157,8 +158,8 @@ const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
               {times(2 + randomValue * 10).map((index) => (
                 <Flex key={index}>
                   <SkeletonBox
-                    height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-                    width={ARTWORK_RAIL_IMAGE_WIDTH}
+                    height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                    width={ARTWORK_RAIL_IMAGE_WIDTH + 100}
                   />
                   <Spacer y={2} />
                   <SkeletonText>Andy Warhol</SkeletonText>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -12,6 +12,10 @@ import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.gr
 import { HomeViewSectionArtworksQuery } from "__generated__/HomeViewSectionArtworksQuery.graphql"
 import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSectionArtworks_section.graphql"
 import { ARTWORK_RAIL_IMAGE_WIDTH, ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
+import {
+  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+} from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
@@ -19,6 +23,7 @@ import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { useMemoizedRandom } from "app/utils/placeholders"
 import { times } from "lodash"
@@ -145,7 +150,10 @@ const homeViewSectionArtworksQuery = graphql`
 
 const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
   const randomValue = useMemoizedRandom()
-  // here adjust placeholder
+  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+    "AREnableArtworkRailRedesignImageAspectRatio"
+  )
+
   return (
     <Skeleton>
       <Flex {...flexProps}>
@@ -157,10 +165,17 @@ const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
             <Join separator={<Spacer x={2} />}>
               {times(2 + randomValue * 10).map((index) => (
                 <Flex key={index}>
-                  <SkeletonBox
-                    height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-                    width={ARTWORK_RAIL_IMAGE_WIDTH + 100}
-                  />
+                  {enableArtworkRailRedesignImageAspectRatio ? (
+                    <SkeletonBox
+                      height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                      width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+                    />
+                  ) : (
+                    <SkeletonBox
+                      height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                      width={ARTWORK_RAIL_IMAGE_WIDTH}
+                    />
+                  )}
                   <Spacer y={2} />
                   <SkeletonText>Andy Warhol</SkeletonText>
                   <SkeletonText>A creative name for a work</SkeletonText>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -150,7 +150,7 @@ const homeViewSectionArtworksQuery = graphql`
 
 const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
   const randomValue = useMemoizedRandom()
-  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+  const enableArtworkRailRedesignImageAspectRatio = useFeatureFlag(
     "AREnableArtworkRailRedesignImageAspectRatio"
   )
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -14,7 +14,7 @@ import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.gr
 import { HomeViewSectionFeaturedCollectionQuery } from "__generated__/HomeViewSectionFeaturedCollectionQuery.graphql"
 import { HomeViewSectionFeaturedCollection_section$key } from "__generated__/HomeViewSectionFeaturedCollection_section.graphql"
 import { ARTWORK_RAIL_IMAGE_WIDTH, ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
-import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
+import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
@@ -152,6 +152,7 @@ const fragment = graphql`
 `
 
 const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => {
+  // here adjust placeholder
   return (
     <Skeleton>
       <SkeletonBox>
@@ -172,7 +173,7 @@ const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => 
           <Join separator={<Spacer x="15px" />}>
             <Flex>
               <SkeletonBox
-                height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
                 width={ARTWORK_RAIL_IMAGE_WIDTH}
               />
               <Spacer y={2} />

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -14,12 +14,17 @@ import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.gr
 import { HomeViewSectionFeaturedCollectionQuery } from "__generated__/HomeViewSectionFeaturedCollectionQuery.graphql"
 import { HomeViewSectionFeaturedCollection_section$key } from "__generated__/HomeViewSectionFeaturedCollection_section.graphql"
 import { ARTWORK_RAIL_IMAGE_WIDTH, ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
+import {
+  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+} from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/LegacyArtworkRailCardImage"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewTracking } from "app/Scenes/HomeView/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { TouchableOpacity, useWindowDimensions } from "react-native"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
@@ -152,7 +157,10 @@ const fragment = graphql`
 `
 
 const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => {
-  // here adjust placeholder
+  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+    "AREnableArtworkRailRedesignImageAspectRatio"
+  )
+
   return (
     <Skeleton>
       <SkeletonBox>
@@ -172,10 +180,17 @@ const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => 
         <Flex flexDirection="row">
           <Join separator={<Spacer x="15px" />}>
             <Flex>
-              <SkeletonBox
-                height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-                width={ARTWORK_RAIL_IMAGE_WIDTH}
-              />
+              {enableArtworkRailRedesignImageAspectRatio ? (
+                <SkeletonBox
+                  height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                  width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+                />
+              ) : (
+                <SkeletonBox
+                  height={LEGACY_ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
+                  width={ARTWORK_RAIL_IMAGE_WIDTH}
+                />
+              )}
               <Spacer y={2} />
               <SkeletonText>Andy Warhol</SkeletonText>
               <SkeletonText>A creative name for a work</SkeletonText>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -157,7 +157,7 @@ const fragment = graphql`
 `
 
 const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => {
-  const enableArtworkRailRedesignImageAspectRatio = !useFeatureFlag(
+  const enableArtworkRailRedesignImageAspectRatio = useFeatureFlag(
     "AREnableArtworkRailRedesignImageAspectRatio"
   )
 


### PR DESCRIPTION
This PR resolves [ONYX-1285] <!-- eg [PROJECT-XXXX] -->

### Description
<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Implement a new Artwork Rail Card design (image only)
The artwork card within a rail should have 
- a consistent height of 215px
- a minimum width of 140px
- a maximum width of 340px
- If the image is thinner than the minimum width, a grey Black05 background is added. This should have a 10px padding at the top and bottom. 
- If the image is wider than the maximum width, a grey Black05 background is added. This should have a 10px padding on the left and right

| wide artwork | tall artwork | updated image skeleton New Home | updated image skeleton Old Home | outdated image skeleton Old Home |
| --- | --- | --- | --- | --- |
| ![Simulator Screenshot - iPhone 15 Plus - 2024-09-27 at 15 28 53](https://github.com/user-attachments/assets/0234cbb8-c49a-4741-85d1-4a890dce711d) | ![Simulator Screenshot - iPhone 15 Plus - 2024-09-27 at 15 29 50](https://github.com/user-attachments/assets/81c1a978-7a4a-406b-88e8-77fab619e9fc) | ![Simulator Screenshot - iPhone 15 Plus - 2024-09-27 at 14 48 34](https://github.com/user-attachments/assets/feba6902-5848-4a45-92ef-1fdde7fc0027) | ![Simulator Screenshot - iPhone 15 Plus - 2024-09-27 at 14 35 09](https://github.com/user-attachments/assets/a24b1da3-2662-4e22-82c5-ffe98a7fc311) | ![Simulator Screenshot - iPhone 15 Plus - 2024-09-26 at 13 17 53](https://github.com/user-attachments/assets/b8cd869d-644b-4d6b-9156-09f176a53e62) |



### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- change of the image size dimensions of an artwork rail card (behind a ff AREnableArtworkRailRedesignImageAspectRatio)- daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1285]: https://artsyproduct.atlassian.net/browse/ONYX-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ