### PR TITLE
fix: alert edit bottom sheet is no longer getting cut off

### DIFF
--- a/src/app/Scenes/SavedSearchAlertsList/Components/AlertBottomSheet.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/AlertBottomSheet.tsx
@@ -35,8 +35,8 @@ export const AlertBottomSheet: React.FC<AlertBottomSheetProps> = ({
       name="AlertBottomSheet"
       onDismiss={onDismiss}
     >
-      <BottomSheetView>
-        <Flex flex={1} mb={4} mx={2} alignItems="center">
+      <BottomSheetView style={{ flex: 1 }}>
+        <Flex mb={4} mx={2} alignItems="center">
           <Join separator={<Spacer y={2} />}>
             <Text variant="sm" fontWeight="bold">
               {title}


### PR DESCRIPTION
This PR resolves [this launch blocking issue](https://www.notion.so/artsy/Alerts-screen-edit-bottom-sheet-is-cut-off-146cab0764a08054b23ed4e54773de29?pvs=4) that was reported in mobile QA

### Description

|Before|After|
|---|---|
|![Simulator Screenshot - iPhone 15 - 2024-11-22 at 17 12 06](https://github.com/user-attachments/assets/b8541206-a848-46cf-886d-c9f0fcb00d13)|![Screenshot_1732291866](https://github.com/user-attachments/assets/a8ddfe39-1117-4310-91dc-41a3c47a0618)|
|<img width="394" alt="Screenshot 2024-11-22 at 17 11 50" src="https://github.com/user-attachments/assets/8b5230e4-cfed-474b-9205-2fb5cffc3b28">|<img width="397" alt="Screenshot 2024-11-22 at 17 11 10" src="https://github.com/user-attachments/assets/4be3d01d-b6e0-4338-8fc5-87061678b7a1">|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- alert edit bottom sheet is no longer getting cut off

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
