### PR TITLE
feat(DIA-1107): fade the second card in as the top card is swiped

### DIFF
--- a/src/app/Components/FancySwiper/FancySwiper.tsx
+++ b/src/app/Components/FancySwiper/FancySwiper.tsx
@@ -74,11 +74,6 @@ export const FancySwiper = ({
   }
 
   const handleLeftSwipe = (toValueY?: number) => {
-    /**
-     * TODO: Before implementing 360º swipe, there was a bug where the card got stuck in space. I
-     * think that happens because this animation sometimes doesn't start.
-     */
-
     // move the card off the screen
     Animated.timing(swiper, {
       toValue: { x: -1000, y: toValueY || 0 },
@@ -115,6 +110,7 @@ export const FancySwiper = ({
       <Flex alignItems="center" flex={1}>
         {remainingCards.map((card, index) => {
           const isTopCard = index === remainingCards.length - 1
+          const isSecondCard = index === remainingCards.length - 2
 
           // We would like to be able to drag the top card only
           const gestureDraggers = isTopCard ? panResponder.panHandlers : {}
@@ -125,6 +121,7 @@ export const FancySwiper = ({
               key={index}
               swiper={swiper}
               isTopCard={isTopCard}
+              isSecondCard={isSecondCard}
               {...gestureDraggers}
             />
           )

--- a/src/app/Components/FancySwiper/FancySwiperCard.tsx
+++ b/src/app/Components/FancySwiper/FancySwiperCard.tsx
@@ -17,7 +17,7 @@ export const FancySwiperCard = memo(
     let bottomCardTransform = undefined
 
     if (isTopCard) {
-      // tilt the top card ever so slightly as it is being swiped
+      // tilt the top card as it is being swiped away
       const rotate = swiper.x.interpolate({
         inputRange: [-SWIPE_MAGNITUDE, 0, SWIPE_MAGNITUDE],
         outputRange: ["-10deg", "0deg", "10deg"],
@@ -27,7 +27,7 @@ export const FancySwiperCard = memo(
         transform: [...swiper.getTranslateTransform(), { rotate }],
       }
 
-      // drop a shadow from the top card and make it more intense as it is swiped
+      // drop a shadow from the top card and make it more intense as it is swiped away
       const shadowOpacity = interpolateSwiper(swiper, MAX_SHADOW_OPACITY)
       const elevation = interpolateSwiper(swiper, MAX_ELEVATION)
 
@@ -38,13 +38,14 @@ export const FancySwiperCard = memo(
         elevation,
       }
     } else if (isSecondCard) {
-      // slightly scale down the second card
+      // make the second card fade in as the top card swipes away
       const opacity = interpolateSwiper(swiper, MAX_OPACITY, MIN_OPACITY)
 
       bottomCardOpacity = {
         opacity,
       }
 
+      // make the second card grow to full size as the top card swipes away
       const scale = interpolateSwiper(swiper, MAX_SCALE, MIN_SCALE)
 
       bottomCardTransform = {

--- a/src/app/Components/FancySwiper/FancySwiperCard.tsx
+++ b/src/app/Components/FancySwiper/FancySwiperCard.tsx
@@ -6,12 +6,15 @@ interface FancySwiperCardProps extends GestureResponderHandlers {
   card: React.ReactNode
   swiper: Animated.ValueXY
   isTopCard: boolean
+  isSecondCard: boolean
 }
 
 export const FancySwiperCard = memo(
-  ({ card, swiper, isTopCard, ...rest }: FancySwiperCardProps) => {
-    let transformStyle = undefined
-    let shadowStyle = undefined
+  ({ card, swiper, isTopCard, isSecondCard, ...rest }: FancySwiperCardProps) => {
+    let topCardShadow = undefined
+    let topCardTransform = undefined
+    let bottomCardOpacity = undefined
+    let bottomCardTransform = undefined
 
     if (isTopCard) {
       // tilt the top card ever so slightly as it is being swiped
@@ -20,19 +23,37 @@ export const FancySwiperCard = memo(
         outputRange: ["-10deg", "0deg", "10deg"],
       })
 
-      transformStyle = {
+      topCardTransform = {
         transform: [...swiper.getTranslateTransform(), { rotate }],
       }
 
       // drop a shadow from the top card and make it more intense as it is swiped
-      const shadowOpacity = interpolateShadowOpacity(swiper)
-      const elevation = interpolateElevation(swiper)
+      const shadowOpacity = interpolateSwiper(swiper, MAX_SHADOW_OPACITY)
+      const elevation = interpolateSwiper(swiper, MAX_ELEVATION)
 
-      shadowStyle = {
+      topCardShadow = {
         shadowOffset: { width: 0, height: 0 },
         shadowRadius: 12,
         shadowOpacity,
         elevation,
+      }
+    } else if (isSecondCard) {
+      // slightly scale down the second card
+      const opacity = interpolateSwiper(swiper, MAX_OPACITY, MIN_OPACITY)
+
+      bottomCardOpacity = {
+        opacity,
+      }
+
+      const scale = interpolateSwiper(swiper, MAX_SCALE, MIN_SCALE)
+
+      bottomCardTransform = {
+        transform: [{ scale }],
+      }
+    } else {
+      // hide the rest of the cards
+      bottomCardOpacity = {
+        opacity: 0,
       }
     }
 
@@ -42,8 +63,10 @@ export const FancySwiperCard = memo(
           position: "absolute",
           width: "100%",
           borderRadius: 10,
-          ...shadowStyle,
-          ...transformStyle,
+          ...topCardShadow,
+          ...topCardTransform,
+          ...bottomCardOpacity,
+          ...bottomCardTransform,
         }}
         testID={isTopCard ? "top-fancy-swiper-card" : undefined}
         {...rest}
@@ -54,42 +77,31 @@ export const FancySwiperCard = memo(
   }
 )
 
-const interpolateShadowOpacity = (swiper: Animated.ValueXY) => {
-  const MAX_SHADOW_OPACITY = 0.13
-
-  const shadowOpacityX = swiper.x.interpolate({
+const interpolateSwiper = (
+  swiper: Animated.ValueXY,
+  maximumOutputValue: number,
+  minimumOutputValue = 0
+) => {
+  const x = swiper.x.interpolate({
     inputRange: [-SWIPE_MAGNITUDE, 0, SWIPE_MAGNITUDE],
-    outputRange: [MAX_SHADOW_OPACITY, 0, MAX_SHADOW_OPACITY],
+    outputRange: [maximumOutputValue, minimumOutputValue, maximumOutputValue],
   })
 
-  const shadowOpacityY = swiper.y.interpolate({
+  const y = swiper.y.interpolate({
     inputRange: [-SWIPE_MAGNITUDE, 0, SWIPE_MAGNITUDE],
-    outputRange: [MAX_SHADOW_OPACITY, 0, MAX_SHADOW_OPACITY],
+    outputRange: [maximumOutputValue, minimumOutputValue, maximumOutputValue],
   })
 
-  return Animated.add(shadowOpacityX, shadowOpacityY).interpolate({
-    inputRange: [0, MAX_SHADOW_OPACITY * 2],
-    outputRange: [0, MAX_SHADOW_OPACITY],
+  return Animated.add(x, y).interpolate({
+    inputRange: [0, maximumOutputValue * 2],
+    outputRange: [minimumOutputValue, maximumOutputValue],
     extrapolate: "clamp",
   })
 }
 
-const interpolateElevation = (swiper: Animated.ValueXY) => {
-  const MAX_ELEVATION = 8
-
-  const elevationX = swiper.x.interpolate({
-    inputRange: [-SWIPE_MAGNITUDE, 0, SWIPE_MAGNITUDE],
-    outputRange: [MAX_ELEVATION, 0, MAX_ELEVATION],
-  })
-
-  const elevationY = swiper.y.interpolate({
-    inputRange: [-SWIPE_MAGNITUDE, 0, SWIPE_MAGNITUDE],
-    outputRange: [MAX_ELEVATION, 0, MAX_ELEVATION],
-  })
-
-  return Animated.add(elevationX, elevationY).interpolate({
-    inputRange: [0, MAX_ELEVATION * 2],
-    outputRange: [0, MAX_ELEVATION],
-    extrapolate: "clamp",
-  })
-}
+const MIN_OPACITY = 0.3
+const MAX_OPACITY = 1
+const MIN_SCALE = 0.9
+const MAX_SCALE = 1
+const MAX_ELEVATION = 8
+const MAX_SHADOW_OPACITY = 0.13


### PR DESCRIPTION
This PR adds a fade-in effect for the second card in a FancySwiper so that it becomes more visible and larger as the top card is swiped away.

| iOS | Android |
|----|-------|
| https://github.com/user-attachments/assets/a1279a9f-ed54-40f4-ba87-689b5bf6d712 | [android_webm.webm](https://github.com/user-attachments/assets/db7e3261-673c-4944-bf00-b47326f55a91) |



### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- Added a fade-in effect for the second card in a FancySwiper

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
