### PR TITLE
chore: wrap individual screens with error boundary

### DIFF
--- a/src/app/Components/NotFoundFailureView.tsx
+++ b/src/app/Components/NotFoundFailureView.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, Button, Screen } from "@artsy/palette-mobile"
+import { Button, Flex, Screen, Text } from "@artsy/palette-mobile"
 import * as Sentry from "@sentry/react-native"
 import { goBack } from "app/system/navigation/navigate"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -9,6 +9,7 @@ import {
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { ModuleDescriptor } from "app/AppRegistry"
+import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
 import { AuthenticatedRoutesParams } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { isModalScreen } from "app/Navigation/Utils/isModalScreen"
 import { goBack } from "app/system/navigation/navigate"
@@ -92,13 +93,15 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = ({
   const tabBarHeight = hidesBottomTabs ? 0 : useBottomTabBarHeight()
 
   return (
-    <Flex
-      flex={1}
-      style={{
-        paddingBottom: hidesBottomTabs ? 0 : tabBarHeight,
-      }}
-    >
-      {children}
-    </Flex>
+    <RetryErrorBoundary>
+      <Flex
+        flex={1}
+        style={{
+          paddingBottom: hidesBottomTabs ? 0 : tabBarHeight,
+        }}
+      >
+        {children}
+      </Flex>
+    </RetryErrorBoundary>
   )
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes this issue raised by @gkartalis.

The problem here is that when an error happens, the outer error boundary intercepts it. But since that error boundary is situated **above** the navigation (it's defined in Providers), it is not with the navigation container context **and** it gets a null value for the `internal_navigationRef`.

The solution here is to wrap every screen with an error boundary. 



https://github.com/user-attachments/assets/a654ba6a-5909-4bd5-8fc0-ef1912fa8e06




<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- wrap individual screens with error boundary - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
