### PR TITLE
fix: safe area insets on add custom artist

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
@@ -5,6 +5,7 @@ import {
   Input,
   InputRef,
   Join,
+  Screen,
   Spacer,
 } from "@artsy/palette-mobile"
 import { RouteProp, useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
@@ -92,7 +93,7 @@ export const AddMyCollectionArtist: React.FC = () => {
   }
 
   return (
-    <>
+    <Screen>
       <ArtsyKeyboardAvoidingView>
         <FancyModalHeader onLeftButtonPress={handleBackPress} hideBottomDivider>
           Add New Artist
@@ -113,7 +114,7 @@ export const AddMyCollectionArtist: React.FC = () => {
           keyboardShouldPersistTaps="handled"
           ref={scrollViewRef}
         >
-          <Flex p={2}>
+          <Flex px={2}>
             <Join separator={<Spacer y={2} />}>
               <Input
                 accessibilityLabel="Artist Name"
@@ -195,6 +196,6 @@ export const AddMyCollectionArtist: React.FC = () => {
           </Flex>
         </ScrollView>
       </ArtsyKeyboardAvoidingView>
-    </>
+    </Screen>
   )
 }

--- a/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tsx
+++ b/src/app/Scenes/MyCollection/Screens/MyCollectionAddCollectedArtists/MyCollectionAddCollectedArtists.tsx
@@ -32,9 +32,9 @@ export const MyCollectionAddCollectedArtists: React.FC<{}> = () => {
   }
 
   return (
-    <Screen>
+    <Screen safeArea={false}>
       <Screen.Body>
-        <Flex flex={1} mt={1}>
+        <Flex flex={1} mt={2}>
           <Suspense fallback={() => null}>
             <MyCollectionAddCollectedArtistsAutosuggest />
           </Suspense>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with the custom artist creation screen.

https://platform.applause.com/company/13083/products/27879/community-issues/6695253

https://github.com/user-attachments/assets/d18fa325-3225-42a9-a430-23d913aadcb7


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog