### PR TITLE
fix: allow visual overflow for title component

### DIFF
--- a/src/app/Components/SectionTitle.tsx
+++ b/src/app/Components/SectionTitle.tsx
@@ -45,7 +45,7 @@ export const SectionTitle: React.FC<{
   return (
     <Wrapper onPress={onPress}>
       <Flex mb={mb} flexDirection="row" alignItems="flex-start">
-        <Flex flex={1} overflow="hidden">
+        <Flex flex={1}>
           <Text variant={titleVariant} ellipsizeMode="tail" numberOfLines={1} testID="title">
             {typeof title === "string" ? titleText : title}
           </Text>


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/Art-Advisor-Home-View-Feedback-abc1123548504ae58051405627fb6c9f?p=11acab0764a0800885a6eabc58c38e1b&pm=s

### Description

A sharp-eyed tester noticed that letters with descenders (g,j,p,q,y) were getting slightly clipped in the standard `SectionTitle` component.

Demonstrated here with those letters inserted and a background added  to show the clipping:

## Before

![overflow hidden](https://github.com/user-attachments/assets/8f89eeda-1e3f-4e80-8a37-e02f7db20b0b)

## After

![overflow auto](https://github.com/user-attachments/assets/0447ea0a-fa3d-4cbb-b1c2-b4d4f2b7dda7)

<details>
<summary>Details about the root cause…</summary>

- SectionTitle [takes](https://github.com/artsy/eigen/blob/7cd48256055229da0b538b1c330586014290ded0/src/app/Components/SectionTitle.tsx#L23) a `titleVariant` prop
- That prop [defaults](https://github.com/artsy/eigen/blob/7cd48256055229da0b538b1c330586014290ded0/src/app/Components/SectionTitle.tsx#L31) to `sm-display`
- That is [drilled](https://github.com/artsy/eigen/blob/7cd48256055229da0b538b1c330586014290ded0/src/app/Components/SectionTitle.tsx#L50) down to the `Text` component
- Where it results (if I'm following the chain correctly, and if Eigen is using Palette's v3 theme) in the following font size and line height from `@artsy/palette-tokens`:

https://github.com/artsy/palette/blob/bd1ad5bc3875a283cf0b035d32f724bb2f9350e3/packages/palette-tokens/src/typography/v3.ts#L66-L69

The problem is that the descenders dip below the 20px line height, which can be a problem in certain layouts, such as the `SectionTitle`.
</details>

Here are the options, in my view:

1. **Most correct, but widest blast radius**
    - Update the `sm-display` variant in `@artsy/palette-tokens` to have a more appropriate `line-height`, so that this issue never comes up in any layout on any platform

2. **Correct enough, affects all `SectionTitles` in Eigen**
    - Update `SectionTitle` to remove the `overflow: hidden` from the `Flex` that contains the `Text`. This will allow the descenders to display even though they are _technically_ overflowing their parent container. 

I've chosen Option 2 in this PR.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists - john` or `Fix phone input misalignment - mary`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Small adjustment to section title typography - Roop

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


