### PR TITLE
fix: clear relay cache on signout

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -5,7 +5,7 @@ import CookieManager from "@react-native-cookies/cookies"
 import { GoogleSignin, statusCodes } from "@react-native-google-signin/google-signin"
 import * as Sentry from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
-import * as RelayCache from "app/system/relay/RelayCache"
+import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
 import {
   handleClassicFacebookAuth,
   handleLimitedFacebookAuth,
@@ -833,7 +833,7 @@ export const getAuthModel = (): AuthModel => ({
       await signOutGoogle(),
       LoginManager.logOut(),
       CookieManager.clearAll(),
-      RelayCache.clearAll(),
+      _globalCacheRef.clear(),
     ])
 
     actions.setSessionState({ isUserIdentified: true })

--- a/src/app/system/devTools/DevMenu/Components/DevTools.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevTools.tsx
@@ -1,4 +1,4 @@
-import { Flex, SearchInput, MenuItem, Text } from "@artsy/palette-mobile"
+import { Flex, MenuItem, SearchInput, Text } from "@artsy/palette-mobile"
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import Clipboard from "@react-native-clipboard/clipboard"
 import * as Sentry from "@sentry/react-native"
@@ -12,7 +12,7 @@ import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMen
 import { DevToggleItem } from "app/system/devTools/DevMenu/Components/DevToggleItem"
 import { eigenSentryReleaseName } from "app/system/errorReporting/setupSentry"
 import { dismissModal, navigate } from "app/system/navigation/navigate"
-import { RelayCache } from "app/system/relay/RelayCache"
+import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
 import { saveToken } from "app/utils/PushNotification"
 import { useUnleashEnvironment } from "app/utils/experiments/hooks"
 import { requestSystemPermissions } from "app/utils/requestPushNotificationsPermission"
@@ -103,9 +103,8 @@ export const DevTools: React.FC<{}> = () => {
           <DevMenuButtonItem
             title="Clear Relay Cache"
             onPress={() => {
-              RelayCache.clearAll().then(() => {
-                toast.show("Relay cache cleared ✅", "middle")
-              })
+              _globalCacheRef.clear()
+              toast.show("Relay cache cleared ✅", "middle")
             }}
           />
           <DevMenuButtonItem

--- a/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/EnvironmentOptions.tsx
@@ -3,7 +3,7 @@ import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { GlobalStore } from "app/store/GlobalStore"
 import { EnvironmentKey, environment } from "app/store/config/EnvironmentModel"
 import { DevMenuButtonItem } from "app/system/devTools/DevMenu/Components/DevMenuButtonItem"
-import { RelayCache } from "app/system/relay/RelayCache"
+import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
 import { capitalize, compact } from "lodash"
 import { useState } from "react"
 import { Alert, AlertButton, TouchableHighlight } from "react-native"
@@ -124,7 +124,7 @@ function envMenuOption(
         GlobalStore.actions.devicePrefs.environment.setEnv(env)
         onClose()
         GlobalStore.actions.auth.signOut()
-        RelayCache.clearAll()
+        _globalCacheRef.clear()
       } else {
         setShowCustomURLOptions(!showCustomURLOptions)
       }

--- a/src/app/system/devTools/DevMenu/Components/NavButtons.tsx
+++ b/src/app/system/devTools/DevMenu/Components/NavButtons.tsx
@@ -1,7 +1,7 @@
-import { Flex, Join, Spacer, LogoutIcon, ReloadIcon, CloseIcon } from "@artsy/palette-mobile"
+import { CloseIcon, Flex, Join, LogoutIcon, ReloadIcon, Spacer } from "@artsy/palette-mobile"
 import { GlobalStore } from "app/store/GlobalStore"
-import { RelayCache } from "app/system/relay/RelayCache"
-import { TouchableOpacity, Alert, DevSettings } from "react-native"
+import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
+import { Alert, DevSettings, TouchableOpacity } from "react-native"
 
 export const NavButtons: React.FC<{ onClose(): void }> = ({ onClose }) => {
   const isLoggedIn = !!GlobalStore.useAppState((state) => !!state.auth.userID)
@@ -34,7 +34,7 @@ export const NavButtons: React.FC<{ onClose(): void }> = ({ onClose }) => {
         {!!__DEV__ && (
           <TouchableOpacity
             onPress={() => {
-              RelayCache.clearAll()
+              _globalCacheRef.clear()
               onClose()
               requestAnimationFrame(() => DevSettings.reload())
             }}

--- a/src/app/system/relay/usePurgeCacheOnAppUpdate.ts
+++ b/src/app/system/relay/usePurgeCacheOnAppUpdate.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import { RelayCache } from "app/system/relay/RelayCache"
+import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
 import { useEffect } from "react"
 import DeviceInfo from "react-native-device-info"
 
@@ -18,7 +18,7 @@ export const usePurgeCacheOnAppUpdate = () => {
           version = value as string
         }
 
-        RelayCache.clearAll()
+        _globalCacheRef.clear()
         AsyncStorage.setItem(APP_CURRENT_VERSION_KEY, version)
       }
     })


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/After-signing-out-from-an-account-that-has-populated-relay-data-then-signin-up-again-i-get-the-a-11ccab0764a080679256f4dafd2cbdf0?pvs=4] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with our relay cache not getting invalidated after sign out. This started to happen after we switched from our custom relay cache middleware to the community cache middleware [here](https://github.com/artsy/eigen/pull/10848).


https://github.com/user-attachments/assets/5878d310-a71d-423c-8304-e1691ef8fa22

**Follow-up:**
Do we still need the relay cache files? maybe we can delete them in an upcoming PR? for future-friday

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- clear relay cache on signout - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
