### PR TITLE
fix: back navigation from artworks

### DIFF
--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,11 +1,6 @@
 import { EventEmitter } from "events"
 import { ActionType, OwnerType, Screen } from "@artsy/cohesion"
-import {
-  CommonActions,
-  NavigationContainerRef,
-  StackActions,
-  TabActions,
-} from "@react-navigation/native"
+import { NavigationContainerRef, StackActions, TabActions } from "@react-navigation/native"
 import { addBreadcrumb, captureMessage } from "@sentry/react-native"
 import { AppModule, modules, ViewOptions } from "app/AppRegistry"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
@@ -139,12 +134,12 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
           // This allows us to also override the back button behavior in the tab
           requestAnimationFrame(() => {
             internal_navigationRef.current?.dispatch(
-              CommonActions.navigate(result.module, { ...result.params, ...options.passProps })
+              StackActions.push(result.module, { ...result.params, ...options.passProps })
             )
           })
         } else {
           internal_navigationRef.current?.dispatch(
-            CommonActions.navigate(result.module, { ...result.params, ...options.passProps })
+            StackActions.push(result.module, { ...result.params, ...options.passProps })
           )
         }
       }
@@ -278,6 +273,7 @@ export function goBack(backProps?: GoBackProps) {
 
   if (enableNewNavigation) {
     if (internal_navigationRef.current?.isReady()) {
+      console.log("===go back===")
       internal_navigationRef.current.dispatch(StackActions.pop())
     }
     return


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/2in1-When-pressing-back-from-the-related-arotowork-or-from-other-works-by-it-navigates-back-twi-13bcab0764a08014b4d1df75565ae57f?pvs=4

### Description

This PR fixes an issue with the back navigation when on the same screen type

**Before**

https://github.com/user-attachments/assets/0d6c8395-de86-4c1e-a372-3eb713f9c4ce




**After**

https://github.com/user-attachments/assets/4654c508-fe83-4b5a-8b12-6c4b2b2a0c11




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
