### PR TITLE
chore: enable AREnableSignupLoginFusion

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
@@ -1,35 +1,45 @@
+import { screen } from "@testing-library/react-native"
 import { Onboarding, OnboardingWelcomeScreens } from "app/Scenes/Onboarding/Onboarding"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { NetworkAwareProvider } from "app/utils/NetworkAwareProvider"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 jest.mock("../OnboardingQuiz/OnboardingQuiz.tsx", () => ({
   OnboardingQuiz: () => "OnboardingQuiz",
 }))
 
 describe("Onboarding", () => {
-  it("renders the welcome screens when the onboarding state is none or complete", () => {
-    const tree1 = renderWithWrappersLEGACY(<Onboarding />)
-    __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "none" } })
-    expect(tree1.root.findAllByType(OnboardingQuiz).length).toEqual(0)
-    expect(tree1.root.findAllByType(OnboardingWelcomeScreens).length).toEqual(1)
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableSignupLoginFusion: false,
+    })
+  })
 
-    const tree2 = renderWithWrappersLEGACY(<Onboarding />)
+  it("renders the welcome screens when the onboarding state is none or complete", () => {
+    renderWithWrappers(<Onboarding />)
+    __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "none" } })
+
+    expect(screen.UNSAFE_queryByType(OnboardingQuiz)).not.toBeOnTheScreen()
+    expect(screen.UNSAFE_getByType(OnboardingWelcomeScreens)).toBeOnTheScreen()
+
+    renderWithWrappers(<Onboarding />)
     __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "complete" } })
-    expect(tree2.root.findAllByType(OnboardingQuiz).length).toEqual(0)
-    expect(tree2.root.findAllByType(OnboardingWelcomeScreens).length).toEqual(1)
+
+    expect(screen.UNSAFE_queryByType(OnboardingQuiz)).not.toBeOnTheScreen()
+    expect(screen.UNSAFE_getByType(OnboardingWelcomeScreens)).toBeOnTheScreen()
   })
 
   it("renders the personalization flow when the onboarding state is incomplete", () => {
-    const tree = renderWithWrappersLEGACY(<Onboarding />)
+    renderWithWrappers(<Onboarding />)
     __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "incomplete" } })
-    expect(tree.root.findAllByType(OnboardingQuiz).length).toEqual(1)
-    expect(tree.root.findAllByType(OnboardingWelcomeScreens).length).toEqual(0)
+    expect(screen.UNSAFE_getByType(OnboardingQuiz)).toBeOnTheScreen()
+    expect(screen.UNSAFE_queryByType(OnboardingWelcomeScreens)).not.toBeOnTheScreen()
   })
 
   it("renders NetworkAwareProvider", () => {
-    const tree = renderWithWrappersLEGACY(<Onboarding />)
-    expect(tree.root.findAllByType(NetworkAwareProvider).length).toEqual(1)
+    renderWithWrappers(<Onboarding />)
+
+    expect(screen.UNSAFE_getByType(NetworkAwareProvider)).toBeOnTheScreen()
   })
 })

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -268,8 +268,9 @@ export const features = {
   },
   AREnableSignupLoginFusion: {
     description: "Enable the fused signup and login flow",
-    readyForRelease: false,
+    readyForRelease: true,
     showInDevMenu: true,
+    echoFlagKey: "AREnableSignupLoginFusion",
   },
   AREnableMarketingCollectionsCategories: {
     description: "Enable marketing collections categories elements in the home view",


### PR DESCRIPTION
This PR enables the AREnableSignupLoginFusion feature flag, which will display the new auth flow to users. It also has an accompanying Echo flag: artsy/echo#687

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Display a redesigned sign up and login flow to users - iskounen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
