### PR TITLE
fix: tab views tracking

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -1,4 +1,4 @@
-import { tappedTabBar } from "@artsy/cohesion"
+import { ActionType, OwnerType, Screen, tappedTabBar } from "@artsy/cohesion"
 import { Flex, Text, useColor } from "@artsy/palette-mobile"
 import { THEME } from "@artsy/palette-tokens"
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
@@ -71,6 +71,7 @@ const AppTabs: React.FC = () => {
             contextScreenOwnerType: BottomTabOption[tabName as BottomTabType],
           })
         )
+        postEventToProviders(tabsTracks.tabScreenView(tabName))
       }
     },
     [selectedTab]
@@ -169,4 +170,32 @@ export const AuthenticatedRoutes: React.FC = () => {
       </AuthenticatedRoutesStack.Group>
     </AuthenticatedRoutesStack.Navigator>
   )
+}
+
+export const tabsTracks = {
+  tabScreenView: (tab: BottomTabType): Screen => {
+    let tabScreen = OwnerType.home
+    switch (tab) {
+      case "home":
+        tabScreen = OwnerType.home
+        break
+      case "inbox":
+        tabScreen = OwnerType.inbox
+        break
+      case "profile":
+        tabScreen = OwnerType.profile
+        break
+      case "search":
+        tabScreen = OwnerType.search
+        break
+      case "sell":
+        tabScreen = OwnerType.sell
+        break
+    }
+
+    return {
+      context_screen_owner_type: tabScreen,
+      action: ActionType.screen,
+    }
+  },
 }

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events"
-import { ActionType, OwnerType, Screen } from "@artsy/cohesion"
 import { StackActions, TabActions } from "@react-navigation/native"
+import { tabsTracks } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { modules } from "app/Navigation/utils/modules"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
@@ -103,7 +103,7 @@ export function switchTab(tab: BottomTabType, props?: object) {
   // like other screens manually track screen views here
   // home handles this on its own since it is default tab
   if (tab !== "home") {
-    postEventToProviders(tracks.tabScreenView(tab))
+    postEventToProviders(tabsTracks.tabScreenView(tab))
   }
 
   if (props) {
@@ -113,34 +113,6 @@ export function switchTab(tab: BottomTabType, props?: object) {
   GlobalStore.actions.bottomTabs.setSelectedTab(tab)
 
   internal_navigationRef?.current?.dispatch(TabActions.jumpTo(tab, props))
-}
-
-const tracks = {
-  tabScreenView: (tab: BottomTabType): Screen => {
-    let tabScreen = OwnerType.home
-    switch (tab) {
-      case "home":
-        tabScreen = OwnerType.home
-        break
-      case "inbox":
-        tabScreen = OwnerType.inbox
-        break
-      case "profile":
-        tabScreen = OwnerType.profile
-        break
-      case "search":
-        tabScreen = OwnerType.search
-        break
-      case "sell":
-        tabScreen = OwnerType.sell
-        break
-    }
-
-    return {
-      context_screen_owner_type: tabScreen,
-      action: ActionType.screen,
-    }
-  },
 }
 
 export function dismissModal(after?: () => void) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR comes as a fix to some data issues noticed by @daytavares in this dashboard
![Screenshot 2024-12-30 at 13 27 40](https://github.com/user-attachments/assets/471f4d15-d51c-4a75-9f0f-a6dbbbe8f5f6)

This happened because when migrating the navigation to the new infra, I didn't migrate the tabs tracking. For some reason, it's using a different tracking way.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix tracking tab screens tracking - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
