### PR TITLE
feat(DIA-896): add an auth model method to identify email addresses

### DIFF
--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -156,9 +156,9 @@ describe("ArtsyWebViewPage", () => {
     it("on iOS", () => {
       const tree = render()
       expect(webViewProps(tree).userAgent).toBe(
-        `Artsy-Mobile ios Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
+        `Artsy-Mobile ios some-system-name/some-system-version Artsy-Mobile/${
           appJson().version
-        }`
+        } Eigen/some-build-number/${appJson().version}`
       )
     })
 
@@ -168,9 +168,9 @@ describe("ArtsyWebViewPage", () => {
       const source = webViewProps(tree).source as any
       expect(source).toHaveProperty("headers")
       expect(source?.headers["User-Agent"]).toBe(
-        `Artsy-Mobile android Artsy-Mobile/${appJson().version} Eigen/some-build-number/${
+        `Artsy-Mobile android some-system-name/some-system-version Artsy-Mobile/${
           appJson().version
-        }`
+        } Eigen/some-build-number/${appJson().version}`
       )
     })
   })

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -839,17 +839,23 @@ export const getAuthModel = (): AuthModel => ({
     actions.setSessionState({ isUserIdentified: true })
   }),
   verifyUser: thunk(async (actions, { email, recaptchaToken }) => {
-    const result = await actions.gravityUnauthenticatedRequest({
-      path: `/api/v1/user/identify`,
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: {
-        email,
-        recaptcha_token: recaptchaToken,
-      },
-    })
+    let result: Response
+
+    try {
+      result = await actions.gravityUnauthenticatedRequest({
+        path: `/api/v1/user/identify`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          email,
+          recaptcha_token: recaptchaToken,
+        },
+      })
+    } catch (error) {
+      return "something_went_wrong"
+    }
 
     if (result.status !== 201) {
       return "something_went_wrong"

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -115,7 +115,7 @@ export function getCurrentEmissionState() {
   // `getUserAgentSync` breaks the Chrome Debugger, so we use a string instead.
   const userAgent = `${
     __DEV__ ? "Artsy-Mobile " + Platform.OS : DeviceInfo.getUserAgentSync()
-  } Artsy-Mobile/${version} Eigen/${DeviceInfo.getBuildNumber()}/${version}`
+  } ${DeviceInfo.getSystemName()}/${DeviceInfo.getSystemVersion()} Artsy-Mobile/${version} Eigen/${DeviceInfo.getBuildNumber()}/${version}`
 
   const data: GlobalStoreModel["native"]["sessionState"] = {
     authenticationToken: state?.auth.userAccessToken || "",

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -880,4 +880,48 @@ describe("AuthModel", () => {
       )
     })
   })
+
+  describe("verifyUser", () => {
+    beforeEach(async () => {
+      mockFetchJsonOnce({
+        xapp_token: "my-special-token",
+        expires_in: "never",
+      })
+      await GlobalStore.actions.auth.getXAppToken()
+      mockFetch.mockClear()
+    })
+
+    it('returns "user_exists" if the user exists', async () => {
+      mockFetchJsonOnce({ exists: true }, 201)
+
+      const result = await GlobalStore.actions.auth.verifyUser({
+        email: "email",
+        recaptchaToken: "token",
+      })
+
+      expect(result).toBe("user_exists")
+    })
+
+    it('returns "user_does_not_exist" if the user does not exist', async () => {
+      mockFetchJsonOnce({ exists: false }, 201)
+
+      const result = await GlobalStore.actions.auth.verifyUser({
+        email: "email",
+        recaptchaToken: "token",
+      })
+
+      expect(result).toBe("user_does_not_exist")
+    })
+
+    it('returns "something_went_wrong" if the request fails', async () => {
+      mockFetchJsonOnce({ error: "bad times" }, 500)
+
+      const result = await GlobalStore.actions.auth.verifyUser({
+        email: "email",
+        recaptchaToken: "token",
+      })
+
+      expect(result).toBe("something_went_wrong")
+    })
+  })
 })

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -155,6 +155,8 @@ jest.mock("react-native-share", () => ({
 
 jest.mock("react-native-device-info", () => ({
   getBuildNumber: () => "some-build-number",
+  getSystemName: () => "some-system-name",
+  getSystemVersion: () => "some-system-version",
   getVersion: jest.fn(),
   getModel: () => "testDevice",
   getUserAgentSync: jest.fn(),


### PR DESCRIPTION
This PR resolves [DIA-896] by adding a new `verifyUser` method to the `AuthModel` that can be used to check whether an email address belongs to an existing user or not.

It is a companion to artsy/gravity#18193

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Added more device information to user agent - iskounen

</details>



[DIA-896]: https://artsyproduct.atlassian.net/browse/DIA-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ