### PR TITLE
fix: city picker padding on city guide

### DIFF
--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -550,10 +550,7 @@ export class GlobalMap extends React.Component<Props, State> {
               style={{ ...this.backgroundImageSize }}
             />
 
-            {/* We do this gymnastics to get accurately the top inset
-              We are injecting two extra margins that on the native side that we need to deduct
-              https://github.com/artsy/eigen/blob/054ef4fea23bf401a53fc3f44bebb30933ca80f2/ios/Artsy/Emission/ViewControllers/ARMapContainerViewController.m#L119
-              https://github.com/artsy/eigen/blob/054ef4fea23bf401a53fc3f44bebb30933ca80f2/ios/Artsy/View_Controllers/Util/ARNavigationController.m#L212
+            {/* TODO: safeArea insets are being reported back incorrectly here, so we have to subtract, we should look further into why, possibly with how we register these components, possibly because they are partially native. 
              */}
             <TopButtonsContainer style={{ top: this.props.safeAreaInsets.top - 12 - 10 }}>
               <Animated.View

--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -1,4 +1,4 @@
-import { Flex, Box, ClassTheme, Text } from "@artsy/palette-mobile"
+import { Box, ClassTheme, Flex, Text } from "@artsy/palette-mobile"
 import MapboxGL from "@rnmapbox/maps"
 import { themeGet } from "@styled-system/theme-get"
 import { GlobalMap_viewer$data } from "__generated__/GlobalMap_viewer.graphql"
@@ -549,7 +549,13 @@ export class GlobalMap extends React.Component<Props, State> {
               resizeMode="cover"
               style={{ ...this.backgroundImageSize }}
             />
-            <TopButtonsContainer style={{ top: this.props.safeAreaInsets.top + 12 }}>
+
+            {/* We do this gymnastics to get accurately the top inset
+              We are injecting two extra margins that on the native side that we need to deduct
+              https://github.com/artsy/eigen/blob/054ef4fea23bf401a53fc3f44bebb30933ca80f2/ios/Artsy/Emission/ViewControllers/ARMapContainerViewController.m#L119
+              https://github.com/artsy/eigen/blob/054ef4fea23bf401a53fc3f44bebb30933ca80f2/ios/Artsy/View_Controllers/Util/ARNavigationController.m#L212
+             */}
+            <TopButtonsContainer style={{ top: this.props.safeAreaInsets.top - 12 - 10 }}>
               <Animated.View
                 style={{
                   transform: [


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/City-guide-drop-down-misaligned-not-sure-if-new-13bcab0764a080838854d7f873a0b78e?pvs=4] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the broken padding on the city guide after the latest navigation changes.



| Before | After |
|--------|--------|
| ![IMG_3D3FA04DBC6D-1](https://github.com/user-attachments/assets/1c664d59-47cb-4ec7-851e-66bc47818e4f) | <img width="744" alt="Screenshot 2024-11-19 at 19 08 41" src="https://github.com/user-attachments/assets/f52012ad-308c-4915-9e1f-0aaaaa1456d7"> | 




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- city picker padding on city guide - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
