### PR TITLE
test(Sales): increase test's timeout

### DIFF
--- a/src/app/Scenes/Sales/Sales.tests.tsx
+++ b/src/app/Scenes/Sales/Sales.tests.tsx
@@ -15,9 +15,11 @@ describe("Sales", () => {
   it("renders without Errors", async () => {
     renderWithRelay()
 
-    await waitFor(() => expect(screen.queryByTestId("SalePlaceholder")).toBeNull())
+    await waitFor(() => expect(screen.queryByTestId("SalePlaceholder")).not.toBeOnTheScreen(), {
+      timeout: 10000,
+    })
 
-    expect(screen.getByTestId("Sales-Screen-ScrollView")).toBeDefined()
+    expect(screen.getByTestId("Sales-Screen-ScrollView")).toBeOnTheScreen()
   })
 
   it("renders the ZeroState when there are no sales", async () => {
@@ -61,9 +63,9 @@ describe("Sales", () => {
     renderWithRelay({
       Query: () => viewer,
     })
-    await waitFor(() => expect(screen.queryByTestId("SalePlaceholder")).toBeNull())
+    await waitFor(() => expect(screen.queryByTestId("SalePlaceholder")).not.toBeOnTheScreen())
 
-    expect(screen.getByText("Auction Lots for You")).toBeDefined()
+    expect(screen.getByText("Auction Lots for You")).toBeOnTheScreen()
   })
 })
 


### PR DESCRIPTION
### Description

Sales test is testing an expensive component, nothing stands out as a problem from the tests. Ideally, we would want to test only the element with the fragment but we're testing something like:
```jsx
    <ProvideScreenTrackingWithCohesionSchema
      info={screen({ context_screen_owner_type: OwnerType.auctions })}
    >
      <Suspense
        fallback={
          <PageWithSimpleHeader title="Auctions">
            <Flex flex={1} justifyContent="center" alignItems="center">
              <Spinner testID="SalePlaceholder" />
            </Flex>
          </PageWithSimpleHeader>
        }
      >
        <Sales />
      </Suspense>
    </ProvideScreenTrackingWithCohesionSchema>
```

The timeout increased in the first test should do the job, but ideally we want to revisit this component structure and then refactor the test to test something lighter.

#noChangelog

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
