### PR TITLE
chore: make text non selectable on search modal

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlayEmptyState.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlayEmptyState.tsx
@@ -17,10 +17,10 @@ export const GlobalSearchInputOverlayEmptyState = () => {
           }}
         />
       </Flex>
-      <Text variant="lg-display" textAlign="center">
+      <Text selectable={false} variant="lg-display" textAlign="center">
         Find the art you love
       </Text>
-      <Text variant="sm-display" textAlign="center" mt={1} color="black60">
+      <Text selectable={false} variant="sm-display" textAlign="center" mt={1} color="black60">
         Search for artists, artworks, galleries and more. Save for later or add alerts.
       </Text>
     </Flex>


### PR DESCRIPTION
This PR resolves:
https://www.notion.so/artsy/Clicking-on-the-empty-area-below-the-Recent-Searches-results-or-the-Find-art-you-love-title-only-144cab0764a0806f86aec1b483fef148?pvs=4

### Description

This PR makes the text on the new search modal non selectable


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog