### PR TITLE
feat(ONYX-1457): add Create Alert Prompt experiment

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "braces": "in the resolutions - needed to resolve a security dependency issue - need to remove this when the issue is resolved and packages are updated"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.222.0",
+    "@artsy/cohesion": "4.223.0",
     "@artsy/palette-mobile": "14.0.15",
     "@artsy/to-title-case": "1.1.0",
     "@braze/react-native-sdk": "11.0.0",

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -28,6 +28,7 @@ import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilter
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { Props as InfiniteScrollGridProps } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
+import { useExperimentVariant } from "app/utils/experiments/hooks"
 import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import {
@@ -70,6 +71,11 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
   const artworks = useMemo(() => extractNodes(artist.artworks), [artist.artworks])
   const artworksCount = artist.artworks?.counts?.total ?? 0
   const gridRef = useRef<MasonryFlashListRef<(typeof artworks)[0]>>(null)
+  const {
+    enabled,
+    variant,
+    trackExperiment: trackCreateAlertPromptExperiment,
+  } = useExperimentVariant("onyx_create-alert-prompt-experiment")
 
   const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
@@ -83,6 +89,10 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
   const setInitialFilterStateAction = ArtworksFiltersStore.useStoreActions(
     (state) => state.setInitialFilterStateAction
   )
+
+  useEffect(() => {
+    trackCreateAlertPromptExperiment()
+  }, [])
 
   useEffect(() => {
     let filters: FilterArray = []
@@ -258,8 +268,8 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     )
   }
 
-  const variant_a = true
-  const variant_b = true
+  const variant_a = enabled && variant === "variant-a"
+  const variant_b = enabled && variant === "variant-b"
 
   const userDidScroll = artworks.length >= 10 // 40
 

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -337,10 +337,9 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         visible={isCreateAlertModalVisible}
       />
 
-      <CreateAlertPromptMessage
-        shouldShowCreateAlertPrompt={!!userDidScroll && variant_b}
-        onPress={() => setIsCreateAlertModalVisible(true)}
-      />
+      {!!userDidScroll && !!variant_b && (
+        <CreateAlertPromptMessage onPress={() => setIsCreateAlertModalVisible(true)} />
+      )}
     </>
   )
 }

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -261,7 +261,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
   const variant_a = true
   const variant_b = true
 
-  const shouldShowCreateAlertPrompt = artworks.length >= 10 // 40
+  const userDidScroll = artworks.length >= 10 // 40
 
   return (
     <>
@@ -294,7 +294,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
               <ArtistArtworksFilterHeader
                 artist={artist}
                 showCreateAlertModal={() => setIsCreateAlertModalVisible(true)}
-                shouldShowCreateAlertPrompt={!!shouldShowCreateAlertPrompt && variant_a}
+                shouldShowCreateAlertPrompt={!!userDidScroll && variant_a}
               />
             </Tabs.SubTabBar>
             <Flex pt={1}>
@@ -328,7 +328,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
       />
 
       <CreateAlertPromptMessage
-        shouldShowCreateAlertPrompt={!!shouldShowCreateAlertPrompt && variant_b}
+        shouldShowCreateAlertPrompt={!!userDidScroll && variant_b}
         onPress={() => setIsCreateAlertModalVisible(true)}
       />
     </>

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -268,8 +268,8 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     )
   }
 
-  const variant_a = enabled && variant === "variant-a"
-  const variant_b = enabled && variant === "variant-b"
+  const variantA = enabled && variant === "variant-a"
+  const variantB = enabled && variant === "variant-b"
 
   const userDidScroll = artworks.length >= 40
 
@@ -304,7 +304,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
               <ArtistArtworksFilterHeader
                 artist={artist}
                 showCreateAlertModal={() => setIsCreateAlertModalVisible(true)}
-                shouldShowCreateAlertPrompt={!!userDidScroll && variant_a}
+                shouldShowCreateAlertPrompt={!!userDidScroll && variantA}
               />
             </Tabs.SubTabBar>
             <Flex pt={1}>
@@ -337,7 +337,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         visible={isCreateAlertModalVisible}
       />
 
-      {!!userDidScroll && !!variant_b && (
+      {!!userDidScroll && !!variantB && (
         <CreateAlertPromptMessage onPress={() => setIsCreateAlertModalVisible(true)} />
       )}
     </>

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -14,6 +14,7 @@ import {
 import { MasonryFlashListRef } from "@shopify/flash-list"
 import { ArtistArtworks_artist$data } from "__generated__/ArtistArtworks_artist.graphql"
 import { ArtistArtworksFilterHeader } from "app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader"
+import { CreateAlertPromptMessage } from "app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage"
 import { CreateSavedSearchModal } from "app/Components/Artist/ArtistArtworks/CreateSavedSearchModal"
 import { useCreateSavedSearchModalFilters } from "app/Components/Artist/ArtistArtworks/hooks/useCreateSavedSearchModalFilters"
 import { useShowArtworksFilterModal } from "app/Components/Artist/ArtistArtworks/hooks/useShowArtworksFilterModal"
@@ -150,7 +151,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     }
   }, [relay.hasMore(), relay.isLoading()])
 
-  const CreateAlertButton = () => {
+  const CreateAlertButton: React.FC = () => {
     return (
       <Button
         variant="outline"
@@ -257,6 +258,11 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     )
   }
 
+  const variant_a = true
+  const variant_b = true
+
+  const shouldShowCreateAlertPrompt = artworks.length >= 10 // 40
+
   return (
     <>
       <Tabs.Masonry
@@ -288,6 +294,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
               <ArtistArtworksFilterHeader
                 artist={artist}
                 showCreateAlertModal={() => setIsCreateAlertModalVisible(true)}
+                shouldShowCreateAlertPrompt={!!shouldShowCreateAlertPrompt && variant_a}
               />
             </Tabs.SubTabBar>
             <Flex pt={1}>
@@ -299,6 +306,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         }
         ListFooterComponent={<ListFooterComponenet />}
       />
+
       <ArtworkFilterNavigator
         {...props}
         id={artist.internalID}
@@ -310,12 +318,18 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         mode={FilterModalMode.ArtistArtworks}
         shouldShowCreateAlertButton
       />
+
       <CreateSavedSearchModal
         attributes={attributes}
         closeModal={() => setIsCreateAlertModalVisible(false)}
         entity={savedSearchEntity}
         onComplete={handleCompleteSavedSearch}
         visible={isCreateAlertModalVisible}
+      />
+
+      <CreateAlertPromptMessage
+        shouldShowCreateAlertPrompt={!!shouldShowCreateAlertPrompt && variant_b}
+        onPress={() => setIsCreateAlertModalVisible(true)}
       />
     </>
   )

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -171,7 +171,11 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         onPress={() => {
           // Could be useful to differenciate between the two at a later point
           tracking.trackEvent(
-            tracks.tappedCreateAlert({ artistId: artist.internalID, artistSlug: artist.slug })
+            tracks.tappedCreateAlert({
+              artistId: artist.internalID,
+              artistSlug: artist.slug,
+              contextModule: ContextModule.artistArtworksGridEnd,
+            })
           )
 
           setIsCreateAlertModalVisible(true)
@@ -338,7 +342,18 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
       />
 
       {!!userDidScroll && !!variantB && (
-        <CreateAlertPromptMessage onPress={() => setIsCreateAlertModalVisible(true)} />
+        <CreateAlertPromptMessage
+          onPress={() => {
+            tracking.trackEvent(
+              tracks.tappedCreateAlert({
+                artistId: artist.internalID,
+                artistSlug: artist.slug,
+                contextModule: ContextModule.artistArtworksCreateAlertPromptMessage,
+              })
+            )
+            setIsCreateAlertModalVisible(true)
+          }}
+        />
       )}
     </>
   )
@@ -438,11 +453,19 @@ export default createPaginationContainer(
 )
 
 const tracks = {
-  tappedCreateAlert: ({ artistId, artistSlug }: { artistId: string; artistSlug: string }) => ({
+  tappedCreateAlert: ({
+    artistId,
+    artistSlug,
+    contextModule,
+  }: {
+    artistId: string
+    artistSlug: string
+    contextModule: ContextModule
+  }) => ({
     action: ActionType.tappedCreateAlert,
     context_screen_owner_type: OwnerType.artist,
     context_screen_owner_id: artistId,
     context_screen_owner_slug: artistSlug,
-    context_module: ContextModule.artistArtworksGridEnd,
+    context_module: contextModule,
   }),
 }

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -271,7 +271,7 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
   const variant_a = enabled && variant === "variant-a"
   const variant_b = enabled && variant === "variant-b"
 
-  const userDidScroll = artworks.length >= 10 // 40
+  const userDidScroll = artworks.length >= 40
 
   return (
     <>

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
@@ -9,11 +9,13 @@ import { graphql, useFragment } from "react-relay"
 interface ArtistArtworksFilterProps {
   artist: ArtistArtworksFilterHeader_artist$key
   showCreateAlertModal: () => void
+  shouldShowCreateAlertPrompt?: boolean
 }
 
 export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = ({
   artist,
   showCreateAlertModal,
+  shouldShowCreateAlertPrompt,
 }) => {
   const data = useFragment(
     graphql`
@@ -43,6 +45,7 @@ export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = (
           onPress={() => {
             showCreateAlertModal()
           }}
+          shouldShowCreateAlertPrompt={shouldShowCreateAlertPrompt}
         />
       </ArtworksFilterHeader>
     </Box>

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
@@ -25,7 +25,7 @@ describe("CreateAlertPromptMessage", () => {
 
   it("renders correctly first time", () => {
     __globalStoreTestUtils__?.injectState({
-      createAlertPrompt: { promptState: { timesShown: 0, dismisDate: 0 } },
+      createAlertPrompt: { promptState: { timesShown: 0, dismissDate: 0 } },
     })
     wrapper()
 
@@ -34,7 +34,7 @@ describe("CreateAlertPromptMessage", () => {
 
   it("is not rendered on the third time", () => {
     __globalStoreTestUtils__?.injectState({
-      createAlertPrompt: { promptState: { timesShown: 2, dismisDate: 0 } },
+      createAlertPrompt: { promptState: { timesShown: 2, dismissDate: 0 } },
     })
     wrapper()
 
@@ -44,7 +44,7 @@ describe("CreateAlertPromptMessage", () => {
   it("renders correctly second time after 3 days", () => {
     __globalStoreTestUtils__?.injectState({
       // 259200000 is 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200000 } },
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200000 } },
     })
     wrapper()
 
@@ -54,7 +54,7 @@ describe("CreateAlertPromptMessage", () => {
   it("is not rendered second time after less than 3 days", () => {
     __globalStoreTestUtils__?.injectState({
       // 259200 is less than 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200 } },
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200 } },
     })
     wrapper()
 

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { Text } from "react-native"
+import { CreateAlertPromptMessage } from "./CreateAlertPromptMessage"
+
+jest.mock("@artsy/palette-mobile", () => ({
+  ...jest.requireActual("@artsy/palette-mobile"),
+}))
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+  }),
+}))
+
+describe("CreateAlertPromptMessage", () => {
+  const wrapper = () =>
+    renderWithWrappers(
+      <CreateAlertPromptMessage onPress={() => jest.fn()}>
+        <Text>Test Children</Text>
+      </CreateAlertPromptMessage>
+    )
+
+  it("renders correctly first time", () => {
+    __globalStoreTestUtils__?.injectState({
+      createAlertPrompt: { promptState: { timesShown: 0, dismisDate: 0 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Searching for a particular artwork?")).toBeOnTheScreen()
+  })
+
+  it("is not rendered on the third time", () => {
+    __globalStoreTestUtils__?.injectState({
+      createAlertPrompt: { promptState: { timesShown: 2, dismisDate: 0 } },
+    })
+    wrapper()
+
+    expect(screen.queryByText("Searching for a particular artwork?")).not.toBeOnTheScreen()
+  })
+
+  it("renders correctly second time after 3 days", () => {
+    __globalStoreTestUtils__?.injectState({
+      // 259200000 is 3 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200000 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Searching for a particular artwork?")).toBeOnTheScreen()
+  })
+
+  it("is not rendered second time after less than 3 days", () => {
+    __globalStoreTestUtils__?.injectState({
+      // 259200 is less than 3 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200 } },
+    })
+    wrapper()
+
+    expect(screen.queryByText("Searching for a particular artwork?")).not.toBeOnTheScreen()
+  })
+})

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tests.tsx
@@ -43,8 +43,8 @@ describe("CreateAlertPromptMessage", () => {
 
   it("renders correctly second time after 3 days", () => {
     __globalStoreTestUtils__?.injectState({
-      // 259200000 is 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200000 } },
+      // 604800000 is 7 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 604800000 } },
     })
     wrapper()
 
@@ -53,7 +53,7 @@ describe("CreateAlertPromptMessage", () => {
 
   it("is not rendered second time after less than 3 days", () => {
     __globalStoreTestUtils__?.injectState({
-      // 259200 is less than 3 days
+      // 259200 is less than 7 days
       createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200 } },
     })
     wrapper()

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -1,9 +1,7 @@
-import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { Button, Message, Text } from "@artsy/palette-mobile"
 import { useShouldShowPrompt } from "app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
-import { useTracking } from "react-tracking"
 
 interface CreateAlertPromptMessageProps {
   onPress: () => void
@@ -13,7 +11,6 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
   const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
   const { updateTimesShown, dontShowCreateAlertPromptAgain, dismissPrompt } =
     GlobalStore.actions.createAlertPrompt
-  const tracking = useTracking()
 
   const { shouldShowPrompt, forcePrompt } = useShouldShowPrompt(promptState)
 
@@ -62,14 +59,4 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
   } else {
     return <></>
   }
-}
-
-const tracks = {
-  tappedCreateAlert: (artistId: string, artistSlug: string): TappedCreateAlert => ({
-    action: ActionType.tappedCreateAlert,
-    context_screen_owner_type: OwnerType.artist,
-    context_screen_owner_id: artistId,
-    context_screen_owner_slug: artistSlug,
-    context_module: ContextModule.artworkGrid,
-  }),
 }

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -1,21 +1,18 @@
-import { Button, Message } from "@artsy/palette-mobile"
+import { Button, Message, Text } from "@artsy/palette-mobile"
 import { useShouldShowPrompt } from "app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
 
 interface CreateAlertPromptMessageProps {
   onPress: () => void
-  shouldShowCreateAlertPrompt: boolean
 }
 
-export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> = ({
-  onPress,
-  shouldShowCreateAlertPrompt,
-}) => {
+export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> = ({ onPress }) => {
   const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
-  const { dismissPrompt, updateTimesShown } = GlobalStore.actions.createAlertPrompt
+  const { updateTimesShown, dontShowCreateAlertPromptAgain, dismissPrompt } =
+    GlobalStore.actions.createAlertPrompt
 
-  const shouldShowPrompt = useShouldShowPrompt(promptState) && shouldShowCreateAlertPrompt
+  const { shouldShowPrompt, forcePrompt } = useShouldShowPrompt(promptState)
 
   useEffect(() => {
     if (shouldShowPrompt) {
@@ -32,24 +29,30 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
         variant="dark"
         IconComponent={() => {
           return (
-            <Button
-              variant="outline"
-              size="small"
-              onPress={() => {
-                const dontShowAgain = true
-                dismissPrompt(dontShowAgain)
-                onPress()
-              }}
-            >
-              Create Alert
-            </Button>
+            <>
+              <Button
+                variant="outline"
+                size="small"
+                onPress={() => {
+                  dismissPrompt()
+                  dontShowCreateAlertPromptAgain()
+                  onPress()
+                }}
+              >
+                Create Alert
+              </Button>
+              {!!forcePrompt && (
+                <Text variant="xs" color="pink">
+                  timesShown: {promptState.timesShown}
+                </Text>
+              )}
+            </>
           )
         }}
         iconPosition="bottom"
         showCloseButton
         onClose={() => {
-          const dontShowAgain = false
-          dismissPrompt(dontShowAgain)
+          dismissPrompt()
         }}
       />
     )

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -1,33 +1,57 @@
 import { Button, Message } from "@artsy/palette-mobile"
+import { useShouldShowPrompt } from "app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useEffect } from "react"
 
 interface CreateAlertPromptMessageProps {
   onPress: () => void
-  shouldShowCreateAlertPrompt?: boolean
+  shouldShowCreateAlertPrompt: boolean
 }
 
 export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> = ({
   onPress,
   shouldShowCreateAlertPrompt,
 }) => {
-  if (!shouldShowCreateAlertPrompt) {
-    return <></>
+  const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
+  const { dismissPrompt, updateTimesShown } = GlobalStore.actions.createAlertPrompt
+
+  const shouldShowPrompt = useShouldShowPrompt(promptState) && shouldShowCreateAlertPrompt
+
+  useEffect(() => {
+    if (shouldShowPrompt) {
+      updateTimesShown()
+    }
+  }, [])
+
+  const handleDismiss = () => {
+    dismissPrompt()
   }
 
-  return (
-    <Message
-      title="Searching for a particular artwork?"
-      titleStyle={{ variant: "sm-display", fontWeight: "bold" }}
-      text="Create an Alert and we’ll let you know when there’s a match."
-      variant="dark"
-      IconComponent={() => {
-        return (
-          <Button variant="outline" size="small" onPress={onPress}>
-            Create Alert
-          </Button>
-        )
-      }}
-      iconPosition="bottom"
-      showCloseButton
-    />
-  )
+  const handleOnPress = () => {
+    handleDismiss()
+    onPress()
+  }
+
+  if (shouldShowPrompt) {
+    return (
+      <Message
+        title="Searching for a particular artwork?"
+        titleStyle={{ variant: "sm-display", fontWeight: "bold" }}
+        text="Create an Alert and we’ll let you know when there’s a match."
+        variant="dark"
+        IconComponent={() => {
+          return (
+            <Button variant="outline" size="small" onPress={handleOnPress}>
+              Create Alert
+            </Button>
+          )
+        }}
+        iconPosition="bottom"
+        showCloseButton
+        onClose={handleDismiss}
+      />
+    )
+  } else {
+    return <></>
+  }
 }

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -23,15 +23,6 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
     }
   }, [])
 
-  const handleDismiss = () => {
-    dismissPrompt()
-  }
-
-  const handleOnPress = () => {
-    handleDismiss()
-    onPress()
-  }
-
   if (shouldShowPrompt) {
     return (
       <Message
@@ -41,14 +32,25 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
         variant="dark"
         IconComponent={() => {
           return (
-            <Button variant="outline" size="small" onPress={handleOnPress}>
+            <Button
+              variant="outline"
+              size="small"
+              onPress={() => {
+                const dontShowAgain = true
+                dismissPrompt(dontShowAgain)
+                onPress()
+              }}
+            >
               Create Alert
             </Button>
           )
         }}
         iconPosition="bottom"
         showCloseButton
-        onClose={handleDismiss}
+        onClose={() => {
+          const dontShowAgain = false
+          dismissPrompt(dontShowAgain)
+        }}
       />
     )
   } else {

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -1,0 +1,33 @@
+import { Button, Message } from "@artsy/palette-mobile"
+
+interface CreateAlertPromptMessageProps {
+  onPress: () => void
+  shouldShowCreateAlertPrompt?: boolean
+}
+
+export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> = ({
+  onPress,
+  shouldShowCreateAlertPrompt,
+}) => {
+  if (!shouldShowCreateAlertPrompt) {
+    return <></>
+  }
+
+  return (
+    <Message
+      title="Searching for a particular artwork?"
+      titleStyle={{ variant: "sm-display", fontWeight: "bold" }}
+      text="Create an Alert and we’ll let you know when there’s a match."
+      variant="dark"
+      IconComponent={() => {
+        return (
+          <Button variant="outline" size="small" onPress={onPress}>
+            Create Alert
+          </Button>
+        )
+      }}
+      iconPosition="bottom"
+      showCloseButton
+    />
+  )
+}

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptMessage.tsx
@@ -1,7 +1,9 @@
+import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { Button, Message, Text } from "@artsy/palette-mobile"
 import { useShouldShowPrompt } from "app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
+import { useTracking } from "react-tracking"
 
 interface CreateAlertPromptMessageProps {
   onPress: () => void
@@ -11,6 +13,7 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
   const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
   const { updateTimesShown, dontShowCreateAlertPromptAgain, dismissPrompt } =
     GlobalStore.actions.createAlertPrompt
+  const tracking = useTracking()
 
   const { shouldShowPrompt, forcePrompt } = useShouldShowPrompt(promptState)
 
@@ -59,4 +62,14 @@ export const CreateAlertPromptMessage: React.FC<CreateAlertPromptMessageProps> =
   } else {
     return <></>
   }
+}
+
+const tracks = {
+  tappedCreateAlert: (artistId: string, artistSlug: string): TappedCreateAlert => ({
+    action: ActionType.tappedCreateAlert,
+    context_screen_owner_type: OwnerType.artist,
+    context_screen_owner_id: artistId,
+    context_screen_owner_slug: artistSlug,
+    context_module: ContextModule.artworkGrid,
+  }),
 }

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
@@ -53,8 +53,8 @@ describe("CreateAlertPromptPopover", () => {
 
   it("renders correctly second time after 3 days", () => {
     __globalStoreTestUtils__?.injectState({
-      // 259200000 is 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200000 } },
+      // 604800000 is 7 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 604800000 } },
     })
     wrapper()
 
@@ -64,7 +64,7 @@ describe("CreateAlertPromptPopover", () => {
 
   it("is not rendered second time after less than 3 days", () => {
     __globalStoreTestUtils__?.injectState({
-      // 259200 is less than 3 days
+      // 259200 is less than 7 days
       createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200 } },
     })
     wrapper()

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
@@ -33,7 +33,7 @@ describe("CreateAlertPromptPopover", () => {
 
   it("renders correctly first time", () => {
     __globalStoreTestUtils__?.injectState({
-      createAlertPrompt: { promptState: { timesShown: 0, dismisDate: 0 } },
+      createAlertPrompt: { promptState: { timesShown: 0, dismissDate: 0 } },
     })
     wrapper()
 
@@ -43,7 +43,7 @@ describe("CreateAlertPromptPopover", () => {
 
   it("is not rendered on the third time", () => {
     __globalStoreTestUtils__?.injectState({
-      createAlertPrompt: { promptState: { timesShown: 2, dismisDate: 0 } },
+      createAlertPrompt: { promptState: { timesShown: 2, dismissDate: 0 } },
     })
     wrapper()
 
@@ -54,7 +54,7 @@ describe("CreateAlertPromptPopover", () => {
   it("renders correctly second time after 3 days", () => {
     __globalStoreTestUtils__?.injectState({
       // 259200000 is 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200000 } },
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200000 } },
     })
     wrapper()
 
@@ -65,7 +65,7 @@ describe("CreateAlertPromptPopover", () => {
   it("is not rendered second time after less than 3 days", () => {
     __globalStoreTestUtils__?.injectState({
       // 259200 is less than 3 days
-      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200 } },
+      createAlertPrompt: { promptState: { timesShown: 1, dismissDate: Date.now() - 259200 } },
     })
     wrapper()
 

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tests.tsx
@@ -1,0 +1,89 @@
+import { screen } from "@testing-library/react-native"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { Text } from "react-native"
+import { CreateAlertPromptPopover } from "./CreateAlertPromptPopover"
+
+jest.mock("@artsy/palette-mobile", () => ({
+  ...jest.requireActual("@artsy/palette-mobile"),
+  Popover: (props: any) => <MockedPopover {...props} />,
+}))
+
+const mockUseIsFocusedMock = jest.fn()
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+  }),
+  useIsFocused: () => mockUseIsFocusedMock(),
+}))
+
+describe("CreateAlertPromptPopover", () => {
+  const wrapper = () =>
+    renderWithWrappers(
+      <CreateAlertPromptPopover>
+        <Text>Test Children</Text>
+      </CreateAlertPromptPopover>
+    )
+
+  beforeEach(() => {
+    mockUseIsFocusedMock.mockReturnValue(true)
+  })
+
+  it("renders correctly first time", () => {
+    __globalStoreTestUtils__?.injectState({
+      createAlertPrompt: { promptState: { timesShown: 0, dismisDate: 0 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Test Children")).toBeOnTheScreen()
+    expect(screen.getByText("Popover")).toBeOnTheScreen()
+  })
+
+  it("is not rendered on the third time", () => {
+    __globalStoreTestUtils__?.injectState({
+      createAlertPrompt: { promptState: { timesShown: 2, dismisDate: 0 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Test Children")).toBeOnTheScreen()
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+  })
+
+  it("renders correctly second time after 3 days", () => {
+    __globalStoreTestUtils__?.injectState({
+      // 259200000 is 3 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200000 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Test Children")).toBeOnTheScreen()
+    expect(screen.getByText("Popover")).toBeOnTheScreen()
+  })
+
+  it("is not rendered second time after less than 3 days", () => {
+    __globalStoreTestUtils__?.injectState({
+      // 259200 is less than 3 days
+      createAlertPrompt: { promptState: { timesShown: 1, dismisDate: Date.now() - 259200 } },
+    })
+    wrapper()
+
+    expect(screen.getByText("Test Children")).toBeOnTheScreen()
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+  })
+})
+
+const MockedPopover: React.FC<any> = ({ children, onDismiss, visible, content }) => {
+  if (!visible) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      <Text onPress={onDismiss}>Popover</Text>
+      <>{children}</>
+      <>{content}</>
+    </>
+  )
+}

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
@@ -7,7 +7,7 @@ export const CreateAlertPromptPopover: React.FC<{}> = ({ children }) => {
   const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
   const { dismissPrompt, updateTimesShown } = GlobalStore.actions.createAlertPrompt
 
-  const shouldShowPrompt = useShouldShowPrompt(promptState)
+  const { shouldShowPrompt, forcePrompt } = useShouldShowPrompt(promptState)
 
   useEffect(() => {
     if (shouldShowPrompt) {
@@ -32,9 +32,16 @@ export const CreateAlertPromptPopover: React.FC<{}> = ({ children }) => {
         </Text>
       }
       content={
-        <Text variant="xs" color="white100">
-          Create an alert and we’ll let you know when there’s a match.
-        </Text>
+        <>
+          <Text variant="xs" color="white100">
+            Create an alert and we’ll let you know when there’s a match.
+          </Text>
+          {!!forcePrompt && (
+            <Text variant="xs" color="pink">
+              timesShown: {promptState.timesShown}
+            </Text>
+          )}
+        </>
       }
     >
       <Flex>{children}</Flex>

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
@@ -1,21 +1,29 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
+import { useShouldShowPrompt } from "app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt"
+import { GlobalStore } from "app/store/GlobalStore"
 import { useEffect } from "react"
 
-export const CreateAlertPromptPopover: React.FC = ({ children }) => {
+export const CreateAlertPromptPopover: React.FC<{}> = ({ children }) => {
+  const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
+  const { dismissPrompt, updateTimesShown } = GlobalStore.actions.createAlertPrompt
+
+  const shouldShowPrompt = useShouldShowPrompt(promptState)
+
   useEffect(() => {
-    // track the time of the prompt being shown
+    if (shouldShowPrompt) {
+      updateTimesShown()
+    }
   }, [])
 
   const handleDismiss = () => {
-    // handle dismiss
+    dismissPrompt()
   }
 
   return (
     <Popover
-      visible={true}
+      visible={shouldShowPrompt}
       onDismiss={handleDismiss}
       onPressOutside={handleDismiss}
-      //  onCloseComplete={clearActivePopover}
       variant="dark"
       placement="bottom"
       title={

--- a/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover.tsx
@@ -1,0 +1,35 @@
+import { Flex, Popover, Text } from "@artsy/palette-mobile"
+import { useEffect } from "react"
+
+export const CreateAlertPromptPopover: React.FC = ({ children }) => {
+  useEffect(() => {
+    // track the time of the prompt being shown
+  }, [])
+
+  const handleDismiss = () => {
+    // handle dismiss
+  }
+
+  return (
+    <Popover
+      visible={true}
+      onDismiss={handleDismiss}
+      onPressOutside={handleDismiss}
+      //  onCloseComplete={clearActivePopover}
+      variant="dark"
+      placement="bottom"
+      title={
+        <Text variant="xs" color="white100" fontWeight="bold">
+          Searching for a particular artwork?
+        </Text>
+      }
+      content={
+        <Text variant="xs" color="white100">
+          Create an alert and we’ll let you know when there’s a match.
+        </Text>
+      }
+    >
+      <Flex>{children}</Flex>
+    </Popover>
+  )
+}

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
@@ -26,8 +26,7 @@ export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) =
      * if Create Alert CTA was pressed withing 2 minutes after the prompt was shown
      *  do not show the prompt again
      * */
-    // TODO: maybe add is the screen is still focused check
-    if (Date.now() - promptState.dismisDate < 120000 && isFocused) {
+    if (Date.now() - promptState.dismissDate < 120000 && isFocused) {
       dontShowCreateAlertPromptAgain()
     }
 

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
@@ -1,6 +1,8 @@
 import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { BellIcon, Flex, Box, Text, TouchableHighlightColor } from "@artsy/palette-mobile"
+import { useIsFocused } from "@react-navigation/native"
 import { SavedSearchButtonV2Popover } from "app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover"
+import { GlobalStore } from "app/store/GlobalStore"
 import { useTracking } from "react-tracking"
 
 export interface SavedSearchButtonV2Props {
@@ -12,10 +14,23 @@ export interface SavedSearchButtonV2Props {
 
 export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) => {
   const { artistId, artistSlug, onPress, shouldShowCreateAlertPrompt } = props
+  const { promptState } = GlobalStore.useAppState((state) => state.createAlertPrompt)
+  const { dontShowCreateAlertPromptAgain } = GlobalStore.actions.createAlertPrompt
   const tracking = useTracking()
+  const isFocused = useIsFocused()
 
   const handlePress = () => {
     onPress()
+
+    /**
+     * if Create Alert CTA was pressed withing 2 minutes after the prompt was shown
+     *  do not show the prompt again
+     * */
+    // TODO: maybe add is the screen is still focused check
+    if (Date.now() - promptState.dismisDate < 120000 && isFocused) {
+      dontShowCreateAlertPromptAgain()
+    }
+
     tracking.trackEvent(tracks.tappedCreateAlert(artistId, artistSlug))
   }
 

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2.tsx
@@ -1,16 +1,17 @@
 import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
 import { BellIcon, Flex, Box, Text, TouchableHighlightColor } from "@artsy/palette-mobile"
-import { ProgressiveOnboardingSaveAlert } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveAlert"
+import { SavedSearchButtonV2Popover } from "app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover"
 import { useTracking } from "react-tracking"
 
 export interface SavedSearchButtonV2Props {
   artistId: string
   artistSlug: string
   onPress: () => void
+  shouldShowCreateAlertPrompt?: boolean
 }
 
 export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) => {
-  const { artistId, artistSlug, onPress } = props
+  const { artistId, artistSlug, onPress, shouldShowCreateAlertPrompt } = props
   const tracking = useTracking()
 
   const handlePress = () => {
@@ -20,7 +21,7 @@ export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) =
 
   return (
     <Flex>
-      <ProgressiveOnboardingSaveAlert>
+      <SavedSearchButtonV2Popover shouldShowCreateAlertPrompt={shouldShowCreateAlertPrompt}>
         <TouchableHighlightColor
           haptic
           onPress={handlePress}
@@ -35,7 +36,7 @@ export const SavedSearchButtonV2: React.FC<SavedSearchButtonV2Props> = (props) =
             </Flex>
           )}
         />
-      </ProgressiveOnboardingSaveAlert>
+      </SavedSearchButtonV2Popover>
     </Flex>
   )
 }

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
@@ -8,7 +8,6 @@ export const SavedSearchButtonV2Popover: React.FC<{ shouldShowCreateAlertPrompt?
   shouldShowCreateAlertPrompt,
 }) => {
   const {
-    isDismissed,
     sessionState: { activePopover },
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
   const isFocused = useIsFocused()
@@ -16,7 +15,6 @@ export const SavedSearchButtonV2Popover: React.FC<{ shouldShowCreateAlertPrompt?
   const isOnboardingFinished =
     isFocused &&
     // make sure threre is no active onboarding popover on the screen
-    isDismissed("alert-create").status &&
     !activePopover
 
   if (isOnboardingFinished && shouldShowCreateAlertPrompt) {

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
@@ -1,0 +1,38 @@
+import { useIsFocused } from "@react-navigation/native"
+import { CreateAlertPromptPopover } from "app/Components/Artist/ArtistArtworks/CreateAlertPromptPopover"
+import { ProgressiveOnboardingSaveAlert } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveAlert"
+import { GlobalStore } from "app/store/GlobalStore"
+
+export const SavedSearchButtonV2Popover: React.FC<{ shouldShowCreateAlertPrompt?: boolean }> = ({
+  children,
+  shouldShowCreateAlertPrompt,
+}) => {
+  const {
+    //  isDismissed,
+    // dismissed,
+    sessionState: { activePopover },
+  } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
+  const isFocused = useIsFocused()
+
+  const isCreateAlertReminderDisplayable =
+    isFocused &&
+    // isDismissed("alert-create").status &&
+    // we only show the createAlertPromptPopover if the onboarding is completed
+    // isDismissed("save-highlight").status &&
+    // make sure threre is no active onboarding popover on the screen
+    !activePopover
+
+  console.log(
+    "[LOGD] isCreateAlertReminderDisplayable = ",
+    shouldShowCreateAlertPrompt,
+    isCreateAlertReminderDisplayable
+  )
+
+  // TODO: would be great if we can tell if the onboarding is finished
+  // or if the onboarding only on this screen is finished
+  if (isCreateAlertReminderDisplayable && shouldShowCreateAlertPrompt) {
+    return <CreateAlertPromptPopover>{children}</CreateAlertPromptPopover>
+  }
+
+  return <ProgressiveOnboardingSaveAlert>{children}</ProgressiveOnboardingSaveAlert>
+}

--- a/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/SavedSearchButtonV2Popover.tsx
@@ -8,29 +8,18 @@ export const SavedSearchButtonV2Popover: React.FC<{ shouldShowCreateAlertPrompt?
   shouldShowCreateAlertPrompt,
 }) => {
   const {
-    //  isDismissed,
-    // dismissed,
+    isDismissed,
     sessionState: { activePopover },
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
   const isFocused = useIsFocused()
 
-  const isCreateAlertReminderDisplayable =
+  const isOnboardingFinished =
     isFocused &&
-    // isDismissed("alert-create").status &&
-    // we only show the createAlertPromptPopover if the onboarding is completed
-    // isDismissed("save-highlight").status &&
     // make sure threre is no active onboarding popover on the screen
+    isDismissed("alert-create").status &&
     !activePopover
 
-  console.log(
-    "[LOGD] isCreateAlertReminderDisplayable = ",
-    shouldShowCreateAlertPrompt,
-    isCreateAlertReminderDisplayable
-  )
-
-  // TODO: would be great if we can tell if the onboarding is finished
-  // or if the onboarding only on this screen is finished
-  if (isCreateAlertReminderDisplayable && shouldShowCreateAlertPrompt) {
+  if (isOnboardingFinished && shouldShowCreateAlertPrompt) {
     return <CreateAlertPromptPopover>{children}</CreateAlertPromptPopover>
   }
 

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
@@ -4,17 +4,16 @@ import { useExperimentVariant } from "app/utils/experiments/hooks"
 export const useShouldShowPrompt = (promptState: CreateAlertPromptModel["promptState"]) => {
   const { payload } = useExperimentVariant("onyx_create-alert-prompt-experiment")
 
-  // unlimited for dev, 2 for production
-  const maxTimesShown = /* __DEV__ ? 123456 : */ 2
-  // 30 seconds for dev, 3 days for production
-  const timeInterval = /* __DEV__ ? 30000 : */ 259200000
-
+  // forcePrompt is used for testing purposes
   const forcePrompt = Boolean(payload && JSON.parse(payload)?.forcePrompt === "true")
 
-  const shouldShowPrompt =
-    (promptState.timesShown <= maxTimesShown &&
-      Date.now() - promptState.dismisDate >= timeInterval) ||
-    forcePrompt
+  // unlimited for dev, 2 for production
+  const maxTimesShown = forcePrompt ? 123456 : 2
+  // 30 seconds for dev, 3 days for production
+  const timeInterval = forcePrompt ? 30000 : 259200000
 
-  return shouldShowPrompt
+  const shouldShowPrompt =
+    promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismisDate >= timeInterval
+
+  return { shouldShowPrompt, forcePrompt }
 }

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
@@ -1,0 +1,13 @@
+import { CreateAlertPromptModel } from "app/store/CreateAlertPromptModel"
+
+export const useShouldShowPrompt = (promptState: CreateAlertPromptModel["promptState"]) => {
+  // unlimited for dev, 2 for production
+  const maxTimesShown = __DEV__ ? 123456 : 2
+  // 30 seconds for dev, 3 days for production
+  const timeInterval = __DEV__ ? 30000 : 259200000
+
+  const shouldShowPrompt =
+    promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismisDate >= timeInterval
+
+  return shouldShowPrompt
+}

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
@@ -13,7 +13,7 @@ export const useShouldShowPrompt = (promptState: CreateAlertPromptModel["promptS
   const timeInterval = forcePrompt ? 30000 : 259200000
 
   const shouldShowPrompt =
-    promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismisDate >= timeInterval
+    promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismissDate >= timeInterval
 
   return { shouldShowPrompt, forcePrompt }
 }

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
@@ -9,8 +9,8 @@ export const useShouldShowPrompt = (promptState: CreateAlertPromptModel["promptS
 
   // unlimited for dev, 2 for production
   const maxTimesShown = forcePrompt ? 123456 : 2
-  // 30 seconds for dev, 3 days for production
-  const timeInterval = forcePrompt ? 30000 : 259200000
+  // 30 seconds for dev, 7 days for production
+  const timeInterval = forcePrompt ? 30000 : 604800000
 
   const shouldShowPrompt =
     promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismissDate >= timeInterval

--- a/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/hooks/useShouldShowPrompt.tsx
@@ -1,13 +1,20 @@
 import { CreateAlertPromptModel } from "app/store/CreateAlertPromptModel"
+import { useExperimentVariant } from "app/utils/experiments/hooks"
 
 export const useShouldShowPrompt = (promptState: CreateAlertPromptModel["promptState"]) => {
+  const { payload } = useExperimentVariant("onyx_create-alert-prompt-experiment")
+
   // unlimited for dev, 2 for production
-  const maxTimesShown = __DEV__ ? 123456 : 2
+  const maxTimesShown = /* __DEV__ ? 123456 : */ 2
   // 30 seconds for dev, 3 days for production
-  const timeInterval = __DEV__ ? 30000 : 259200000
+  const timeInterval = /* __DEV__ ? 30000 : */ 259200000
+
+  const forcePrompt = Boolean(payload && JSON.parse(payload)?.forcePrompt === "true")
 
   const shouldShowPrompt =
-    promptState.timesShown <= maxTimesShown && Date.now() - promptState.dismisDate >= timeInterval
+    (promptState.timesShown <= maxTimesShown &&
+      Date.now() - promptState.dismisDate >= timeInterval) ||
+    forcePrompt
 
   return shouldShowPrompt
 }

--- a/src/app/Scenes/Artist/Artist.tests.tsx
+++ b/src/app/Scenes/Artist/Artist.tests.tsx
@@ -85,15 +85,22 @@ describe("Artist", () => {
     expect(screen.getByText("Overview")).toBeTruthy()
   })
 
-  it("tracks a page view", async () => {
+  it("tracks a page view and onyx_create-alert-prompt-experiment experiment", async () => {
     renderWithHookWrappersTL(<TestWrapper />, getRelayEnvironment(), { includeNavigation: true })
 
     mockMostRecentOperation("ArtistAboveTheFoldQuery")
 
     await flushPromiseQueue()
 
-    expect(postEventToProviders).toHaveBeenCalledTimes(1)
+    expect(postEventToProviders).toHaveBeenCalledTimes(2)
     expect(postEventToProviders).toHaveBeenNthCalledWith(1, {
+      action: "experiment_viewed",
+      experiment_name: "onyx_create-alert-prompt-experiment",
+      payload: undefined,
+      service: "unleash",
+      variant_name: "control",
+    })
+    expect(postEventToProviders).toHaveBeenNthCalledWith(2, {
       context_screen: "Artist",
       context_screen_owner_id: '<mock-value-for-field-"internalID">',
       context_screen_owner_slug: '<mock-value-for-field-"slug">',

--- a/src/app/store/CreateAlertPromptModel.ts
+++ b/src/app/store/CreateAlertPromptModel.ts
@@ -3,7 +3,7 @@ import { action, Action } from "easy-peasy"
 export interface CreateAlertPromptModel {
   promptState: {
     timesShown: number
-    dismisDate: number
+    dismissDate: number
   }
   updateTimesShown: Action<this>
   dismissPrompt: Action<this>
@@ -13,7 +13,7 @@ export interface CreateAlertPromptModel {
 export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
   promptState: {
     timesShown: 0,
-    dismisDate: 0,
+    dismissDate: 0,
   },
   updateTimesShown: action((state) => {
     state.promptState.timesShown = state.promptState.timesShown + 1
@@ -21,7 +21,7 @@ export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
   dismissPrompt: action((state) => {
     state.promptState = {
       ...state.promptState,
-      dismisDate: Date.now(),
+      dismissDate: Date.now(),
     }
   }),
   dontShowCreateAlertPromptAgain: action((state) => {

--- a/src/app/store/CreateAlertPromptModel.ts
+++ b/src/app/store/CreateAlertPromptModel.ts
@@ -1,0 +1,28 @@
+import { action, Action } from "easy-peasy"
+
+export const MAX_SHOWN_RECENT_PRICE_RANGES = 5
+
+export interface CreateAlertPromptModel {
+  promptState: {
+    timesShown: number
+    dismisDate: number
+  }
+  updateTimesShown: Action<this>
+  dismissPrompt: Action<this>
+}
+
+export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
+  promptState: {
+    timesShown: 0,
+    dismisDate: 0,
+  },
+  updateTimesShown: action((state) => {
+    state.promptState.timesShown = state.promptState.timesShown + 1
+  }),
+  dismissPrompt: action((state) => {
+    state.promptState = {
+      timesShown: state.promptState.timesShown + 1,
+      dismisDate: Date.now(),
+    }
+  }),
+})

--- a/src/app/store/CreateAlertPromptModel.ts
+++ b/src/app/store/CreateAlertPromptModel.ts
@@ -1,14 +1,12 @@
 import { action, Action } from "easy-peasy"
 
-export const MAX_SHOWN_RECENT_PRICE_RANGES = 5
-
 export interface CreateAlertPromptModel {
   promptState: {
     timesShown: number
     dismisDate: number
   }
   updateTimesShown: Action<this>
-  dismissPrompt: Action<this>
+  dismissPrompt: Action<this, boolean>
 }
 
 export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
@@ -19,9 +17,9 @@ export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
   updateTimesShown: action((state) => {
     state.promptState.timesShown = state.promptState.timesShown + 1
   }),
-  dismissPrompt: action((state) => {
+  dismissPrompt: action((state, dontShowAgain) => {
     state.promptState = {
-      timesShown: state.promptState.timesShown + 1,
+      timesShown: state.promptState.timesShown + (dontShowAgain ? 1 : 0),
       dismisDate: Date.now(),
     }
   }),

--- a/src/app/store/CreateAlertPromptModel.ts
+++ b/src/app/store/CreateAlertPromptModel.ts
@@ -6,7 +6,8 @@ export interface CreateAlertPromptModel {
     dismisDate: number
   }
   updateTimesShown: Action<this>
-  dismissPrompt: Action<this, boolean>
+  dismissPrompt: Action<this>
+  dontShowCreateAlertPromptAgain: Action<this>
 }
 
 export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
@@ -17,10 +18,16 @@ export const getCreateAlertPromptModel = (): CreateAlertPromptModel => ({
   updateTimesShown: action((state) => {
     state.promptState.timesShown = state.promptState.timesShown + 1
   }),
-  dismissPrompt: action((state, dontShowAgain) => {
+  dismissPrompt: action((state) => {
     state.promptState = {
-      timesShown: state.promptState.timesShown + (dontShowAgain ? 1 : 0),
+      ...state.promptState,
       dismisDate: Date.now(),
+    }
+  }),
+  dontShowCreateAlertPromptAgain: action((state) => {
+    state.promptState = {
+      ...state.promptState,
+      timesShown: state.promptState.timesShown + 1,
     }
   }),
 })

--- a/src/app/store/GlobalStoreModel.ts
+++ b/src/app/store/GlobalStoreModel.ts
@@ -11,6 +11,7 @@ import {
   getSubmissionModel,
   SubmissionModel,
 } from "app/Scenes/SellWithArtsy/utils/submissionModelState"
+import { CreateAlertPromptModel, getCreateAlertPromptModel } from "app/store/CreateAlertPromptModel"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import {
   ProgressiveOnboardingModel,
@@ -57,6 +58,7 @@ interface GlobalStoreStateModel {
   requestedPriceEstimates: RequestedPriceEstimatesModel
   recentPriceRanges: RecentPriceRangesModel
   progressiveOnboarding: ProgressiveOnboardingModel
+  createAlertPrompt: CreateAlertPromptModel
 }
 export interface GlobalStoreModel extends GlobalStoreStateModel {
   rehydrate: Action<this, DeepPartial<State<GlobalStoreStateModel>>>
@@ -144,6 +146,7 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
   requestedPriceEstimates: getRequestedPriceEstimatesModel(),
   recentPriceRanges: getRecentPriceRangesModel(),
   progressiveOnboarding: getProgressiveOnboardingModel(),
+  createAlertPrompt: getCreateAlertPromptModel(),
 
   setSessionState: action((state, payload) => {
     state.sessionState = { ...state.sessionState, ...payload }

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -57,9 +57,10 @@ export const Versions = {
   DeleteDirtyArtworkDetails: 44,
   AddSubmissionDraft: 45,
   DeleteArtworkAndArtistViewOption: 46,
+  AddcreateAlertPrompt: 47,
 }
 
-export const CURRENT_APP_VERSION = Versions.DeleteArtworkAndArtistViewOption
+export const CURRENT_APP_VERSION = Versions.AddcreateAlertPrompt
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -329,6 +330,14 @@ export const artsyAppMigrations: Migrations = {
   [Versions.DeleteArtworkAndArtistViewOption]: (state) => {
     delete state.userPrefs.artworkViewOption
     delete state.userPrefs.artistViewOption
+  },
+  [Versions.AddcreateAlertPrompt]: (state) => {
+    state.createAlertPrompt = {
+      promptState: {
+        timesShown: 0,
+        dismissDate: 0,
+      },
+    }
   },
 }
 

--- a/src/app/utils/experiments/experiments.ts
+++ b/src/app/utils/experiments/experiments.ts
@@ -41,7 +41,7 @@ export const experiments = {
     fallbackEnabled: true,
     fallbackVariant: "control",
     variantSuggestions: ["control", "variant-a", "variant-b"],
-    // payloadSuggestions: ['{"forcePrompt": "true"}', '{"forcePrompt": "false"}'],
+    payloadSuggestions: ['{"forcePrompt": "true"}', '{"forcePrompt": "false"}'],
   },
 } satisfies { [key: string]: ExperimentDescriptor }
 

--- a/src/app/utils/experiments/experiments.ts
+++ b/src/app/utils/experiments/experiments.ts
@@ -36,6 +36,13 @@ export const experiments = {
     variantSuggestions: ["control", "variant-b", "variant-c"],
     payloadSuggestions: ['{"forceDots": "true"}', '{"forceDots": "false"}'],
   },
+  "onyx_create-alert-prompt-experiment": {
+    description: "Show create alert prompt on artist page",
+    fallbackEnabled: true,
+    fallbackVariant: "control",
+    variantSuggestions: ["control", "variant-a", "variant-b"],
+    // payloadSuggestions: ['{"forcePrompt": "true"}', '{"forcePrompt": "false"}'],
+  },
 } satisfies { [key: string]: ExperimentDescriptor }
 
 export type EXPERIMENT_NAME = keyof typeof experiments

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@artsy/cohesion@4.222.0":
-  version "4.222.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.222.0.tgz#3cfaedb2c20b942293a7e9dcb731ef6e1e18f49c"
-  integrity sha512-B0GdaXIYCINZ3BzHJC0Zu/dkfeGwq/dkFNzG6tNXaAyrhKN6dfgGrdJpbQxOt+IJA1cQk9EOQek6V/bskemmiw==
+"@artsy/cohesion@4.223.0":
+  version "4.223.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.223.0.tgz#5817e34184f22780df2195207fc27126d4406009"
+  integrity sha512-IvUIECyARCldivlGldVVmr3ckBZU9uaT7MZL3A2zjuj9uUPlRdnQGrLY2t4qFavhdr3f5jixQ871rUciGo7j7w==
   dependencies:
     core-js "3"
 
@@ -1846,7 +1846,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
   version "7.26.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.4.tgz#ac3a2a84b908dde6d463c3bfa2c5fdc1653574bd"
   integrity sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==
@@ -1885,6 +1885,19 @@
     "@babel/parser" "^7.25.6"
     "@babel/template" "^7.25.0"
     "@babel/types" "^7.25.6"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3":
+  version "7.26.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.4.tgz#ac3a2a84b908dde6d463c3bfa2c5fdc1653574bd"
+  integrity sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.3"
+    "@babel/parser" "^7.26.3"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.26.3"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -14674,7 +14687,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14788,7 +14810,7 @@ stringify-entities@^3.1.0:
     character-entities-legacy "^1.0.0"
     xtend "^4.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14801,6 +14823,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -16225,7 +16254,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16238,6 +16267,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This PR resolves [ONYX-1457] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Help increase awareness of the Create Alert function from the artist page (high traffic and high impact)
[Figma](https://www.figma.com/design/zRKGxOWHhq3kcNiNAZCig3/OtH-App%3A-Alerts-and-Activity?node-id=340-44256&m=dev)

1. Implement two variants and control variant
- control: nothing changes
- variant-a: popover component
- variant-b: message components with CTA
3. For variants `a` and `b` the component should be shown:
- after 40 artworks is loaded
- max 2 times per user 
- the second time the user will see the popover or message component will be minimum in 7 days
- when after seeing the component the user clicks "Create Alert" CTA, the popover or message should not be shown again
4. Make sure the popover component is not shown together with any of the progressive onboarding components at the same time on the same screen 


Also adding the `payloadSuggestions: ['{"forcePrompt": "true"}', '{"forcePrompt": "false"}']` for testing purposes. Inspired by @anandaroop 🙏 

When `forcePrompt === true` the max times to show the component is 123456 and the waiting time is 30 seconds instead of 3 days. Also, in case of a forced prompt I display a text that says how many times the component has been shown. If the Create Alert CTA was not pressed after seeing the component, on the next render of the component the number will increase by 1. If Create Alert CTA was pressed, the number will be increased by 2. This functionality was added for testing purposes. 

#### iOS
| Popover | Message |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/61346c96-109b-4185-becd-5a0ca1de3a3f" width="250"/> | <video src="https://github.com/user-attachments/assets/d5387c46-643d-49c5-99ef-cb10f84bfdb3" width="250"/> |

#### Android
| Popover | Message |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/bd85636b-b1f4-4abb-80f7-917e412ae28a" width="250"/> | <video src="https://github.com/user-attachments/assets/9d8b43e0-511d-4626-a243-b1a00ffe068d" width="250"/> | 


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add Create Alert Prompt experiment (onyx_create-alert-prompt-experiment)

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1457]: https://artsyproduct.atlassian.net/browse/ONYX-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ