### PR TITLE
build(ci): build-test-js fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ commands:
             scripts/ci/generate-manifest.js .manifests/cocoapods '^ios/Podfile' '^Gemfile'
             scripts/ci/generate-manifest.js .manifests/native_code '^\.manifests/node_modules' '^ios/Podfile' '^Gemfile' '^dist/' '^ios/Artsy' '^patches/react-native' '^\.env\.example'
             scripts/ci/generate-manifest.js .manifests/android_native '^\.manifests/node_modules' '^android/' '^patches/react-native' '^\.env\.example'
-            scripts/ci/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^dist/'
   setup-env-file:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,7 @@ workflows:
 
       - test-js
 
-      # - build-test-js
+      - build-test-js
 
       - horizon/block:
           context: horizon
@@ -570,7 +570,7 @@ workflows:
           requires:
             - test-js
             - check-code
-            # - build-test-js
+            - build-test-js
             - horizon/block
 
       - build-test-app-android:
@@ -581,7 +581,7 @@ workflows:
           requires:
             - test-js
             - check-code
-            # - build-test-js
+            - build-test-js
             - horizon/block
 
       - update-metaphysics:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -551,7 +551,7 @@ workflows:
 
       - test-js
 
-      - build-test-js
+      # - build-test-js
 
       - horizon/block:
           context: horizon
@@ -570,7 +570,7 @@ workflows:
           requires:
             - test-js
             - check-code
-            - build-test-js
+            # - build-test-js
             - horizon/block
 
       - build-test-app-android:
@@ -581,7 +581,7 @@ workflows:
           requires:
             - test-js
             - check-code
-            - build-test-js
+            # - build-test-js
             - horizon/block
 
       - update-metaphysics:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
     steps:
       - node/install-packages:
           pkg-manager: yarn
-          cache-version: v10
+          cache-version: v12
   run-relay-compiler:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ commands:
             scripts/ci/generate-manifest.js .manifests/cocoapods '^ios/Podfile' '^Gemfile'
             scripts/ci/generate-manifest.js .manifests/native_code '^\.manifests/node_modules' '^ios/Podfile' '^Gemfile' '^dist/' '^ios/Artsy' '^patches/react-native' '^\.env\.example'
             scripts/ci/generate-manifest.js .manifests/android_native '^\.manifests/node_modules' '^android/' '^patches/react-native' '^\.env\.example'
+            scripts/ci/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^dist/'
   setup-env-file:
     steps:
       - run:
@@ -393,16 +394,6 @@ jobs:
               echo 'You forgot to run `yarn relay` before comitting'
               exit 1
             fi
-      - run:
-          name: Generate app_build manifest
-          command: ./scripts/ci/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^dist/'
-      - store_artifacts:
-          path: .manifests
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .manifests
-            - dist
 
   build-test-app-ios:
     environment:


### PR DESCRIPTION
### Description

WIP - trying to figure out whats wrong with build-test-js job and specifically with `scripts/ci/generate-manifest.js .manifests/app_build '^\./manifests/native_code' '^dist/'` generation.

As a first step I am adding it on the initial generation of manifests to see how it will behave

#nochangelog