### PR TITLE
fix: add save icons back

### DIFF
--- a/src/app/Scenes/Home/Components/ArtworkModuleRail.tsx
+++ b/src/app/Scenes/Home/Components/ArtworkModuleRail.tsx
@@ -135,6 +135,7 @@ const ArtworkModuleRail: React.FC<ArtworkModuleRailProps & RailScrollProps> = ({
           navigate(artwork.href)
         }}
         onMorePress={handlePressMore}
+        showSaveIcon
       />
     </Flex>
   )

--- a/src/app/Scenes/Home/Components/ArtworkRecommendationsRail.tsx
+++ b/src/app/Scenes/Home/Components/ArtworkRecommendationsRail.tsx
@@ -86,6 +86,7 @@ export const ArtworkRecommendationsRail: React.FC<
           onMorePress={() => handleMorePress("viewAll")}
           onViewableItemsChanged={onViewableItemsChanged}
           viewabilityConfig={viewabilityConfig}
+          showSaveIcon
         />
       </View>
     </Flex>

--- a/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
+++ b/src/app/Scenes/Home/Components/MarketingCollectionRail.tsx
@@ -110,6 +110,7 @@ export const MarketingCollectionRail: React.FC<MarketingCollectionRailProps> = m
           onMorePress={handleMorePress}
           hideCuratorsPickSignal
           hideIncreasedInterestSignal
+          showSaveIcon
         />
       </Flex>
     )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Addresses [Notion card](https://www.notion.so/artsy/Artwork-cards-don-t-have-heart-icon-10ecab0764a0807cb35fd5f10a699578?pvs=4)

Addressed in this PR: [chore(ONYX-1290): Remove artwork the rail size option & use large artwork rails everywhere](https://github.com/artsy/eigen/pull/10758)

In the `<LargeArtworkRail />` component `showSaveIcon` value defaults to `true`. On the `<ArtworkRail />` it defaults to `false`. If we want to show `showSaveIcon` on the `<ArtworkRail />` component we need to add it to the properties

https://github.com/artsy/eigen/pull/10758/files#diff-39b21dfbe8319ae394ce4112df93df27b7c99da48018d654b7540c4c7d89e669L23
### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: add save icons back - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
