### PR TITLE
chore(tests): delete tests that fail for uncontrolled input

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountEmail.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountEmail.tests.tsx
@@ -43,17 +43,6 @@ describe("OnboardingCreateAccountEmail", () => {
   })
 
   describe("Form", () => {
-    it("renders the right email from the formik context", async () => {
-      renderWithWrappers(<Test />)
-      const emailInput = screen.getByTestId("emailInput")
-
-      expect(emailInput).toHaveTextContent("")
-
-      fireEvent.changeText(emailInput, "test@email.com")
-
-      expect(emailInput).toHaveProp("value", "test@email.com")
-    })
-
     it("does not validate email when the user is still typing", () => {
       renderWithWrappers(<Test />)
       const emailInput = screen.getByTestId("emailInput")

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountName.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountName.tests.tsx
@@ -56,17 +56,6 @@ describe("OnboardingCreateAccountName", () => {
   })
 
   describe("Form", () => {
-    it("renders the right name from the formik context", () => {
-      renderWithWrappers(<Test />)
-      const nameInput = screen.getByTestId("nameInput")
-
-      expect(nameInput).toHaveTextContent("")
-
-      fireEvent.changeText(nameInput, "Andy warhol")
-
-      expect(nameInput).toHaveProp("value", "Andy warhol")
-    })
-
     it("does not submit when the user did not accept the terms and conditions", async () => {
       renderWithWrappers(<Test />)
       const nameInput = screen.getByTestId("nameInput")

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountPassword.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountPassword.tests.tsx
@@ -45,18 +45,6 @@ describe("OnboardingCreateAccountPassword", () => {
   })
 
   describe("Form", () => {
-    it("renders the right password from the formik context", () => {
-      renderWithWrappers(<Test />)
-
-      const passwordInput = screen.getByTestId("passwordInput")
-
-      expect(passwordInput).toHaveTextContent("")
-
-      fireEvent.changeText(passwordInput, "1ValidPassword")
-
-      expect(passwordInput).toHaveProp("value", "1ValidPassword")
-    })
-
     it("does not validate password when the user is still typing", () => {
       renderWithWrappers(<Test />)
       const passwordInput = screen.getByTestId("passwordInput")

--- a/src/app/Scenes/Search/components/SearchInput.tests.tsx
+++ b/src/app/Scenes/Search/components/SearchInput.tests.tsx
@@ -26,15 +26,6 @@ describe("SearchInput", () => {
     expect(refineMock).toBeCalledWith("text")
   })
 
-  it("should have the correct value prop", () => {
-    renderWithWrappers(<TestRenderer />)
-    const searchInput = screen.getByTestId("search-input")
-
-    fireEvent.changeText(searchInput, "text")
-
-    expect(searchInput).toHaveProp("value", "text")
-  })
-
   it("track event when the text is changed", () => {
     renderWithWrappers(<TestRenderer />)
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Palette mobile inputs have been updated to be uncontrolled for performance benefits: https://github.com/artsy/palette-mobile/pull/281

This is a good change but caused some tests to fail: https://app.circleci.com/pipelines/github/artsy/eigen/61963/workflows/a45351d9-8ce7-457f-aa97-194eec848590/jobs/214287/parallel-runs/6?filterBy=FAILED, these tests are generally of the form "type something" then "check if the value exists in the input", since value is not set in input in uncontrolled inputs these fail. Talked with George and we think these tests are really just basic funcionality of inputs themselves and are already tested in palette-mobile so just getting rid of them. We did verify in both onboarding and search that the new inputs work and show text. 

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix failing tests due to palette-mobile upgrade

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
