### PR TITLE
fix(hack-15): Remove unused notification permissions

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2677,7 +2677,7 @@ SPEC CHECKSUMS:
   appcenter-core: 3f5907606dfbf4ffe62cb7798210174c2608a7d9
   AppCenterReactNativeShared: 01df23849b1c3c6eb8c4049f54322635650e98f0
   Base64: cecfb41a004124895a7bcee567a89bae5a89d49b
-  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   braze-react-native-sdk: 578aa5dcc064b0260a288d7b74607cc4b846a7bb
   BrazeKit: 879da791a0f4e247846a06c6de95f8b93f4579df
   BrazeLocation: 59af48eafcf233a8ef16de3f6900955332113fe4
@@ -2708,7 +2708,7 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
   FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
   FLKAutoLayout: 106b14dbae09d32c6730190f4e78a959759ba4a4
-  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
+  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
   glog: 69ef571f3de08433d766d614c73a9838a06bf7eb

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -34,8 +34,6 @@ export type UserPushNotificationSettings =
   | "receivePurchaseNotification"
   | "receiveSaleOpeningClosingNotification"
   | "receiveOrderNotification"
-  | "receiveViewingRoomNotification"
-  | "receivePartnerShowNotification"
   | "receivePartnerOfferNotification"
 
 export const OpenSettingsBanner = () => (
@@ -257,24 +255,6 @@ export const MyProfilePushNotifications: React.FC<{
             disabled={isLoading}
             onChange={(value) => {
               handleUpdateUserNotificationSettings("receiveNewSalesNotification", value)
-            }}
-          />
-          <SwitchMenu
-            title="New Viewing Rooms for You"
-            description="New viewing rooms added by galleries you follow"
-            value={!!userNotificationSettings.receiveViewingRoomNotification}
-            disabled={isLoading}
-            onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveViewingRoomNotification", value)
-            }}
-          />
-          <SwitchMenu
-            title="New Shows for You"
-            description="New shows added by galleries you follow"
-            value={!!userNotificationSettings.receivePartnerShowNotification}
-            disabled={isLoading}
-            onChange={(value) => {
-              handleUpdateUserNotificationSettings("receivePartnerShowNotification", value)
             }}
           />
           <SwitchMenu


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

>[!IMPORTANT]
> This change is part of [Migrating push to Pulse](https://www.notion.so/artsy/Consolidate-push-notification-responsibilities-in-Pulse-17ecab0764a080a3864ee0bc64268dcf?pvs=4) hackathon project

### Description

This PR is a prerequisite to artsy/gravity#18498 🔒 and artsy/gravity#18503 🔒 to clean up gravity and move all push notification login to Pulse

This PR removes `New Viewing Rooms for You` and `New Shows for You` notification permissions since they haven't been used for quite some time


### Screenshots
| | Before | After |
|---|---|---|
| Android | ![image](https://github.com/user-attachments/assets/86a2e4ae-6d13-478a-9e99-1b05da9c2a75) | ![image](https://github.com/user-attachments/assets/d5806416-7ebe-4e43-83bd-149a58a362d9) |
| iOS | ![image](https://github.com/user-attachments/assets/81f8b187-72f5-462c-bedc-d1bb575a9169) | ![image](https://github.com/user-attachments/assets/4baeafea-0245-4f58-978c-283b4621b71e) |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Remove New Viewing Rooms for You and New Shows for You notification permission

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
