### PR TITLE
feat: add a dev tool to forget about disovered artworks

### DIFF
--- a/src/app/store/GlobalStoreModel.ts
+++ b/src/app/store/GlobalStoreModel.ts
@@ -72,6 +72,7 @@ export interface GlobalStoreModel extends GlobalStoreStateModel {
 
   // for dev only.
   _setVersion: Action<this, number>
+  _forgetDiscoveredArtworks: Action<this>
 
   // for testing only. noop otherwise.
   __inject: Action<this, DeepPartial<State<GlobalStoreStateModel>>>
@@ -157,6 +158,10 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
   // for dev only.
   _setVersion: action((state, newVersion) => {
     state.version = newVersion
+  }),
+
+  _forgetDiscoveredArtworks: action((state) => {
+    state.infiniteDiscovery.discoveredArtworkIds = []
   }),
 
   // for testing only. noop otherwise.

--- a/src/app/system/devTools/DevMenu/Components/DevTools.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevTools.tsx
@@ -63,13 +63,6 @@ export const DevTools: React.FC<{}> = () => {
               dismissModal(() => navigate("/art-quiz"))
             }}
           />
-          <DevMenuButtonItem
-            title="Forget Discovered Artworks"
-            onPress={() => {
-              GlobalStore.actions._forgetDiscoveredArtworks()
-              toast.show("What discovered artworks? ✅", "middle")
-            }}
-          />
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
             <Flex>
               <MenuItem title="Migration version" />
@@ -129,6 +122,13 @@ export const DevTools: React.FC<{}> = () => {
             onPress={() => {
               __clearDissmissed()
               toast.show("Progressive Onboarding progress cleared ✅", "middle")
+            }}
+          />
+          <DevMenuButtonItem
+            title="Clear Infinite Discovery artworks"
+            onPress={() => {
+              GlobalStore.actions._forgetDiscoveredArtworks()
+              toast.show("Infinite Discovery artworks cleared ✅", "middle")
             }}
           />
           <DevMenuButtonItem title={`Active Unleash env: ${capitalize(unleashEnv)}`} />

--- a/src/app/system/devTools/DevMenu/Components/DevTools.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevTools.tsx
@@ -63,6 +63,13 @@ export const DevTools: React.FC<{}> = () => {
               dismissModal(() => navigate("/art-quiz"))
             }}
           />
+          <DevMenuButtonItem
+            title="Forget Discovered Artworks"
+            onPress={() => {
+              GlobalStore.actions._forgetDiscoveredArtworks()
+              toast.show("What discovered artworks? ✅", "middle")
+            }}
+          />
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
             <Flex>
               <MenuItem title="Migration version" />


### PR DESCRIPTION
As users browse artworks in Infinite Discovery, we compile a list of artworks that the user has received from the backend, and we store this on the device, and send it with each request for more batches of artworks so that we don't see the same artwork twice.

However, it is possible that a user sees all of the artworks that are available, which results in a blank Infinite Discovery screen. That happens a lot during development while working on the card swiping action and animation, and it is frustrating to have to reinstall the app to get an empty list of discovered artworks.

This PR adds a tool to the dev menu to clear that list of discovered artworks so we can keep working in the same app install.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Added a dev tool to allow users to clear their list of discovered artworks

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
