### PR TITLE
fix: broken bottom tabs on tablets

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -1,5 +1,5 @@
 import { tappedTabBar } from "@artsy/cohesion"
-import { Text, useColor } from "@artsy/palette-mobile"
+import { Flex, Text, useColor } from "@artsy/palette-mobile"
 import { THEME } from "@artsy/palette-tokens"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
@@ -76,13 +76,30 @@ const AppTabs: React.FC = () => {
           },
           tabBarHideOnKeyboard: true,
           tabBarIcon: ({ focused }) => {
-            return <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
+            return (
+              <Flex flex={1}>
+                <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
+              </Flex>
+            )
           },
           tabBarLabel: () => {
             return (
-              <Text variant="xxs" style={{ top: -4 }} selectable={false}>
-                {bottomTabsConfig[route.name].name}
-              </Text>
+              <Flex
+                flex={1}
+                position="absolute"
+                alignItems="flex-end"
+                justifyContent="flex-end"
+                height={BOTTOM_TABS_HEIGHT}
+              >
+                <Text
+                  variant="xxs"
+                  style={{ top: Platform.OS === "ios" ? -4 : 0 }}
+                  selectable={false}
+                  textAlign="center"
+                >
+                  {bottomTabsConfig[route.name].name}
+                </Text>
+              </Flex>
             )
           },
           tabBarActiveTintColor: THEME.colors["black100"],


### PR DESCRIPTION
This PR resolves https://artsyproduct.atlassian.net/browse/PBRW-175

### Description

This PR fixes the broken bottom navigation on tablets


<img width="744" alt="Screenshot 2024-11-26 at 19 07 22" src="https://github.com/user-attachments/assets/93a59839-b9cd-48b2-8c0f-4d1b12d57c22">

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>


#nochangelog