### PR TITLE
test(home view): improve coverage 

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
@@ -141,7 +141,7 @@ const fragment = graphql`
 const HomeViewSectionArticlesCardsPlaceholder: React.FC<FlexProps> = (flexProps) => {
   return (
     <Skeleton>
-      <Flex {...flexProps}>
+      <Flex {...flexProps} testID="HomeViewSectionArticlesCardsPlaceholder">
         <Flex mx={2} p={2} border="1px solid" borderColor="black30" gap={2}>
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
             <SkeletonText variant="lg-display">title</SkeletonText>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
@@ -127,7 +127,7 @@ const HomeViewSectionCardsChipsPlaceholder: React.FC = () => {
 
   return (
     <Skeleton>
-      <Flex py={2}>
+      <Flex py={2} testID="HomeViewSectionCardsChipsPlaceholder">
         <Flex px={2}>
           <SectionTitle title="Discover Something New" />
         </Flex>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -168,7 +168,7 @@ const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => 
       <SkeletonBox>
         <SkeletonBox height={HEADER_IMAGE_HEIGHT} />
 
-        <Flex mx={2} mt={2}>
+        <Flex mx={2} mt={2} testID="HomeViewSectionFeaturedCollectionPlaceholder">
           <SkeletonText color="white100" variant="lg-display" mb={0.5}>
             Section Title
           </SkeletonText>

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -21,7 +21,7 @@ import { HomeViewSectionViewingRoomsQueryRenderer } from "app/Scenes/HomeView/Se
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { CleanRelayFragment } from "app/utils/relayHelpers"
 
-interface SectionProps extends FlexProps {
+export interface SectionProps extends FlexProps {
   section: CleanRelayFragment<HomeViewSectionGeneric_section$data>
   index: number
 }

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticles.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticles.tests.tsx
@@ -31,10 +31,60 @@ describe("HomeViewSectionArticles", () => {
     `,
   })
 
+  it("does not render the section if no articles are available", () => {
+    renderWithRelay({
+      HomeViewSectionArticles: () => ({
+        internalID: "home-view-section-latest-articles",
+        component: {
+          title: "Latest Articles",
+        },
+        articlesConnection: null,
+      }),
+    })
+
+    expect(screen.queryByText("Latest Articles")).not.toBeOnTheScreen()
+    expect(screen.toJSON()).toBeNull()
+  })
+
   it("renders a list of articles", () => {
     renderWithRelay({
       HomeViewSectionArticles: () => ({
         internalID: "home-view-section-latest-articles",
+        contextModule: "articleRail",
+        component: {
+          title: "Latest Articles",
+        },
+        articlesConnection: {
+          edges: [
+            {
+              node: {
+                thumbnailTitle: "Article 1",
+                slug: "article-1",
+                internalID: "article-1-id",
+              },
+            },
+            {
+              node: {
+                thumbnailTitle: "Article 2",
+                slug: "article-2",
+                internalID: "article-2-id",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("Latest Articles")).toBeOnTheScreen()
+    expect(screen.getByText("Article 1")).toBeOnTheScreen()
+    expect(screen.getByText("Article 2")).toBeOnTheScreen()
+  })
+
+  it("tracks article navigation", () => {
+    renderWithRelay({
+      HomeViewSectionArticles: () => ({
+        internalID: "home-view-section-latest-articles",
+        contextModule: "articleRail",
         component: {
           title: "Latest Articles",
         },
@@ -64,20 +114,61 @@ describe("HomeViewSectionArticles", () => {
     expect(screen.getByText("Article 2")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Article 2"))
-    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
-        [
-          {
-            "action": "tappedArticleGroup",
-            "context_module": "<mock-value-for-field-"contextModule">",
-            "context_screen_owner_type": "home",
-            "destination_screen_owner_id": "article-2-id",
-            "destination_screen_owner_slug": "article-2",
-            "destination_screen_owner_type": "article",
-            "horizontal_slide_position": 1,
-            "module_height": "double",
-            "type": "thumbnail",
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedArticleGroup",
+      context_module: "articleRail",
+      context_screen_owner_type: "home",
+      destination_screen_owner_id: "article-2-id",
+      destination_screen_owner_slug: "article-2",
+      destination_screen_owner_type: "article",
+      horizontal_slide_position: 1,
+      module_height: "double",
+      type: "thumbnail",
+    })
+  })
+
+  it("tracks view-all navigation", () => {
+    renderWithRelay({
+      HomeViewSectionArticles: () => ({
+        internalID: "home-view-section-latest-articles",
+        contextModule: "articleRail",
+        component: {
+          title: "Latest Articles",
+          behaviors: {
+            viewAll: {
+              ownerType: "articles",
+              href: "/articles",
+            },
           },
-        ]
-      `)
+        },
+        articlesConnection: {
+          edges: [
+            {
+              node: {
+                thumbnailTitle: "Article 1",
+                internalID: "article-1-id",
+              },
+            },
+            {
+              node: {
+                thumbnailTitle: "Article 2",
+                internalID: "article-2-id",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    fireEvent.press(screen.getByText("Latest Articles"))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedArticleGroup",
+      context_module: "articleRail",
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: "articles",
+      type: "viewAll",
+    })
   })
 })

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCards.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCards.tests.tsx
@@ -1,7 +1,9 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { HomeViewSectionCardsTestsQuery } from "__generated__/HomeViewSectionCardsTestsQuery.graphql"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionCards } from "app/Scenes/HomeView/Sections/HomeViewSectionCards"
+import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -27,13 +29,75 @@ describe("HomeViewSectionCards", () => {
     `,
   })
 
-  it("renders", () => {
+  it("does not render if no cards are available", () => {
     renderWithRelay({
       HomeViewSectionCards: () => ({
         component: { title: "Explore by category" },
+        cardsConnection: null,
+      }),
+    })
+
+    expect(screen.queryByText("Explore by category")).not.toBeOnTheScreen()
+  })
+
+  it("renders a list of cards", () => {
+    renderWithRelay({
+      HomeViewSectionCards: () => ({
+        component: { title: "Explore by category" },
+        cardsConnection: {
+          edges: [
+            {
+              node: {
+                title: "Card 1",
+              },
+            },
+            {
+              node: {
+                title: "Card 2",
+              },
+            },
+          ],
+        },
       }),
     })
 
     expect(screen.getByText("Explore by category")).toBeOnTheScreen()
+    expect(screen.getByText(/Card 1/)).toBeOnTheScreen()
+    expect(screen.getByText(/Card 2/)).toBeOnTheScreen()
+  })
+
+  it("navigates and tracks card clicks", () => {
+    renderWithRelay({
+      HomeViewSectionCards: () => ({
+        component: { title: "Explore by category" },
+        contextModule: "some-cards",
+        cardsConnection: {
+          edges: [
+            {
+              node: {
+                title: "Card 1",
+                href: "/card-1",
+                entityID: "Collect by Price",
+                entityType: "collectionsCategory",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    fireEvent.press(screen.getByText(/Card 1/))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "tappedCardGroup",
+        context_module: "some-cards",
+        context_screen_owner_type: "home",
+        destination_screen_owner_id: "Collect by Price",
+        destination_screen_owner_type: "collectionsCategory",
+      })
+    )
+
+    expect(navigate).toHaveBeenCalledWith(expect.stringMatching("/collections-by-category/Card 1"))
   })
 })

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionFeaturedCollection.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionFeaturedCollection.tests.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { HomeViewSectionFeaturedCollectionTestQuery } from "__generated__/HomeViewSectionFeaturedCollectionTestQuery.graphql"
+import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
+import { HomeViewSectionFeaturedCollection } from "app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection"
+import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("HomeViewSectionFeaturedCollection", () => {
+  const { renderWithRelay } = setupTestWrapper<HomeViewSectionFeaturedCollectionTestQuery>({
+    Component: (props) => {
+      if (!props.homeView.section) {
+        return null
+      }
+      return (
+        <HomeViewStoreProvider>
+          <HomeViewSectionFeaturedCollection section={props.homeView.section} index={0} />
+        </HomeViewStoreProvider>
+      )
+    },
+    query: graphql`
+      query HomeViewSectionFeaturedCollectionTestQuery @relay_test_operation {
+        homeView {
+          section(id: "home-view-section-foo-bar-collection-artworks") {
+            ... on HomeViewSectionArtworks {
+              ...HomeViewSectionFeaturedCollection_section
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  it("does not render the section if no artworks are available", () => {
+    renderWithRelay({
+      HomeViewComponent: () => ({
+        title: "The Foo Bar Collection",
+      }),
+
+      ArtworkConnection: () => ({
+        totalCount: 0,
+        edges: [],
+      }),
+    })
+
+    expect(screen.queryByText("The Foo Bar Collection")).not.toBeOnTheScreen()
+    expect(screen.toJSON()).toBeNull()
+  })
+
+  it("renders a list of artworks", () => {
+    renderWithRelay({
+      HomeViewSectionArtworks: () => ({
+        internalID: "home-view-section-foo-bar-collection-artworks",
+        component: {
+          title: "The Foo Bar Collection",
+        },
+        artworksConnection: {
+          edges: [
+            {
+              node: {
+                title: "Artwork 1",
+              },
+            },
+            {
+              node: {
+                title: "Artwork 2",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("The Foo Bar Collection")).toBeOnTheScreen()
+    expect(screen.getByText(/Artwork 1/)).toBeOnTheScreen()
+    expect(screen.getByText(/Artwork 2/)).toBeOnTheScreen()
+  })
+
+  describe("tapping on view-all", () => {
+    it("fires an event and navigates", () => {
+      renderWithRelay({
+        HomeViewSectionArtworks: () => ({
+          contextModule: "fooBarRail",
+          component: {
+            behaviors: {
+              viewAll: {
+                buttonText: "Browse All Artworks",
+                href: "/foo-bar-artworks",
+                ownerType: "collection",
+              },
+            },
+          },
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  internalID: "artwork-1-id",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      fireEvent.press(screen.getByText(/Browse All Artworks/))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "tappedArtworkGroup",
+          context_module: "fooBarRail",
+          context_screen_owner_type: "home",
+          destination_screen_owner_type: "collection",
+          type: "viewAll",
+        })
+      )
+
+      expect(navigate).toHaveBeenCalledWith("/foo-bar-artworks")
+    })
+  })
+
+  describe("tapping on an artwork", () => {
+    it("fires an event and navigates", () => {
+      renderWithRelay({
+        HomeViewSectionArtworks: () => ({
+          contextModule: "fooBarRail",
+          artworksConnection: {
+            edges: [
+              {
+                node: {
+                  internalID: "artwork-1-id",
+                  title: "Artwork 1",
+                  slug: "artwork-1-slug",
+                  href: "/artwork-1-href",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      fireEvent.press(screen.getByText(/Artwork 1/))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "tappedArtworkGroup",
+          context_module: "fooBarRail",
+          context_screen_owner_type: "home",
+          destination_screen_owner_id: "artwork-1-id",
+          destination_screen_owner_slug: "artwork-1-slug",
+        })
+      )
+
+      expect(navigate).toHaveBeenCalledWith("/artwork-1-href")
+    })
+  })
+})

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionSales.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionSales.tests.tsx
@@ -71,6 +71,7 @@ describe("HomeViewSectionSales", () => {
     renderWithRelay({
       HomeViewSectionSales: () => ({
         internalID: "home-view-section-sales",
+        contextModule: "auctionRail",
         component: {
           title: "Auctions",
           behaviors: {
@@ -107,22 +108,75 @@ describe("HomeViewSectionSales", () => {
 
     fireEvent.press(screen.getByText("sale 2"))
 
-    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
-        [
-          {
-            "action": "tappedAuctionGroup",
-            "context_module": "<mock-value-for-field-"contextModule">",
-            "context_screen_owner_type": "home",
-            "destination_screen_owner_id": "sale-2-id",
-            "destination_screen_owner_slug": "sale-2-slug",
-            "destination_screen_owner_type": "sale",
-            "horizontal_slide_position": 1,
-            "module_height": "double",
-            "type": "thumbnail",
-          },
-        ]
-      `)
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "tappedAuctionGroup",
+        context_module: "auctionRail",
+        context_screen_owner_type: "home",
+        destination_screen_owner_id: "sale-2-id",
+        destination_screen_owner_slug: "sale-2-slug",
+        destination_screen_owner_type: "sale",
+        horizontal_slide_position: 1,
+        module_height: "double",
+        type: "thumbnail",
+      })
+    )
 
     expect(navigate).toHaveBeenCalledWith("/sale-2-href")
+  })
+
+  it("tracks view-all properly", async () => {
+    renderWithRelay({
+      HomeViewSectionSales: () => ({
+        internalID: "home-view-section-sales",
+        contextModule: "auctionRail",
+        component: {
+          title: "Auctions",
+          behaviors: {
+            viewAll: {
+              href: "/auctions",
+              buttonText: "Browse All Auctions",
+              ownerType: "auctions",
+            },
+          },
+        },
+        salesConnection: {
+          edges: [
+            {
+              node: {
+                name: "sale 1",
+                href: "/sale-1-href",
+                internalID: "sale-1-id",
+                slug: "sale-1-slug",
+                liveURLIfOpen: null,
+              },
+            },
+            {
+              node: {
+                name: "sale 2",
+                href: "/sale-2-href",
+                internalID: "sale-2-id",
+                slug: "sale-2-slug",
+                liveURLIfOpen: null,
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    fireEvent.press(screen.getByText("Browse All Auctions"))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "tappedAuctionResultGroup",
+        context_module: "auctionRail",
+        context_screen_owner_type: "home",
+        destination_screen_owner_type: "auctions",
+        type: "viewAll",
+      })
+    )
+
+    expect(navigate).toHaveBeenCalledWith("/auctions")
   })
 })

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionViewingRooms.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionViewingRooms.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/r
 import { HomeViewSectionViewingRoomsTestsQuery } from "__generated__/HomeViewSectionViewingRoomsTestsQuery.graphql"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionViewingRooms } from "app/Scenes/HomeView/Sections/HomeViewSectionViewingRooms"
+import { navigate } from "app/system/navigation/navigate"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -128,5 +129,61 @@ describe("HomeViewSectionViewingRooms", () => {
         },
       ]
   `)
+
+    expect(navigate).toHaveBeenCalledWith(
+      "/viewing-room/alessandro-pessoli-ardente-primavera-number-1"
+    )
+  })
+
+  it("navigates and tracks view-all taps when href is provided", async () => {
+    const { mockResolveLastOperation } = renderWithRelay({
+      HomeViewSectionViewingRooms: () => ({
+        internalID: "home-view-section-viewing-rooms",
+        contextModule: "viewingRoomsRail",
+        component: {
+          title: "Viewing Rooms",
+          behaviors: {
+            viewAll: {
+              href: "/viewing-rooms",
+              buttonText: "View All",
+              ownerType: "viewingRooms",
+            },
+          },
+        },
+      }),
+    })
+
+    expect(screen.getByText("Viewing Rooms")).toBeOnTheScreen()
+
+    mockResolveLastOperation({
+      ViewingRoomsConnection: () => ({
+        edges: [
+          {
+            node: {
+              title: "viewing room 1",
+            },
+          },
+          {
+            node: {
+              title: "viewing room 2",
+            },
+          },
+        ],
+      }),
+    })
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId("viewing-room-rail-placeholder"))
+
+    fireEvent.press(screen.getByText("Viewing Rooms"))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedViewingRoomGroup",
+      context_module: "viewingRoomsRail",
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: "viewingRooms",
+      type: "viewAll",
+    })
+
+    expect(navigate).toHaveBeenCalledWith("/viewing-rooms")
   })
 })

--- a/src/app/Scenes/HomeView/Sections/__tests__/Section.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/Section.tests.tsx
@@ -1,0 +1,117 @@
+import { screen, render } from "@testing-library/react-native"
+import { Section, SectionProps } from "app/Scenes/HomeView/Sections/Section"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+jest.mock("app/utils/hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
+}))
+
+const mockUseFeatureFlag = useFeatureFlag as jest.Mock
+mockUseFeatureFlag.mockImplementation(() => true)
+
+describe("Section", () => {
+  describe("when in __DEV__ mode", () => {
+    beforeAll(() => {
+      // @ts-ignore
+      global.__DEV__ = true
+    })
+
+    afterAll(() => {
+      // @ts-ignore
+      global.__DEV__ = false
+    })
+
+    it("raises an error if section ID is missing", () => {
+      const section = {
+        internalID: null,
+      }
+      expect(() => {
+        render(
+          // @ts-expect-error internalID=null intentionally
+          <Section section={section} index={1} />
+        )
+      }).toThrow()
+    })
+
+    it("renders a message if section type is not recognized", () => {
+      const section = {
+        __typename: "SomeUnknownSectionType",
+        internalID: "42",
+      } as SectionProps["section"]
+      renderWithWrappers(<Section section={section} index={1} />)
+      expect(screen.getByText(/Non supported section/)).toBeOnTheScreen()
+    })
+  })
+
+  describe("when not in __DEV__ mode", () => {
+    beforeAll(() => {
+      // @ts-ignore
+      global.__DEV__ = false
+    })
+
+    afterAll(() => {
+      // @ts-ignore
+      global.__DEV__ = false
+    })
+
+    it("does not raise an error if section ID is missing", () => {
+      const section = {
+        internalID: null,
+      }
+      expect(() => {
+        render(
+          // @ts-expect-error internalID=null intentionally
+          <Section section={section} index={1} />
+        )
+      }).not.toThrow()
+    })
+
+    it("does not render a message if section type is not recognized", () => {
+      const section = {
+        __typename: "SomeUnknownSectionType",
+        internalID: "42",
+      } as SectionProps["section"]
+      renderWithWrappers(<Section section={section} index={1} />)
+      expect(screen.queryByText(/Non supported section/)).not.toBeOnTheScreen()
+    })
+  })
+
+  describe("with an optional component.type", () => {
+    it("renders FeaturedCollection", () => {
+      const section = {
+        __typename: "SomeSectionType",
+        internalID: "42",
+        component: {
+          type: "FeaturedCollection",
+        },
+      } as SectionProps["section"]
+      renderWithWrappers(<Section section={section} index={1} />)
+      expect(screen.getByTestId("HomeViewSectionFeaturedCollectionPlaceholder")).toBeOnTheScreen()
+    })
+
+    it("renders FeaturedCollection", () => {
+      const section = {
+        __typename: "SomeSectionType",
+        internalID: "42",
+        component: {
+          type: "ArticlesCard",
+        },
+      } as SectionProps["section"]
+      renderWithWrappers(<Section section={section} index={1} />)
+      expect(screen.getByTestId("HomeViewSectionArticlesCardsPlaceholder")).toBeOnTheScreen()
+    })
+
+    it("renders Chips", () => {
+      const section = {
+        __typename: "SomeSectionType",
+        internalID: "42",
+        component: {
+          type: "Chips",
+        },
+      } as SectionProps["section"]
+      renderWithWrappers(<Section section={section} index={1} />)
+      expect(screen.getByTestId("HomeViewSectionCardsChipsPlaceholder")).toBeOnTheScreen()
+    })
+  })
+})

--- a/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
@@ -93,7 +93,7 @@ describe("HomeView", () => {
     expect(screen.getByText("Tap here to verify your email address")).toBeTruthy()
   })
 
-  describe("home view experiements", () => {
+  describe("home view experiments", () => {
     it("fires an experiment_viewed event for enabled experiments", () => {
       renderWithRelay({
         HomeView: () => ({


### PR DESCRIPTION
This PR resolves [ONYX-1249] 

### Description

This addresses some gaps in test coverage in the new home view frontend code:

- I used Jest's code coverage capabilities to assess which implementations were most lacking in coverage.
- I aimed to get red of all the 🔴 red that I could, but left 🟡 yellow alone: i.e. improvement not perfection

<img width=500 src=https://github.com/user-attachments/assets/9f184d80-8271-48b9-909f-9f715a9a93f3 />

```sh
# coverage report like above generated with 
yarn jest src/app/Scenes/HomeView --coverage --collectCoverageFrom="src/app/Scenes/HomeView/**/*"
```



Consider this also a plea to prioritize test coverage as you add to the home view.

Here's another example of leveraging Jest to help you ensure that you've added a suitable amount of coverage when working on an implementation:

```sh
yarn jest --watch \
  src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCards.tests.tsx \
  --coverage --collectCoverageFrom src/app/Scenes/HomeView/Sections/HomeViewSectionCards.tsx
```


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Improve test coverage for home view

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1249]: https://artsyproduct.atlassian.net/browse/ONYX-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ