### PR TITLE
fix: Close Info bottom sheet on tapping Close button

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
+++ b/src/app/Components/Artist/ArtistInsights/ArtistInsightsAuctionResults.tests.tsx
@@ -208,7 +208,7 @@ describe("ArtistInsightsAuctionResults", () => {
         }),
       })
 
-      expect(extractText(tree.root.findAllByType(Text)[5])).toBe(
+      expect(extractText(tree.root.findAllByType(Text)[1])).toBe(
         "1 result • Sorted by most recent sale date"
       )
     })
@@ -224,7 +224,7 @@ describe("ArtistInsightsAuctionResults", () => {
           },
         }),
       })
-      expect(extractText(tree.root.findAllByType(Text)[5])).toBe(
+      expect(extractText(tree.root.findAllByType(Text)[1])).toBe(
         "10 results • Sorted by most recent sale date"
       )
     })

--- a/src/app/Components/BottomSheet/AutoHeightBottomSheet.tsx
+++ b/src/app/Components/BottomSheet/AutoHeightBottomSheet.tsx
@@ -10,6 +10,8 @@ export const AutoHeightBottomSheet: React.FC<AutoHeightBottomSheetProps> = ({
   children,
   ...rest
 }) => {
+  if (!rest.visible) return null
+
   return (
     <AutomountedBottomSheetModal enableDynamicSizing {...rest}>
       <BottomSheetView>{children}</BottomSheetView>

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -229,6 +229,8 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
           activeOpacity={0.8}
           onLongPress={handleAndroidLongPress}
           delayLongPress={1200}
+          onPress={undefined}
+          testID="android-context-menu-trigger"
         >
           {children}
         </TouchableHighlight>

--- a/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
+++ b/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
@@ -2,7 +2,6 @@ import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ArtworkRailCardTestsQuery } from "__generated__/ArtworkRailCardTestsQuery.graphql"
 import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Platform } from "react-native"
 import { graphql } from "react-relay"
@@ -38,8 +37,6 @@ describe("ContextMenuArtwork", () => {
       const artworkCard = screen.getByTestId("android-context-menu-trigger")
 
       fireEvent(artworkCard, "onLongPress")
-
-      await flushPromiseQueue()
 
       await waitFor(() => {
         expect(screen.getByText("Create alert")).toBeOnTheScreen()

--- a/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
+++ b/src/app/Components/ContextMenu/__tests__/ContextMenuArtwork.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { ArtworkRailCardTestsQuery } from "__generated__/ArtworkRailCardTestsQuery.graphql"
 import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { Platform } from "react-native"
 import { graphql } from "react-relay"
@@ -34,9 +35,11 @@ describe("ContextMenuArtwork", () => {
     it("shows context menu on long press", async () => {
       renderWithRelay()
 
-      const artworkCard = screen.getByTestId("artwork-card")
+      const artworkCard = screen.getByTestId("android-context-menu-trigger")
 
       fireEvent(artworkCard, "onLongPress")
+
+      await flushPromiseQueue()
 
       await waitFor(() => {
         expect(screen.getByText("Create alert")).toBeOnTheScreen()

--- a/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Artwork/Components/MyCollectionArtworkSubmissionStatus.tests.tsx
@@ -43,7 +43,7 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
     })
 
     expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
-    expect(screen.queryAllByText("Complete Submission")).toHaveLength(2)
+    expect(screen.queryAllByText("Complete Submission")).toHaveLength(1)
   })
 
   it("displays submission status in LISTED state", () => {
@@ -60,7 +60,7 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
     })
 
     expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
-    expect(screen.queryAllByText("Listed")).toHaveLength(2)
+    expect(screen.queryAllByText("Listed")).toHaveLength(1)
   })
 
   it("does not display action label in LISTED state", () => {
@@ -95,7 +95,7 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
     })
 
     expect(screen.queryByTestId("MyCollectionArtworkSubmissionStatus-Container")).not.toBe(null)
-    expect(screen.queryAllByText("Submission Unsuccessful")).toHaveLength(2)
+    expect(screen.queryAllByText("Submission Unsuccessful")).toHaveLength(1)
   })
 
   it("navigatess to submission flow ShippingLocation when action label is pressed and Tier 2", () => {
@@ -113,7 +113,7 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
       },
     })
 
-    expect(screen.queryAllByText("Complete Listing")).toHaveLength(2)
+    expect(screen.queryAllByText("Complete Listing")).toHaveLength(1)
     fireEvent.press(screen.getByTestId("action-label"))
     expect(navigate).toHaveBeenCalledWith("/sell/submissions/some-external-id/edit", {
       passProps: {
@@ -139,7 +139,7 @@ describe("MyCollectionArtworkSubmissionStatus", () => {
       },
     })
 
-    expect(screen.queryAllByText("Complete Submission")).toHaveLength(2)
+    expect(screen.queryAllByText("Complete Submission")).toHaveLength(1)
     fireEvent.press(screen.getByTestId("action-label"))
     expect(navigate).toHaveBeenCalledWith("/sell/submissions/some-external-id/edit", {
       passProps: {


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

Close Info bottom sheet on tapping Close button.

| Before | After |
| --- | --- |
|https://github.com/user-attachments/assets/98cef454-4e4a-4220-96e7-46fabed6f19e|https://github.com/user-attachments/assets/87477406-f228-46cd-a870-c723bdadb32f |






### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: Correctly close Info bottom sheet on tapping Close button - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
