### PR TITLE
chore: improvements to ModalStack rehydration logic

### DIFF
--- a/scripts/utils/flip-table
+++ b/scripts/utils/flip-table
@@ -51,6 +51,9 @@ rm -rf src/__generated__/*.graphql.ts
 echo 'Clear build artefacts (╯ರ ~ ರ）╯︵ ┻━┻'
 find dist/ ! -name '.gitkeep' -type f -exec rm -f {} +
 
+echo 'Setup Assets'
+yarn setup:artsy
+
 echo 'Reinstall dependencies ┬─┬ノ( º _ ºノ)'
 yarn install:all
 

--- a/src/app/Components/Modals/LoadingModal.tsx
+++ b/src/app/Components/Modals/LoadingModal.tsx
@@ -1,4 +1,5 @@
-import { Flex, Color, Spinner } from "@artsy/palette-mobile"
+import { Color, Flex, Spinner } from "@artsy/palette-mobile"
+import { ReactNode } from "react"
 import { Modal, ModalProps } from "react-native"
 
 interface LoadingModalProps {
@@ -24,12 +25,18 @@ const LoadingModal: React.FC<LoadingModalProps & ModalProps> = ({
   )
 }
 
-export const LoadingSpinner: React.FC<{ dark?: boolean }> = ({ dark = false }) => {
+export const LoadingSpinner: React.FC<{ dark?: boolean; children?: ReactNode }> = ({
+  dark = false,
+  children,
+}) => {
   const { backgroundColor, spinnerColor } = getColors(dark)
 
   return (
-    <Flex flex={1} alignItems="center" justifyContent="center" style={{ backgroundColor }}>
-      <Spinner color={spinnerColor} />
+    <Flex flex={1} justifyContent="center" style={{ backgroundColor }}>
+      <Flex alignItems="center">
+        <Spinner color={spinnerColor} size="large" />
+        {children}
+      </Flex>
     </Flex>
   )
 }

--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -10,7 +10,7 @@ import { Action, Middleware } from "redux"
 import logger from "redux-logger"
 import { version } from "./../../../app.json"
 import { getGlobalStoreModel, GlobalStoreModel, GlobalStoreState } from "./GlobalStoreModel"
-import { FeatureMap } from "./config/FeaturesModel"
+import { DevToggleMap, FeatureMap } from "./config/FeaturesModel"
 import { persistenceMiddleware, unpersist } from "./persistence"
 
 function createGlobalStore() {
@@ -68,7 +68,7 @@ export const __globalStoreTestUtils__ = __TEST__
       setProductionMode() {
         this.injectState({ devicePrefs: { environment: { env: "production" } } })
       },
-      injectFeatureFlags(options: Partial<FeatureMap>) {
+      injectFeatureFlags(options: Partial<FeatureMap> | Partial<DevToggleMap>) {
         this.injectState({ artsyPrefs: { features: { localOverrides: options } } })
       },
       getCurrentState: () => globalStoreInstance().getState(),

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -384,6 +384,10 @@ export const devToggles: { [key: string]: DevToggleDescriptor } = {
   DTEnableNewImageLabel: {
     description: "Show a label on new OpaqueImageView",
   },
+  DTDisableNavigationStateRehydration: {
+    description:
+      "Disable navigation state rehydration. This change only affects DEV builds. In release builds, navigation state is never rehydrated.",
+  },
 }
 
 export const isDevToggle = (name: FeatureName | DevToggleName): name is DevToggleName => {

--- a/src/app/system/navigation/ModalStack.tsx
+++ b/src/app/system/navigation/ModalStack.tsx
@@ -1,3 +1,4 @@
+import { Flex, Text } from "@artsy/palette-mobile"
 import { NavigationContainer, Route } from "@react-navigation/native"
 import {
   CardStyleInterpolators,
@@ -41,7 +42,17 @@ export const ModalStack: React.FC = ({ children }) => {
   const trackSiftAndroid = Platform.OS === "android" && enableAdditionalSiftAndroidTracking
 
   if (!isReady) {
-    return <LoadingSpinner />
+    return (
+      <LoadingSpinner>
+        {!!__DEV__ && (
+          <Flex px={2} mt={2}>
+            <Text color="devpurple" variant="xs" italic textAlign="center">
+              This spinner is only visible in DEV mode.{"\n"}
+            </Text>
+          </Flex>
+        )}
+      </LoadingSpinner>
+    )
   }
 
   return (

--- a/src/app/system/navigation/useReloadedDevNavigationState.ts
+++ b/src/app/system/navigation/useReloadedDevNavigationState.ts
@@ -15,9 +15,8 @@ export const useReloadedDevNavigationState = (key: string) => {
     "DTDisableNavigationStateRehydration"
   )
 
-  const isNavigationStateRehydrationEnabled =
-    // We only rehydrate navigation state in dev mode
-    !__DEV__ || !isNavigationStateRehydrationDisabledToggle
+  // We only rehydrate navigation state on dev builds and if the toggle is disabled
+  const isNavigationStateRehydrationEnabled = __DEV__ && !isNavigationStateRehydrationDisabledToggle
 
   const [isReady, setIsReady] = useState(isNavigationStateRehydrationEnabled ? false : true)
   const launchCount = ArtsyNativeModule.launchCount

--- a/src/app/system/navigation/useReloadedDevNavigationState.ts
+++ b/src/app/system/navigation/useReloadedDevNavigationState.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { NavigationState } from "@react-navigation/native"
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
+import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useEffect, useState } from "react"
 
 export const PREVIOUS_LAUNCH_COUNT_KEY = "previous-launch-count-key"
@@ -10,7 +11,15 @@ export const PREVIOUS_LAUNCH_COUNT_KEY = "previous-launch-count-key"
  * It will save the navigation state to AsyncStorage and reload it when the app is reloaded.
  */
 export const useReloadedDevNavigationState = (key: string) => {
-  const [isReady, setIsReady] = useState(__DEV__ ? false : true)
+  const isNavigationStateRehydrationDisabledToggle = useDevToggle(
+    "DTDisableNavigationStateRehydration"
+  )
+
+  const isNavigationStateRehydrationEnabled =
+    // We only rehydrate navigation state in dev mode
+    !__DEV__ || !isNavigationStateRehydrationDisabledToggle
+
+  const [isReady, setIsReady] = useState(isNavigationStateRehydrationEnabled ? false : true)
   const launchCount = ArtsyNativeModule.launchCount
   // TODO: This seems to be unreliable and return undefined in some cases
   // Look if should be removed in favor of the native module
@@ -20,7 +29,7 @@ export const useReloadedDevNavigationState = (key: string) => {
   const [initialState, setInitialState] = useState()
 
   useEffect(() => {
-    if (!__DEV__) {
+    if (!isNavigationStateRehydrationEnabled) {
       return
     }
 
@@ -54,14 +63,13 @@ export const useReloadedDevNavigationState = (key: string) => {
   }, [isReady])
 
   const saveSession = (state: NavigationState | undefined) => {
-    if (__DEV__) {
+    if (isNavigationStateRehydrationEnabled) {
       AsyncStorage.setItem(key, JSON.stringify(state))
     }
   }
 
   return {
-    // Double checking that this can only be false in dev and test
-    isReady: isReady || !__DEV__,
+    isReady: isReady,
     initialState,
     saveSession,
   }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR comes as a follow-up to https://github.com/artsy/eigen/pull/10189 and based on feedback [here](https://artsy.slack.com/archives/C07ANEV7RNV/p1728234779230509) (For Open source contributors; the spinner is quiet annoying and it's bad UX)
- Clarify that the spinner doesn't show up on release builds
- Add toggle to disable navigation state rehydration
- Flip table was missing an important command - `setup:artsy` - I added it.

___ **This is what you will see now instead of just a spinner - what do you think about it?** ___

<img src="https://github.com/user-attachments/assets/6cd5d952-d638-4b1e-8d10-27036fb16770" width="400"/>


**Second Thoughts**
Since the state is already hydrated on app start, maybe we can start saving the navigation state inside global store as well and have it ready for us 🤷. I can look at that at a future time 👀 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- improvements to ModalStack rehydration logic

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
