### PR TITLE
fix: cacheable home view section card query

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
@@ -148,7 +148,7 @@ const HomeViewSectionCardPlaceholder: React.FC<FlexProps> = (flexProps) => {
 }
 
 const homeViewSectionCardQuery = graphql`
-  query HomeViewSectionCardQuery($id: String!) @cacheable {
+  query HomeViewSectionCardQuery($id: String!) {
     homeView {
       section(id: $id) {
         ...HomeViewSectionCard_section


### PR DESCRIPTION
This PR removes the `@cacheable` directive from the Home View card section query. That directive prevents the `X-ACCESS-TOKEN` from propagating to Metaphysics, so Metaphysics assumes that the request is unauthenticated. This, in turn, prevents home view sections with `requiresAuthentication: true` to not display.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Removed a @cacheable directive from a home view query

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
