### PR TITLE
docs(home view): add note about user agent string

### DIFF
--- a/src/app/store/GlobalStore.tsx
+++ b/src/app/store/GlobalStore.tsx
@@ -108,6 +108,10 @@ export function getCurrentEmissionState() {
   const state = globalStoreInstance().getState() ?? null
 
   // `getUserAgentSync` breaks the Chrome Debugger, so we use a string instead.
+  //
+  // Note also that the specific format of the user-agent string that is constructed here
+  // may be relied upon by Metaphysics for determining what content to present to Eigen.
+  // See: https://github.com/artsy/metaphysics/pull/6297
   const userAgent = `${
     __DEV__ ? "Artsy-Mobile " + Platform.OS : DeviceInfo.getUserAgentSync()
   } ${DeviceInfo.getSystemName()}/${DeviceInfo.getSystemVersion()} Artsy-Mobile/${version} Eigen/${DeviceInfo.getBuildNumber()}/${version}`


### PR DESCRIPTION
This PR resolves [this suggestion](https://github.com/artsy/metaphysics/pull/6297#pullrequestreview-2494966720)

### Description

Adds context for how the user-agent string is used in Metaphysics.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add a note re: user-agent string

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
