### PR TITLE
feat(EMI-2237): Update iOS in-app push notification style

### DIFF
--- a/ios/Artsy/App/ARAppDelegate.mm
+++ b/ios/Artsy/App/ARAppDelegate.mm
@@ -129,8 +129,10 @@ static ARAppDelegate *_sharedInstance = nil;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     [self setupForAppLaunch:launchOptions];
-
     [self setupAnalytics:application withLaunchOptions:launchOptions];
+    
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    center.delegate = [self remoteNotificationsDelegate];
 
     [[FBSDKApplicationDelegate sharedInstance] application:application
         didFinishLaunchingWithOptions:launchOptions];

--- a/ios/Artsy/App/ARAppNotificationsDelegate.h
+++ b/ios/Artsy/App/ARAppNotificationsDelegate.h
@@ -4,7 +4,7 @@
 #import <React/RCTDevSettings.h>
 #import <UserNotifications/UNUserNotificationCenter.h>
 
-@interface ARAppNotificationsDelegate : NSObject <JSApplicationRemoteNotificationsDelegate>
+@interface ARAppNotificationsDelegate : NSObject <JSApplicationRemoteNotificationsDelegate, UNUserNotificationCenterDelegate>
 
 typedef NS_ENUM(NSInteger, ARAppNotificationsRequestContext) {
     ARAppNotificationsRequestContextLaunch,

--- a/ios/ArtsyTests/App_Tests/ARAppNotificationsDelegateTests.m
+++ b/ios/ArtsyTests/App_Tests/ARAppNotificationsDelegateTests.m
@@ -99,51 +99,6 @@ describe(@"receiveRemoteNotification", ^{
             });
         });
     });
-
-    describe(@"running in the foreground", ^{
-        beforeEach(^{
-            appState = UIApplicationStateActive;
-        });
-
-        itBehavesLike(@"when receiving a notification", nil);
-
-        it(@"displays a notification", ^{
-            id mock = [OCMockObject mockForClass:[ARNotificationView class]];
-            [[mock expect] showNoticeInView:OCMOCK_ANY title:@"New Works For You" response:OCMOCK_ANY];
-
-            [delegate applicationDidReceiveRemoteNotification:notification inApplicationState:appState];
-
-            [mock verify];
-            [mock stopMocking];
-        });
-
-        it(@"triggers an analytics event when a notification has been tapped", ^{
-            id mockNotificationView = [OCMockObject mockForClass:[ARNotificationView class]];
-            [[mockNotificationView stub] showNoticeInView:OCMOCK_ANY
-                                                    title:OCMOCK_ANY
-                                                 response:[OCMArg checkWithBlock:^(dispatch_block_t callback) {
-                                                    callback();
-                                                    return YES;
-                                                 }]];
-
-            [[mockEmissionSharedInstance stub] sendEvent:ARAnalyticsNotificationReceived traits:OCMOCK_ANY];
-            [[mockEmissionSharedInstance expect] sendEvent:ARAnalyticsNotificationTapped traits:DictionaryWithAppState(notification, appState)];
-
-            [delegate applicationDidReceiveRemoteNotification:notification inApplicationState:appState];
-
-            [mockEmissionSharedInstance verify];
-            [mockNotificationView stopMocking];
-        });
-
-        it(@"defaults message to url", ^{
-            id mock = [OCMockObject mockForClass:[ARNotificationView class]];
-            [[mock expect] showNoticeInView:OCMOCK_ANY title:@"http://artsy.net/feature" response:OCMOCK_ANY];
-            [delegate applicationDidReceiveRemoteNotification:@{ @"url" : @"http://artsy.net/feature" } inApplicationState:appState];
-
-            [mock verify];
-            [mock stopMocking];
-        });
-    });
 });
 
 SpecEnd;


### PR DESCRIPTION
This PR resolves [EMI-2237] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the native iOS in-app notification view to the default notification style when the app is in the foreground


### Videos
| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/ec30e635-10d0-4fc0-b829-cc6c875ce748" /> | <video src="https://github.com/user-attachments/assets/e2e34107-3e1b-49cc-873c-9b90f037b260" /> | 


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- Update the iOS notification style when the app is in the foreground

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2237]: https://artsyproduct.atlassian.net/browse/EMI-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ