### PR TITLE
fix(DIA-1068): prevent artwork cards from freezing

### DIFF
--- a/src/app/Components/FancySwiper/FancySwiper.tsx
+++ b/src/app/Components/FancySwiper/FancySwiper.tsx
@@ -7,8 +7,13 @@ import { FancySwiperCard } from "./FancySwiperCard"
 // the amount of swiping that is considered a full swipe
 export const SWIPE_MAGNITUDE = 100
 
+export type FancySwiperCard = {
+  content: React.ReactNode
+  artworkId: string
+}
+
 interface FancySwiperProps {
-  cards: React.ReactNode[]
+  cards: FancySwiperCard[]
   hideActionButtons?: boolean
   onSwipeAnywhere?: () => void
   onSwipeLeft?: () => void
@@ -117,8 +122,8 @@ export const FancySwiper = ({
 
           return (
             <FancySwiperCard
-              card={card}
-              key={index}
+              card={card.content}
+              key={card.artworkId}
               swiper={swiper}
               isTopCard={isTopCard}
               isSecondCard={isSecondCard}

--- a/src/app/Components/FancySwiper/FancySwiper.tsx
+++ b/src/app/Components/FancySwiper/FancySwiper.tsx
@@ -7,13 +7,13 @@ import { FancySwiperCard } from "./FancySwiperCard"
 // the amount of swiping that is considered a full swipe
 export const SWIPE_MAGNITUDE = 100
 
-export type FancySwiperCard = {
+export type FancySwiperArtworkCard = {
   content: React.ReactNode
   artworkId: string
 }
 
 interface FancySwiperProps {
-  cards: FancySwiperCard[]
+  cards: FancySwiperArtworkCard[]
   hideActionButtons?: boolean
   onSwipeAnywhere?: () => void
   onSwipeLeft?: () => void

--- a/src/app/Components/FancySwiper/__tests__/FancySwiper.tests.tsx
+++ b/src/app/Components/FancySwiper/__tests__/FancySwiper.tests.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react-native"
-import { FancySwiper } from "app/Components/FancySwiper/FancySwiper"
+import { FancySwiper, FancySwiperArtworkCard } from "app/Components/FancySwiper/FancySwiper"
 import { swipeLeft, swipeRight } from "app/Components/FancySwiper/__tests__/utils"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
@@ -19,4 +19,7 @@ describe("FancySwiper", () => {
   })
 })
 
-const cards: React.ReactNode[] = [<></>, <></>]
+const cards: FancySwiperArtworkCard[] = [
+  { content: <></>, artworkId: "artwork-id-1" },
+  { content: <></>, artworkId: "artwork-id-2" },
+]

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -157,8 +157,8 @@ const ArtQuizArtworksScreen = () => {
   }
 
   const artworkCards: FancySwiperArtworkCard[] = useMemo(() => {
-    return artworks.map((artwork, index) => ({
-      content: <ArtQuizArtworkCard artwork={artwork} key={index} />,
+    return artworks.map((artwork) => ({
+      content: <ArtQuizArtworkCard artwork={artwork} key={artwork.internalID} />,
       artworkId: artwork.internalID,
     }))
   }, [artworks])

--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -6,7 +6,7 @@ import {
 } from "__generated__/ArtQuizArtworksQuery.graphql"
 import { ArtQuizArtworksSaveMutation } from "__generated__/ArtQuizArtworksSaveMutation.graphql"
 import { ArtQuizArtworksUpdateQuizMutation } from "__generated__/ArtQuizArtworksUpdateQuizMutation.graphql"
-import { FancySwiper } from "app/Components/FancySwiper/FancySwiper"
+import { FancySwiper, FancySwiperArtworkCard } from "app/Components/FancySwiper/FancySwiper"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -156,12 +156,14 @@ const ArtQuizArtworksScreen = () => {
     })
   }
 
-  const artworkCards: React.ReactNode[] = useMemo(
-    () => artworks.map((artwork, index) => <ArtQuizArtworkCard artwork={artwork} key={index} />),
-    [artworks]
-  )
+  const artworkCards: FancySwiperArtworkCard[] = useMemo(() => {
+    return artworks.map((artwork, index) => ({
+      content: <ArtQuizArtworkCard artwork={artwork} key={index} />,
+      artworkId: artwork.internalID,
+    }))
+  }, [artworks])
 
-  const unswipedCards: React.ReactNode[] = artworkCards.slice(activeCardIndex)
+  const unswipedCards: FancySwiperArtworkCard[] = artworkCards.slice(activeCardIndex)
 
   return (
     <Screen>

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
   Touchable,
 } from "@artsy/palette-mobile"
-import { FancySwiper } from "app/Components/FancySwiper/FancySwiper"
+import { FancySwiper, FancySwiperCard } from "app/Components/FancySwiper/FancySwiper"
 import { useToast } from "app/Components/Toast/toastHook"
 import { InfiniteDiscoveryArtworkCard } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard"
 import { InfiniteDiscoveryBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheet"
@@ -64,11 +64,14 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     setArtworks((previousArtworks) => previousArtworks.concat(newArtworks))
   }, [data, extractNodes, setArtworks])
 
-  const artworkCards: React.ReactNode[] = useMemo(() => {
-    return artworks.map((artwork, i) => <InfiniteDiscoveryArtworkCard artwork={artwork} key={i} />)
+  const artworkCards: FancySwiperCard[] = useMemo(() => {
+    return artworks.map((artwork) => ({
+      content: <InfiniteDiscoveryArtworkCard artwork={artwork} key={artwork.internalID} />,
+      artworkId: artwork.internalID,
+    }))
   }, [artworks])
 
-  const unswipedCards: React.ReactNode[] = artworkCards.slice(index)
+  const unswipedCards: FancySwiperCard[] = artworkCards.slice(index)
 
   const handleBackPressed = () => {
     if (index > 0) {

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
   Touchable,
 } from "@artsy/palette-mobile"
-import { FancySwiper, FancySwiperCard } from "app/Components/FancySwiper/FancySwiper"
+import { FancySwiper, FancySwiperArtworkCard } from "app/Components/FancySwiper/FancySwiper"
 import { useToast } from "app/Components/Toast/toastHook"
 import { InfiniteDiscoveryArtworkCard } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard"
 import { InfiniteDiscoveryBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheet"
@@ -64,14 +64,14 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     setArtworks((previousArtworks) => previousArtworks.concat(newArtworks))
   }, [data, extractNodes, setArtworks])
 
-  const artworkCards: FancySwiperCard[] = useMemo(() => {
+  const artworkCards: FancySwiperArtworkCard[] = useMemo(() => {
     return artworks.map((artwork) => ({
       content: <InfiniteDiscoveryArtworkCard artwork={artwork} key={artwork.internalID} />,
       artworkId: artwork.internalID,
     }))
   }, [artworks])
 
-  const unswipedCards: FancySwiperCard[] = artworkCards.slice(index)
+  const unswipedCards: FancySwiperArtworkCard[] = artworkCards.slice(index)
 
   const handleBackPressed = () => {
     if (index > 0) {


### PR DESCRIPTION
This PR fixes a bug in Infinite Discovery where, after the first 3 swipes, the 4th card would be on top for an instant before being replaced by another card. When trying to swipe this new card that appeared, users would not be able to swipe it, so the Infinite Discovery would come to a halt. It looked like this:

https://github.com/user-attachments/assets/01942f3d-653c-43ad-97e8-e5614d8be60e

I was struggling to debug this, so I decided to pass each card's artwork ID to FancySwiper so that I could print out the ID of each artwork card in the stack as I was swiping. Lo and behold, the bug stopped happening.

The only real change that I made was to use the artwork IDs for each artwork card's `key` field, so that seems to have fixed the buggy behavior. (@araujobarret and @MounirDhahri, I am haunted by the echoes of [this thread](https://github.com/artsy/eigen/pull/11439#discussion_r1933394560)). Here is how it behaves now:

https://github.com/user-attachments/assets/aeb225d9-7390-4357-a3ea-194b1eca8fa1

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fixed a bug where Infinite Discovery cards were freezing

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
