### PR TITLE
chore: prep for 8.58.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "appName": "eigen",
-  "version": "8.57.0",
+  "version": "8.58.0",
   "isAndroidBeta": false,
   "codePushReleaseName": "none",
   "codePushDist": "none"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Prep for 8.58.0


Seems like the auto generated bump didn't work this time around, not sure if it is related with AppStore not approving the app yet.



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

#nochangelog