### PR TITLE
chore: disable biome

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+  "biome.enabled": false,
   "cSpell.diagnosticLevel": "Hint",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"


### PR DESCRIPTION
This PR adds a VS Code configuration to disable [Biome](https://biomejs.dev/) to silence the errors that it is throwing after we added it to the Artsy Omakase.

### Changelog updates

#### Dev changes

- Disabled Biome
