### PR TITLE
feat: Do not show Long Press quick tip on first app launch

### DIFF
--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingLongPressContextMenu.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingLongPressContextMenu.tsx
@@ -1,9 +1,12 @@
 import { Flex, Popover, Text } from "@artsy/palette-mobile"
 import { useIsFocused } from "@react-navigation/native"
 import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
-import { GlobalStore } from "app/store/GlobalStore"
+import { getCurrentEmissionState, GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Platform } from "react-native"
+
+// We don't want to show the onboarding popover on the first launch
+const MIN_LAUNCH_COUNT = 2
 
 export const ProgressiveOnboardingLongPressContextMenu: React.FC = ({ children }) => {
   const enableLongPressContextMenuOnboarding = useFeatureFlag(
@@ -15,6 +18,7 @@ export const ProgressiveOnboardingLongPressContextMenu: React.FC = ({ children }
       : "AREnableArtworkCardContextMenuAndroid"
   )
 
+  const launchCount = getCurrentEmissionState().launchCount
   const {
     isDismissed,
     sessionState: { isReady },
@@ -23,7 +27,10 @@ export const ProgressiveOnboardingLongPressContextMenu: React.FC = ({ children }
   const isFocused = useIsFocused()
 
   const isDisplayable =
-    isReady && !isDismissed("long-press-artwork-context-menu").status && isFocused
+    launchCount >= MIN_LAUNCH_COUNT &&
+    isReady &&
+    !isDismissed("long-press-artwork-context-menu").status &&
+    isFocused
   const { isActive, clearActivePopover } = useSetActivePopover(isDisplayable)
 
   const handleDismiss = () => {


### PR DESCRIPTION
Resolves https://artsy.slack.com/archives/C05EQL4R5N0/p1739185851472429

 <!-- eg [PROJECT-XXXX] -->

### Description

Do not show the Artwork Long Press quick tip on the first app launch.

<img width="674" alt="Bildschirmfoto 2025-02-10 um 12 29 58" src="https://github.com/user-attachments/assets/bd5d3fec-1c5c-41a8-9325-e4f9de9134cb" />

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Do not show Long Press quick tip on first app launch (min second session) - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
