### PR TITLE
fix: back navigation on android

### DIFF
--- a/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
+++ b/src/app/Components/GlobalSearchInput/GlobalSearchInputOverlay.tsx
@@ -91,7 +91,7 @@ export const GlobalSearchInputOverlay: React.FC<{
     if (visible) {
       hideModal()
     }
-    return true
+    return false
   })
 
   useEffect(() => {

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -59,6 +59,7 @@ export const registerScreen: React.FC<StackNavigatorScreenProps> = ({ name, modu
         headerTitle: "",
         headerTitleAlign: "center",
         ...module.options.screenOptions,
+        gestureEnabled: true,
         headerShadowVisible: Platform.OS === "ios",
         headerTitleStyle: {
           fontFamily: THEMES.v3.fonts.sans.regular,

--- a/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
@@ -2,10 +2,10 @@ import {
   ArtsyKeyboardAvoidingView,
   Button,
   Flex,
-  Join,
-  Spacer,
   Input,
   InputRef,
+  Join,
+  Spacer,
 } from "@artsy/palette-mobile"
 import { RouteProp, useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"


### PR DESCRIPTION
This PR resolves https://www.notion.so/artsy/Android-back-button-doesn-t-navigate-back-across-the-app-146cab0764a080a1be5adf144fb06dfb?pvs=4

### Description
This PR fixes the android back navigation issue that was reported during the QA session. 
Two issues were present:
- `gestureEnabled` wasn't set to `true`
- the search modal was overriding the default back handler 


https://github.com/user-attachments/assets/eef4601d-6b43-494e-ab69-9d81b6bc5ff3


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
