### PR TITLE
chore: add pickup available line to shipping infor on artwork

### DIFF
--- a/src/app/Scenes/Artwork/Components/ShippingAndTaxes.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ShippingAndTaxes.tests.tsx
@@ -51,6 +51,7 @@ describe("ShippingAndTaxes", () => {
 
     expect(screen.getByText(/City, State, Country/)).toBeDefined()
     expect(screen.getByText(/Shipping: Calculated in checkout/)).toBeDefined()
+    expect(screen.getByText(/Pickup available/)).toBeDefined()
     expect(screen.getByText(/VAT included in price/)).toBeDefined()
   })
 
@@ -103,6 +104,7 @@ const artwork = {
   shippingOrigin: "City, State, Country",
   shippingInfo: "Shipping: Calculated in checkout",
   priceIncludesTaxDisplay: "VAT included in price",
+  pickupAvailable: true,
   taxInfo: {
     displayText: "Tax Info",
     moreInfo: {

--- a/src/app/Scenes/Artwork/Components/ShippingAndTaxes.tsx
+++ b/src/app/Scenes/Artwork/Components/ShippingAndTaxes.tsx
@@ -10,7 +10,8 @@ interface ShippingAndTaxesProps {
 }
 
 const ShippingAndTaxes: React.FC<ShippingAndTaxesProps> = ({ artwork }) => {
-  const { shippingInfo, shippingOrigin, priceIncludesTaxDisplay, taxInfo } = artwork
+  const { shippingInfo, shippingOrigin, pickupAvailable, priceIncludesTaxDisplay, taxInfo } =
+    artwork
   const { trackEvent } = useTracking()
 
   const handleLearnMorePress = () => {
@@ -33,32 +34,38 @@ const ShippingAndTaxes: React.FC<ShippingAndTaxesProps> = ({ artwork }) => {
       {!artwork.isUnlisted && (
         <>
           <Text variant="md">Shipping and taxes</Text>
-          <Spacer y={1} />
+          <Spacer y={2} />
         </>
       )}
 
       {!!shippingOrigin && (
-        <Text variant="sm" color="black60" mb={0.5}>
+        <Text variant="sm" color="black60">
           Ships from {shippingOrigin}
         </Text>
       )}
-
       {!!shippingInfo && (
-        <Text variant="xs" color="black60">
+        <Text variant="sm" color="black60">
           {shippingInfo}
         </Text>
       )}
+      {!!pickupAvailable && (
+        <Text variant="sm" color="black60">
+          Pickup available
+        </Text>
+      )}
+
+      {(!!priceIncludesTaxDisplay || !!taxInfo) && <Spacer y={2} />}
 
       {!!priceIncludesTaxDisplay && (
-        <Text variant="xs" color="black60">
+        <Text variant="sm" color="black60">
           {priceIncludesTaxDisplay}
         </Text>
       )}
 
       {!!taxInfo && (
-        <Text variant="xs" color="black60">
+        <Text variant="sm" color="black60">
           {taxInfo.displayText}{" "}
-          <LinkText variant="xs" onPress={handleLearnMorePress}>
+          <LinkText variant="sm" onPress={handleLearnMorePress}>
             {taxInfo.moreInfo.displayText}
           </LinkText>
         </Text>
@@ -73,6 +80,7 @@ export const ShippingAndTaxesFragmentContainer = createFragmentContainer(Shippin
       isUnlisted
       shippingOrigin
       shippingInfo
+      pickupAvailable
       priceIncludesTaxDisplay
       taxInfo {
         displayText


### PR DESCRIPTION
#hackathon related PR.

### Description

This adds a 'pickup available line' to shipping section of artwork screen and also adds a minor adjustment in spacing in preparation of change that will be done in MP.

Current view without MP changes:

PickupAvailable:
<img width="290" alt="Screenshot 2025-01-23 at 12 48 24 PM" src="https://github.com/user-attachments/assets/7f6592b9-145c-44f5-9ef5-85f6449b1923" />

Pickup not available:
<img width="289" alt="Screenshot 2025-01-23 at 12 49 52 PM" src="https://github.com/user-attachments/assets/318e82e9-818f-4d49-b0b6-ce316d030300" />


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- pickup available added on artwork screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
