### PR TITLE
fix(APPLAUSE-6695174): screen is blocked after complete profile prompt

### DIFF
--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -109,15 +109,7 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   }
 
   return (
-    <AutomountedBottomSheetModal
-      visible={visible}
-      onDismiss={handleDismiss}
-      enableDynamicSizing
-      style={{
-        // this allows us to test assertions about the visibility of this modal
-        display: visible ? "flex" : "none",
-      }}
-    >
+    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
       <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <Box p={2}>
           <Text>{message}</Text>


### PR DESCRIPTION
This PR resolves a bug where the complete profile prompt was blocking the screen after a user dismissed it. This bug was only reproducible on Android devices, and was not reproducible for the prompt to add artists to MyCollection.

| BEFORE | AFTER |
|---------|--------|
| ![Screenshot_1734474150](https://github.com/user-attachments/assets/cb431df9-98cc-4eea-95b7-dc9626367ded) | ![Screenshot_1734474179](https://github.com/user-attachments/assets/f2315372-d779-4925-b467-872920adb6e9) |

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Fixed a bug where the screen was blocked after users were prompted to complete their profile

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
