### PR TITLE
chore(PBRW-228): my collection submitted swa works unable to be deleted

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -396,14 +396,14 @@
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "67d1be5993e49fbaba0bbd38492c33a2bc007ef7",
         "is_verified": false,
-        "line_number": 625
+        "line_number": 626
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx",
         "hashed_secret": "6414700358f2ae5762917a164e2e30df8783fc4e",
         "is_verified": false,
-        "line_number": 711
+        "line_number": 712
       }
     ],
     "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx": [
@@ -1134,5 +1134,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-28T15:38:18Z"
+  "generated_at": "2024-12-04T19:56:20Z"
 }

--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -2716,6 +2716,9 @@ type ArtworkConsignmentSubmission {
   externalID: String
   inProgress: Boolean
   internalID: String
+
+  # Whether the user is allowed to edit the associated My Collection artwork.
+  isEditable: Boolean
   isSold: Boolean
 
   # Submission state.

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -1,6 +1,12 @@
-import { screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { Text } from "react-native"
 import { MyCollectionArtworkScreen } from "./MyCollectionArtwork"
+
+jest.mock("@artsy/palette-mobile", () => ({
+  ...jest.requireActual("@artsy/palette-mobile"),
+  Popover: (props: any) => <MockedPopover {...props} />,
+}))
 
 describe("My Collection Artwork", () => {
   const { renderWithRelay } = setupTestWrapper({ Component: MyCollectionArtworkScreen })
@@ -26,14 +32,11 @@ describe("My Collection Artwork", () => {
   })
 
   describe("Edit button", () => {
-    it("should be hidden when consignmentSubmission is available", async () => {
+    it("should be visible, greyed out and open a popover when submission process is not complete", async () => {
       renderWithRelay({
         Artwork: () => ({
-          id: "random-id",
-          artist: { internalID: "internal-id" },
-          medium: "medium",
-          category: "medium",
-          consignmentSubmission: { internalID: "submission-id" },
+          ...artwork,
+          consignmentSubmission: { internalID: "submission-id", state: "SUBMITTED" }, // "SUBMITTED", "DRAFT", "HOLD", "RESUBMITTED"
         }),
       })
 
@@ -41,18 +44,32 @@ describe("My Collection Artwork", () => {
         screen.queryByTestId("my-collection-artwork-placeholder")
       )
 
-      expect(screen.queryByText("Edit")).not.toBeOnTheScreen()
+      expect(screen.getByText("Edit")).toBeOnTheScreen()
+      expect(screen.getByText("Edit").props.color).toEqual("black60")
+
+      fireEvent.press(screen.getByText("Edit"))
+
+      expect(screen.getByText("Popover")).toBeOnTheScreen()
     })
 
-    it("should be visible when consignmentSubmission is not available", async () => {
+    it("should be visible when the artwork submission is complete", async () => {
       renderWithRelay({
         Artwork: () => ({
-          id: "random-id",
-          artist: { internalID: "internal-id" },
-          medium: "medium",
-          category: "medium",
-          consignmentSubmission: null,
+          ...artwork,
+          consignmentSubmission: { internalID: "submission-id", state: "PUBLISHED" }, // "PUBLISHED", "REJECTED" or "CLOSED",
         }),
+      })
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId("my-collection-artwork-placeholder")
+      )
+
+      expect(screen.getByText("Edit")).toBeOnTheScreen()
+    })
+
+    it("should be visible when the artwork does not have an associated submission", async () => {
+      renderWithRelay({
+        Artwork: () => ({ ...artwork, consignmentSubmission: null }),
       })
 
       await waitForElementToBeRemoved(() =>
@@ -63,3 +80,19 @@ describe("My Collection Artwork", () => {
     })
   })
 })
+
+const artwork = {
+  id: "random-id",
+  artist: { internalID: "internal-id" },
+  medium: "medium",
+  category: "medium",
+}
+
+const MockedPopover: React.FC<any> = ({ children, onDismiss }) => {
+  return (
+    <>
+      <Text onPress={onDismiss}>Popover</Text>
+      {children}
+    </>
+  )
+}

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tests.tsx
@@ -36,7 +36,7 @@ describe("My Collection Artwork", () => {
       renderWithRelay({
         Artwork: () => ({
           ...artwork,
-          consignmentSubmission: { internalID: "submission-id", state: "SUBMITTED" }, // "SUBMITTED", "DRAFT", "HOLD", "RESUBMITTED"
+          consignmentSubmission: { internalID: "submission-id", isEditable: false },
         }),
       })
 
@@ -56,7 +56,7 @@ describe("My Collection Artwork", () => {
       renderWithRelay({
         Artwork: () => ({
           ...artwork,
-          consignmentSubmission: { internalID: "submission-id", state: "PUBLISHED" }, // "PUBLISHED", "REJECTED" or "CLOSED",
+          consignmentSubmission: { internalID: "submission-id", isEditable: true },
         }),
       })
 

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -1,10 +1,19 @@
 import { ActionType, ContextModule, EditCollectedArtwork, OwnerType } from "@artsy/cohesion"
-import { DEFAULT_HIT_SLOP, Flex, Join, Screen, Separator, Text } from "@artsy/palette-mobile"
+import {
+  DEFAULT_HIT_SLOP,
+  Flex,
+  Join,
+  Popover,
+  Screen,
+  Separator,
+  Text,
+} from "@artsy/palette-mobile"
 import { MyCollectionArtworkQuery } from "__generated__/MyCollectionArtworkQuery.graphql"
 import { LoadingSpinner } from "app/Components/Modals/LoadingModal"
 import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import { MyCollectionArtworkAboutWork } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork"
 import { MyCollectionArtworkArticles } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkArticles"
+import { ELIGIBLE_TO_EIDIT_STATES } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -34,6 +43,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
   const { trackEvent } = useTracking()
 
   const [isRefreshing, setIsRefetching] = useState(false)
+  const [isToolTipVisible, setIsToolTipVisible] = useState(false)
 
   const queryVariables = {
     artworkId: artworkId || "",
@@ -76,6 +86,10 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
     })
   }, [artwork])
 
+  const handleNotEditable = () => {
+    setIsToolTipVisible(true)
+  }
+
   if (!artwork) {
     return (
       <Flex flex={1} justifyContent="center" alignItems="center">
@@ -86,20 +100,45 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const articles = extractNodes(artwork.artist?.articles)
 
-  const isEditable = !artwork.consignmentSubmission?.internalID
+  const isEditable =
+    !artwork.consignmentSubmission?.internalID ||
+    (artwork.consignmentSubmission?.internalID &&
+      ELIGIBLE_TO_EIDIT_STATES.includes(artwork.consignmentSubmission?.state))
 
   return (
     <Screen>
       <Screen.Header
         onBack={goBack}
         rightElements={
-          !!isEditable && (
+          !!isEditable ? (
             <TouchableOpacity onPress={handleEdit} hitSlop={DEFAULT_HIT_SLOP}>
               <Text>Edit</Text>
             </TouchableOpacity>
+          ) : (
+            <Popover
+              visible={isToolTipVisible}
+              onDismiss={() => setIsToolTipVisible(false)}
+              onPressOutside={() => setIsToolTipVisible(false)}
+              placement="bottom"
+              title={
+                <Text variant="xs" color="white100" fontWeight="500">
+                  Thank you for submitting!
+                </Text>
+              }
+              content={
+                <Text variant="xs" color="white100">
+                  Editing will be available once the submission process is complete.
+                </Text>
+              }
+            >
+              <TouchableOpacity onPress={handleNotEditable} hitSlop={DEFAULT_HIT_SLOP}>
+                <Text color="black60">Edit</Text>
+              </TouchableOpacity>
+            </Popover>
           )
         }
       />
+
       <Screen.ScrollView
         contentContainerStyle={{ paddingBottom: 80 }}
         refreshControl={
@@ -279,6 +318,7 @@ export const ArtworkMetaProps = graphql`
     # TODO: move logic to the edit artwork view https://artsyproduct.atlassian.net/browse/CX-2846
     consignmentSubmission @optionalField {
       internalID
+      state
       displayText
     }
     pricePaid {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -13,7 +13,6 @@ import { LoadingSpinner } from "app/Components/Modals/LoadingModal"
 import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import { MyCollectionArtworkAboutWork } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkAboutWork"
 import { MyCollectionArtworkArticles } from "app/Scenes/MyCollection/Screens/Artwork/Components/ArtworkAbout/MyCollectionArtworkArticles"
-import { ELIGIBLE_TO_EIDIT_STATES } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -100,10 +99,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const articles = extractNodes(artwork.artist?.articles)
 
-  const isEditable =
-    !artwork.consignmentSubmission?.internalID ||
-    (artwork.consignmentSubmission?.internalID &&
-      ELIGIBLE_TO_EIDIT_STATES.includes(artwork.consignmentSubmission?.state))
+  const isEditable = !artwork.consignmentSubmission || artwork.consignmentSubmission?.isEditable
 
   return (
     <Screen>
@@ -318,7 +314,7 @@ export const ArtworkMetaProps = graphql`
     # TODO: move logic to the edit artwork view https://artsyproduct.atlassian.net/browse/CX-2846
     consignmentSubmission @optionalField {
       internalID
-      state
+      isEditable
       displayText
     }
     pricePaid {

--- a/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/MyCollectionArtwork.tsx
@@ -99,7 +99,7 @@ const MyCollectionArtwork: React.FC<MyCollectionArtworkScreenProps> = ({
 
   const articles = extractNodes(artwork.artist?.articles)
 
-  const isEditable = !artwork.consignmentSubmission || artwork.consignmentSubmission?.isEditable
+  const isEditable = artwork.consignmentSubmission?.isEditable
 
   return (
     <Screen>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -482,6 +482,7 @@ describe("MyCollectionArtworkForm", () => {
                   consignmentSubmission: {
                     displayText: "In progress",
                     internalID: "submission-id",
+                    state: "SUBMITTED",
                   },
                   dimensions: {
                     in: "23",

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tests.tsx
@@ -482,7 +482,7 @@ describe("MyCollectionArtworkForm", () => {
                   consignmentSubmission: {
                     displayText: "In progress",
                     internalID: "submission-id",
-                    state: "SUBMITTED",
+                    isEditable: false,
                   },
                   dimensions: {
                     in: "23",

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
@@ -39,5 +39,3 @@ export const SUBMIT_ARTWORK_APPROVED_SUBMISSION_STEPS: SubmitArtworkScreen[] = [
 ]
 
 export const TIER_1_STATES = ["DRAFT", "SUBMITTED"]
-
-export const ELIGIBLE_TO_EIDIT_STATES = ["REJECTED", "CLOSED", "PUBLISHED"]

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/constants.ts
@@ -39,3 +39,5 @@ export const SUBMIT_ARTWORK_APPROVED_SUBMISSION_STEPS: SubmitArtworkScreen[] = [
 ]
 
 export const TIER_1_STATES = ["DRAFT", "SUBMITTED"]
+
+export const ELIGIBLE_TO_EIDIT_STATES = ["REJECTED", "CLOSED", "PUBLISHED"]


### PR DESCRIPTION
This PR resolves [PBRW-228] or [ONYX-1431] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
We cannot edit artworks that have submission in progress, but we came up with a compromise:
- display Edit button always
- when no submission or submission is compete navigate to the edit flow
- when submission is in progress display edit button greyed out and show popover on click

iOS

https://github.com/user-attachments/assets/03607a1c-abfe-469a-b5dd-f283ffdd658d


Android 
<img width="300" src="https://github.com/user-attachments/assets/9fdb1a0c-45e1-4704-a6fc-307453cb2c4c" />

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- adjust Edit button behavior on My Collection Artwork screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-228]: https://artsyproduct.atlassian.net/browse/PBRW-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ONYX-1431]: https://artsyproduct.atlassian.net/browse/ONYX-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ