### PR TITLE
fix(iOS): foreground notifications linking (/w images)

### DIFF
--- a/ios/Artsy/App/ARAppNotificationsDelegate.m
+++ b/ios/Artsy/App/ARAppNotificationsDelegate.m
@@ -222,13 +222,17 @@
 // Handle the tapping on the notification when the app in the foreground
 -(void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler{
     BOOL processedByBraze = ARAppDelegate.braze != nil && [ARAppDelegate.braze.notifications handleUserNotificationWithResponse:response
-                                                                                                      withCompletionHandler:completionHandler];
-    if (processedByBraze) {
-      return;
-    }
+                                                                                                    withCompletionHandler:completionHandler];
     
     NSDictionary *userInfo = response.notification.request.content.userInfo;
     NSMutableDictionary *notificationInfo = [[NSMutableDictionary alloc] initWithDictionary:userInfo];
+    
+    if (processedByBraze) {
+      NSString *url = userInfo[@"ab_uri"];
+      [self tappedNotification:userInfo url:url];
+      return;
+    }
+    
 
     [self tappedNotification:notificationInfo url:userInfo[@"url"]];
     completionHandler();


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes an issue where when the app was in foreground and received a notification with an image, when the user tapped on it we weren't getting properly redirected to the correct page in the app.

Fixes these two issues:
- [Braze-Notification-opens-Deeplink-if-the-user-is-on-the-Foreground](https://www.notion.so/artsy/Braze-Notification-opens-Deeplink-if-the-user-is-on-the-App-17bcab0764a0805989c5c87648218a89?pvs=4)
- [Users-don-t-receive-push-notifications-when-the-app-is-in-the-foreground](https://www.notion.so/artsy/Users-don-t-receive-push-notifications-when-the-app-is-in-the-foreground-17bcab0764a080feafc0da3c5d167dbf?pvs=4)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- foreground notifications linking (/w images)

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
