### PR TITLE
chore: update placeholder copy on search modal

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tests.tsx
@@ -18,7 +18,7 @@ describe("GlobalSearchInput", () => {
   it("renders the search label properly", () => {
     renderWithWrappers(<GlobalSearchInput />)
 
-    expect(/Search artists, artworks, etc/).toBeTruthy()
+    expect(/Search Artsy/).toBeTruthy()
   })
 
   it("tracks the search bar tapped event", () => {

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -2,7 +2,6 @@ import { ActionType, ContextModule } from "@artsy/cohesion"
 import { Flex, RoundSearchInput, Touchable } from "@artsy/palette-mobile"
 import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/GlobalSearchInputOverlay"
 import { ICON_HIT_SLOP } from "app/Components/constants"
-import { SEARCH_INPUT_PLACEHOLDER } from "app/Scenes/Search/Search"
 import { useSelectedTab } from "app/utils/hooks/useSelectedTab"
 import { Fragment, useState } from "react"
 import { useTracking } from "react-tracking"
@@ -32,7 +31,7 @@ export const GlobalSearchInput: React.FC<{}> = () => {
         */}
         <Flex pointerEvents="none">
           <RoundSearchInput
-            placeholder={SEARCH_INPUT_PLACEHOLDER}
+            placeholder="Search Artsy"
             accessibilityHint="Search artists, artworks, galleries etc."
             accessibilityLabel="Search artists, artworks, galleries etc."
             maxLength={55}

--- a/src/app/Scenes/Search/Search.tests.tsx
+++ b/src/app/Scenes/Search/Search.tests.tsx
@@ -17,7 +17,7 @@ describe("Search", () => {
   it("should render a text input with placeholder and no pills", async () => {
     const { env } = renderWithRelay()
 
-    const searchInput = screen.getByPlaceholderText("Search artists, artworks, etc")
+    const searchInput = screen.getByPlaceholderText("Search artists, artworks, galleries, etc.")
 
     expect(searchInput).toBeTruthy()
 
@@ -43,7 +43,7 @@ describe("Search", () => {
   it("Top pill should be selected by default", async () => {
     const { env } = renderWithRelay()
 
-    const searchInput = screen.getByPlaceholderText("Search artists, artworks, etc")
+    const searchInput = screen.getByPlaceholderText("Search artists, artworks, galleries, etc.")
 
     fireEvent.changeText(searchInput, "text")
 
@@ -56,7 +56,7 @@ describe("Search", () => {
   it("when clear button is pressed", async () => {
     const { env } = renderWithRelay()
 
-    const searchInput = screen.getByPlaceholderText("Search artists, artworks, etc")
+    const searchInput = screen.getByPlaceholderText("Search artists, artworks, galleries, etc.")
 
     fireEvent(searchInput, "changeText", "prev value")
 
@@ -77,7 +77,7 @@ describe("Search", () => {
   it("when cancel button is pressed", async () => {
     const { env } = renderWithRelay()
 
-    const searchInput = screen.getByPlaceholderText("Search artists, artworks, etc")
+    const searchInput = screen.getByPlaceholderText("Search artists, artworks, galleries, etc.")
 
     fireEvent(searchInput, "changeText", "prev value")
     // needed to resolve the relay operation triggered for the text change
@@ -98,7 +98,7 @@ describe("Search", () => {
   it("should render all the default pills", async () => {
     const { env } = renderWithRelay()
 
-    const searchInput = screen.getByPlaceholderText("Search artists, artworks, etc")
+    const searchInput = screen.getByPlaceholderText("Search artists, artworks, galleries, etc.")
 
     fireEvent(searchInput, "changeText", "Ba")
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -32,9 +32,9 @@ import { getContextModuleByPillName } from "./helpers"
 import { PillType } from "./types"
 
 export const SEARCH_INPUT_PLACEHOLDER = [
-  "Search artists, artworks, galleries etc.",
-  "Search artists, artworks, etc",
-  "Search artworks, etc",
+  "Search artists, artworks, galleries, etc.",
+  "Search artists, artworks, etc.",
+  "Search artworks, etc.",
   "Search",
 ]
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -32,6 +32,7 @@ import { getContextModuleByPillName } from "./helpers"
 import { PillType } from "./types"
 
 export const SEARCH_INPUT_PLACEHOLDER = [
+  "Search artists, artworks, galleries etc.",
   "Search artists, artworks, etc",
   "Search artworks, etc",
   "Search",


### PR DESCRIPTION
This PR resolves:
https://www.notion.so/artsy/Input-placeholder-copy-144cab0764a0806aae2dd64bef9b6f48?pvs=4

### Description
This PR updates the placeholder copy on the search modal input 


https://github.com/user-attachments/assets/468dfcae-f442-499f-b743-bd7addeace33


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog