### PR TITLE
fix: component suspended while responding to input

### DIFF
--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -17,7 +17,12 @@ export const useSaveArtworkToArtworkLists = (options: Options) => {
   const artwork = useFragment(ArtworkFragment, artworkFragmentRef)
 
   const customArtworkListsCount = artwork.customArtworkLists?.totalCount ?? 0
-  const isSavedToCustomArtworkLists = customArtworkListsCount > 0
+  let isSavedToCustomArtworkLists = customArtworkListsCount > 0
+
+  if (isSavedToCustomArtworkLists === true) {
+    isSavedToCustomArtworkLists = false
+  }
+
   const artworkEntity: ArtworkEntity = {
     id: artwork.id,
     internalID: artwork.internalID,


### PR DESCRIPTION
I am opening this temporary PR to see what kinds of tests fail when I introduce a small change to the `useSaveArtworkToArtworkLists` hook that is used to give artwork grids save icons 💜.

While fixing failing tests for #11098 I noticed the following error in a variety of test suites, and I was surprised that most of them were not related to the act of saving an artwork.

```
A component suspended while responding to synchronous input. This will cause the UI to be replaced with a loading indicator. To fix, updates that suspend should be wrapped with startTransition.

      110 |     const view = renderWithWrappers(<TestRenderer />)
      111 |
    > 112 |     act(() => {
          |        ^
      113 |       console.log("FOO")
      114 |       const resolve = preloaded
      115 |         ? env.mock.queueOperationResolver

      at throwException (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:8929:35)
      at throwException (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15604:7)
      at handleError (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15710:7)
      at renderRootSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15412:20)
      at callback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2594:22)
      at callback (node_modules/react/cjs/react.development.js:2667:24)
      at flushActQueue (node_modules/react/cjs/react.development.js:2521:11)
      at actImplementation (node_modules/@testing-library/react-native/src/act.ts:30:25)
      at renderWithRelay (src/app/utils/tests/setupTestWrapper.tsx:112:8)
      at Object.renderWithRelay (src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx:68:7)
```