### PR TITLE
fix(PBRW-338): broken info button inside modals

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
+++ b/src/app/Scenes/SavedSearchAlert/Components/Form.tsx
@@ -116,6 +116,7 @@ export const Form: React.FC<FormProps> = ({
                   matching works are added to Artsy.
                 </Text>
               }
+              isPresentedModally
             />
             <Spacer y={4} />
           </>

--- a/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/CreateSavedSearchAlert.tsx
@@ -58,7 +58,12 @@ export const CreateSavedSearchAlert: React.FC<CreateSavedSearchAlertProps> = (pr
           saveSession(state)
         }}
       >
-        <Modal visible={visible} presentationStyle="fullScreen" statusBarTranslucent>
+        <Modal
+          visible={visible}
+          presentationStyle="fullScreen"
+          statusBarTranslucent
+          animationType="slide"
+        >
           <SafeAreaView style={{ flex: 1 }}>
             <KeyboardAvoidingView
               style={{ flex: 1 }}


### PR DESCRIPTION
This PR resolves [PBRW-338] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue happening at the create alert modal info button.
The problem here is that the bottom sheet modal component from rn-bottom-sheet couldn't be shown on top of the modal from react-native on Android. In iOS it's not an issue because we are anyway using a custom implementation of the modal (`FullScreenOverlay`). Here, I am updating the implementation on Android to use the modal from RN in case we are using the info button inside a modal.


https://github.com/user-attachments/assets/dd958aa9-9b13-49b0-b89c-f896d67f682e


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix info button inside modals - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-338]: https://artsyproduct.atlassian.net/browse/PBRW-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ