### PR TITLE
feat: hide Bidding info for live auction in progress as it's not reliable.

### DIFF
--- a/src/app/Scenes/MyBids/ActiveLotStanding.tests.tsx
+++ b/src/app/Scenes/MyBids/ActiveLotStanding.tests.tsx
@@ -15,8 +15,9 @@ const defaultSaleArtwork = {
     },
   },
   sale: {
+    isLiveOpen: false,
     endAt: "2020-08-05T15:00:00+00:00",
-    status: "closed",
+    status: "",
   },
   lotState: {
     soldStatus: "sold",

--- a/src/app/Scenes/MyBids/ActiveLotStanding.tests.tsx
+++ b/src/app/Scenes/MyBids/ActiveLotStanding.tests.tsx
@@ -17,7 +17,7 @@ const defaultSaleArtwork = {
   sale: {
     isLiveOpen: false,
     endAt: "2020-08-05T15:00:00+00:00",
-    status: "",
+    status: "closed",
   },
   lotState: {
     soldStatus: "sold",
@@ -57,19 +57,32 @@ describe(ActiveLotStanding, () => {
       expect(extractText(tree.root)).toContain("Highest bid")
     })
 
-    it("says 'Highest bid' if the user is winning the lot but the reserveStatus is ReserveNotMet in a Live Auction", () => {
+    it("says 'Highest bid' if the user is winning but reserveStatus is ReserveNotMet in auction with Live part", () => {
       const date = new Date()
       date.setDate(date.getDate() + 1)
       const tree = renderWithWrappersLEGACY(
         <ActiveLotStanding
           saleArtwork={saleArtworkFixture({
             isHighestBidder: true,
-            sale: { liveStartAt: date },
+            sale: { liveStartAt: date, isLiveOpen: false },
             lotState: { reserveStatus: "ReserveNotMet" },
           })}
         />
       )
       expect(extractText(tree.root)).toContain("Highest bid")
+    })
+
+    it("hides winning info if auction with Live part are in Live bidding", () => {
+      const tree = renderWithWrappersLEGACY(
+        <ActiveLotStanding
+          saleArtwork={saleArtworkFixture({
+            isHighestBidder: true,
+            sale: { liveStartAt: new Date(), isLiveOpen: true },
+            lotState: { reserveStatus: "ReserveNotMet" },
+          })}
+        />
+      )
+      expect(extractText(tree.root)).not.toContain("Highest bid")
     })
 
     it("says 'Reserve not met' if the user is winning the lot, but the reserveStatus is ReserveNotMet", () => {

--- a/src/app/Scenes/MyBids/ClosedLotStanding.tests.tsx
+++ b/src/app/Scenes/MyBids/ClosedLotStanding.tests.tsx
@@ -16,6 +16,7 @@ const defaultSaleArtwork = {
     },
   },
   sale: {
+    isLiveOpen: false,
     endAt: "2020-08-05T15:00:00+00:00",
     status: "closed",
   },

--- a/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
+++ b/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
@@ -1,12 +1,11 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Text } from "@artsy/palette-mobile"
 import { ActiveLotStanding_saleArtwork$data } from "__generated__/ActiveLotStanding_saleArtwork.graphql"
-import { TimelySale } from "app/Scenes/MyBids/helpers/timely"
 import { navigate } from "app/system/navigation/navigate"
+import { useScreenDimensions } from "app/utils/hooks"
 import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
-import { useScreenDimensions } from "app/utils/hooks"
 import { HighestBid, Outbid, ReserveNotMet } from "./BiddingStatuses"
 import { LotFragmentContainer as Lot } from "./Lot"
 
@@ -15,15 +14,19 @@ export const ActiveLotStanding = ({
 }: {
   saleArtwork: ActiveLotStanding_saleArtwork$data
 }) => {
-  const timelySale = TimelySale.create(saleArtwork?.sale!)
+  const tracking = useTracking()
+  const { isSmallScreen } = useScreenDimensions()
+
+  const sale = saleArtwork?.sale
+  if (!sale) {
+    return null
+  }
 
   const sellingPrice =
     saleArtwork?.currentBid?.display ||
     saleArtwork?.lotState?.sellingPrice?.display ||
     saleArtwork?.estimate
   const bidCount = saleArtwork?.lotState?.bidCount
-  const tracking = useTracking()
-  const { isSmallScreen } = useScreenDimensions()
 
   const displayBidCount = (): string | undefined => {
     if (isSmallScreen) {
@@ -46,13 +49,10 @@ export const ActiveLotStanding = ({
   }
 
   return (
-    saleArtwork && (
-      <TouchableOpacity
-        onPress={() => handleLotTap()}
-        style={{ marginHorizontal: 0, width: "100%" }}
-      >
-        <Flex flexDirection="row" justifyContent="space-between">
-          <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen} />
+    <TouchableOpacity onPress={() => handleLotTap()} style={{ marginHorizontal: 0, width: "100%" }}>
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen} />
+        {!sale.isLiveOpen && (
           <Flex>
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
@@ -62,8 +62,7 @@ export const ActiveLotStanding = ({
               </Text>
             </Flex>
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-              {!timelySale.isLAI &&
-              saleArtwork?.isHighestBidder &&
+              {saleArtwork?.isHighestBidder &&
               saleArtwork?.lotState?.reserveStatus === "ReserveNotMet" ? (
                 <ReserveNotMet />
               ) : saleArtwork?.isHighestBidder ? (
@@ -73,9 +72,9 @@ export const ActiveLotStanding = ({
               )}
             </Flex>
           </Flex>
-        </Flex>
-      </TouchableOpacity>
-    )
+        )}
+      </Flex>
+    </TouchableOpacity>
   )
 }
 
@@ -86,6 +85,7 @@ export const ActiveLotStandingFragmentContainer = createFragmentContainer(Active
       isHighestBidder
       sale {
         status
+        isLiveOpen
         liveStartAt
         endAt
       }

--- a/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
+++ b/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
@@ -62,7 +62,8 @@ export const ActiveLotStanding = ({
               </Text>
             </Flex>
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-              {saleArtwork?.isHighestBidder &&
+              {!sale.liveStartAt &&
+              saleArtwork?.isHighestBidder &&
               saleArtwork?.lotState?.reserveStatus === "ReserveNotMet" ? (
                 <ReserveNotMet />
               ) : saleArtwork?.isHighestBidder ? (

--- a/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
+++ b/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
@@ -54,6 +54,15 @@ export const Passed = () => (
   </Text>
 )
 
+export const BiddingLiveNow = () => (
+  <>
+    <Text variant="xs" color="blue100">
+      {" "}
+      Bidding live now
+    </Text>
+  </>
+)
+
 export const Watching = () => (
   <>
     <BookmarkFill />

--- a/src/app/Scenes/MyBids/Components/LotStatusListItem.tsx
+++ b/src/app/Scenes/MyBids/Components/LotStatusListItem.tsx
@@ -27,7 +27,9 @@ const LotStatusListItem: React.FC<Props> = ({ saleArtwork, saleIsClosed }) => {
     return <WatchedLotFragmentContainer saleArtwork={saleArtwork} />
   }
 
-  const isComplete = completeStatuses.includes(saleArtwork.lotState?.soldStatus?.toLowerCase()!)
+  const isComplete = completeStatuses.includes(
+    saleArtwork.lotState?.soldStatus?.toLowerCase() || ""
+  )
 
   return isComplete ? (
     <ClosedLotStandingFragmentContainer saleArtwork={saleArtwork} />

--- a/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
+++ b/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
@@ -1,8 +1,12 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { SaleActiveBidItem_lotStanding$data } from "__generated__/SaleActiveBidItem_lotStanding.graphql"
-import { HighestBid, Outbid, ReserveNotMet } from "app/Scenes/MyBids/Components/BiddingStatuses"
+import {
+  HighestBid,
+  Outbid,
+  ReserveNotMet,
+  BiddingLiveNow,
+} from "app/Scenes/MyBids/Components/BiddingStatuses"
 import { LotFragmentContainer } from "app/Scenes/MyBids/Components/Lot"
-import { TimelySale } from "app/Scenes/MyBids/helpers/timely"
 import { navigate } from "app/system/navigation/navigate"
 import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -12,22 +16,17 @@ interface SaleActiveBidItemProps {
 }
 
 export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStanding }) => {
-  const timelySale = TimelySale.create(lotStanding?.sale!)
-  const isLAI = timelySale.isLiveBiddingNow()
-
-  const sellingPrice = lotStanding?.mostRecentBid?.maxBid?.display
-  const bidCount = lotStanding?.saleArtwork?.counts?.bidderPositions
-  const { saleArtwork } = lotStanding
-
+  const saleArtwork = lotStanding?.saleArtwork
   if (!saleArtwork) {
     return null
   }
 
+  const sellingPrice = lotStanding.mostRecentBid?.maxBid?.display
+  const bidCount = saleArtwork.counts?.bidderPositions
+
   return (
     <TouchableOpacity
-      onPress={() =>
-        lotStanding?.saleArtwork?.artwork?.href && navigate(lotStanding.saleArtwork.artwork.href)
-      }
+      onPress={() => saleArtwork.artwork?.href && navigate(saleArtwork.artwork.href)}
     >
       <Flex flexDirection="row" justifyContent="space-between">
         <LotFragmentContainer saleArtwork={saleArtwork} />
@@ -40,9 +39,10 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
             </Text>
           </Flex>
           <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-            {!isLAI &&
-            lotStanding?.activeBid?.isWinning &&
-            lotStanding?.saleArtwork?.reserveStatus === "ReserveNotMet" ? (
+            {saleArtwork.sale?.isLiveOpen ? (
+              <BiddingLiveNow />
+            ) : lotStanding?.activeBid?.isWinning &&
+              saleArtwork.reserveStatus === "ReserveNotMet" ? (
               <ReserveNotMet />
             ) : lotStanding?.activeBid?.isWinning ? (
               <HighestBid />
@@ -68,6 +68,7 @@ export const SaleActiveBidItemContainer = createFragmentContainer(SaleActiveBidI
         }
       }
       saleArtwork {
+        ...Lot_saleArtwork
         reserveStatus
         counts {
           bidderPositions
@@ -78,10 +79,10 @@ export const SaleActiveBidItemContainer = createFragmentContainer(SaleActiveBidI
         artwork {
           href
         }
-        ...Lot_saleArtwork
-      }
-      sale {
-        liveStartAt
+        sale {
+          isLiveOpen
+          slug
+        }
       }
     }
   `,

--- a/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
+++ b/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
@@ -31,13 +31,15 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
       <Flex flexDirection="row" justifyContent="space-between">
         <LotFragmentContainer saleArtwork={saleArtwork} />
         <Flex>
-          <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
-            <Text variant="xs">{sellingPrice}</Text>
-            <Text variant="xs" color="black60">
-              {" "}
-              ({bidCount} {bidCount === 1 ? "bid" : "bids"})
-            </Text>
-          </Flex>
+          {!saleArtwork.sale?.isLiveOpen && (
+            <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
+              <Text variant="xs">{sellingPrice}</Text>
+              <Text variant="xs" color="black60">
+                {" "}
+                ({bidCount} {bidCount === 1 ? "bid" : "bids"})
+              </Text>
+            </Flex>
+          )}
           <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
             {saleArtwork.sale?.isLiveOpen ? (
               <BiddingLiveNow />

--- a/src/app/Scenes/Sale/Components/SaleActiveBids.tsx
+++ b/src/app/Scenes/Sale/Components/SaleActiveBids.tsx
@@ -46,8 +46,8 @@ export const SaleActiveBids: React.FC<SaleActiveBidsProps> = ({ me, relay, saleI
       <FlatList
         data={me.lotStandings}
         ListHeaderComponent={() => <SectionTitle title="Your active bids" />}
-        ItemSeparatorComponent={() => <Separator my={0.5} />}
-        renderItem={({ item }) => <SaleActiveBidItemContainer lotStanding={item!} />}
+        ItemSeparatorComponent={() => <Separator my={1} />}
+        renderItem={({ item }) => <SaleActiveBidItemContainer lotStanding={item} />}
         keyExtractor={(item) => `${item?.saleArtwork?.slug}`}
       />
     </Flex>

--- a/src/app/Scenes/Sale/SaleActiveBidItem.tests.tsx
+++ b/src/app/Scenes/Sale/SaleActiveBidItem.tests.tsx
@@ -164,12 +164,15 @@ describe("SaleActiveBidItem", () => {
     expect(tree.root.findAllByType(Outbid)).toHaveLength(1)
   })
 
-  it("renders BiddingLiveNow if the sale is in live bidding state", () => {
+  it("renders BiddingLiveNow and hides bids info if the sale is in live bidding state", () => {
     const tree = renderWithWrappersLEGACY(<TestRenderer />)
 
     const liveBiddingLot = {
       ...lotStanding,
       saleArtwork: {
+        counts: {
+          bidderPositions: 1,
+        },
         sale: {
           isLiveOpen: true,
         },
@@ -183,6 +186,7 @@ describe("SaleActiveBidItem", () => {
 
     resolveMostRecentRelayOperation(mockEnvironment, mockProps)
 
+    expect(extractText(tree.root)).not.toContain("1 bid")
     expect(tree.root.findAllByType(BiddingLiveNow)).toHaveLength(1)
   })
 

--- a/src/app/Scenes/Sale/SaleActiveBidItem.tests.tsx
+++ b/src/app/Scenes/Sale/SaleActiveBidItem.tests.tsx
@@ -1,5 +1,10 @@
 import { SaleActiveBidItemTestsQuery } from "__generated__/SaleActiveBidItemTestsQuery.graphql"
-import { HighestBid, Outbid, ReserveNotMet } from "app/Scenes/MyBids/Components/BiddingStatuses"
+import {
+  HighestBid,
+  Outbid,
+  ReserveNotMet,
+  BiddingLiveNow,
+} from "app/Scenes/MyBids/Components/BiddingStatuses"
 import { navigate } from "app/system/navigation/navigate"
 import { extractText } from "app/utils/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
@@ -157,6 +162,28 @@ describe("SaleActiveBidItem", () => {
     resolveMostRecentRelayOperation(mockEnvironment, mockProps)
 
     expect(tree.root.findAllByType(Outbid)).toHaveLength(1)
+  })
+
+  it("renders BiddingLiveNow if the sale is in live bidding state", () => {
+    const tree = renderWithWrappersLEGACY(<TestRenderer />)
+
+    const liveBiddingLot = {
+      ...lotStanding,
+      saleArtwork: {
+        sale: {
+          isLiveOpen: true,
+        },
+      },
+    }
+    const mockProps = {
+      Me: () => ({
+        lotStandings: [liveBiddingLot],
+      }),
+    }
+
+    resolveMostRecentRelayOperation(mockEnvironment, mockProps)
+
+    expect(tree.root.findAllByType(BiddingLiveNow)).toHaveLength(1)
   })
 
   it("renders the right bid count if the user has only 1 bid", () => {


### PR DESCRIPTION
Solves  [[EMI-2234](https://artsyproduct.atlassian.net/browse/EMI-2234)] 

### Description

We do not have a good way currently to get the timely status of bids in the auction that is in live bidding state. So instead of displaying wrong outbid/winning info the decision is to display Bidding live now note instead on Auction page. Also hide bidding info in this case in myBids screen.

#### Screenshots

Auction page:

|Android|iOs|
|---|---|
|<img width="293" alt="Screenshot 2025-02-27 at 1 21 10 PM" src="https://github.com/user-attachments/assets/e9098e28-d653-40b0-91cb-4d6eed1e4e10" />|<img width="399" alt="Screenshot 2025-02-27 at 1 17 57 PM" src="https://github.com/user-attachments/assets/c5a101e6-0a07-4829-a29b-0cd0c2c42125" />|

myBids page:

|Android|iOs|
|---|---|
|<img width="294" alt="Screenshot 2025-02-27 at 1 55 20 PM" src="https://github.com/user-attachments/assets/7dc485e7-047c-4e44-8976-9d26ef2173ec" />|<img width="410" alt="Screenshot 2025-02-27 at 1 55 52 PM" src="https://github.com/user-attachments/assets/459dfcba-879c-473f-861c-9655cf785da4" />|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- display Bidding live now for lots in actively live bidding auctions on Auction page

#### Android user-facing changes

- display Bidding live now for lots in actively live bidding auctions on Auction page

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md



[EMI-2234]: https://artsyproduct.atlassian.net/browse/EMI-2234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ