### PR TITLE
fix: Allow closing the filter modal on the Artist Series screen

### DIFF
--- a/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Box, Tabs, useScreenDimensions, Flex, useSpace } from "@artsy/palette-mobile"
+import { Box, Flex, Tabs, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { MasonryFlashListRef } from "@shopify/flash-list"
 import { ArtistSeriesArtworks_artistSeries$key } from "__generated__/ArtistSeriesArtworks_artistSeries.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
@@ -62,20 +62,16 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
     })
   }, [artworksTotal])
 
-  const handleFilterToggle = () => {
-    setFilterArtworkModalVisible((prev) => {
-      return !prev
-    })
-  }
-
   const openFilterArtworksModal = () => {
     tracking.trackEvent(tracks.openFilterWindow(data.id, data.slug))
-    handleFilterToggle()
+
+    setFilterArtworkModalVisible(true)
   }
 
   const closeFilterArtworksModal = () => {
     tracking.trackEvent(tracks.closeFilterWindow(data.id, data.slug))
-    handleFilterToggle()
+
+    setFilterArtworkModalVisible(false)
   }
 
   const loadMore = useCallback(() => {


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

After closing the filter modal on the Artist Series screen, it automatically opens again after a few milliseconds.

Not toggling the state that handles the visibility of the filter modal and instead setting it to `false` or `true` directly fixed the issue.



| Before | After |
| --- | --- |
|https://github.com/user-attachments/assets/78023f38-a898-46f0-abdd-92f10cbe32f0 |https://github.com/user-attachments/assets/906630d1-7f69-427e-978a-dfa2187df3c3 |


**Screenshots**

| | |
| --- | --- |
|![Simulator Screenshot - iPhone 16 - 2024-11-29 at 09 26 04](https://github.com/user-attachments/assets/133bce27-e1dc-47ca-b40c-2cb0499e8a22) | ![Simulator Screenshot - iPhone 16 - 2024-11-29 at 09 35 44](https://github.com/user-attachments/assets/825f85d6-74f7-485e-b4db-215f7e3453d8)|


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: Allow closing the filter modal on the Artist Series screen - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
