### PR TITLE
fix: avoid prefetching when following deeplinks

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -31,7 +31,7 @@ import { requestPushNotificationsPermission } from "app/utils/requestPushNotific
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
 import { useSwitchStatusBarStyle } from "app/utils/useStatusBarStyle"
 import { RefObject, Suspense, useCallback, useEffect, useState } from "react"
-import { FlatList, RefreshControl } from "react-native"
+import { FlatList, Linking, RefreshControl } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
 export const NUMBER_OF_SECTIONS_TO_LOAD = 10
@@ -86,10 +86,15 @@ export const HomeView: React.FC = () => {
   const sections = extractNodes(data?.homeView.sectionsConnection)
 
   useEffect(() => {
-    prefetchUrl<SearchQuery>("search", searchQueryDefaultVariables)
-    prefetchUrl("my-profile")
-    prefetchUrl("inbox")
-    prefetchUrl("sell")
+    Linking.getInitialURL().then((url) => {
+      const isDeepLink = !!url
+      if (!isDeepLink) {
+        prefetchUrl<SearchQuery>("search", searchQueryDefaultVariables)
+        prefetchUrl("my-profile")
+        prefetchUrl("inbox")
+        prefetchUrl("sell")
+      }
+    })
   }, [])
 
   useEffect(() => {

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -25,6 +25,7 @@ import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
 import { extractNodes } from "app/utils/extractNodes"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
+import { useIsDeepLink } from "app/utils/hooks/useIsDeepLink"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import { requestPushNotificationsPermission } from "app/utils/requestPushNotificationsPermission"
@@ -191,6 +192,8 @@ const HomeViewScreenComponent: React.FC = () => {
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const showPlayground = useDevToggle("DTShowPlayground")
 
+  const { isDeepLink } = useIsDeepLink()
+
   useSwitchStatusBarStyle("dark-content", "dark-content")
 
   useEffect(() => {
@@ -204,6 +207,12 @@ const HomeViewScreenComponent: React.FC = () => {
       return
     }
   }, [artQuizState, isNavigationReady])
+
+  // We want to avoid rendering the home view when the user comes back from a deep link
+  // Because it triggers a lot of queries that affect the user's experience and can be avoided
+  if (isDeepLink !== false) {
+    return null
+  }
 
   if (artQuizState === "incomplete") {
     return null

--- a/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
@@ -15,6 +15,12 @@ const requestPushNotificationsPermissionSpy = jest.spyOn(
   "requestPushNotificationsPermission"
 )
 
+jest.mock("app/utils/hooks/useIsDeepLink", () => {
+  return {
+    useIsDeepLink: jest.fn().mockReturnValue({ isDeepLink: false }),
+  }
+})
+
 describe("HomeView", () => {
   const { renderWithRelay } = setupTestWrapper<HomeViewSectionArtworksTestsQuery>({
     Component: () => {

--- a/src/app/utils/hooks/useIsDeepLink.tests.ts
+++ b/src/app/utils/hooks/useIsDeepLink.tests.ts
@@ -1,8 +1,8 @@
 import { renderHook } from "@testing-library/react-hooks"
+import { matchRoute } from "app/routes"
 import { useIsDeepLink } from "app/utils/hooks/useIsDeepLink"
 import { Linking } from "react-native"
 
-// Existing mocks
 const mockUseIsFocusedMock = jest.fn()
 jest.mock("@react-navigation/native", () => ({
   useIsFocused: () => mockUseIsFocusedMock(),
@@ -14,13 +14,18 @@ jest.mock("react-native", () => ({
   },
 }))
 
-// Start of the new test case
+jest.mock("app/routes", () => ({
+  matchRoute: jest.fn(),
+}))
+
 describe("useIsDeepLink", () => {
   const mockLinkingGetInitialURL = Linking.getInitialURL as jest.Mock
+  const mockMatchRoute = matchRoute as jest.Mock
 
   it("should return true if opened from a deep link", async () => {
     // Setup the mock to return the specific URL
-    mockLinkingGetInitialURL.mockResolvedValue("artsy:///foo/bar")
+    mockLinkingGetInitialURL.mockResolvedValue("artsy:///artwork/foo")
+    mockMatchRoute.mockReturnValue({ type: "match", module: "Artwork" })
     mockUseIsFocusedMock.mockReturnValue(true)
 
     // Render the hook under test
@@ -34,6 +39,7 @@ describe("useIsDeepLink", () => {
     })
     expect(mockUseIsFocusedMock).toHaveBeenCalled()
     expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+    expect(mockMatchRoute).toHaveBeenCalled()
   })
 
   it("should return false if not opened from a deep link", async () => {
@@ -50,11 +56,13 @@ describe("useIsDeepLink", () => {
     expect(result.current.isDeepLink).toEqual(false)
     expect(mockUseIsFocusedMock).toHaveBeenCalled()
     expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+    expect(mockMatchRoute).toHaveBeenCalled()
   })
 
   it("should return false if opened from a link to /", async () => {
     // Setup the mock to return null
     mockLinkingGetInitialURL.mockResolvedValue("artsy:///")
+    mockMatchRoute.mockReturnValue({ type: "match", module: "Home" })
     mockUseIsFocusedMock.mockReturnValue(true)
 
     // Render the hook under test
@@ -66,5 +74,6 @@ describe("useIsDeepLink", () => {
     expect(result.current.isDeepLink).toEqual(false)
     expect(mockUseIsFocusedMock).toHaveBeenCalled()
     expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+    expect(mockMatchRoute).toHaveBeenCalled()
   })
 })

--- a/src/app/utils/hooks/useIsDeepLink.tests.ts
+++ b/src/app/utils/hooks/useIsDeepLink.tests.ts
@@ -1,0 +1,54 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useIsDeepLink } from "app/utils/hooks/useIsDeepLink"
+import { Linking } from "react-native"
+
+// Existing mocks
+const mockUseIsFocusedMock = jest.fn()
+jest.mock("@react-navigation/native", () => ({
+  useIsFocused: () => mockUseIsFocusedMock(),
+}))
+
+jest.mock("react-native", () => ({
+  Linking: {
+    getInitialURL: jest.fn(),
+  },
+}))
+
+// Start of the new test case
+describe("useIsDeepLink", () => {
+  const mockLinkingGetInitialURL = Linking.getInitialURL as jest.Mock
+
+  it("should return true if opened from a deep link", async () => {
+    // Setup the mock to return the specific URL
+    mockLinkingGetInitialURL.mockResolvedValue("artst.net/foo/bar")
+    mockUseIsFocusedMock.mockReturnValue(true)
+
+    // Render the hook under test
+    const { result, waitForNextUpdate } = renderHook(() => useIsDeepLink())
+
+    // Wait for async effects to resolve
+    await waitForNextUpdate()
+
+    expect(result.current).toEqual({
+      isDeepLink: true,
+    })
+    expect(mockUseIsFocusedMock).toHaveBeenCalled()
+    expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+  })
+
+  it("should return false if not opened from a deep link", async () => {
+    // Setup the mock to return null
+    mockLinkingGetInitialURL.mockResolvedValue(null)
+    mockUseIsFocusedMock.mockReturnValue(true)
+
+    // Render the hook under test
+    const { result, waitForNextUpdate } = renderHook(() => useIsDeepLink())
+
+    // Wait for async effects to resolve
+    await waitForNextUpdate()
+
+    expect(result.current.isDeepLink).toEqual(false)
+    expect(mockUseIsFocusedMock).toHaveBeenCalled()
+    expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+  })
+})

--- a/src/app/utils/hooks/useIsDeepLink.tests.ts
+++ b/src/app/utils/hooks/useIsDeepLink.tests.ts
@@ -20,7 +20,7 @@ describe("useIsDeepLink", () => {
 
   it("should return true if opened from a deep link", async () => {
     // Setup the mock to return the specific URL
-    mockLinkingGetInitialURL.mockResolvedValue("artst.net/foo/bar")
+    mockLinkingGetInitialURL.mockResolvedValue("artsy:///foo/bar")
     mockUseIsFocusedMock.mockReturnValue(true)
 
     // Render the hook under test
@@ -39,6 +39,22 @@ describe("useIsDeepLink", () => {
   it("should return false if not opened from a deep link", async () => {
     // Setup the mock to return null
     mockLinkingGetInitialURL.mockResolvedValue(null)
+    mockUseIsFocusedMock.mockReturnValue(true)
+
+    // Render the hook under test
+    const { result, waitForNextUpdate } = renderHook(() => useIsDeepLink())
+
+    // Wait for async effects to resolve
+    await waitForNextUpdate()
+
+    expect(result.current.isDeepLink).toEqual(false)
+    expect(mockUseIsFocusedMock).toHaveBeenCalled()
+    expect(mockLinkingGetInitialURL).toHaveBeenCalled()
+  })
+
+  it("should return false if opened from a link to /", async () => {
+    // Setup the mock to return null
+    mockLinkingGetInitialURL.mockResolvedValue("artsy:///")
     mockUseIsFocusedMock.mockReturnValue(true)
 
     // Render the hook under test

--- a/src/app/utils/hooks/useIsDeepLink.ts
+++ b/src/app/utils/hooks/useIsDeepLink.ts
@@ -9,7 +9,7 @@ import { Linking } from "react-native"
  *
  * This can be used to avoid rendering content in previous screens in react-navigation history
  *
- * @returns {isDeepLink: boolean | null} isDeepLink is true if the user came from a deep link
+ * @returns {isDeepLink: boolean | null}` isDeepLink` is true if the user came from a deep link. Initially, it is set to `null` while retrieving the deep link URL asynchronously and will be set to `false` if retrieving the `URL` fails.
  */
 export const useIsDeepLink = () => {
   const [isDeepLink, setIsDeepLink] = useState<boolean | null>(null)
@@ -37,11 +37,7 @@ export const useIsDeepLink = () => {
         const isHomeLink = result.type === "match" && result.module === "Home"
         const shouldTreatAsDeepLink = !isHomeLink && !isExternalUrl
 
-        if (shouldTreatAsDeepLink) {
-          setIsDeepLink(true)
-        } else {
-          setIsDeepLink(false)
-        }
+        setIsDeepLink(shouldTreatAsDeepLink)
       })
       .catch((error) => {
         console.error("Error getting initial URL", error)

--- a/src/app/utils/hooks/useIsDeepLink.ts
+++ b/src/app/utils/hooks/useIsDeepLink.ts
@@ -1,4 +1,5 @@
 import { useIsFocused } from "@react-navigation/native"
+import { matchRoute } from "app/routes"
 import { useEffect, useState } from "react"
 import { Linking } from "react-native"
 
@@ -31,13 +32,15 @@ export const useIsDeepLink = () => {
           return
         }
 
-        const targetURL = url.replace("artsy://", "")
-        const isDeepLink = targetURL !== "/"
+        const result = matchRoute(url)
+        const isExternalUrl = result.type === "external_url"
+        const isHomeLink = result.type === "match" && result.module === "Home"
+        const shouldTreatAsDeepLink = !isHomeLink && !isExternalUrl
 
-        if (!isDeepLink) {
-          setIsDeepLink(false)
-        } else {
+        if (shouldTreatAsDeepLink) {
           setIsDeepLink(true)
+        } else {
+          setIsDeepLink(false)
         }
       })
       .catch((error) => {

--- a/src/app/utils/hooks/useIsDeepLink.ts
+++ b/src/app/utils/hooks/useIsDeepLink.ts
@@ -1,0 +1,42 @@
+import { useIsFocused } from "@react-navigation/native"
+import { useEffect, useState } from "react"
+import { Linking } from "react-native"
+
+/**
+ * This is a hook that returns whether the user came from a deep link or not
+ * This can be used to avoid rendering content in previous screens in react-navigation history
+ * @returns {isDeepLink: boolean | null} isDeepLink is true if the user came from a deep link
+ */
+export const useIsDeepLink = () => {
+  const [isDeepLink, setIsDeepLink] = useState<boolean | null>(null)
+
+  const isFocused = useIsFocused()
+
+  useEffect(() => {
+    // When the user comes back from a deep link,
+    // we want to show content again
+    if (isFocused && isDeepLink === true) {
+      setIsDeepLink(false)
+    }
+  }, [isFocused])
+
+  useEffect(() => {
+    Linking.getInitialURL()
+      .then((url) => {
+        const isDeepLink = !!url
+        if (!isDeepLink) {
+          setIsDeepLink(false)
+        } else {
+          setIsDeepLink(true)
+        }
+      })
+      .catch((error) => {
+        console.error("Error getting initial URL", error)
+        setIsDeepLink(false)
+      })
+  }, [])
+
+  return {
+    isDeepLink,
+  }
+}

--- a/src/app/utils/hooks/useIsDeepLink.ts
+++ b/src/app/utils/hooks/useIsDeepLink.ts
@@ -3,8 +3,11 @@ import { useEffect, useState } from "react"
 import { Linking } from "react-native"
 
 /**
- * This is a hook that returns whether the user came from a deep link or not
+ * This is a hook that returns whether or not the user came from a deep link
+ * (defined as a direct navigation to a route other than "/").
+ *
  * This can be used to avoid rendering content in previous screens in react-navigation history
+ *
  * @returns {isDeepLink: boolean | null} isDeepLink is true if the user came from a deep link
  */
 export const useIsDeepLink = () => {
@@ -23,7 +26,14 @@ export const useIsDeepLink = () => {
   useEffect(() => {
     Linking.getInitialURL()
       .then((url) => {
-        const isDeepLink = !!url
+        if (!url) {
+          setIsDeepLink(false)
+          return
+        }
+
+        const targetURL = url.replace("artsy://", "")
+        const isDeepLink = targetURL !== "/"
+
         if (!isDeepLink) {
           setIsDeepLink(false)
         } else {

--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -2,6 +2,7 @@ import { homeViewScreenQueryVariables } from "app/Scenes/HomeView/HomeView"
 import { GlobalStore } from "app/store/GlobalStore"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import { useEffect } from "react"
+import { Linking } from "react-native"
 import RNBootSplash from "react-native-bootsplash"
 
 const HOME_VIEW_SPLASH_SCREEN_DELAY = 500
@@ -20,13 +21,17 @@ export const useHideSplashScreen = () => {
 
     if (isHydrated) {
       if (isLoggedIn && isNavigationReady) {
-        prefetchUrl("/", homeViewScreenQueryVariables(), {
-          force: false,
+        Linking.getInitialURL().then((url) => {
+          const isDeepLink = !!url
+          if (!isDeepLink) {
+            prefetchUrl("/", homeViewScreenQueryVariables(), {
+              force: false,
+            })
+          }
+          setTimeout(() => {
+            hideSplashScreen()
+          }, HOME_VIEW_SPLASH_SCREEN_DELAY)
         })
-
-        setTimeout(() => {
-          hideSplashScreen()
-        }, HOME_VIEW_SPLASH_SCREEN_DELAY)
 
         return
       }


### PR DESCRIPTION
This PR resolves [ONYX-1392] <!-- eg [PROJECT-XXXX] -->

Co-authored-by: @brainbicycle 
Co-authored-by: @MounirDhahri 
Co-authored-by: @olerichter00 

### Description

The goal here is to avoid prefetching when following a deep link, in order to avoid an unnecessary [stampede](https://artsy.slack.com/archives/CA8SANW3W/p1731532192977049?thread_ts=1731531969.773739&cid=CA8SANW3W) that results in API latency.

We observe that prefetching happens in a few ways:

1. A lighter home view prefetch is initiated from the splash screen
    - can be avoided by checking if we are following a deep link
2. A heavier prefetch for a subset of home view sections’ content
    - can also be avoided by declining to render the home view _at all_ when launching via deep link
2. Content for other tabs is initiated from the home view
    - can be avoided thanks to the previous point

### After this change

| Case | Behavior | Screencap |
|--------|--------|--------|
| Launching the app normally | **Performs** prefetching, as before | <video alt="regular launch" src="https://github.com/user-attachments/assets/f31c8ab6-2cb5-40de-940f-f753098fd709" /> |
| Launching via deep link | **Avoids** prefetching | <video alt="deep link" src="https://github.com/user-attachments/assets/c0644b54-ed09-4702-9b63-c4a691adde79" /> |
| Launching via deep link, then returning to home | **Fetches the content just-in-time** rather than prefetch. This is the necessary de-optimization that allows us to avoid the stampede of API requests | <video alt="deep link then home" src="https://github.com/user-attachments/assets/c3d3e2b6-13dc-47ea-a7ff-a96b459eba2c" /> | 
| Launching via link to `/` | **Performs** prefetching, as before | <video alt="home link" src="https://github.com/user-attachments/assets/3e30408d-58c7-456b-902f-d0814249a2e7" /> |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Avoids prefetching home view content when opening a deep link

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1392]: https://artsyproduct.atlassian.net/browse/ONYX-1392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ