### PR TITLE
fix: add back button to auction results screen

### DIFF
--- a/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
+++ b/src/app/Scenes/AuctionResults/AuctionResultsScreenWrapper.tsx
@@ -1,10 +1,10 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import { Flex, Screen, Text } from "@artsy/palette-mobile"
+import { BackButton, Flex, Screen, Text, useSpace } from "@artsy/palette-mobile"
 import { AuctionResultsScreenWrapperContainerQuery } from "__generated__/AuctionResultsScreenWrapperContainerQuery.graphql"
 import { AuctionResultsScreenWrapper_me$data } from "__generated__/AuctionResultsScreenWrapper_me.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { AuctionResultsList, LoadingSkeleton } from "app/Components/AuctionResultsList"
-import { navigate } from "app/system/navigation/navigate"
+import { goBack, navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { extractNodes } from "app/utils/extractNodes"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -191,6 +191,8 @@ const getDescriptionByState = (state: AuctionResultsState) => {
 export const AuctionResultsScreenScreenWrapperQueryQueryRenderer: React.FC<{
   state: AuctionResultsState
 }> = ({ state = AuctionResultsState.ALL }) => {
+  const space = useSpace()
+
   return (
     <Screen>
       <QueryRenderer<AuctionResultsScreenWrapperContainerQuery>
@@ -218,6 +220,13 @@ export const AuctionResultsScreenScreenWrapperQueryQueryRenderer: React.FC<{
             sort: AuctionResultsSorts.DATE_DESC,
           },
         })}
+      />
+      <BackButton
+        style={{
+          padding: space(2),
+          position: "absolute",
+        }}
+        onPress={goBack}
       />
     </Screen>
   )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds the back button to auction results screen.

![Group 32](https://github.com/user-attachments/assets/dce98f84-8541-4626-8179-286ac7652490)


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog