### PR TITLE
fix: explore artists link on home tab

### DIFF
--- a/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/EmptyMessage.tsx
@@ -1,16 +1,17 @@
 import {
-  Spacer,
-  Flex,
-  Box,
-  Text,
-  Button,
-  Join,
-  FilterIcon,
-  BellIcon,
   ArtworkIcon,
+  BellIcon,
+  Box,
+  Button,
+  FilterIcon,
+  Flex,
+  Join,
+  Spacer,
+  Text,
 } from "@artsy/palette-mobile"
 import SearchIcon from "app/Components/Icons/SearchIcon"
-import { navigate } from "app/system/navigation/navigate"
+import { GlobalStore } from "app/store/GlobalStore"
+import { navigate, popToRoot } from "app/system/navigation/navigate"
 import { ScrollView } from "react-native"
 
 interface InfoSectionProps {
@@ -64,6 +65,8 @@ const t = {
 }
 
 export const EmptyMessage: React.FC = () => {
+  const selectedTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
+
   return (
     <ScrollView>
       <Box px={2} py={4}>
@@ -77,7 +80,17 @@ export const EmptyMessage: React.FC = () => {
           <InfoSection title={t.match.title} body={t.match.body} icon={<ArtworkIcon />} />
         </Join>
         <Spacer y={4} />
-        <Button block variant="outline" onPress={() => navigate("/")}>
+        <Button
+          block
+          variant="outline"
+          onPress={() => {
+            if (selectedTab === "home") {
+              popToRoot()
+            } else {
+              navigate("/")
+            }
+          }}
+        >
           {t.button.label}
         </Button>
       </Box>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description


This PR fixes the following bug: Tapping 'Explore Artist' fails to trigger navigation on Edit Alert page.

Link: https://platform.applause.com/company/13083/products/27879/community-issues/6696714


https://github.com/user-attachments/assets/f9512123-794e-4783-bed6-47c1cf91765d


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog