### PR TITLE
fix: Update Artsy Guarantee position in Conversation

### DIFF
--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -40,8 +40,7 @@ export const ToastComponent = ({
   const toastDuration = TOAST_DURATION_MAP[duration]
   const color = useColor()
   const { width, height } = useScreenDimensions()
-  const { top: topSafeAreaInset, bottom: bottomSafeAreaInset } =
-    useScreenDimensions().safeAreaInsets
+  const { bottom: bottomSafeAreaInset } = useScreenDimensions().safeAreaInsets
   const [opacityAnim] = useState(new Animated.Value(0))
 
   const { showActionSheetWithOptions } = useActionSheet()
@@ -172,8 +171,7 @@ export const ToastComponent = ({
       }
       top={
         placement === "top"
-          ? topSafeAreaInset +
-            NAVBAR_HEIGHT +
+          ? NAVBAR_HEIGHT +
             EDGE_TOAST_PADDING +
             positionIndex * (EDGE_TOAST_HEIGHT + EDGE_TOAST_PADDING)
           : undefined

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -142,7 +142,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
     <>
       <ToastComponent
         id={1}
-        positionIndex={-0.3}
+        positionIndex={-0.7}
         message="To be covered by the Artsy Guarantee, always communicate and pay through the Artsy platform."
         placement="top"
         backgroundColor="blue100"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue with the Artsy Guarantee toast that shows up in Conversation screen


### Videos
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/b55d3f96-3eaa-4dc1-b739-4a6249fb7207" /> | <video src="https://github.com/user-attachments/assets/726ce0d4-ebdc-404b-b409-812c23a96ebd" /> |
| iOS | <video src="https://github.com/user-attachments/assets/076b618c-2a9c-4cd5-8d19-48f4b0cb51ee" /> | <video src="https://github.com/user-attachments/assets/6f1f2120-9cc2-45ba-a757-28d0ca457b48" /> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [X] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix Artsy Guarantee toast position

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
