### PR TITLE
feat: Long-press artwork context menu for Android

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -92,30 +92,30 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
         contextScreenOwnerSlug={contextScreenOwnerSlug}
         contextScreenOwnerType={contextScreenOwnerType}
       >
-        <ContextMenuArtwork
-          contextModule={contextModule}
-          contextScreenOwnerType={contextScreenOwnerType}
-          onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
-          onSupressArtwork={supressArtwork}
-          artwork={artwork}
-          artworkDisplayProps={{
-            dark,
-            showPartnerName,
-            hideArtistName,
-            lotLabel,
-            SalePriceComponent,
-          }}
-        >
-          <Box pr={2}>
-            <RouterLink
-              to={href || artwork.href}
-              underlayColor={backgroundColor}
-              activeOpacity={0.8}
-              onPress={onPress}
-              // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
-              onLongPress={() => {}}
-              delayLongPress={400}
-              testID={testID}
+        <Box pr={2}>
+          <RouterLink
+            to={href || artwork.href}
+            underlayColor={backgroundColor}
+            activeOpacity={0.8}
+            onPress={onPress}
+            // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
+            onLongPress={() => {}}
+            delayLongPress={400}
+            testID={testID}
+          >
+            <ContextMenuArtwork
+              contextModule={contextModule}
+              contextScreenOwnerType={contextScreenOwnerType}
+              onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
+              onSupressArtwork={supressArtwork}
+              artwork={artwork}
+              artworkDisplayProps={{
+                dark,
+                showPartnerName,
+                hideArtistName,
+                lotLabel,
+                SalePriceComponent,
+              }}
             >
               <Flex
                 height={
@@ -161,9 +161,9 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                   contextScreenOwnerType={contextScreenOwnerType}
                 />
               </Flex>
-            </RouterLink>
-          </Box>
-        </ContextMenuArtwork>
+            </ContextMenuArtwork>
+          </RouterLink>
+        </Box>
 
         <CreateArtworkAlertModal
           artwork={artwork}

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -230,6 +230,21 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     setAndroidVisible(true)
   }
 
+  if (isIOS && enableContextMenuIOS) {
+    return (
+      <ContextMenu
+        actions={contextActions}
+        onPress={handleContextPress}
+        onCancel={handleContextCancel}
+        preview={artworkPreviewComponent(artwork)}
+        hideShadows={true}
+        previewBackgroundColor={!!dark ? color("black100") : color("white100")}
+      >
+        {children}
+      </ContextMenu>
+    )
+  }
+
   // Fall back to a bottom sheet on Android
   if (!isIOS && enableContextMenuAndroid) {
     return (
@@ -273,22 +288,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     )
   }
 
-  if (!enableContextMenuIOS) {
-    return <>{children}</>
-  }
-
-  return (
-    <ContextMenu
-      actions={contextActions}
-      onPress={handleContextPress}
-      onCancel={handleContextCancel}
-      preview={artworkPreviewComponent(artwork)}
-      hideShadows={true}
-      previewBackgroundColor={!!dark ? color("black100") : color("white100")}
-    >
-      {children}
-    </ContextMenu>
-  )
+  return <>{children}</>
 }
 
 const artworkFragment = graphql`

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -14,7 +14,7 @@ import { useDislikeArtwork } from "app/utils/mutations/useDislikeArtwork"
 import { Schema } from "app/utils/track"
 import { isEmpty } from "lodash"
 import { useState } from "react"
-import { InteractionManager, Platform } from "react-native"
+import { InteractionManager, Platform, SafeAreaView } from "react-native"
 import ContextMenu, { ContextMenuAction, ContextMenuProps } from "react-native-context-menu-view"
 import { TouchableHighlight } from "react-native-gesture-handler"
 import { HapticFeedbackTypes, trigger } from "react-native-haptic-feedback"
@@ -259,30 +259,32 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
         </TouchableHighlight>
 
         <AutoHeightBottomSheet visible={androidVisible} onDismiss={() => setAndroidVisible(false)}>
-          <Flex pb={4} pt={1} mx={2} height="100%">
-            <Flex ml={-1} mb={1}>
-              {artworkPreviewComponent(artwork)}
+          <SafeAreaView>
+            <Flex mx={2} my={2}>
+              <Flex ml={-1} mb={1}>
+                {artworkPreviewComponent(artwork)}
+              </Flex>
+
+              <Join separator={<Separator borderColor="black10" my={1} />}>
+                {contextActions.map((action, index) => {
+                  return (
+                    <Touchable
+                      key={index}
+                      onPress={() => {
+                        setAndroidVisible(false)
+
+                        action.onPress?.()
+                      }}
+                    >
+                      <Box>
+                        <Text>{action.title}</Text>
+                      </Box>
+                    </Touchable>
+                  )
+                })}
+              </Join>
             </Flex>
-
-            <Join separator={<Separator borderColor="black10" my={1} />}>
-              {contextActions.map((action, index) => {
-                return (
-                  <Touchable
-                    key={index}
-                    onPress={() => {
-                      setAndroidVisible(false)
-
-                      action.onPress?.()
-                    }}
-                  >
-                    <Box>
-                      <Text>{action.title}</Text>
-                    </Box>
-                  </Touchable>
-                )
-              })}
-            </Join>
-          </Flex>
+          </SafeAreaView>
         </AutoHeightBottomSheet>
       </>
     )

--- a/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
+++ b/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import { ArtworkRailCardTestsQuery } from "__generated__/ArtworkRailCardTestsQuery.graphql"
+import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { Platform } from "react-native"
+import { graphql } from "react-relay"
+
+describe("ContextMenuArtwork", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkRailCardTestsQuery>({
+    Component: (props) => {
+      if (!props.artwork) return null
+
+      return <ArtworkRailCard {...props} artwork={props.artwork} testID="artwork-card" />
+    },
+    query: graphql`
+      query ContextMenuArtworkTestsQuery @relay_test_operation {
+        artwork(id: "the-artwork") {
+          ...ArtworkRailCard_artwork
+        }
+      }
+    `,
+  })
+
+  describe("on Android", () => {
+    beforeEach(() => {
+      Platform.OS = "android"
+
+      __globalStoreTestUtils__?.injectFeatureFlags({
+        AREnableArtworkCardContextMenuAndroid: true,
+      })
+    })
+
+    it("shows context menu on long press", async () => {
+      renderWithRelay()
+
+      const artworkCard = screen.getByTestId("artwork-card")
+
+      fireEvent(artworkCard, "onLongPress")
+
+      await waitFor(() => {
+        expect(screen.getByText("Create alert")).toBeOnTheScreen()
+      })
+      await waitFor(() => {
+        expect(screen.getByText("Share")).toBeOnTheScreen()
+      })
+    })
+
+    describe("when feature flag is disabled", () => {
+      beforeEach(() => {
+        __globalStoreTestUtils__?.injectFeatureFlags({
+          AREnableArtworkCardContextMenuAndroid: false,
+        })
+      })
+
+      it("does NOT show context menu on long press", async () => {
+        renderWithRelay()
+
+        const artworkCard = screen.getByTestId("artwork-card")
+
+        fireEvent(artworkCard, "onLongPress")
+
+        await waitFor(() => {
+          expect(screen.queryByText("Create alert")).not.toBeOnTheScreen()
+        })
+      })
+    })
+  })
+})

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -259,9 +259,9 @@ export const features = {
   },
   AREnableArtworkCardContextMenuAndroid: {
     description: "Enable long press menu on artwork cards for Android",
-    readyForRelease: true,
+    readyForRelease: false,
     showInDevMenu: true,
-    echoFlagKey: "AREnableArtworkCardContextMenuAndroid",
+    // echoFlagKey: "AREnableArtworkCardContextMenuAndroid",
   },
 } satisfies { [key: string]: FeatureDescriptor }
 

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -257,6 +257,12 @@ export const features = {
     readyForRelease: false,
     showInDevMenu: true,
   },
+  AREnableArtworkCardContextMenuAndroid: {
+    description: "Enable long press menu on artwork cards for Android",
+    readyForRelease: true,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableArtworkCardContextMenuAndroid",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [ONYX-1474] <!-- eg [PROJECT-XXXX] -->

### Description

This implements the Artwork card long-press context menu for Android using a bottom sheet.

* Feature Flag: `AREnableArtworkCardContextMenuAndroid`

### Screenshots

**Android**
|![Screenshot_1737974340](https://github.com/user-attachments/assets/ac13a78f-7f02-432c-84ba-90d2e4f7132f) | ![Screenshot_1737974335](https://github.com/user-attachments/assets/d91c0a8e-d32f-4f26-ba2a-f4e7cbe62d72) |
| --- | --- |
| | |







**iOS**
| ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-01-27 at 11 30 04](https://github.com/user-attachments/assets/191e44cf-bf2f-485d-a1fc-49439d33753e) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2025-01-27 at 11 24 37](https://github.com/user-attachments/assets/3e8c83c1-b912-47fa-b965-beeb3581b7f3) |
| --- | --- |
| | |





### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Artwork card long-press context menu for Android - ole

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1474]: https://artsyproduct.atlassian.net/browse/ONYX-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ