### PR TITLE
fix: hide header on activity screen

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -346,6 +346,9 @@ export const modules = defineModules({
     options: {
       fullBleed: true,
       hidesBottomTabs: true,
+      screenOptions: {
+        headerShown: false,
+      },
     },
   }),
   ActivityItem: reactModule({
@@ -353,6 +356,9 @@ export const modules = defineModules({
     options: {
       fullBleed: true,
       hidesBottomTabs: true,
+      screenOptions: {
+        headerShown: false,
+      },
     },
   }),
   About: reactModule({


### PR DESCRIPTION
### Description

This PR fixes an issue introduced here https://github.com/artsy/eigen/pull/11178
I accidentally not add `headerShown: false` to the activity list.

| Header | Header |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 Pro - 2024-11-25 at 16 21 53](https://github.com/user-attachments/assets/588741cf-ba6c-4c21-a7ae-8fcbcd8e1767) | ![Simulator Screenshot - iPhone 16 Pro - 2024-11-25 at 16 21 47](https://github.com/user-attachments/assets/95711ae0-483c-4d04-ad19-c431b508f19d) | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog