### PR TITLE
fix(PBRW-487): Fix double artwork navigation issues

### DIFF
--- a/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksContent.tsx
+++ b/src/app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksContent.tsx
@@ -18,7 +18,7 @@ import { NavigationHeader } from "app/Components/NavigationHeader"
 import { BrowseSimilarWorksProps } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks"
 import { BrowseSimilarWorksExploreMoreButton } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorksExploreMoreButton"
 import { extractPills } from "app/Scenes/SavedSearchAlert/pillExtractors"
-import { goBack, navigate } from "app/system/navigation/navigate"
+import { goBack } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
@@ -114,13 +114,7 @@ const SimilarArtworksContainer: React.FC<{ attributes: SearchCriteriaAttributes 
 
     return (
       <>
-        <GenericGrid
-          width={screen.width - space(2)}
-          artworks={artworks}
-          onPress={(internalID: string) => {
-            navigate(`artwork/${internalID}`)
-          }}
-        />
+        <GenericGrid width={screen.width - space(2)} artworks={artworks} />
         <Spacer y={2} />
         <BrowseSimilarWorksExploreMoreButton attributes={attributes} />
       </>

--- a/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
+++ b/src/app/Scenes/SavedSearchAlert/AlertArtworksGrid.tsx
@@ -66,14 +66,7 @@ export const AlertArtworksGrid: FC<AlertArtworksGridProps> = ({ alertId, fetchKe
             {numWorks} currently on Artsy match your criteria. See our top picks for you:
           </Text>
           <Spacer y={1} />
-          <GenericGrid
-            width={screen.width - space(2)}
-            artworks={artworks}
-            hideSaveIcon
-            onPress={(slug: string) => {
-              navigate?.(`artwork/${slug}`)
-            }}
-          />
+          <GenericGrid width={screen.width - space(2)} artworks={artworks} hideSaveIcon />
         </Flex>
       )}
       {artworksCount === 0 && (

--- a/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
+++ b/src/app/Scenes/SavedSearchAlert/screens/ConfirmationScreen.tsx
@@ -225,9 +225,6 @@ const MatchingArtworks: React.FC<MatchingArtworksProps> = ({ artworksConnection,
         onPress={(slug: string, artwork?: ArtworkGridItem_artwork$data) => {
           closeModal?.()
           trackEvent(tracks.tappedArtworkGroup(slug, artwork?.collectorSignals))
-          requestAnimationFrame(() => {
-            navigate?.(`artwork/${slug}`)
-          })
         }}
       />
 


### PR DESCRIPTION
This PR resolves [PBRW-487] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

This PR fixes the issue with double navigation to the artwork screen that can be found in Similar Artworks screen, Alert Confirmation screen and Alert Artworks screen

I believe this issue comes from the `RouterLink` component wrapping the Artwork component which helps with the artwork navigation, as well as adding a separate `onPress` prop to the generic artwork grid, causing the two navigation calls to run
In this PR, I just removed the onPress that calls for a `navigate` to fix the issue, but I'm open to any other suggestions

### Videos

#### Android
| | Before | After |
|---|---|---|
| Similar Artworks | <video src="https://github.com/user-attachments/assets/48cc5a5e-167f-4796-a9dd-767d8d75aaae" /> | <video src="https://github.com/user-attachments/assets/2c720bf7-243e-4fad-9858-89313712b087" /> |
| Alert Confirmation | <video src="https://github.com/user-attachments/assets/dbde9107-acb6-418c-acda-f0d143e661ff" /> | <video src="https://github.com/user-attachments/assets/a2d65e1c-4b3b-47c0-92f9-5f7af237c365" /> |
| Alert Artworks | <video src="https://github.com/user-attachments/assets/9f46746c-7bc2-4af0-899b-04e81077123f" /> | <video src="https://github.com/user-attachments/assets/9b3e1fac-39c5-49f0-9240-f8163e09f10f" /> |

#### iOS
| | Before | After |
|---|---|---|
| Similar Artworks | <video src="https://github.com/user-attachments/assets/06287c7e-b35b-45af-a2b5-0595e598255b" /> | <video src="https://github.com/user-attachments/assets/704deb41-4548-461b-8617-60ea75eac475" /> |
| Alert Confirmation | <video src="https://github.com/user-attachments/assets/42d26e14-ae4d-484a-9bb2-e2bad4cc6299" /> | <video src="https://github.com/user-attachments/assets/06caf6a5-4acb-4814-ae06-828f1eb6d045" /> |
| Alert Artworks | <video src="https://github.com/user-attachments/assets/fea35235-30d1-4b35-9b1d-4d3b677266ad" /> | <video src="https://github.com/user-attachments/assets/94edf10c-94bb-4adb-86a7-052fa6390c57" /> |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix double artwork navigation in Similar Artworks, Alert Confirmation screen, and Alerts Artworks

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-487]: https://artsyproduct.atlassian.net/browse/PBRW-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ