### PR TITLE
fix(PBRW-510): Fix issue with the app freezing after Make Offer flow

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tests.tsx
@@ -1,6 +1,5 @@
-import { act, fireEvent, screen } from "@testing-library/react-native"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { goBack, switchTab } from "app/system/navigation/navigate"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { OfferSubmittedModal } from "./OfferSubmittedModal"
 
@@ -19,22 +18,30 @@ jest.mock("app/utils/useWebViewEvent", () => ({
 }))
 
 describe("OfferSubmittedModal", () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ advanceTimers: true })
+  })
+
   afterEach(() => {
     jest.clearAllMocks()
+    jest.useRealTimers()
   })
 
   it("renders", async () => {
     renderWithWrappers(<OfferSubmittedModal />)
+
     act(() => callback?.({ orderCode: "1234", message: "Test message" }))
 
-    await flushPromiseQueue()
+    jest.advanceTimersByTime(2000)
 
-    expect(screen.getByText("Thank you, your offer has been submitted")).toBeTruthy()
+    await screen.findByText("Thank you, your offer has been submitted")
+
+    expect(screen.getByText("Thank you, your offer has been submitted")).toBeOnTheScreen()
     expect(
       screen.getByText("Negotiation with the gallery will continue in the Inbox.")
-    ).toBeTruthy()
-    expect(screen.getByText("Offer #1234")).toBeTruthy()
-    expect(screen.getByText("Test message")).toBeTruthy()
+    ).toBeOnTheScreen()
+    expect(screen.getByText("Offer #1234")).toBeOnTheScreen()
+    expect(screen.getByText("Test message")).toBeOnTheScreen()
     expect(goBack).toHaveBeenCalledTimes(1)
   })
 
@@ -42,11 +49,10 @@ describe("OfferSubmittedModal", () => {
     renderWithWrappers(<OfferSubmittedModal />)
     act(() => callback?.({ orderCode: "1234", message: "Test message" }))
 
-    await flushPromiseQueue()
-    fireEvent.press(screen.getAllByText("Go to inbox")[0])
+    jest.advanceTimersByTime(2000)
 
-    // Wait for modal dismissal
-    await flushPromiseQueue()
-    expect(switchTab).toHaveBeenCalledWith("inbox")
+    fireEvent.press(screen.getByText("Go to inbox"))
+
+    await waitFor(() => expect(switchTab).toHaveBeenCalledWith("inbox"))
   })
 })

--- a/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
@@ -15,9 +15,9 @@ export const OfferSubmittedModal: React.FC = () => {
       setOfferData({ code: args.orderCode ?? "", message: args.message ?? "" })
       goBack()
       // Wait for the back animation to finish before showing the modal
-      InteractionManager.runAfterInteractions(() => {
+      setTimeout(() => {
         setVisible(true)
-      })
+      }, 2000)
     }
   )
 

--- a/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/OfferSubmittedModal.tsx
@@ -3,7 +3,7 @@ import { NavigationHeader } from "app/Components/NavigationHeader"
 import { goBack, switchTab } from "app/system/navigation/navigate"
 import { useSetWebViewCallback } from "app/utils/useWebViewEvent"
 import React, { useState } from "react"
-import { Modal } from "react-native"
+import { InteractionManager, Modal } from "react-native"
 
 export const OfferSubmittedModal: React.FC = () => {
   const [visible, setVisible] = useState(false)
@@ -15,7 +15,7 @@ export const OfferSubmittedModal: React.FC = () => {
       setOfferData({ code: args.orderCode ?? "", message: args.message ?? "" })
       goBack()
       // Wait for the back animation to finish before showing the modal
-      requestAnimationFrame(() => {
+      InteractionManager.runAfterInteractions(() => {
         setVisible(true)
       })
     }
@@ -24,7 +24,7 @@ export const OfferSubmittedModal: React.FC = () => {
   const onGoToInbox = () => {
     setVisible(false)
     // Go to inbox after the modal is closed
-    requestAnimationFrame(() => {
+    InteractionManager.runAfterInteractions(() => {
       switchTab("inbox")
     })
   }
@@ -34,7 +34,7 @@ export const OfferSubmittedModal: React.FC = () => {
   }
 
   return (
-    <Modal visible={visible} onRequestClose={onClose} animationType="fade" statusBarTranslucent>
+    <Modal visible={visible} onRequestClose={onClose} animationType="fade">
       <Screen>
         <NavigationHeader rightCloseButton onRightButtonPress={onClose}>
           Make Offer


### PR DESCRIPTION
This PR resolves [PBRW-510] <!-- eg [PROJECT-XXXX] -->

### Description

Video of the behavior after the fix:

<video src="https://github.com/user-attachments/assets/65b5944e-2467-4084-beb9-64c06a9fc8e2" width="500" />



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix unresponsive artwork screen after make offer 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-510]: https://artsyproduct.atlassian.net/browse/PBRW-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ