### PR TITLE
chore: increase bottom tabs top padding

### DIFF
--- a/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
+++ b/src/app/Scenes/BottomTabs/BottomTabsButton.tsx
@@ -121,7 +121,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
       }}
       {...buttonProps}
     >
-      <View style={{ flex: 1 }}>
+      <Flex flex={1} pt={enableNewNavigation ? 0.5 : 0}>
         <ProgressiveOnboardingFindSavedArtwork tab={tab}>
           <Flex flex={1} alignItems="center" overflow="hidden">
             <Flex flex={1} height={ICON_HEIGHT} width={ICON_WIDTH} justifyContent="center">
@@ -188,7 +188,7 @@ export const BottomTabsButton: React.FC<BottomTabsButtonProps> = ({
             </View>
           </IconWrapper>
         )}
-      </View>
+      </Flex>
     </Touchable>
   )
 }


### PR DESCRIPTION
This PR resolves:

https://www.notion.so/artsy/Likely-related-but-buttom-navigation-bars-seem-to-have-less-padding-at-the-top-144cab0764a080aa81dcdb81295786fa?pvs=4

### Description

This PR increase the top padding on the bottom tabs.

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/6c92c4e1-c057-47c9-acc7-5ee9b3a2be3e" > | <img src="https://github.com/user-attachments/assets/04e6dcd1-e32a-4661-b301-d1b3ee5d879f" > | 




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog