### PR TITLE
fix: galleries for you fallback height

### DIFF
--- a/src/app/Components/ImageWithFallback/ImageWithFallback.tests.tsx
+++ b/src/app/Components/ImageWithFallback/ImageWithFallback.tests.tsx
@@ -4,7 +4,7 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("ImageWithFallback", () => {
   it("renders without error", () => {
-    renderWithWrappers(<ImageWithFallback />)
+    renderWithWrappers(<ImageWithFallback width={100} height={100} />)
   })
 
   it("renders the image when a url is passed", async () => {

--- a/src/app/Components/ImageWithFallback/ImageWithFallback.tsx
+++ b/src/app/Components/ImageWithFallback/ImageWithFallback.tsx
@@ -1,8 +1,10 @@
 import { Box, Image, ImageProps } from "@artsy/palette-mobile"
 
-// Extend ImageProps but make `src` optional
+// Extend ImageProps but make `src` optional, require height and width
 type ImageWithFallbackProps = Omit<ImageProps, "src"> & {
   src?: string | null
+  height: number
+  width: number
 }
 
 export const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({
@@ -16,7 +18,7 @@ export const ImageWithFallback: React.FC<ImageWithFallbackProps> = ({
       <Box
         testID="fallback-image"
         width={width}
-        height={height ?? 250}
+        height={height}
         backgroundColor="black10"
         borderRadius="md"
       />

--- a/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
+++ b/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
@@ -79,7 +79,7 @@ export const PartnerListItem: React.FC<PartnerListItemProps> = ({
       <Touchable onPress={handlePress}>
         <Flex width={width} mx="auto">
           <Flex>
-            <ImageWithFallback src={imageUrl} aspectRatio={1.33} width={width} />
+            <ImageWithFallback src={imageUrl} height={width / 1.33} width={width} />
 
             {!!showInitials && (
               <Flex


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

GalleriesForYou was passing aspectRatio rather than height and we weren't handling in the fallback image, since it is only place just calculating height there and requiring width and height in the props to avoid in future. 


![fallback](https://github.com/user-attachments/assets/b654ae5f-ae99-45c8-8a4c-2c7ba0a31c30)


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- galleries for you fix fallback height - brian, george

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
