### PR TITLE
fix: remove focus from a test in the AuthModel test suite

### DIFF
--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -791,11 +791,9 @@ describe("AuthModel", () => {
       })
     })
 
-    fit("tracks createdAccount when user is signed up", async () => {
+    it("tracks createdAccount when user is signed up", async () => {
       mockFetchJsonOnce({ access_token: "x-access-token" }, 201)
       mockFetchJsonOnce({ email: "emailFromArtsy@mail.com" })
-      mockFetchJsonOnce({ access_token: "x-access-token" }, 201)
-      mockFetchJsonOnce({ id: "my-user-id" })
 
       await GlobalStore.actions.auth.authGoogle2()
 


### PR DESCRIPTION
I forgot to remove a `fit` from #11036 so this PR does that and removes some mocks that were causing other tests in the suite to fail.