### PR TITLE
fix: Missing artwork ID in SWA My Collection flow

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -11,6 +11,7 @@ import { SubmitArtworkStackNavigation } from "app/Scenes/SellWithArtsy/ArtworkFo
 import { fetchArtworkInformation } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation"
 import { getInitialSubmissionFormValuesFromArtwork } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValuesFromArtwork"
 import { SubmissionModel } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
+import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { dismissModal, switchTab } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useRefreshControl } from "app/utils/refreshHelpers"
@@ -48,9 +49,11 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
     try {
       setIsLoading(true)
       // Fetch Artwork Details
+
       const artwork = await fetchArtworkInformation(artworkID)
+
       if (artwork) {
-        const formValues = {
+        const artworkValues = {
           ...getInitialSubmissionFormValuesFromArtwork(artwork),
           submissionId: values.submissionId,
           externalId: values.externalId,
@@ -58,7 +61,15 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
           userEmail: values.userEmail,
           userPhone: values.userPhone,
         }
-        setValues(formValues)
+
+        const submission = await createOrUpdateSubmission(artworkValues, values.submissionId)
+
+        setValues({
+          ...artworkValues,
+          submissionId: submission?.internalID || values.submissionId,
+          externalId: submission?.externalID || values.externalId,
+        })
+
         setIsLoading(false)
 
         navigation.navigate("AddTitle")

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFromMyCollection.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkFromMyCollection.tests.tsx
@@ -12,10 +12,17 @@ jest.mock("app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext", () 
     }
   },
 }))
-
 jest.mock("app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation", () => ({
   fetchArtworkInformation: jest.fn().mockResolvedValue({ artwork: mockedFetchedArtwork }),
 }))
+jest.mock(
+  "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission",
+  () => ({
+    createOrUpdateSubmission: jest
+      .fn()
+      .mockResolvedValue({ internalID: "internal-id", externalID: "external-id" }),
+  })
+)
 
 describe("SubmitArtworkFromMyCollection", () => {
   beforeEach(() => {


### PR DESCRIPTION
This PR resolves [ONYX-1381] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes a launch-blocking bug. The artwork ID is not present on the Image step in the SWA flow when choosing an artwork from My Collection. However, the ID is necessary to upload assets/images to the submission.

The ID is not present in this step because, after choosing the artwork, the form values get initialized, but no submission is created (-> no ID).

This PR is a quick fix, and I will follow up with some simplifications. It should be able to create a submission from a My Collection artwork by just passing the artwork ID to the `createSubmission` mutation, which we should do in this case. This way, the form values do not have to be initialized manually.


| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 15 Plus - 2024-10-31 at 11 07 58](https://github.com/user-attachments/assets/c578fa32-9874-4ccb-9924-5e4f757e8d33) | ![Simulator Screenshot - iPhone 15 Plus - 2024-10-31 at 11 07 00](https://github.com/user-attachments/assets/3e54c530-08dd-4a2e-9772-55b31e27c21c) |






### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix Image upload step when selecting a My Collection artwork in the SWA flow - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1381]: https://artsyproduct.atlassian.net/browse/ONYX-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ