### PR TITLE
chore: skip cache when checking build status

### DIFF
--- a/scripts/deploys/deploy-beta-android
+++ b/scripts/deploys/deploy-beta-android
@@ -5,7 +5,7 @@ source ./scripts/ci/ci-setup-export-vars
 
 # Check if there is a build in progress
 echo "Checking if there is a build in progress..."
-build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-android -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
+build_status=$(curl "https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-android?filter=running&limit=1&shallow=true" -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
 
 # Check if the build status is "running"
 if [ "$build_status" = "running" ]; then

--- a/scripts/deploys/deploy-beta-android
+++ b/scripts/deploys/deploy-beta-android
@@ -5,7 +5,7 @@ source ./scripts/ci/ci-setup-export-vars
 
 # Check if there is a build in progress
 echo "Checking if there is a build in progress..."
-build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-android -s | jq -r '.[0].status')
+build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-android -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
 
 # Check if the build status is "running"
 if [ "$build_status" = "running" ]; then

--- a/scripts/deploys/deploy-beta-ios
+++ b/scripts/deploys/deploy-beta-ios
@@ -5,7 +5,7 @@ source ./scripts/ci/ci-setup-export-vars
 
 # Check if there is a build in progress
 echo "Checking if there is a build in progress..."
-build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-ios -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
+build_status=$(curl "https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-ios?filter=running&limit=1&shallow=true" -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
 
 # Check if the build status is "running"
 if [ "$build_status" = "running" ]; then

--- a/scripts/deploys/deploy-beta-ios
+++ b/scripts/deploys/deploy-beta-ios
@@ -5,7 +5,7 @@ source ./scripts/ci/ci-setup-export-vars
 
 # Check if there is a build in progress
 echo "Checking if there is a build in progress..."
-build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-ios -s | jq -r '.[0].status')
+build_status=$(curl https://circleci.com/api/v1.1/project/github/artsy/eigen/tree/beta-ios -s -H 'Cache-Control: no-cache' | jq -r '.[0].status')
 
 # Check if the build status is "running"
 if [ "$build_status" = "running" ]; then


### PR DESCRIPTION
### Description

This PR comes as a follow-up to https://artsy.slack.com/archives/C02BAQ5K7/p1728649506233649?thread_ts=1728649134.119499&cid=C02BAQ5K7. 

In the thread above, I ran the deploy scripts and wasn't asked to confirm to override the ongoing build. After running the same request locally, I noticed that I was getting the build status as `success` while it was `running`. I assume there is something wrong with cache and I am trying to fix that by explicitly skipping the cache.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- skip cache when checking build status - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
