### PR TITLE
fix(APPLAUSE-6694868): forgot password link does not work in link account

### DIFF
--- a/src/app/Scenes/Onboarding/Onboarding.tsx
+++ b/src/app/Scenes/Onboarding/Onboarding.tsx
@@ -88,6 +88,12 @@ export const OnboardingWelcomeScreens = () => {
           <StackNavigator.Group screenOptions={{ ...TransitionPresets.SlideFromRightIOS }}>
             <StackNavigator.Screen name="OnboardingHome" component={AuthApp} />
             <StackNavigator.Screen name="OnboardingSocialLink" component={OnboardingSocialLink} />
+            {/**
+             * There are two "Forgot Password?" forms in this flow:
+             * 1. The ForgotPasswordStep step in the OnboardingHome screen
+             * 2. The ForgotPassword screen linked-to in the OnboardingSocialLink screen
+             */}
+            <StackNavigator.Screen name="ForgotPassword" component={ForgotPassword} />
             <StackNavigator.Screen name="OnboardingWebView" component={OnboardingWebView} />
           </StackNavigator.Group>
         ) : (


### PR DESCRIPTION
This PR fixes an applause bug in which the Forgot Password flow was not accessible when a social account was being linked to an existing Artsy account with the same email address.

The solution was to reintroduce the `ForgotPassword` screen that the `OnboardingSocialLink` screen was expecting to be present. This allows users to request a forgotten password email. However, it raises two (non-blocking) issues:

1. The Forgot Password step navigates users back to the start of the login flow instead of back to the `OnboardingSocialLink` screen. Users will need to attempt to connect their social account once more.
2. The auth flow now has two separate "Forgot Password?" forms, which could be confusing for future developers. I left some comments to mitigate this.

https://github.com/user-attachments/assets/9480ea4e-906c-4bbe-ad89-d540e99c3d10


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Allowed users to request a forgotten password during social account linking

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
