### PR TITLE
fix: do not display urgency signals on the HomeViewSectionFeaturedCollection rail

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -109,9 +109,11 @@ export const HomeViewSectionFeaturedCollection: React.FC<
           dark
           showPartnerName
           artworks={artworks}
-          showSaveIcon
           onPress={handleOnArtworkPress}
           onMorePress={onSectionViewAll}
+          hideCuratorsPickSignal
+          hideIncreasedInterestSignal
+          showSaveIcon
         />
       </Flex>
 


### PR DESCRIPTION
This PR resolves Notion tickets: [1](https://www.notion.so/artsy/Urgency-Signals-displayed-across-the-HomeView-Curators-Pick-Increased-Interest-I-haven-t-teste-10ecab0764a080cebb5cc39ac48c2fd6?pvs=4) and [2](https://www.notion.so/artsy/Feels-redundant-that-the-Curators-Pick-signals-show-up-on-all-artworks-under-the-Curator-s-Picks-10ecab0764a0809faa9de1ac8329e664?pvs=4)
### Description

Do not display urgency signals on the HomeViewSectionFeaturedCollection rail - we missed two props when implementing the Rail on the new Home View: `hideCuratorsPickSignal` and `hideIncreasedInterestSignal`

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
| Before | After | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/b5e9a0dc-3307-4fa3-aae6-0285c77300d4) | ![image](https://github.com/user-attachments/assets/29244c6b-6724-4013-87b0-eaec44bf1e78) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- (HomeView) Do not display urgency signals on the HomeViewSectionFeaturedCollection rail - daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
