### PR TITLE
fix: Avoid double prefetching on artwork grid

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -32,7 +32,6 @@ import { ArtworkItemCTAs } from "app/Scenes/Artwork/Components/ArtworkItemCTAs"
 import { useGetNewSaveAndFollowOnArtworkCardExperimentVariant } from "app/Scenes/Artwork/utils/useGetNewSaveAndFollowOnArtworkCardExperimentVariant"
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { ElementInView } from "app/utils/ElementInView"
 import { useArtworkBidding } from "app/utils/Websockets/auctions/useArtworkBidding"
 import { getArtworkSignalTrackingFields } from "app/utils/getArtworkSignalTrackingFields"
 import { saleMessageOrBidInfo } from "app/utils/getSaleMessgeOrBidInfo"
@@ -41,7 +40,6 @@ import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NUM_COLUMNS_MASONRY } from "app/utils/masonryHelpers"
 import { useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { RandomNumberGenerator } from "app/utils/placeholders"
-import { usePrefetch } from "app/utils/queryPrefetching"
 import {
   ArtworkActionTrackingProps,
   tracks as artworkActionTracks,
@@ -126,14 +124,12 @@ export const Artwork: React.FC<ArtworkProps> = ({
 }) => {
   const itemRef = useRef<any>()
   const color = useColor()
-  const prefetchUrl = usePrefetch()
   const tracking = useTracking()
   const [showCreateArtworkAlertModal, setShowCreateArtworkAlertModal] = useState(false)
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const enableNewSaveAndFollowOnArtworkCard = useFeatureFlag(
     "AREnableNewSaveAndFollowOnArtworkCard"
   )
-  const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
   const {
     enabled,
     enableShowOldSaveCTA,
@@ -280,205 +276,197 @@ export const Artwork: React.FC<ArtworkProps> = ({
     await item._disappearable?.disappear()
   }
 
-  const handleVisible = () => {
-    if (enableViewPortPrefetching && artwork.href) {
-      prefetchUrl(artwork.href)
-    }
-  }
-
   const displayArtworkSocialSignal =
     !isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals
 
   return (
-    <ElementInView onVisible={handleVisible}>
-      <Disappearable ref={(ref) => ((artwork as any)._disappearable = ref)}>
-        <ContextMenuArtwork
-          onSupressArtwork={() => handleSupress(artwork as any)}
-          contextModule={contextModule}
-          contextScreenOwnerType={contextScreenOwnerType}
-          onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
-          artwork={artwork}
-          hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
+    <Disappearable ref={(ref) => ((artwork as any)._disappearable = ref)}>
+      <ContextMenuArtwork
+        onSupressArtwork={() => handleSupress(artwork as any)}
+        contextModule={contextModule}
+        contextScreenOwnerType={contextScreenOwnerType}
+        onCreateAlertActionPress={() => setShowCreateArtworkAlertModal(true)}
+        artwork={artwork}
+        hideCreateAlertOnArtworkPreview={hideCreateAlertOnArtworkPreview}
+      >
+        <RouterLink
+          haptic
+          underlayColor={color("white100")}
+          activeOpacity={0.8}
+          onPress={handleTap}
+          // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
+          onLongPress={() => {}}
+          delayLongPress={400}
+          navigationProps={navigationProps}
+          to={artwork.href}
+          testID={`artworkGridItem-${artwork.title}`}
         >
-          <RouterLink
-            haptic
-            underlayColor={color("white100")}
-            activeOpacity={0.8}
-            onPress={handleTap}
-            // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
-            onLongPress={() => {}}
-            delayLongPress={400}
-            navigationProps={navigationProps}
-            to={artwork.href}
-            testID={`artworkGridItem-${artwork.title}`}
-          >
-            <View ref={itemRef}>
-              {!!artwork.image?.url && (
-                <View>
-                  <Image
-                    src={artwork.image.url}
-                    aspectRatio={artwork.image.aspectRatio ?? 1}
-                    height={height}
-                    width={Number(height) * (artwork.image.aspectRatio ?? 1)}
-                    blurhash={showBlurhash ? artwork.image.blurhash : undefined}
-                    resizeMode="contain"
+          <View ref={itemRef}>
+            {!!artwork.image?.url && (
+              <View>
+                <Image
+                  src={artwork.image.url}
+                  aspectRatio={artwork.image.aspectRatio ?? 1}
+                  height={height}
+                  width={Number(height) * (artwork.image.aspectRatio ?? 1)}
+                  blurhash={showBlurhash ? artwork.image.blurhash : undefined}
+                  resizeMode="contain"
+                />
+              </View>
+            )}
+            {!!canShowAuctionProgressBar && (
+              <Box mt={1}>
+                <DurationProvider startAt={endsAt ?? undefined}>
+                  <LotProgressBar
+                    duration={null}
+                    startAt={artwork.sale?.startAt}
+                    extendedBiddingPeriodMinutes={artwork.sale.extendedBiddingPeriodMinutes}
+                    extendedBiddingIntervalMinutes={artwork.sale.extendedBiddingIntervalMinutes}
+                    biddingEndAt={endsAt}
+                    hasBeenExtended={lotSaleExtended}
                   />
-                </View>
-              )}
-              {!!canShowAuctionProgressBar && (
-                <Box mt={1}>
-                  <DurationProvider startAt={endsAt ?? undefined}>
-                    <LotProgressBar
-                      duration={null}
-                      startAt={artwork.sale?.startAt}
-                      extendedBiddingPeriodMinutes={artwork.sale.extendedBiddingPeriodMinutes}
-                      extendedBiddingIntervalMinutes={artwork.sale.extendedBiddingIntervalMinutes}
-                      biddingEndAt={endsAt}
-                      hasBeenExtended={lotSaleExtended}
-                    />
-                  </DurationProvider>
-                </Box>
-              )}
+                </DurationProvider>
+              </Box>
+            )}
 
+            <Flex
+              flexDirection={positionCTAs}
+              justifyContent="space-between"
+              mt={1}
+              style={artworkMetaStyle}
+            >
               <Flex
-                flexDirection={positionCTAs}
-                justifyContent="space-between"
-                mt={1}
-                style={artworkMetaStyle}
+                flexGrow={positionCTAs === "column" ? 1 : undefined}
+                flex={positionCTAs === "row" ? 1 : undefined}
               >
-                <Flex
-                  flexGrow={positionCTAs === "column" ? 1 : undefined}
-                  flex={positionCTAs === "row" ? 1 : undefined}
-                >
-                  {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
-                    <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
-                      Lot {artwork.saleArtwork.lotLabel}
+                {!!showLotLabel && !!artwork.saleArtwork?.lotLabel && (
+                  <Text variant="xs" numberOfLines={1} caps {...lotLabelTextStyle}>
+                    Lot {artwork.saleArtwork.lotLabel}
+                  </Text>
+                )}
+                {!!artwork.artistNames && (
+                  <Text
+                    lineHeight="18px"
+                    weight="regular"
+                    variant="xs"
+                    numberOfLines={1}
+                    {...artistNamesTextStyle}
+                  >
+                    {artwork.artistNames}
+                  </Text>
+                )}
+                {!!artwork.title && (
+                  <Text
+                    lineHeight="18px"
+                    variant="xs"
+                    weight="regular"
+                    color="black60"
+                    numberOfLines={1}
+                    {...titleTextStyle}
+                  >
+                    <Text lineHeight="18px" variant="xs" weight="regular">
+                      {artwork.title}
                     </Text>
-                  )}
-                  {!!artwork.artistNames && (
-                    <Text
-                      lineHeight="18px"
-                      weight="regular"
-                      variant="xs"
-                      numberOfLines={1}
-                      {...artistNamesTextStyle}
-                    >
-                      {artwork.artistNames}
+                    {artwork.date ? `, ${artwork.date}` : ""}
+                  </Text>
+                )}
+                {!hidePartner && !!artwork.partner?.name && (
+                  <Text
+                    variant="xs"
+                    lineHeight="18px"
+                    color="black60"
+                    numberOfLines={1}
+                    {...partnerNameTextStyle}
+                  >
+                    {artwork.partner.name}
+                  </Text>
+                )}
+                {!!displayPriceOfferMessage && (
+                  <Flex flexDirection="row">
+                    <Text lineHeight="20px" variant="xs" numberOfLines={1} fontWeight="bold">
+                      {priceOfferMessage.priceWithDiscountMessage}
                     </Text>
-                  )}
-                  {!!artwork.title && (
-                    <Text
-                      lineHeight="18px"
-                      variant="xs"
-                      weight="regular"
-                      color="black60"
-                      numberOfLines={1}
-                      {...titleTextStyle}
-                    >
-                      <Text lineHeight="18px" variant="xs" weight="regular">
-                        {artwork.title}
-                      </Text>
-                      {artwork.date ? `, ${artwork.date}` : ""}
+                    <Text color="black60" variant="xs">
+                      {" "}
+                      (List price: {priceOfferMessage.priceListedMessage})
                     </Text>
-                  )}
-                  {!hidePartner && !!artwork.partner?.name && (
-                    <Text
-                      variant="xs"
-                      lineHeight="18px"
-                      color="black60"
-                      numberOfLines={1}
-                      {...partnerNameTextStyle}
-                    >
-                      {artwork.partner.name}
-                    </Text>
-                  )}
-                  {!!displayPriceOfferMessage && (
-                    <Flex flexDirection="row">
-                      <Text lineHeight="20px" variant="xs" numberOfLines={1} fontWeight="bold">
-                        {priceOfferMessage.priceWithDiscountMessage}
-                      </Text>
-                      <Text color="black60" variant="xs">
-                        {" "}
-                        (List price: {priceOfferMessage.priceListedMessage})
-                      </Text>
-                    </Flex>
-                  )}
-                  {!!saleInfo && !hideSaleInfo && !displayPriceOfferMessage && (
-                    <ArtworkSaleMessage
-                      artwork={artwork}
-                      saleMessage={saleInfo}
-                      displayLimitedTimeOfferSignal={displayLimitedTimeOfferSignal}
-                      saleInfoTextStyle={saleInfoTextStyle}
-                    />
-                  )}
-
-                  {!!artwork.isUnlisted && (
-                    <Text lineHeight="18px" variant="xs" numberOfLines={1} fontWeight="bold">
-                      Exclusive Access
-                    </Text>
-                  )}
-
-                  {!!isAuction && !!collectorSignals && (
-                    <ArtworkAuctionTimer
-                      collectorSignals={collectorSignals}
-                      hideRegisterBySignal={hideRegisterBySignal}
-                    />
-                  )}
-
-                  {!!displayArtworkSocialSignal && (
-                    <ArtworkSocialSignal
-                      collectorSignals={collectorSignals}
-                      hideCuratorsPick={hideCuratorsPickSignal}
-                      hideIncreasedInterest={hideIncreasedInterestSignal}
-                    />
-                  )}
-                </Flex>
-
-                {!!showOldSaveCTA && (
-                  <Flex flexDirection="row" alignItems="flex-start">
-                    {!!isAuction && !!collectorSignals?.auction?.lotWatcherCount && (
-                      <Text lineHeight="18px" variant="xs" numberOfLines={1}>
-                        {collectorSignals.auction.lotWatcherCount}
-                      </Text>
-                    )}
-                    <Touchable
-                      haptic
-                      onPress={disableArtworksListPrompt ? handleArtworkSave : saveArtworkToLists}
-                      testID="save-artwork-icon"
-                    >
-                      <ArtworkHeartIcon isSaved={!!isSaved} index={itemIndex} />
-                    </Touchable>
                   </Flex>
                 )}
+                {!!saleInfo && !hideSaleInfo && !displayPriceOfferMessage && (
+                  <ArtworkSaleMessage
+                    artwork={artwork}
+                    saleMessage={saleInfo}
+                    displayLimitedTimeOfferSignal={displayLimitedTimeOfferSignal}
+                    saleInfoTextStyle={saleInfoTextStyle}
+                  />
+                )}
 
-                {!!enableNewSaveAndFollowOnArtworkCard &&
-                  !!(enableNewSaveCTA || enableNewSaveAndFollowCTAs) && (
-                    <Spacer y={positionCTAs === "column" ? 0.5 : 0} />
-                  )}
+                {!!artwork.isUnlisted && (
+                  <Text lineHeight="18px" variant="xs" numberOfLines={1} fontWeight="bold">
+                    Exclusive Access
+                  </Text>
+                )}
 
-                <ArtworkItemCTAs
-                  artwork={artwork}
-                  showSaveIcon={!hideSaveIcon}
-                  showFollowIcon={!hideFollowIcon}
-                  hideViewFollowsLink={hideViewFollowsLink}
-                  contextModule={contextModule}
-                  contextScreen={contextScreen}
-                  contextScreenOwnerId={contextScreenOwnerId}
-                  contextScreenOwnerSlug={contextScreenOwnerSlug}
-                  contextScreenOwnerType={contextScreenOwnerType}
-                />
+                {!!isAuction && !!collectorSignals && (
+                  <ArtworkAuctionTimer
+                    collectorSignals={collectorSignals}
+                    hideRegisterBySignal={hideRegisterBySignal}
+                  />
+                )}
+
+                {!!displayArtworkSocialSignal && (
+                  <ArtworkSocialSignal
+                    collectorSignals={collectorSignals}
+                    hideCuratorsPick={hideCuratorsPickSignal}
+                    hideIncreasedInterest={hideIncreasedInterestSignal}
+                  />
+                )}
               </Flex>
-            </View>
-          </RouterLink>
-        </ContextMenuArtwork>
 
-        <CreateArtworkAlertModal
-          artwork={artwork}
-          onClose={() => setShowCreateArtworkAlertModal(false)}
-          visible={showCreateArtworkAlertModal}
-        />
-      </Disappearable>
-    </ElementInView>
+              {!!showOldSaveCTA && (
+                <Flex flexDirection="row" alignItems="flex-start">
+                  {!!isAuction && !!collectorSignals?.auction?.lotWatcherCount && (
+                    <Text lineHeight="18px" variant="xs" numberOfLines={1}>
+                      {collectorSignals.auction.lotWatcherCount}
+                    </Text>
+                  )}
+                  <Touchable
+                    haptic
+                    onPress={disableArtworksListPrompt ? handleArtworkSave : saveArtworkToLists}
+                    testID="save-artwork-icon"
+                  >
+                    <ArtworkHeartIcon isSaved={!!isSaved} index={itemIndex} />
+                  </Touchable>
+                </Flex>
+              )}
+
+              {!!enableNewSaveAndFollowOnArtworkCard &&
+                !!(enableNewSaveCTA || enableNewSaveAndFollowCTAs) && (
+                  <Spacer y={positionCTAs === "column" ? 0.5 : 0} />
+                )}
+
+              <ArtworkItemCTAs
+                artwork={artwork}
+                showSaveIcon={!hideSaveIcon}
+                showFollowIcon={!hideFollowIcon}
+                hideViewFollowsLink={hideViewFollowsLink}
+                contextModule={contextModule}
+                contextScreen={contextScreen}
+                contextScreenOwnerId={contextScreenOwnerId}
+                contextScreenOwnerSlug={contextScreenOwnerSlug}
+                contextScreenOwnerType={contextScreenOwnerType}
+              />
+            </Flex>
+          </View>
+        </RouterLink>
+      </ContextMenuArtwork>
+
+      <CreateArtworkAlertModal
+        artwork={artwork}
+        onClose={() => setShowCreateArtworkAlertModal(false)}
+        visible={showCreateArtworkAlertModal}
+      />
+    </Disappearable>
   )
 }
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Avoid double prefetching on artwork grid

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
