### PR TITLE
chore: support dark mode for new Save and Follow CTAs

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -76,12 +76,12 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
     ;(artwork as DissapearableArtwork)?._disappearable?.disappear()
   }
 
-  // 36 = 20 (padding) + 16 (icon size) + 5 (top padding)
+  // 36 = 20 (padding) + 18 (icon size) + 5 (top padding)
   const likeAndFollowCTAPadding =
     showSaveIcon &&
     enableNewSaveAndFollowOnArtworkCard &&
     (enableNewSaveCTA || enableNewSaveAndFollowCTAs)
-      ? 41
+      ? 43
       : 0
   const artworkRailCardMetaPadding = 10
   const artworkRailCardMetaDataHeight =
@@ -155,6 +155,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
               <ArtworkItemCTAs
                 artwork={artwork}
                 showSaveIcon={showSaveIcon}
+                dark={dark}
                 contextModule={contextModule}
                 contextScreen={contextScreen}
                 contextScreenOwnerId={contextScreenOwnerId}

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -95,7 +95,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
     auctionSignals: collectorSignals?.auction,
   })
 
-  const { primaryTextColor, secondaryTextColor } = useMetaDataTextColor({ dark })
+  const { primaryColor, secondaryColor } = useMetaDataTextColor({ dark })
 
   const displayLimitedTimeOfferSignal =
     collectorSignals?.partnerOffer?.isAvailable && !sale?.isAuction
@@ -137,14 +137,14 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
     >
       <Flex flex={1}>
         {!!lotLabel && (
-          <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1}>
+          <Text lineHeight="20px" color={secondaryColor} numberOfLines={1}>
             Lot {lotLabel}
           </Text>
         )}
 
         {!hideArtistName && !!artistNames && (
           <RNText numberOfLines={1} ellipsizeMode="tail">
-            <Text color={primaryTextColor} lineHeight="20px" variant="xs">
+            <Text color={primaryColor} lineHeight="20px" variant="xs">
               {artistNames}
             </Text>
           </RNText>
@@ -152,10 +152,10 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
 
         {!!title && (
           <RNText numberOfLines={1} ellipsizeMode="tail">
-            <Text lineHeight="20px" color={secondaryTextColor} variant="xs">
+            <Text lineHeight="20px" color={secondaryColor} variant="xs">
               {title}
               {!!date && (
-                <Text lineHeight="20px" color={secondaryTextColor} variant="xs">
+                <Text lineHeight="20px" color={secondaryColor} variant="xs">
                   {title && date ? ", " : ""}
                   {date}
                 </Text>
@@ -166,7 +166,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
 
         {!!showPartnerName && !!partner?.name && (
           <RNText numberOfLines={1} ellipsizeMode="tail">
-            <Text lineHeight="20px" variant="xs" color={secondaryTextColor}>
+            <Text lineHeight="20px" variant="xs" color={secondaryColor}>
               {partner?.name}
             </Text>
           </RNText>
@@ -187,7 +187,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
           <Text
             lineHeight="20px"
             variant="xs"
-            color={primaryTextColor}
+            color={primaryColor}
             numberOfLines={1}
             fontWeight="bold"
           >
@@ -236,7 +236,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
                 testID="empty-heart-icon"
                 height={HEART_ICON_SIZE}
                 width={HEART_ICON_SIZE}
-                fill={primaryTextColor}
+                fill={primaryColor}
               />
             )}
           </Touchable>

--- a/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
@@ -5,12 +5,9 @@ export const useMetaDataTextColor = ({ dark }: { dark: boolean }) => {
 
   const backgroundColor = dark ? "black100" : "white100"
 
-  const ctaBackgroundColor = dark ? "black100" : "black5"
-
   return {
     primaryColor,
     secondaryColor,
     backgroundColor,
-    ctaBackgroundColor,
   }
 }

--- a/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
@@ -1,22 +1,16 @@
 export const useMetaDataTextColor = ({ dark }: { dark: boolean }) => {
-  const primaryTextColor = dark ? "white100" : "black100"
+  const primaryColor = dark ? "white100" : "black100"
 
-  const secondaryTextColor = dark ? "black15" : "black60"
+  const secondaryColor = dark ? "black15" : "black60"
 
   const backgroundColor = dark ? "black100" : "white100"
 
-  const saveAndFollowCTAColor = dark ? "white100" : "black100"
-
-  const saveAndFollowCTAFillColor = dark ? "white100" : "black100"
-
-  const saveAndFollowCTABackgroundColor = dark ? "black100" : "black5"
+  const ctaBackgroundColor = dark ? "black100" : "black5"
 
   return {
-    primaryTextColor,
-    secondaryTextColor,
+    primaryColor,
+    secondaryColor,
     backgroundColor,
-    saveAndFollowCTAColor,
-    saveAndFollowCTAFillColor,
-    saveAndFollowCTABackgroundColor,
+    ctaBackgroundColor,
   }
 }

--- a/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailUtils.tsx
@@ -5,5 +5,18 @@ export const useMetaDataTextColor = ({ dark }: { dark: boolean }) => {
 
   const backgroundColor = dark ? "black100" : "white100"
 
-  return { primaryTextColor, secondaryTextColor, backgroundColor }
+  const saveAndFollowCTAColor = dark ? "white100" : "black100"
+
+  const saveAndFollowCTAFillColor = dark ? "white100" : "black100"
+
+  const saveAndFollowCTABackgroundColor = dark ? "black100" : "black5"
+
+  return {
+    primaryTextColor,
+    secondaryTextColor,
+    backgroundColor,
+    saveAndFollowCTAColor,
+    saveAndFollowCTAFillColor,
+    saveAndFollowCTABackgroundColor,
+  }
 }

--- a/src/app/Components/ArtworkRail/ArtworkSaleMessage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkSaleMessage.tsx
@@ -23,14 +23,14 @@ export const ArtworkSaleMessage: React.FC<ArtworkSaleMessageProps> = ({
 }) => {
   const { collectorSignals, sale } = useFragment(fragment, artwork)
 
-  const { primaryTextColor } = useMetaDataTextColor({ dark })
+  const { primaryColor } = useMetaDataTextColor({ dark })
 
   const partnerOfferEndAt = collectorSignals?.partnerOffer?.endAt
     ? formattedTimeLeft(getTimer(collectorSignals?.partnerOffer.endAt).time).timerCopy
     : ""
 
   const auctionInLiveBidding = sale?.isAuction && collectorSignals?.auction?.liveBiddingStarted
-  const saleInfoTextColor = auctionInLiveBidding ? "blue100" : primaryTextColor
+  const saleInfoTextColor = auctionInLiveBidding ? "blue100" : primaryColor
   const saleInfoTextWeight = auctionInLiveBidding ? "normal" : "bold"
 
   const { parts } = parsedSaleMessage(saleMessage)

--- a/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtworkPreviewCard.tsx
@@ -44,7 +44,7 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
 
   const saleMessage = saleMessageOrBidInfo({ artwork, isSmallTile: true })
 
-  const { primaryTextColor, secondaryTextColor, backgroundColor } = useMetaDataTextColor({ dark })
+  const { primaryColor, secondaryColor, backgroundColor } = useMetaDataTextColor({ dark })
 
   const getTextHeight = () => {
     return ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT
@@ -69,26 +69,26 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
       >
         <Flex flex={1} backgroundColor={backgroundColor}>
           {!!lotLabel && (
-            <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1}>
+            <Text lineHeight="20px" color={secondaryColor} numberOfLines={1}>
               Lot {lotLabel}
             </Text>
           )}
           {!hideArtistName && !!artistNames && (
-            <Text color={primaryTextColor} numberOfLines={1} lineHeight="20px" variant="xs">
+            <Text color={primaryColor} numberOfLines={1} lineHeight="20px" variant="xs">
               {artistNames}
             </Text>
           )}
           {!!title && (
             <Text
               lineHeight="20px"
-              color={secondaryTextColor}
+              color={secondaryColor}
               numberOfLines={1}
               variant="xs"
               fontStyle="italic"
             >
               {title}
               {!!date && (
-                <Text lineHeight="20px" color={secondaryTextColor} numberOfLines={1} variant="xs">
+                <Text lineHeight="20px" color={secondaryColor} numberOfLines={1} variant="xs">
                   {title && date ? ", " : ""}
                   {date}
                 </Text>
@@ -97,7 +97,7 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
           )}
 
           {!!showPartnerName && !!partner?.name && (
-            <Text lineHeight="20px" variant="xs" color={secondaryTextColor} numberOfLines={1}>
+            <Text lineHeight="20px" variant="xs" color={secondaryColor} numberOfLines={1}>
               {partner?.name}
             </Text>
           )}
@@ -107,7 +107,7 @@ export const ContextMenuArtworkPreviewCard: React.FC<ContextMenuArtworkPreviewCa
                 <Text
                   lineHeight="20px"
                   variant="xs"
-                  color={primaryTextColor}
+                  color={primaryColor}
                   numberOfLines={1}
                   fontWeight={500}
                 >

--- a/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
@@ -55,8 +55,7 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
       "onyx_artwork-card-save-and-follow-cta-redesign"
     )
 
-  const { saveAndFollowCTAColor, saveAndFollowCTAFillColor, saveAndFollowCTABackgroundColor } =
-    useMetaDataTextColor({ dark })
+  const { primaryColor, ctaBackgroundColor } = useMetaDataTextColor({ dark })
 
   const artwork = useFragment(artworkFragment, artworkProp)
 
@@ -109,21 +108,21 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
     <ArtworkItemCTAsWrapper
       onPress={saveArtworkToLists}
       testID="save-artwork"
-      backgroundColor={saveAndFollowCTABackgroundColor}
+      backgroundColor={ctaBackgroundColor}
     >
       {isSaved ? (
         <NewFillHeartIcon
           testID="heart-icon-filled"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill={saveAndFollowCTAFillColor}
+          fill={primaryColor}
         />
       ) : (
         <NewHeartIcon
           testID="heart-icon-empty"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill={saveAndFollowCTAColor}
+          fill={primaryColor}
         />
       )}
 
@@ -139,21 +138,21 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
     <ArtworkItemCTAsWrapper
       onPress={handleFollowToggle}
       testID="follow-artist"
-      backgroundColor={saveAndFollowCTABackgroundColor}
+      backgroundColor={ctaBackgroundColor}
     >
       {artist?.isFollowed ? (
         <FollowArtistFillIcon
           testID="follow-icon-filled"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill={saveAndFollowCTAFillColor}
+          fill={primaryColor}
         />
       ) : (
         <FollowArtistIcon
           testID="follow-icon-empty"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill={saveAndFollowCTAColor}
+          fill={primaryColor}
         />
       )}
     </ArtworkItemCTAsWrapper>

--- a/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
@@ -55,7 +55,7 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
       "onyx_artwork-card-save-and-follow-cta-redesign"
     )
 
-  const { primaryColor, ctaBackgroundColor } = useMetaDataTextColor({ dark })
+  const { primaryColor } = useMetaDataTextColor({ dark })
 
   const artwork = useFragment(artworkFragment, artworkProp)
 
@@ -105,11 +105,7 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
   }
 
   const saveCTA = (
-    <ArtworkItemCTAsWrapper
-      onPress={saveArtworkToLists}
-      testID="save-artwork"
-      backgroundColor={ctaBackgroundColor}
-    >
+    <ArtworkItemCTAsWrapper onPress={saveArtworkToLists} testID="save-artwork" dark={dark}>
       {isSaved ? (
         <NewFillHeartIcon
           testID="heart-icon-filled"
@@ -135,11 +131,7 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
   )
 
   const followCTA = (
-    <ArtworkItemCTAsWrapper
-      onPress={handleFollowToggle}
-      testID="follow-artist"
-      backgroundColor={ctaBackgroundColor}
-    >
+    <ArtworkItemCTAsWrapper onPress={handleFollowToggle} testID="follow-artist" dark={dark}>
       {artist?.isFollowed ? (
         <FollowArtistFillIcon
           testID="follow-icon-filled"
@@ -177,9 +169,9 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
 
 const ArtworkItemCTAsWrapper: React.FC<{
   onPress?: () => void
-  backgroundColor?: string
+  dark?: boolean
   testID: string
-}> = ({ onPress, backgroundColor, testID, children }) => {
+}> = ({ onPress, dark, testID, children }) => {
   return (
     <Touchable
       haptic
@@ -195,17 +187,11 @@ const ArtworkItemCTAsWrapper: React.FC<{
         flexDirection="row"
         p={1}
         borderRadius={50}
-        style={
-          backgroundColor === "black100"
-            ? {
-                borderColor: "white",
-                borderWidth: 1,
-              }
-            : {}
-        }
+        borderColor={dark ? "white" : undefined}
+        borderWidth={dark ? 1 : undefined}
         justifyContent="center"
         alignItems="center"
-        backgroundColor={backgroundColor}
+        backgroundColor={dark ? "black100" : "black5"}
       >
         {children}
       </Flex>

--- a/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkItemCTAs.tsx
@@ -12,6 +12,7 @@ import {
 import { ArtworkItemCTAs_artwork$key } from "__generated__/ArtworkItemCTAs_artwork.graphql"
 import { useFollowArtist } from "app/Components/Artist/useFollowArtist"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { useMetaDataTextColor } from "app/Components/ArtworkRail/ArtworkRailUtils"
 import { ARTWORK_RAIL_CARD_CTA_ICON_SIZE } from "app/Components/constants"
 import { useGetNewSaveAndFollowOnArtworkCardExperimentVariant } from "app/Scenes/Artwork/utils/useGetNewSaveAndFollowOnArtworkCardExperimentVariant"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -27,6 +28,7 @@ interface ArtworkItemCTAsProps extends ArtworkActionTrackingProps {
   artwork: ArtworkItemCTAs_artwork$key
   showSaveIcon?: boolean
   showFollowIcon?: boolean
+  dark?: boolean
 }
 
 export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
@@ -36,6 +38,7 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
    * Show follow icon by default, but allow it to be hidden on specific grids
    */
   showFollowIcon = true,
+  dark = false,
   contextModule,
   contextScreen,
   contextScreenOwnerId,
@@ -51,6 +54,9 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
     useGetNewSaveAndFollowOnArtworkCardExperimentVariant(
       "onyx_artwork-card-save-and-follow-cta-redesign"
     )
+
+  const { saveAndFollowCTAColor, saveAndFollowCTAFillColor, saveAndFollowCTABackgroundColor } =
+    useMetaDataTextColor({ dark })
 
   const artwork = useFragment(artworkFragment, artworkProp)
 
@@ -100,19 +106,24 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
   }
 
   const saveCTA = (
-    <ArtworkItemCTAsWrapper onPress={saveArtworkToLists} testID="save-artwork">
+    <ArtworkItemCTAsWrapper
+      onPress={saveArtworkToLists}
+      testID="save-artwork"
+      backgroundColor={saveAndFollowCTABackgroundColor}
+    >
       {isSaved ? (
         <NewFillHeartIcon
           testID="heart-icon-filled"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill="black100"
+          fill={saveAndFollowCTAFillColor}
         />
       ) : (
         <NewHeartIcon
           testID="heart-icon-empty"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
+          fill={saveAndFollowCTAColor}
         />
       )}
 
@@ -125,19 +136,24 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
   )
 
   const followCTA = (
-    <ArtworkItemCTAsWrapper onPress={handleFollowToggle} testID="follow-artist">
+    <ArtworkItemCTAsWrapper
+      onPress={handleFollowToggle}
+      testID="follow-artist"
+      backgroundColor={saveAndFollowCTABackgroundColor}
+    >
       {artist?.isFollowed ? (
         <FollowArtistFillIcon
           testID="follow-icon-filled"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
-          fill="black100"
+          fill={saveAndFollowCTAFillColor}
         />
       ) : (
         <FollowArtistIcon
           testID="follow-icon-empty"
           height={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
           width={ARTWORK_RAIL_CARD_CTA_ICON_SIZE}
+          fill={saveAndFollowCTAColor}
         />
       )}
     </ArtworkItemCTAsWrapper>
@@ -160,11 +176,11 @@ export const ArtworkItemCTAs: React.FC<ArtworkItemCTAsProps> = ({
   } else return null
 }
 
-const ArtworkItemCTAsWrapper: React.FC<{ onPress?: () => void; testID: string }> = ({
-  onPress,
-  testID,
-  children,
-}) => {
+const ArtworkItemCTAsWrapper: React.FC<{
+  onPress?: () => void
+  backgroundColor?: string
+  testID: string
+}> = ({ onPress, backgroundColor, testID, children }) => {
   return (
     <Touchable
       haptic
@@ -180,9 +196,17 @@ const ArtworkItemCTAsWrapper: React.FC<{ onPress?: () => void; testID: string }>
         flexDirection="row"
         p={1}
         borderRadius={50}
+        style={
+          backgroundColor === "black100"
+            ? {
+                borderColor: "white",
+                borderWidth: 1,
+              }
+            : {}
+        }
         justifyContent="center"
         alignItems="center"
-        backgroundColor="black5"
+        backgroundColor={backgroundColor}
       >
         {children}
       </Flex>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -299,7 +299,7 @@ export const features = {
     description: "Redesign Save CTA and Add Follow CTA on Artwork Grid/Rail",
     readyForRelease: false,
     showInDevMenu: true,
-    /* echoFlagKey: "AREnableNewSaveAndFollowOnArtworkCard" */
+    echoFlagKey: "AREnableNewSaveAndFollowOnArtworkCard",
   },
   AREnablePaymentFailureBanner: {
     description: "Enable payment failure banner",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Resolves [Need an alternative for dark mode (if we’re continuing with Curator’s picks in current format)](https://www.notion.so/artsy/Need-an-alternative-for-dark-mode-if-we-re-continuing-with-Curator-s-picks-in-current-format-13ecab0764a0804eb63cf9241e9ea903?pvs=4)
It's not clear when the dark background is going to be removed from the Curator's Picks rail, so implementing dark mode support for new Save and Follow CTAs

| Before | After | Android |
| --- | --- | --- | 
| ![image](https://github.com/user-attachments/assets/cfa19396-1d89-4291-8010-03aec59ba2d5) | ![image](https://github.com/user-attachments/assets/488272b7-eaa2-4c98-b58a-fcbc9067ca4d) | ![Screenshot_1732101888](https://github.com/user-attachments/assets/98cf8429-3289-4299-bf86-0d33f038bd1f) | 


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- support dark mode for new Save and Follow CTAs (ff AREnableNewSaveAndFollowOnArtworkCard)

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
