### PR TITLE
feat(DIA-898): use shared password field for sign-up and login [WIP]

### DIFF
--- a/src/app/Scenes/Onboarding/Auth2/components/PasswordInput.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/PasswordInput.tsx
@@ -1,0 +1,68 @@
+import { Input, useTheme } from "@artsy/palette-mobile"
+import { LoginPasswordStepFormValues } from "app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep"
+import { SignUpPasswordStepFormValues } from "app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep"
+import { FormikContextType, useFormikContext } from "formik"
+
+interface PasswordInputProps {
+  ref: React.RefObject<Input>
+}
+
+export const PasswordInput = <
+  T extends LoginPasswordStepFormValues | SignUpPasswordStepFormValues,
+>({
+  ref,
+}: PasswordInputProps) => {
+  const {
+    dirty,
+    errors,
+    handleChange,
+    handleSubmit,
+    setErrors,
+    touched,
+    validateForm,
+    values,
+  }: FormikContextType<T> = useFormikContext<T>()
+
+  const { color } = useTheme()
+
+  return (
+    <Input
+      autoCapitalize="none"
+      autoComplete="password"
+      autoCorrect={false}
+      blurOnSubmit={false}
+      error={
+        values.password.length > 0 || touched.password
+          ? (errors.password as string | undefined)
+          : undefined
+      }
+      placeholderTextColor={color("black30")}
+      ref={ref}
+      returnKeyType="done"
+      secureTextEntry
+      // textContentType="oneTimeCode"
+      // We need to to set textContentType to password here
+      // enable autofill of login details from the device keychain.
+      textContentType="password"
+      testID="password"
+      title="Password"
+      value={values.password}
+      onChangeText={(text) => {
+        // Hide error when the user starts to type again
+        if (errors.password) {
+          setErrors({
+            password: undefined,
+          })
+          validateForm()
+        }
+        handleChange("password")(text)
+      }}
+      onSubmitEditing={() => {
+        if (dirty && !!values.password) {
+          handleSubmit()
+        }
+      }}
+      onBlur={validateForm}
+    />
+  )
+}

--- a/src/app/Scenes/Onboarding/Auth2/components/PasswordInput.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/components/PasswordInput.tsx
@@ -2,26 +2,18 @@ import { Input, useTheme } from "@artsy/palette-mobile"
 import { LoginPasswordStepFormValues } from "app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep"
 import { SignUpPasswordStepFormValues } from "app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep"
 import { FormikContextType, useFormikContext } from "formik"
+import { forwardRef } from "react"
 
-interface PasswordInputProps {
-  ref: React.RefObject<Input>
-}
-
-export const PasswordInput = <
-  T extends LoginPasswordStepFormValues | SignUpPasswordStepFormValues,
->({
-  ref,
-}: PasswordInputProps) => {
+export const PasswordInput = forwardRef<Input>((_props, ref) => {
   const {
     dirty,
     errors,
     handleChange,
     handleSubmit,
-    setErrors,
-    touched,
     validateForm,
     values,
-  }: FormikContextType<T> = useFormikContext<T>()
+  }: FormikContextType<LoginPasswordStepFormValues | SignUpPasswordStepFormValues> =
+    useFormikContext<LoginPasswordStepFormValues | SignUpPasswordStepFormValues>()
 
   const { color } = useTheme()
 
@@ -31,11 +23,7 @@ export const PasswordInput = <
       autoComplete="password"
       autoCorrect={false}
       blurOnSubmit={false}
-      error={
-        values.password.length > 0 || touched.password
-          ? (errors.password as string | undefined)
-          : undefined
-      }
+      error={errors.password}
       placeholderTextColor={color("black30")}
       ref={ref}
       returnKeyType="done"
@@ -48,13 +36,6 @@ export const PasswordInput = <
       title="Password"
       value={values.password}
       onChangeText={(text) => {
-        // Hide error when the user starts to type again
-        if (errors.password) {
-          setErrors({
-            password: undefined,
-          })
-          validateForm()
-        }
         handleChange("password")(text)
       }}
       onSubmitEditing={() => {
@@ -65,4 +46,4 @@ export const PasswordInput = <
       onBlur={validateForm}
     />
   )
-}
+})

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -31,7 +31,6 @@ export const LoginPasswordStep: React.FC = () => {
   return (
     <Formik<LoginPasswordStepFormValues>
       initialValues={{ password: "" }}
-      validateOnChange={true}
       validationSchema={Yup.object().shape({
         password: Yup.string().required("Password field is required"),
       })}
@@ -113,7 +112,7 @@ const LoginPasswordStepForm: React.FC = () => {
 
       <Spacer y={2} />
 
-      <Button block width="100%" onPress={handleSubmit} disabled={!isValid} loading={isSubmitting}>
+      <Button block width={100} onPress={handleSubmit} disabled={!isValid} loading={isSubmitting}>
         Continue
       </Button>
 

--- a/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/LoginPasswordStep.tsx
@@ -7,8 +7,8 @@ import {
   Spacer,
   Text,
   Touchable,
-  useTheme,
 } from "@artsy/palette-mobile"
+import { PasswordInput } from "app/Scenes/Onboarding/Auth2/components/PasswordInput"
 import {
   useAuthNavigation,
   useAuthScreen,
@@ -20,7 +20,7 @@ import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
 import * as Yup from "yup"
 
-interface LoginPasswordStepFormValues {
+export interface LoginPasswordStepFormValues {
   password: string
 }
 
@@ -84,24 +84,12 @@ export const LoginPasswordStep: React.FC = () => {
 }
 
 const LoginPasswordStepForm: React.FC = () => {
-  const {
-    dirty,
-    errors,
-    handleChange,
-    handleSubmit,
-    isSubmitting,
-    isValid,
-    resetForm,
-    setErrors,
-    touched,
-    validateForm,
-    values,
-  } = useFormikContext<LoginPasswordStepFormValues>()
+  const { handleSubmit, isSubmitting, isValid, resetForm } =
+    useFormikContext<LoginPasswordStepFormValues>()
 
   const navigation = useAuthNavigation()
   const screen = useAuthScreen()
   const passwordRef = useRef<Input>(null)
-  const { color } = useTheme()
 
   useInputAutofocus({
     screenName: "LoginPasswordStep",
@@ -121,40 +109,7 @@ const LoginPasswordStepForm: React.FC = () => {
 
       <Text variant="sm-display">Welcome back to Artsy</Text>
 
-      <Input
-        autoCapitalize="none"
-        autoComplete="password"
-        autoCorrect={false}
-        blurOnSubmit={false}
-        error={values.password.length > 0 || touched.password ? errors.password : undefined}
-        placeholderTextColor={color("black30")}
-        ref={passwordRef}
-        returnKeyType="done"
-        secureTextEntry
-        // textContentType="oneTimeCode"
-        // We need to to set textContentType to password here
-        // enable autofill of login details from the device keychain.
-        textContentType="password"
-        testID="password"
-        title="Password"
-        value={values.password}
-        onChangeText={(text) => {
-          // Hide error when the user starts to type again
-          if (errors.password) {
-            setErrors({
-              password: undefined,
-            })
-            validateForm()
-          }
-          handleChange("password")(text)
-        }}
-        onSubmitEditing={() => {
-          if (dirty && !!values.password) {
-            handleSubmit()
-          }
-        }}
-        onBlur={validateForm}
-      />
+      <PasswordInput ref={passwordRef} />
 
       <Spacer y={2} />
 

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -21,7 +21,6 @@ export const SignUpPasswordStep: React.FC = () => {
   return (
     <Formik<SignUpPasswordStepFormValues>
       initialValues={{ password: "" }}
-      validateOnChange={true}
       validationSchema={Yup.object().shape({
         password: Yup.string()
           .min(8, "Your password should be at least 8 characters")

--- a/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/SignUpPasswordStep.tsx
@@ -1,13 +1,5 @@
-import {
-  BackButton,
-  Button,
-  Flex,
-  Input,
-  LinkText,
-  Spacer,
-  Text,
-  useTheme,
-} from "@artsy/palette-mobile"
+import { BackButton, Button, Flex, Input, LinkText, Spacer, Text } from "@artsy/palette-mobile"
+import { PasswordInput } from "app/Scenes/Onboarding/Auth2/components/PasswordInput"
 import {
   useAuthNavigation,
   useAuthScreen,
@@ -18,7 +10,7 @@ import { Formik, useFormikContext } from "formik"
 import React, { useRef } from "react"
 import * as Yup from "yup"
 
-interface SignUpPasswordStepFormValues {
+export interface SignUpPasswordStepFormValues {
   password: string
 }
 
@@ -29,6 +21,7 @@ export const SignUpPasswordStep: React.FC = () => {
   return (
     <Formik<SignUpPasswordStepFormValues>
       initialValues={{ password: "" }}
+      validateOnChange={true}
       validationSchema={Yup.object().shape({
         password: Yup.string()
           .min(8, "Your password should be at least 8 characters")
@@ -57,20 +50,11 @@ export const SignUpPasswordStep: React.FC = () => {
 }
 
 const SignUpPasswordStepForm: React.FC = () => {
-  const {
-    errors,
-    handleChange,
-    handleSubmit,
-    isSubmitting,
-    isValid,
-    setErrors,
-    values,
-    resetForm,
-  } = useFormikContext<SignUpPasswordStepFormValues>()
+  const { handleSubmit, isSubmitting, isValid, resetForm } =
+    useFormikContext<SignUpPasswordStepFormValues>()
 
   const navigation = useAuthNavigation()
   const screen = useAuthScreen()
-  const { color } = useTheme()
   const passwordRef = useRef<Input>(null)
 
   useInputAutofocus({
@@ -91,31 +75,7 @@ const SignUpPasswordStepForm: React.FC = () => {
 
       <Text variant="sm-display">Welcome to Artsy</Text>
 
-      <Input
-        autoCapitalize="none"
-        autoComplete="password"
-        autoCorrect={false}
-        blurOnSubmit={false}
-        error={errors.password}
-        placeholder="Password"
-        placeholderTextColor={color("black30")}
-        ref={passwordRef}
-        returnKeyType="done"
-        secureTextEntry
-        textContentType="none"
-        title="Password"
-        value={values.password}
-        onChangeText={(text) => {
-          // Hide error when the user starts to type again
-          if (errors.password) {
-            setErrors({
-              password: undefined,
-            })
-          }
-          handleChange("password")(text)
-        }}
-        onSubmitEditing={handleSubmit}
-      />
+      <PasswordInput ref={passwordRef} />
 
       <Spacer y={2} />
 


### PR DESCRIPTION
This PR resolves [DIA-898]

### Description

In order to prevent any drift between the implementation of the password input field between the sign-up and login flows, I created a shared component.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-898]: https://artsyproduct.atlassian.net/browse/DIA-898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ