### PR TITLE
chore(ONYX-1389): hide create alert on artwork preview on onboarding

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -85,6 +85,7 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   updateRecentSearchesOnTap?: boolean
   numColumns?: number
   hideViewFollowsLink?: boolean
+  hideCreateAlertOnArtworkPreview?: boolean
 }
 
 export const Artwork: React.FC<ArtworkProps> = ({
@@ -119,6 +120,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
   updateRecentSearchesOnTap = false,
   numColumns = NUM_COLUMNS_MASONRY,
   hideViewFollowsLink = false,
+  hideCreateAlertOnArtworkPreview = false,
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
@@ -293,6 +295,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
         contextScreenOwnerType={contextScreenOwnerType}
         onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
         artwork={artwork}
+        hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
       >
         <Touchable
           haptic

--- a/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
+++ b/src/app/Components/ArtworkGrids/InfiniteScrollArtworksGrid.tsx
@@ -123,6 +123,8 @@ export interface Props extends ArtworkActionTrackingProps {
   hideRegisterBySignal?: boolean
 
   hideViewFollowsLink?: boolean
+
+  hideCreateAlertOnArtworkPreview?: boolean
 }
 
 interface PrivateProps {
@@ -188,6 +190,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
   hidePartner = false,
   hideRegisterBySignal,
   hideViewFollowsLink = false,
+  hideCreateAlertOnArtworkPreview = false,
   hideSaveIcon = false,
   isLoading,
   isMyCollection = false,
@@ -362,6 +365,7 @@ const InfiniteScrollArtworksGrid: React.FC<Props & PrivateProps> = ({
             hideCuratorsPickSignal={hideCuratorsPick}
             hideRegisterBySignal={hideRegisterBySignal}
             hideViewFollowsLink={hideViewFollowsLink}
+            hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -35,6 +35,7 @@ interface ContextMenuArtworkProps {
   artworkDisplayProps?: ArtworkDisplayProps
   contextScreenOwnerType?: ScreenOwnerType
   contextModule?: ContextModule
+  hideCreateAlertOnArtworkPreview?: boolean
 }
 
 const artworkFragment = graphql`
@@ -75,6 +76,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
   onSupressArtwork,
   contextScreenOwnerType,
   contextModule,
+  hideCreateAlertOnArtworkPreview,
   ...restProps
 }) => {
   const artwork = useFragment(artworkFragment, restProps.artwork)
@@ -193,7 +195,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
       })
     }
 
-    if (enableCreateAlerts) {
+    if (enableCreateAlerts && !hideCreateAlertOnArtworkPreview) {
       // Put create alert at front since it is high intent
       contextMenuActions.unshift({
         title: "Create alert",

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingMarketingCollection.tsx
@@ -57,6 +57,7 @@ const OnboardingMarketingCollection: React.FC<OnboardingMarketingCollectionProps
           hideCuratorsPick={slug === "curators-picks-emerging"}
           hideIncreasedInterest={slug === "curators-picks-emerging"}
           hideViewFollowsLink
+          hideCreateAlertOnArtworkPreview
         />
         <Flex p={2} backgroundColor="white">
           <Button block onPress={() => navigate("OnboardingPostFollowLoadingScreen")} mb={1}>


### PR DESCRIPTION
This PR resolves [ONYX-1389] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Hide "Create alert" option on the long press Artwork preview on the rails on the onboarding flow

| Before | After | Other Artwork grids on the app |
| --- | --- | --- |
| ![IMAGE 2024-11-29 11:57:58](https://github.com/user-attachments/assets/e20ffd3e-f3f0-4938-ab2c-92e8f539ed4f) | ![IMAGE 2024-11-29 11:57:54](https://github.com/user-attachments/assets/869bbac6-a726-4a46-9314-42148e011348) | ![IMAGE 2024-11-29 11:58:02](https://github.com/user-attachments/assets/0716f816-a942-495c-8afe-0c7f2b62d6f0) |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Hide "Create alert" option on the long press Artwork preview on the rails on the onboarding flow

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1389]: https://artsyproduct.atlassian.net/browse/ONYX-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ