### PR TITLE
fix(tools): use session auth and reintroduce license check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,9 @@ jobs:
       - run:
           name: Update rollout if needed
           command: ./scripts/deploys/update-android-rollout-if-needed
+      - run:
+          name: Notify if license agreement needs to be signed
+          command: ./scripts/deploys/notify-if-new-license-agreement
 
   deploy-nightly-beta:
     environment:

--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -9,9 +9,11 @@ end
 
 desc "Checks app store connect if a license agreement needs to be signed"
 lane :notify_if_new_license_agreement do
-  # TODO: This login method will no longer work for CI with 2fa being enforced
-  # Check spaceship docs for future support with api key
-  client = Spaceship::Tunes.login(ENV['FASTLANE_USERNAME'], ENV['FASTLANE_PASSWORD'])
+  # TODO: This login method uses a stored session, expires every 30 days and needs to be refreshed via
+  # `bundle exec fastlane spaceauth`
+  # then update the session env var in .env.releases with the output session
+  # this is annoying, keep an eye out for token based auth in future
+  client = Spaceship::Tunes.login
   client.team_id = '479887'
   messages = Spaceship::Tunes.client.fetch_program_license_agreement_messages
 

--- a/scripts/deploys/notify-if-new-license-agreement
+++ b/scripts/deploys/notify-if-new-license-agreement
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-
-bundle install
 bundle exec fastlane notify_if_new_license_agreement


### PR DESCRIPTION
This PR resolves [PHIRE-1420] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This broke when we started using 2fa, unfortunately it looks like this still does not support token based auth but I was unaware you can use a fastlane session in CI and it should last around 30 days, a little annoying but should be fairly easy to refresh.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- bring back license agreement reminder - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1420]: https://artsyproduct.atlassian.net/browse/PHIRE-1420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ