### PR TITLE
fix: navigate back to tab behaviour

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -13,7 +13,7 @@ import { BottomTabsButton } from "app/Scenes/BottomTabs/BottomTabsButton"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
-import { internal_navigationRef, switchTab } from "app/system/navigation/navigate"
+import { internal_navigationRef } from "app/system/navigation/navigate"
 import { postEventToProviders } from "app/utils/track/providers"
 import { Platform } from "react-native"
 
@@ -63,10 +63,12 @@ const AppTabs: React.FC = () => {
       screenListeners={{
         tabPress: (e) => {
           // the tab name is saved in e.target postfixed with random string like sell-Nw_wCNTWwOg95v
-          const tabName = Object.keys(bottomTabsConfig).find((tab) => e.target?.startsWith(tab))
+          const tabName = Object.keys(bottomTabsConfig).find(
+            (tab) => e.target?.startsWith(tab)
+          ) as BottomTabType
 
-          if (tabName) {
-            switchTab(tabName as BottomTabType)
+          if (Object.keys(BottomTabOption).includes(tabName)) {
+            GlobalStore.actions.bottomTabs.setSelectedTab(tabName)
             postEventToProviders(
               tappedTabBar({
                 tab: bottomTabsConfig[tabName as BottomTabType].analyticsDescription,


### PR DESCRIPTION
### Issue description

Visit any screen with visible tab on the home view
Go to Search
Go back to Home

Expected result:
- Find yourself in the screen you were at

Actual result:
- Navigate back to home view

| Before | After |
|--------|--------|
| <Video src="https://github.com/user-attachments/assets/474708bd-9585-43b5-b5b7-76d8e11413ee" /> | <Video src="https://github.com/user-attachments/assets/371e2bb8-e37f-42bf-8314-a2e4d7af2542" /> | 











<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [X] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog