### PR TITLE
chore: search overlay on tab press

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tests.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tests.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearchInput"
 import { useSelectedTab } from "app/utils/hooks/useSelectedTab"
@@ -8,6 +9,10 @@ jest.mock("app/utils/hooks/useSelectedTab", () => ({
   useSelectedTab: jest.fn(),
 }))
 
+jest.mock("app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress", () => ({
+  useDismissSearchOverlayOnTabBarPress: jest.fn(),
+}))
+
 describe("GlobalSearchInput", () => {
   const mockUseledTab = useSelectedTab as jest.Mock
 
@@ -16,20 +21,20 @@ describe("GlobalSearchInput", () => {
   })
 
   it("renders the search label properly", () => {
-    renderWithWrappers(<GlobalSearchInput />)
+    renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
 
     expect(/Search Artsy/).toBeTruthy()
   })
 
   it("tracks the search bar tapped event", () => {
-    renderWithWrappers(<GlobalSearchInput />)
+    renderWithWrappers(<GlobalSearchInput ownerType={OwnerType.home} />)
 
     fireEvent.press(screen.getByTestId("search-button"))
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "tappedGlobalSearchBar",
-        context_module: "home",
+        context_screen_owner_type: "home",
       })
     )
   })

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInput.tsx
@@ -1,15 +1,18 @@
-import { ActionType, ContextModule } from "@artsy/cohesion"
+import { ActionType, OwnerType } from "@artsy/cohesion"
 import { Flex, RoundSearchInput, Touchable } from "@artsy/palette-mobile"
 import { GlobalSearchInputOverlay } from "app/Components/GlobalSearchInput/GlobalSearchInputOverlay"
+import { useDismissSearchOverlayOnTabBarPress } from "app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress"
 import { ICON_HIT_SLOP } from "app/Components/constants"
-import { useSelectedTab } from "app/utils/hooks/useSelectedTab"
 import { Fragment, useState } from "react"
 import { useTracking } from "react-tracking"
 
-export const GlobalSearchInput: React.FC<{}> = () => {
+export const GlobalSearchInput: React.FC<{
+  ownerType: OwnerType
+}> = ({ ownerType }) => {
   const [isVisible, setIsVisible] = useState(false)
   const tracking = useTracking()
-  const selectedTab = useSelectedTab()
+
+  useDismissSearchOverlayOnTabBarPress({ isVisible, ownerType, setIsVisible })
 
   return (
     <Fragment>
@@ -17,7 +20,7 @@ export const GlobalSearchInput: React.FC<{}> = () => {
         onPress={() => {
           tracking.trackEvent(
             tracks.tappedGlobalSearchBar({
-              contextModule: selectedTab as ContextModule,
+              ownerType,
             })
           )
           setIsVisible(true)
@@ -40,14 +43,18 @@ export const GlobalSearchInput: React.FC<{}> = () => {
           />
         </Flex>
       </Touchable>
-      <GlobalSearchInputOverlay visible={isVisible} hideModal={() => setIsVisible(false)} />
+      <GlobalSearchInputOverlay
+        ownerType={ownerType}
+        visible={isVisible}
+        hideModal={() => setIsVisible(false)}
+      />
     </Fragment>
   )
 }
 
 const tracks = {
-  tappedGlobalSearchBar: ({ contextModule }: { contextModule: ContextModule }) => ({
+  tappedGlobalSearchBar: ({ ownerType }: { ownerType: OwnerType }) => ({
     action: ActionType.tappedGlobalSearchBar,
-    context_module: contextModule,
+    context_screen_owner_type: ownerType,
   }),
 }

--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { Box, Flex, RoundSearchInput, Spacer, Spinner, useSpace } from "@artsy/palette-mobile"
 import { Portal } from "@gorhom/portal"
 import { FadeIn } from "app/Components/FadeIn"
@@ -78,10 +79,11 @@ const GlobalSearchInputOverlayContent: React.FC<{ query: string }> = ({ query })
   )
 }
 
-export const GlobalSearchInputOverlay: React.FC<{ visible: boolean; hideModal: () => void }> = ({
-  visible,
-  hideModal,
-}) => {
+export const GlobalSearchInputOverlay: React.FC<{
+  ownerType: OwnerType
+  visible: boolean
+  hideModal: () => void
+}> = ({ hideModal, ownerType, visible }) => {
   const [query, setQuery] = useState("")
   const insets = useSafeAreaInsets()
 
@@ -104,7 +106,7 @@ export const GlobalSearchInputOverlay: React.FC<{ visible: boolean; hideModal: (
 
   return (
     <FadeIn style={{ flex: 1 }} slide={false}>
-      <Portal hostName="SearchOverlay">
+      <Portal hostName={`${ownerType}-SearchOverlay`}>
         <Flex style={{ ...StyleSheet.absoluteFillObject }}>
           <Flex flex={1} backgroundColor="white100" style={{ ...insets }}>
             <Flex px={2} pt={2}>

--- a/src/app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress.ts
+++ b/src/app/Components/GlobalSearchInput/utils/useDismissSearchOverlayOnTabBarPress.ts
@@ -1,0 +1,35 @@
+import { useIsFocused, useNavigation } from "@react-navigation/native"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useEffect } from "react"
+
+/**
+ * Dismisses the GlobalSearchInputOverlay when the tab bar is pressed
+ */
+export const useDismissSearchOverlayOnTabBarPress = ({
+  isVisible,
+  ownerType,
+  setIsVisible,
+}: {
+  isVisible: boolean
+  ownerType: string
+  setIsVisible: React.Dispatch<React.SetStateAction<boolean>>
+}) => {
+  const isFocused = useIsFocused()
+  const selectedTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
+
+  const navigation = useNavigation()
+
+  useEffect(() => {
+    const tabsNavigation = navigation?.getParent()
+    const unsubscribe = tabsNavigation?.addListener("tabPress" as any, () => {
+      if (!isFocused || !isVisible) {
+        return
+      }
+
+      if (ownerType === selectedTab.toLowerCase()) {
+        setIsVisible(false)
+      }
+    })
+    return unsubscribe
+  }, [isVisible, selectedTab, navigation, isFocused])
+}

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -13,7 +13,7 @@ import { BottomTabsButton } from "app/Scenes/BottomTabs/BottomTabsButton"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
-import { internal_navigationRef } from "app/system/navigation/navigate"
+import { internal_navigationRef, switchTab } from "app/system/navigation/navigate"
 import { postEventToProviders } from "app/utils/track/providers"
 import { Platform } from "react-native"
 
@@ -66,6 +66,7 @@ const AppTabs: React.FC = () => {
           const tabName = Object.keys(bottomTabsConfig).find((tab) => e.target?.startsWith(tab))
 
           if (tabName) {
+            switchTab(tabName as BottomTabType)
             postEventToProviders(
               tappedTabBar({
                 tab: bottomTabsConfig[tabName as BottomTabType].analyticsDescription,

--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -1,3 +1,4 @@
+import { OwnerType } from "@artsy/cohesion"
 import { ArtsyLogoBlackIcon, Box, Flex } from "@artsy/palette-mobile"
 import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearchInput"
 import { PaymentFailureBanner } from "app/Scenes/HomeView/Components/PaymentFailureBanner"
@@ -30,7 +31,7 @@ export const HomeHeader: React.FC = () => {
             alignItems="center"
           >
             <Flex flex={1}>
-              <GlobalSearchInput />
+              <GlobalSearchInput ownerType={OwnerType.home} />
             </Flex>
             <Flex alignItems="flex-end">
               <ActivityIndicator hasUnseenNotifications={hasUnseenNotifications} />

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -205,7 +205,7 @@ export const HomeViewScreen: React.FC = () => {
         <Suspense fallback={<HomeViewScreenPlaceholder />}>
           <HomeView />
         </Suspense>
-        <PortalHost name="SearchOverlay" />
+        <PortalHost name={`${OwnerType.home}-SearchOverlay`} />
       </RetryErrorBoundary>
     </HomeViewStoreProvider>
   )

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -135,7 +135,7 @@ export const Search: React.FC = () => {
       <ArtsyKeyboardAvoidingView>
         <Flex p={2} pb={0}>
           {enableNewSearchModal ? (
-            <GlobalSearchInput />
+            <GlobalSearchInput ownerType={OwnerType.search} />
           ) : (
             <SearchInput
               ref={searchProviderValues?.inputRef}
@@ -209,7 +209,7 @@ export const SearchScreen: React.FC<SearchScreenProps> = () => {
           <Search />
         </Suspense>
       </Screen>
-      <PortalHost name="SearchOverlay" />
+      <PortalHost name={`${OwnerType.search}-SearchOverlay`} />
     </>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR allows us to dismiss the search overlay on tab bar press. While working on this, I noticed that the overlay was closing twice on both tabs. This is because we had the same new for the portal - so I separated the naming of the portals.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

https://github.com/user-attachments/assets/074996b8-c42b-4756-821c-0df1bf3c822a


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.


#nochangelog