### PR TITLE
fix: truncated text+no ellipsizeMode on Android rail card meta

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -13,9 +13,9 @@ import {
   ArtworkActionTrackingProps,
   tracks as artworkActionTracks,
 } from "app/utils/track/ArtworkActions"
+import { Text as RNText } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
-
 // These are the props that are shared between ArtworkRailCard and ArtworkRailCardMeta
 export interface ArtworkRailCardCommonProps extends ArtworkActionTrackingProps {
   dark?: boolean
@@ -137,27 +137,25 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
         )}
 
         {!hideArtistName && !!artistNames && (
-          <Text color={primaryTextColor} numberOfLines={1} lineHeight="20px" variant="xs">
-            {artistNames}
-          </Text>
+          <RNText numberOfLines={1} ellipsizeMode="tail">
+            <Text color={primaryTextColor} lineHeight="20px" variant="xs">
+              {artistNames}
+            </Text>
+          </RNText>
         )}
 
         {!!title && (
-          <Text
-            lineHeight="20px"
-            color={secondaryTextColor}
-            numberOfLines={1}
-            variant="xs"
-            fontStyle="italic"
-          >
-            {title}
-            {!!date && (
-              <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1} variant="xs">
-                {title && date ? ", " : ""}
-                {date}
-              </Text>
-            )}
-          </Text>
+          <RNText numberOfLines={1} ellipsizeMode="tail">
+            <Text lineHeight="20px" color={secondaryTextColor} variant="xs" fontStyle="italic">
+              {title}
+              {!!date && (
+                <Text lineHeight="20px" color={secondaryTextColor} variant="xs">
+                  {title && date ? ", " : ""}
+                  {date}
+                </Text>
+              )}
+            </Text>
+          </RNText>
         )}
 
         {!!showPartnerName && !!partner?.name && (


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR addresses the artwork title and artist name truncation not happening properly on android. - Surfaced during our mobile QA Session https://www.notion.so/artsy/Android-Artwork-title-not-center-aligned-cuts-off-on-Artwork-Rails-12acab0764a08052b672dac3c0c0d79a?pvs=4

Context:

Seems like our palette-mobile text doesn't handle properly the `ellipsizeMode` properly although the prop is being passed correctly, I am thinking that it might have to do with styled components.

In the meantime found this workaround, using RNText (the original react native text) as a wrapper / parent for the problematic surfaces the palette-mobile texts seem to inherit correctly both `numOfLines` and `ellipsizeMode`. 

See screenshots below:

|Before|After|
|---|---|
|<img width="410" alt="Screenshot 2024-10-30 at 14 42 01" src="https://github.com/user-attachments/assets/3083bfdb-e0b2-400d-8b10-9dbfe570a14f">|<img width="408" alt="Screenshot 2024-10-30 at 14 41 32" src="https://github.com/user-attachments/assets/edf41245-759a-4608-b59f-db719d1bc1c1">|
|<img width="413" alt="Screenshot 2024-10-30 at 14 40 07" src="https://github.com/user-attachments/assets/7ef316e2-c71f-4c29-b83e-cc72fa240c47">|<img width="410" alt="Screenshot 2024-10-30 at 14 41 24" src="https://github.com/user-attachments/assets/2ec6e3ae-e3e1-4f89-b83a-31e44e3357ae">|
|<img width="412" alt="Screenshot 2024-10-30 at 14 39 50" src="https://github.com/user-attachments/assets/ef67f1d7-dd4c-4639-958e-7fca44fc4708">|<img width="408" alt="Screenshot 2024-10-30 at 14 37 15" src="https://github.com/user-attachments/assets/57932f8e-70b7-4a4d-9b1d-ad72af9ceff1">|
|<img width="417" alt="Screenshot 2024-10-30 at 14 39 39" src="https://github.com/user-attachments/assets/11a37cb1-0380-4640-8f9e-df86f7c95b7e">|<img width="411" alt="Screenshot 2024-10-30 at 14 37 25" src="https://github.com/user-attachments/assets/a98c85c7-a383-4625-ac74-7bbda98a816d">|


#### iOS

<video src="https://github.com/user-attachments/assets/e4c86679-9420-4a61-b415-1112613e6ed1" width="400" />


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- truncated text+no ellipsizeMode on Android rail card meta 

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
