### PR TITLE
fix: deep link analytics event triggered twice

### DIFF
--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -15,6 +15,10 @@ export function useDeepLinks() {
   const { trackEvent } = useTracking()
 
   useEffect(() => {
+    if (!isNavigationReady) {
+      return
+    }
+
     Linking.getInitialURL().then((url) => {
       if (url) {
         handleDeepLink(url)
@@ -23,6 +27,10 @@ export function useDeepLinks() {
   }, [isNavigationReady])
 
   useEffect(() => {
+    if (!isNavigationReady) {
+      return
+    }
+
     const subscription = Linking.addListener("url", ({ url }) => {
       handleDeepLink(url)
     })


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/Deeplink-opened-analytics-event-called-twice-13bcab0764a080b78390cf08dbc51759?pvs=4

### Description

This PR fixes an issue where deep links calls are getting triggered twice. This was happening because I forgot to check if the navigation is ready before handling the deep link.

| Before | After |
|--------|--------|
| <Video src="https://github.com/user-attachments/assets/40da0526-0e1e-4e35-a41f-497976f2e6ec" /> | <Video src="https://github.com/user-attachments/assets/cc2c8f4c-a9d0-4710-bfb5-550958b839c7" /> | 



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix deep link analytics event triggered twice - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
