### PR TITLE
fix: Avoid calling navigate twice from Artwork rail

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tests.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkGridItemTestsQuery } from "__generated__/ArtworkGridItemTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { navigate } from "app/system/navigation/navigate"
 import { useExperimentVariant } from "app/utils/experiments/hooks"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -36,6 +37,21 @@ describe("ArtworkGridItem", () => {
     })
     ;(useExperimentVariant as jest.Mock).mockReturnValue({
       enabled: false,
+    })
+  })
+
+  describe("navigation", () => {
+    it("navigates to the Artwork screen", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          title: "Some Kind of Dinosaur",
+          slug: "cool-artwork",
+        }),
+      })
+
+      fireEvent.press(screen.getByTestId("artworkGridItem-Some Kind of Dinosaur"))
+
+      expect(navigate).toHaveBeenCalledExactlyOnceWith('<mock-value-for-field-"href">')
     })
   })
 

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -32,7 +32,6 @@ import { ArtworkItemCTAs } from "app/Scenes/Artwork/Components/ArtworkItemCTAs"
 import { useGetNewSaveAndFollowOnArtworkCardExperimentVariant } from "app/Scenes/Artwork/utils/useGetNewSaveAndFollowOnArtworkCardExperimentVariant"
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { navigate } from "app/system/navigation/navigate"
 import { ElementInView } from "app/utils/ElementInView"
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
@@ -225,14 +224,6 @@ export const Artwork: React.FC<ArtworkProps> = ({
 
     addArtworkToRecentSearches()
     trackArtworkTap()
-
-    if (artwork.href) {
-      if (partnerOffer && !!hasEnded) {
-        navigate?.(artwork.href, { passProps: { artworkOfferExpired: true } })
-      } else {
-        navigate?.(artwork.href)
-      }
-    }
   }
 
   const navigationProps = partnerOffer && !!hasEnded ? { artworkOfferExpired: true } : undefined


### PR DESCRIPTION
Resolves https://github.com/artsy/eigen/pull/11293/files#r1913175557 

 <!-- eg [PROJECT-XXXX] -->

### Description

Avoid calling navigate twice from the Artwork rail.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
