### PR TITLE
fix: debounce push analytics call to avoid double tracking 

### DIFF
--- a/src/app/utils/PushNotification.ts
+++ b/src/app/utils/PushNotification.ts
@@ -185,13 +185,10 @@ export const handleReceivedNotification = (
     const now = Date.now()
     // track notification tapped event only in android
     // ios handles it in the native side
-    if (Platform.OS === "android") {
-      // debounce events to avoid double tracking
-      // once we resolve the underlying issue with double handleReceivedNotification calls we can remove
-      if (now - lastEventTimestamp < DEBOUNCE_THRESHOLD) {
-        return
-      }
+    // debounce events to avoid double tracking
+    // once we resolve the underlying issue with double handleReceivedNotification calls we can remove
 
+    if (Platform.OS === "android" && now - lastEventTimestamp > DEBOUNCE_THRESHOLD) {
       lastEventTimestamp = now
 
       SegmentTrackingProvider.postEvent({


### PR DESCRIPTION
This PR resolves [PHIRE-1203] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This avoids tracking push calls 2x. In some scenarios both our onInitialNotification and push notification configuration call both call handlePushNotification resulting in 2x analytics calls and probably other bugginess. This is a bandaid fix to debounce the analytics call. 

This revealed a couple problems:
- our navigation ready check is unreliable at least on Android, I believe it is because main nav is ready but not individual tabs, this is another motivation to refactor our nav code, the 2x push calls unintentionally makes push nav more reliable but it is flaky still
- our push integration is double handling push sometimes which should be fixed but I avoided because it made push nav less reliable


#### Before

https://github.com/user-attachments/assets/3f5c9365-d357-416a-b326-6d5a323ae2b6


#### After

https://github.com/user-attachments/assets/954111cd-d92b-4dd0-a65f-83008b1cf9f3



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- 

#### Dev changes

- fix double tracking push tapped calls - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1203]: https://artsyproduct.atlassian.net/browse/PHIRE-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ