### PR TITLE
feat: optional chaining for safer access to notificationPreferences

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -60,7 +60,7 @@ export const EditSavedSearchAlert: React.FC<EditSavedSearchAlertProps> = (props)
   )
 
   const { settings, ...attributes } = me?.alert ?? {}
-  const isCustomAlertsNotificationsEnabled = viewer.notificationPreferences.some((preference) => {
+  const isCustomAlertsNotificationsEnabled = viewer?.notificationPreferences?.some((preference) => {
     return (
       preference.channel === "email" &&
       preference.name === "custom_alerts" &&

--- a/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
+++ b/src/app/Scenes/SavedSearchAlert/containers/CreateSavedSearchContentContainer.tsx
@@ -32,7 +32,7 @@ const CreateSavedSearchAlertContent: React.FC<CreateSavedSearchAlertContentProps
   const isPreviouslyFocused = useRef(false)
   const [refetching, setRefetching] = useState(false)
   const [enablePushNotifications, setEnablePushNotifications] = useState(true)
-  const isCustomAlertsNotificationsEnabled = viewer?.notificationPreferences.some((preference) => {
+  const isCustomAlertsNotificationsEnabled = viewer?.notificationPreferences?.some((preference) => {
     return (
       preference.channel === "email" &&
       preference.name === "custom_alerts" &&


### PR DESCRIPTION
This PR resolves [PBRW-410] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes a potential by optional chaining for safer access to notificationPreferences.

Previously some users were getting this error:

<img width="366" alt="Screenshot 2025-02-05 at 10 19 33" src="https://github.com/user-attachments/assets/2a4fa627-4b36-4058-bb1e-f1a972f54c84" />

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- optional chaining for safer access to notificationPreferences

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-410]: https://artsyproduct.atlassian.net/browse/PBRW-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ