### PR TITLE
fix: Missing artwork ID in My Collection Submit for Sale flow

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tests.tsx
@@ -12,6 +12,14 @@ import { MyCollectionWhySell } from "./MyCollectionWhySell"
 jest.mock("app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation", () => ({
   fetchArtworkInformation: () => Promise.resolve(artworkWithoutSubmission),
 }))
+jest.mock(
+  "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission",
+  () => ({
+    createOrUpdateSubmission: jest
+      .fn()
+      .mockResolvedValue({ internalID: "internal-id", externalID: "external-id" }),
+  })
+)
 
 describe("MyCollectionWhySell", () => {
   let mockEnvironment: ReturnType<typeof createMockEnvironment>
@@ -115,7 +123,7 @@ describe("MyCollectionWhySell", () => {
                 signature: null,
                 source: "MY_COLLECTION",
                 state: "DRAFT",
-                submissionId: null,
+                submissionId: "internal-id",
                 title: "Welcome Mat",
                 userEmail: "",
                 userName: "",
@@ -270,7 +278,7 @@ describe("MyCollectionWhySell", () => {
               signature: null,
               source: "MY_COLLECTION",
               state: "DRAFT",
-              submissionId: null,
+              submissionId: "internal-id",
               title: "Welcome Mat",
               userEmail: "",
               userName: "",

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
@@ -86,8 +86,8 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
 
               const submission = await createOrUpdateSubmission(initialValues, null)
 
-              ;(initialValues.submissionId = submission?.internalID || null),
-                (passProps.initialValues = initialValues)
+              initialValues.submissionId = submission?.internalID || null
+              passProps.initialValues = initialValues
               passProps.initialStep = "AddTitle"
 
               navigate("/sell/submissions/new", { passProps })

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
@@ -72,8 +72,11 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
               const artworkData = await fetchArtworkInformation(artwork.internalID)
 
               if (!artworkData) {
+                console.error(
+                  "Failed to fetch artwork details when submitting My Collection artwork for sale."
+                )
                 Alert.alert(
-                  "Failed to fetch artwork details or create submission.",
+                  "Failed to fetch artwork details.",
                   "Please try again or enter details manually."
                 )
                 return
@@ -89,6 +92,10 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
 
               navigate("/sell/submissions/new", { passProps })
             } catch (error) {
+              console.error(
+                "Failed to fetch artwork details or create submission when submitting My Collection artwork for sale.",
+                error
+              )
               Alert.alert(
                 "Failed to fetch artwork details or create submission.",
                 "Please try again or enter details manually."

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionWhySell.tsx
@@ -4,8 +4,10 @@ import { MyCollectionWhySell_artwork$key } from "__generated__/MyCollectionWhySe
 import { SubmitArtworkProps } from "app/Scenes/SellWithArtsy/ArtworkForm/SubmitArtworkForm"
 import { fetchArtworkInformation } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/fetchArtworkInformation"
 import { getInitialSubmissionFormValuesFromArtwork } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/getInitialSubmissionValuesFromArtwork"
+import { createOrUpdateSubmission } from "app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/utils/createOrUpdateSubmission"
 import { navigate } from "app/system/navigation/navigate"
 import { Schema } from "app/utils/track"
+import { Alert } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -51,28 +53,47 @@ export const MyCollectionWhySell: React.FC<MyCollectionWhySellProps> = (props) =
           mb={2}
           block
           onPress={async () => {
-            trackEvent(
-              tracks.tappedSellArtwork(
-                setContextModule,
-                artwork.internalID,
-                artwork.slug,
-                setContextScreen,
-                "Submit This Artwork to Sell"
+            try {
+              trackEvent(
+                tracks.tappedSellArtwork(
+                  setContextModule,
+                  artwork.internalID,
+                  artwork.slug,
+                  setContextScreen,
+                  "Submit This Artwork to Sell"
+                )
               )
-            )
-            const passProps: SubmitArtworkProps = {
-              initialValues: {},
-              initialStep: "StartFlow",
-              hasStartedFlowFromMyCollection: true,
-            }
+              const passProps: SubmitArtworkProps = {
+                initialValues: {},
+                initialStep: "StartFlow",
+                hasStartedFlowFromMyCollection: true,
+              }
 
-            const artworkData = await fetchArtworkInformation(artwork.internalID)
+              const artworkData = await fetchArtworkInformation(artwork.internalID)
 
-            if (artworkData) {
-              passProps.initialValues = getInitialSubmissionFormValuesFromArtwork(artworkData)
+              if (!artworkData) {
+                Alert.alert(
+                  "Failed to fetch artwork details or create submission.",
+                  "Please try again or enter details manually."
+                )
+                return
+              }
+
+              const initialValues = getInitialSubmissionFormValuesFromArtwork(artworkData)
+
+              const submission = await createOrUpdateSubmission(initialValues, null)
+
+              ;(initialValues.submissionId = submission?.internalID || null),
+                (passProps.initialValues = initialValues)
               passProps.initialStep = "AddTitle"
+
+              navigate("/sell/submissions/new", { passProps })
+            } catch (error) {
+              Alert.alert(
+                "Failed to fetch artwork details or create submission.",
+                "Please try again or enter details manually."
+              )
             }
-            navigate("/sell/submissions/new", { passProps })
           }}
           testID="submitArtworkToSellButton"
         >

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -76,6 +76,10 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
         setCurrentStep("AddTitle")
       }
     } catch (error) {
+      console.error(
+        "Failed to fetch artwork details or create submission when starting sell flow from My Collection.",
+        error
+      )
       Alert.alert(
         "Failed to fetch artwork details or create submission.",
         "Please try again or enter details manually."

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkFromMyCollectionArtworks.tsx
@@ -77,7 +77,7 @@ export const SubmitArtworkFromMyCollectionArtworks: React.FC<{}> = () => {
       }
     } catch (error) {
       Alert.alert(
-        "Failed to fetch artwork details, ",
+        "Failed to fetch artwork details or create submission.",
         "Please try again or enter details manually."
       )
     } finally {


### PR DESCRIPTION
This PR resolves [ONYX-1381](https://artsyproduct.atlassian.net/browse/ONYX-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

Related to https://github.com/artsy/eigen/pull/11045

**Description**

This PR fixes a launch-blocking bug. The artwork ID is not present on the Image step in the SWA flow when submitting an artwork from My Collection for sale. However, the ID is necessary to upload assets/images to the submission.

The ID is not present in this step because, after choosing the artwork, the form values get initialized, but no submission is created (-> no ID).

This PR is a quick fix, and I will follow up with some simplifications. It should be able to create a submission from a My Collection artwork by just passing the artwork ID to the createSubmission mutation, which we should do in this case. This way, the form values do not have to be initialized manually.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix Image upload step when submitting a My Collection artwork for sale in the SWA flow - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1381]: https://artsyproduct.atlassian.net/browse/ONYX-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ