### PR TITLE
feat: infinite disco — send seen artworks to BE

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -8,11 +8,13 @@ import {
   Spinner,
   Touchable,
 } from "@artsy/palette-mobile"
+import { captureMessage } from "@sentry/react-native"
 import { FancySwiper, FancySwiperArtworkCard } from "app/Components/FancySwiper/FancySwiper"
 import { useToast } from "app/Components/Toast/toastHook"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 import { InfiniteDiscoveryArtworkCard } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard"
 import { InfiniteDiscoveryBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheet"
+import { useCreateUserSeenArtwork } from "app/Scenes/InfiniteDiscovery/mutations/useCreateUserSeenArtwork"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack, navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -41,6 +43,7 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   const REFETCH_BUFFER = 3
   const toast = useToast()
   const { trackEvent } = useTracking()
+  const [commitMutation] = useCreateUserSeenArtwork()
 
   const { addDisoveredArtworkId } = GlobalStore.actions.infiniteDiscovery
 
@@ -61,6 +64,23 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
    */
   useEffect(() => {
     const newArtworks = extractNodes(data.discoverArtworks)
+
+    if (index === 0) {
+      commitMutation({
+        variables: {
+          input: {
+            artworkId: newArtworks[index].internalID,
+          },
+        },
+        onError: (error) => {
+          if (__DEV__) {
+            console.error(error)
+          } else {
+            captureMessage(`useCreateUserSeenArtwork ${error?.message}`)
+          }
+        },
+      })
+    }
 
     setArtworks((previousArtworks) => previousArtworks.concat(newArtworks))
   }, [data, extractNodes, setArtworks])
@@ -109,6 +129,21 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
           context_screen_owner_id: artworks[newMaxIndexReached].internalID,
           context_screen_owner_slug: artworks[newMaxIndexReached].slug,
           context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
+        })
+
+        commitMutation({
+          variables: {
+            input: {
+              artworkId: artworks[newMaxIndexReached].internalID,
+            },
+          },
+          onError: (error) => {
+            if (__DEV__) {
+              console.error(error)
+            } else {
+              captureMessage(`useCreateUserSeenArtwork ${error?.message}`)
+            }
+          },
         })
       }
       setMaxIndexReached(newMaxIndexReached)

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -64,12 +64,18 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
    */
   useEffect(() => {
     const newArtworks = extractNodes(data.discoverArtworks)
+    setArtworks((previousArtworks) => previousArtworks.concat(newArtworks))
+  }, [data, extractNodes, setArtworks])
 
-    if (index === 0) {
+  /**
+   * sends the first seen artwork to the server
+   */
+  useEffect(() => {
+    if (artworks.length > 0 && index === 0) {
       commitMutation({
         variables: {
           input: {
-            artworkId: newArtworks[index].internalID,
+            artworkId: artworks[index].internalID,
           },
         },
         onError: (error) => {
@@ -81,9 +87,7 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
         },
       })
     }
-
-    setArtworks((previousArtworks) => previousArtworks.concat(newArtworks))
-  }, [data, extractNodes, setArtworks])
+  }, [artworks])
 
   const artworkCards: FancySwiperArtworkCard[] = useMemo(() => {
     return artworks.map((artwork) => ({

--- a/src/app/Scenes/InfiniteDiscovery/mutations/useCreateUserSeenArtwork.ts
+++ b/src/app/Scenes/InfiniteDiscovery/mutations/useCreateUserSeenArtwork.ts
@@ -1,0 +1,53 @@
+import { useCreateUserSeenArtworkMutation } from "__generated__/useCreateUserSeenArtworkMutation.graphql"
+import { Disposable, UseMutationConfig, graphql, useMutation } from "react-relay"
+
+type CommitConfig = UseMutationConfig<useCreateUserSeenArtworkMutation>
+type Response = [(config: CommitConfig) => Disposable, boolean]
+
+export const useCreateUserSeenArtwork = (): Response => {
+  const [initialCommit, inProgress] = useMutation<useCreateUserSeenArtworkMutation>(
+    CreateUserSeenArtworkMutation
+  )
+
+  const commit = (config: CommitConfig) => {
+    return initialCommit({
+      ...config,
+      onCompleted: (data, errors) => {
+        const response = data.createUserSeenArtwork?.userSeenArtworkOrError
+
+        if (response?.__typename === "CreateUserSeenArtworkFailure") {
+          const errorMessage = response?.mutationError?.message
+
+          if (errorMessage) {
+            const error = new Error(errorMessage)
+            config.onError?.(error)
+          }
+        } else {
+          config.onCompleted?.(data, errors)
+        }
+      },
+    })
+  }
+
+  return [commit, inProgress]
+}
+
+const CreateUserSeenArtworkMutation = graphql`
+  mutation useCreateUserSeenArtworkMutation($input: CreateUserSeenArtworkInput!) {
+    createUserSeenArtwork(input: $input) {
+      userSeenArtworkOrError {
+        __typename
+
+        ... on CreateUserSeenArtworkSuccess {
+          artworkId
+        }
+
+        ... on CreateUserSeenArtworkFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/InfiniteDiscovery/mutations/useCreateUserSeenArtwork.ts
+++ b/src/app/Scenes/InfiniteDiscovery/mutations/useCreateUserSeenArtwork.ts
@@ -38,10 +38,6 @@ const CreateUserSeenArtworkMutation = graphql`
       userSeenArtworkOrError {
         __typename
 
-        ... on CreateUserSeenArtworkSuccess {
-          artworkId
-        }
-
         ... on CreateUserSeenArtworkFailure {
           mutationError {
             message


### PR DESCRIPTION
### Description

We now have a backend to track seen artworks for the Infinite Discovery project. Currently, `discoverArtworks` does not take BE seen artworks into account (though there is an argument in the query that allows this, and merging [this PR](https://github.com/artsy/metaphysics/pull/6454) will make it possible to enable via a feature flag).

In this PR, I add functionality to store seen artworks on the BE only. After it’s merged, whenever we feel that our BE is ready for internal tracking, we can simply enable the feature flag on the Metaphysics side.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- infinite disco - persist seen artworks - @nickskalkin 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
