### PR TITLE
chore: use bidder stored on sale for determining if credit card info or creating bidder info is required.

### DIFF
--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -981,8 +981,12 @@ describe("ConfirmBid", () => {
 
   const saleArtworkRegisteredForBidding: ConfirmBid_sale_artwork$data = {
     ...saleArtwork,
+    endAt: "2018-05-13T20:22:42+00:00",
+    extendedBiddingEndAt: null,
     sale: {
       ...baseSaleArtwork.sale,
+      live_start_at: null,
+      cascadingEndTimeIntervalMinutes: null,
       bidder: {
         id: "1234567",
       },

--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -595,6 +595,7 @@ describe("ConfirmBid", () => {
                 partner: {
                   name: "Christie's",
                 },
+                bidder: null,
                 slug: "best-art-sale-in-town",
               },
             },
@@ -978,6 +979,16 @@ describe("ConfirmBid", () => {
     },
   }
 
+  const saleArtworkRegisteredForBidding: ConfirmBid_sale_artwork$data = {
+    ...saleArtwork,
+    sale: {
+      ...baseSaleArtwork.sale,
+      bidder: {
+        id: "1234567",
+      },
+    },
+  }
+
   const mockRequestResponses = {
     updateMyUserProfile: {
       updateMyUserProfile: {
@@ -1135,7 +1146,6 @@ describe("ConfirmBid", () => {
     },
     me: {
       has_qualified_credit_cards: true,
-      bidders: null,
     },
     navigator: mockNavigator,
   } as any
@@ -1149,9 +1159,7 @@ describe("ConfirmBid", () => {
 
   const initialPropsForRegisteredUser = {
     ...initialProps,
-    me: {
-      bidders: [{ qualified_for_bidding: true }],
-    },
+    sale_artwork: saleArtworkRegisteredForBidding,
   } as any
 
   const initialPropsForCascadingSale = {

--- a/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid.tests.tsx
@@ -935,6 +935,7 @@ describe("ConfirmBid", () => {
       partner: {
         name: "Christie's",
       },
+      bidder: null,
     },
     lot_label: "538",
   }

--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -76,10 +76,10 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     super(props)
 
     const { has_qualified_credit_cards } = this.props.me
-    const { bidder } = this.props.sale_artwork.sale
+    const bidder = this.props.sale_artwork?.sale?.bidder
     const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-      bidder,
-      has_qualified_credit_cards
+      !!bidder,
+      !!has_qualified_credit_cards
     )
 
     this.state = {
@@ -362,11 +362,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
           console.error("ConfirmBid.tsx", error.message)
         }
         const { has_qualified_credit_cards } = this.props.me
-        const { bidder } = this.props.sale_artwork.sale
+        const bidder = this.props.sale_artwork?.sale?.bidder
 
         const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-          bidder,
-          has_qualified_credit_cards
+          !!bidder,
+          !!has_qualified_credit_cards
         )
         this.setState({ requiresCheckbox, requiresPaymentInformation })
       },
@@ -620,10 +620,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     return this.props.increments[this.state.selectedBidIndex]
   }
 
-  private determineDisplayRequirements(bidder, hasQualifiedCreditCards: boolean) {
-    const isRegistered = !!bidder
-    const requiresCheckbox = !isRegistered
-    const requiresPaymentInformation = !(isRegistered || hasQualifiedCreditCards)
+  private determineDisplayRequirements(hasBidder: boolean, hasQualifiedCreditCards: boolean) {
+    const requiresCheckbox = !hasBidder
+    const requiresPaymentInformation = !(hasBidder || hasQualifiedCreditCards)
     return { requiresCheckbox, requiresPaymentInformation }
   }
 }

--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -75,12 +75,19 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   constructor(props: ConfirmBidProps) {
     super(props)
 
+    console.log("HERE HERE HERE!!!!")
+    console.log(props.sale_artwork.sale.bidder)
+    console.log("-------------------------")
+
     const { bidders, has_qualified_credit_cards } = this.props.me
     const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
+      props.sale_artwork.sale.bidder,
       // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
       bidders,
       has_qualified_credit_cards
     )
+
+    console.log(requiresPaymentInformation)
 
     this.state = {
       // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -362,7 +369,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
           console.error("ConfirmBid.tsx", error.message)
         }
         const { bidders, has_qualified_credit_cards } = this.props.me
+        console.log("XXXXXXXXXXXXXXXXXXXXX")
+        console.log(this.props)
+        console.log("-------------------------")
         const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
+          null,
           // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
           bidders,
           has_qualified_credit_cards
@@ -620,10 +631,16 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   }
 
   private determineDisplayRequirements(
+    bidder,
     bidders: ReadonlyArray<any>,
     hasQualifiedCreditCards: boolean
   ) {
-    const isRegistered = bidders && bidders.length > 0
+    console.log("INSIDE >>>>>>>>>>>>>>>> !!!!")
+    console.log(bidder)
+    console.log(hasQualifiedCreditCards)
+    console.log("-------------------------")
+
+    const isRegistered = !!bidder
     const requiresCheckbox = !isRegistered
     const requiresPaymentInformation = !(isRegistered || hasQualifiedCreditCards)
     return { requiresCheckbox, requiresPaymentInformation }
@@ -646,6 +663,9 @@ export const ConfirmBidScreen = createRefetchContainer(
           cascadingEndTimeIntervalMinutes
           partner {
             name
+          }
+          bidder {
+            id
           }
         }
         artwork {

--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -75,19 +75,12 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
   constructor(props: ConfirmBidProps) {
     super(props)
 
-    console.log("HERE HERE HERE!!!!")
-    console.log(props.sale_artwork.sale.bidder)
-    console.log("-------------------------")
-
-    const { bidders, has_qualified_credit_cards } = this.props.me
+    const { has_qualified_credit_cards } = this.props.me
+    const { bidder } = this.props.sale_artwork.sale
     const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-      props.sale_artwork.sale.bidder,
-      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-      bidders,
+      bidder,
       has_qualified_credit_cards
     )
-
-    console.log(requiresPaymentInformation)
 
     this.state = {
       // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
@@ -368,14 +361,11 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         if (error) {
           console.error("ConfirmBid.tsx", error.message)
         }
-        const { bidders, has_qualified_credit_cards } = this.props.me
-        console.log("XXXXXXXXXXXXXXXXXXXXX")
-        console.log(this.props)
-        console.log("-------------------------")
+        const { has_qualified_credit_cards } = this.props.me
+        const { bidder } = this.props.sale_artwork.sale
+
         const { requiresCheckbox, requiresPaymentInformation } = this.determineDisplayRequirements(
-          null,
-          // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-          bidders,
+          bidder,
           has_qualified_credit_cards
         )
         this.setState({ requiresCheckbox, requiresPaymentInformation })
@@ -630,16 +620,7 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
     return this.props.increments[this.state.selectedBidIndex]
   }
 
-  private determineDisplayRequirements(
-    bidder,
-    bidders: ReadonlyArray<any>,
-    hasQualifiedCreditCards: boolean
-  ) {
-    console.log("INSIDE >>>>>>>>>>>>>>>> !!!!")
-    console.log(bidder)
-    console.log(hasQualifiedCreditCards)
-    console.log("-------------------------")
-
+  private determineDisplayRequirements(bidder, hasQualifiedCreditCards: boolean) {
     const isRegistered = !!bidder
     const requiresCheckbox = !isRegistered
     const requiresPaymentInformation = !(isRegistered || hasQualifiedCreditCards)
@@ -686,19 +667,13 @@ export const ConfirmBidScreen = createRefetchContainer(
     me: graphql`
       fragment ConfirmBid_me on Me {
         has_qualified_credit_cards: hasQualifiedCreditCards
-        bidders(saleID: $saleID) {
-          id
-        }
       }
     `,
   },
   graphql`
-    query ConfirmBidRefetchQuery($saleID: String!) {
+    query ConfirmBidRefetchQuery {
       me {
         has_qualified_credit_cards: hasQualifiedCreditCards
-        bidders(saleID: $saleID) {
-          id
-        }
       }
     }
   `

--- a/src/app/Components/Bidding/Screens/SelectMaxBid.tests.tsx
+++ b/src/app/Components/Bidding/Screens/SelectMaxBid.tests.tsx
@@ -10,7 +10,7 @@ describe("SelectMaxBid", () => {
       <SelectMaxBidContainer me={me!} sale_artwork={sale_artwork!} navigator={null!} />
     ),
     query: graphql`
-      query SelectMaxBidTestsQuery($saleID: String!) @relay_test_operation {
+      query SelectMaxBidTestsQuery @relay_test_operation {
         sale_artwork: saleArtwork(id: "wow") {
           ...SelectMaxBid_sale_artwork
         }


### PR DESCRIPTION
This PR comes from investigating https://artsyproduct.atlassian.net/browse/EMI-2224. The issue described there is not exactly the same but in a process discovered the bug where user is required to reenter the credit card after their bid has been outbid right away

### Description

Following the pattern currently present in Force and reading the bidding info from sale on sale_artwork. Seems like there authenticatedUser is automatically applied to the data returns properly.

#### iOS
| Popover | Message |
| --- | --- |
| ![bidding_old](https://github.com/user-attachments/assets/918e4707-1800-425c-aaeb-bda6ec5499b8)  |  ![bidding](https://github.com/user-attachments/assets/283643ee-a912-48b9-aa18-8a04c5428434) |


### PR Checklist

- [ x ] I have tested my changes on **iOS** and **Android**.
- [ x ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ x ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ x ] I have added **tests**, or my changes don't require any.
- [ x ] I added an **[app state migration]**, or my changes do not require one.
- [ x ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ x ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use bidder status from sale instead of me when determining bidder registration when bidding

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
