### PR TITLE
fix(PBRW-512): form being reset 2 times and race conditions

### DIFF
--- a/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
+++ b/src/app/utils/ArtworkInquiry/ArtworkInquiryStore.tsx
@@ -21,7 +21,11 @@ export const artworkInquiryStateReducer = (
 ): ArtworkInquiryContextState => {
   switch (action.type) {
     case "resetForm":
-      return initialArtworkInquiryState
+      return {
+        ...inquiryState,
+        inquiryQuestions: [],
+        shippingLocation: null,
+      }
 
     case "selectShippingLocation":
       return {


### PR DESCRIPTION
This PR resolves [PBRW-512] <!-- eg [PROJECT-XXXX] -->

### Description

There was a bug where the form state was called to reset 2 times, and that was resetting the other modals we show.
- isolates resetting the form state from the modal visibility toggle
- debounce the reset of the prefilled message and refreshes it when the modal visibility changes to false

Fix:

https://github.com/user-attachments/assets/fc515740-0fa4-419e-bfc8-cee8699bf87a

No changes expected given questions options on an Inquiry:

https://github.com/user-attachments/assets/264dfa35-ef42-40ef-83bd-56df9b9c9af5




### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: prompts not showing when inquiring on artworks

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-512]: https://artsyproduct.atlassian.net/browse/PBRW-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ