### PR TITLE
feat: simplify bottom tabs logic

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -1,4 +1,6 @@
 import { tappedTabBar } from "@artsy/cohesion"
+import { Text } from "@artsy/palette-mobile"
+import { THEME } from "@artsy/palette-tokens"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { AppModule, modules } from "app/AppRegistry"
@@ -8,14 +10,16 @@ import { ProfileTab } from "app/Navigation/AuthenticatedRoutes/ProfileTab"
 import { SearchTab } from "app/Navigation/AuthenticatedRoutes/SearchTab"
 import { SellTab } from "app/Navigation/AuthenticatedRoutes/SellTab"
 import { registerSharedModalRoutes } from "app/Navigation/AuthenticatedRoutes/SharedRoutes"
+import { useBottomTabsBadges } from "app/Navigation/Utils/useBottomTabsBadges"
 import { BottomTabOption, BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
-import { BottomTabsButton } from "app/Scenes/BottomTabs/BottomTabsButton"
+import { BottomTabsIcon } from "app/Scenes/BottomTabs/BottomTabsIcon"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
 import { internal_navigationRef } from "app/system/navigation/navigate"
 import { postEventToProviders } from "app/utils/track/providers"
 import { Platform } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 if (Platform.OS === "ios") {
   require("app/Navigation/AuthenticatedRoutes/NativeScreens")
@@ -39,7 +43,12 @@ type TabRoutesParams = {
 
 const Tab = createBottomTabNavigator<TabRoutesParams>()
 
+const BOTTOM_TABS_HEIGHT = 60
+
 const AppTabs: React.FC = () => {
+  const { tabsBadges } = useBottomTabsBadges()
+  const insets = useSafeAreaInsets()
+
   return (
     <Tab.Navigator
       screenOptions={({ route }) => {
@@ -49,15 +58,26 @@ const AppTabs: React.FC = () => {
           tabBarStyle: {
             animate: true,
             position: "absolute",
+            height: BOTTOM_TABS_HEIGHT + insets.bottom,
             display:
               currentRoute && modules[currentRoute as AppModule]?.options.hidesBottomTabs
                 ? "none"
                 : "flex",
           },
           tabBarHideOnKeyboard: true,
-          tabBarButton: (props) => {
-            return <BottomTabsButton tab={route.name} onPress={props.onPress} />
+          tabBarIcon: ({ focused }) => {
+            return <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
           },
+          tabBarLabel: () => {
+            return (
+              <Text variant="xxs" style={{ top: -2 }}>
+                {bottomTabsConfig[route.name].name}
+              </Text>
+            )
+          },
+          tabBarActiveTintColor: THEME.colors["black100"],
+          tabBarInactiveTintColor: THEME.colors["black60"],
+          ...tabsBadges[route.name],
         }
       }}
       screenListeners={{

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -70,7 +70,7 @@ const AppTabs: React.FC = () => {
           },
           tabBarLabel: () => {
             return (
-              <Text variant="xxs" style={{ top: -2 }}>
+              <Text variant="xxs" style={{ top: -4 }} selectable={false}>
                 {bottomTabsConfig[route.name].name}
               </Text>
             )

--- a/src/app/Navigation/Utils/useBottomTabsBadges.tests.ts
+++ b/src/app/Navigation/Utils/useBottomTabsBadges.tests.ts
@@ -1,0 +1,97 @@
+import { useColor, useSpace } from "@artsy/palette-mobile"
+import { renderHook } from "@testing-library/react-hooks"
+import { useVisualClue } from "app/utils/hooks/useVisualClue"
+import { useTabBarBadge } from "app/utils/useTabBarBadge"
+import { useBottomTabsBadges } from "./useBottomTabsBadges"
+
+// Mocking the necessary imports
+jest.mock("@artsy/palette-mobile", () => ({
+  useColor: jest.fn(),
+  useSpace: jest.fn(),
+}))
+jest.mock("app/utils/hooks/useVisualClue", () => ({
+  useVisualClue: jest.fn(),
+}))
+
+jest.mock("app/utils/useTabBarBadge", () => ({
+  useTabBarBadge: jest.fn(),
+}))
+
+// Settings for the test
+describe("useBottomTabsBadges", () => {
+  const mockUseColor = useColor as jest.Mock
+  const mockUseSpace = useSpace as jest.Mock
+  const mockUseVisualClue = useVisualClue as jest.Mock
+  const mockUseTabBarBadge = useTabBarBadge as jest.Mock
+
+  beforeEach(() => {
+    mockUseColor.mockReturnValue((color: string) => color)
+    mockUseSpace.mockReturnValue(() => 10)
+  })
+
+  it("returns default badge states when no clues or notifications are present", () => {
+    mockUseVisualClue.mockReturnValue({ showVisualClue: () => false })
+    mockUseTabBarBadge.mockReturnValue({
+      unreadConversationsCount: 0,
+      hasUnseenNotifications: false,
+    })
+
+    const { result } = renderHook(() => useBottomTabsBadges())
+
+    expect(result.current.tabsBadges).toMatchObject({
+      home: { badgeCount: undefined, badgeStyle: {} },
+      search: { badgeCount: undefined, badgeStyle: {} },
+      inbox: { badgeCount: undefined, badgeStyle: {} },
+      sell: { badgeCount: undefined, badgeStyle: {} },
+      profile: { badgeCount: undefined, badgeStyle: {} },
+    })
+  })
+
+  it('updates badge for "home" tab when unseen notifications are present', () => {
+    mockUseVisualClue.mockReturnValue({ showVisualClue: () => false })
+    mockUseTabBarBadge.mockReturnValue({
+      hasUnseenNotifications: true,
+    })
+
+    const { result } = renderHook(() => useBottomTabsBadges())
+
+    expect(result.current.tabsBadges.home).toMatchObject({
+      badgeCount: "",
+      badgeStyle: {
+        // Whatever style we have here
+      },
+    })
+  })
+
+  it('updates badge for "inbox" tab when unseen notifications are present', () => {
+    mockUseVisualClue.mockReturnValue({ showVisualClue: () => false })
+    mockUseTabBarBadge.mockReturnValue({
+      unreadConversationsCount: 5,
+    })
+
+    const { result } = renderHook(() => useBottomTabsBadges())
+
+    expect(result.current.tabsBadges.inbox).toMatchObject({
+      badgeCount: 5,
+      badgeStyle: {
+        // Whatever style we have here
+      },
+    })
+  })
+
+  it('prioritises conversations count over visual clues for "inbox" tab', () => {
+    mockUseVisualClue.mockReturnValue({ showVisualClue: () => true })
+    mockUseTabBarBadge.mockReturnValue({
+      unreadConversationsCount: 5,
+    })
+
+    const { result } = renderHook(() => useBottomTabsBadges())
+
+    expect(result.current.tabsBadges.inbox).toMatchObject({
+      badgeCount: 5,
+      badgeStyle: {
+        // Whatever style we have here
+      },
+    })
+  })
+})

--- a/src/app/Navigation/Utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/Utils/useBottomTabsBadges.ts
@@ -1,0 +1,88 @@
+import { useColor, useSpace } from "@artsy/palette-mobile"
+import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
+import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
+import { useVisualClue } from "app/utils/hooks/useVisualClue"
+import { useTabBarBadge } from "app/utils/useTabBarBadge"
+import { StyleProp, TextStyle } from "react-native"
+
+const VISUAL_CLUE_HEIGHT = 10
+
+type BadgeProps = { badgeCount?: string | number; badgeStyle: StyleProp<TextStyle> }
+/**
+ * This hook is used to get the badge deftails each tab
+ */
+export const useBottomTabsBadges = () => {
+  const color = useColor()
+  const space = useSpace()
+
+  const { showVisualClue } = useVisualClue()
+
+  const { unreadConversationsCount, hasUnseenNotifications } = useTabBarBadge()
+
+  const tabsBadges: Record<string, BadgeProps> = {}
+
+  const visualClueStyles = {
+    backgroundColor: color("blue100"),
+    top: space(1),
+    minWidth: VISUAL_CLUE_HEIGHT,
+    maxHeight: VISUAL_CLUE_HEIGHT,
+    borderRadius: VISUAL_CLUE_HEIGHT / 2,
+    borderColor: color("white100"),
+    borderWidth: 1,
+  }
+
+  const hasVisualCluesForTab = (tab: BottomTabType) => {
+    const visualClues = bottomTabsConfig[tab].visualClues
+    if (!visualClues) {
+      return false
+    }
+
+    return visualClues?.find(showVisualClue)
+  }
+
+  Object.keys(bottomTabsConfig).forEach((tab) => {
+    const defaultBadgeProps: BadgeProps = {
+      badgeCount: undefined,
+      badgeStyle: {},
+    }
+
+    tabsBadges[tab] = defaultBadgeProps
+
+    if (hasVisualCluesForTab(tab as BottomTabType)) {
+      tabsBadges[tab] = {
+        badgeCount: "",
+        badgeStyle: {
+          ...visualClueStyles,
+        },
+      }
+    }
+
+    switch (tab) {
+      case "home": {
+        if (hasUnseenNotifications) {
+          tabsBadges[tab] = {
+            badgeCount: "",
+            badgeStyle: {
+              ...visualClueStyles,
+            },
+          }
+        }
+        return
+      }
+
+      case "inbox": {
+        if (unreadConversationsCount) {
+          tabsBadges[tab] = {
+            badgeCount: unreadConversationsCount,
+            badgeStyle: {
+              backgroundColor: color("red100"),
+            },
+          }
+        }
+        return
+      }
+    }
+  })
+
+  return { tabsBadges }
+}

--- a/src/app/Navigation/Utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/Utils/useBottomTabsBadges.ts
@@ -9,7 +9,9 @@ const VISUAL_CLUE_HEIGHT = 10
 
 type BadgeProps = { badgeCount?: string | number; badgeStyle: StyleProp<TextStyle> }
 /**
- * This hook is used to get the badge deftails each tab
+ * This hook is used to get badge details for each bottom tab
+ * @returns an object with the badge count and style for each tab
+ * @example { home: { badgeCount: 5, badgeStyle: { backgroundColor: "red" } }, search: { badgeCount: undefined, badgeStyle: {} } }
  */
 export const useBottomTabsBadges = () => {
   const color = useColor()

--- a/src/app/Scenes/BottomTabs/bottomTabsConfig.tsx
+++ b/src/app/Scenes/BottomTabs/bottomTabsConfig.tsx
@@ -1,5 +1,4 @@
 import { OwnerType, TappedTabBarArgs } from "@artsy/cohesion"
-import { VisualCluesConstMap } from "app/store/config/visualClues"
 import { BottomTabType } from "./BottomTabType"
 
 export type BottomTabRoute = "/" | "/search" | "/inbox" | "/sell" | "/my-profile"
@@ -37,6 +36,5 @@ export const bottomTabsConfig: {
     route: "/my-profile",
     analyticsDescription: OwnerType.profile,
     name: "Profile",
-    visualClues: [VisualCluesConstMap.MyCollectionInsights],
   },
 }

--- a/src/app/Scenes/BottomTabs/bottomTabsConfig.tsx
+++ b/src/app/Scenes/BottomTabs/bottomTabsConfig.tsx
@@ -1,4 +1,5 @@
 import { OwnerType, TappedTabBarArgs } from "@artsy/cohesion"
+import { VisualCluesConstMap } from "app/store/config/visualClues"
 import { BottomTabType } from "./BottomTabType"
 
 export type BottomTabRoute = "/" | "/search" | "/inbox" | "/sell" | "/my-profile"
@@ -9,6 +10,7 @@ export const bottomTabsConfig: {
     route: BottomTabRoute
     analyticsDescription: TappedTabBarArgs["tab"]
     name: string
+    visualClues?: string[]
   }
 } = {
   home: {
@@ -35,5 +37,6 @@ export const bottomTabsConfig: {
     route: "/my-profile",
     analyticsDescription: OwnerType.profile,
     name: "Profile",
+    visualClues: [VisualCluesConstMap.MyCollectionInsights],
   },
 }


### PR DESCRIPTION
### Description

This PR comes as a follow-up on https://github.com/artsy/eigen/pull/10977

**Motivation:**

Currently, we have our own buttons to render the bottom tab bars. The button is listening to state changes, visual clues changes, watches for unread conversation and notifications count, and has plenty of logic that makes it a lot more expensive than it should be. This led in the past to delays when tapping it and it's quite easy to mess up things inside it and affect performance.

In this PR, I am suggesting that we align with react-navigation bottom tabs API and take advantage out of the box of all the performance improvements it comes with. There isn't something that I can think of that we can not do with the new API that we could have had before, I could however think of so many improvements this change will bring to us:
- Easier API
- Easier to debug
- Best code to maintain is no code
- Out of the box new features with the upcoming react-navigation upgrades
- Native like interactions
- Easier styling (it was quite hard to make the bottom tabs 10 pixels longer in an earlier [PR](https://github.com/artsy/eigen/pull/11156#discussion_r1850666837))


<img width="1055" alt="Screenshot 2024-11-22 at 09 57 04" src="https://github.com/user-attachments/assets/3d70c5c6-9fff-4d6e-bfad-e66ccafec80e">


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
