### PR TITLE
fix: keep splash screen visible for 500ms

### DIFF
--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -6,7 +6,7 @@ import { usePrefetch } from "app/utils/queryPrefetching"
 import { useEffect } from "react"
 import RNBootSplash from "react-native-bootsplash"
 
-const HOME_VIEW_QUERY_AVERAGE_LATENCY = 500
+const HOME_VIEW_SPLASH_SCREEN_DELAY = 500
 
 export const useHideSplashScreen = () => {
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
@@ -32,7 +32,7 @@ export const useHideSplashScreen = () => {
           })
           setTimeout(() => {
             hideSplashScreen()
-          }, HOME_VIEW_QUERY_AVERAGE_LATENCY)
+          }, HOME_VIEW_SPLASH_SCREEN_DELAY)
         }
         return
       }

--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -6,6 +6,8 @@ import { usePrefetch } from "app/utils/queryPrefetching"
 import { useEffect } from "react"
 import RNBootSplash from "react-native-bootsplash"
 
+const HOME_VIEW_QUERY_AVERAGE_LATENCY = 500
+
 export const useHideSplashScreen = () => {
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const isHydrated = GlobalStore.useAppState((state) => state.sessionState.isHydrated)
@@ -28,13 +30,9 @@ export const useHideSplashScreen = () => {
           prefetchUrl("/", homeViewScreenQueryVariables(), {
             force: false,
           })
-            ?.then(() => {
-              hideSplashScreen()
-            })
-            .catch((error) => {
-              console.error("Failed to prefetch home view", error)
-              hideSplashScreen()
-            })
+          setTimeout(() => {
+            hideSplashScreen()
+          }, HOME_VIEW_QUERY_AVERAGE_LATENCY)
         }
         return
       }
@@ -42,6 +40,5 @@ export const useHideSplashScreen = () => {
         hideSplashScreen()
       }
     }
-    hideSplashScreen()
   }, [isHydrated, isLoggedIn, isNavigationReady])
 }


### PR DESCRIPTION
### Description

This PR is an attempt to improve our homeview elements rendering logic. 
The idea from this PR is the following, we don't want to show an empty home view then suddenly have multiple sections show up at the same time. We can't avoid that because the home view query is still active. So what can we do about it?
We can wait for the prefetching query to finish. That's good, but! what if it takes forever or never finishes god forbid! 
How about we wait for a bit, enough for the query to finish (_usually_), then hide the splash screen. For how long should we wait, the average [query duration in datadog ](https://app.datadoghq.com/dashboard/z95-ftb-4qe/home-view-health?fromUser=true&refresh_mode=sliding&tpl_var_env%5B0%5D=%2A&from_ts=1728057263324&to_ts=1728662063324&live=true)

<img width="863" alt="Screenshot 2024-10-11 at 18 10 49" src="https://github.com/user-attachments/assets/21daaba6-9183-46da-9c37-87059d17b922">

**Note: I know this will add 500ms to the splash screen but the user was going to wait anyway and it's pretty subtle. Let me know what you think**

https://github.com/user-attachments/assets/aedf925e-125d-41aa-bba6-04dc295b8174




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- gracefully show home view content after splash screen - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
