### PR TITLE
chore: remove sentry bootstrap environment

### DIFF
--- a/index-common.js
+++ b/index-common.js
@@ -17,7 +17,6 @@ if (__DEV__) {
   } catch {}
 }
 
-require("./src/app/system/errorReporting/setupSentry").setupSentry({ environment: "bootstrap" })
 import "react-native-url-polyfill/auto"
 const { AppRegistry } = require("react-native")
 

--- a/src/app/system/errorReporting/setupSentry.ts
+++ b/src/app/system/errorReporting/setupSentry.ts
@@ -71,7 +71,7 @@ export function setupSentry(props: SetupSentryProps = { debug: false }) {
     tracesSampleRate: props.debug ? 1.0 : 0.1,
     debug: props.debug,
     integrations: [
-      new Sentry.ReactNativeTracing({
+      Sentry.reactNativeTracingIntegration({
         routingInstrumentation,
         beforeNavigate: (context: TransactionContext) => {
           /**


### PR DESCRIPTION
This PR resolves [PHIRE-1263] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

- gets rid of bootstrap env
- updates sentry tracing init to use non-deprecated method

I started this ticket intending to lower our sample rate but then realized because we are initializing sentry 2x once without debug flag we are probably sending many more events due to this. 

I think we should try getting rid of the bootstrap environment, it only initializes a little earlier than our main sentry env and it causes duplicate event reporting in sentry, confusion on where to look for events and probably other issues due to having 2 initialized instances. I think if we want sentry initialized early we should do it on native side once if necessary. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- remove sentry bootstrap env - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1263]: https://artsyproduct.atlassian.net/browse/PHIRE-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ