### PR TITLE
fix: Revert: "fix: deep link analytics event triggered twice"

### DIFF
--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -15,10 +15,6 @@ export function useDeepLinks() {
   const { trackEvent } = useTracking()
 
   useEffect(() => {
-    if (!isNavigationReady) {
-      return
-    }
-
     Linking.getInitialURL().then((url) => {
       if (url) {
         handleDeepLink(url)
@@ -27,10 +23,6 @@ export function useDeepLinks() {
   }, [isNavigationReady])
 
   useEffect(() => {
-    if (!isNavigationReady) {
-      return
-    }
-
     const subscription = Linking.addListener("url", ({ url }) => {
       handleDeepLink(url)
     })


### PR DESCRIPTION
### Description
This PR reverts the changes on artsy/eigen#11110 since we believe it introduced a bug when opening notifications on iOS from a killed state
The bug is not allowing the deeplinking to work after tapping the notification
This is an attempt to fix the [bugs reported](https://www.notion.so/artsy/Braze-push-Does-not-navigate-the-user-from-killed-state-14ccab0764a0801a80b2c19af333ea32?pvs=4) 🔒 in the release candidate branch

<details><summary>Changelog</summary>
### Changelog updates

#### Dev changes

- fix broken deeplinking with iOS push notification from killed state

<!-- end_changelog_updates -->

</details>

