### PR TITLE
chore(ONYX-1433): add processing state to the images that do not have image path, enable Continue CTA

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation.ts
@@ -94,9 +94,9 @@ const artworkFormPhotosSchema = Yup.object().shape({
     .min(__TEST__ ? 0 : 1)
     .of(
       Yup.object().shape({
-        id: Yup.string(),
-        geminiToken: Yup.string(),
-        path: Yup.string().required(),
+        id: Yup.string().required(),
+        geminiToken: Yup.string().required(),
+        path: Yup.string(),
       })
     ),
 })

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/UploadPhotos/UploadPhotosPhotoItem.tsx
@@ -78,7 +78,13 @@ export const PhotoItem = ({
           testID="Submission_Image"
         />
       ) : (
-        <SkeletonBox height={IMAGE_SIZE} width={IMAGE_SIZE}></SkeletonBox>
+        <SkeletonBox height={IMAGE_SIZE} width={IMAGE_SIZE} justifyContent="flex-end">
+          {!!photo.geminiToken && (
+            <Text p={0.5} variant="xs">
+              Processing...
+            </Text>
+          )}
+        </SkeletonBox>
       )}
       {!hideDeleteButton && (
         <Flex


### PR DESCRIPTION
This PR resolves [ONYX-1433] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
As discussed [here](https://artsy.slack.com/archives/C05EQL4R5N0/p1734432658233589) adding "Processing..." state to the images that do not yet have a path. Making the Continue CTA enabled in this scenario


https://github.com/user-attachments/assets/6fb04d02-471d-41a1-9e05-15b00508426a


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add processing state to the images that do not have image path, enable Continue CTA

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1433]: https://artsyproduct.atlassian.net/browse/ONYX-1433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ