### PR TITLE
refactor: infinite discovery - rely on backed to exclude seen artworks (remove discoveredArtworkIds)

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -46,8 +46,6 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   const { trackEvent } = useTracking()
   const [commitMutation] = useCreateUserSeenArtwork()
 
-  const { addDisoveredArtworkId } = GlobalStore.actions.infiniteDiscovery
-
   const savedArtworksCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.savedArtworksCount
   )
@@ -125,8 +123,6 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     if (!artwork) {
       return
     }
-
-    addDisoveredArtworkId(artwork.internalID)
 
     trackEvent(tracks.displayedNewArtwork(artwork.internalID, artwork.slug))
 
@@ -277,23 +273,16 @@ const InfiniteDiscoverySpinner: React.FC = () => (
 export const InfiniteDiscoveryQueryRenderer: React.FC = () => {
   const [queryRef, loadQuery] = useQueryLoader<InfiniteDiscoveryQuery>(infiniteDiscoveryQuery)
 
-  const discoveredArtworksIds = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.discoveredArtworkIds
-  )
   const { resetSavedArtworksCount } = GlobalStore.actions.infiniteDiscovery
 
   useEffect(() => {
     resetSavedArtworksCount()
   }, [])
 
-  /**
-   * This fetches the first batch of artworks. discoveredArtworksIds is omitted from the list of
-   * dependencies to prevent this from being called unnecessarily, since that list is updated when
-   * new artworks are fetched.
-   */
+  // This fetches the first batch of artworks
   useEffect(() => {
     if (!queryRef) {
-      loadQuery({ excludeArtworkIds: discoveredArtworksIds })
+      loadQuery({ excludeArtworkIds: [] })
     }
   }, [loadQuery, queryRef])
 
@@ -302,7 +291,7 @@ export const InfiniteDiscoveryQueryRenderer: React.FC = () => {
   }
 
   const fetchMoreArtworks = (undiscoveredArtworks: string[]) => {
-    loadQuery({ excludeArtworkIds: discoveredArtworksIds.concat(undiscoveredArtworks) })
+    loadQuery({ excludeArtworkIds: undiscoveredArtworks })
   }
 
   return <InfiniteDiscovery fetchMoreArtworks={fetchMoreArtworks} queryRef={queryRef} />

--- a/src/app/store/GlobalStoreModel.ts
+++ b/src/app/store/GlobalStoreModel.ts
@@ -62,7 +62,6 @@ export interface GlobalStoreModel extends GlobalStoreStateModel {
 
   // for dev only.
   _setVersion: Action<this, number>
-  _forgetDiscoveredArtworks: Action<this>
 
   // for testing only. noop otherwise.
   __inject: Action<this, DeepPartial<State<GlobalStoreStateModel>>>
@@ -146,10 +145,6 @@ export const getGlobalStoreModel = (): GlobalStoreModel => ({
   // for dev only.
   _setVersion: action((state, newVersion) => {
     state.version = newVersion
-  }),
-
-  _forgetDiscoveredArtworks: action((state) => {
-    state.infiniteDiscovery.discoveredArtworkIds = []
   }),
 
   // for testing only. noop otherwise.

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -1,28 +1,14 @@
 import { Action, action } from "easy-peasy"
 
-const MAX_DISCOVERED_ARTWORKS = 2000
-
 export interface InfiniteDiscoveryModel {
-  discoveredArtworkIds: string[]
   savedArtworksCount: number
-  addDisoveredArtworkId: Action<this, string>
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
   resetSavedArtworksCount: Action<this>
 }
 
 export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
-  discoveredArtworkIds: [],
   savedArtworksCount: 0,
-  addDisoveredArtworkId: action((state, artworkId) => {
-    if (!state.discoveredArtworkIds.includes(artworkId)) {
-      state.discoveredArtworkIds.push(artworkId)
-
-      if (state.discoveredArtworkIds.length > MAX_DISCOVERED_ARTWORKS) {
-        state.discoveredArtworkIds.shift()
-      }
-    }
-  }),
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
   }),

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -1205,4 +1205,24 @@ describe("App version Versions.AddInfiniteDiscoveryModel", () => {
       expect(migratedState.devicePrefs.forcedColorScheme).toEqual(undefined)
     })
   })
+
+  describe("App version Versions.RemoveDiscoveredArtworkIdsFromInfiniteDiscoveryModel", () => {
+    it("removes discoveredArtworkIds from infiniteDiscovery model", () => {
+      const migrationToTest = Versions.RemoveDiscoveredArtworkIdsFromInfiniteDiscoveryModel
+
+      const previousState = migrate({
+        state: { version: 0 },
+        toVersion: migrationToTest - 1,
+      }) as any
+
+      previousState.infiniteDiscovery.discoveredArtworkIds = ["artwork-1", "artwork-2"]
+
+      const migratedState = migrate({
+        state: previousState,
+        toVersion: migrationToTest,
+      }) as any
+
+      expect(migratedState.infiniteDiscovery.discoveredArtworkIds).toBeUndefined()
+    })
+  })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -63,9 +63,10 @@ export const Versions = {
   RemoveArworkSubmissionModel: 50,
   RemoveRequestPriceEstimateModel: 51,
   RefactorDarkModeValues: 52,
+  RemoveDiscoveredArtworkIdsFromInfiniteDiscoveryModel: 53,
 }
 
-export const CURRENT_APP_VERSION = Versions.RefactorDarkModeValues
+export const CURRENT_APP_VERSION = Versions.RemoveDiscoveredArtworkIdsFromInfiniteDiscoveryModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -363,6 +364,9 @@ export const artsyAppMigrations: Migrations = {
     state.devicePrefs.darkModeOption = "system"
     delete state.devicePrefs.usingSystemColorScheme
     delete state.devicePrefs.forcedColorScheme
+  },
+  [Versions.RemoveDiscoveredArtworkIdsFromInfiniteDiscoveryModel]: (state) => {
+    delete state.infiniteDiscovery.discoveredArtworkIds
   },
 }
 

--- a/src/app/system/devTools/DevMenu/Components/DevTools.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevTools.tsx
@@ -124,13 +124,6 @@ export const DevTools: React.FC<{}> = () => {
               toast.show("Progressive Onboarding progress cleared ✅", "middle")
             }}
           />
-          <DevMenuButtonItem
-            title="Clear Infinite Discovery artworks"
-            onPress={() => {
-              GlobalStore.actions._forgetDiscoveredArtworks()
-              toast.show("Infinite Discovery artworks cleared ✅", "middle")
-            }}
-          />
           <DevMenuButtonItem title={`Active Unleash env: ${capitalize(unleashEnv)}`} />
 
           <DevMenuButtonItem


### PR DESCRIPTION
### Description

Stop using local storage for `discoveredArtworkIds`—backend will do it instead.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
