### PR TITLE
fix(ONYX-1422): do not switch tabs when navigating to follows

### DIFF
--- a/src/app/Components/Artist/useFollowArtist.ts
+++ b/src/app/Components/Artist/useFollowArtist.ts
@@ -2,7 +2,7 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { useFollowArtist_artist$key } from "__generated__/useFollowArtist_artist.graphql"
 import { useFollowArtist_artist_Mutation } from "__generated__/useFollowArtist_artist_Mutation.graphql"
 import { useToast } from "app/Components/Toast/toastHook"
-import { navigate, switchTab } from "app/system/navigation/navigate"
+import { navigate } from "app/system/navigation/navigate"
 import { Schema } from "app/utils/track"
 import { useState } from "react"
 import { useFragment, graphql, useMutation } from "react-relay"
@@ -129,7 +129,6 @@ export const useFollowArtist = (options: Options) => {
         toast.show("Artist Followed", "bottom", {
           cta: "View Follows",
           onPress: () => {
-            switchTab("profile")
             navigate("favorites")
           },
           backgroundColor: "green100",


### PR DESCRIPTION
This PR resolves [ONYX-1422] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Do not switch tabs when navigating to follows from the follow confirmation toast. Not switching tabs to make sure the back button leads us back to the home view and not the the profile main page
Resolves [Notion Card](https://www.notion.so/artsy/When-clicking-on-View-Follows-on-the-toast-after-following-an-artist-from-the-New-Works-for-You--13ecab0764a08071b69ce302a91f9250?pvs=4)

https://github.com/user-attachments/assets/9a41eedd-08ad-4956-b891-3bd6f2f5cafe


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- do not switch tabs when navigating to follows from the follow confirmation toast

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1422]: https://artsyproduct.atlassian.net/browse/ONYX-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ