### PR TITLE
fix(home view): status bar safe area

### DIFF
--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -1,7 +1,6 @@
 import { ArtsyLogoBlackIcon, Flex, Box, useSpace } from "@artsy/palette-mobile"
 import { AlphaVersionIndicator } from "app/Scenes/HomeView/Components/AlphaVersionIndicator"
 import { GlobalStore } from "app/store/GlobalStore"
-import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
@@ -9,11 +8,10 @@ export const HomeHeader: React.FC = () => {
     (state) => state.bottomTabs.hasUnseenNotifications
   )
 
-  const { top } = useSafeAreaInsets()
   const space = useSpace()
 
   return (
-    <Box style={{ paddingTop: space(2) + top, paddingBottom: space(2) }}>
+    <Box style={{ paddingTop: space(2), paddingBottom: space(2) }}>
       <Flex flexDirection="row" px={2} justifyContent="space-between" alignItems="center">
         <Box flex={1}>
           <AlphaVersionIndicator />

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -125,7 +125,7 @@ export const HomeView: React.FC = () => {
   }
 
   return (
-    <Screen safeArea={false}>
+    <Screen safeArea={true}>
       <Screen.Body fullwidth>
         <FlatList
           ref={flashlistRef}
@@ -154,7 +154,7 @@ export const HomeView: React.FC = () => {
 const HomeViewScreenPlaceholder: React.FC = () => {
   return (
     <ProvidePlaceholderContext>
-      <Screen safeArea={false}>
+      <Screen safeArea={true}>
         <Screen.Body fullwidth>
           <Flex testID="new-home-view-skeleton">
             <HomeHeader />


### PR DESCRIPTION
This PR resolves [ONYX-1347]

### Description

We noticed that the safe area wasn't in use on the new home view Screen component, thus allowing for content to appear behind the status bar:

<img width="200" src="https://github.com/user-attachments/assets/aa6d1f91-259c-4de3-b9ab-432a0cd3a643" />

---

This PR toggles the safe area on, and adjusts the placeholder accordingly:


| Android | iOS |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/15b32ebf-def0-46d2-a097-c4f18b808d20" /> | <video src="https://github.com/user-attachments/assets/76eba366-ffd1-4566-9107-93bd531fae05" /> | 








### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Respect safe area top inset on new home view — Roop

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1347]: https://artsyproduct.atlassian.net/browse/ONYX-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ