### PR TITLE
fix: Modernize iOS widget config

### DIFF
--- a/ios/Artsy.xcodeproj/project.pbxproj
+++ b/ios/Artsy.xcodeproj/project.pbxproj
@@ -1676,14 +1676,14 @@
 			children = (
 				CB4326B927E8FAD900B29DD6 /* ArtsyWidgets.swift */,
 				CB4326AD27E8FAD900B29DD6 /* Assets.xcassets */,
+				CB43268B27E8FA6B00B29DD6 /* Assets.xcassets */,
 				CB43269D27E8FAD900B29DD6 /* FeaturedArtworks */,
 				CB4326AE27E8FAD900B29DD6 /* Fixtures.swift */,
 				CB43269627E8FAD800B29DD6 /* FullBleed */,
+				CB43268D27E8FA6B00B29DD6 /* Info.plist */,
 				CB4326AF27E8FAD900B29DD6 /* LatestArticles */,
 				CB4326BA27E8FAD900B29DD6 /* Models */,
 				CB4326A727E8FAD900B29DD6 /* Shared */,
-				CB43268B27E8FA6B00B29DD6 /* Assets.xcassets */,
-				CB43268D27E8FA6B00B29DD6 /* Info.plist */,
 			);
 			path = ArtsyWidget;
 			sourceTree = "<group>";
@@ -1691,10 +1691,10 @@
 		CB43269627E8FAD800B29DD6 /* FullBleed */ = {
 			isa = PBXGroup;
 			children = (
+				CB43269A27E8FAD900B29DD6 /* FullBleed.swift */,
 				CB43269727E8FAD900B29DD6 /* FullBleed+Entry.swift */,
 				CB43269827E8FAD900B29DD6 /* FullBleed+Provider.swift */,
 				CB43269927E8FAD900B29DD6 /* FullBleed+Timeline.swift */,
-				CB43269A27E8FAD900B29DD6 /* FullBleed.swift */,
 				CB43269B27E8FAD900B29DD6 /* FullBleed+View.swift */,
 				CB43269C27E8FAD900B29DD6 /* FullBleed+Widget.swift */,
 			);
@@ -1704,15 +1704,15 @@
 		CB43269D27E8FAD900B29DD6 /* FeaturedArtworks */ = {
 			isa = PBXGroup;
 			children = (
-				CB43269E27E8FAD900B29DD6 /* FeaturedArtworks+Entry.swift */,
-				CB43269F27E8FAD900B29DD6 /* FeaturedArtworks+SmallView.swift */,
-				CB4326A027E8FAD900B29DD6 /* FeaturedArtworks+Timeline.swift */,
-				CB4326A127E8FAD900B29DD6 /* FeaturedArtworks+Widget.swift */,
-				CB4326A227E8FAD900B29DD6 /* FeaturedArtworks+Provider.swift */,
-				CB4326A327E8FAD900B29DD6 /* FeaturedArtworks+View.swift */,
 				CB4326A427E8FAD900B29DD6 /* FeaturedArtworks.swift */,
+				CB43269E27E8FAD900B29DD6 /* FeaturedArtworks+Entry.swift */,
 				CB4326A527E8FAD900B29DD6 /* FeaturedArtworks+LargeView.swift */,
 				CB4326A627E8FAD900B29DD6 /* FeaturedArtworks+MediumView.swift */,
+				CB4326A227E8FAD900B29DD6 /* FeaturedArtworks+Provider.swift */,
+				CB43269F27E8FAD900B29DD6 /* FeaturedArtworks+SmallView.swift */,
+				CB4326A027E8FAD900B29DD6 /* FeaturedArtworks+Timeline.swift */,
+				CB4326A327E8FAD900B29DD6 /* FeaturedArtworks+View.swift */,
+				CB4326A127E8FAD900B29DD6 /* FeaturedArtworks+Widget.swift */,
 			);
 			path = FeaturedArtworks;
 			sourceTree = "<group>";
@@ -1720,11 +1720,11 @@
 		CB4326A727E8FAD900B29DD6 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				CB4326A827E8FAD900B29DD6 /* PrimaryText.swift */,
 				CB4326A927E8FAD900B29DD6 /* ImageUrl.swift */,
+				CB4326A827E8FAD900B29DD6 /* PrimaryText.swift */,
 				CB4326AA27E8FAD900B29DD6 /* Schedule.swift */,
-				CB4326AB27E8FAD900B29DD6 /* WidgetUrl.swift */,
 				CB4326AC27E8FAD900B29DD6 /* SecondaryText.swift */,
+				CB4326AB27E8FAD900B29DD6 /* WidgetUrl.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1732,15 +1732,15 @@
 		CB4326AF27E8FAD900B29DD6 /* LatestArticles */ = {
 			isa = PBXGroup;
 			children = (
-				CB4326B027E8FAD900B29DD6 /* LatestArticles+View.swift */,
+				CB4326B827E8FAD900B29DD6 /* LatestArticles.swift */,
 				CB4326B127E8FAD900B29DD6 /* LatestArticles+Entry.swift */,
-				CB4326B227E8FAD900B29DD6 /* LatestArticles+Widget.swift */,
-				CB4326B327E8FAD900B29DD6 /* LatestArticles+MediumView.swift */,
-				CB4326B427E8FAD900B29DD6 /* LatestArticles+Timeline.swift */,
 				CB4326B527E8FAD900B29DD6 /* LatestArticles+LargeView.swift */,
+				CB4326B327E8FAD900B29DD6 /* LatestArticles+MediumView.swift */,
 				CB4326B627E8FAD900B29DD6 /* LatestArticles+Provider.swift */,
 				CB4326B727E8FAD900B29DD6 /* LatestArticles+SmallView.swift */,
-				CB4326B827E8FAD900B29DD6 /* LatestArticles.swift */,
+				CB4326B427E8FAD900B29DD6 /* LatestArticles+Timeline.swift */,
+				CB4326B027E8FAD900B29DD6 /* LatestArticles+View.swift */,
+				CB4326B227E8FAD900B29DD6 /* LatestArticles+Widget.swift */,
 			);
 			path = LatestArticles;
 			sourceTree = "<group>";
@@ -1748,16 +1748,16 @@
 		CB4326BA27E8FAD900B29DD6 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				CB4326BB27E8FAD900B29DD6 /* ArticleStore.swift */,
-				CB4326BC27E8FAD900B29DD6 /* VolleyClient.swift */,
-				CB4326BD27E8FAD900B29DD6 /* VolleyPayload.swift */,
-				CB4326BE27E8FAD900B29DD6 /* ArtworkImage.swift */,
-				CB4326BF27E8FAD900B29DD6 /* Artist.swift */,
-				CB4326C027E8FAD900B29DD6 /* ArtworkStore.swift */,
-				CB4326C127E8FAD900B29DD6 /* VolleyMetric.swift */,
-				CB4326C227E8FAD900B29DD6 /* Artwork.swift */,
 				CB4326C327E8FAD900B29DD6 /* Article.swift */,
 				CB4326C427E8FAD900B29DD6 /* ArticleParser.swift */,
+				CB4326BB27E8FAD900B29DD6 /* ArticleStore.swift */,
+				CB4326BF27E8FAD900B29DD6 /* Artist.swift */,
+				CB4326C227E8FAD900B29DD6 /* Artwork.swift */,
+				CB4326BE27E8FAD900B29DD6 /* ArtworkImage.swift */,
+				CB4326C027E8FAD900B29DD6 /* ArtworkStore.swift */,
+				CB4326BC27E8FAD900B29DD6 /* VolleyClient.swift */,
+				CB4326C127E8FAD900B29DD6 /* VolleyMetric.swift */,
+				CB4326BD27E8FAD900B29DD6 /* VolleyPayload.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+LargeView.swift
@@ -5,13 +5,23 @@ private struct TopArtwork: SwiftUI.View {
     let artwork: Artwork
     
     var body: some SwiftUI.View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            actualBody().containerBackground(for: .widget) {
+                Color.white
+            }
+        } else {
+            actualBody()
+        }
+    }
+    
+    func actualBody() -> some SwiftUI.View {
         let artsyLogo = UIImage(named: "BlackArtsyLogo")!
         let artworkImage = artwork.image!
         let artistName = artwork.artist.name
         let artworkTitle = artwork.title
         let artworkUrl = artwork.url
         
-        HStack(alignment: .bottom) {
+        return HStack(alignment: .bottom) {
             Image(uiImage: artworkImage)
                 .resizable()
                 .scaledToFit()

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+MediumView.swift
@@ -5,13 +5,23 @@ private struct TopArtwork: SwiftUI.View {
     let artwork: Artwork
     
     var body: some SwiftUI.View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            actualBody().containerBackground(for: .widget) {
+                Color.white
+            }
+        } else {
+            actualBody()
+        }
+    }
+    
+    func actualBody() -> some SwiftUI.View {
         let artsyLogo = UIImage(named: "BlackArtsyLogo")!
         let artworkImage = artwork.image!
         let artistName = artwork.artist.name
         let artworkTitle = artwork.title
         let artworkUrl = artwork.url
         
-        HStack(alignment: .bottom) {
+        return HStack(alignment: .bottom) {
             Image(uiImage: artworkImage)
                 .resizable()
                 .scaledToFit()

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+SmallView.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+SmallView.swift
@@ -12,12 +12,22 @@ extension FeaturedArtworks {
         }
         
         var body: some SwiftUI.View {
+            if #available(iOSApplicationExtension 17.0, *) {
+                actualBody().containerBackground(for: .widget) {
+                    Color.white
+                }
+            } else {
+                actualBody()
+            }
+        }
+        
+        func actualBody() -> some SwiftUI.View {
             let artsyLogo = UIImage(named: "BlackArtsyLogo")!
             let artworkImage = artwork.image!
             let artistName = artwork.artist.name
             let artworkUrl = artwork.url
             
-            VStack() {
+            return VStack() {
                 HStack(alignment: .top) {
                     Image(uiImage: artworkImage)
                         .resizable()

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
@@ -4,14 +4,16 @@ import WidgetKit
 
 extension FeaturedArtworks {
     struct Widget: SwiftUI.Widget {
+        static let description: String = "A curated selection of newly uploaded works from galleries, fairs, and auctions."
+        static let displayName: String = "New This Week"
         static let kind: String = "FeaturedArtworksWidget"
         
         var body: some WidgetConfiguration {
             StaticConfiguration(kind: Widget.kind, provider: Provider()) { entry in
                 View(entry: entry)
             }
-            .configurationDisplayName("New This Week")
-            .description("A curated selection of newly uploaded works from galleries, fairs, and auctions.")
+            .configurationDisplayName(Widget.displayName)
+            .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }
     }

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
@@ -13,6 +13,7 @@ extension FeaturedArtworks {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .containerBackgroundRemovable(false)
             .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)

--- a/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
+++ b/ios/ArtsyWidget/FeaturedArtworks/FeaturedArtworks+Widget.swift
@@ -13,6 +13,7 @@ extension FeaturedArtworks {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }

--- a/ios/ArtsyWidget/FullBleed/FullBleed+View.swift
+++ b/ios/ArtsyWidget/FullBleed/FullBleed+View.swift
@@ -15,13 +15,23 @@ extension FullBleed {
         }
         
         var body: some SwiftUI.View {
+            if #available(iOSApplicationExtension 17.0, *) {
+                actualBody().containerBackground(for: .widget) {
+                    Color.white
+                }
+            } else {
+                actualBody()
+            }
+        }
+        
+        func actualBody() -> some SwiftUI.View {
             let artsyLogo = UIImage(named: "WhiteArtsyLogo")!
             let artworkImage = artwork.image!
             let artistName = artwork.artist.name
             let artworkTitle = artwork.title
             let artworkUrl = artwork.url
             
-            GeometryReader { geo in
+            return GeometryReader { geo in
                 ZStack() {
                     Image(uiImage: artworkImage)
                         .resizable()

--- a/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
+++ b/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
@@ -4,14 +4,16 @@ import WidgetKit
 
 extension FullBleed {
     struct Widget: SwiftUI.Widget {
+        static let description: String = "A curated selection of newly uploaded works from galleries, fairs, and auctions."
+        static let displayName: String = "New This Week"
         static let kind: String = "FullBleedWidget"
         
         var body: some WidgetConfiguration {
             StaticConfiguration(kind: Widget.kind, provider: Provider()) { entry in
                 View(entry: entry)
             }
-            .configurationDisplayName("New This Week")
-            .description("A curated selection of newly uploaded works from galleries, fairs, and auctions.")
+            .configurationDisplayName(Widget.displayName)
+            .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }
     }

--- a/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
+++ b/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
@@ -13,6 +13,7 @@ extension FullBleed {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .containerBackgroundRemovable(false)
             .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)

--- a/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
+++ b/ios/ArtsyWidget/FullBleed/FullBleed+Widget.swift
@@ -13,6 +13,7 @@ extension FullBleed {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+LargeView.swift
@@ -8,11 +8,21 @@ extension LatestArticles {
         let entry: Entry
         
         var body: some SwiftUI.View {
+            if #available(iOSApplicationExtension 17.0, *) {
+                actualBody().containerBackground(for: .widget) {
+                    Color.white
+                }
+            } else {
+                actualBody()
+            }
+        }
+        
+        func actualBody() -> some SwiftUI.View {
             let artsyLogo = UIImage(named: "BlackArtsyLogo")!
             let articles = entry.articles
             let artsyUrl = WidgetUrl.from(link: "https://www.artsy.net")!
             
-            VStack() {
+            return VStack() {
                 HStack(alignment: .center) {
                     Link(destination: artsyUrl) {
                         Text("LATEST ARTICLES")

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+MediumView.swift
@@ -8,11 +8,21 @@ extension LatestArticles {
         let entry: Entry
         
         var body: some SwiftUI.View {
+            if #available(iOSApplicationExtension 17.0, *) {
+                actualBody().containerBackground(for: .widget) {
+                    Color.white
+                }
+            } else {
+                actualBody()
+            }
+        }
+        
+        func actualBody() -> some SwiftUI.View {
             let artsyLogo = UIImage(named: "BlackArtsyLogo")!
             let articles = entry.articles[0...1]
             let artsyUrl = WidgetUrl.from(link: "https://www.artsy.net")!
             
-            VStack() {
+            return VStack() {
                 HStack(alignment: .center) {
                     Link(destination: artsyUrl) {
                         Text("LATEST ARTICLES")

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+SmallView.swift
@@ -12,12 +12,22 @@ extension LatestArticles {
         }
         
         var body: some SwiftUI.View {
+            if #available(iOSApplicationExtension 17.0, *) {
+                actualBody().containerBackground(for: .widget) {
+                    Color.white
+                }
+            } else {
+                actualBody()
+            }
+        }
+        
+        func actualBody() -> some SwiftUI.View {
             let artsyLogo = UIImage(named: "WhiteArtsyLogo")!
             let articleImage = article.image!
             let articleTitle = article.title
             let articleUrl = article.url!
             
-            GeometryReader { geo in
+            return GeometryReader { geo in
                 ZStack() {
                     Image(uiImage: articleImage)
                         .resizable()

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
@@ -13,6 +13,7 @@ extension LatestArticles {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .containerBackgroundRemovable(false)
             .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
@@ -4,14 +4,16 @@ import WidgetKit
 
 extension LatestArticles {
     struct Widget: SwiftUI.Widget {
+        static let description: String = "The latest articles from Artsy Editorial."
+        static let displayName: String = "Editorial"
         static let kind: String = "LatestArticlesWidget"
         
         var body: some WidgetConfiguration {
             StaticConfiguration(kind: Widget.kind, provider: Provider()) { entry in
                 View(entry: entry)
             }
-            .configurationDisplayName("Editorial")
-            .description("The latest articles from Artsy Editorial.")
+            .configurationDisplayName(Widget.displayName)
+            .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }
     }

--- a/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
+++ b/ios/ArtsyWidget/LatestArticles/LatestArticles+Widget.swift
@@ -13,6 +13,7 @@ extension LatestArticles {
                 View(entry: entry)
             }
             .configurationDisplayName(Widget.displayName)
+            .contentMarginsDisabled()
             .description(Widget.description)
             .supportedFamilies(View.supportedFamilies)
         }


### PR DESCRIPTION
This PR fixes a number of rough edges with our iOS widget.

<details><summary>screenshots</summary>

![sabretooth-000035@2x](https://github.com/user-attachments/assets/504f05f4-2f59-4139-951f-8d4a8cf2eddc)
![sabretooth-000034@2x](https://github.com/user-attachments/assets/12b535a5-af06-4601-9ab4-58f99384b50e)


</details> 

## contentMarginsDisabled

This configuration turns off an annoying thing where Apple is attempting to limit the developer to a "safe" content area. I guess I see what they are going for here but for us it's all wrong. We want our widget area to extend all the way to the edge and this configuration restores that layout.

## containerBackgroundRemovable

This configuration is used by iOS to decide how to render the widget in various scenarios where a background does not make sense. Think the Lock Screen - those widgets should not have a background. In our case we don't support the Lock Screen and further we do not want our background to ever be removed. Setting this to false ensures we always render correctly.

## containerBackground

This view modifier is only available in iOS 17 or later but is required to be called when it _is_ available. For us the previous setting ensures the background will not be removed but the view doesn't know this. In order to preview the widget in Xcode we have to call this. Because the minimum iOS version is 16 I had to wrap this call with availability checks and so my solution was to extract a function for the actual body of the widget. Once we are able to drop support for iOS 16 then I can reverse this and simplify the views.

/cc @artsy/amber-devs