### PR TITLE
fix: Sell flow navigation on hardware back button press for Android

### DIFF
--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
@@ -17,9 +17,10 @@ import {
 } from "app/Scenes/SellWithArtsy/ArtworkForm/Utils/validation"
 import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubmitArtworkTracking"
 import { goBack } from "app/system/navigation/navigate"
+import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { useFormikContext } from "formik"
 import { useEffect, useMemo } from "react"
-import { Alert, BackHandler } from "react-native"
+import { Alert } from "react-native"
 
 export const SubmitArtworkFormEvents = new EventEmitter()
 SubmitArtworkFormEvents.setMaxListeners(20)
@@ -96,15 +97,10 @@ export const useSubmissionContext = () => {
     }, [currentStep])
   }
 
-  // Navigate to the previous step when the hardware back button is pressed (Android)
-  useEffect(() => {
-    const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
-      navigateToPreviousStep()
-      return true
-    })
-
-    return () => subscription.remove()
-  }, [])
+  useBackHandler(() => {
+    navigateToPreviousStep()
+    return true
+  })
 
   return {
     isValid,

--- a/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
+++ b/src/app/Scenes/SellWithArtsy/ArtworkForm/Utils/useSubmissionContext.ts
@@ -19,7 +19,7 @@ import { useSubmitArtworkTracking } from "app/Scenes/SellWithArtsy/Hooks/useSubm
 import { goBack } from "app/system/navigation/navigate"
 import { useFormikContext } from "formik"
 import { useEffect, useMemo } from "react"
-import { Alert } from "react-native"
+import { Alert, BackHandler } from "react-native"
 
 export const SubmitArtworkFormEvents = new EventEmitter()
 SubmitArtworkFormEvents.setMaxListeners(20)
@@ -95,6 +95,16 @@ export const useSubmissionContext = () => {
       }
     }, [currentStep])
   }
+
+  // Navigate to the previous step when the hardware back button is pressed (Android)
+  useEffect(() => {
+    const subscription = BackHandler.addEventListener("hardwareBackPress", () => {
+      navigateToPreviousStep()
+      return true
+    })
+
+    return () => subscription.remove()
+  }, [])
 
   return {
     isValid,


### PR DESCRIPTION
This PR resolves [PBRW-344] <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds a listener to the hardware back button (Android) to ensure proper navigation to the previous step in the Sell flow.

Without this fix, the bottom navigation of the flow did not update correctly.

| Before | After |
| --- | --- |
|![Screenshot_1737968072](https://github.com/user-attachments/assets/091e3e9f-ab92-411b-83d4-67b837f79c4d) |![Screenshot_1737968033](https://github.com/user-attachments/assets/f42d9eeb-ccfc-42a3-9ec6-14b51914b78f) |



### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-344]: https://artsyproduct.atlassian.net/browse/PBRW-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ