### PR TITLE
fix: modules module path

### DIFF
--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -66,10 +66,13 @@ export const ToastComponent = ({
       return TABBAR_HEIGHT
     }
 
-    const { modules } = require("app/Navigation/routes")
+    const { modules } = require("app/Navigation/utils/modules")
 
     const moduleName = internal_navigationRef?.current?.getCurrentRoute()
       ?.name as keyof typeof modules
+
+    console.log({ modules })
+    console.log({ moduleName })
 
     const isBottomTabHidden = modules[moduleName]?.options?.hidesBottomTabs
 


### PR DESCRIPTION
This PR updates the module path used to access `modules` when displaying a toast message. I noticed that I received the following error message after performing actions that should have displayed a toast (ex. removing an artist from My Collection):

![Simulator Screenshot - iPhone 16 Plus - 2024-12-17 at 12 45 35](https://github.com/user-attachments/assets/e8ab45cf-f669-4336-8153-90504030a894)

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Updated the module path for navigation modules to be able to view toast messages

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
