### PR TITLE
fix(PBRW-359): broken presentation on tooltip icon

### DIFF
--- a/src/app/Components/Buttons/InfoButton.tsx
+++ b/src/app/Components/Buttons/InfoButton.tsx
@@ -1,4 +1,12 @@
-import { Button, Flex, InfoCircleIcon, Spacer, Text, Touchable } from "@artsy/palette-mobile"
+import {
+  Button,
+  Flex,
+  InfoCircleIcon,
+  Spacer,
+  Text,
+  Touchable,
+  useSpace,
+} from "@artsy/palette-mobile"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
 import React, { forwardRef, useImperativeHandle, useState } from "react"
 import { Platform, ScrollView } from "react-native"
@@ -74,28 +82,29 @@ export const AutoHeightInfoModal: React.FC<{
   title?: string
   modalContent: JSX.Element
 }> = ({ visible, onDismiss, modalTitle, title, modalContent }) => {
-  const isIos = Platform.OS === "ios"
+  const space = useSpace()
 
   return (
     <AutoHeightBottomSheet
       visible={visible}
       onDismiss={onDismiss}
       containerComponent={
-        isIos ? ({ children }) => <FullWindowOverlay>{children}</FullWindowOverlay> : undefined
+        Platform.OS === "ios"
+          ? ({ children }) => <FullWindowOverlay>{children}</FullWindowOverlay>
+          : undefined
       }
     >
-      <Flex pb={4} pt={1} height="100%">
+      <Flex pb={4} pt={1}>
         <Text mx={2} variant="lg-display">
           {modalTitle ?? title}
         </Text>
 
         <Spacer y={2} />
 
-        <Flex flex={1}>
-          <ScrollView>
-            <Flex px={2}>{modalContent}</Flex>
-          </ScrollView>
-        </Flex>
+        <ScrollView contentContainerStyle={{ paddingHorizontal: space(2) }}>
+          {modalContent}
+        </ScrollView>
+
         <Spacer y={2} />
 
         <Flex px={2}>


### PR DESCRIPTION
This PR resolves [PBRW-359] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the broken presentation after pressing on the tooltip icon the saves tab. I don't have a concrete explanation about why this is breaking. However my assumption is that the bottomsheet modal doesn't like when different heights are being specified because it breaks it's built in height calculation


https://github.com/user-attachments/assets/8e8a3697-f5c1-497a-bddf-62cf47be81a0


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix broken saved and follows button tooltip animation - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-359]: https://artsyproduct.atlassian.net/browse/PBRW-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ