### PR TITLE
feat: Add prefetching capability to artwork grids

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -32,6 +32,7 @@ import { ArtworkItemCTAs } from "app/Scenes/Artwork/Components/ArtworkItemCTAs"
 import { useGetNewSaveAndFollowOnArtworkCardExperimentVariant } from "app/Scenes/Artwork/utils/useGetNewSaveAndFollowOnArtworkCardExperimentVariant"
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
+import { ElementInView } from "app/utils/ElementInView"
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
 import { saleMessageOrBidInfo } from "app/utils/getSaleMessgeOrBidInfo"
@@ -40,6 +41,7 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NUM_COLUMNS_MASONRY } from "app/utils/masonryHelpers"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { RandomNumberGenerator } from "app/utils/placeholders"
+import { usePrefetch } from "app/utils/queryPrefetching"
 import {
   ArtworkActionTrackingProps,
   tracks as artworkActionTracks,
@@ -124,6 +126,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
+  const prefetchUrl = usePrefetch()
   const tracking = useTracking()
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
@@ -131,6 +134,7 @@ export const Artwork: React.FC<ArtworkProps> = ({
   const enableNewSaveAndFollowOnArtworkCard = useFeatureFlag(
     "AREnableNewSaveAndFollowOnArtworkCard"
   )
+  const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
 
   const {
     enabled,
@@ -288,188 +292,190 @@ export const Artwork: React.FC<ArtworkProps> = ({
     !isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals
 
   return (
-    <Disappearable ref={(ref) => ((artwork as any)._disappearable = ref)}>
-      <ContextMenuArtwork
-        onSupressArtwork={() => handleSupress(artwork as any)}
-        contextModule={contextModule}
-        contextScreenOwnerType={contextScreenOwnerType}
-        onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
-        artwork={artwork}
-        hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
-      >
-        <Touchable
-          haptic
-          underlayColor={color("white100")}
-          activeOpacity={0.8}
-          onPress={handleTap}
-          testID={`artworkGridItem-${artwork.title}`}
+    <ElementInView onVisible={() => enableViewPortPrefetching && prefetchUrl(artwork.href)}>
+      <Disappearable ref={(ref) => ((artwork as any)._disappearable = ref)}>
+        <ContextMenuArtwork
+          onSupressArtwork={() => handleSupress(artwork as any)}
+          contextModule={contextModule}
+          contextScreenOwnerType={contextScreenOwnerType}
+          onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
+          artwork={artwork}
+          hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
         >
-          <View ref={itemRef}>
-            {!!artwork.image?.url && (
-              <View>
-                <Image
-                  src={artwork.image.url}
-                  aspectRatio={artwork.image.aspectRatio ?? 1}
-                  height={height}
-                  width={Number(height) * (artwork.image.aspectRatio ?? 1)}
-                  blurhash={showBlurhash ? artwork.image.blurhash : undefined}
-                  resizeMode="contain"
-                />
-              </View>
-            )}
-            {!!canShowAuctionProgressBar && (
-              <Box mt={1}>
-                <DurationProvider startAt={endsAt ?? undefined}>
-                  <LotProgressBar
-                    duration={null}
-                    startAt={artwork.sale?.startAt}
-                    extendedBiddingPeriodMinutes={artwork.sale.extendedBiddingPeriodMinutes}
-                    extendedBiddingIntervalMinutes={artwork.sale.extendedBiddingIntervalMinutes}
-                    biddingEndAt={endsAt}
-                    hasBeenExtended={lotSaleExtended}
+          <Touchable
+            haptic
+            underlayColor={color("white100")}
+            activeOpacity={0.8}
+            onPress={handleTap}
+            testID={`artworkGridItem-${artwork.title}`}
+          >
+            <View ref={itemRef}>
+              {!!artwork.image?.url && (
+                <View>
+                  <Image
+                    src={artwork.image.url}
+                    aspectRatio={artwork.image.aspectRatio ?? 1}
+                    height={height}
+                    width={Number(height) * (artwork.image.aspectRatio ?? 1)}
+                    blurhash={showBlurhash ? artwork.image.blurhash : undefined}
+                    resizeMode="contain"
                   />
-                </DurationProvider>
-              </Box>
-            )}
-
-            <Flex
-              flexDirection={positionCTAs}
-              justifyContent="space-between"
-              mt={1}
-              style={artworkMetaStyle}
-            >
-              <Flex
-                flexGrow={positionCTAs === "column" ? 1 : undefined}
-                flex={positionCTAs === "row" ? 1 : undefined}
-              >
-                {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
-                  <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
-                    Lot {artwork.saleArtwork.lotLabel}
-                  </Text>
-                )}
-                {!!artwork.artistNames && (
-                  <Text
-                    lineHeight="18px"
-                    weight="regular"
-                    variant="xs"
-                    numberOfLines={1}
-                    {...artistNamesTextStyle}
-                  >
-                    {artwork.artistNames}
-                  </Text>
-                )}
-                {!!artwork.title && (
-                  <Text
-                    lineHeight="18px"
-                    variant="xs"
-                    weight="regular"
-                    color="black60"
-                    numberOfLines={1}
-                    {...titleTextStyle}
-                  >
-                    <Text lineHeight="18px" variant="xs" weight="regular">
-                      {artwork.title}
-                    </Text>
-                    {artwork.date ? `, ${artwork.date}` : ""}
-                  </Text>
-                )}
-                {!hidePartner && !!artwork.partner?.name && (
-                  <Text
-                    variant="xs"
-                    lineHeight="18px"
-                    color="black60"
-                    numberOfLines={1}
-                    {...partnerNameTextStyle}
-                  >
-                    {artwork.partner.name}
-                  </Text>
-                )}
-                {!!displayPriceOfferMessage && (
-                  <Flex flexDirection="row">
-                    <Text lineHeight="20px" variant="xs" numberOfLines={1} fontWeight="bold">
-                      {priceOfferMessage.priceWithDiscountMessage}
-                    </Text>
-                    <Text color="black60" variant="xs">
-                      {" "}
-                      (List price: {priceOfferMessage.priceListedMessage})
-                    </Text>
-                  </Flex>
-                )}
-                {!!saleInfo && !hideSaleInfo && !displayPriceOfferMessage && (
-                  <ArtworkSaleMessage
-                    artwork={artwork}
-                    saleMessage={saleInfo}
-                    displayLimitedTimeOfferSignal={displayLimitedTimeOfferSignal}
-                    saleInfoTextStyle={saleInfoTextStyle}
-                  />
-                )}
-
-                {!!artwork.isUnlisted && (
-                  <Text lineHeight="18px" variant="xs" numberOfLines={1} fontWeight="bold">
-                    Exclusive Access
-                  </Text>
-                )}
-
-                {!!isAuction && !!collectorSignals && (
-                  <ArtworkAuctionTimer
-                    collectorSignals={collectorSignals}
-                    hideRegisterBySignal={hideRegisterBySignal}
-                  />
-                )}
-
-                {!!displayArtworkSocialSignal && (
-                  <ArtworkSocialSignal
-                    collectorSignals={collectorSignals}
-                    hideCuratorsPick={hideCuratorsPickSignal}
-                    hideIncreasedInterest={hideIncreasedInterestSignal}
-                  />
-                )}
-              </Flex>
-
-              {!!showOldSaveCTA && (
-                <Flex flexDirection="row" alignItems="flex-start">
-                  {!!isAuction && !!collectorSignals?.auction?.lotWatcherCount && (
-                    <Text lineHeight="18px" variant="xs" numberOfLines={1}>
-                      {collectorSignals.auction.lotWatcherCount}
-                    </Text>
-                  )}
-                  <Touchable
-                    haptic
-                    onPress={disableArtworksListPrompt ? handleArtworkSave : saveArtworkToLists}
-                    testID="save-artwork-icon"
-                  >
-                    <ArtworkHeartIcon isSaved={!!isSaved} index={itemIndex} />
-                  </Touchable>
-                </Flex>
+                </View>
+              )}
+              {!!canShowAuctionProgressBar && (
+                <Box mt={1}>
+                  <DurationProvider startAt={endsAt ?? undefined}>
+                    <LotProgressBar
+                      duration={null}
+                      startAt={artwork.sale?.startAt}
+                      extendedBiddingPeriodMinutes={artwork.sale.extendedBiddingPeriodMinutes}
+                      extendedBiddingIntervalMinutes={artwork.sale.extendedBiddingIntervalMinutes}
+                      biddingEndAt={endsAt}
+                      hasBeenExtended={lotSaleExtended}
+                    />
+                  </DurationProvider>
+                </Box>
               )}
 
-              {!!enableNewSaveAndFollowOnArtworkCard &&
-                !!(enableNewSaveCTA || enableNewSaveAndFollowCTAs) && (
-                  <Spacer y={positionCTAs === "column" ? 0.5 : 0} />
+              <Flex
+                flexDirection={positionCTAs}
+                justifyContent="space-between"
+                mt={1}
+                style={artworkMetaStyle}
+              >
+                <Flex
+                  flexGrow={positionCTAs === "column" ? 1 : undefined}
+                  flex={positionCTAs === "row" ? 1 : undefined}
+                >
+                  {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
+                    <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
+                      Lot {artwork.saleArtwork.lotLabel}
+                    </Text>
+                  )}
+                  {!!artwork.artistNames && (
+                    <Text
+                      lineHeight="18px"
+                      weight="regular"
+                      variant="xs"
+                      numberOfLines={1}
+                      {...artistNamesTextStyle}
+                    >
+                      {artwork.artistNames}
+                    </Text>
+                  )}
+                  {!!artwork.title && (
+                    <Text
+                      lineHeight="18px"
+                      variant="xs"
+                      weight="regular"
+                      color="black60"
+                      numberOfLines={1}
+                      {...titleTextStyle}
+                    >
+                      <Text lineHeight="18px" variant="xs" weight="regular">
+                        {artwork.title}
+                      </Text>
+                      {artwork.date ? `, ${artwork.date}` : ""}
+                    </Text>
+                  )}
+                  {!hidePartner && !!artwork.partner?.name && (
+                    <Text
+                      variant="xs"
+                      lineHeight="18px"
+                      color="black60"
+                      numberOfLines={1}
+                      {...partnerNameTextStyle}
+                    >
+                      {artwork.partner.name}
+                    </Text>
+                  )}
+                  {!!displayPriceOfferMessage && (
+                    <Flex flexDirection="row">
+                      <Text lineHeight="20px" variant="xs" numberOfLines={1} fontWeight="bold">
+                        {priceOfferMessage.priceWithDiscountMessage}
+                      </Text>
+                      <Text color="black60" variant="xs">
+                        {" "}
+                        (List price: {priceOfferMessage.priceListedMessage})
+                      </Text>
+                    </Flex>
+                  )}
+                  {!!saleInfo && !hideSaleInfo && !displayPriceOfferMessage && (
+                    <ArtworkSaleMessage
+                      artwork={artwork}
+                      saleMessage={saleInfo}
+                      displayLimitedTimeOfferSignal={displayLimitedTimeOfferSignal}
+                      saleInfoTextStyle={saleInfoTextStyle}
+                    />
+                  )}
+
+                  {!!artwork.isUnlisted && (
+                    <Text lineHeight="18px" variant="xs" numberOfLines={1} fontWeight="bold">
+                      Exclusive Access
+                    </Text>
+                  )}
+
+                  {!!isAuction && !!collectorSignals && (
+                    <ArtworkAuctionTimer
+                      collectorSignals={collectorSignals}
+                      hideRegisterBySignal={hideRegisterBySignal}
+                    />
+                  )}
+
+                  {!!displayArtworkSocialSignal && (
+                    <ArtworkSocialSignal
+                      collectorSignals={collectorSignals}
+                      hideCuratorsPick={hideCuratorsPickSignal}
+                      hideIncreasedInterest={hideIncreasedInterestSignal}
+                    />
+                  )}
+                </Flex>
+
+                {!!showOldSaveCTA && (
+                  <Flex flexDirection="row" alignItems="flex-start">
+                    {!!isAuction && !!collectorSignals?.auction?.lotWatcherCount && (
+                      <Text lineHeight="18px" variant="xs" numberOfLines={1}>
+                        {collectorSignals.auction.lotWatcherCount}
+                      </Text>
+                    )}
+                    <Touchable
+                      haptic
+                      onPress={disableArtworksListPrompt ? handleArtworkSave : saveArtworkToLists}
+                      testID="save-artwork-icon"
+                    >
+                      <ArtworkHeartIcon isSaved={!!isSaved} index={itemIndex} />
+                    </Touchable>
+                  </Flex>
                 )}
 
-              <ArtworkItemCTAs
-                artwork={artwork}
-                showSaveIcon={!hideSaveIcon}
-                showFollowIcon={!hideFollowIcon}
-                hideViewFollowsLink={hideViewFollowsLink}
-                contextModule={contextModule}
-                contextScreen={contextScreen}
-                contextScreenOwnerId={contextScreenOwnerId}
-                contextScreenOwnerSlug={contextScreenOwnerSlug}
-                contextScreenOwnerType={contextScreenOwnerType}
-              />
-            </Flex>
-          </View>
-        </Touchable>
-      </ContextMenuArtwork>
+                {!!enableNewSaveAndFollowOnArtworkCard &&
+                  !!(enableNewSaveCTA || enableNewSaveAndFollowCTAs) && (
+                    <Spacer y={positionCTAs === "column" ? 0.5 : 0} />
+                  )}
 
-      <CreateArtworkAlertModal
-        artwork={artwork}
-        onClose={() => setShowCreateArtworkAlertModal(false)}
-        visible={showCreateArtworkAlertModal}
-      />
-    </Disappearable>
+                <ArtworkItemCTAs
+                  artwork={artwork}
+                  showSaveIcon={!hideSaveIcon}
+                  showFollowIcon={!hideFollowIcon}
+                  hideViewFollowsLink={hideViewFollowsLink}
+                  contextModule={contextModule}
+                  contextScreen={contextScreen}
+                  contextScreenOwnerId={contextScreenOwnerId}
+                  contextScreenOwnerSlug={contextScreenOwnerSlug}
+                  contextScreenOwnerType={contextScreenOwnerType}
+                />
+              </Flex>
+            </View>
+          </Touchable>
+        </ContextMenuArtwork>
+
+        <CreateArtworkAlertModal
+          artwork={artwork}
+          onClose={() => setShowCreateArtworkAlertModal(false)}
+          visible={showCreateArtworkAlertModal}
+        />
+      </Disappearable>
+    </ElementInView>
   )
 }
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -288,11 +288,17 @@ export const Artwork: React.FC<ArtworkProps> = ({
     await item._disappearable?.disappear()
   }
 
+  const handleVisible = () => {
+    if (enableViewPortPrefetching && artwork.href) {
+      prefetchUrl(artwork.href)
+    }
+  }
+
   const displayArtworkSocialSignal =
     !isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals
 
   return (
-    <ElementInView onVisible={() => enableViewPortPrefetching && prefetchUrl(artwork.href)}>
+    <ElementInView onVisible={handleVisible}>
       <Disappearable ref={(ref) => ((artwork as any)._disappearable = ref)}>
         <ContextMenuArtwork
           onSupressArtwork={() => handleSupress(artwork as any)}

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -265,6 +265,12 @@ export const features = {
     readyForRelease: false,
     showInDevMenu: true,
   },
+  AREnableViewPortPrefetching: {
+    description: "Enable viewport prefetching",
+    readyForRelease: true,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableViewPortPrefetching",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -17,9 +17,11 @@ export const usePrefetch = () => {
 }
 
 const prefetchRoute = async <TQuery extends OperationType>(
-  route: string,
+  route?: string | null,
   variables?: VariablesOf<TQuery>
 ) => {
+  if (!route) return null
+
   if (await isRateLimited()) {
     if (logPrefetching) console.log("[queryPrefetching] Rate limit reached.")
     return


### PR DESCRIPTION
This PR resolves [ONYX-1391] <!-- eg [PROJECT-XXXX] -->

### Description

This adds prefetching capability to artwork grids. The solution uses the already existing [ElementInView](https://github.com/artsy/eigen/blob/main/src/app/utils/ElementInView.tsx) component.

The feature can be toggled with an [Echo feature flag](https://github.com/artsy/echo/pull/747). Just in case something goes wrong...

In the next iteration, I'll try to find a more universal solution similar to Force's [RouterLink](https://github.com/artsy/force/blob/main/src/System/Components/RouterLink.tsx#L37) component that has prefetching capability.


---

This PR uses the already implemented solution ElementInView](https://github.com/artsy/eigen/blob/main/src/app/utils/ElementInView.tsx), an alternative would have been to use the package [react-native-intersection-observer](https://www.npmjs.com/package/react-native-intersection-observer).


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add prefetching capability to artwork grids - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1391]: https://artsyproduct.atlassian.net/browse/ONYX-1391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ