### PR TITLE
fix: purchase button disappears

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012-2022 Art.sy, Inc.
+Copyright (c) 2012-2025 Art.sy, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eigen",
   "version": "1.21.52",
-  "native-code-version": 44,
+  "license": "MIT",
   "description": "Artsy mobile app.",
   "engines": {
     "node": "20.x",
@@ -91,7 +91,6 @@
     "react-native"
   ],
   "contributors": "See docs/thanks.md",
-  "license": "MIT",
   "bugs": {
     "url": "https://github.com/artsy/eigen/issues"
   },

--- a/src/app/Components/ArtsyWebView.tsx
+++ b/src/app/Components/ArtsyWebView.tsx
@@ -226,6 +226,14 @@ export const ArtsyWebView = forwardRef<
         return
       }
 
+      // TODO: For not we are not redirecting to home from webviews because of artsy logo
+      // in purchase flow breaking things. We should instead hide the artsy logo or not redirect to home
+      // when in eigen purchase flow.
+      if (result.type === "match" && result.module === "Home") {
+        stopLoading(true)
+        return
+      }
+
       // if it's a route that we know we don't have a native view for, keep it in the webview
       // only vanityURLs which do not have a native screen ends up in the webview. So also keep in webview for VanityUrls
       // TODO:- Handle cases where a vanityURl lands in a webview and then webview url navigation state changes


### PR DESCRIPTION
This PR resolves [PBRW-412] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This is a workaround for the purchase button disappearing after tapping the artsy logo in the purchase flow.

This is happening because this logo redirects to https://www.artsy.net which maps to the Home module, so under the modal navigation happens and this breaks the display of the artwork page. This just prevents navigation in this case.

### Follow-up: 

This is not a great solution I think it would be better to **remove the artsy logo** or make tapping a no-op when visiting the checkout pages from Eigen in **force**.

### Screenshots

<details><summary>Before</summary>
<p>

https://github.com/user-attachments/assets/61573616-df21-43c9-a357-7aab6fb341a3

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/697410e6-1502-4b65-af77-78625d9cb3d0

</p>
</details> 





### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix purchase button disappearing in artwork page - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-412]: https://artsyproduct.atlassian.net/browse/PBRW-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ