### PR TITLE
feat(home view, analytics): fire experiment event only once per session

### DIFF
--- a/src/app/Scenes/HomeView/HomeViewContext.ts
+++ b/src/app/Scenes/HomeView/HomeViewContext.ts
@@ -2,18 +2,27 @@ import { Action, action, createContextStore } from "easy-peasy"
 
 interface HomeViewStoreModel {
   trackedSections: string[]
+  trackedExperiments: string[]
 
   addTrackedSection: Action<this, string>
+  addTrackedExperiment: Action<this, string>
 }
 
 const HomeViewStoreModel: HomeViewStoreModel = {
   trackedSections: [],
+  trackedExperiments: [],
 
   addTrackedSection: action((state, payload) => {
     if (state.trackedSections.includes(payload)) {
       return
     }
     state.trackedSections.push(payload)
+  }),
+  addTrackedExperiment: action((state, payload) => {
+    if (state.trackedExperiments.includes(payload)) {
+      return
+    }
+    state.trackedExperiments.push(payload)
   }),
 }
 

--- a/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
@@ -94,7 +94,7 @@ describe("HomeView", () => {
   })
 
   describe("home view experiements", () => {
-    it("fires an experiement_viewed event for enabled experiments", () => {
+    it("fires an experiment_viewed event for enabled experiments", () => {
       renderWithRelay({
         HomeView: () => ({
           experiments: [
@@ -117,7 +117,7 @@ describe("HomeView", () => {
       )
     })
 
-    it("does not fire an experiement_viewed event for disabled experiments", () => {
+    it("does not fire an experiment_viewed event for disabled experiments", () => {
       renderWithRelay({
         HomeView: () => ({
           experiments: [
@@ -137,7 +137,7 @@ describe("HomeView", () => {
       )
     })
 
-    it("does not fire an experiement_viewed event when variant is missing", () => {
+    it("does not fire an experiment_viewed event when variant is missing", () => {
       renderWithRelay({
         HomeView: () => ({
           experiments: [

--- a/src/app/Scenes/HomeView/useHomeViewExperimentTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewExperimentTracking.ts
@@ -1,5 +1,6 @@
 import { ExperimentViewed, ActionType, OwnerType } from "@artsy/cohesion"
 import { HomeViewQuery$data } from "__generated__/HomeViewQuery.graphql"
+import { HomeViewStore } from "app/Scenes/HomeView/HomeViewContext"
 import { compact } from "lodash"
 import { useEffect } from "react"
 import { useTracking } from "react-tracking"
@@ -7,6 +8,10 @@ import { useTracking } from "react-tracking"
 export function useHomeViewExperimentTracking(
   homeViewExperiments: HomeViewQuery$data["homeView"]["experiments"]
 ) {
+  const trackedExperiments = HomeViewStore.useStoreState((state) => state.trackedExperiments)
+  const addTrackedExperiment = HomeViewStore.useStoreActions(
+    (actions) => actions.addTrackedExperiment
+  )
   const { trackEvent } = useTracking()
 
   function trackViewedExperiment(name: string, variant: string) {
@@ -29,7 +34,10 @@ export function useHomeViewExperimentTracking(
       } else if (!variant) {
         console.warn(`Experiment variant is missing for: ${name}`)
       } else {
-        trackViewedExperiment(name, variant)
+        if (!trackedExperiments.includes(name)) {
+          trackViewedExperiment(name, variant)
+          addTrackedExperiment(name)
+        }
       }
     })
   }, [homeViewExperiments])

--- a/src/app/Scenes/HomeView/useHomeViewExperimentTracking.ts
+++ b/src/app/Scenes/HomeView/useHomeViewExperimentTracking.ts
@@ -31,13 +31,17 @@ export function useHomeViewExperimentTracking(
     experiments.forEach(({ name, variant, enabled }) => {
       if (!enabled) {
         console.warn(`Experiment is not enabled: ${name}`)
-      } else if (!variant) {
+        return
+      }
+
+      if (!variant) {
         console.warn(`Experiment variant is missing for: ${name}`)
-      } else {
-        if (!trackedExperiments.includes(name)) {
-          trackViewedExperiment(name, variant)
-          addTrackedExperiment(name)
-        }
+        return
+      }
+
+      if (!trackedExperiments.includes(name)) {
+        trackViewedExperiment(name, variant)
+        addTrackedExperiment(name)
       }
     })
   }, [homeViewExperiments])


### PR DESCRIPTION
This PR resolves [ONYX-1371] <!-- eg [PROJECT-XXXX] -->

### Description

Follow-up to #11048 which ensures that each experiment's `experiment_viewed` event is fired only once per session.

Recording here of Metaphysics + Eigen to demonstrate:

1. Initial home view request returns one experiment (`onyx_experiment_home_view_test`)
2. That experiment gets tracked
3. During the same session _another_ experiment is enabled (`onyx_experiment_home_view_test_2`)
4. That experiment also gets tracked, without re-firing the event for the first one.

<video src="https://github.com/user-attachments/assets/ee640155-9dd6-4f17-a8f1-d6201fbc88c9" />



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Ensure experiment_viewed fired only once per home view experiment

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1371]: https://artsyproduct.atlassian.net/browse/ONYX-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ