### PR TITLE
fix(artwork rail): change image resize mode to "cover"

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -73,7 +73,7 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           aspectRatio={image.aspectRatio}
           blurhash={showBlurhash ? image.blurhash : undefined}
           performResize={false}
-          resizeMode="contain"
+          resizeMode="cover"
           testID="artwork-rail-card-image"
         />
       )}


### PR DESCRIPTION
This PR resolves this QA launch-blocking bug:
https://www.notion.so/artsy/Border-around-artwork-rail-images-12acab0764a080e298c1d1ca455895c9

### Description

| Before | After |
|--------|--------|
| <img width="100%" src="https://github.com/user-attachments/assets/f77ca03b-e492-4daa-8815-1ec7c24c8ff3" /> | <img width="100%" src="https://github.com/user-attachments/assets/cfc1ce82-191f-440c-b38a-01c003bfec8f" /> | 

QA uncovered an issue where some images appear to have hairline rules visible on their borders. 

(See ⬆️ in the **Before** column the sides of the first image and the top/bottom of the second image.)

The hairline itself, if you really zoom in there, turns out to be the blurhash showing through because it is not completely covered by the final image! Notice the gradient from the pale green down to the dark blue here:

<img width=300 src=https://github.com/user-attachments/assets/73567d44-6f37-443a-8c51-70b40398c9d9 />

<br />
<br />

The root cause appears to be tiny sub-pixel differences between the [calculated size](https://github.com/artsy/eigen/blob/d11b1b2641028e1c41fdbf8260799cf24a4ad5cd/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx#L42-L53) of the image component and the actual image source file itself.

For example in the "before" image above, the calculated size is `215 x 215` but the image source file is `1100 x 1104`

When resized in `contain` mode, the image is shrunk to <code><b>214.2</b> x 215</code>, which leaves a little strip visible on either side.

Furthermore this difference is really apparent when the artwork image (contrary to our guidelines!) has a white buffer around it, as these images do ([see original](https://d32dm0rphc51dk.cloudfront.net/6J96qGWaeOrgf47eGx4IYg/large.jpg)).

This QA caught a perfect storm of multiple such images which made the problem very visible.

### Solution

If we instead resize this in `cover` mode, the image is scaled down just enough to completely cover the `215 x 215` container, and therefore leaves none of the background blurhash showing through. This fix comes at the expense of "throwing away" a minuscule 1-pixel or so line of image data, which is more acceptable than the alternative imo.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix hairline image issue on artwork rail images

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
