### PR TITLE
fix: Correctly filter CollectorProfileUpdatePromptNotificationItem in Activity rail

### DIFF
--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -142,6 +142,9 @@ const notificationsConnectionFragment = graphql`
                 internalID
               }
             }
+            ... on CollectorProfileUpdatePromptNotificationItem {
+              __typename
+            }
           }
 
           ...ActivityItem_notification

--- a/src/app/Scenes/Activity/ActivityList.tsx
+++ b/src/app/Scenes/Activity/ActivityList.tsx
@@ -24,7 +24,9 @@ export const ActivityList: React.FC<ActivityListProps> = ({ viewer, type }) => {
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter(shouldDisplayNotification)
+  const notifications = notificationsNodes.filter((notification) =>
+    shouldDisplayNotification(notification, "list")
+  )
 
   const handleLoadMore = () => {
     if (!hasNext || isLoadingNext) {
@@ -127,6 +129,8 @@ const notificationsConnectionFragment = graphql`
             totalCount
           }
           item {
+            __typename
+
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {
                 totalCount
@@ -139,6 +143,7 @@ const notificationsConnectionFragment = graphql`
               }
             }
           }
+
           ...ActivityItem_notification
         }
       }

--- a/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
@@ -83,7 +83,7 @@ describe("shouldDisplayNotification", () => {
       notificationType: "ARTICLE_FEATURED_ARTIST",
       artworks: undefined,
       item: {
-        article: { internalID: "asdf" },
+        article: null,
         __typename: "ArticleFeaturedArtistNotificationItem",
       },
     })

--- a/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
+++ b/src/app/Scenes/Activity/utils/__tests__/shouldDisplayNotification.tests.ts
@@ -28,7 +28,10 @@ describe("shouldDisplayNotification", () => {
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
       artworks: undefined,
-      item: { viewingRoomsConnection: { totalCount: 1 } },
+      item: {
+        viewingRoomsConnection: { totalCount: 1 },
+        __typename: "ViewingRoomPublishedNotificationItem",
+      },
     })
     expect(result4).toEqual(true)
 
@@ -36,7 +39,7 @@ describe("shouldDisplayNotification", () => {
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
       artworks: undefined,
-      item: { article: { internalID: "1" } },
+      item: { article: { internalID: "1" }, __typename: "ArticleFeaturedArtistNotificationItem" },
     })
     expect(result5).toEqual(true)
   })
@@ -68,7 +71,10 @@ describe("shouldDisplayNotification", () => {
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
       artworks: undefined,
-      item: { viewingRoomsConnection: { totalCount: 0 } },
+      item: {
+        viewingRoomsConnection: { totalCount: 0 },
+        __typename: "ViewingRoomPublishedNotificationItem",
+      },
     })
     expect(result4).toEqual(false)
 
@@ -76,7 +82,10 @@ describe("shouldDisplayNotification", () => {
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
       artworks: undefined,
-      item: {},
+      item: {
+        article: { internalID: "asdf" },
+        __typename: "ArticleFeaturedArtistNotificationItem",
+      },
     })
     expect(result5).toEqual(false)
   })

--- a/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
+++ b/src/app/Scenes/Activity/utils/shouldDisplayNotification.ts
@@ -1,15 +1,18 @@
 import { ActivityList_viewer$data } from "__generated__/ActivityList_viewer.graphql"
+import { ActivityRail_viewer$data } from "__generated__/ActivityRail_viewer.graphql"
 import { isArtworksBasedNotification } from "app/Scenes/Activity/utils/isArtworksBasedNotification"
+import { ExtractNodeType } from "app/utils/relayHelpers"
 
-export type NotificationNode = NonNullable<
-  NonNullable<NonNullable<ActivityList_viewer$data["notificationsConnection"]>["edges"]>[0]
->["node"]
+export type NotificationNode =
+  | ExtractNodeType<ActivityList_viewer$data["notificationsConnection"]>
+  | ExtractNodeType<ActivityRail_viewer$data["notificationsConnection"]>
 
 export const shouldDisplayNotification = (
   notification:
     | Pick<NonNullable<NotificationNode>, "notificationType" | "artworks" | "item">
     | null
-    | undefined
+    | undefined,
+  mode: "rail" | "list" = "list"
 ) => {
   if (!notification) {
     return false
@@ -20,13 +23,20 @@ export const shouldDisplayNotification = (
     return artworksCount > 0
   }
 
-  if (notification.notificationType === "VIEWING_ROOM_PUBLISHED") {
+  if (notification.item?.__typename === "ViewingRoomPublishedNotificationItem") {
     const viewingRoomsCount = notification.item?.viewingRoomsConnection?.totalCount ?? 0
     return viewingRoomsCount > 0
   }
 
-  if (notification.notificationType === "ARTICLE_FEATURED_ARTIST") {
+  if (notification.item?.__typename === "ArticleFeaturedArtistNotificationItem") {
     return !!notification.item?.article?.internalID
+  }
+
+  if (
+    mode === "rail" &&
+    notification.item?.__typename === "CollectorProfileUpdatePromptNotificationItem"
+  ) {
+    return false
   }
 
   return true

--- a/src/app/Scenes/HomeView/Components/ActivityRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityRail.tsx
@@ -23,8 +23,9 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, viewer }) => 
 
   const notificationsNodes = extractNodes(data?.notificationsConnection)
 
-  const notifications = notificationsNodes.filter(shouldDisplayNotification)
-
+  const notifications = notificationsNodes.filter((notification) =>
+    shouldDisplayNotification(notification, "rail")
+  )
   if (notifications.length === 0) {
     return null
   }
@@ -79,10 +80,16 @@ const notificationsConnectionFragment = graphql`
             totalCount
           }
           item {
+            __typename
+
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {
                 totalCount
               }
+            }
+
+            ... on CollectorProfileUpdatePromptNotificationItem {
+              __typename
             }
 
             ... on ArticleFeaturedArtistNotificationItem {
@@ -91,6 +98,7 @@ const notificationsConnectionFragment = graphql`
               }
             }
           }
+
           ...ActivityRailItem_item
         }
       }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
@@ -39,8 +39,8 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
   const tracking = useHomeViewTracking()
 
   const section = useFragment(sectionFragment, sectionProp)
-  const notifications = extractNodes(section.notificationsConnection).filter(
-    shouldDisplayNotification
+  const notifications = extractNodes(section.notificationsConnection).filter((notification) =>
+    shouldDisplayNotification(notification, "rail")
   )
   const viewAll = section.component?.behaviors?.viewAll
 
@@ -134,6 +134,8 @@ const sectionFragment = graphql`
           }
           targetHref
           item {
+            __typename
+
             ... on ViewingRoomPublishedNotificationItem {
               viewingRoomsConnection(first: 1) {
                 totalCount


### PR DESCRIPTION
This PR resolves [PBRW-392] <!-- eg [PROJECT-XXXX] -->

### Description

I’ve looked into the code, and it could be related to [this line](https://github.com/artsy/eigen/blob/f78303a22940f20d1a97cd9343537311617e90ad/src/app/Scenes/HomeView/Components/ActivityRailItem.tsx#L45), which prevents rendering activity items with the type name CollectorProfileUpdatePromptNotificationItem man shrugging Activities by this type get filtered out in the rail item component instead of the rail. This could be the reason why the rail is still rendering.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Correctly filter CollectorProfileUpdatePromptNotificationItem in Activity rail. - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-392]: https://artsyproduct.atlassian.net/browse/PBRW-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ