### PR TITLE
fix(ONYX-1383): some artwork rail images get mangled after horizontal scrolling

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -1,23 +1,19 @@
 import { Box, Flex, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
-import { ListRenderItem } from "@shopify/flash-list"
 import {
   ArtworkRail_artworks$data,
   ArtworkRail_artworks$key,
 } from "__generated__/ArtworkRail_artworks.graphql"
-import {
-  ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
-  ArtworkRailCard,
-} from "app/Components/ArtworkRail/ArtworkRailCard"
+import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
-  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
 } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
-import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
+import { PrefetchFlatList } from "app/Components/PrefetchFlatList"
 import { RandomWidthPlaceholderText } from "app/utils/placeholders"
 import { ArtworkActionTrackingProps } from "app/utils/track/ArtworkActions"
 import React, { ReactElement, useCallback } from "react"
-import { FlatList, ViewabilityConfig } from "react-native"
+import { FlatList, ListRenderItem, ViewabilityConfig } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
@@ -88,9 +84,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = ({
     [hideArtistName, onPress, showPartnerName]
   )
   return (
-    <PrefetchFlashList
+    <PrefetchFlatList
       data={artworks}
-      estimatedItemSize={ARTWORK_RAIL_CARD_MINIMUM_WIDTH}
       horizontal
       keyExtractor={(item) => item.internalID}
       ListFooterComponent={
@@ -140,7 +135,7 @@ export const ArtworkRailPlaceholder: React.FC = () => {
         <Flex key={index}>
           <SkeletonBox
             height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-            width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+            width={ARTWORK_RAIL_CARD_MIN_WIDTH * 2}
           />
           <Spacer y={2} />
           <SkeletonText>Artist</SkeletonText>

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -3,6 +3,8 @@ import { ArtworkRailCard_artwork$key } from "__generated__/ArtworkRailCard_artwo
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_CARD_MAX_WIDTH,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
   ArtworkRailCardImage,
 } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import {
@@ -21,7 +23,6 @@ import { GestureResponderEvent, PixelRatio, TouchableHighlight } from "react-nat
 import { graphql, useFragment } from "react-relay"
 
 export const ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT = PixelRatio.getFontScale() * 100
-export const ARTWORK_RAIL_CARD_MINIMUM_WIDTH = 140
 
 export interface ArtworkRailCardProps
   extends ArtworkActionTrackingProps,
@@ -112,6 +113,8 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                 containerHeight ?? ARTWORK_RAIL_CARD_IMAGE_HEIGHT + artworkRailCardMetaDataHeight
               }
               justifyContent="flex-start"
+              minWidth={ARTWORK_RAIL_CARD_MIN_WIDTH}
+              maxWidth={ARTWORK_RAIL_CARD_MAX_WIDTH}
             >
               <ArtworkRailCardImage artwork={artwork} />
 

--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -7,8 +7,10 @@ export interface ArtworkRailCardImageProps {
   artwork: ArtworkRailCardImage_artwork$key
 }
 export const ARTWORK_RAIL_CARD_IMAGE_HEIGHT = 215
-export const ARTWORK_RAIL_MIN_IMAGE_WIDTH = 140
-export const ARTWORK_RAIL_MAX_IMAGE_WIDTH = 340
+
+export const ARTWORK_RAIL_CARD_MIN_WIDTH = 140
+export const ARTWORK_RAIL_CARD_MAX_WIDTH = 340
+
 const PADDING = 10
 
 export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...restProps }) => {
@@ -28,24 +30,21 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
     let verticalPadding = 0
 
     // Case when the image width is narrower than the maximum width
-    if (imageWidth <= ARTWORK_RAIL_MIN_IMAGE_WIDTH) {
-      containerWidth = ARTWORK_RAIL_MIN_IMAGE_WIDTH
+    if (imageWidth <= ARTWORK_RAIL_CARD_MIN_WIDTH) {
+      containerWidth = ARTWORK_RAIL_CARD_MIN_WIDTH
       verticalPadding = PADDING
     }
 
     // Case when the image width is wider than the maximum width
-    if (imageWidth >= ARTWORK_RAIL_MAX_IMAGE_WIDTH) {
-      containerWidth = ARTWORK_RAIL_MAX_IMAGE_WIDTH
+    if (imageWidth >= ARTWORK_RAIL_CARD_MAX_WIDTH) {
+      containerWidth = ARTWORK_RAIL_CARD_MAX_WIDTH
       horizontalPadding = PADDING
     }
 
     const displayImageWidth =
-      imageWidth <= ARTWORK_RAIL_MIN_IMAGE_WIDTH
-        ? Math.min(imageWidth, ARTWORK_RAIL_MIN_IMAGE_WIDTH) - 2 * horizontalPadding
-        : Math.min(
-            Math.max(imageWidth, ARTWORK_RAIL_MIN_IMAGE_WIDTH),
-            ARTWORK_RAIL_MAX_IMAGE_WIDTH
-          ) -
+      imageWidth <= ARTWORK_RAIL_CARD_MIN_WIDTH
+        ? Math.min(imageWidth, ARTWORK_RAIL_CARD_MIN_WIDTH) - 2 * horizontalPadding
+        : Math.min(Math.max(imageWidth, ARTWORK_RAIL_CARD_MIN_WIDTH), ARTWORK_RAIL_CARD_MAX_WIDTH) -
           2 * horizontalPadding
 
     const displayImageHeight =

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -14,7 +14,7 @@ import { HomeViewSectionArtworks_section$key } from "__generated__/HomeViewSecti
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
-  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
 } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
@@ -163,7 +163,7 @@ const HomeViewSectionArtworksPlaceholder: React.FC<FlexProps> = (flexProps) => {
                 <Flex key={index}>
                   <SkeletonBox
                     height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-                    width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+                    width={ARTWORK_RAIL_CARD_MIN_WIDTH * 2}
                   />
                   <Spacer y={1} />
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -16,7 +16,7 @@ import { HomeViewSectionFeaturedCollection_section$key } from "__generated__/Hom
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
-  ARTWORK_RAIL_MIN_IMAGE_WIDTH,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
 } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
@@ -178,7 +178,7 @@ const HomeViewSectionFeaturedCollectionPlaceholder: React.FC<FlexProps> = () => 
             <Flex>
               <SkeletonBox
                 height={ARTWORK_RAIL_CARD_IMAGE_HEIGHT}
-                width={ARTWORK_RAIL_MIN_IMAGE_WIDTH * 2}
+                width={ARTWORK_RAIL_CARD_MIN_WIDTH * 2}
               />
               <Spacer y={2} />
               <SkeletonText>Andy Warhol</SkeletonText>

--- a/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
+++ b/src/app/Scenes/SellWithArtsy/Components/SellWithArtsyRecentlySold.tsx
@@ -6,11 +6,11 @@ import {
   SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection$key,
 } from "__generated__/SellWithArtsyRecentlySold_recentlySoldArtworkTypeConnection.graphql"
 import { ArtworkRailProps } from "app/Components/ArtworkRail/ArtworkRail"
+import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import {
-  ARTWORK_RAIL_CARD_MINIMUM_WIDTH,
-  ArtworkRailCard,
-} from "app/Components/ArtworkRail/ArtworkRailCard"
-import { ARTWORK_RAIL_CARD_IMAGE_HEIGHT } from "app/Components/ArtworkRail/ArtworkRailCardImage"
+  ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
+} from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import { PrefetchFlashList } from "app/Components/PrefetchFlashList"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -126,7 +126,7 @@ const RecentlySoldArtworksRail: React.FC<RecentlySoldArtworksRailProps> = ({
     <PrefetchFlashList
       // We need to set the maximum number of artworks to not cause layout shifts
       data={recentlySoldArtworks.slice(0, MAX_NUMBER_OF_ARTWORKS)}
-      estimatedItemSize={ARTWORK_RAIL_CARD_MINIMUM_WIDTH}
+      estimatedItemSize={ARTWORK_RAIL_CARD_MIN_WIDTH}
       horizontal
       keyExtractor={(item, index) => String(item?.artwork?.slug || index)}
       ItemSeparatorComponent={() => <Spacer x="15px" />}


### PR DESCRIPTION
This PR resolves [ONYX-1383] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Use flatList instead of FlashList on artwork rails

Follow-up on https://github.com/artsy/eigen/pull/11142: The max and min width for the artwork rail card were missing. Adding these constraints resolved the issue where the metadata was stretched to its full width. More details: https://artsy.slack.com/archives/C02BAQ5K7/p1732116471982649

Summary after the bug investigation: https://artsy.slack.com/archives/C02BAQ5K7/p1732102644251849

Screenshots confirming that the layout of the artwork rail card is not broken when using FlatList

| Android FF is off | Android FF is on | iOS FF is off | iOS FF is on |
| --- | --- | --- | --- |
| ![Screenshot_1732712502](https://github.com/user-attachments/assets/342528fc-d015-40e3-b3d0-24817103b32f) | ![Screenshot_1732712559](https://github.com/user-attachments/assets/f788d4e3-8b94-4775-a878-3972958b14c1) | ![image](https://github.com/user-attachments/assets/3f1413dd-9823-47bc-90c0-260de7b4c198) | ![image](https://github.com/user-attachments/assets/a86d5959-efba-4548-a1d9-25ffb1ace32b) |


https://github.com/user-attachments/assets/f2380738-9121-4ceb-9f6e-481c42a2c033


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- some artwork rail images get mangled after horizontal scrolling (use flatList instead of FlashList on artwork rails)

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1383]: https://artsyproduct.atlassian.net/browse/ONYX-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ