### PR TITLE
fix: Prevent `onPress` from being called when opening long-press context menu opens

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -305,6 +305,9 @@ export const Artwork: React.FC<ArtworkProps> = ({
             underlayColor={color("white100")}
             activeOpacity={0.8}
             onPress={handleTap}
+            // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
+            onLongPress={() => {}}
+            delayLongPress={400}
             navigationProps={navigationProps}
             to={artwork.href}
             testID={`artworkGridItem-${artwork.title}`}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -108,6 +108,9 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
               underlayColor={backgroundColor}
               activeOpacity={0.8}
               onPress={onPress}
+              // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
+              onLongPress={() => {}}
+              delayLongPress={400}
               testID={testID}
             >
               <Flex


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Occasionally-the-long-press-results-in-a-navigation-to-the-artwork-AND-the-modal-menu-176cab0764a080bd9f63c64253e8c8da?pvs=4

### Description

This PR prevents `onPress` from being triggered on the artwork rail and grid when the long-press context menu opens. 

Occasionally, when opening the long-press context menu with a brief press, navigation to the artwork screen occurred simultaneously with the context menu opening. 

The issue and the fix are described in https://github.com/mpiannucci/react-native-context-menu-view/issues/60.

### Videos

**Before:**
https://github.com/user-attachments/assets/8b3c824d-036b-41eb-b927-a9b2fcb51916

**After:**
https://github.com/user-attachments/assets/3b600124-16c0-463b-af55-ffc455e2a841



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prevent `onPress` from being called when opening long-press context menu on artwork rail & grid - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
