### PR TITLE
fix: city guide warnings

### DIFF
--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -550,7 +550,7 @@ export class GlobalMap extends React.Component<Props, State> {
               style={{ ...this.backgroundImageSize }}
             />
 
-            {/* TODO: safeArea insets are being reported back incorrectly here, so we have to subtract, we should look further into why, possibly with how we register these components, possibly because they are partially native. 
+            {/* TODO: safeArea insets are being reported back incorrectly here, so we have to subtract, we should look further into why, possibly with how we register these components, possibly because they are partially native.
              */}
             <TopButtonsContainer style={{ top: this.props.safeAreaInsets.top - 12 - 10 }}>
               <Animated.View
@@ -588,8 +588,8 @@ export class GlobalMap extends React.Component<Props, State> {
                 ref={this.map}
                 style={{ width: "100%", height: Dimensions.get("window").height }}
                 {...mapProps}
-                onRegionIsChanging={this.onRegionIsChanging}
-                onDidFinishRenderingMapFully={this.onDidFinishRenderingMapFully}
+                onCameraChanged={this.onRegionIsChanging}
+                onDidFinishLoadingMap={this.onDidFinishRenderingMapFully}
                 attributionEnabled
                 logoEnabled
                 logoPosition={{ bottom: 150, left: 10 }}
@@ -692,7 +692,7 @@ export class GlobalMap extends React.Component<Props, State> {
         { lat, lng },
         visibleFeatures
       )
-      const points = clusterEngine.getLeaves(nearestFeature.properties.cluster_id, Infinity)
+      const points = clusterEngine.getLeaves(nearestFeature?.properties?.cluster_id, Infinity)
       activeShows = points.map((a) => a.properties) as any
       this.setState({
         nearestFeature,


### PR DESCRIPTION
This PR resolves [PHIRE-1400] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes deprecation warnings for `onDidFinishRenderingMapFully` and `onRegionIsChanging` and replacing them with the new properties.

Also attempts to fix https://artsyproduct.atlassian.net/browse/PHIRE-1400 type error by making the code more defensive

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- city guide warnings

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1400]: https://artsyproduct.atlassian.net/browse/PHIRE-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ