### PR TITLE
refactor(auth2): More smoothing out of auth screens 

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
@@ -55,7 +55,7 @@ export const MyCollectionArtworkFormArtist: React.FC<
   }
 
   const handleBack = () => {
-    // TOOD: The state doesn't need to be stored in the global store
+    // TODO: The state doesn't need to be stored in the global store
     GlobalStore.actions.myCollection.artwork.resetForm()
     goBack()
   }

--- a/src/app/Scenes/Onboarding/Auth2/AuthContext.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/AuthContext.tsx
@@ -2,8 +2,7 @@ import { OnboardingWebViewRoute } from "app/Scenes/Onboarding/OnboardingWebView"
 import { action, Action, createContextStore } from "easy-peasy"
 
 export type AuthScreens = {
-  WelcomeStep: undefined
-  LoginEmailStep: undefined
+  LoginWelcomeStep: undefined
   LoginPasswordStep: { email: string }
   LoginOTPStep: { otpMode: "standard" | "on_demand"; email: string; password: string }
   ForgotPasswordStep: { requestedPasswordReset: boolean } | undefined
@@ -29,7 +28,7 @@ interface AuthContextModel {
 
 export const AuthContext = createContextStore<AuthContextModel>({
   isMounted: false,
-  currentScreen: { name: "WelcomeStep" },
+  currentScreen: { name: "LoginWelcomeStep" },
   previousScreens: [],
   isModalExpanded: false,
 

--- a/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
@@ -5,11 +5,12 @@ import { LoginPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/LoginPassw
 import { SignUpNameStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep"
 import { SignUpPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep"
 import { WelcomeStep } from "app/Scenes/Onboarding/Auth2/scenes/WelcomeStep"
+import { ScrollView } from "react-native-gesture-handler"
 
 export const AuthScenes: React.FC = () => {
   return (
     <>
-      <>
+      <ScrollView keyboardShouldPersistTaps="always" scrollEnabled={false}>
         <AuthScreen name="WelcomeStep">
           <WelcomeStep />
         </AuthScreen>
@@ -33,7 +34,7 @@ export const AuthScenes: React.FC = () => {
         <AuthScreen name="SignUpPasswordStep">
           <SignUpPasswordStep />
         </AuthScreen>
-      </>
+      </ScrollView>
     </>
   )
 }

--- a/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
@@ -2,17 +2,17 @@ import { AuthScreen } from "app/Scenes/Onboarding/Auth2/components/AuthScreen"
 import { ForgotPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep"
 import { LoginOTPStep } from "app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep"
 import { LoginPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep"
+import { LoginWelcomeStep } from "app/Scenes/Onboarding/Auth2/scenes/LoginWelcomeStep"
 import { SignUpNameStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep"
 import { SignUpPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep"
-import { WelcomeStep } from "app/Scenes/Onboarding/Auth2/scenes/WelcomeStep"
 import { ScrollView } from "react-native-gesture-handler"
 
 export const AuthScenes: React.FC = () => {
   return (
     <>
       <ScrollView keyboardShouldPersistTaps="always" scrollEnabled={false}>
-        <AuthScreen name="WelcomeStep">
-          <WelcomeStep />
+        <AuthScreen name="LoginWelcomeStep">
+          <LoginWelcomeStep />
         </AuthScreen>
 
         <AuthScreen name="LoginPasswordStep">

--- a/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/AuthScenes.tsx
@@ -5,12 +5,11 @@ import { LoginPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/LoginPassw
 import { SignUpNameStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep"
 import { SignUpPasswordStep } from "app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep"
 import { WelcomeStep } from "app/Scenes/Onboarding/Auth2/scenes/WelcomeStep"
-import { ScrollView } from "react-native-gesture-handler"
 
 export const AuthScenes: React.FC = () => {
   return (
     <>
-      <ScrollView keyboardShouldPersistTaps="always">
+      <>
         <AuthScreen name="WelcomeStep">
           <WelcomeStep />
         </AuthScreen>
@@ -34,7 +33,7 @@ export const AuthScenes: React.FC = () => {
         <AuthScreen name="SignUpPasswordStep">
           <SignUpPasswordStep />
         </AuthScreen>
-      </ScrollView>
+      </>
     </>
   )
 }

--- a/src/app/Scenes/Onboarding/Auth2/__tests__/AuthApp.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/__tests__/AuthApp.test.tsx
@@ -1,0 +1,5 @@
+describe("AuthApp", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/__tests__/AuthContext.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/__tests__/AuthContext.test.tsx
@@ -1,0 +1,5 @@
+describe("AuthContext", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/__tests__/AuthScenes.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/__tests__/AuthScenes.test.tsx
@@ -1,0 +1,5 @@
+describe("AuthScenes", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/components/AuthModal.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/AuthModal.tsx
@@ -5,7 +5,7 @@ import { Dimensions, KeyboardAvoidingView, Platform } from "react-native"
 import { Easing } from "react-native-reanimated"
 
 const HEIGHT = {
-  WelcomeStep: 320,
+  LoginWelcomeStep: 320,
   LoginEmailStep: 320,
   LoginPasswordStep: 320,
   ForgotPasswordStep: 320,
@@ -25,7 +25,7 @@ export const AuthModal: React.FC = ({ children }) => {
 
   const height = (() => {
     if (isModalExpanded) {
-      return HEIGHT[currentScreen?.name ?? "WelcomeStep"]
+      return HEIGHT[currentScreen?.name ?? "LoginWelcomeStep"]
     }
 
     return HEIGHT.collapsed

--- a/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
@@ -10,6 +10,8 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ children, name }) => {
   const { currentScreen } = AuthContext.useStoreState((state) => state)
   const isVisible = name === currentScreen?.name
 
+  if (!isVisible) return null
+
   return (
     <>
       <Flex display={isVisible ? "flex" : "none"}>{children}</Flex>

--- a/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
@@ -10,8 +10,6 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ children, name }) => {
   const { currentScreen } = AuthContext.useStoreState((state) => state)
   const isVisible = name === currentScreen?.name
 
-  // if (!isVisible) return null
-
   return (
     <>
       <Flex display={isVisible ? "flex" : "none"}>{children}</Flex>

--- a/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/AuthScreen.tsx
@@ -10,7 +10,7 @@ export const AuthScreen: React.FC<AuthScreenProps> = ({ children, name }) => {
   const { currentScreen } = AuthContext.useStoreState((state) => state)
   const isVisible = name === currentScreen?.name
 
-  if (!isVisible) return null
+  // if (!isVisible) return null
 
   return (
     <>

--- a/src/app/Scenes/Onboarding/Auth2/components/__tests__/AuthScreen.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/__tests__/AuthScreen.test.tsx
@@ -1,0 +1,5 @@
+describe("AuthScreen", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/hooks/__tests__/useAuthNavigation.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/hooks/__tests__/useAuthNavigation.test.tsx
@@ -1,0 +1,5 @@
+describe("useAuthNavigation", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus.tsx
@@ -14,7 +14,7 @@ export const useInputAutofocus = ({
   screenName,
   inputRef,
   enabled = true,
-  delay = 0,
+  delay = 100,
 }: UseInputAutofocusProps) => {
   const currentScreen = useAuthScreen()
 
@@ -27,10 +27,16 @@ export const useInputAutofocus = ({
       return
     }
 
+    let timeout: NodeJS.Timeout
+
     requestAnimationFrame(() => {
-      setTimeout(() => {
+      timeout = setTimeout(() => {
         inputRef.current?.focus()
       }, delay)
     })
+
+    return () => {
+      clearTimeout(timeout)
+    }
   }, [currentScreen])
 }

--- a/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
@@ -143,7 +143,7 @@ const ForgotPasswordStepForm: React.FC = () => {
 
           <Button
             variant="fillDark"
-            onPress={() => navigation.navigate({ name: "WelcomeStep" })}
+            onPress={() => navigation.navigate({ name: "LoginWelcomeStep" })}
             block
             haptic="impactMedium"
             testID="returnToLoginButton"

--- a/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
@@ -16,38 +16,37 @@ interface ForgotPasswordStepFormValues {
 export const ForgotPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
 
-  const initialValues: ForgotPasswordStepFormValues = { email: "" }
-
-  const validationSchema = Yup.object().shape({
-    email: Yup.string()
-      .email("Please provide a valid email address")
-      .required("Email field is required"),
-  })
-
-  const onSubmit = async (
-    { email }: ForgotPasswordStepFormValues,
-    { setErrors, resetForm }: FormikHelpers<ForgotPasswordStepFormValues>
-  ) => {
-    const res = await GlobalStore.actions.auth.forgotPassword({
-      email,
-    })
-
-    if (!res) {
-      setErrors({
-        email: "Couldn’t send reset password link. Please try again, or contact support@artsy.net",
-      })
-    } else {
-      navigation.navigate({
-        name: "ForgotPasswordStep",
-        params: { requestedPasswordReset: true },
-      })
-
-      resetForm()
-    }
-  }
-
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
+    <Formik
+      initialValues={{ email: "" }}
+      onSubmit={async (
+        { email }: ForgotPasswordStepFormValues,
+        { setErrors, resetForm }: FormikHelpers<ForgotPasswordStepFormValues>
+      ) => {
+        const res = await GlobalStore.actions.auth.forgotPassword({
+          email,
+        })
+
+        if (!res) {
+          setErrors({
+            email:
+              "Couldn’t send reset password link. Please try again, or contact support@artsy.net",
+          })
+        } else {
+          navigation.navigate({
+            name: "ForgotPasswordStep",
+            params: { requestedPasswordReset: true },
+          })
+
+          resetForm()
+        }
+      }}
+      validationSchema={Yup.object().shape({
+        email: Yup.string()
+          .email("Please provide a valid email address")
+          .required("Email field is required"),
+      })}
+    >
       <ForgotPasswordStepForm />
     </Formik>
   )

--- a/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
@@ -5,7 +5,7 @@ import {
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
 import { GlobalStore } from "app/store/GlobalStore"
-import { FormikProvider, useFormik, useFormikContext } from "formik"
+import { Formik, FormikHelpers, useFormikContext } from "formik"
 import { useRef } from "react"
 import * as Yup from "yup"
 
@@ -16,38 +16,40 @@ interface ForgotPasswordStepFormValues {
 export const ForgotPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
 
-  const formik = useFormik<ForgotPasswordStepFormValues>({
-    initialValues: { email: "" },
-    onSubmit: async ({ email }, { setErrors, resetForm }) => {
-      const res = await GlobalStore.actions.auth.forgotPassword({
-        email,
-      })
-      if (!res) {
-        // For security purposes, we are returning a generic error message
-        setErrors({
-          email:
-            "Couldn’t send reset password link. Please try again, or contact support@artsy.net",
-        })
-      } else {
-        navigation.navigate({
-          name: "ForgotPasswordStep",
-          params: { requestedPasswordReset: true },
-        })
+  const initialValues: ForgotPasswordStepFormValues = { email: "" }
 
-        resetForm()
-      }
-    },
-    validationSchema: Yup.object().shape({
-      email: Yup.string()
-        .email("Please provide a valid email address")
-        .required("Email field is required"),
-    }),
+  const validationSchema = Yup.object().shape({
+    email: Yup.string()
+      .email("Please provide a valid email address")
+      .required("Email field is required"),
   })
 
+  const onSubmit = async (
+    { email }: ForgotPasswordStepFormValues,
+    { setErrors, resetForm }: FormikHelpers<ForgotPasswordStepFormValues>
+  ) => {
+    const res = await GlobalStore.actions.auth.forgotPassword({
+      email,
+    })
+
+    if (!res) {
+      setErrors({
+        email: "Couldn’t send reset password link. Please try again, or contact support@artsy.net",
+      })
+    } else {
+      navigation.navigate({
+        name: "ForgotPasswordStep",
+        params: { requestedPasswordReset: true },
+      })
+
+      resetForm()
+    }
+  }
+
   return (
-    <FormikProvider value={formik}>
+    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
       <ForgotPasswordStepForm />
-    </FormikProvider>
+    </Formik>
   )
 }
 

--- a/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/ForgotPasswordStep.tsx
@@ -5,7 +5,7 @@ import {
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
 import { GlobalStore } from "app/store/GlobalStore"
-import { Formik, FormikHelpers, useFormikContext } from "formik"
+import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
 import * as Yup from "yup"
 
@@ -17,12 +17,9 @@ export const ForgotPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
 
   return (
-    <Formik
+    <Formik<ForgotPasswordStepFormValues>
       initialValues={{ email: "" }}
-      onSubmit={async (
-        { email }: ForgotPasswordStepFormValues,
-        { setErrors, resetForm }: FormikHelpers<ForgotPasswordStepFormValues>
-      ) => {
+      onSubmit={async ({ email }, { setErrors, resetForm }) => {
         const res = await GlobalStore.actions.auth.forgotPassword({
           email,
         })

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
@@ -26,37 +26,36 @@ interface LoginOTPStepFormValues {
 export const LoginOTPStep: React.FC = () => {
   const screen = useAuthScreen()
 
-  const initialValues: LoginOTPStepFormValues = { otp: "" }
-
-  const validationSchema = Yup.object().shape({
-    otp: Yup.string().required("This field is required"),
-  })
-
-  const onSubmit = async (
-    { otp }: LoginOTPStepFormValues,
-    { setErrors, resetForm }: FormikHelpers<LoginOTPStepFormValues>
-  ) => {
-    const res = await GlobalStore.actions.auth.signIn({
-      oauthProvider: "email",
-      oauthMode: "email",
-      email: screen.params?.email,
-      password: screen.params?.password,
-      otp: otp.trim(),
-    })
-
-    if (res === "invalid_otp") {
-      setErrors({ otp: "Invalid two-factor authentication code" })
-    } else if (res !== "success") {
-      setErrors({ otp: "Something went wrong. Please try again, or contact support@artsy.net" })
-    }
-
-    if (res === "success") {
-      resetForm()
-    }
-  }
-
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
+    <Formik
+      initialValues={{ otp: "" }}
+      validateOnChange={false}
+      validationSchema={Yup.object().shape({
+        otp: Yup.string().required("This field is required"),
+      })}
+      onSubmit={async (
+        { otp }: LoginOTPStepFormValues,
+        { setErrors, resetForm }: FormikHelpers<LoginOTPStepFormValues>
+      ) => {
+        const res = await GlobalStore.actions.auth.signIn({
+          oauthProvider: "email",
+          oauthMode: "email",
+          email: screen.params?.email,
+          password: screen.params?.password,
+          otp: otp.trim(),
+        })
+
+        if (res === "invalid_otp") {
+          setErrors({ otp: "Invalid two-factor authentication code" })
+        } else if (res !== "success") {
+          setErrors({ otp: "Something went wrong. Please try again, or contact support@artsy.net" })
+        }
+
+        if (res === "success") {
+          resetForm()
+        }
+      }}
+    >
       <LoginOTPStepForm />
     </Formik>
   )

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
@@ -14,9 +14,11 @@ import {
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
+import { waitForSubmit } from "app/Scenes/Onboarding/Auth2/utils/waitForSubmit"
 import { GlobalStore } from "app/store/GlobalStore"
 import { Formik, useFormikContext } from "formik"
 import { useRef, useState } from "react"
+import { Keyboard } from "react-native"
 import * as Yup from "yup"
 
 interface LoginOTPStepFormValues {
@@ -34,6 +36,8 @@ export const LoginOTPStep: React.FC = () => {
         otp: Yup.string().required("This field is required"),
       })}
       onSubmit={async ({ otp }, { setErrors, resetForm }) => {
+        Keyboard.dismiss()
+
         const res = await GlobalStore.actions.auth.signIn({
           oauthProvider: "email",
           oauthMode: "email",
@@ -41,6 +45,8 @@ export const LoginOTPStep: React.FC = () => {
           password: screen.params?.password,
           otp: otp.trim(),
         })
+
+        await waitForSubmit()
 
         if (res === "invalid_otp") {
           setErrors({ otp: "Invalid two-factor authentication code" })

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginOTPStep.tsx
@@ -15,7 +15,7 @@ import {
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
 import { GlobalStore } from "app/store/GlobalStore"
-import { Formik, FormikHelpers, useFormikContext } from "formik"
+import { Formik, useFormikContext } from "formik"
 import { useRef, useState } from "react"
 import * as Yup from "yup"
 
@@ -27,16 +27,13 @@ export const LoginOTPStep: React.FC = () => {
   const screen = useAuthScreen()
 
   return (
-    <Formik
+    <Formik<LoginOTPStepFormValues>
       initialValues={{ otp: "" }}
       validateOnChange={false}
       validationSchema={Yup.object().shape({
         otp: Yup.string().required("This field is required"),
       })}
-      onSubmit={async (
-        { otp }: LoginOTPStepFormValues,
-        { setErrors, resetForm }: FormikHelpers<LoginOTPStepFormValues>
-      ) => {
+      onSubmit={async ({ otp }, { setErrors, resetForm }) => {
         const res = await GlobalStore.actions.auth.signIn({
           oauthProvider: "email",
           oauthMode: "email",

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -15,7 +15,7 @@ import {
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
 import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
-import { Formik, FormikHelpers, useFormikContext } from "formik"
+import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
 import * as Yup from "yup"
 
@@ -28,16 +28,13 @@ export const LoginPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
 
   return (
-    <Formik
+    <Formik<LoginPasswordStepFormValues>
       initialValues={{ password: "" }}
       validateOnChange={false}
       validationSchema={Yup.object().shape({
         password: Yup.string().required("Password field is required"),
       })}
-      onSubmit={async (
-        { password }: LoginPasswordStepFormValues,
-        { setErrors, resetForm }: FormikHelpers<LoginPasswordStepFormValues>
-      ) => {
+      onSubmit={async ({ password }, { setErrors, resetForm }) => {
         const res = await GlobalStore.actions.auth.signIn({
           oauthProvider: "email",
           oauthMode: "email",

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -13,6 +13,7 @@ import {
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
+import { waitForSubmit } from "app/Scenes/Onboarding/Auth2/utils/waitForSubmit"
 import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
 import { Formik, useFormikContext } from "formik"
@@ -41,6 +42,8 @@ export const LoginPasswordStep: React.FC = () => {
           email: screen.params?.email,
           password,
         })
+
+        await waitForSubmit()
 
         if (res === "otp_missing") {
           navigation.navigate({

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -24,62 +24,61 @@ interface LoginPasswordStepFormValues {
 }
 
 export const LoginPasswordStep: React.FC = () => {
-  const navigation = useAuthNavigation()
   const screen = useAuthScreen()
-
-  const initialValues: LoginPasswordStepFormValues = { password: "" }
-
-  const validationSchema = Yup.object().shape({
-    password: Yup.string().required("Password field is required"),
-  })
-
-  const onSubmit = async (
-    { password }: LoginPasswordStepFormValues,
-    { setErrors, resetForm }: FormikHelpers<LoginPasswordStepFormValues>
-  ) => {
-    const res = await GlobalStore.actions.auth.signIn({
-      oauthProvider: "email",
-      oauthMode: "email",
-      email: screen.params?.email,
-      password,
-    })
-
-    if (res === "otp_missing") {
-      navigation.navigate({
-        name: "LoginOTPStep",
-        params: {
-          otpMode: "standard",
-          email: screen.params?.email,
-          password,
-        },
-      })
-    } else if (res === "on_demand_otp_missing") {
-      navigation.navigate({
-        name: "LoginOTPStep",
-        params: {
-          otpMode: "on_demand",
-          email: screen.params?.email,
-          password,
-        },
-      })
-    }
-
-    if (res === "auth_blocked") {
-      showBlockedAuthError("sign in")
-      return
-    }
-
-    if (res !== "success" && res !== "otp_missing" && res !== "on_demand_otp_missing") {
-      setErrors({ password: "Incorrect email or password" }) // pragma: allowlist secret
-    }
-
-    if (res === "success") {
-      resetForm()
-    }
-  }
+  const navigation = useAuthNavigation()
 
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
+    <Formik
+      initialValues={{ password: "" }}
+      validateOnChange={false}
+      validationSchema={Yup.object().shape({
+        password: Yup.string().required("Password field is required"),
+      })}
+      onSubmit={async (
+        { password }: LoginPasswordStepFormValues,
+        { setErrors, resetForm }: FormikHelpers<LoginPasswordStepFormValues>
+      ) => {
+        const res = await GlobalStore.actions.auth.signIn({
+          oauthProvider: "email",
+          oauthMode: "email",
+          email: screen.params?.email,
+          password,
+        })
+
+        if (res === "otp_missing") {
+          navigation.navigate({
+            name: "LoginOTPStep",
+            params: {
+              otpMode: "standard",
+              email: screen.params?.email,
+              password,
+            },
+          })
+        } else if (res === "on_demand_otp_missing") {
+          navigation.navigate({
+            name: "LoginOTPStep",
+            params: {
+              otpMode: "on_demand",
+              email: screen.params?.email,
+              password,
+            },
+          })
+        }
+
+        if (res === "auth_blocked") {
+          showBlockedAuthError("sign in")
+          return
+        }
+
+        if (res !== "success" && res !== "otp_missing" && res !== "on_demand_otp_missing") {
+          setErrors({ password: "Incorrect email or password" }) // pragma: allowlist secret
+        }
+
+        if (res === "success") {
+          resetForm()
+        }
+      }}
+    >
       <LoginPasswordStepForm />
     </Formik>
   )
@@ -107,7 +106,6 @@ const LoginPasswordStepForm: React.FC = () => {
   useInputAutofocus({
     screenName: "LoginPasswordStep",
     inputRef: passwordRef,
-    delay: 0,
   })
 
   const handleBackButtonPress = () => {

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -18,6 +18,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
 import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
+import { Keyboard } from "react-native"
 import * as Yup from "yup"
 
 interface LoginPasswordStepFormValues {
@@ -36,6 +37,8 @@ export const LoginPasswordStep: React.FC = () => {
         password: Yup.string().required("Password field is required"),
       })}
       onSubmit={async ({ password }, { setErrors, resetForm }) => {
+        Keyboard.dismiss()
+
         const res = await GlobalStore.actions.auth.signIn({
           oauthProvider: "email",
           oauthMode: "email",

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginWelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginWelcomeStep.tsx
@@ -19,7 +19,7 @@ import { navigate } from "app/system/navigation/navigate"
 import { osMajorVersion } from "app/utils/platformUtil"
 import { Formik, useFormikContext } from "formik"
 import React, { useRef, useState } from "react"
-import { Alert, Image, InteractionManager, Platform } from "react-native"
+import { Alert, Image, InteractionManager, Keyboard, Platform } from "react-native"
 import * as Yup from "yup"
 
 interface LoginEmailFormValues {
@@ -47,6 +47,8 @@ export const LoginWelcomeStep: React.FC = () => {
             .required("Email field is required"),
         })}
         onSubmit={async ({ email }, { resetForm }) => {
+          Keyboard.dismiss()
+
           // FIXME
           if (!token) {
             Alert.alert("Something went wrong. Please try again, or contact support@artsy.net")

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
@@ -24,48 +24,47 @@ interface SignUpNameStepFormValues {
 export const SignUpNameStep: React.FC = () => {
   const screen = useAuthScreen()
 
-  const initialValues: SignUpNameStepFormValues = {
-    name: "",
-    acceptedTerms: false,
-    agreedToReceiveEmails: false,
-  }
-
-  const validationSchema = Yup.object().shape({
-    name: Yup.string().trim().required("Full name field is required"),
-  })
-
-  const onSubmit = async (
-    { acceptedTerms, agreedToReceiveEmails, name }: SignUpNameStepFormValues,
-    { resetForm }: FormikHelpers<SignUpNameStepFormValues>
-  ) => {
-    if (!acceptedTerms) {
-      return
-    }
-
-    const res = await GlobalStore.actions.auth.signUp({
-      oauthProvider: "email",
-      oauthMode: "email",
-      email: screen.params?.email,
-      password: screen.params?.password,
-      name: name.trim(),
-      agreedToReceiveEmails,
-    })
-
-    if (!res.success) {
-      if (res.error === "blocked_attempt") {
-        showBlockedAuthError("sign up")
-      } else {
-        Alert.alert("Try again", res.message)
-      }
-    }
-
-    if (res.success) {
-      resetForm()
-    }
-  }
-
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
+    <Formik
+      initialValues={{
+        name: "",
+        acceptedTerms: false,
+        agreedToReceiveEmails: false,
+      }}
+      validateOnChange={false}
+      validationSchema={Yup.object().shape({
+        name: Yup.string().trim().required("Full name field is required"),
+      })}
+      onSubmit={async (
+        { acceptedTerms, agreedToReceiveEmails, name }: SignUpNameStepFormValues,
+        { resetForm }: FormikHelpers<SignUpNameStepFormValues>
+      ) => {
+        if (!acceptedTerms) {
+          return
+        }
+
+        const res = await GlobalStore.actions.auth.signUp({
+          oauthProvider: "email",
+          oauthMode: "email",
+          email: screen.params?.email,
+          password: screen.params?.password,
+          name: name.trim(),
+          agreedToReceiveEmails,
+        })
+
+        if (!res.success) {
+          if (res.error === "blocked_attempt") {
+            showBlockedAuthError("sign up")
+          } else {
+            Alert.alert("Try again", res.message)
+          }
+        }
+
+        if (res.success) {
+          resetForm()
+        }
+      }}
+    >
       <SignUpNameStepForm />
     </Formik>
   )

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
@@ -10,7 +10,7 @@ import { EmailSubscriptionCheckbox } from "app/Scenes/Onboarding/OnboardingCreat
 import { TermsOfServiceCheckbox } from "app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox"
 import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
-import { Formik, FormikHelpers, useFormikContext } from "formik"
+import { Formik, useFormikContext } from "formik"
 import React, { useRef, useState } from "react"
 import { Alert, Keyboard } from "react-native"
 import * as Yup from "yup"
@@ -25,7 +25,7 @@ export const SignUpNameStep: React.FC = () => {
   const screen = useAuthScreen()
 
   return (
-    <Formik
+    <Formik<SignUpNameStepFormValues>
       initialValues={{
         name: "",
         acceptedTerms: false,
@@ -35,11 +35,8 @@ export const SignUpNameStep: React.FC = () => {
       validationSchema={Yup.object().shape({
         name: Yup.string().trim().required("Full name field is required"),
       })}
-      onSubmit={async (
-        { acceptedTerms, agreedToReceiveEmails, name }: SignUpNameStepFormValues,
-        { resetForm }: FormikHelpers<SignUpNameStepFormValues>
-      ) => {
-        if (!acceptedTerms) {
+      onSubmit={async (values, { resetForm }) => {
+        if (!values.acceptedTerms) {
           return
         }
 
@@ -48,8 +45,8 @@ export const SignUpNameStep: React.FC = () => {
           oauthMode: "email",
           email: screen.params?.email,
           password: screen.params?.password,
-          name: name.trim(),
-          agreedToReceiveEmails,
+          name: values.name.trim(),
+          agreedToReceiveEmails: values.agreedToReceiveEmails,
         })
 
         if (!res.success) {
@@ -104,11 +101,14 @@ const SignUpNameStepForm: React.FC = () => {
         autoCorrect={false}
         blurOnSubmit={false}
         error={errors.name}
+        keyboardType="name-phone-pad"
         maxLength={128}
         placeholder="First and last name"
         placeholderTextColor={color("black30")}
         ref={nameRef}
         returnKeyType="done"
+        spellCheck={false}
+        textContentType="name"
         title="Full Name"
         value={values.name}
         onChangeText={(text) => {

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpNameStep.tsx
@@ -13,7 +13,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
 import { Formik, useFormikContext } from "formik"
 import React, { useRef, useState } from "react"
-import { Alert } from "react-native"
+import { Alert, Keyboard } from "react-native"
 import * as Yup from "yup"
 
 interface SignUpNameStepFormValues {
@@ -40,6 +40,8 @@ export const SignUpNameStep: React.FC = () => {
         if (!values.acceptedTerms) {
           return
         }
+
+        Keyboard.dismiss()
 
         const res = await GlobalStore.actions.auth.signUp({
           oauthProvider: "email",

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -4,6 +4,7 @@ import {
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
+import { waitForSubmit } from "app/Scenes/Onboarding/Auth2/utils/waitForSubmit"
 import { Formik, useFormikContext } from "formik"
 import React, { useRef } from "react"
 import * as Yup from "yup"
@@ -27,7 +28,9 @@ export const SignUpPasswordStep: React.FC = () => {
           .matches(/[0-9]/, "Your password should contain at least one digit")
           .required("Password field is required"),
       })}
-      onSubmit={({ password }, { resetForm }) => {
+      onSubmit={async ({ password }, { resetForm }) => {
+        await waitForSubmit()
+
         navigation.navigate({
           name: "SignUpNameStep",
           params: {
@@ -45,8 +48,16 @@ export const SignUpPasswordStep: React.FC = () => {
 }
 
 const SignUpPasswordStepForm: React.FC = () => {
-  const { errors, handleChange, handleSubmit, isValid, setErrors, values, resetForm } =
-    useFormikContext<SignUpPasswordStepFormValues>()
+  const {
+    errors,
+    handleChange,
+    handleSubmit,
+    isSubmitting,
+    isValid,
+    setErrors,
+    values,
+    resetForm,
+  } = useFormikContext<SignUpPasswordStepFormValues>()
 
   const navigation = useAuthNavigation()
   const { color } = useTheme()
@@ -74,7 +85,6 @@ const SignUpPasswordStepForm: React.FC = () => {
         autoCapitalize="none"
         autoComplete="password"
         autoCorrect={false}
-        blurOnSubmit={false}
         error={errors.password}
         placeholder="Password"
         placeholderTextColor={color("black30")}
@@ -98,7 +108,7 @@ const SignUpPasswordStepForm: React.FC = () => {
 
       <Spacer y={2} />
 
-      <Button block width={100} onPress={handleSubmit} disabled={!isValid}>
+      <Button block width={100} onPress={handleSubmit} disabled={!isValid} loading={isSubmitting}>
         Continue
       </Button>
     </Flex>

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -7,6 +7,7 @@ import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAut
 import { waitForSubmit } from "app/Scenes/Onboarding/Auth2/utils/waitForSubmit"
 import { Formik, useFormikContext } from "formik"
 import React, { useRef } from "react"
+import { Keyboard } from "react-native"
 import * as Yup from "yup"
 
 interface SignUpPasswordStepFormValues {
@@ -29,6 +30,8 @@ export const SignUpPasswordStep: React.FC = () => {
           .required("Password field is required"),
       })}
       onSubmit={async ({ password }, { resetForm }) => {
+        Keyboard.dismiss()
+
         await waitForSubmit()
 
         navigation.navigate({

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -4,7 +4,7 @@ import {
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
-import { Formik, FormikHelpers, useFormikContext } from "formik"
+import { Formik, useFormikContext } from "formik"
 import React, { useRef } from "react"
 import * as Yup from "yup"
 
@@ -17,7 +17,7 @@ export const SignUpPasswordStep: React.FC = () => {
   const screen = useAuthScreen()
 
   return (
-    <Formik
+    <Formik<SignUpPasswordStepFormValues>
       initialValues={{ password: "" }}
       validationSchema={Yup.object().shape({
         password: Yup.string()
@@ -27,10 +27,7 @@ export const SignUpPasswordStep: React.FC = () => {
           .matches(/[0-9]/, "Your password should contain at least one digit")
           .required("Password field is required"),
       })}
-      onSubmit={(
-        { password }: SignUpPasswordStepFormValues,
-        { resetForm }: FormikHelpers<SignUpPasswordStepFormValues>
-      ) => {
+      onSubmit={({ password }, { resetForm }) => {
         navigation.navigate({
           name: "SignUpNameStep",
           params: {
@@ -84,7 +81,7 @@ const SignUpPasswordStepForm: React.FC = () => {
         ref={passwordRef}
         returnKeyType="done"
         secureTextEntry
-        textContentType="password"
+        textContentType="none"
         title="Password"
         value={values.password}
         onChangeText={(text) => {

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -3,7 +3,7 @@ import {
   useAuthNavigation,
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
-import { FormikProvider, useFormik, useFormikContext } from "formik"
+import { Formik, FormikHelpers, useFormikContext } from "formik"
 import React from "react"
 import * as Yup from "yup"
 
@@ -15,33 +15,36 @@ export const SignUpPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
   const screen = useAuthScreen()
 
-  const formik = useFormik<SignUpPasswordStepFormValues>({
-    initialValues: { password: "" },
-    onSubmit: ({ password }, { resetForm }) => {
-      navigation.navigate({
-        name: "SignUpNameStep",
-        params: {
-          email: screen.params?.email,
-          password: password,
-        },
-      })
+  const initialValues: SignUpPasswordStepFormValues = { password: "" }
 
-      resetForm()
-    },
-    validationSchema: Yup.object().shape({
-      password: Yup.string()
-        .min(8, "Your password should be at least 8 characters")
-        .matches(/[A-Z]/, "Your password should contain at least one uppercase letter")
-        .matches(/[a-z]/, "Your password should contain at least one lowercase letter")
-        .matches(/[0-9]/, "Your password should contain at least one digit")
-        .required("Password field is required"),
-    }),
+  const validationSchema = Yup.object().shape({
+    password: Yup.string()
+      .min(8, "Your password should be at least 8 characters")
+      .matches(/[A-Z]/, "Your password should contain at least one uppercase letter")
+      .matches(/[a-z]/, "Your password should contain at least one lowercase letter")
+      .matches(/[0-9]/, "Your password should contain at least one digit")
+      .required("Password field is required"),
   })
 
+  const onSubmit = (
+    { password }: SignUpPasswordStepFormValues,
+    { resetForm }: FormikHelpers<SignUpPasswordStepFormValues>
+  ) => {
+    navigation.navigate({
+      name: "SignUpNameStep",
+      params: {
+        email: screen.params?.email,
+        password,
+      },
+    })
+
+    resetForm()
+  }
+
   return (
-    <FormikProvider value={formik}>
+    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
       <SignUpPasswordStepForm />
-    </FormikProvider>
+    </Formik>
   )
 }
 
@@ -50,7 +53,6 @@ const SignUpPasswordStepForm: React.FC = () => {
     useFormikContext<SignUpPasswordStepFormValues>()
 
   const navigation = useAuthNavigation()
-
   const { color } = useTheme()
 
   const handleBackButtonPress = () => {

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -3,8 +3,9 @@ import {
   useAuthNavigation,
   useAuthScreen,
 } from "app/Scenes/Onboarding/Auth2/hooks/useAuthNavigation"
+import { useInputAutofocus } from "app/Scenes/Onboarding/Auth2/hooks/useInputAutofocus"
 import { Formik, FormikHelpers, useFormikContext } from "formik"
-import React from "react"
+import React, { useRef } from "react"
 import * as Yup from "yup"
 
 interface SignUpPasswordStepFormValues {
@@ -15,34 +16,32 @@ export const SignUpPasswordStep: React.FC = () => {
   const navigation = useAuthNavigation()
   const screen = useAuthScreen()
 
-  const initialValues: SignUpPasswordStepFormValues = { password: "" }
-
-  const validationSchema = Yup.object().shape({
-    password: Yup.string()
-      .min(8, "Your password should be at least 8 characters")
-      .matches(/[A-Z]/, "Your password should contain at least one uppercase letter")
-      .matches(/[a-z]/, "Your password should contain at least one lowercase letter")
-      .matches(/[0-9]/, "Your password should contain at least one digit")
-      .required("Password field is required"),
-  })
-
-  const onSubmit = (
-    { password }: SignUpPasswordStepFormValues,
-    { resetForm }: FormikHelpers<SignUpPasswordStepFormValues>
-  ) => {
-    navigation.navigate({
-      name: "SignUpNameStep",
-      params: {
-        email: screen.params?.email,
-        password,
-      },
-    })
-
-    resetForm()
-  }
-
   return (
-    <Formik initialValues={initialValues} onSubmit={onSubmit} validationSchema={validationSchema}>
+    <Formik
+      initialValues={{ password: "" }}
+      validationSchema={Yup.object().shape({
+        password: Yup.string()
+          .min(8, "Your password should be at least 8 characters")
+          .matches(/[A-Z]/, "Your password should contain at least one uppercase letter")
+          .matches(/[a-z]/, "Your password should contain at least one lowercase letter")
+          .matches(/[0-9]/, "Your password should contain at least one digit")
+          .required("Password field is required"),
+      })}
+      onSubmit={(
+        { password }: SignUpPasswordStepFormValues,
+        { resetForm }: FormikHelpers<SignUpPasswordStepFormValues>
+      ) => {
+        navigation.navigate({
+          name: "SignUpNameStep",
+          params: {
+            email: screen.params?.email,
+            password,
+          },
+        })
+
+        resetForm()
+      }}
+    >
       <SignUpPasswordStepForm />
     </Formik>
   )
@@ -54,6 +53,12 @@ const SignUpPasswordStepForm: React.FC = () => {
 
   const navigation = useAuthNavigation()
   const { color } = useTheme()
+  const passwordRef = useRef<Input>(null)
+
+  useInputAutofocus({
+    screenName: "SignUpPasswordStep",
+    inputRef: passwordRef,
+  })
 
   const handleBackButtonPress = () => {
     navigation.goBack()
@@ -76,6 +81,7 @@ const SignUpPasswordStepForm: React.FC = () => {
         error={errors.password}
         placeholder="Password"
         placeholderTextColor={color("black30")}
+        ref={passwordRef}
         returnKeyType="done"
         secureTextEntry
         textContentType="password"

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/ForgotPasswordStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/ForgotPasswordStep.test.tsx
@@ -1,0 +1,5 @@
+describe("ForgotPasswordStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginOTPStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginOTPStep.test.tsx
@@ -1,0 +1,5 @@
+describe("LoginOTPStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginPasswordStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginPasswordStep.test.tsx
@@ -1,0 +1,5 @@
+describe("LoginPasswordStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginWelcomeStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/LoginWelcomeStep.test.tsx
@@ -1,0 +1,5 @@
+describe("LoginWelcomeStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/SignUpNameStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/SignUpNameStep.test.tsx
@@ -1,0 +1,5 @@
+describe("SignUpNameStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/SignUpPasswordStep.test.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/SignUpPasswordStep.test.tsx
@@ -1,0 +1,5 @@
+describe("SignUpPasswordStep", () => {
+  it("renders correctly", () => {
+    // TODO
+  })
+})

--- a/src/app/Scenes/Onboarding/Auth2/utils/waitForSubmit.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/utils/waitForSubmit.tsx
@@ -1,0 +1,6 @@
+/**
+ * Slight delay to smooth out keyboard transitions between submission steps
+ */
+export const waitForSubmit = async (delay = 1500) => {
+  await Promise.resolve((resolve: any) => setTimeout(resolve, delay))
+}

--- a/src/app/Scenes/Onboarding/Auth2/utils/waitForSubmit.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/utils/waitForSubmit.tsx
@@ -2,5 +2,5 @@
  * Slight delay to smooth out keyboard transitions between submission steps
  */
 export const waitForSubmit = async (delay = 1500) => {
-  await Promise.resolve((resolve: any) => setTimeout(resolve, delay))
+  return new Promise((resolve: any) => setTimeout(resolve, delay))
 }


### PR DESCRIPTION
### Description

This cleans things up a bit more:
- Avoid the use of `useFormik` hooks [per the docs](https://formik.org/docs/api/useFormik#use-cases-for-useformik), and instead rely on standard `<Formik>`, which has performance benefits 
- On submit, collapse the keyboard, wait, then show keyboard again when the next screen appears. This is pretty standard native UX for mult-step login flows, and the only way we can get around the UI jank involving the keyboard QuickType bar (suggestions), which **jumps** the modal, vs animating, as the quick type bar appears / disappears instantly. 

Also stubbed out test files for a future PR. 

@iskounen - this one is pretty uncontroversial so gonna merge to get a beta out before monday but happy to follow up on any comments 👍 

cc @artsy/diamond-devs 