### PR TITLE
feat: Change state of orders with new offer from partner to Counteroffer Received

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -202,7 +202,7 @@ describe("OrderHistoryRow", () => {
   })
 
   describe("update payment method button", () => {
-    it("is includes a message and button go fix payment when the displayState is PAYMENT_FAILED", () => {
+    it("includes a message and button go fix payment when the displayState is PAYMENT_FAILED", () => {
       renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
@@ -295,7 +295,7 @@ describe("OrderHistoryRow", () => {
       expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Offer")
     })
 
-    it("shows 'view order' when the order has an approved offer", () => {
+    it("shows 'view offer' when the order has an approved offer", () => {
       renderWithRelay({
         CommerceOrder: () => ({
           ...mockOrder,
@@ -304,7 +304,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Order")
+      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Offer")
     })
 
     it("navigates to the counteroffer when the order has a submitted offer", () => {
@@ -314,15 +314,16 @@ describe("OrderHistoryRow", () => {
           internalID: "internal-id",
           displayState: "SUBMITTED",
           mode: "OFFER",
+          buyerAction: "OFFER_RECEIVED",
         }),
       })
-      const button = screen.UNSAFE_getByProps({ testID: "view-order-button" })
+      const button = screen.UNSAFE_getByProps({ testID: "counteroffer-button" })
 
       fireEvent.press(button)
 
       expect(navigate).toHaveBeenCalledWith("/orders/internal-id", {
         modal: true,
-        passProps: { orderID: "internal-id", title: "Make Offer" },
+        passProps: { orderID: "internal-id", title: "Review Offer" },
       })
     })
 

--- a/src/app/utils/getOrderStatus.ts
+++ b/src/app/utils/getOrderStatus.ts
@@ -1,6 +1,9 @@
 import { CommerceOrderDisplayStateEnum } from "__generated__/OrderDetailsHeader_info.graphql"
+import { CommerceBuyerOfferActionEnum } from "__generated__/OrderHistoryRow_order.graphql"
 
-export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): string {
+export function getOrderStatus(
+  displayState: CommerceOrderDisplayStateEnum | CommerceBuyerOfferActionEnum
+): string {
   switch (displayState) {
     case "SUBMITTED":
       return "pending"
@@ -20,6 +23,8 @@ export function getOrderStatus(displayState: CommerceOrderDisplayStateEnum): str
       return "canceled"
     case "PAYMENT_FAILED":
       return "payment failed"
+    case "OFFER_RECEIVED":
+      return "counteroffer received"
     default:
       return ""
   }


### PR DESCRIPTION
This PR resolves [https://artsyproduct.atlassian.net/browse/EMI-2203]

### Description
The change here introduces 'Counteroffer Received' which we decide based on 'buyerAction' that is received from MP. For now I bundled the counteroffer states for incomplete orders as those are requiring the same action from the collector. 

Ideally we should move this additional 'buyerState' calculation to the server or MP and not repeat the calculation here and in Force but we decided to not do this refactor for now before we discuss more cohesive overhaul of Order/Offer states.

I noticed we are not relying on this 'buyerAction' when displaying the state in Inbox. Instead we repeat the calculation inline and derive the 'kind' variable there. Believe that should be refactored to use 'buyerState' as well. But that is a separate task.


| Before | After |
|--------|--------|
| <img width="402" alt="Screenshot 2024-12-11 at 3 08 23 PM" src="https://github.com/user-attachments/assets/36921b9d-2c26-49e1-af7d-a658549cd8c9" /> | <img width="402" alt="Screenshot 2024-12-11 at 3 08 23 PM" src="https://github.com/user-attachments/assets/a0b4caab-6973-44f1-83e3-87941a3ad8b5" /> | 




### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Updates to Order History tab to include 'Counteroffer Received' state

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
