### PR TITLE
chore: deprecate FancyModal

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -412,7 +412,7 @@
         "filename": "src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx",
         "hashed_secret": "4d32797fc3625cc2a1608f59fdbc5b378caed77b",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 150
       }
     ],
     "src/app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow.tests.tsx": [
@@ -1134,5 +1134,5 @@
       }
     ]
   },
-  "generated_at": "2024-12-04T19:56:20Z"
+  "generated_at": "2025-01-10T17:13:48Z"
 }

--- a/src/app/Components/AbandonFlowModal.tsx
+++ b/src/app/Components/AbandonFlowModal.tsx
@@ -1,7 +1,8 @@
-import { CloseIcon, Spacer, Box, Text, Button } from "@artsy/palette-mobile"
+import { Box, Button, CloseIcon, Spacer, Text } from "@artsy/palette-mobile"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { popToRoot } from "app/system/navigation/navigate"
-import { FancyModal } from "./FancyModal/FancyModal"
+import { Modal } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 
 interface AbandonFlowModalProps {
   isVisible: boolean
@@ -23,39 +24,41 @@ export const AbandonFlowModal: React.FC<AbandonFlowModalProps> = ({
   onLeave,
 }) => {
   return (
-    <FancyModal visible={isVisible}>
-      <NavigationHeader
-        hideBottomDivider
-        renderRightButton={() => <CloseIcon width={26} height={26} />}
-        onRightButtonPress={onDismiss}
-      />
-      <Box px={2}>
-        <Text variant="lg-display" mb={2}>
-          {title}
-        </Text>
-        <Text variant="sm-display" mb={4}>
-          {subtitle}
-        </Text>
-        <Button
-          onPress={() => {
-            if (onLeave) {
-              onLeave()
-              return
-            }
-            // not sure why we pop to root instead of just going back here
-            popToRoot()
-          }}
-          block
-          variant="fillDark"
-          size="large"
-        >
-          {leaveButtonTitle}
-        </Button>
-        <Spacer y={1} />
-        <Button onPress={onDismiss} block variant="outline" size="large">
-          {continueButtonTitle}
-        </Button>
-      </Box>
-    </FancyModal>
+    <Modal visible={isVisible} presentationStyle="pageSheet" animationType="slide">
+      <SafeAreaView>
+        <NavigationHeader
+          hideBottomDivider
+          renderRightButton={() => <CloseIcon width={26} height={26} />}
+          onRightButtonPress={onDismiss}
+        />
+        <Box px={2}>
+          <Text variant="lg-display" mb={2}>
+            {title}
+          </Text>
+          <Text variant="sm-display" mb={4}>
+            {subtitle}
+          </Text>
+          <Button
+            onPress={() => {
+              if (onLeave) {
+                onLeave()
+                return
+              }
+              // not sure why we pop to root instead of just going back here
+              popToRoot()
+            }}
+            block
+            variant="fillDark"
+            size="large"
+          >
+            {leaveButtonTitle}
+          </Button>
+          <Spacer y={1} />
+          <Button onPress={onDismiss} block variant="outline" size="large">
+            {continueButtonTitle}
+          </Button>
+        </Box>
+      </SafeAreaView>
+    </Modal>
   )
 }

--- a/src/app/Components/AbandonFlowModal.tsx
+++ b/src/app/Components/AbandonFlowModal.tsx
@@ -1,7 +1,7 @@
 import { CloseIcon, Spacer, Box, Text, Button } from "@artsy/palette-mobile"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { popToRoot } from "app/system/navigation/navigate"
 import { FancyModal } from "./FancyModal/FancyModal"
-import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
 
 interface AbandonFlowModalProps {
   isVisible: boolean
@@ -24,7 +24,7 @@ export const AbandonFlowModal: React.FC<AbandonFlowModalProps> = ({
 }) => {
   return (
     <FancyModal visible={isVisible}>
-      <FancyModalHeader
+      <NavigationHeader
         hideBottomDivider
         renderRightButton={() => <CloseIcon width={26} height={26} />}
         onRightButtonPress={onDismiss}

--- a/src/app/Components/ArtsyWebView.tests.tsx
+++ b/src/app/Components/ArtsyWebView.tests.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { appJson } from "app/utils/jsonFiles"
@@ -89,14 +89,14 @@ describe("ArtsyWebViewPage", () => {
 
   it(`renders a back button normally`, () => {
     render()
-    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeFalse()
-    expect(screen.UNSAFE_getByType(FancyModalHeader).props.onLeftButtonPress).not.toBeUndefined()
+    expect(screen.UNSAFE_getByType(NavigationHeader).props.useXButton).toBeFalse()
+    expect(screen.UNSAFE_getByType(NavigationHeader).props.onLeftButtonPress).not.toBeUndefined()
   })
 
   it("renders a close button when presented modally", () => {
     render({ isPresentedModally: true })
-    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeTrue()
-    expect(screen.UNSAFE_getByType(FancyModalHeader).props.onLeftButtonPress).not.toBeUndefined()
+    expect(screen.UNSAFE_getByType(NavigationHeader).props.useXButton).toBeTrue()
+    expect(screen.UNSAFE_getByType(NavigationHeader).props.onLeftButtonPress).not.toBeUndefined()
   })
 
   it("renders a back button when presented modally and internal navigation is has happened", () => {
@@ -105,7 +105,7 @@ describe("ArtsyWebViewPage", () => {
       ...mockOnNavigationStateChange,
       canGoBack: true,
     })
-    expect(screen.UNSAFE_getByType(FancyModalHeader).props.useXButton).toBeFalsy()
+    expect(screen.UNSAFE_getByType(NavigationHeader).props.useXButton).toBeFalsy()
   })
 
   it("shares the correct URL", () => {

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -20,7 +20,7 @@ import { Edge } from "react-native-safe-area-context"
 import Share from "react-native-share"
 import WebView, { WebViewNavigation, WebViewProps } from "react-native-webview"
 import { useTracking } from "react-tracking"
-import { FancyModalHeader } from "./FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 
 export interface ArtsyWebViewConfig {
   title?: string
@@ -132,7 +132,7 @@ export const ArtsyWebViewPage = ({
     <Screen>
       <Flex flex={1} backgroundColor="white">
         <ArtsyKeyboardAvoidingView>
-          <FancyModalHeader
+          <NavigationHeader
             useXButton={!!isPresentedModally && !canGoBack}
             onLeftButtonPress={leftButton}
             useShareButton={showShareButton}
@@ -142,7 +142,7 @@ export const ArtsyWebViewPage = ({
             }
           >
             {title}
-          </FancyModalHeader>
+          </NavigationHeader>
           <ArtsyWebView
             url={url}
             ref={ref}

--- a/src/app/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/SingleSelectOption.tsx
@@ -3,13 +3,13 @@ import { ParamListBase } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { FilterData } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFilterBackHeader } from "app/Components/ArtworkFilter/components/ArtworkFilterBackHeader"
-import { FancyModalHeaderProps } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeaderProps } from "app/Components/NavigationHeader"
 import { TouchableRow } from "app/Components/TouchableRow"
 import React, { Fragment } from "react"
 import { FlatList, ScrollView } from "react-native"
 import styled from "styled-components/native"
 
-interface SingleSelectOptionScreenProps extends FancyModalHeaderProps {
+interface SingleSelectOptionScreenProps extends NavigationHeaderProps {
   navigation: StackNavigationProp<ParamListBase>
   filterHeaderText: string
   selectedOption: FilterData

--- a/src/app/Components/Bidding/Screens/BidResult.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tsx
@@ -6,7 +6,7 @@ import { Timer } from "app/Components/Bidding/Components/Timer"
 import { Title } from "app/Components/Bidding/Components/Title"
 import { Flex } from "app/Components/Bidding/Elements/Flex"
 import { BidderPositionResult } from "app/Components/Bidding/types"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Markdown } from "app/Components/Markdown"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { dismissModal, navigate } from "app/system/navigation/navigate"
@@ -95,7 +95,7 @@ export class BidResult extends React.Component<BidResultProps> {
 
     return (
       <View style={{ flex: 1 }}>
-        <FancyModalHeader useXButton onLeftButtonPress={() => dismissModal()} />
+        <NavigationHeader useXButton onLeftButtonPress={() => dismissModal()} />
         <Container mt={6}>
           <View>
             <Flex alignItems="center">

--- a/src/app/Components/Bidding/Screens/BillingAddress.tsx
+++ b/src/app/Components/Bidding/Screens/BillingAddress.tsx
@@ -3,7 +3,7 @@ import { findCountryNameByCountryCode } from "app/Components/Bidding/Utils/findC
 import { validateAddressFieldsPresence } from "app/Components/Bidding/Validators/validateAddressFieldsPresence"
 import { Address } from "app/Components/Bidding/types"
 import { CountrySelect } from "app/Components/CountrySelect"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Stack } from "app/Components/Stack"
 import { ArtsyKeyboardAvoidingView } from "app/utils/ArtsyKeyboardAvoidingView"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
@@ -101,9 +101,9 @@ export const BillingAddress: React.FC<BillingAddressProps> = ({
 
   return (
     <ArtsyKeyboardAvoidingView>
-      <FancyModalHeader onLeftButtonPress={() => navigator?.pop()}>
+      <NavigationHeader onLeftButtonPress={() => navigator?.pop()}>
         Add billing address
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView
         ref={scrollViewRef}
         contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 50 }}

--- a/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
+++ b/src/app/Components/Bidding/Screens/ConfirmBid/index.tsx
@@ -15,7 +15,7 @@ import { BidResultScreen } from "app/Components/Bidding/Screens/BidResult"
 import { bidderPositionQuery } from "app/Components/Bidding/Screens/ConfirmBid/BidderPositionQuery"
 import { PriceSummary } from "app/Components/Bidding/Screens/ConfirmBid/PriceSummary"
 import { Address, Bid, PaymentCardTextFieldParams } from "app/Components/Bidding/types"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { partnerName } from "app/Scenes/Artwork/Components/ArtworkExtraLinks/partnerName"
@@ -470,9 +470,9 @@ export class ConfirmBid extends React.Component<ConfirmBidProps, ConfirmBidState
         }}
       >
         <Flex m={0} flex={1} flexDirection="column">
-          <FancyModalHeader onLeftButtonPress={() => this.props.navigator?.pop()}>
+          <NavigationHeader onLeftButtonPress={() => this.props.navigator?.pop()}>
             Confirm your bid
-          </FancyModalHeader>
+          </NavigationHeader>
           <ScrollView scrollEnabled>
             <Flex alignItems="center" pt={2}>
               <Timer

--- a/src/app/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/app/Components/Bidding/Screens/CreditCardForm.tsx
@@ -20,7 +20,7 @@ import { creditCardFormValidationSchema } from "app/Components/Bidding/Validator
 import { Address } from "app/Components/Bidding/types"
 import { CountrySelect } from "app/Components/CountrySelect"
 import { CreditCardField } from "app/Components/CreditCardField/CreditCardField"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Select } from "app/Components/Select/SelectV2"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import { useFormik } from "formik"
@@ -111,7 +111,7 @@ export const CreditCardForm: React.FC<CreditCardFormProps> = ({
 
   return (
     <ArtsyKeyboardAvoidingView>
-      <FancyModalHeader onLeftButtonPress={() => navigator.pop()}>Add Credit Card</FancyModalHeader>
+      <NavigationHeader onLeftButtonPress={() => navigator.pop()}>Add Credit Card</NavigationHeader>
 
       <ScrollView
         contentContainerStyle={{ padding: space(2), paddingBottom: space(4) }}

--- a/src/app/Components/Bidding/Screens/PhoneNumberForm.tsx
+++ b/src/app/Components/Bidding/Screens/PhoneNumberForm.tsx
@@ -1,6 +1,6 @@
 import { Box, Button } from "@artsy/palette-mobile"
 import { BottomAlignedButtonWrapper } from "app/Components/Buttons/BottomAlignedButtonWrapper"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Input } from "app/Components/Input"
 import { PhoneInput } from "app/Components/Input/PhoneInput"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
@@ -58,9 +58,9 @@ export const PhoneNumberForm: React.FC<PhoneNumberFormProps> = (props) => {
       }}
     >
       <BottomAlignedButtonWrapper buttonComponent={buttonComponent}>
-        <FancyModalHeader onLeftButtonPress={() => navigator?.pop()}>
+        <NavigationHeader onLeftButtonPress={() => navigator?.pop()}>
           Add phone number
-        </FancyModalHeader>
+        </NavigationHeader>
         <ScrollView
           scrollEnabled={false}
           contentContainerStyle={{ marginHorizontal: 20, marginTop: 10 }}

--- a/src/app/Components/Bidding/Screens/Registration.tsx
+++ b/src/app/Components/Bidding/Screens/Registration.tsx
@@ -13,7 +13,7 @@ import { Registration_sale$data } from "__generated__/Registration_sale.graphql"
 import { PaymentInfo } from "app/Components/Bidding/Components/PaymentInfo"
 import { PhoneInfo } from "app/Components/Bidding/Components/PhoneInfo"
 import { Address, PaymentCardTextFieldParams } from "app/Components/Bidding/types"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Modal } from "app/Components/Modal"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { dismissModal, navigate } from "app/system/navigation/navigate"
@@ -527,7 +527,7 @@ export const RegistrationQueryRenderer: React.FC<{ saleID: string; navigator: Na
 }) => {
   return (
     <View style={{ flex: 1 }}>
-      <FancyModalHeader
+      <NavigationHeader
         onLeftButtonPress={() => {
           Alert.alert("Are you sure you want to leave?", "", [
             {
@@ -545,7 +545,7 @@ export const RegistrationQueryRenderer: React.FC<{ saleID: string; navigator: Na
         useXButton
       >
         Register to bid
-      </FancyModalHeader>
+      </NavigationHeader>
       <QueryRenderer<RegistrationQuery>
         environment={getRelayEnvironment()}
         query={graphql`

--- a/src/app/Components/Bidding/Screens/RegistrationResult.tsx
+++ b/src/app/Components/Bidding/Screens/RegistrationResult.tsx
@@ -2,7 +2,7 @@ import { Text, Button } from "@artsy/palette-mobile"
 import { Icon20 } from "app/Components/Bidding/Components/Icon"
 import { Title } from "app/Components/Bidding/Components/Title"
 import { Flex } from "app/Components/Bidding/Elements/Flex"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Markdown } from "app/Components/Markdown"
 import { dismissModal } from "app/system/navigation/navigate"
 import { defaultRules } from "app/utils/renderMarkdown"
@@ -159,7 +159,7 @@ export class RegistrationResult extends React.Component<RegistrationResultProps>
 
     return (
       <View style={{ flex: 1 }}>
-        <FancyModalHeader useXButton onLeftButtonPress={() => dismissModal()} />
+        <NavigationHeader useXButton onLeftButtonPress={() => dismissModal()} />
         <View style={{ padding: 20 }}>
           <Flex alignItems="center">
             {status !== RegistrationStatus.RegistrationStatusPending && (

--- a/src/app/Components/Bidding/Screens/SelectMaxBid.tsx
+++ b/src/app/Components/Bidding/Screens/SelectMaxBid.tsx
@@ -2,7 +2,7 @@ import { Flex, Button } from "@artsy/palette-mobile"
 import { SelectMaxBidQuery } from "__generated__/SelectMaxBidQuery.graphql"
 import { SelectMaxBid_me$data } from "__generated__/SelectMaxBid_me.graphql"
 import { SelectMaxBid_sale_artwork$data } from "__generated__/SelectMaxBid_sale_artwork.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Select } from "app/Components/Select"
 import { dismissModal } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -134,9 +134,9 @@ export const SelectMaxBidQueryRenderer: React.FC<{
   // TODO: artworkID can be nil, so omit that part of the query if it is.
   return (
     <Flex flex={1}>
-      <FancyModalHeader useXButton onLeftButtonPress={() => dismissModal()}>
+      <NavigationHeader useXButton onLeftButtonPress={() => dismissModal()}>
         Place a max bid
-      </FancyModalHeader>
+      </NavigationHeader>
       <QueryRenderer<SelectMaxBidQuery>
         environment={getRelayEnvironment()}
         query={graphql`

--- a/src/app/Components/FancyModal/FancyModal.tsx
+++ b/src/app/Components/FancyModal/FancyModal.tsx
@@ -13,6 +13,11 @@ import {
 } from "./FancyModalCard"
 import { FancyModalContext } from "./FancyModalContext"
 
+/**
+ *
+ * @deprecated use RN Modal instead
+ *
+ */
 export const FancyModal: React.FC<{
   visible: boolean
   maxHeight?: number

--- a/src/app/Components/NavigationHeader.tsx
+++ b/src/app/Components/NavigationHeader.tsx
@@ -13,7 +13,7 @@ import { ResponsiveAlignItemsValue } from "app/Components/Bidding/Elements/types
 import { TouchableOpacity } from "react-native"
 import styled from "styled-components/native"
 
-export interface FancyModalHeaderProps {
+export interface NavigationHeaderProps {
   hideBottomDivider?: boolean
   leftButtonText?: string
   onLeftButtonPress?: () => void
@@ -28,9 +28,7 @@ export interface FancyModalHeaderProps {
   alignItems?: ResponsiveAlignItemsValue
 }
 
-// Beware: If you're using this in the context of a non fancy modal,
-// it might break the behaviour of ArtsyKeyboardAvoidingView
-export const FancyModalHeader: React.FC<FancyModalHeaderProps> = ({
+export const NavigationHeader: React.FC<NavigationHeaderProps> = ({
   children,
   hideBottomDivider = false,
   leftButtonText,

--- a/src/app/Components/ShareSheet/ShareSheet.tsx
+++ b/src/app/Components/ShareSheet/ShareSheet.tsx
@@ -17,7 +17,7 @@ import {
 import Clipboard from "@react-native-clipboard/clipboard"
 import Sentry, { captureException, captureMessage } from "@sentry/react-native"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
 import { CustomShareSheetItem } from "app/Components/ShareSheet/ShareSheetItem"
 import { getShareImages, shareContent } from "app/Components/ShareSheet/helpers"
@@ -165,9 +165,9 @@ export const ShareSheet = () => {
       visible={isVisible}
       onBackgroundPressed={() => hideShareSheet()}
     >
-      <FancyModalHeader useXButton onLeftButtonPress={() => hideShareSheet()}>
+      <NavigationHeader useXButton onLeftButtonPress={() => hideShareSheet()}>
         Share
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView>
         {data.type !== "sale" && data.type !== "default" && (
           <InstagramStoryViewShot

--- a/src/app/Components/ShareSheet/ShareSheet.tsx
+++ b/src/app/Components/ShareSheet/ShareSheet.tsx
@@ -11,22 +11,22 @@ import {
   LinkIcon,
   MoreIcon,
   ShareIcon,
-  useScreenDimensions,
   WhatsAppAppIcon,
 } from "@artsy/palette-mobile"
+import { BottomSheetScrollView, BottomSheetView } from "@gorhom/bottom-sheet"
 import Clipboard from "@react-native-clipboard/clipboard"
 import Sentry, { captureException, captureMessage } from "@sentry/react-native"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
+import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
 import { CustomShareSheetItem } from "app/Components/ShareSheet/ShareSheetItem"
 import { getShareImages, shareContent } from "app/Components/ShareSheet/helpers"
 import { useToast } from "app/Components/Toast/toastHook"
 import { InstagramStoryViewShot } from "app/Scenes/Artwork/Components/InstagramStoryViewShot"
+import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useCanOpenURL } from "app/utils/useCanOpenURL"
 import { useRef } from "react"
-import { ScrollView } from "react-native"
 import Config from "react-native-config"
 import Share, { Social } from "react-native-share"
 import ViewShot from "react-native-view-shot"
@@ -36,7 +36,6 @@ export const ShareSheet = () => {
   const { isVisible, item: data, hideShareSheet } = useShareSheet()
   const isArtwork = data?.type === "artwork"
   const showWhatsAppItem = useCanOpenURL("whatsapp://send?phone=+491898")
-  const { height: screenHeight } = useScreenDimensions()
   const toast = useToast()
   const shotRef = useRef<ViewShot>(null)
   const showInstagramStoriesItem =
@@ -160,43 +159,46 @@ export const ShareSheet = () => {
   }
 
   return (
-    <FancyModal
-      maxHeight={screenHeight / 2}
+    <AutomountedBottomSheetModal
       visible={isVisible}
-      onBackgroundPressed={() => hideShareSheet()}
+      onDismiss={hideShareSheet}
+      enableDynamicSizing
+      snapPoints={SNAP_POINTS}
     >
-      <NavigationHeader useXButton onLeftButtonPress={() => hideShareSheet()}>
-        Share
-      </NavigationHeader>
-      <ScrollView>
-        {data.type !== "sale" && data.type !== "default" && (
-          <InstagramStoryViewShot
-            shotRef={shotRef}
-            href={currentImageUrl}
-            artist={data.artists?.[0]?.name ?? ""}
-            title={data?.title}
-          />
-        )}
+      <BottomSheetView style={{ flex: 1 }}>
+        <NavigationHeader useXButton onLeftButtonPress={() => hideShareSheet()}>
+          Share
+        </NavigationHeader>
+        <BottomSheetScrollView>
+          {data.type !== "sale" && data.type !== "default" && (
+            <InstagramStoryViewShot
+              shotRef={shotRef}
+              href={currentImageUrl}
+              artist={data.artists?.[0]?.name ?? ""}
+              title={data?.title}
+            />
+          )}
 
-        {!!showWhatsAppItem && (
-          <CustomShareSheetItem
-            title="WhatsApp"
-            Icon={<WhatsAppAppIcon />}
-            onPress={shareOnWhatsApp}
-          />
-        )}
-        {!!showInstagramStoriesItem && (
-          <CustomShareSheetItem
-            title="Instagram Stories"
-            Icon={<InstagramAppIcon />}
-            onPress={shareOnInstagramStory}
-          />
-        )}
+          {!!showWhatsAppItem && (
+            <CustomShareSheetItem
+              title="WhatsApp"
+              Icon={<WhatsAppAppIcon />}
+              onPress={shareOnWhatsApp}
+            />
+          )}
+          {!!showInstagramStoriesItem && (
+            <CustomShareSheetItem
+              title="Instagram Stories"
+              Icon={<InstagramAppIcon />}
+              onPress={shareOnInstagramStory}
+            />
+          )}
 
-        <CustomShareSheetItem title="Copy link" Icon={<LinkIcon />} onPress={handleCopyLink} />
-        <CustomShareSheetItem title="More" Icon={<MoreIcon />} onPress={handleMorePress} />
-      </ScrollView>
-    </FancyModal>
+          <CustomShareSheetItem title="Copy link" Icon={<LinkIcon />} onPress={handleCopyLink} />
+          <CustomShareSheetItem title="More" Icon={<MoreIcon />} onPress={handleMorePress} />
+        </BottomSheetScrollView>
+      </BottomSheetView>
+    </AutomountedBottomSheetModal>
   )
 }
 

--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text, RadioDot } from "@artsy/palette-mobile"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { TouchableRow } from "app/Components/TouchableRow"
 
 export interface SortOption {
@@ -28,9 +28,9 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
       onBackgroundPressed={onCloseModal}
       onModalFinishedClosing={onModalFinishedClosing}
     >
-      <FancyModalHeader useXButton onLeftButtonPress={onCloseModal}>
+      <NavigationHeader useXButton onLeftButtonPress={onCloseModal}>
         Sort By
-      </FancyModalHeader>
+      </NavigationHeader>
       {options.map((option) => {
         const selected = selectedValue === option.value
 

--- a/src/app/Components/SortByModal/SortByModal.tsx
+++ b/src/app/Components/SortByModal/SortByModal.tsx
@@ -1,7 +1,7 @@
-import { Flex, Text, RadioDot } from "@artsy/palette-mobile"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
+import { Flex, RadioDot, Text } from "@artsy/palette-mobile"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { TouchableRow } from "app/Components/TouchableRow"
+import { Modal } from "react-native"
 
 export interface SortOption {
   value: string
@@ -22,33 +22,36 @@ export const SortByModal: React.FC<SortByModalProps> = (props) => {
     props
 
   return (
-    <FancyModal
+    <Modal
       visible={visible}
-      maxHeight={250}
-      onBackgroundPressed={onCloseModal}
-      onModalFinishedClosing={onModalFinishedClosing}
+      onRequestClose={onCloseModal}
+      onDismiss={onModalFinishedClosing}
+      presentationStyle="pageSheet"
+      animationType="slide"
     >
-      <NavigationHeader useXButton onLeftButtonPress={onCloseModal}>
-        Sort By
-      </NavigationHeader>
-      {options.map((option) => {
-        const selected = selectedValue === option.value
+      <Flex height={250} width="100%">
+        <NavigationHeader useXButton onLeftButtonPress={onCloseModal}>
+          Sort By
+        </NavigationHeader>
+        {options.map((option) => {
+          const selected = selectedValue === option.value
 
-        return (
-          <TouchableRow
-            accessibilityState={{ selected }}
-            key={option.value}
-            onPress={() => onSelectOption(option)}
-          >
-            <Flex flexDirection="row" p={2} alignItems="center" justifyContent="space-between">
-              <Flex flex={1} mr={1}>
-                <Text numberOfLines={2}>{option.text}</Text>
+          return (
+            <TouchableRow
+              accessibilityState={{ selected }}
+              key={option.value}
+              onPress={() => onSelectOption(option)}
+            >
+              <Flex flexDirection="row" p={2} alignItems="center" justifyContent="space-between">
+                <Flex flex={1} mr={1}>
+                  <Text numberOfLines={2}>{option.text}</Text>
+                </Flex>
+                <RadioDot selected={selected} />
               </Flex>
-              <RadioDot selected={selected} />
-            </Flex>
-          </TouchableRow>
-        )
-      })}
-    </FancyModal>
+            </TouchableRow>
+          )
+        })}
+      </Flex>
+    </Modal>
   )
 }

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -45,8 +45,8 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       _FancyModalPageWrapper,
       ToastProvider, // uses: GlobalStoreProvider
       GravityWebsocketContextProvider, // uses GlobalStoreProvider
-      ShareSheetProvider, // uses _FancyModalPageWrapper
       ArtworkListsProvider,
+      ShareSheetProvider, // uses BottomSheetProvider
     ],
     children
   )
@@ -71,9 +71,9 @@ export const TestProviders: React.FC<{ skipRelay?: boolean; includeNavigation?: 
       Theme,
       Screen.ScreenScrollContextProvider,
       PopoverMessageProvider,
-      ShareSheetProvider,
       ToastProvider,
       ArtworkListsProvider,
+      ShareSheetProvider,
     ],
     children
   )

--- a/src/app/Scenes/Artwork/Components/ArtworkError.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkError.tsx
@@ -2,7 +2,7 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Join, Spacer, Spinner, Text } from "@artsy/palette-mobile"
 import { ArtworkErrorQuery } from "__generated__/ArtworkErrorQuery.graphql"
 import { ArtworkErrorRecentlyViewed_homePage$key } from "__generated__/ArtworkErrorRecentlyViewed_homePage.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { ArtworkModuleRailFragmentContainer } from "app/Scenes/HomeView/Components/ArtworkModuleRail"
 import { ArtworkRecommendationsRail } from "app/Scenes/HomeView/Components/ArtworkRecommendationsRail"
@@ -28,7 +28,7 @@ export const ArtworkError: React.FC<ArtworkErrorProps> = ({ homePage, me, viewer
 
   return (
     <Flex flex={1}>
-      <FancyModalHeader onLeftButtonPress={goBack} />
+      <NavigationHeader onLeftButtonPress={goBack} />
 
       <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
         <Flex p={2}>
@@ -92,7 +92,7 @@ export const ArtworkErrorScreen: React.FC<{}> = withSuspense({
     if (!data.homePage || !data.me || !data.viewer) {
       return (
         <Flex flex={1}>
-          <FancyModalHeader onLeftButtonPress={goBack}>Artwork can't be found</FancyModalHeader>
+          <NavigationHeader onLeftButtonPress={goBack}>Artwork can't be found</NavigationHeader>
           <Flex p={2}>
             <Text variant="lg-display">The artwork you were looking for isn't available.</Text>
           </Flex>

--- a/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksContent.tsx
+++ b/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksContent.tsx
@@ -13,7 +13,7 @@ import {
 } from "__generated__/BrowseSimilarWorksContentQuery.graphql"
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import GenericGrid, { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { BrowseSimilarWorksProps } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks"
 import { BrowseSimilarWorksExploreMoreButton } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksExploreMoreButton"
 import { extractPills } from "app/Scenes/SavedSearchAlert/pillExtractors"
@@ -42,9 +42,9 @@ export const BrowseSimilarWorksContent: React.FC<BrowseSimilarWorksContentProps>
 
   return (
     <Flex flex={1}>
-      <FancyModalHeader
+      <NavigationHeader
         onLeftButtonPress={goBack}
-      >{`Works by ${entity.artists[0].name}`}</FancyModalHeader>
+      >{`Works by ${entity.artists[0].name}`}</NavigationHeader>
       <ScrollView
         contentContainerStyle={{
           paddingBottom: bottomInset,

--- a/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksErrorState.tsx
+++ b/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksErrorState.tsx
@@ -1,11 +1,11 @@
 import { SimpleMessage, Flex } from "@artsy/palette-mobile"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { goBack } from "app/system/navigation/navigate"
 
 export const BrowseSimilarWorksErrorState: React.FC = () => {
   return (
     <Flex flex={1}>
-      <FancyModalHeader onLeftButtonPress={goBack}>Works by -</FancyModalHeader>
+      <NavigationHeader onLeftButtonPress={goBack}>Works by -</NavigationHeader>
       <Flex mx={2} mt={2}>
         <SimpleMessage>Could not load artwork</SimpleMessage>
       </Flex>

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/InquiryModal.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, InfoCircleIcon, Input, Screen, Text } from "@artsy/palette-m
 import { InquiryModal_artwork$key } from "__generated__/InquiryModal_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { useSendInquiry_me$key } from "__generated__/useSendInquiry_me.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CompleteProfilePrompt } from "app/Scenes/Artwork/Components/CommercialButtons/CompleteProfilePrompt"
 import { InquiryQuestionOption } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryQuestionOption"
 import { InquirySuccessNotification } from "app/Scenes/Artwork/Components/CommercialButtons/InquirySuccessNotification"
@@ -103,7 +103,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork: _artwork, m
     <>
       <Modal visible={state.inquiryModalVisible} onDismiss={handleDismiss} statusBarTranslucent>
         <Screen>
-          <FancyModalHeader
+          <NavigationHeader
             leftButtonText="Cancel"
             onLeftButtonPress={handleDismiss}
             rightButtonText="Send"
@@ -111,7 +111,7 @@ export const InquiryModal: React.FC<InquiryModalProps> = ({ artwork: _artwork, m
             onRightButtonPress={() => sendInquiry(message)}
           >
             Contact Gallery
-          </FancyModalHeader>
+          </NavigationHeader>
           {!!error && (
             <Flex
               bg="red100"

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
@@ -1,10 +1,9 @@
 import { Flex, Text } from "@artsy/palette-mobile"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { NavigationHeader } from "app/Components/NavigationHeader"
 import { LocationAutocomplete } from "app/Components/LocationAutocomplete"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { LocationWithDetails } from "app/utils/googleMaps"
 import React, { useState } from "react"
-import { ScrollView } from "react-native"
+import { Modal, ScrollView } from "react-native"
 
 interface ShippingModalProps {
   toggleVisibility: () => void
@@ -19,7 +18,12 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
   const [locationDetails, setLocationDetails] = useState<LocationWithDetails | null>(null)
 
   return (
-    <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
+    <Modal
+      visible={modalIsVisible}
+      onRequestClose={toggleVisibility}
+      presentationStyle="formSheet"
+      animationType="slide"
+    >
       <NavigationHeader
         leftButtonText="Cancel"
         onLeftButtonPress={() => {
@@ -51,6 +55,6 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
           />
         </Flex>
       </ScrollView>
-    </FancyModal>
+    </Modal>
   )
 }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ShippingModal.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { LocationAutocomplete } from "app/Components/LocationAutocomplete"
 import { LocationWithDetails } from "app/utils/googleMaps"
 import React, { useState } from "react"
@@ -20,7 +20,7 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
 
   return (
     <FancyModal visible={modalIsVisible} onBackgroundPressed={() => toggleVisibility()}>
-      <FancyModalHeader
+      <NavigationHeader
         leftButtonText="Cancel"
         onLeftButtonPress={() => {
           toggleVisibility()
@@ -33,7 +33,7 @@ export const ShippingModal: React.FC<ShippingModalProps> = (props) => {
         rightButtonDisabled={!locationDetails}
       >
         Add Location
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView keyboardShouldPersistTaps="always" contentContainerStyle={{ flex: 1 }}>
         <Flex m={2} flex={1}>
           <LocationAutocomplete

--- a/src/app/Scenes/ArtworkList/ArtworkListHeader.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkListHeader.tsx
@@ -1,6 +1,6 @@
 import { MoreIcon } from "@artsy/palette-mobile"
 import { ArtworkListHeader_me$key } from "__generated__/ArtworkListHeader_me.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { ManageArtworkListView } from "app/Scenes/ArtworkList/ManageArtworkListView"
 import { goBack } from "app/system/navigation/navigate"
 import { FC, useCallback, useState } from "react"
@@ -34,7 +34,7 @@ export const ArtworkListHeader: FC<ArtworkListHeaderProps> = ({ me }) => {
 
   return (
     <>
-      <FancyModalHeader
+      <NavigationHeader
         onLeftButtonPress={goBack}
         renderRightButton={() => {
           if (artworkListEntity) {

--- a/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MakeOfferModal.tsx
@@ -2,7 +2,7 @@ import { ActionType, OwnerType } from "@artsy/cohesion"
 import { BorderBox, Flex, Text, Button } from "@artsy/palette-mobile"
 import { MakeOfferModalQuery } from "__generated__/MakeOfferModalQuery.graphql"
 import { MakeOfferModal_artwork$data } from "__generated__/MakeOfferModal_artwork.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails } from "app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails"
 import { dismissModal } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -36,9 +36,9 @@ export const MakeOfferModal: React.FC<MakeOfferModalProps> = ({ ...props }) => {
 
   return (
     <View>
-      <FancyModalHeader rightButtonDisabled hideBottomDivider>
+      <NavigationHeader rightButtonDisabled hideBottomDivider>
         Make Offer
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView showsVerticalScrollIndicator={false}>
         <Flex p={2}>
           <Text variant="lg-display">Select edition set</Text>

--- a/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Screen, Text } from "@artsy/palette-mobile"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { goBack, switchTab } from "app/system/navigation/navigate"
 import { useSetWebViewCallback } from "app/utils/useWebViewEvent"
 import React, { useState } from "react"
@@ -36,9 +36,9 @@ export const OfferSubmittedModal: React.FC = () => {
   return (
     <Modal visible={visible} onRequestClose={onClose} animationType="fade" statusBarTranslucent>
       <Screen>
-        <FancyModalHeader rightCloseButton onRightButtonPress={onClose}>
+        <NavigationHeader rightCloseButton onRightButtonPress={onClose}>
           Make Offer
-        </FancyModalHeader>
+        </NavigationHeader>
         <Box flex={1} py={4} px={2}>
           <Text variant="lg-display">Thank you, your offer has been submitted</Text>
           <Text variant="sm" color="black60">

--- a/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/PurchaseModal.tsx
@@ -2,7 +2,7 @@ import { ActionType, OwnerType } from "@artsy/cohesion"
 import { BorderBox, Button, Flex, Text } from "@artsy/palette-mobile"
 import { PurchaseModalQuery } from "__generated__/PurchaseModalQuery.graphql"
 import { PurchaseModal_artwork$data } from "__generated__/PurchaseModal_artwork.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CollapsibleArtworkDetailsFragmentContainer as CollapsibleArtworkDetails } from "app/Scenes/Artwork/Components/CommercialButtons/CollapsibleArtworkDetails"
 import { dismissModal } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -37,9 +37,9 @@ export const PurchaseModal: React.FC<PurchaseModalProps> = ({ ...props }) => {
 
   return (
     <View>
-      <FancyModalHeader rightButtonDisabled hideBottomDivider>
+      <NavigationHeader rightButtonDisabled hideBottomDivider>
         Purchase
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView showsVerticalScrollIndicator={false}>
         <Flex p={2}>
           <Text variant="lg-display">Select edition set</Text>

--- a/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artist/AddMyCollectionArtist.tsx
@@ -11,7 +11,7 @@ import {
 import { RouteProp, useIsFocused, useNavigation, useRoute } from "@react-navigation/native"
 import { StackNavigationProp } from "@react-navigation/stack"
 import { AbandonFlowModal } from "app/Components/AbandonFlowModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { ArtworkFormScreen } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
 import { useFormik } from "formik"
 import React, { useEffect, useRef, useState } from "react"
@@ -96,9 +96,9 @@ export const AddMyCollectionArtist: React.FC<{ useNativeHeader?: boolean }> = (p
     <Screen safeArea={false}>
       <ArtsyKeyboardAvoidingView>
         {!props.useNativeHeader && (
-          <FancyModalHeader onLeftButtonPress={handleBackPress} hideBottomDivider>
+          <NavigationHeader onLeftButtonPress={handleBackPress} hideBottomDivider>
             Add New Artist
-          </FancyModalHeader>
+          </NavigationHeader>
         )}
 
         <AbandonFlowModal

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/RarityLegacy.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/RarityLegacy.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text, Separator } from "@artsy/palette-mobile"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Input, INPUT_HEIGHT, InputTitle } from "app/Components/Input"
 import { Select } from "app/Components/Select"
 import { useArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm"
@@ -79,9 +79,9 @@ export const RarityInfoModal: React.FC<{
 }> = ({ title, visible, onDismiss }) => {
   return (
     <FancyModal visible={visible} onBackgroundPressed={onDismiss} testID="RarityInfoModal">
-      <FancyModalHeader onLeftButtonPress={onDismiss} useXButton>
+      <NavigationHeader onLeftButtonPress={onDismiss} useXButton>
         {title}
-      </FancyModalHeader>
+      </NavigationHeader>
       <Separator />
       <Flex m={2}>
         {artworkRarityClassifications.map((classification) => (

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/RarityLegacy.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Components/RarityLegacy.tsx
@@ -1,11 +1,11 @@
-import { Flex, Text, Separator } from "@artsy/palette-mobile"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { NavigationHeader } from "app/Components/NavigationHeader"
+import { Flex, Separator, Text } from "@artsy/palette-mobile"
 import { Input, INPUT_HEIGHT, InputTitle } from "app/Components/Input"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { Select } from "app/Components/Select"
 import { useArtworkForm } from "app/Scenes/MyCollection/Screens/ArtworkForm/Form/useArtworkForm"
 import { artworkRarityClassifications } from "app/utils/artworkRarityClassifications"
 import React, { useState } from "react"
+import { Modal } from "react-native"
 
 export type AttributionClassType = "LIMITED_EDITION" | "OPEN_EDITION" | "UNIQUE" | "UNKNOWN_EDITION"
 
@@ -78,7 +78,13 @@ export const RarityInfoModal: React.FC<{
   onDismiss(): any
 }> = ({ title, visible, onDismiss }) => {
   return (
-    <FancyModal visible={visible} onBackgroundPressed={onDismiss} testID="RarityInfoModal">
+    <Modal
+      visible={visible}
+      onRequestClose={onDismiss}
+      testID="RarityInfoModal"
+      presentationStyle="pageSheet"
+      animationType="slide"
+    >
       <NavigationHeader onLeftButtonPress={onDismiss} useXButton>
         {title}
       </NavigationHeader>
@@ -91,6 +97,6 @@ export const RarityInfoModal: React.FC<{
           </Flex>
         ))}
       </Flex>
-    </FancyModal>
+    </Modal>
   )
 }

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tests.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react-native"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { MyCollectionArtworkStore } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkStore"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 import { showPhotoActionSheet } from "app/utils/requestPhotos"
@@ -43,7 +43,7 @@ describe("MyCollectionAddPhotos", () => {
 
   it("updates header with correct label based on number of photos selected", () => {
     const wrapper = renderWithWrappersLEGACY(mockAddPhotos)
-    expect(wrapper.root.findByType(FancyModalHeader).props.children).toStrictEqual([
+    expect(wrapper.root.findByType(NavigationHeader).props.children).toStrictEqual([
       "Photos ",
       "(2)",
     ])

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormAddPhotos.tsx
@@ -1,7 +1,7 @@
 import { AddIcon, BorderBox, Box, Flex, XCircleIcon, useColor } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
 import { StackScreenProps } from "@react-navigation/stack"
-import { FancyModalHeader as NavHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader as NavHeader } from "app/Components/NavigationHeader"
 import { ArtworkFormScreen } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
 import { Image as ImageProps } from "app/Scenes/MyCollection/State/MyCollectionArtworkModel"
 import { GlobalStore } from "app/store/GlobalStore"

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtist.tsx
@@ -4,7 +4,7 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { AutosuggestResult } from "app/Components/AutosuggestResults/AutosuggestResults"
 import { AutosuggestResultsPlaceholder } from "app/Components/AutosuggestResults/AutosuggestResultsPlaceholder"
 import { SimpleErrorMessage } from "app/Components/ErrorView/SimpleErrorMessage"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { ScreenMargin } from "app/Scenes/MyCollection/Components/ScreenMargin"
 import { ArtistAutosuggest } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistAutosuggest"
 import { ArtworkFormScreen } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm"
@@ -62,9 +62,9 @@ export const MyCollectionArtworkFormArtist: React.FC<
 
   return (
     <>
-      <FancyModalHeader hideBottomDivider onLeftButtonPress={handleBack}>
+      <NavigationHeader hideBottomDivider onLeftButtonPress={handleBack}>
         Select an Artist
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScreenMargin>
         <ErrorBoundary fallback={<SimpleErrorMessage />}>
           <Suspense fallback={<Placeholder />}>

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormArtwork.tsx
@@ -2,7 +2,7 @@ import { ActionType, ContextModule, OwnerType, TappedSkip } from "@artsy/cohesio
 import { Flex, Spacer } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { MyCollectionArtworkFormArtworkQuery } from "__generated__/MyCollectionArtworkFormArtworkQuery.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import LoadingModal from "app/Components/Modals/LoadingModal"
 import { ArtistSearchResult } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtistSearchResult"
 import { ArtworkAutosuggest } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/ArtworkAutosuggest"
@@ -111,14 +111,14 @@ export const MyCollectionArtworkFormArtwork: React.FC<
 
   return (
     <>
-      <FancyModalHeader
+      <NavigationHeader
         onLeftButtonPress={handleBackButtonPress}
         rightButtonText="Skip"
         onRightButtonPress={onSkip}
         hideBottomDivider
       >
         Select an Artwork
-      </FancyModalHeader>
+      </NavigationHeader>
       <Flex flex={1} px={2}>
         {!!formik.values.artistSearchResult && (
           <ArtistSearchResult result={formik.values.artistSearchResult} />

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tests.tsx
@@ -1,5 +1,5 @@
 import { StackNavigationProp } from "@react-navigation/stack"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CategoryPicker } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/CategoryPicker"
 import { Dimensions } from "app/Scenes/MyCollection/Screens/ArtworkForm/Components/Dimensions"
 import { MyCollectionArtworkStore } from "app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkStore"
@@ -10,8 +10,8 @@ import { MyCollectionArtworkFormMain } from "./MyCollectionArtworkFormMain"
 
 jest.mock("formik")
 
-jest.mock("app/Components/FancyModal/FancyModalHeader", () => ({
-  FancyModalHeader: () => null,
+jest.mock("app/Components/NavigationHeader", () => ({
+  NavigationHeader: () => null,
 }))
 
 jest.mock("app/Components/ArtistAutosuggest/ArtistAutosuggest", () => ({
@@ -74,7 +74,7 @@ describe("AddEditArtwork", () => {
       </MyCollectionArtworkStore.Provider>
     )
     const wrapper = renderWithWrappersLEGACY(artworkForm)
-    const expected = [FancyModalHeader, CategoryPicker, Dimensions]
+    const expected = [NavigationHeader, CategoryPicker, Dimensions]
     expected.forEach((Component) => {
       expect(wrapper.root.findByType(Component as React.ComponentType)).toBeDefined()
     })
@@ -136,7 +136,7 @@ describe("AddEditArtwork", () => {
     })
 
     const wrapper = renderWithWrappersLEGACY(artworkForm)
-    wrapper.root.findByType(FancyModalHeader).props.onRightButtonPress()
+    wrapper.root.findByType(NavigationHeader).props.onRightButtonPress()
 
     expect(mockShowActionSheetWithOptions).toHaveBeenCalled()
 

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/Screens/MyCollectionArtworkFormMain.tsx
@@ -17,7 +17,7 @@ import { useActionSheet } from "@expo/react-native-action-sheet"
 import { StackScreenProps } from "@react-navigation/stack"
 import { captureMessage } from "@sentry/react-native"
 import { AbandonFlowModal } from "app/Components/AbandonFlowModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { MoneyInput } from "app/Components/Input/MoneyInput"
 import { LocationAutocomplete, buildLocationDisplay } from "app/Components/LocationAutocomplete"
 import { ScreenMargin } from "app/Scenes/MyCollection/Components/ScreenMargin"
@@ -247,7 +247,7 @@ export const MyCollectionArtworkFormMain: React.FC<
           />
         ) : null}
 
-        <FancyModalHeader
+        <NavigationHeader
           onLeftButtonPress={() => {
             if (isFormDirty() && mode === "edit") {
               setShowAbandonModal(true)
@@ -266,7 +266,7 @@ export const MyCollectionArtworkFormMain: React.FC<
           hideBottomDivider
         >
           {addOrEditLabel} Details
-        </FancyModalHeader>
+        </NavigationHeader>
 
         <AbandonFlowModal
           isVisible={!!showAbandonModal && mode === "edit"}

--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsBigCardsSwiper.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightsBigCardsSwiper.tsx
@@ -1,6 +1,6 @@
 import { Flex, Screen, useColor, useSpace } from "@artsy/palette-mobile"
 import { CareerHighlightsBigCardsSwiperQuery } from "__generated__/CareerHighlightsBigCardsSwiperQuery.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { useSpringValue } from "app/Scenes/Artwork/Components/ImageCarousel/useSpringValue"
 import { goBack } from "app/system/navigation/navigate"
 import { useScreenDimensions } from "app/utils/hooks"
@@ -139,7 +139,7 @@ const CareerHighlightsBigCardsSwiperScreen: React.FC<CareerHighlightsBigCardsSwi
   return (
     <>
       <Flex>
-        <FancyModalHeader
+        <NavigationHeader
           alignItems="flex-start"
           rightCloseButton
           onRightButtonPress={() => goBack()}
@@ -158,7 +158,7 @@ const CareerHighlightsBigCardsSwiperScreen: React.FC<CareerHighlightsBigCardsSwi
               <StepDot key={key} index={index} />
             ))}
           </Flex>
-        </FancyModalHeader>
+        </NavigationHeader>
       </Flex>
       <ScrollView
         horizontal

--- a/src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/SelectArtist.tests.tsx
@@ -1,5 +1,6 @@
-import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { MedianSalePriceAtAuctionQuery } from "__generated__/MedianSalePriceAtAuctionQuery.graphql"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import { useLazyLoadQuery } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
@@ -49,7 +50,7 @@ describe("SelectArtist", () => {
       })
 
       // Modal is hidden and the artist is updated
-      await waitForElementToBeRemoved(() => screen.queryByTestId("select-artist-modal"))
+      await flushPromiseQueue()
 
       expect(screen.getByText("Banksy")).toBeTruthy()
     })
@@ -91,7 +92,9 @@ describe("SelectArtist", () => {
           ...insights,
         },
       })
-      await waitForElementToBeRemoved(() => screen.queryByTestId("select-artist-modal"))
+
+      // Wait for modal to be dismissed
+      await flushPromiseQueue()
 
       // Modal is hidden and the artist is updated
       expect(screen.getByText("Amoako Boafo")).toBeTruthy()

--- a/src/app/Scenes/MyCollection/Screens/Insights/SelectArtistModal.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/SelectArtistModal.tsx
@@ -6,7 +6,7 @@ import {
 } from "__generated__/MedianSalePriceAtAuctionQuery.graphql"
 import { SelectArtistModal_myCollectionInfo$key } from "__generated__/SelectArtistModal_myCollectionInfo.graphql"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { SearchInput } from "app/Components/SearchInput"
 import { extractNodes } from "app/utils/extractNodes"
 import { normalizeText } from "app/utils/normalizeText"
@@ -64,9 +64,9 @@ export const SelectArtistModal: React.FC<SelectArtistModalProps> = ({
       fullScreen
       animationPosition="right"
     >
-      <FancyModalHeader onLeftButtonPress={closeModal} hideBottomDivider>
+      <NavigationHeader onLeftButtonPress={closeModal} hideBottomDivider>
         <Text variant="sm-display">Select Artist</Text>
-      </FancyModalHeader>
+      </NavigationHeader>
 
       <Flex flex={1} px={2}>
         <Flex pt={1} pb={2}>

--- a/src/app/Scenes/MyCollection/Screens/Insights/SelectArtistModal.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/SelectArtistModal.tsx
@@ -5,12 +5,13 @@ import {
   MedianSalePriceAtAuctionQuery$data,
 } from "__generated__/MedianSalePriceAtAuctionQuery.graphql"
 import { SelectArtistModal_myCollectionInfo$key } from "__generated__/SelectArtistModal_myCollectionInfo.graphql"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { SearchInput } from "app/Components/SearchInput"
 import { extractNodes } from "app/utils/extractNodes"
 import { normalizeText } from "app/utils/normalizeText"
 import React, { useEffect, useState } from "react"
+import { Modal } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import { graphql, usePaginationFragment } from "react-relay"
 import { SelectArtistList } from "./Components/MyCollectionSelectArtist"
 import { artistsQueryVariables } from "./MedianSalePriceAtAuction"
@@ -57,41 +58,42 @@ export const SelectArtistModal: React.FC<SelectArtistModalProps> = ({
   }, [query])
 
   return (
-    <FancyModal
+    <Modal
       testID="select-artist-modal"
       visible={visible}
-      onBackgroundPressed={closeModal}
-      fullScreen
-      animationPosition="right"
+      onDismiss={closeModal}
+      animationType="slide"
     >
-      <NavigationHeader onLeftButtonPress={closeModal} hideBottomDivider>
-        <Text variant="sm-display">Select Artist</Text>
-      </NavigationHeader>
+      <SafeAreaView style={{ flex: 1 }} edges={["top"]}>
+        <NavigationHeader onLeftButtonPress={closeModal} hideBottomDivider>
+          <Text variant="sm-display">Select Artist</Text>
+        </NavigationHeader>
 
-      <Flex flex={1} px={2}>
-        <Flex pt={1} pb={2}>
-          <SearchInput
-            testID="select-artists-search-input"
-            placeholder="Search Artist from Your Collection"
-            value={query}
-            onChangeText={setQuery}
-            error={
-              filteredArtists.length === 0 && normalizedQuery
-                ? "Please select from the list of artists in your collection with insights available."
-                : ""
-            }
+        <Flex flex={1} px={2}>
+          <Flex pt={1} pb={2}>
+            <SearchInput
+              testID="select-artists-search-input"
+              placeholder="Search Artist from Your Collection"
+              value={query}
+              onChangeText={setQuery}
+              error={
+                filteredArtists.length === 0 && normalizedQuery
+                  ? "Please select from the list of artists in your collection with insights available."
+                  : ""
+              }
+            />
+          </Flex>
+
+          <SelectArtistList
+            artistsList={normalizedQuery ? filteredArtists : artistsList}
+            ListHeaderComponent={!normalizedQuery ? ListHeaderComponent : undefined}
+            onEndReached={handleLoadMore}
+            isLoadingNext={isLoadingNext}
+            onItemPress={onItemPress}
           />
         </Flex>
-
-        <SelectArtistList
-          artistsList={normalizedQuery ? filteredArtists : artistsList}
-          ListHeaderComponent={!normalizedQuery ? ListHeaderComponent : undefined}
-          onEndReached={handleLoadMore}
-          isLoadingNext={isLoadingNext}
-          onItemPress={onItemPress}
-        />
-      </Flex>
-    </FancyModal>
+      </SafeAreaView>
+    </Modal>
   )
 }
 

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -4,7 +4,6 @@ import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { buildLocationDisplay } from "app/Components/LocationAutocomplete"
-import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
 import {
   UserProfileFields,
   UserProfileFormikSchema,
@@ -109,13 +108,7 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   }
 
   return (
-    <AutomountedBottomSheetModal
-      visible={visible}
-      onDismiss={handleDismiss}
-      enableDynamicSizing
-      snapPoints={SNAP_POINTS}
-      enableOverDrag={false}
-    >
+    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
       <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <Box p={2}>
           <Text>{message}</Text>

--- a/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditModal.tsx
@@ -4,6 +4,7 @@ import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { buildLocationDisplay } from "app/Components/LocationAutocomplete"
+import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
 import {
   UserProfileFields,
   UserProfileFormikSchema,
@@ -52,10 +53,9 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
     initialValues: {
       name: data.name ?? "",
       displayLocation: { display: buildLocationDisplay(data.location ?? null) },
-      location:
-        {
-          ...data.location,
-        } ?? undefined,
+      location: {
+        ...data.location,
+      },
       profession: data.profession ?? "",
       otherRelevantPositions: data.otherRelevantPositions ?? "",
     },
@@ -109,7 +109,13 @@ export const MyProfileEditModal: React.FC<MyProfileEditModalProps> = ({
   }
 
   return (
-    <AutomountedBottomSheetModal visible={visible} onDismiss={handleDismiss} enableDynamicSizing>
+    <AutomountedBottomSheetModal
+      visible={visible}
+      onDismiss={handleDismiss}
+      enableDynamicSizing
+      snapPoints={SNAP_POINTS}
+      enableOverDrag={false}
+    >
       <BottomSheetScrollView keyboardShouldPersistTaps="always">
         <Box p={2}>
           <Text>{message}</Text>

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,4 +1,3 @@
-import { ArtsyKeyboardAvoidingView } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
 import { TransitionPresets, createStackNavigator } from "@react-navigation/stack"
 import {
@@ -15,7 +14,7 @@ import {
   useReloadedDevNavigationState,
 } from "app/system/navigation/useReloadedDevNavigationState"
 import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
-import { Modal } from "react-native"
+import { KeyboardAvoidingView, Modal, Platform } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import {
   CreateSavedSearchAlertNavigationStack,
@@ -39,29 +38,32 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
   }
 
   return (
-    <ArtsyKeyboardAvoidingView>
-      <SavedSearchStoreProvider
-        runtimeModel={{
-          ...savedSearchModel,
-          attributes: localizeHeightAndWidthAttributes({
-            attributes: attributes,
-            from: "in",
-            to: sizeMetric || localizedUnit,
-          }),
-          currentArtworkID,
-          entity,
-          unit: sizeMetric || localizedUnit,
+    <SavedSearchStoreProvider
+      runtimeModel={{
+        ...savedSearchModel,
+        attributes: localizeHeightAndWidthAttributes({
+          attributes: attributes,
+          from: "in",
+          to: sizeMetric || localizedUnit,
+        }),
+        currentArtworkID,
+        entity,
+        unit: sizeMetric || localizedUnit,
+      }}
+    >
+      <NavigationContainer
+        independent
+        initialState={initialState}
+        onStateChange={(state) => {
+          saveSession(state)
         }}
       >
-        <NavigationContainer
-          independent
-          initialState={initialState}
-          onStateChange={(state) => {
-            saveSession(state)
-          }}
-        >
-          <Modal visible={visible} presentationStyle="fullScreen" statusBarTranslucent>
-            <SafeAreaView style={{ flex: 1 }}>
+        <Modal visible={visible} presentationStyle="fullScreen" statusBarTranslucent>
+          <SafeAreaView style={{ flex: 1 }}>
+            <KeyboardAvoidingView
+              style={{ flex: 1 }}
+              behavior={Platform.OS === "ios" ? "padding" : "height"}
+            >
               <Stack.Navigator
                 // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
                 detachInactiveScreens={false}
@@ -103,10 +105,10 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                   }}
                 />
               </Stack.Navigator>
-            </SafeAreaView>
-          </Modal>
-        </NavigationContainer>
-      </SavedSearchStoreProvider>
-    </ArtsyKeyboardAvoidingView>
+            </KeyboardAvoidingView>
+          </SafeAreaView>
+        </Modal>
+      </NavigationContainer>
+    </SavedSearchStoreProvider>
   )
 }

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -1,7 +1,6 @@
-import { ArtsyKeyboardAvoidingView, Box } from "@artsy/palette-mobile"
+import { ArtsyKeyboardAvoidingView } from "@artsy/palette-mobile"
 import { NavigationContainer } from "@react-navigation/native"
 import { TransitionPresets, createStackNavigator } from "@react-navigation/stack"
-import { FancyModal } from "app/Components/FancyModal/FancyModal"
 import {
   SavedSearchStoreProvider,
   savedSearchModel,
@@ -16,6 +15,8 @@ import {
   useReloadedDevNavigationState,
 } from "app/system/navigation/useReloadedDevNavigationState"
 import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
+import { Modal } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import {
   CreateSavedSearchAlertNavigationStack,
   CreateSavedSearchAlertProps,
@@ -59,8 +60,8 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
             saveSession(state)
           }}
         >
-          <FancyModal visible={visible} fullScreen>
-            <Box flex={1}>
+          <Modal visible={visible} presentationStyle="fullScreen" statusBarTranslucent>
+            <SafeAreaView style={{ flex: 1 }}>
               <Stack.Navigator
                 // force it to not use react-native-screens, which is broken inside a react-native Modal for some reason
                 detachInactiveScreens={false}
@@ -102,8 +103,8 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
                   }}
                 />
               </Stack.Navigator>
-            </Box>
-          </FancyModal>
+            </SafeAreaView>
+          </Modal>
         </NavigationContainer>
       </SavedSearchStoreProvider>
     </ArtsyKeyboardAvoidingView>

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -4,7 +4,7 @@ import { NavigationProp, RouteProp, useNavigation, useRoute } from "@react-navig
 import { captureMessage } from "@sentry/react-native"
 import { CreateSavedSearchContentContainerQuery } from "__generated__/CreateSavedSearchContentContainerQuery.graphql"
 import { CreateSavedSearchContentContainer_viewer$data } from "__generated__/CreateSavedSearchContentContainer_viewer.graphql"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { SavedSearchAlertForm } from "app/Scenes/SavedSearchAlert/SavedSearchAlertForm"
 import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -84,7 +84,7 @@ const CreateSavedSearchAlertContent: React.FC<CreateSavedSearchAlertContentProps
 
   return (
     <Box flex={1}>
-      <FancyModalHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
+      <NavigationHeader useXButton hideBottomDivider onLeftButtonPress={onClosePress} />
       <SavedSearchAlertForm
         initialValues={{ name: "", email: userAllowsEmails, push: enablePushNotifications }}
         contentContainerStyle={{ paddingTop: 0 }}

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -8,7 +8,7 @@ import {
   FilterArtworksInput,
 } from "__generated__/ConfirmationScreenMatchingArtworksQuery.graphql"
 import GenericGrid, { GenericGridPlaceholder } from "app/Components/ArtworkGrids/GenericGrid"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 import { SavedSearchStore } from "app/Scenes/SavedSearchAlert/SavedSearchStore"
 import { useSavedSearchPills } from "app/Scenes/SavedSearchAlert/useSavedSearchPills"
@@ -61,7 +61,7 @@ export const ConfirmationScreen: React.FC = () => {
 
   return (
     <Box flex={1}>
-      <FancyModalHeader hideBottomDivider useXButton onLeftButtonPress={handleLeftButtonPress} />
+      <NavigationHeader hideBottomDivider useXButton onLeftButtonPress={handleLeftButtonPress} />
       <Box flex={1}>
         <Text variant="lg" px={2}>
           Your alert has been saved

--- a/src/app/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/EmailPreferencesScreen.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@artsy/palette-mobile"
 import { StackScreenProps } from "@react-navigation/stack"
 import { ArtsyWebView } from "app/Components/ArtsyWebView"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { CreateSavedSearchAlertNavigationStack } from "app/Scenes/SavedSearchAlert/SavedSearchAlertModel"
 
 type Props = StackScreenProps<CreateSavedSearchAlertNavigationStack, "EmailPreferences">
@@ -14,7 +14,7 @@ export const EmailPreferencesScreen: React.FC<Props> = (props) => {
 
   return (
     <Box flex={1}>
-      <FancyModalHeader hideBottomDivider onLeftButtonPress={handleLeftButtonPress} />
+      <NavigationHeader hideBottomDivider onLeftButtonPress={handleLeftButtonPress} />
       <ArtsyWebView url="/unsubscribe" />
     </Box>
   )

--- a/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/SavedSearchFilterScreen.tsx
@@ -2,7 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { Button, Flex, Spacer, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { SearchCriteria } from "app/Components/ArtworkFilter/SavedSearch/types"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { SavedSearchFilterAdditionalGeneIDs } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAdditionalGeneIDs"
 import { SavedSearchFilterAppliedFilters } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterAppliedFilters"
 import { SavedSearchFilterArtistSeriesQR } from "app/Scenes/SavedSearchAlert/Components/SavedSearchFilterArtistSeries"
@@ -29,14 +29,14 @@ export const SavedSearchFilterScreen: React.FC<{}> = () => {
         context_screen_owner_type: OwnerType.alertFilters,
       })}
     >
-      <FancyModalHeader
+      <NavigationHeader
         hideBottomDivider
         onLeftButtonPress={navigation.goBack}
         renderRightButton={ClearAllButton}
         onRightButtonPress={() => {}}
       >
         Filters
-      </FancyModalHeader>
+      </NavigationHeader>
       <ScrollView>
         <SavedSearchFilterAppliedFilters />
         <SavedSearchFilterAdditionalGeneIDs />

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { SavedSearchesListTestsQuery } from "__generated__/SavedSearchesListTestsQuery.graphql"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { PanGesture } from "react-native-gesture-handler"
 import { fireGestureHandler, getByGestureTestId } from "react-native-gesture-handler/jest-utils"
@@ -93,10 +94,13 @@ describe("SavedSearches", () => {
     expect(screen.getByText("Sort By")).toBeTruthy()
   })
 
-  it("should display sort options when Sort By button is pressed", () => {
+  it("should display sort options when Sort By button is pressed", async () => {
     renderWithRelay()
 
     fireEvent.press(screen.getByText("Sort By"))
+
+    // Wait for the modal to show up
+    await flushPromiseQueue()
 
     expect(screen.getByText("Recently Added")).toBeTruthy()
     expect(screen.getByText("Name (A-Z)")).toBeTruthy()
@@ -106,11 +110,15 @@ describe("SavedSearches", () => {
     const { env } = renderWithRelay()
 
     fireEvent.press(screen.getByText("Sort By"))
-    fireEvent.press(screen.getByText("Name (A-Z)"))
+
+    // Wait for the modal to show up
+    await flushPromiseQueue()
+
+    fireEvent.press(screen.getByText("Recently Added"))
 
     await waitFor(() => {
       const operation = env.mock.getMostRecentOperation()
-      expect(operation.fragment.variables.sort).toBe("NAME_ASC")
+      expect(operation.fragment.variables.sort).toBe("ENABLED_AT_DESC")
     })
   })
 

--- a/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
+++ b/src/app/Scenes/SavedSearchAlertsList/Components/SavedSearchesList.tsx
@@ -164,6 +164,10 @@ export const SavedSearchesListWrapper: React.FC<SavedSearchListWrapperProps> = (
 
   const handleCloseModal = () => {
     setModalVisible(false)
+    // onDismiss doesn't get called on TEST Environments so we need to manually call it
+    if (__TEST__) {
+      handleSortByModalClosed()
+    }
   }
 
   const handleLoadMore = () => {
@@ -218,7 +222,7 @@ export const SavedSearchesListWrapper: React.FC<SavedSearchListWrapperProps> = (
    * More context here: https://github.com/facebook/react-native/issues/16182#issuecomment-333814201
    */
   const handleSortByModalClosed = () => {
-    if (selectedSortValue === prevSelectedSortValue) {
+    if (selectedSortValue === prevSelectedSortValue && !__TEST__) {
       return
     }
 

--- a/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/InfoModal/InfoModal.tsx
+++ b/src/app/Scenes/SellWithArtsy/SubmitArtwork/ArtworkDetails/InfoModal/InfoModal.tsx
@@ -1,6 +1,6 @@
 import { Spacer, Flex, Text, Button, ButtonProps, useSpace } from "@artsy/palette-mobile"
 import { FancyModal } from "app/Components/FancyModal/FancyModal"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { ViewStyle } from "react-native"
 
 interface Props {
@@ -24,9 +24,9 @@ export const InfoModal: React.FC<Props> = ({
   const space = useSpace()
   return (
     <FancyModal visible={visible} onBackgroundPressed={onDismiss} fullScreen={fullScreen}>
-      <FancyModalHeader onLeftButtonPress={onDismiss} hideBottomDivider useXButton>
+      <NavigationHeader onLeftButtonPress={onDismiss} hideBottomDivider useXButton>
         {!!title && <Text fontSize={24}>{title}</Text>}
-      </FancyModalHeader>
+      </NavigationHeader>
 
       <Flex style={[{ margin: space(2) }, containerStyle]}>{children}</Flex>
       <Spacer y={2} />

--- a/src/app/utils/useStickyScrollHeader.tsx
+++ b/src/app/utils/useStickyScrollHeader.tsx
@@ -1,5 +1,5 @@
 import { Flex, Text } from "@artsy/palette-mobile"
-import { FancyModalHeader } from "app/Components/FancyModal/FancyModalHeader"
+import { NavigationHeader } from "app/Components/NavigationHeader"
 import { useMemo, useRef } from "react"
 import { Animated, NativeScrollEvent, NativeSyntheticEvent } from "react-native"
 
@@ -28,17 +28,17 @@ export const useStickyScrollHeader = ({
   header =
     !header && !!headerText ? (
       <Flex backgroundColor="white">
-        <FancyModalHeader>
+        <NavigationHeader>
           <Flex flex={1} pt={0.5} flexDirection="row">
             <Text variant="sm-display" numberOfLines={1} style={{ flexShrink: 1 }}>
               {headerText}
             </Text>
           </Flex>
-        </FancyModalHeader>
+        </NavigationHeader>
       </Flex>
     ) : (
       <Flex backgroundColor="white">
-        <FancyModalHeader>{header}</FancyModalHeader>
+        <NavigationHeader>{header}</NavigationHeader>
       </Flex>
     )
 


### PR DESCRIPTION
#future-friday

### Description

A few years ago, we needed to have our own fancy modal to have native like "presentation sheet" modals overlapping. We called that `FancyModal`. The latter is no longer needed since we get the same behaviour from `react-navigation` `presentation: "formsheet"` and RN `Modal` `prenstationStyle: "formSheet"|"pageSheet"`.

### Benefits of this work
- We don't need to maintain our custom Fancy Modal.
- We can move faster and safer without being afraid of breaking keyboard avoidance in the future.
- We can remove the old `FancyModalContext` and `ArtsyKeyboardAvoidingViewContext` components.

| Screen | Screenshot |
|--------|--------|
| Rarity Modal | <img width="691" alt="Screenshot 2025-01-10 at 17 03 11" src="https://github.com/user-attachments/assets/bee4774b-7bc4-4ab9-a01d-2add8f6dd05a" /> |
| Create Alert Modal | <img width="704" alt="Screenshot 2025-01-10 at 16 57 08" src="https://github.com/user-attachments/assets/99055edd-c6db-41c5-9e45-8ec5f24c30f2" /> |
| Add Location Modal | <img width="697" alt="Screenshot 2025-01-10 at 16 53 36" src="https://github.com/user-attachments/assets/cfc5e079-ff20-45e8-b07a-9ae27c54a514" /> |
| Share Modal | <img width="689" alt="Screenshot 2025-01-10 at 17 10 56" src="https://github.com/user-attachments/assets/67eaf539-310c-4564-9728-f43d895efcb2" /> | 
| Select Artist on Price Insights | <img width="688" alt="Screenshot 2025-01-10 at 17 14 16" src="https://github.com/user-attachments/assets/191407b6-c938-4faa-bdd3-58dbb8dc9aa1" /> | 
| Abandon Modal | <img width="686" alt="Screenshot 2025-01-10 at 17 13 23" src="https://github.com/user-attachments/assets/635f2471-7962-4a56-8db1-414a891c72ee" /> | 





In this PR, I am migrating some of the screens we have to the latter.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Deprecate FancyModal - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
