### PR TITLE
fix: fix icons and metadata alignment on ArtworkGridItem

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -333,13 +333,11 @@ export const Artwork: React.FC<ArtworkProps> = ({
               mt={1}
               style={artworkMetaStyle}
             >
-              <Flex>
+              <Flex flexGrow={1}>
                 {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
-                  <>
-                    <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
-                      Lot {artwork.saleArtwork.lotLabel}
-                    </Text>
-                  </>
+                  <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
+                    Lot {artwork.saleArtwork.lotLabel}
+                  </Text>
                 )}
                 {!!artwork.artistNames && (
                   <Text
@@ -419,6 +417,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
                   />
                 )}
               </Flex>
+
               {!!showOldSaveCTA && (
                 <Flex flexDirection="row" alignItems="flex-start">
                   {!!isAuction && !!collectorSignals?.auction?.lotWatcherCount && (

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -333,7 +333,10 @@ export const Artwork: React.FC<ArtworkProps> = ({
               mt={1}
               style={artworkMetaStyle}
             >
-              <Flex flexGrow={1}>
+              <Flex
+                flexGrow={positionCTAs === "column" ? 1 : undefined}
+                flex={positionCTAs === "row" ? 1 : undefined}
+              >
                 {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
                   <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
                     Lot {artwork.saleArtwork.lotLabel}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Addresses notion bug: https://www.notion.so/artsy/variant-b-variant-c-The-meta-data-is-not-visible-on-the-grids-on-the-artist-page-but-show-up-when-13ecab0764a0805891ffdb96af05ac79?pvs=4

Follow up on https://github.com/artsy/eigen/pull/11134. The fix in this PR was **breaking** alignment of the save CTA:
 <img width="200" alt="image" src="https://github.com/user-attachments/assets/63706e9d-e041-4b41-8260-b979f4d27ade">

Because we use different flexDirection value for different experiments, the layout was breaking. When displaying the data in a column, we need to use flexGrow and when in the row - flex.

```
flexGrow={positionCTAs === "column" ? 1 : undefined}
flex={positionCTAs === "row" ? 1 : undefined}
```

**Fix:**
| Fixed missing metadata data on the grids on artwork screen | Fixed Save CTA alignment |
| --- | --- |
| ![IMAGE 2024-11-21 18:57:21](https://github.com/user-attachments/assets/1f95feab-7fc8-453c-a6e9-bbc4f73cba60) | ![IMAGE 2024-11-21 18:57:26](https://github.com/user-attachments/assets/5ba7ba09-a241-4036-a5b9-496618a2705e) |

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix icons and metadata alignment on ArtworkGridItem

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
