### PR TITLE
fix: broken my-profile tap after purchase

### DIFF
--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -1238,3 +1238,10 @@ for (const moduleName of Object.keys(modules)) {
     })
   }
 }
+
+export const TabModuleNames = Object.keys(modules).filter((moduleName) => {
+  const descriptor = modules[moduleName as AppModule]
+  return (
+    descriptor.type === "react" && descriptor.Component && descriptor.options.isRootViewForTabName
+  )
+})

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -627,6 +627,7 @@ export const modules = defineModules({
   Conversation: reactModule({
     Component: Conversation,
     options: {
+      isRootViewForTabName: "inbox",
       onlyShowInTabName: "inbox",
       screenOptions: {
         headerShown: false,
@@ -730,6 +731,7 @@ export const modules = defineModules({
     Component: HomeViewScreen,
     options: {
       isRootViewForTabName: "home",
+      onlyShowInTabName: "home",
       fullBleed: true,
       screenOptions: {
         headerShown: false,
@@ -758,6 +760,7 @@ export const modules = defineModules({
     Component: InboxQueryRenderer,
     options: {
       isRootViewForTabName: "inbox",
+      onlyShowInTabName: "inbox",
       fullBleed: true,
       screenOptions: {
         headerShown: false,
@@ -926,6 +929,7 @@ export const modules = defineModules({
     Component: MyProfile,
     options: {
       isRootViewForTabName: "profile",
+      onlyShowInTabName: "profile",
       fullBleed: true,
       screenOptions: {
         headerShown: false,
@@ -1124,6 +1128,7 @@ export const modules = defineModules({
     Component: SellWithArtsy,
     options: {
       isRootViewForTabName: "sell",
+      onlyShowInTabName: "sell",
       fullBleed: true,
       screenOptions: {
         headerShown: false,
@@ -1154,6 +1159,7 @@ export const modules = defineModules({
     Component: SearchScreen,
     options: {
       isRootViewForTabName: "search",
+      onlyShowInTabName: "search",
       fullBleed: true,
       screenOptions: {
         headerShown: false,
@@ -1238,10 +1244,3 @@ for (const moduleName of Object.keys(modules)) {
     })
   }
 }
-
-export const TabModuleNames = Object.keys(modules).filter((moduleName) => {
-  const descriptor = modules[moduleName as AppModule]
-  return (
-    descriptor.type === "react" && descriptor.Component && descriptor.options.isRootViewForTabName
-  )
-})

--- a/src/app/AppRegistry.tsx
+++ b/src/app/AppRegistry.tsx
@@ -627,7 +627,6 @@ export const modules = defineModules({
   Conversation: reactModule({
     Component: Conversation,
     options: {
-      isRootViewForTabName: "inbox",
       onlyShowInTabName: "inbox",
       screenOptions: {
         headerShown: false,

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -2,17 +2,10 @@ import { OwnerType } from "@artsy/cohesion"
 import { Flex, Text } from "@artsy/palette-mobile"
 import * as Sentry from "@sentry/react-native"
 import { addBreadcrumb } from "@sentry/react-native"
-import { TabModuleNames, modules } from "app/AppRegistry"
 import { BottomTabRoutes } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { matchRoute } from "app/routes"
 import { GlobalStore, getCurrentEmissionState } from "app/store/GlobalStore"
-import {
-  GoBackProps,
-  dismissModal,
-  goBack,
-  navigate,
-  switchTab,
-} from "app/system/navigation/navigate"
+import { GoBackProps, dismissModal, goBack, navigate } from "app/system/navigation/navigate"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
@@ -229,18 +222,6 @@ export const ArtsyWebView = forwardRef<
         return
       }
 
-      if (result.type === "match" && TabModuleNames.includes(result.module)) {
-        const module = modules[result.module]
-
-        dismissModal(() => {
-          if (module.options.isRootViewForTabName) {
-            switchTab(module.options.isRootViewForTabName)
-          }
-        })
-
-        return
-      }
-
       // if it's a route that we know we don't have a native view for, keep it in the webview
       // only vanityURLs which do not have a native screen ends up in the webview. So also keep in webview for VanityUrls
       // TODO:- Handle cases where a vanityURl lands in a webview and then webview url navigation state changes
@@ -279,7 +260,9 @@ export const ArtsyWebView = forwardRef<
         dismissModal(() => {
           // We need to navigate only after the modal has been dismissed to avoid a race
           // condition breaking the UI
-          navigate(targetURL)
+          setTimeout(() => {
+            navigate(targetURL)
+          }, 500)
         })
       } else {
         navigate(targetURL)

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -258,11 +258,8 @@ export const ArtsyWebView = forwardRef<
 
       if (shouldDismissModal) {
         dismissModal(() => {
-          // We need to navigate only after the modal has been dismissed to avoid a race
           // condition breaking the UI
-          setTimeout(() => {
-            navigate(targetURL)
-          }, 500)
+          navigate(targetURL)
         })
       } else {
         navigate(targetURL)

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -2,10 +2,17 @@ import { OwnerType } from "@artsy/cohesion"
 import { Flex, Text } from "@artsy/palette-mobile"
 import * as Sentry from "@sentry/react-native"
 import { addBreadcrumb } from "@sentry/react-native"
+import { TabModuleNames, modules } from "app/AppRegistry"
 import { BottomTabRoutes } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { matchRoute } from "app/routes"
 import { GlobalStore, getCurrentEmissionState } from "app/store/GlobalStore"
-import { GoBackProps, dismissModal, goBack, navigate } from "app/system/navigation/navigate"
+import {
+  GoBackProps,
+  dismissModal,
+  goBack,
+  navigate,
+  switchTab,
+} from "app/system/navigation/navigate"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
@@ -219,6 +226,18 @@ export const ArtsyWebView = forwardRef<
       // to the articles route, which would cause a loop and once in the webview to
       // redirect you to either a native article view or an article webview
       if (result.type === "match" && result.module === "Article") {
+        return
+      }
+
+      if (result.type === "match" && TabModuleNames.includes(result.module)) {
+        const module = modules[result.module]
+
+        dismissModal(() => {
+          if (module.options.isRootViewForTabName) {
+            switchTab(module.options.isRootViewForTabName)
+          }
+        })
+
         return
       }
 

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -71,6 +71,7 @@ export function addWebViewRoute(url: string, config?: ArtsyWebViewConfig) {
     config?.alwaysPresentModally ? "ModalWebView" : "ReactWebView",
     (params) => ({
       url: replaceParams(url, params),
+      isPresentedModally: !!config?.alwaysPresentModally,
       ...config,
     })
   )

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -93,13 +93,16 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
     } else {
       if (module.options.onlyShowInTabName) {
         switchTab(module.options.onlyShowInTabName)
-        // We wait for a frame to allow the tab to be switched before we navigate
-        // This allows us to also override the back button behavior in the tab
-        requestAnimationFrame(() => {
-          internal_navigationRef.current?.dispatch(
-            StackActions.push(result.module, { ...result.params, ...options.passProps })
-          )
-        })
+
+        if (!module.options.isRootViewForTabName) {
+          // We wait for a frame to allow the tab to be switched before we navigate
+          // This allows us to also override the back button behavior in the tab
+          requestAnimationFrame(() => {
+            internal_navigationRef.current?.dispatch(
+              StackActions.push(result.module, { ...result.params, ...options.passProps })
+            )
+          })
+        }
       } else {
         internal_navigationRef.current?.dispatch(
           StackActions.push(result.module, { ...result.params, ...options.passProps })

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -238,8 +238,10 @@ export function dismissModal(after?: () => void) {
     if (Platform.OS === "android") {
       navigationEvents.emit("modalDismissed")
     }
-
-    after?.()
+    // we might get a race condition that causes the UI to freeze
+    requestAnimationFrame(() => {
+      after?.()
+    })
   })
 }
 

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -241,10 +241,8 @@ export function dismissModal(after?: () => void) {
     if (Platform.OS === "android") {
       navigationEvents.emit("modalDismissed")
     }
-    // we might get a race condition that causes the UI to freeze
-    requestAnimationFrame(() => {
-      after?.()
-    })
+
+    after?.()
   })
 }
 

--- a/src/app/system/navigation/routes.tests.ts
+++ b/src/app/system/navigation/routes.tests.ts
@@ -671,6 +671,7 @@ describe("artsy.net routes", () => {
        "module": "ModalWebView",
        "params": {
          "alwaysPresentModally": true,
+         "isPresentedModally": true,
          "url": "/terms",
        },
        "type": "match",
@@ -684,6 +685,7 @@ describe("artsy.net routes", () => {
        "module": "ModalWebView",
        "params": {
          "alwaysPresentModally": true,
+         "isPresentedModally": true,
          "url": "/privacy",
        },
        "type": "match",
@@ -696,6 +698,7 @@ describe("artsy.net routes", () => {
       {
         "module": "ReactWebView",
         "params": {
+          "isPresentedModally": false,
           "url": "/unsubscribe",
         },
         "type": "match",
@@ -870,6 +873,7 @@ describe("artsy.net routes", () => {
         "module": "ModalWebView",
         "params": {
           "alwaysPresentModally": true,
+          "isPresentedModally": true,
           "url": "/conditions-of-sale",
         },
         "type": "match",
@@ -1129,6 +1133,7 @@ describe("artsy.net routes", () => {
       {
         "module": "ReactWebView",
         "params": {
+          "isPresentedModally": false,
           "url": "/categories",
         },
         "type": "match",
@@ -1142,6 +1147,7 @@ describe("artsy.net routes", () => {
         "module": "ModalWebView",
         "params": {
           "alwaysPresentModally": true,
+          "isPresentedModally": true,
           "url": "/privacy",
         },
         "type": "match",
@@ -1184,6 +1190,7 @@ describe("artsy.net routes", () => {
       {
         "module": "ReactWebView",
         "params": {
+          "isPresentedModally": false,
           "url": "/the/mighty/boosh",
         },
         "type": "match",
@@ -1193,6 +1200,7 @@ describe("artsy.net routes", () => {
       {
         "module": "ReactWebView",
         "params": {
+          "isPresentedModally": false,
           "url": "/one-hundred/years-of/solitude",
         },
         "type": "match",
@@ -1249,12 +1257,16 @@ describe("addWebViewRoute", () => {
   it("returns a route matcher for web views", () => {
     const matcher = addWebViewRoute("/conditions-of-sale")
     expect(matcher.module).toBe("ReactWebView")
-    expect(matcher.match(["conditions-of-sale"])).toEqual({ url: "/conditions-of-sale" })
+    expect(matcher.match(["conditions-of-sale"])).toEqual({
+      isPresentedModally: false,
+      url: "/conditions-of-sale",
+    })
   })
 
   it("inlines params and wildcards in the original route", () => {
     const matcher = addWebViewRoute("/artist/:artistID/*")
     expect(matcher.match(["artist", "banksy", "auction-results", "8907"])).toEqual({
+      isPresentedModally: false,
       url: "/artist/banksy/auction-results/8907",
     })
   })
@@ -1262,6 +1274,7 @@ describe("addWebViewRoute", () => {
   it("inlines params in the original order history route", () => {
     const matcher = addWebViewRoute("/user/purchases/:orderID")
     expect(matcher.match(["user", "purchases", "8907"])).toEqual({
+      isPresentedModally: false,
       url: "/user/purchases/8907",
     })
   })
@@ -1269,6 +1282,7 @@ describe("addWebViewRoute", () => {
   it("inlines params in the original article route", () => {
     const matcher = addWebViewRoute("/article/:orderID")
     expect(matcher.match(["article", "article-article"])).toEqual({
+      isPresentedModally: false,
       url: "/article/article-article",
     })
   })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with tapping on `my-profile` on a webview.

**What was the root cause of the issue?**
When we need to switch from a modal to a screen nested in a tab where the modal is not present, `react-navigation` gets confused. We avoid that by baby sitting it: first dismiss the modal then navigate to the tab, then to the screen. In our case, none of that was happening because I forgot to note MyProfile tab/screen as a "Tab screen".

https://github.com/user-attachments/assets/0ad11c53-ba0b-40ee-91be-ba711af9860b



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [X] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

#nochangelog