### PR TITLE
fix: remove @cacheable from HomeViewSectionTasks

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionTasks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionTasks.tsx
@@ -142,7 +142,7 @@ const HomeViewSectionTasksPlaceholder: React.FC<FlexProps> = (flexProps) => {
 }
 
 const homeViewSectionTasksQuery = graphql`
-  query HomeViewSectionTasksQuery($id: String!) @cacheable {
+  query HomeViewSectionTasksQuery($id: String!) {
     homeView {
       section(id: $id) {
         ...HomeViewSectionTasks_section


### PR DESCRIPTION
### Description

This PR removes `@cacheable` from the `HomeViewSectionTasks` query. The latter sets `force` to `true` and therefore by definition should not be cacheable.


| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/37bd626e-32e5-43af-a273-59f5e47367f1" /> | <img src="https://github.com/user-attachments/assets/6e84b71d-a640-4abb-a742-e699d0078feb" /> | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog