### PR TITLE
fix(HomeView): ensure consistent highlight opacity for articles rail

### DIFF
--- a/src/app/Components/ArticleCard.tests.tsx
+++ b/src/app/Components/ArticleCard.tests.tsx
@@ -1,5 +1,5 @@
-import { Touchable } from "@artsy/palette-mobile"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { ArticleCard } from "./ArticleCard"
 
 it("renders without throwing an error", () => {
@@ -13,7 +13,9 @@ it("renders without throwing an error", () => {
     },
   }
 
-  const tree = renderWithWrappersLEGACY(<ArticleCard article={article as any} onPress={onPress} />)
-  tree.root.findAllByType(Touchable)[0].props.onPress()
+  renderWithWrappers(<ArticleCard article={article as any} onPress={onPress} />)
+
+  fireEvent(screen.getByTestId("article-card"), "press")
+
   expect(onPress).toHaveBeenCalled()
 })

--- a/src/app/Components/ArticleCard.tests.tsx
+++ b/src/app/Components/ArticleCard.tests.tsx
@@ -1,5 +1,5 @@
+import { Touchable } from "@artsy/palette-mobile"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
-import { TouchableWithoutFeedback } from "react-native"
 import { ArticleCard } from "./ArticleCard"
 
 it("renders without throwing an error", () => {
@@ -14,6 +14,6 @@ it("renders without throwing an error", () => {
   }
 
   const tree = renderWithWrappersLEGACY(<ArticleCard article={article as any} onPress={onPress} />)
-  tree.root.findAllByType(TouchableWithoutFeedback)[0].props.onPress()
+  tree.root.findAllByType(Touchable)[0].props.onPress()
   expect(onPress).toHaveBeenCalled()
 })

--- a/src/app/Components/ArticleCard.tsx
+++ b/src/app/Components/ArticleCard.tsx
@@ -1,15 +1,9 @@
-import { Spacer, Flex, useTheme, Text } from "@artsy/palette-mobile"
+import { Spacer, Flex, useTheme, Text, Touchable } from "@artsy/palette-mobile"
 import { ArticleCard_article$data } from "__generated__/ArticleCard_article.graphql"
 import { OpaqueImageView } from "app/Components/OpaqueImageView2"
 import { navigate } from "app/system/navigation/navigate"
 import { DateTime } from "luxon"
-import {
-  GestureResponderEvent,
-  TouchableWithoutFeedback,
-  useWindowDimensions,
-  View,
-  ViewProps,
-} from "react-native"
+import { GestureResponderEvent, useWindowDimensions, View, ViewProps } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
 export const ARTICLE_CARD_IMAGE_WIDTH = 295
@@ -36,7 +30,7 @@ export const ArticleCard: React.FC<ArticleCardProps> = ({ article, onPress, isFl
 
   return (
     <Flex width={isFluid ? "100%" : ARTICLE_CARD_IMAGE_WIDTH}>
-      <TouchableWithoutFeedback onPress={onTap} testID="article-card">
+      <Touchable onPress={onTap} testID="article-card">
         <Flex width={isFluid ? "100%" : ARTICLE_CARD_IMAGE_WIDTH} overflow="hidden">
           {!!imageURL &&
             (isFluid ? (
@@ -74,7 +68,7 @@ export const ArticleCard: React.FC<ArticleCardProps> = ({ article, onPress, isFl
             </Text>
           )}
         </Flex>
-      </TouchableWithoutFeedback>
+      </Touchable>
     </Flex>
   )
 }


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/Artsy-Editorial-rail-seems-to-be-the-only-one-whose-items-don-t-show-the-touchable-highlight-effect--10ecab0764a080d18fceee049b852ea7

### Description

Fixes a minor inconsistency that was present in both old and new home screens — the article rail was the only one whose card didn't have a touchable opacity highlight:

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/98f22760-815a-4b0e-afa9-879ec0003f4d" /> | <video src="https://github.com/user-attachments/assets/85b59b77-6a56-48ad-a9d5-ebee8734527f" /> | 




### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Ensure consistent touchable highlight for articles rail — Roop

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
