### PR TITLE
fix(PBRW-397): Dismiss modal on foreground Push Notification tap

### DIFF
--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -5,7 +5,13 @@ import { addBreadcrumb } from "@sentry/react-native"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { BottomTabRoutes } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { GlobalStore, getCurrentEmissionState } from "app/store/GlobalStore"
-import { GoBackProps, dismissModal, goBack, navigate } from "app/system/navigation/navigate"
+import {
+  GoBackProps,
+  dismissModal,
+  goBack,
+  navigate,
+  navigationEvents,
+} from "app/system/navigation/navigate"
 import { matchRoute } from "app/system/navigation/utils/matchRoute"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
@@ -89,6 +95,18 @@ export const ArtsyWebViewPage = ({
       }
     }
   }
+
+  const handleModalDismiss = () => {
+    dismissModal()
+  }
+
+  useEffect(() => {
+    const emitter = navigationEvents.addListener("requestModalDismiss", handleModalDismiss)
+
+    return () => {
+      emitter.removeListener("requestModalDismiss", handleModalDismiss)
+    }
+  }, [])
 
   const handleGoBack = () => {
     if (backAction) {

--- a/src/app/store/NativeModel.ts
+++ b/src/app/store/NativeModel.ts
@@ -91,6 +91,7 @@ listenToNativeEvents((event: NativeEvent) => {
       return
     case "REQUEST_NAVIGATION": {
       const { route, props } = event.payload
+      navigationEvents.emit("requestModalDismiss")
       navigate(route, { passProps: props })
       return
     }

--- a/src/app/utils/PushNotification.ts
+++ b/src/app/utils/PushNotification.ts
@@ -9,7 +9,7 @@ import {
   unsafe_getUserAccessToken,
 } from "app/store/GlobalStore"
 import { PendingPushNotification } from "app/store/PendingPushNotificationModel"
-import { navigate } from "app/system/navigation/navigate"
+import { navigate, navigationEvents } from "app/system/navigation/navigate"
 import { Platform } from "react-native"
 import DeviceInfo from "react-native-device-info"
 import PushNotification, { ReceivedNotification } from "react-native-push-notification"
@@ -208,6 +208,7 @@ export const handleReceivedNotification = (
     }
     const hasUrl = !!notification.data.url
     if (isLoggedIn && hasUrl) {
+      navigationEvents.emit("requestModalDismiss")
       navigate(notification.data.url as string, {
         passProps: notification.data,
         ignoreDebounce: true,


### PR DESCRIPTION
This PR resolves [PBRW-397] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue where push notifications don't navigate the users when a webview modal is present

### Demo

| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/a875bad3-7708-4767-b6ae-1dbbb1b18796" /> | <video src="https://github.com/user-attachments/assets/df5bc43f-ef2f-4229-9cd5-aae53b230125" /> |
| iOS | <video src="https://github.com/user-attachments/assets/f3eee367-b4f4-4a4d-adcb-51243c3c64a0" /> | <video src="https://github.com/user-attachments/assets/d14367d8-de83-4495-8462-adb235238bf3" /> |



	

	
	










<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- navigate the user on foreground push when a webview modal is visible

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-397]: https://artsyproduct.atlassian.net/browse/PBRW-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ