### PR TITLE
fix: modal issues on android

### DIFF
--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tests.tsx
@@ -1,9 +1,4 @@
-import {
-  fireEvent,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { InquiryModalTestsQuery } from "__generated__/InquiryModalTestsQuery.graphql"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { AUTOMATED_MESSAGES } from "app/Scenes/Artwork/Components/CommercialButtons/constants"
@@ -99,12 +94,11 @@ describe("inquiry modal", () => {
 
   it("closes when the 'cancel' button is pressed", async () => {
     renderWithRelay()
+    expect(screen.getByText("What information are you looking for?")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Cancel"))
 
-    await waitForElementToBeRemoved(() =>
-      screen.queryByText("What information are you looking for?")
-    )
+    expect(screen.queryByText("What information are you looking for?")).not.toBeOnTheScreen()
   })
 
   it("tracks an event when the inquiry modal is closed", async () => {

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -1,8 +1,7 @@
-import { Box, Flex, InfoCircleIcon, Input, Text } from "@artsy/palette-mobile"
+import { Box, Flex, InfoCircleIcon, Input, Screen, Text } from "@artsy/palette-mobile"
 import { InquiryModal_artwork$key } from "__generated__/InquiryModal_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { useSendInquiry_me$key } from "__generated__/useSendInquiry_me.graphql"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
 import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryQuestionOption } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption"
@@ -17,7 +16,7 @@ import { LocationWithDetails } from "app/utils/googleMaps"
 import { useUpdateCollectorProfile } from "app/utils/mutations/useUpdateCollectorProfile"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useRef, useState } from "react"
-import { ScrollView } from "react-native"
+import { Modal, ScrollView } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 import { CollapsibleArtworkDetailsFragmentContainer } from "./CollapsibleArtworkDetails"
@@ -102,92 +101,94 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork: _artwork, m
 
   return (
     <>
-      <FancyModal visible={state.inquiryModalVisible} onBackgroundPressed={handleDismiss}>
-        <FancyModalHeader
-          leftButtonText="Cancel"
-          onLeftButtonPress={handleDismiss}
-          rightButtonText="Send"
-          rightButtonDisabled={state.inquiryQuestions.length === 0 && message === ""}
-          onRightButtonPress={() => sendInquiry(message)}
-        >
-          Contact Gallery
-        </FancyModalHeader>
-        {!!error && (
-          <Flex
-            bg="red100"
-            py={1}
-            alignItems="center"
-            position="absolute"
-            top={6}
-            width={1}
-            zIndex={5}
+      <Modal visible={state.inquiryModalVisible} onDismiss={handleDismiss} statusBarTranslucent>
+        <Screen>
+          <FancyModalHeader
+            leftButtonText="Cancel"
+            onLeftButtonPress={handleDismiss}
+            rightButtonText="Send"
+            rightButtonDisabled={state.inquiryQuestions.length === 0 && message === ""}
+            onRightButtonPress={() => sendInquiry(message)}
           >
-            <Text variant="xs" color="white">
-              Sorry, we were unable to send this message. Please try again.
-            </Text>
-          </Flex>
-        )}
-        <ScrollView ref={scrollViewRef}>
-          <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
-          <Box px={2}>
-            <Box my={2}>
-              <Text variant="sm">What information are you looking for?</Text>
-              {artwork.inquiryQuestions?.map((inquiryQuestion) => {
-                if (!inquiryQuestion) {
-                  return false
-                }
-                const { internalID: id, question } = inquiryQuestion
-                return id === InquiryQuestionIDs.Shipping ? (
-                  <InquiryQuestionOption
-                    key={id}
-                    id={id}
-                    question={question}
-                    setShippingModalVisibility={setShippingModalVisibility}
-                  />
-                ) : (
-                  <InquiryQuestionOption key={id} id={id} question={question} />
-                )
-              })}
-            </Box>
-            <Box
-              mb={4}
-              onLayout={({ nativeEvent }) => {
-                setAddMessageYCoordinate(nativeEvent.layout.y)
-              }}
+            Contact Gallery
+          </FancyModalHeader>
+          {!!error && (
+            <Flex
+              bg="red100"
+              py={1}
+              alignItems="center"
+              position="absolute"
+              top={6}
+              width={1}
+              zIndex={5}
             >
-              <Input
-                multiline
-                placeholder="Add a custom note..."
-                title="Add message"
-                accessibilityLabel="Add message"
-                value={message ? message : ""}
-                onChangeText={setMessage}
-                onFocus={scrollToInput}
-                style={{ justifyContent: "flex-start" }}
-              />
-            </Box>
-            <Box flexDirection="row">
-              <InfoCircleIcon mr={0.5} style={{ marginTop: 2 }} />
-              <Box flex={1}>
-                <Text variant="xs" color="black60">
-                  By clicking send, we will share your profile with {artwork.partner?.name}. Update
-                  your profile at any time in{" "}
-                  <Text variant="xs" onPress={handleSettingsPress}>
-                    Settings
+              <Text variant="xs" color="white">
+                Sorry, we were unable to send this message. Please try again.
+              </Text>
+            </Flex>
+          )}
+          <ScrollView ref={scrollViewRef}>
+            <CollapsibleArtworkDetailsFragmentContainer artwork={artwork} />
+            <Box px={2}>
+              <Box my={2}>
+                <Text variant="sm">What information are you looking for?</Text>
+                {artwork.inquiryQuestions?.map((inquiryQuestion) => {
+                  if (!inquiryQuestion) {
+                    return false
+                  }
+                  const { internalID: id, question } = inquiryQuestion
+                  return id === InquiryQuestionIDs.Shipping ? (
+                    <InquiryQuestionOption
+                      key={id}
+                      id={id}
+                      question={question}
+                      setShippingModalVisibility={setShippingModalVisibility}
+                    />
+                  ) : (
+                    <InquiryQuestionOption key={id} id={id} question={question} />
+                  )
+                })}
+              </Box>
+              <Box
+                mb={4}
+                onLayout={({ nativeEvent }) => {
+                  setAddMessageYCoordinate(nativeEvent.layout.y)
+                }}
+              >
+                <Input
+                  multiline
+                  placeholder="Add a custom note..."
+                  title="Add message"
+                  accessibilityLabel="Add message"
+                  value={message ? message : ""}
+                  onChangeText={setMessage}
+                  onFocus={scrollToInput}
+                  style={{ justifyContent: "flex-start" }}
+                />
+              </Box>
+              <Box flexDirection="row">
+                <InfoCircleIcon mr={0.5} style={{ marginTop: 2 }} />
+                <Box flex={1}>
+                  <Text variant="xs" color="black60">
+                    By clicking send, we will share your profile with {artwork.partner?.name}.
+                    Update your profile at any time in{" "}
+                    <Text variant="xs" onPress={handleSettingsPress}>
+                      Settings
+                    </Text>
+                    .
                   </Text>
-                  .
-                </Text>
+                </Box>
               </Box>
             </Box>
-          </Box>
-        </ScrollView>
-        <ShippingModal
-          toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
-          modalIsVisible={shippingModalVisibility}
-          setLocation={selectShippingLocation}
-          location={state.shippingLocation}
-        />
-      </FancyModal>
+          </ScrollView>
+          <ShippingModal
+            toggleVisibility={() => setShippingModalVisibility(!shippingModalVisibility)}
+            modalIsVisible={shippingModalVisibility}
+            setLocation={selectShippingLocation}
+            location={state.shippingLocation}
+          />
+        </Screen>
+      </Modal>
       <InquirySuccessNotification />
 
       <CompleteProfilePrompt

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkCondition.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkCondition.tests.tsx
@@ -76,8 +76,7 @@ describe("SubmitArtworkCondition", () => {
     await screen.findByText("Fair")
     fireEvent.press(screen.getByText("Fair"))
 
-    // The value is going to be rendered twice because it's also available in the Select component
-    expect(screen.getAllByText("Fair")).toHaveLength(2)
+    expect(screen.getAllByText("Fair")).toHaveLength(1)
 
     fireEvent(screen.getByText("Add Additional Condition Details"), "onChangeText", "Pretty fair")
 

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkPurchaseHistory.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkPurchaseHistory.tests.tsx
@@ -4,7 +4,6 @@ import {
   SubmitArtworkPurchaseHistory,
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Components/SubmitArtworkPurchaseHistory"
 import { renderWithSubmitArtworkWrapper } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/testWrappers"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 
 describe("SubmitArtworkPurchaseHistory", () => {
   it("shows and updates properly the purchase infromation", async () => {
@@ -16,10 +15,8 @@ describe("SubmitArtworkPurchaseHistory", () => {
     expect(purchaseInformationSelect).toBeOnTheScreen()
 
     fireEvent.press(purchaseInformationSelect)
-    // Wait for the select modal to show up
-    await flushPromiseQueue()
 
     fireEvent.press(screen.getByText(PROVENANCE_LIST[0].label))
-    expect(screen.getAllByText(PROVENANCE_LIST[0].label)).toHaveLength(2)
+    expect(screen.getAllByText(PROVENANCE_LIST[0].label)).toHaveLength(1)
   })
 })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkPurchaseHistory.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkPurchaseHistory.tests.tsx
@@ -16,7 +16,16 @@ describe("SubmitArtworkPurchaseHistory", () => {
 
     fireEvent.press(purchaseInformationSelect)
 
-    fireEvent.press(screen.getByText(PROVENANCE_LIST[0].label))
-    expect(screen.getAllByText(PROVENANCE_LIST[0].label)).toHaveLength(1)
+    fireEvent.press(screen.getByText("Purchase information"))
+
+    // wait for modal to open
+    await screen.findByText(PROVENANCE_LIST[0].label)
+
+    // check if all options are visible
+    expect(screen.getByText(PROVENANCE_LIST[1].label)).toBeOnTheScreen()
+    expect(screen.getByText(PROVENANCE_LIST[2].label)).toBeOnTheScreen()
+    expect(screen.getByText(PROVENANCE_LIST[3].label)).toBeOnTheScreen()
+    expect(screen.getByText(PROVENANCE_LIST[4].label)).toBeOnTheScreen()
+    expect(screen.getByText(PROVENANCE_LIST[5].label)).toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkShippingLocation.tests.tsx
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Components/__tests__/SubmitArtworkShippingLocation.tests.tsx
@@ -63,8 +63,6 @@ describe("SubmitArtworkShippingLocation", () => {
 
     fireEvent.press(screen.getByText(COUNTRY_SELECT_OPTIONS[0].label as string))
 
-    expect(screen.getAllByText(COUNTRY_SELECT_OPTIONS[0].label as string)).toHaveLength(2)
-
     expect(screen.getByText("Address Line 1")).toBeOnTheScreen()
 
     expect(screen.getByText("Address Line 2")).toBeOnTheScreen()


### PR DESCRIPTION
This PR resolves [This notion card](https://www.notion.so/artsy/Android-Keyboard-aware-view-doesn-t-work-properly-on-modals-170cab0764a08048b6ffd281c95d00b9?pvs=4)
### Description

Makes Modals full screen by replacing `<FancyModal />` with `<Modal />` from `react-native`.

This solves the issue in android that we had with the keyboard avoiding view pushing the content outside of the screen that @MrSltun found during Sprintly Mobile QA Changes.  

#### Android

|Before|After|
|---|---|
|![androidcg](https://github.com/user-attachments/assets/728adf31-aa49-4cc7-b968-86161f551484)|![AndroidcontactGalleryAfter](https://github.com/user-attachments/assets/84c9bd53-86e6-45c8-90c1-0ec90ffb809f)|
|![androidCountry](https://github.com/user-attachments/assets/0e9baf14-552a-4453-89e5-722ff569e5b5)|![AndroidcountryAfter](https://github.com/user-attachments/assets/40f94892-ab27-4d59-ab98-190129874bb2)|


#### iOS

|Before|After|
|---|---|
|![CountryIOsBefore](https://github.com/user-attachments/assets/0b36dd3f-9b4d-4e25-99a5-d726172c1464)|![iosCountryAfter](https://github.com/user-attachments/assets/f28f44db-90b7-4408-bd6a-7acc4a860cb9)|
|![CGIOSB4](https://github.com/user-attachments/assets/10cd06e3-29dd-4177-b4f8-0b7771126ed3)|![iOSCGafter](https://github.com/user-attachments/assets/5e7257b2-6dad-437e-995b-6cfa8ec1547c)|



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
