### PR TITLE
fix: StatusBar fixes

### DIFF
--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -6,6 +6,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useSwitchStatusBarStyle } from "app/utils/useStatusBarStyle"
 import { useEffect } from "react"
 
 export const InnerHomeContainer = () => {
@@ -21,6 +22,8 @@ export const InnerHomeContainer = () => {
   const navigateToArtQuiz = async () => {
     await navigate("/art-quiz")
   }
+
+  useSwitchStatusBarStyle("light-content", "dark-content")
 
   useEffect(() => {
     if (artQuizState === "incomplete" && isNavigationReady) {

--- a/src/app/Scenes/Home/HomeContainer.tsx
+++ b/src/app/Scenes/Home/HomeContainer.tsx
@@ -23,7 +23,7 @@ export const InnerHomeContainer = () => {
     await navigate("/art-quiz")
   }
 
-  useSwitchStatusBarStyle("light-content", "dark-content")
+  useSwitchStatusBarStyle("dark-content", "dark-content")
 
   useEffect(() => {
     if (artQuizState === "incomplete" && isNavigationReady) {

--- a/src/app/Scenes/Onboarding/OnboardingWelcome.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingWelcome.tsx
@@ -13,6 +13,7 @@ import {
   DEFAULT_NAVIGATION_BAR_COLOR,
 } from "app/NativeModules/ArtsyNativeModule"
 import { useScreenDimensions } from "app/utils/hooks"
+import { useSwitchStatusBarStyle } from "app/utils/useStatusBarStyle"
 import backgroundImage from "images/WelcomeImage.webp"
 import { MotiView } from "moti"
 import { useEffect } from "react"
@@ -58,6 +59,8 @@ export const OnboardingWelcome: React.FC<OnboardingWelcomeProps> = ({ navigation
       )
     }
   }, [])
+
+  useSwitchStatusBarStyle("light-content", "dark-content")
 
   useEffect(() => {
     if (Platform.OS === "ios") {

--- a/src/app/utils/useAndroidAppStyling.ts
+++ b/src/app/utils/useAndroidAppStyling.ts
@@ -1,4 +1,7 @@
-import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
+import {
+  ArtsyNativeModule,
+  DEFAULT_NAVIGATION_BAR_COLOR,
+} from "app/NativeModules/ArtsyNativeModule"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
 import { Platform } from "react-native"
@@ -15,6 +18,7 @@ export const useAndroidAppStyling = () => {
         }
 
         if (isLoggedIn && Platform.OS === "android") {
+          ArtsyNativeModule.setNavigationBarColor(DEFAULT_NAVIGATION_BAR_COLOR)
           ArtsyNativeModule.setAppLightContrast(false)
         }
       }, 500)

--- a/src/app/utils/useAndroidAppStyling.ts
+++ b/src/app/utils/useAndroidAppStyling.ts
@@ -1,7 +1,7 @@
 import { ArtsyNativeModule } from "app/NativeModules/ArtsyNativeModule"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
-import { Platform, StatusBar } from "react-native"
+import { Platform } from "react-native"
 
 export const useAndroidAppStyling = () => {
   const isHydrated = GlobalStore.useAppState((state) => state.sessionState.isHydrated)
@@ -15,8 +15,7 @@ export const useAndroidAppStyling = () => {
         }
 
         if (isLoggedIn && Platform.OS === "android") {
-          ArtsyNativeModule.setAppStyling()
-          StatusBar.setBarStyle("dark-content")
+          ArtsyNativeModule.setAppLightContrast(false)
         }
       }, 500)
     }


### PR DESCRIPTION
This PR resolves [PHIRE-1287] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes a regression that was introduced in https://github.com/artsy/eigen/pull/10953. The issue was reported by @dblandin in slack (see [thread](https://artsy.slack.com/archives/C02BAQ5K7/p1729773548707709))

#### Before Login

|After||
|---|---|
|Device has|Light Theme|
|![Screenshot_20241029-145018](https://github.com/user-attachments/assets/4c89e896-e674-4644-b177-14cff4811dbf)|![Screenshot_20241029-130921](https://github.com/user-attachments/assets/969cd621-bcb8-48bd-9595-eb728cd2af8e)|
|![Screenshot_20241029-130941](https://github.com/user-attachments/assets/6bd45b71-8928-496d-9591-6d61c659cb47)|![Screenshot_20241029-131001](https://github.com/user-attachments/assets/7954b68e-af14-401b-b504-abb4d67d9b05)|
|Device has|Dark Theme|
|![Screenshot_20241029-145018](https://github.com/user-attachments/assets/4c89e896-e674-4644-b177-14cff4811dbf)|![Screenshot_20241029-130921](https://github.com/user-attachments/assets/969cd621-bcb8-48bd-9595-eb728cd2af8e)|
|![Screenshot_20241029-130941](https://github.com/user-attachments/assets/6bd45b71-8928-496d-9591-6d61c659cb47)|![Screenshot_20241029-131001](https://github.com/user-attachments/assets/7954b68e-af14-401b-b504-abb4d67d9b05)|

#### Follow ups:

Created a follow up ticket in order to simplify both KeyboardAvoidingView and all the different ways we have to override the statusBar on the android side of things [here](https://artsyproduct.atlassian.net/browse/PHIRE-1297)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- jumpy bottom tab bar when keyboard pops up - gkartalis

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1287]: https://artsyproduct.atlassian.net/browse/PHIRE-1287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ