### PR TITLE
fix: Android long-press back button fix

### DIFF
--- a/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
+++ b/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
@@ -24,7 +24,7 @@ export const AutomountedBottomSheetModal: FC<AutomountedBottomSheetModalProps> =
 
   // dismiss modal on back button press on Android
   useBackHandler(() => {
-    if (ref.current && modalIsPresented) {
+    if (ref.current && modalIsPresented && visible) {
       ref.current.dismiss()
       return true
     } else {

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -201,10 +201,6 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
 
   const [androidVisible, setAndroidVisible] = useState(false)
 
-  const handleAndroidLongPress = () => {
-    setAndroidVisible(true)
-  }
-
   if (isIOS && enableContextMenuIOS) {
     return (
       <ContextMenu
@@ -227,8 +223,8 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
         <TouchableHighlight
           underlayColor={color("white100")}
           activeOpacity={0.8}
-          onLongPress={handleAndroidLongPress}
-          onPress={undefined}
+          onLongPress={() => setAndroidVisible(true)}
+          delayLongPress={1200}
         >
           {children}
         </TouchableHighlight>

--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -216,6 +216,10 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     )
   }
 
+  const handleAndroidLongPress = () => {
+    setAndroidVisible(true)
+  }
+
   // Fall back to a bottom sheet on Android
   if (!isIOS && enableContextMenuAndroid) {
     return (
@@ -223,7 +227,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
         <TouchableHighlight
           underlayColor={color("white100")}
           activeOpacity={0.8}
-          onLongPress={() => setAndroidVisible(true)}
+          onLongPress={handleAndroidLongPress}
           delayLongPress={1200}
         >
           {children}


### PR DESCRIPTION
This PR resolves [PBRW-400] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes two bugs:

1. When opening an artwork from the artwork rail, the long-press context menu would also open after navigating back.
2. After opening and closing a bottom sheet, the back button might stop working because the back button handler from the bottom sheet does not properly bubble up the event.

I resolved the first issues by setting `delayLongPress` to prevent `onLongPress` from being triggered when opening the artwork. And the second one by fixing a condition from the bottom sheets back button handler.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-400]: https://artsyproduct.atlassian.net/browse/PBRW-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ