### PR TITLE
chore: hide keyboard after scroll on artwork list

### DIFF
--- a/src/app/Scenes/Search/SearchArtworksGrid.tsx
+++ b/src/app/Scenes/Search/SearchArtworksGrid.tsx
@@ -107,6 +107,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
           // this number is the estimated size of the artworkGridItem component
           estimatedItemSize={ESTIMATED_MASONRY_ITEM_SIZE}
           keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
           ListEmptyComponent={
             <Box mb="80px" pt={6}>
               <Box px={2}>


### PR DESCRIPTION
This PR resolves:
https://www.notion.so/artsy/Shall-we-close-the-virtual-keyboard-when-the-user-scrolls-through-the-results-Especially-when-searc-144cab0764a08094965cc81ccdd72c6b?pvs=4

### Description
This PR updates the keyboard behaviour on the artworks grid to dismiss on scroll.


https://github.com/user-attachments/assets/67e76964-32cf-4a45-8419-2e6effc86ba4




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog