### PR TITLE
refactor(GlobalStore): move onboardingState to onboardingModel

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -152,7 +152,7 @@ const AppTabs: React.FC = () => {
 export const AuthenticatedRoutesStack = createNativeStackNavigator()
 
 export const AuthenticatedRoutes: React.FC = () => {
-  const onboardingState = GlobalStore.useAppState((state) => state.auth.onboardingState)
+  const onboardingState = GlobalStore.useAppState((state) => state.onboarding.onboardingState)
 
   if (onboardingState === "incomplete") {
     return <OnboardingQuiz />

--- a/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizResults/ArtQuizResults.tsx
@@ -15,7 +15,7 @@ const ResultsScreen = () => {
   const hasSavedArtworks = queryResult.me?.quiz.savedArtworks.length
 
   useEffect(() => {
-    GlobalStore.actions.auth.setArtQuizState("complete")
+    GlobalStore.actions.onboarding.setArtQuizState("complete")
   }, [])
 
   if (hasSavedArtworks) {

--- a/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizWelcome.tsx
@@ -32,7 +32,7 @@ export const ArtQuizWelcome = () => {
             block
             variant="text"
             onPress={() => {
-              GlobalStore.actions.auth.setArtQuizState("complete")
+              GlobalStore.actions.onboarding.setArtQuizState("complete")
               navigate("/", {
                 replaceActiveScreen: true,
               })

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -185,7 +185,7 @@ export const HomeView: React.FC = memo(() => {
 })
 
 const HomeViewScreenComponent: React.FC = () => {
-  const artQuizState = GlobalStore.useAppState((state) => state.auth.onboardingArtQuizState)
+  const artQuizState = GlobalStore.useAppState((state) => state.onboarding.onboardingArtQuizState)
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const showPlayground = useDevToggle("DTShowPlayground")
 

--- a/src/app/Scenes/Onboarding/Onboarding.tsx
+++ b/src/app/Scenes/Onboarding/Onboarding.tsx
@@ -168,7 +168,7 @@ const DevMenu = () => (
   <DevMenuDefault onClose={() => __unsafe__onboardingNavigationRef.current?.goBack()} />
 )
 export const Onboarding = () => {
-  const onboardingState = GlobalStore.useAppState((state) => state.auth.onboardingState)
+  const onboardingState = GlobalStore.useAppState((state) => state.onboarding.onboardingState)
   const fpsCounter = useDevToggle("DTFPSCounter")
 
   return (

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
@@ -18,13 +18,13 @@ describe("Onboarding", () => {
 
   it("renders the welcome screens when the onboarding state is none or complete", () => {
     renderWithWrappers(<Onboarding />)
-    __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "none" } })
+    __globalStoreTestUtils__?.injectState({ onboarding: { onboardingState: "none" } })
 
     expect(screen.UNSAFE_queryByType(OnboardingQuiz)).toBeFalsy()
     expect(screen.UNSAFE_getByType(OnboardingWelcomeScreens)).toBeTruthy()
 
     renderWithWrappers(<Onboarding />)
-    __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "complete" } })
+    __globalStoreTestUtils__?.injectState({ onboarding: { onboardingState: "complete" } })
 
     expect(screen.UNSAFE_queryByType(OnboardingQuiz)).toBeFalsy()
     expect(screen.UNSAFE_getByType(OnboardingWelcomeScreens)).toBeTruthy()
@@ -32,7 +32,7 @@ describe("Onboarding", () => {
 
   it("renders the personalization flow when the onboarding state is incomplete", () => {
     renderWithWrappers(<Onboarding />)
-    __globalStoreTestUtils__?.injectState({ auth: { onboardingState: "incomplete" } })
+    __globalStoreTestUtils__?.injectState({ onboarding: { onboardingState: "incomplete" } })
     expect(screen.UNSAFE_getByType(OnboardingQuiz)).toBeTruthy()
     expect(screen.UNSAFE_queryByType(OnboardingWelcomeScreens)).toBeFalsy()
   })

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuestionThree.tsx
@@ -32,7 +32,7 @@ export const OnboardingQuestionThree = () => {
       trackAnsweredQuestionThree(questionThree)
     }
     if (questionThree === OPTION_THE_ART_TASTE_QUIZ) {
-      GlobalStore.actions.auth.setArtQuizState("incomplete")
+      GlobalStore.actions.onboarding.setArtQuizState("incomplete")
       onDone()
     } else {
       // @ts-expect-error

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
@@ -35,7 +35,7 @@ export const OnboardingQuiz = () => {
 
   const onDone = () => {
     trackCompletedOnboarding()
-    GlobalStore.actions.auth.setState({ onboardingState: "complete" })
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
 
   const { commitMutation } = useUpdateUserProfile(onDone)

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingWelcome.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingWelcome.tsx
@@ -181,7 +181,7 @@ const OnboardingWelcome = () => {
               variant="fillDark"
               block
               haptic="impactMedium"
-              onPress={() => GlobalStore.actions.auth.setState({ onboardingState: "complete" })}
+              onPress={() => GlobalStore.actions.onboarding.setOnboardingState("complete")}
             >
               Skip
             </Button>

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -89,9 +89,6 @@ type OAuthParams =
   | AppleOAuthParams
   | FacebookLimitedOAuthParams
 
-type OnboardingState = "none" | "incomplete" | "complete"
-type OnboardingArtQuizState = "none" | "incomplete" | "complete"
-
 export interface AuthPromiseResolveType {
   success: boolean
 }
@@ -123,8 +120,6 @@ export interface AuthModel {
   userAccessTokenExpiresIn: string | null
   xAppToken: string | null
   xApptokenExpiresIn: string | null
-  onboardingState: OnboardingState
-  onboardingArtQuizState: OnboardingArtQuizState
   userEmail: string | null
   previousSessionUserID: string | null
 
@@ -137,7 +132,7 @@ export interface AuthModel {
   getUser: Thunk<this, { accessToken: string }, {}, GlobalStoreModel>
   signIn: Thunk<
     this,
-    { email: string; onboardingState?: OnboardingState; onSignIn?: () => void } & OAuthParams,
+    { email: string; onSignIn?: () => void } & OAuthParams,
     {},
     GlobalStoreModel,
     Promise<SignInStatus>
@@ -187,7 +182,6 @@ export interface AuthModel {
     GlobalStoreModel,
     ReturnType<typeof fetch>
   >
-  setArtQuizState: Action<this, OnboardingArtQuizState>
   identifyUser: Action<this>
   signOut: Thunk<this>
   verifyUser: Thunk<
@@ -214,8 +208,6 @@ export const getAuthModel = (): AuthModel => ({
   userAccessTokenExpiresIn: null,
   xAppToken: null,
   xApptokenExpiresIn: null,
-  onboardingState: "none",
-  onboardingArtQuizState: "none",
   userEmail: null,
   previousSessionUserID: null,
   userHasArtsyEmail: computed((state) => isArtsyEmail(state.userEmail ?? "")),
@@ -303,7 +295,7 @@ export const getAuthModel = (): AuthModel => ({
     ).json()
   }),
   signIn: thunk(async (actions, args, store) => {
-    const { oauthProvider, oauthMode, email, onboardingState, onSignIn } = args
+    const { oauthProvider, oauthMode, email, onSignIn } = args
 
     const grantTypeMap = {
       accessToken: "oauth_token",
@@ -351,7 +343,6 @@ export const getAuthModel = (): AuthModel => ({
         userAccessTokenExpiresIn: expires_in,
         userID: user.id,
         userEmail: email,
-        onboardingState: onboardingState ?? "complete",
       })
 
       // TODO: do we need to set requested push permissions false here
@@ -431,7 +422,6 @@ export const getAuthModel = (): AuthModel => ({
             oauthMode,
             email,
             accessToken: args.accessToken,
-            onboardingState: "incomplete",
           })
           break
         case "jwt":
@@ -440,7 +430,6 @@ export const getAuthModel = (): AuthModel => ({
             oauthMode,
             email,
             jwt: args.jwt,
-            onboardingState: "incomplete",
           })
           break
         case "idToken":
@@ -450,7 +439,6 @@ export const getAuthModel = (): AuthModel => ({
             email,
             idToken: args.idToken,
             appleUid: args.appleUid,
-            onboardingState: "incomplete",
           })
           break
         case "email":
@@ -459,7 +447,6 @@ export const getAuthModel = (): AuthModel => ({
             oauthMode,
             email,
             password: args.password,
-            onboardingState: "incomplete",
           })
           break
         default:
@@ -966,9 +953,6 @@ export const getAuthModel = (): AuthModel => ({
         }
       }
     })
-  }),
-  setArtQuizState: action((state, artQuizState) => {
-    state.onboardingArtQuizState = artQuizState
   }),
   identifyUser: action((state) => {
     const { userID: userId } = state

--- a/src/app/store/GlobalStoreModel.ts
+++ b/src/app/store/GlobalStoreModel.ts
@@ -13,6 +13,7 @@ import {
 } from "app/Scenes/SellWithArtsy/utils/submissionModelState"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
 import { getInfiniteDiscoveryModel, InfiniteDiscoveryModel } from "app/store/InfiniteDiscoveryModel"
+import { getOnboardingModel, OnboardingModel } from "app/store/OnboardingModel"
 import {
   ProgressiveOnboardingModel,
   getProgressiveOnboardingModel,
@@ -48,6 +49,7 @@ interface GlobalStoreStateModel {
   search: SearchModel
   myCollection: MyCollectionModel
   auth: AuthModel
+  onboarding: OnboardingModel
   toast: ToastModel
   pendingPushNotification: PendingPushNotificationModel
   artsyPrefs: ArtsyPrefsModel
@@ -137,6 +139,7 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
   myCollection: getMyCollectionModel(),
   artsyPrefs: getArtsyPrefsModel(),
   auth: getAuthModel(),
+  onboarding: getOnboardingModel(),
   toast: getToastModel(),
   devicePrefs: getDevicePrefsModel(),
   pendingPushNotification: getPendingPushNotificationModel(),

--- a/src/app/store/OnboardingModel.ts
+++ b/src/app/store/OnboardingModel.ts
@@ -1,0 +1,22 @@
+import { Action, action } from "easy-peasy"
+
+type OnboardingState = "none" | "incomplete" | "complete"
+type OnboardingArtQuizState = "none" | "incomplete" | "complete"
+
+export interface OnboardingModel {
+  onboardingState: OnboardingState
+  onboardingArtQuizState: OnboardingArtQuizState
+  setArtQuizState: Action<this, OnboardingArtQuizState>
+  setOnboardingState: Action<this, OnboardingState>
+}
+
+export const getOnboardingModel = (): OnboardingModel => ({
+  onboardingState: "incomplete",
+  onboardingArtQuizState: "none",
+  setArtQuizState: action((state, artQuizState) => {
+    state.onboardingArtQuizState = artQuizState
+  }),
+  setOnboardingState: action((state, onboardingState) => {
+    state.onboardingState = onboardingState
+  }),
+})

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -333,7 +333,9 @@ describe("AuthModel", () => {
       })
 
       expect(result.success).toBe(true)
-      expect(__globalStoreTestUtils__?.getCurrentState().auth.onboardingState).toBe("incomplete")
+      expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
+        "incomplete"
+      )
       expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe(
         "my-access-token"
       )

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -1060,4 +1060,29 @@ describe("App version Versions.AddInfiniteDiscoveryModel", () => {
       discoveredArtworkIds: [],
     })
   })
+
+  describe("App version Versions.MoveOnboardingStateToOnboardingModel", () => {
+    it("moves onboardingState and onboardingArtQuizState to the Onboarding model", () => {
+      const migrationToTest = Versions.MoveOnboardingStateToOnboardingModel
+
+      const previousState = migrate({
+        state: { version: 0 },
+        toVersion: migrationToTest - 1,
+      }) as any
+
+      previousState.auth.onboardingState = "incomplete"
+      previousState.auth.onboardingArtQuizState = "none"
+
+      const migratedState = migrate({
+        state: previousState,
+        toVersion: migrationToTest,
+      }) as any
+
+      expect(migratedState.auth.onboardingState).toEqual(undefined)
+      expect(migratedState.auth.onboardingArtQuizState).toEqual(undefined)
+
+      expect(migratedState.onboarding.onboardingState).toEqual("incomplete")
+      expect(migratedState.onboarding.onboardingArtQuizState).toEqual("none")
+    })
+  })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -58,9 +58,10 @@ export const Versions = {
   AddSubmissionDraft: 45,
   DeleteArtworkAndArtistViewOption: 46,
   AddInfiniteDiscoveryModel: 47,
+  MoveOnboardingStateToOnboardingModel: 48,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddInfiniteDiscoveryModel
+export const CURRENT_APP_VERSION = Versions.MoveOnboardingStateToOnboardingModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -335,6 +336,15 @@ export const artsyAppMigrations: Migrations = {
     state.infiniteDiscovery = {
       discoveredArtworkIds: [],
     }
+  },
+  [Versions.MoveOnboardingStateToOnboardingModel]: (state) => {
+    state.onboarding = {
+      onboardingState:
+        state.auth.onboardingState === "none" ? "incomplete" : state.auth.onboardingState,
+      onboardingArtQuizState: state.auth.onboardingArtQuizState,
+    }
+    delete state.auth.onboardingState
+    delete state.auth.onboardingArtQuizState
   },
 }
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

We noticed with @brainbicycle while pairing to fix some other unrelated navigation issues that when calling `GlobalStore.actions.auth.setState({ onboardingState: "complete" })` on some parts of the codebase we managed to reproduce reliably the `Proxy handler is null` error (stacktrace [here](https://artsynet.sentry.io/issues/6207698490/events/fb6fc7b4ccc9480fbd44c0b07d3fdf62/)).

What we noticed in more detail was that the `auth` property in `GlobalStore` was replaced with the error resulting in the store not having access to the rest of the variables there that are needed for auth.

<img width="1600" alt="Screenshot 2025-01-29 at 15 46 37" src="https://github.com/user-attachments/assets/6479cea3-9545-4305-b00b-a1e978fd368c" />


This is an attempt to decouple the onboardingStates from the auth in order to not affect the auth variables with anything onboarding related since these are used for navigating users after they sign up to prevent this weirdness.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- move onboardingState to onboardingModel

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
