### PR TITLE
fix: fetch all home view sections at once to avoid placeholders while scrolling

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -24,7 +24,7 @@ import { Suspense, useCallback, useEffect, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
-export const NUMBER_OF_SECTIONS_TO_LOAD = 5
+export const NUMBER_OF_SECTIONS_TO_LOAD = 30
 // Hard coding the value here because 30px is not a valid value for the spacing unit
 // and we need it to be consistent with 60px spacing between sections
 export const HOME_VIEW_SECTIONS_SEPARATOR_HEIGHT = "30px"


### PR DESCRIPTION
### Description

We received feedback that some sections do not load in time. This issue is most noticeable while scrolling (even when scrolling slowly). The reason for this is that we fetch new sections as we scroll, and it takes time to retrieve their data. One idea that was discussed during the post-QA session with the team was to fetch more sections at once (currently, we fetch five).

The Home view screen is rendered in two steps. In the first step, we fetch a small amount of data – only section titles and __typenames. This information is needed to begin rendering the sections.

```graphql
query {
  homeView {
    sectionsConnection(first: 20) {
      edges {
        node {
          __typename
          internalID
          component {
            title
            type
          }
        }
      }
    }
  }
}
```

After the sections are fetched from the backend, each section renders a query renderer component, which requests its own data.

The first step is quite fast. I haven’t noticed a significant difference between fetching 5 sections and 20. However, it is important to note that this could change – currently, sections are hardcoded in Metaphysics, but in the future, we may want to resolve them dynamically, which could make the fetch operation slower.

Small before/after demo – notice that there are no visible placeholders after the initial render in the ‘after’ video.

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/953bcda0-a283-4e39-8db3-944146da9e20" /> 
 | <video src="https://github.com/user-attachments/assets/52547e88-7476-4dcc-ab87-60935d08a246" /> |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
