### PR TITLE
chore: redirect to native /orders screen instead of /settings/purchases

### DIFF
--- a/src/app/Scenes/HomeView/Components/PaymentFailureBanner.tsx
+++ b/src/app/Scenes/HomeView/Components/PaymentFailureBanner.tsx
@@ -65,9 +65,7 @@ export const PaymentFailureBanner: React.FC = () => {
     tracking.tappedChangePaymentMethod(failedPayments)
 
     const route =
-      failedPayments.length === 1
-        ? `orders/${failedPayments[0].internalID}/payment/new`
-        : `settings/purchases`
+      failedPayments.length === 1 ? `orders/${failedPayments[0].internalID}/payment/new` : `orders`
 
     navigate(route)
   }, [failedPayments, tracking])

--- a/src/app/Scenes/HomeView/Components/__tests__/PaymentFailureBanner.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/PaymentFailureBanner.tests.tsx
@@ -94,7 +94,7 @@ describe("PaymentFailureBanner", () => {
     expect(text).toBeTruthy()
 
     fireEvent.press(link)
-    expect(navigate).toHaveBeenCalledWith("settings/purchases")
+    expect(navigate).toHaveBeenCalledWith("orders")
   })
 
   it("does not render the banner when there are no payment failures", () => {


### PR DESCRIPTION
This PR resolves [EMI-2165](https://artsyproduct.atlassian.net/browse/EMI-2165)]

### Description

Redirect to Order History screen from failed payment banner in case of multiple payments failures.

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [X] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Redirect to Order History screen from failed payment banner in case of multiple payments failures. - oxaudo

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
