### PR TITLE
chore: hide search modal on back button press

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -10,6 +10,7 @@ import { MAX_SHOWN_RECENT_SEARCHES, useRecentSearches } from "app/Scenes/Search/
 import { SearchPills } from "app/Scenes/Search/SearchPills"
 import { SearchResults } from "app/Scenes/Search/SearchResults"
 import { SEARCH_PILLS } from "app/Scenes/Search/constants"
+import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { Suspense, useEffect, useState } from "react"
 import { ScrollView, StyleSheet } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -83,6 +84,13 @@ export const GlobalSearchInputOverlay: React.FC<{ visible: boolean; hideModal: (
 }) => {
   const [query, setQuery] = useState("")
   const insets = useSafeAreaInsets()
+
+  useBackHandler(() => {
+    if (visible) {
+      hideModal()
+    }
+    return true
+  })
 
   useEffect(() => {
     if (!visible) {


### PR DESCRIPTION
This PR resolves
https://www.notion.so/artsy/Sliding-from-the-left-doesn-t-navigate-me-back-to-the-home-screen-after-opening-the-search-iOS-144cab0764a080e8956be0dfb69642cc?pvs=4

### Description
This PR hides the search modal on back button press

___
**Using Back Button**


https://github.com/user-attachments/assets/615c5b14-fcd3-439b-9ade-9e5a2e5a67b5


___
**Using the back gesture**

https://github.com/user-attachments/assets/013f4b98-14f7-41da-b28d-40998834da35



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog