### PR TITLE
chore(analytics): update default view all behavior for auction results section

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tests.tsx
@@ -101,7 +101,7 @@ describe("HomeViewSectionAuctionResults", () => {
     expect(navigate).toHaveBeenCalledWith("/artist/artist-2/auction-result/auction-result-2-id")
   })
 
-  it("navigates to ViewAll when the user taps the 'View All' button", () => {
+  it("navigates to requested `href` destination when the user taps the 'View All' button", () => {
     renderWithRelay({
       HomeViewSectionAuctionResults: () => ({
         internalID: "home-view-section-latest-auction-results",
@@ -111,7 +111,7 @@ describe("HomeViewSectionAuctionResults", () => {
           behaviors: {
             viewAll: {
               buttonText: "View All",
-              href: "/auction-results-for-artists-you-follow-view-all-href",
+              href: "/example-href",
             },
           },
           auctionResultsConnection: {
@@ -130,6 +130,41 @@ describe("HomeViewSectionAuctionResults", () => {
     expect(screen.getByText("View All")).toBeOnTheScreen()
     fireEvent.press(screen.getByText("View All"))
 
-    expect(navigate).toHaveBeenCalledWith("/auction-results-for-artists-you-follow-view-all-href")
+    expect(navigate).toHaveBeenCalledWith("/example-href")
+  })
+
+  it("navigates to default View All implementation when `href` is unspecified and the user taps the 'View All' button", () => {
+    renderWithRelay({
+      HomeViewSectionAuctionResults: () => ({
+        internalID: "home-view-section-latest-auction-results",
+        component: {
+          title: "Latest Auction Results",
+          href: "/auction-results-for-artists-you-follow-href",
+          behaviors: {
+            viewAll: {
+              buttonText: "View All",
+              href: null,
+            },
+          },
+          auctionResultsConnection: {},
+        },
+      }),
+    })
+
+    expect(screen.getByText("View All")).toBeOnTheScreen()
+    fireEvent.press(screen.getByText("View All"))
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "action": "tappedAuctionResultGroup",
+            "context_module": "<mock-value-for-field-"contextModule">",
+            "context_screen_owner_type": "home",
+            "destination_screen_owner_type": "auctionResultsForArtistsYouFollow",
+            "type": "viewAll",
+          },
+        ]
+      `)
+    expect(navigate).toHaveBeenCalledWith("/auction-results-for-artists-you-follow")
   })
 })

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults.tsx
@@ -64,9 +64,13 @@ export const HomeViewSectionAuctionResults: React.FC<HomeViewSectionAuctionResul
 
       navigate(viewAll.href)
     } else {
+      // TODO: This default view all behavior navigates to the existing Auction
+      // "Results From Artists You Follow" screen. This should eventually be
+      // updated to navigate to a HomeViewSectionAuctionResults screen and we can
+      // use the `component > behaviors > viewAll > ownerType` value.
       tracking.tappedAuctionResultGroupViewAll(
         section.contextModule as ContextModule,
-        OwnerType.lotsByArtistsYouFollow
+        OwnerType.auctionResultsForArtistsYouFollow
       )
 
       navigate("/auction-results-for-artists-you-follow")


### PR DESCRIPTION
### Description

- chore(analytics): update default view all behavior for auction results section

Discovered that we had the wrong value specified during a recent QA pass on the new Home View ([notes](https://www.notion.so/artsy/Eigen-Home-View-Analytics-Sync-112cab0764a0805391ecda25bf26fa33?pvs=4#112cab0764a080f1b136e01f7c79d6a0) 🔒 ).

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

- chore(analytics): update default view all behavior for auction results section

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
