### PR TITLE
fix: Align rate limit middleware and prefetching rate limiter

### DIFF
--- a/src/app/system/relay/middlewares/rateLimitMiddleware.ts
+++ b/src/app/system/relay/middlewares/rateLimitMiddleware.ts
@@ -14,7 +14,7 @@ export const rateLimitMiddleware = (
     interval,
     logger = console.log.bind(console, "[RELAY-NETWORK]"),
   }: RateLimitMiddlewareOpts = {
-    limit: 70,
+    limit: 100,
     interval: 1000,
   }
 ): Middleware => {

--- a/src/app/system/relay/middlewares/rateLimitMiddleware.ts
+++ b/src/app/system/relay/middlewares/rateLimitMiddleware.ts
@@ -14,7 +14,7 @@ export const rateLimitMiddleware = (
     interval,
     logger = console.log.bind(console, "[RELAY-NETWORK]"),
   }: RateLimitMiddlewareOpts = {
-    limit: 50,
+    limit: 70,
     interval: 1000,
   }
 ): Middleware => {

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -8,7 +8,7 @@ import { fetchQuery, GraphQLTaggedNode } from "react-relay"
 import { OperationType, Variables, VariablesOf } from "relay-runtime"
 import { logPrefetching } from "./loggers"
 
-const DEFAULT_QUERIES_PER_INTERVAL = 180
+const DEFAULT_QUERIES_PER_INTERVAL = 60
 
 let limiter: RateLimiter
 


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

In https://github.com/artsy/eigen/pull/11293, I have increased the rate limit for prefetching, but I am now seeing error messages because it is not aligned with the rate limit middleware limit.

This PR increases the limit of the middleware slightly and decreases the prefetching limit to avoid this situation. 

This fix is for the next release and I don't want to adjust the rate limiting middleware (https://github.com/artsy/eigen/pull/3408) too much without extensive testing and understanding why the limit is so small.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
