### PR TITLE
fix: Replace Touchable component in RouterLink

### DIFF
--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -1,9 +1,9 @@
-import { Touchable, TouchableProps } from "@artsy/palette-mobile"
+import { TouchableProps } from "@artsy/palette-mobile"
 import { navigate } from "app/system/navigation/navigate"
 import { ElementInView } from "app/utils/ElementInView"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { usePrefetch } from "app/utils/queryPrefetching"
-import { GestureResponderEvent } from "react-native"
+import { GestureResponderEvent, TouchableOpacity } from "react-native"
 
 interface RouterLinkProps {
   disablePrefetch?: boolean
@@ -45,13 +45,19 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
     }
   }
 
+  const touchableProps = {
+    activeOpacity: 0.65,
+    onPress: handlePress,
+    ...restProps,
+  }
+
   if (!isPrefetchingEnabled) {
-    return <Touchable {...restProps} onPress={handlePress} />
+    return <TouchableOpacity {...touchableProps} />
   }
 
   return (
     <ElementInView onVisible={handleVisible}>
-      <Touchable {...restProps} onPress={handlePress} />
+      <TouchableOpacity {...touchableProps} />
     </ElementInView>
   )
 }


### PR DESCRIPTION

### Description

This replaces the Touchable component used in RouterLink. I noticed that on some surfaces, the `Touchable` from palette mobile does not highlight on touch. Palette mobile uses `TouchableHighlight`, which does not seem to work correctly.

In this PR, I simply replace it with `TouchableOpacity`, which seems to work as expected.

This is a "quick" fix, and I'll start a conversation about making the change in palette-mobile.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Replace Touchable component in RouterLink - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
