### PR TITLE
fix: bring back staging indicator on bottom tabs

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -1,5 +1,5 @@
 import { tappedTabBar } from "@artsy/cohesion"
-import { Text } from "@artsy/palette-mobile"
+import { Text, useColor } from "@artsy/palette-mobile"
 import { THEME } from "@artsy/palette-tokens"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
@@ -17,6 +17,7 @@ import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
 import { internal_navigationRef } from "app/system/navigation/navigate"
+import { useIsStaging } from "app/utils/hooks/useIsStaging"
 import { postEventToProviders } from "app/utils/track/providers"
 import { Platform } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
@@ -47,7 +48,14 @@ const BOTTOM_TABS_HEIGHT = 60
 
 const AppTabs: React.FC = () => {
   const { tabsBadges } = useBottomTabsBadges()
+  const color = useColor()
+  const isStaging = useIsStaging()
   const insets = useSafeAreaInsets()
+
+  const stagingTabBarStyle = {
+    borderTopColor: color("devpurple"),
+    borderTopWidth: 1,
+  }
 
   return (
     <Tab.Navigator
@@ -63,6 +71,8 @@ const AppTabs: React.FC = () => {
               currentRoute && modules[currentRoute as AppModule]?.options.hidesBottomTabs
                 ? "none"
                 : "flex",
+
+            ...(isStaging ? stagingTabBarStyle : {}),
           },
           tabBarHideOnKeyboard: true,
           tabBarIcon: ({ focused }) => {


### PR DESCRIPTION
### Description

This PR brings back the staging indicator to the bottom tabs

![Simulator Screenshot - iPhone 16 Pro - 2024-11-22 at 16 19 39](https://github.com/user-attachments/assets/7b9423fc-1b33-473c-82cb-0645b8924ccf)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- bring back staging indicator on bottom tabs - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
