### PR TITLE
fix: hide bottom tabs on live auction webview

### DIFF
--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -215,7 +215,9 @@ export const ArtsyWebView = forwardRef<
       // to a different vanityURL that we can handle inapp, such as Fair & Partner.
       if (
         result.type === "match" &&
-        ["ReactWebView", "ModalWebView", "VanityURLEntity"].includes(result.module)
+        ["ReactWebView", "ModalWebView", "VanityURLEntity", "LiveAuctionWebView"].includes(
+          result.module
+        )
       ) {
         if (innerRef.current) {
           innerRef.current.shareTitleUrl = targetURL

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -1474,6 +1474,7 @@ export const liveDotArtsyRoutes = defineRoutes([
         Component: LiveAuctionView,
         options: {
           alwaysPresentModally: true,
+          hidesBottomTabs: true,
           screenOptions: {
             gestureEnabled: false,
             headerShown: false,
@@ -1483,9 +1484,11 @@ export const liveDotArtsyRoutes = defineRoutes([
       }
     : {
         path: "/*",
-        name: "ReactWebView",
+        name: "LiveAuctionWebView",
         Component: ArtsyWebViewPage,
         options: {
+          alwaysPresentModally: true,
+          hidesBottomTabs: true,
           screenOptions: {
             gestureEnabled: false,
             headerShown: false,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR allows us to hide the bottom tabs on the live auction webview.

For the sake of testing, I changed the iOS simulator to show a webview as well in order to test this. My android setup was broken but the logic here is the same.

https://github.com/user-attachments/assets/04cbd563-6ce9-4589-a934-042e34146610



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog