### PR TITLE
fix: sort & filter modal performance issues

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -1,5 +1,4 @@
 import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
-import { Flex } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
 import { TransitionPresets, createStackNavigator } from "@react-navigation/stack"
 import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
@@ -32,12 +31,12 @@ import { TimePeriodOptionsScreen } from "app/Components/ArtworkFilter/Filters/Ti
 import { ViewAsOptionsScreen } from "app/Components/ArtworkFilter/Filters/ViewAsOptions"
 import { WaysToBuyOptionsScreen } from "app/Components/ArtworkFilter/Filters/WaysToBuyOptions"
 import { YearOptionsScreen } from "app/Components/ArtworkFilter/Filters/YearOptions"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { GlobalStore } from "app/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
 import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import { useEffect, useState } from "react"
-import { ViewProps } from "react-native"
+import { Modal, ViewProps } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import { useTracking } from "react-tracking"
 import {
   FilterModalMode as ArtworkFilterMode,
@@ -314,13 +313,8 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
 
   return (
     <NavigationContainer independent>
-      <FancyModal
-        visible={props.visible}
-        onBackgroundPressed={handleClosingModal}
-        fullScreen
-        animationPosition="right"
-      >
-        <Flex flex={1}>
+      <Modal visible={props.visible} onDismiss={handleClosingModal} animationType="slide">
+        <SafeAreaView edges={["top"]} style={{ flex: 1 }}>
           <Stack.Navigator
             // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
             detachInactiveScreens={false}
@@ -409,8 +403,8 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
             attributes={attributes}
             sizeMetric={filterState.sizeMetric}
           />
-        </Flex>
-      </FancyModal>
+        </SafeAreaView>
+      </Modal>
     </NavigationContainer>
   )
 }

--- a/src/app/Scenes/Search/SearchArtworksGrid.tests.tsx
+++ b/src/app/Scenes/Search/SearchArtworksGrid.tests.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { SearchArtworksGridTestsQuery } from "__generated__/SearchArtworksGridTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { Modal } from "react-native"
 import { graphql } from "react-relay"
 import { SearchArtworksGridPaginationContainer } from "./SearchArtworksGrid"
 
@@ -49,7 +49,7 @@ describe("SearchArtworksGrid", () => {
   it("tracks filter modal closing", () => {
     renderWithRelay()
 
-    screen.UNSAFE_getAllByType(FancyModal)[0].props.onBackgroundPressed()
+    screen.UNSAFE_getAllByType(Modal)[0].props.onDismiss()
 
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       [


### PR DESCRIPTION
### Description

This PR fixes an outstanding issue we have with the filter modal which still rely on the old `FancyModal` 😮.

`FancyModal` is actually no longer needed and IMO, **should** be deprecated because there is nothing we can't do anymore with the native Modal component and we don't need the cards stack and the **extremely** complicated custom cards layering logic.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog