### PR TITLE
fix: Hides onboarding flow after sign in

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/Onboarding.tests.tsx
@@ -16,13 +16,7 @@ describe("Onboarding", () => {
     })
   })
 
-  it("renders the welcome screens when the onboarding state is none or complete", () => {
-    renderWithWrappers(<Onboarding />)
-    __globalStoreTestUtils__?.injectState({ onboarding: { onboardingState: "none" } })
-
-    expect(screen.UNSAFE_queryByType(OnboardingQuiz)).toBeFalsy()
-    expect(screen.UNSAFE_getByType(OnboardingWelcomeScreens)).toBeTruthy()
-
+  it("renders the welcome screens when the onboarding state is complete", () => {
     renderWithWrappers(<Onboarding />)
     __globalStoreTestUtils__?.injectState({ onboarding: { onboardingState: "complete" } })
 

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -345,6 +345,7 @@ export const getAuthModel = (): AuthModel => ({
         userEmail: email,
       })
 
+      GlobalStore.actions.onboarding.setOnboardingState("complete")
       // TODO: do we need to set requested push permissions false here
 
       if (oauthProvider === "email") {
@@ -455,6 +456,7 @@ export const getAuthModel = (): AuthModel => ({
 
       // Setting up user prefs from gravity after successsfull registration.
       GlobalStore.actions.userPrefs.fetchRemoteUserPrefs()
+      GlobalStore.actions.onboarding.setOnboardingState("incomplete")
 
       return { success: true, message: "" }
     }

--- a/src/app/store/OnboardingModel.ts
+++ b/src/app/store/OnboardingModel.ts
@@ -1,6 +1,6 @@
 import { Action, action } from "easy-peasy"
 
-type OnboardingState = "none" | "incomplete" | "complete"
+type OnboardingState = "incomplete" | "complete"
 type OnboardingArtQuizState = "none" | "incomplete" | "complete"
 
 export interface OnboardingModel {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue with the onboarding always showing up when the user signs in
This is a follow-up PR after #11458 


| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/0b687eef-7ae4-4672-a1c4-a6a5692fb7eb" /> | <video src="https://github.com/user-attachments/assets/80685d0c-0516-4794-8c9b-904184b8ff2c" /> |
| iOS | <video src="https://github.com/user-attachments/assets/9ff16246-a638-46fc-a645-5958b56368f3" /> | <video src="https://github.com/user-attachments/assets/c4a266e7-cea4-438e-a16d-5788a4a692d1" /> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- hide onboarding when users sign in

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
