### PR TITLE
fix: simple ESLint errors in bidding test suites

### DIFF
--- a/src/app/Components/Bidding/Screens/BidResult.tests.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { BidResultTestsQuery } from "__generated__/BidResultTestsQuery.graphql"
 import { BidResult_sale_artwork$data } from "__generated__/BidResult_sale_artwork.graphql"
 import { BidderPositionResult } from "app/Components/Bidding/types"
@@ -73,27 +73,23 @@ describe("BidResult component", () => {
 
   describe("high bidder", () => {
     it("renders a timer", () => {
-      const { getByLabelText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.winning} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.winning} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      expect(getByLabelText("Countdown")).toBeTruthy()
+      expect(screen.getByLabelText("Countdown")).toBeTruthy()
     })
 
     it("dismisses the controller when the continue button is pressed", () => {
-      const { getByText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.winning} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.winning} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      fireEvent.press(getByText("Continue"))
+      fireEvent.press(screen.getByText("Continue"))
       jest.runAllTicks()
 
       expect(dismissModal).toHaveBeenCalled()
@@ -103,27 +99,23 @@ describe("BidResult component", () => {
 
   describe("low bidder", () => {
     it("renders a timer", () => {
-      const { getByLabelText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.outbid} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.outbid} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      expect(getByLabelText("Countdown")).toBeTruthy()
+      expect(screen.getByLabelText("Countdown")).toBeTruthy()
     })
 
     it("pops to root when bid-again button is pressed", () => {
-      const { getByText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.outbid} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.outbid} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      fireEvent.press(getByText("Bid again"))
+      fireEvent.press(screen.getByText("Bid again"))
 
       expect(refreshBidderInfoMock).toHaveBeenCalled()
       expect(refreshSaleArtworkInfoMock).toHaveBeenCalled()
@@ -133,27 +125,23 @@ describe("BidResult component", () => {
 
   describe("live bidding has started", () => {
     it("doesn't render a timer", () => {
-      const { queryByLabelText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.live_bidding_started} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.live_bidding_started} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      expect(queryByLabelText("Countdown")).toBeFalsy()
+      expect(screen.queryByLabelText("Countdown")).toBeFalsy()
     })
 
     it("dismisses controller and presents live interface when continue button is pressed", () => {
-      const { getByText } = renderWithWrappers(
-        <TestWrapper bidderPositionResult={Statuses.live_bidding_started} />
-      )
+      renderWithWrappers(<TestWrapper bidderPositionResult={Statuses.live_bidding_started} />)
 
       resolveMostRecentRelayOperation(mockEnvironment, {
         Sale: () => sale,
       })
 
-      fireEvent.press(getByText("Continue"))
+      fireEvent.press(screen.getByText("Continue"))
       jest.runAllTicks()
 
       expect(navigate).toHaveBeenCalledWith("https://live-staging.artsy.net/sale-id", {

--- a/src/app/Components/Bidding/Screens/BillingAddress.tests.tsx
+++ b/src/app/Components/Bidding/Screens/BillingAddress.tests.tsx
@@ -1,33 +1,23 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { FakeNavigator } from "app/Components/Bidding/Helpers/FakeNavigator"
 import { mockFullAddress } from "app/Components/Bidding/__mocks__/billingAddress"
-import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { BillingAddress } from "./BillingAddress"
 
 describe("BillingAddress component", () => {
   const onSubmitMock = jest.fn()
   const fakeNavigator = new FakeNavigator()
 
-  it("renders without throwing an error", () => {
-    const billingAddressComponent = renderWithWrappersLEGACY(
-      <BillingAddress onSubmit={onSubmitMock} navigator={fakeNavigator as any} />
-    )
-
-    expect(billingAddressComponent).toBeTruthy()
-  })
-
   it("renders 7 inputs and correctly mutates typed values", () => {
-    const { getByTestId } = renderWithWrappers(
-      <BillingAddress onSubmit={onSubmitMock} navigator={fakeNavigator as any} />
-    )
+    renderWithWrappers(<BillingAddress onSubmit={onSubmitMock} navigator={fakeNavigator as any} />)
 
-    const nameInput = getByTestId("input-full-name")
-    const address1Input = getByTestId("input-address-1")
-    const address2Input = getByTestId("input-address-2")
-    const cityInput = getByTestId("input-city")
-    const stateInput = getByTestId("input-state-province-region")
-    const postcodeInput = getByTestId("input-post-code")
-    const phoneInput = getByTestId("input-phone")
+    const nameInput = screen.getByTestId("input-full-name")
+    const address1Input = screen.getByTestId("input-address-1")
+    const address2Input = screen.getByTestId("input-address-2")
+    const cityInput = screen.getByTestId("input-city")
+    const stateInput = screen.getByTestId("input-state-province-region")
+    const postcodeInput = screen.getByTestId("input-post-code")
+    const phoneInput = screen.getByTestId("input-phone")
 
     fireEvent.changeText(nameInput, "mockName")
     fireEvent.changeText(address1Input, "mockAddress1")
@@ -47,7 +37,7 @@ describe("BillingAddress component", () => {
   })
 
   it("correctly populates relevant inputs with the passed address fields", () => {
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <BillingAddress
         onSubmit={onSubmitMock}
         billingAddress={mockFullAddress}
@@ -55,17 +45,19 @@ describe("BillingAddress component", () => {
       />
     )
 
-    expect(getByTestId("input-full-name").props.value).toEqual(mockFullAddress.fullName)
-    expect(getByTestId("input-address-1").props.value).toEqual(mockFullAddress.addressLine1)
-    expect(getByTestId("input-address-2").props.value).toEqual(mockFullAddress.addressLine2)
-    expect(getByTestId("input-city").props.value).toEqual(mockFullAddress.city)
-    expect(getByTestId("input-state-province-region").props.value).toEqual(mockFullAddress.state)
-    expect(getByTestId("input-post-code").props.value).toEqual(mockFullAddress.postalCode)
-    expect(getByTestId("input-phone").props.value).toEqual(mockFullAddress.phoneNumber)
+    expect(screen.getByTestId("input-full-name").props.value).toEqual(mockFullAddress.fullName)
+    expect(screen.getByTestId("input-address-1").props.value).toEqual(mockFullAddress.addressLine1)
+    expect(screen.getByTestId("input-address-2").props.value).toEqual(mockFullAddress.addressLine2)
+    expect(screen.getByTestId("input-city").props.value).toEqual(mockFullAddress.city)
+    expect(screen.getByTestId("input-state-province-region").props.value).toEqual(
+      mockFullAddress.state
+    )
+    expect(screen.getByTestId("input-post-code").props.value).toEqual(mockFullAddress.postalCode)
+    expect(screen.getByTestId("input-phone").props.value).toEqual(mockFullAddress.phoneNumber)
   })
 
   it("fires the passed callback when address is submitted and no required field is missing", () => {
-    const { getByTestId } = renderWithWrappers(
+    renderWithWrappers(
       <BillingAddress
         onSubmit={onSubmitMock}
         billingAddress={mockFullAddress}
@@ -73,7 +65,7 @@ describe("BillingAddress component", () => {
       />
     )
 
-    getByTestId("button-add").props.onClick()
+    screen.getByTestId("button-add").props.onClick()
 
     expect(onSubmitMock).toHaveBeenCalled()
   })

--- a/src/app/Components/Bidding/Screens/PhoneNumberForm.tests.tsx
+++ b/src/app/Components/Bidding/Screens/PhoneNumberForm.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, waitFor } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { FakeNavigator } from "app/Components/Bidding/Helpers/FakeNavigator"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { PhoneNumberForm } from "./PhoneNumberForm"
@@ -7,40 +7,25 @@ describe("PhoneNumberForm component", () => {
   const onSubmitMock = jest.fn()
   const fakeNavigator = new FakeNavigator()
 
-  it("renders without throwing an error", () => {
-    const container = renderWithWrappers(
-      <PhoneNumberForm onSubmit={onSubmitMock} navigator={fakeNavigator as any} />
-    )
-
-    expect(container).toBeTruthy()
-  })
-
   it("User can immediately type their phone number and save it after load", async () => {
-    const [phoneNumber, formattedPhoneNumber] = ["7738675309", "+1 (773) 867-5309"]
+    renderWithWrappers(<PhoneNumberForm onSubmit={onSubmitMock} navigator={fakeNavigator as any} />)
 
-    const container = renderWithWrappers(
-      <PhoneNumberForm onSubmit={onSubmitMock} navigator={fakeNavigator as any} />
-    )
-    const { getByTestId } = container
+    const phoneInput = screen.getByTestId("phone-input")
+    fireEvent.changeText(phoneInput, "2125554444")
 
-    const phoneInput = getByTestId("phone-input")
-    fireEvent.changeText(phoneInput, phoneNumber)
-
-    fireEvent.press(container.queryAllByText("Add phone number")[1])
-    await waitFor(() => expect(onSubmitMock).toHaveBeenLastCalledWith(formattedPhoneNumber))
+    fireEvent.press(screen.queryAllByText("Add phone number")[1])
+    await waitFor(() => expect(onSubmitMock).toHaveBeenLastCalledWith("+1 (212) 555-4444"))
   })
 
   it("correctly populates relevant inputs with the passed address fields", () => {
-    const [phoneNumber, formattedPhoneNumber] = ["7738675309", "(773) 867-5309"]
-
-    const container = renderWithWrappers(
+    renderWithWrappers(
       <PhoneNumberForm
         onSubmit={onSubmitMock}
         navigator={fakeNavigator as any}
-        phoneNumber={phoneNumber}
+        phoneNumber="2125554444"
       />
     )
 
-    expect(container.getByTestId("phone-input")?.props.value).toEqual(formattedPhoneNumber)
+    expect(screen.getByTestId("phone-input")?.props.value).toEqual("(212) 555-4444")
   })
 })

--- a/src/app/Components/Bidding/Screens/RegistrationResult.tests.tsx
+++ b/src/app/Components/Bidding/Screens/RegistrationResult.tests.tsx
@@ -1,8 +1,9 @@
-import { LinkText, Button } from "@artsy/palette-mobile"
+import { LinkText } from "@artsy/palette-mobile"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { Icon20 } from "app/Components/Bidding/Components/Icon"
 import { dismissModal, navigate } from "app/system/navigation/navigate"
 import { extractText } from "app/utils/tests/extractText"
-import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
+import { renderWithWrappers, renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 
 import { Linking } from "react-native"
 import { RegistrationResult, RegistrationStatus } from "./RegistrationResult"
@@ -82,18 +83,22 @@ describe("Registration result component", () => {
     const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
     )
-    await (await view.root.findByType(LinkText)).props.onPress()
+
+    const linkText = await view.root.findByType(LinkText)
+    await linkText.props.onPress()
     expect(Linking.openURL).toBeCalledWith("mailto:support@artsy.net")
   })
 
-  it("dismisses the controller when the continue button is pressed", async () => {
+  it("dismisses the controller when the continue button is pressed", () => {
     jest.useFakeTimers({
       legacyFakeTimers: true,
     })
-    const view = renderWithWrappersLEGACY(
+    renderWithWrappers(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />
     )
-    ;(await view.root.findByType(Button)).props.onPress()
+
+    fireEvent.press(screen.getByTestId("continue-button"))
+
     jest.runAllTicks()
 
     expect(dismissModal).toHaveBeenCalled()

--- a/src/app/Components/Bidding/Screens/RegistrationResult.tests.tsx
+++ b/src/app/Components/Bidding/Screens/RegistrationResult.tests.tsx
@@ -9,91 +9,91 @@ import { RegistrationResult, RegistrationStatus } from "./RegistrationResult"
 
 describe("Registration result component", () => {
   it("renders registration pending properly", () => {
-    const tree = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult
         status={RegistrationStatus.RegistrationStatusPending}
         needsIdentityVerification={false}
       />
     )
-    expect(extractText(tree.root)).toMatch("Registration pending")
-    expect(extractText(tree.root)).toMatch(
+    expect(extractText(view.root)).toMatch("Registration pending")
+    expect(extractText(view.root)).toMatch(
       "Artsy is reviewing your registration and you will receive an email when it has been confirmed. Please email "
     )
-    expect(extractText(tree.root)).not.toMatch(
+    expect(extractText(view.root)).not.toMatch(
       "This auction requires Artsy to verify your identity before bidding."
     )
   })
 
   it("renders registration pending with an explanation about IDV", () => {
-    const tree = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult
         status={RegistrationStatus.RegistrationStatusPending}
         needsIdentityVerification
       />
     )
 
-    expect(extractText(tree.root)).toMatch("Registration pending")
-    expect(extractText(tree.root)).toMatch(
+    expect(extractText(view.root)).toMatch("Registration pending")
+    expect(extractText(view.root)).toMatch(
       "This auction requires Artsy to verify your identity before bidding."
     )
-    expect(extractText(tree.root)).not.toMatch(
+    expect(extractText(view.root)).not.toMatch(
       "Artsy is reviewing your registration and you will receive an email when it has been confirmed. Please email "
     )
   })
 
-  it("does not render the icon when the registration status is pending", () => {
-    const component = renderWithWrappersLEGACY(
+  it("does not render the icon when the registration status is pending", async () => {
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusPending} />
     )
 
-    expect(component.root.findAllByType(Icon20).length).toEqual(0)
+    expect((await view.root.findAllByType(Icon20)).length).toEqual(0)
   })
 
   it("renders registration complete properly", () => {
-    const tree = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />
     )
-    expect(extractText(tree.root)).toMatch("Registration complete")
+    expect(extractText(view.root)).toMatch("Registration complete")
   })
 
   it("renders registration error properly", () => {
-    const tree = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
     )
 
-    expect(extractText(tree.root)).toMatch("An error occurred")
-    expect(extractText(tree.root)).toMatch("Please contact")
-    expect(extractText(tree.root)).toMatch("with any questions.")
+    expect(extractText(view.root)).toMatch("An error occurred")
+    expect(extractText(view.root)).toMatch("Please contact")
+    expect(extractText(view.root)).toMatch("with any questions.")
   })
 
   it("renders an error screen when the status is a network error", () => {
-    const tree = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusNetworkError} />
     )
 
-    expect(extractText(tree.root)).toMatch("An error occurred")
-    expect(extractText(tree.root)).toMatch("Please\ncheck your internet connection\nand try again.")
+    expect(extractText(view.root)).toMatch("An error occurred")
+    expect(extractText(view.root)).toMatch("Please\ncheck your internet connection\nand try again.")
   })
 
   it("renders registration error and mailto link properly", async () => {
     Linking.canOpenURL = jest.fn().mockReturnValue(Promise.resolve(true))
     Linking.openURL = jest.fn()
 
-    const component = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusError} />
     )
-    await component.root.findByType(LinkText).props.onPress()
+    await (await view.root.findByType(LinkText)).props.onPress()
     expect(Linking.openURL).toBeCalledWith("mailto:support@artsy.net")
   })
 
-  it("dismisses the controller when the continue button is pressed", () => {
+  it("dismisses the controller when the continue button is pressed", async () => {
     jest.useFakeTimers({
       legacyFakeTimers: true,
     })
-    const component = renderWithWrappersLEGACY(
+    const view = renderWithWrappersLEGACY(
       <RegistrationResult status={RegistrationStatus.RegistrationStatusComplete} />
     )
-    component.root.findByType(Button).props.onPress()
+    ;(await view.root.findByType(Button)).props.onPress()
     jest.runAllTicks()
 
     expect(dismissModal).toHaveBeenCalled()

--- a/src/app/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/app/Components/Bidding/Screens/RegistrationResult.tsx
@@ -100,7 +100,7 @@ const resultEnumToPageName = (result: RegistrationStatus) => {
     ({
       context_screen: resultEnumToPageName(props.status),
       context_screen_owner_type: null,
-    } as any) /* STRICTNESS_MIGRATION */
+    }) as any /* STRICTNESS_MIGRATION */
 )
 export class RegistrationResult extends React.Component<RegistrationResultProps> {
   backButtonListener?: NativeEventSubscription = undefined
@@ -172,7 +172,13 @@ export class RegistrationResult extends React.Component<RegistrationResultProps>
               {msg}
             </Markdown>
           </Flex>
-          <Button variant="outline" onPress={() => dismissModal()} block width={100}>
+          <Button
+            variant="outline"
+            onPress={() => dismissModal()}
+            block
+            width={100}
+            testID="continue-button"
+          >
             {status === RegistrationStatus.RegistrationStatusPending
               ? "View works in this sale"
               : "Continue"}

--- a/src/app/Components/Bidding/Screens/SelectMaxBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/SelectMaxBid.tests.tsx
@@ -28,7 +28,7 @@ describe("SelectMaxBid", () => {
 
     // shows a spinner while fetching new bid increments
     screen.UNSAFE_getByType(SelectMaxBid).instance._test_refreshSaleArtwork(true) // hacky way to call this, but its an old component that needs refactoring
-    expect(screen.queryByTestId("spinner")).toBeTruthy()
+    expect(screen.getByTestId("spinner")).toBeTruthy()
 
     // removes the spinner once the refetch is complete
     screen.UNSAFE_getByType(SelectMaxBid).instance._test_refreshSaleArtwork(false) // hacky way to call this, but its an old component that needs refactoring


### PR DESCRIPTION
This PR fixes a bunch of simple ESLint errors in the bidding test suites. There is more clean-up that can be done in these tests. For example, a lot of them use old `view.root.findAllByType(Button)` matchers that should be converted to Testing Library tests. However, the goal of this PR is to do some quick clean-up so that developers don't need to `--no-verify` commits when they work in these files in the future.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Clean up ESLint errors in bidding test suite

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
