### PR TITLE
fix: shows for you rail broken padding

### DIFF
--- a/src/app/Scenes/Home/Components/ShowsRail.tsx
+++ b/src/app/Scenes/Home/Components/ShowsRail.tsx
@@ -1,5 +1,13 @@
 import { ActionType, ContextModule, OwnerType, TappedShowGroup } from "@artsy/cohesion"
-import { Flex, Join, SkeletonBox, SkeletonText, Spacer, Text } from "@artsy/palette-mobile"
+import {
+  Flex,
+  FlexProps,
+  Join,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+  Text,
+} from "@artsy/palette-mobile"
 import { ShowsRailQuery } from "__generated__/ShowsRailQuery.graphql"
 import {
   ShowsRail_showsConnection$data,
@@ -21,7 +29,7 @@ import { FlatList } from "react-native"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
 
-interface ShowsRailProps {
+interface ShowsRailProps extends FlexProps {
   disableLocation: boolean
   location?: Location | null
   contextModule?: ContextModule
@@ -33,7 +41,7 @@ interface ShowsRailProps {
 const NUMBER_OF_SHOWS = 10
 
 export const ShowsRail: React.FC<ShowsRailProps> = memo(
-  ({ disableLocation, location, contextModule, onTrack, title }) => {
+  ({ disableLocation, location, contextModule, onTrack, title, ...flexProps }) => {
     const tracking = useTracking()
 
     const queryVariables = location
@@ -56,7 +64,7 @@ export const ShowsRail: React.FC<ShowsRailProps> = memo(
     }
 
     return (
-      <Flex>
+      <Flex {...flexProps}>
         <Flex mx={2}>
           <SectionTitle title={title} />
         </Flex>
@@ -144,7 +152,7 @@ export const tracks = {
   }),
 }
 
-interface ShowsRailContainerProps {
+interface ShowsRailContainerProps extends FlexProps {
   title: string
   disableLocation?: boolean
   contextModule?: ContextModule
@@ -155,7 +163,7 @@ export const ShowsRailContainer: React.FC<ShowsRailContainerProps> = ({
   disableLocation = false,
   contextModule,
   onTrack,
-  ...restProps
+  ...flexProps
 }) => {
   const visualizeLocation = useDevToggle("DTLocationDetectionVisialiser")
 
@@ -177,7 +185,7 @@ export const ShowsRailContainer: React.FC<ShowsRailContainerProps> = ({
       )}
 
       <ShowsRail
-        {...restProps}
+        {...flexProps}
         location={location}
         disableLocation={disableLocation}
         contextModule={contextModule}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
@@ -10,7 +10,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
-interface HomeViewSectionShowsProps {
+interface HomeViewSectionShowsProps extends FlexProps {
   section: HomeViewSectionShows_section$key
   index: number
 }
@@ -26,7 +26,7 @@ export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({
   const tracking = useHomeViewTracking()
 
   return (
-    <Flex {...flexProps}>
+    <Flex>
       <ShowsRailContainer
         title={component?.title || "Shows"}
         disableLocation={!enableShowsForYouLocation}
@@ -38,6 +38,7 @@ export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({
             index
           )
         }}
+        {...flexProps}
       />
       <HomeViewSectionSentinel
         contextModule={section.contextModule as ContextModule}


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/Too-much-padding-below-Shows-for-You-section-iOS-production-11acab0764a080879716cabc4dec6e7b?pvs=4]

### Description

When working on this, I noticed that the bug reported is not really a bug, it's actually working as defined because I assume at least one show has a title that spans over 3 lines. I did however notice an issue when there are no shows available, the padding breaks.

**Before**

https://github.com/user-attachments/assets/a231ed79-5749-4994-a1bd-b82cb8272b02


**After**

https://github.com/user-attachments/assets/2fb3358e-c261-4ab9-aeb5-da7571bf842b


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix shows for you rail broken padding when no shows are available on home - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
