### PR TITLE
chore: increase max returned recent searches

### DIFF
--- a/src/app/Scenes/Search/SearchModel.tests.tsx
+++ b/src/app/Scenes/Search/SearchModel.tests.tsx
@@ -94,6 +94,12 @@ describe("Recent Searches", () => {
 })
 
 describe(useRecentSearches, () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableNewSearchModal: true,
+    })
+  })
+
   it("truncates the list of recent searches", async () => {
     let localRecentSearches: SearchModel["recentSearches"] = []
     let globalRecentSearches: SearchModel["recentSearches"] = []
@@ -128,7 +134,7 @@ describe(useRecentSearches, () => {
 
     await flushPromiseQueue()
 
-    expect(localRecentSearches.length).toBe(5)
+    expect(localRecentSearches.length).toBe(10)
     expect(globalRecentSearches.length).toBe(10)
 
     tree.update(
@@ -139,7 +145,7 @@ describe(useRecentSearches, () => {
 
     await flushPromiseQueue()
 
-    expect(localRecentSearches.length).toBe(8)
+    expect(localRecentSearches.length).toBe(10)
     expect(globalRecentSearches.length).toBe(10)
   })
 })

--- a/src/app/Scenes/Search/SearchModel.tsx
+++ b/src/app/Scenes/Search/SearchModel.tsx
@@ -1,5 +1,6 @@
 import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Action, action } from "easy-peasy"
 
 export const MAX_SAVED_RECENT_SEARCHES = 100
@@ -40,7 +41,9 @@ export const getSearchModel = (): SearchModel => ({
 })
 
 export const useRecentSearches = (numSearches: number = MAX_SHOWN_RECENT_SEARCHES) => {
+  const enableNewSearchModal = useFeatureFlag("AREnableNewSearchModal")
+
   return GlobalStore.useAppState((state) => {
     return state.search.recentSearches
-  }).slice(0, numSearches)
+  }).slice(0, enableNewSearchModal ? MAX_SAVED_RECENT_SEARCHES : numSearches)
 }


### PR DESCRIPTION
This PR resolves:
https://www.notion.so/artsy/Recent-Searches-still-capped-at-5-max-rendered-result-event-though-more-seem-to-be-persisted-availab-144cab0764a080f29629f220c45f5a29?pvs=4

### Description
This PR increases the number of recent searches allowed in the new search modal


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog