### PR TITLE
chore: simplify routing logic [Part 2]: navigate.tsx 

### DIFF
--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,13 +1,13 @@
 import { EventEmitter } from "events"
 import { ActionType, OwnerType, Screen } from "@artsy/cohesion"
 import { NavigationContainerRef, StackActions, TabActions } from "@react-navigation/native"
-import { addBreadcrumb, captureMessage } from "@sentry/react-native"
 import { AppModule, modules, ViewOptions } from "app/AppRegistry"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { matchRoute } from "app/routes"
 import { GlobalStore, unsafe__getSelectedTab, unsafe_getFeatureFlag } from "app/store/GlobalStore"
 import { propsStore } from "app/store/PropsStore"
+import { getValidTargetURL } from "app/system/navigation/utils/getValidTargetURL"
 import { postEventToProviders } from "app/utils/track/providers"
 import { visualize } from "app/utils/visualizer"
 import { InteractionManager, Linking, Platform } from "react-native"
@@ -37,59 +37,14 @@ export interface NavigateOptions {
   replaceActiveScreen?: boolean
   // Only when onlyShowInTabName specified
   popToRootTabView?: boolean
-  ignoreDebounce?: boolean
   showInTabName?: BottomTabType
 }
 
-let lastInvocation = { url: "", timestamp: 0 }
-
 export async function navigate(url: string, options: NavigateOptions = {}) {
-  let targetURL = url
-
-  addBreadcrumb({
-    message: `navigate to ${url}`,
-    category: "navigation",
-    data: { url, options },
-    level: "info",
-  })
-
-  // handle artsy:// urls, we can just remove it
-  targetURL = url.replace("artsy://", "")
+  const enableNewNavigation = unsafe_getFeatureFlag("AREnableNewNavigation")
+  const targetURL = await getValidTargetURL(url)
 
   visualize("NAV", targetURL, { targetURL, options }, "DTShowNavigationVisualiser")
-
-  // Debounce double taps
-  const ignoreDebounce = options.ignoreDebounce ?? false
-  if (
-    lastInvocation.url === targetURL &&
-    Date.now() - lastInvocation.timestamp < 1000 &&
-    !ignoreDebounce
-  ) {
-    return
-  }
-
-  lastInvocation = { url: targetURL, timestamp: Date.now() }
-
-  // marketing url requires redirect
-  if (targetURL.startsWith("https://click.artsy.net")) {
-    let response
-    try {
-      response = await fetch(targetURL)
-    } catch (error) {
-      if (__DEV__) {
-        console.warn(error)
-      } else {
-        captureMessage(
-          `[navigate] Error fetching marketing url redirect on: ${targetURL} failed with error: ${error}`,
-          "error"
-        )
-      }
-    }
-
-    if (response?.url) {
-      targetURL = response.url
-    }
-  }
 
   const result = matchRoute(targetURL)
 
@@ -99,13 +54,50 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
   }
 
   const module = modules[result.module]
-  const presentModally = options.modal ?? module.options.alwaysPresentModally ?? false
+
   const {
     replaceActiveModal = false,
     replaceActiveScreen = false,
     popToRootTabView,
     showInTabName,
   } = options
+
+  if (enableNewNavigation) {
+    if (!internal_navigationRef.current || !internal_navigationRef.current?.isReady()) {
+      if (__DEV__) {
+        throw new Error(
+          `You are attempting to navigate before the navigation is ready.{\n}
+           Make sure that the App NavigationContainer isReady is ready`
+        )
+      }
+      return
+    }
+
+    if (replaceActiveModal || replaceActiveScreen) {
+      internal_navigationRef.current.dispatch(
+        StackActions.replace(result.module, { ...result.params, ...options.passProps })
+      )
+    } else {
+      if (module.options.onlyShowInTabName) {
+        switchTab(module.options.onlyShowInTabName)
+        // We wait for a frame to allow the tab to be switched before we navigate
+        // This allows us to also override the back button behavior in the tab
+        requestAnimationFrame(() => {
+          internal_navigationRef.current?.dispatch(
+            StackActions.push(result.module, { ...result.params, ...options.passProps })
+          )
+        })
+      } else {
+        internal_navigationRef.current?.dispatch(
+          StackActions.push(result.module, { ...result.params, ...options.passProps })
+        )
+      }
+    }
+
+    return
+  }
+
+  const presentModally = options.modal ?? module.options.alwaysPresentModally ?? false
 
   const screenDescriptor: ViewDescriptor = {
     type: module.type,
@@ -117,34 +109,6 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
       ...options.passProps,
     },
     ...module.options,
-  }
-
-  const enableNewNavigation = unsafe_getFeatureFlag("AREnableNewNavigation")
-
-  if (enableNewNavigation) {
-    if (internal_navigationRef.current?.isReady()) {
-      if (replaceActiveModal || replaceActiveScreen) {
-        internal_navigationRef.current.dispatch(
-          StackActions.replace(result.module, { ...result.params, ...options.passProps })
-        )
-      } else {
-        if (module.options.onlyShowInTabName) {
-          switchTab(module.options.onlyShowInTabName)
-          // We wait for a frame to allow the tab to be switched before we navigate
-          // This allows us to also override the back button behavior in the tab
-          requestAnimationFrame(() => {
-            internal_navigationRef.current?.dispatch(
-              StackActions.push(result.module, { ...result.params, ...options.passProps })
-            )
-          })
-        } else {
-          internal_navigationRef.current?.dispatch(
-            StackActions.push(result.module, { ...result.params, ...options.passProps })
-          )
-        }
-      }
-    }
-    return
   }
 
   // Set props which we will reinject later. See HACKS.md

--- a/src/app/system/navigation/utils/getValidTargetURL.tests.ts
+++ b/src/app/system/navigation/utils/getValidTargetURL.tests.ts
@@ -1,0 +1,48 @@
+import * as sentry from "@sentry/react-native"
+import fetchMock from "jest-fetch-mock"
+import { getValidTargetURL } from "./getValidTargetURL"
+
+describe("getValidTargetURL", () => {
+  beforeAll(() => {
+    fetchMock.enableMocks()
+  })
+
+  beforeEach(() => {
+    fetchMock.resetMocks()
+  })
+
+  it("should strip artsy protocol from the URL", async () => {
+    const url = "artsy://artist/andy-warhol"
+    const result = await getValidTargetURL(url)
+    expect(result).toEqual("artist/andy-warhol")
+  })
+
+  it("should return the original URL if no redirects are necessary", async () => {
+    const url = "https://www.artsy.net/artist/andy-warhol"
+    const result = await getValidTargetURL(url)
+    expect(result).toEqual(url)
+  })
+
+  it("should handle an error during fetch and log it if not in development", async () => {
+    const url = "https://click.artsy.net/redirect"
+    fetchMock.mockReject(new Error("Network failure"))
+
+    // @ts-expect-error
+    global.__DEV__ = false
+    const spy = jest.spyOn(sentry, "captureMessage").mockImplementation()
+
+    const result = await getValidTargetURL(url)
+    expect(result).toEqual(url)
+    expect(spy).toBeCalled()
+    spy.mockRestore()
+  })
+
+  it("should correctly resolve redirected URL", async () => {
+    const originalUrl = "https://click.artsy.net/redirect"
+    const redirectedUrl = "https://www.artsy.net/feature"
+    fetchMock.mockResponseOnce("", { url: redirectedUrl })
+
+    const result = await getValidTargetURL(originalUrl)
+    expect(result).toEqual(redirectedUrl)
+  })
+})

--- a/src/app/system/navigation/utils/getValidTargetURL.ts
+++ b/src/app/system/navigation/utils/getValidTargetURL.ts
@@ -1,0 +1,36 @@
+import { captureMessage } from "@sentry/react-native"
+
+/**
+ * This helper function is used to convert the href to a valid screen name that can be navigated to.
+ * This is required because the href can be a non trivial marketing url that needs additional handling.
+ * @param url
+ * @returns targetURL
+ */
+export const getValidTargetURL = async (url: string) => {
+  let targetURL = url
+
+  targetURL = url.replace("artsy://", "")
+
+  // marketing url requires redirect
+  if (targetURL.startsWith("https://click.artsy.net")) {
+    let response
+    try {
+      response = await fetch(targetURL)
+    } catch (error) {
+      if (__DEV__) {
+        console.warn(error)
+      } else {
+        captureMessage(
+          `[navigate] Error fetching marketing url redirect on: ${targetURL} failed with error: ${error}`,
+          "error"
+        )
+      }
+    }
+
+    if (response?.url) {
+      targetURL = response.url
+    }
+  }
+
+  return targetURL
+}

--- a/src/app/utils/PushNotification.tests.ts
+++ b/src/app/utils/PushNotification.tests.ts
@@ -150,7 +150,6 @@ describe("Push Notification Tests", () => {
       Push.handleReceivedNotification(notification)
       expect(navigate).toHaveBeenNthCalledWith(1, notification.data.url, {
         passProps: notification.data,
-        ignoreDebounce: true,
       })
     })
 

--- a/src/app/utils/PushNotification.ts
+++ b/src/app/utils/PushNotification.ts
@@ -210,7 +210,6 @@ export const handleReceivedNotification = (
     if (isLoggedIn && hasUrl) {
       navigate(notification.data.url as string, {
         passProps: notification.data,
-        ignoreDebounce: true,
       })
       // clear any pending notification
       GlobalStore.actions.pendingPushNotification.setPendingPushNotification(null)


### PR DESCRIPTION
### Description

This PR brings some simplifications to `navigate`. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- simplify routing logic [Part 2]: navigate.tsx 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
