### PR TITLE
fix(REVERT): bring back double deeplink tracking

### DIFF
--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -15,6 +15,10 @@ export function useDeepLinks() {
   const { trackEvent } = useTracking()
 
   useEffect(() => {
+    if (!isNavigationReady) {
+      return
+    }
+
     Linking.getInitialURL().then((url) => {
       if (url) {
         handleDeepLink(url)
@@ -23,6 +27,10 @@ export function useDeepLinks() {
   }, [isNavigationReady])
 
   useEffect(() => {
+    if (!isNavigationReady) {
+      return
+    }
+
     const subscription = Linking.addListener("url", ({ url }) => {
       handleDeepLink(url)
     })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Brings back the #11110 fix of double tracking

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#nochangelog