### PR TITLE
feat(DIA-1165): Add an optional “Save” copy to the save widget in Eigen.

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -15,7 +15,7 @@ import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSav
 import { GlobalStore } from "app/store/GlobalStore"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
-import { memo, useState } from "react"
+import { memo } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -58,8 +58,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
       },
     })
 
-    const [isSaving, setIsSaving] = useState(false)
-
     if (!artwork) {
       return null
     }
@@ -74,9 +72,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     return (
       <Flex backgroundColor="white100" width="100%" style={{ borderRadius: 10 }}>
-        {/* main outer container */}
-
-        {/* artist name and avatar */}
         <Flex mx={2} my={1}>
           <ArtistListItemContainer
             artist={artwork.artists?.[0]}
@@ -87,15 +82,10 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             contextScreenOwnerSlug={artwork.slug}
           />
         </Flex>
-
-        {/* image itself */}
         <Flex alignItems="center" minHeight={MAX_ARTWORK_HEIGHT} justifyContent="center">
           {!!src && <Image src={src} height={size.height} width={size.width} />}
         </Flex>
-
-        {/* spaces out artwork data and save buttons section */}
         <Flex flexDirection="row" justifyContent="space-between" p={1} mx={2}>
-          {/* artwork data (internal ID, title, date, and sale message (price, etc)) */}
           <Flex>
             <Text color="blue" variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>
               {artwork.internalID}
@@ -116,18 +106,10 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             </Flex>
             <Text variant="sm-display">{artwork.saleMessage}</Text>
           </Flex>
-
-          {/* save button specifically and button logic */}
           <Touchable
             haptic
             hitSlop={{ bottom: 10, right: 10, left: 10, top: 10 }}
-            // onPress={saveArtworkToLists}
-            onPress={async () => {
-              if (isSaving) return
-              setIsSaving(true)
-              await saveArtworkToLists()
-              setIsSaving(false)
-            }}
+            onPress={saveArtworkToLists}
             testID="save-artwork-icon"
           >
             <Flex
@@ -137,23 +119,11 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
               style={{
                 width: HEART_CIRCLE_SIZE + 40,
                 height: HEART_CIRCLE_SIZE,
-                borderRadius: (HEART_CIRCLE_SIZE + 30) / 2,
+                borderRadius: 30,
                 backgroundColor: color("black5"),
-                paddingHorizontal: 10,
               }}
             >
-              {/* when the artwork is saved */}
               {!!isSaved ? (
-                // <Flex
-                //   style={{
-                //     width: HEART_CIRCLE_SIZE,
-                //     height: HEART_CIRCLE_SIZE,
-                //     borderRadius: HEART_CIRCLE_SIZE,
-                //     backgroundColor: color("black50"),
-                //     justifyContent: "center",
-                //     alignItems: "center",
-                //   }}
-                // >
                 <HeartFillIcon
                   testID="filled-heart-icon"
                   height={HEART_ICON_SIZE}
@@ -161,26 +131,14 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                   fill="blue100"
                 />
               ) : (
-                // {/* </Flex> */}
-                // <Flex
-                //   style={{
-                //     width: HEART_CIRCLE_SIZE,
-                //     height: HEART_CIRCLE_SIZE,
-                //     borderRadius: HEART_CIRCLE_SIZE,
-                //     backgroundColor: color("black5"),
-                //     justifyContent: "center",
-                //     alignItems: "center",
-                //   }}
-                // >
                 <HeartIcon
                   testID="empty-heart-icon"
                   height={HEART_ICON_SIZE}
                   width={HEART_ICON_SIZE}
                   fill="black100"
                 />
-                // {/* </Flex> */}
               )}
-              <Text ml={0.5} variant="sm-display" color={isSaving ? "gray10" : "black100"}>
+              <Text ml={0.5} variant="sm-display">
                 {isSaved ? "Saved" : "Save"}
               </Text>
             </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -15,7 +15,7 @@ import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSav
 import { GlobalStore } from "app/store/GlobalStore"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
-import { memo } from "react"
+import { memo, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -58,6 +58,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
       },
     })
 
+    const [isSaving, setIsSaving] = useState(false)
+
     if (!artwork) {
       return null
     }
@@ -72,6 +74,9 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     return (
       <Flex backgroundColor="white100" width="100%" style={{ borderRadius: 10 }}>
+        {/* main outer container */}
+
+        {/* artist name and avatar */}
         <Flex mx={2} my={1}>
           <ArtistListItemContainer
             artist={artwork.artists?.[0]}
@@ -83,11 +88,14 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           />
         </Flex>
 
+        {/* image itself */}
         <Flex alignItems="center" minHeight={MAX_ARTWORK_HEIGHT} justifyContent="center">
           {!!src && <Image src={src} height={size.height} width={size.width} />}
         </Flex>
 
+        {/* spaces out artwork data and save buttons section */}
         <Flex flexDirection="row" justifyContent="space-between" p={1} mx={2}>
+          {/* artwork data (internal ID, title, date, and sale message (price, etc)) */}
           <Flex>
             <Text color="blue" variant="sm-display" ellipsizeMode="tail" numberOfLines={1}>
               {artwork.internalID}
@@ -108,49 +116,74 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             </Flex>
             <Text variant="sm-display">{artwork.saleMessage}</Text>
           </Flex>
+
+          {/* save button specifically and button logic */}
           <Touchable
             haptic
-            hitSlop={{ bottom: 5, right: 5, left: 5, top: 5 }}
-            onPress={saveArtworkToLists}
+            hitSlop={{ bottom: 10, right: 10, left: 10, top: 10 }}
+            // onPress={saveArtworkToLists}
+            onPress={async () => {
+              if (isSaving) return
+              setIsSaving(true)
+              await saveArtworkToLists()
+              setIsSaving(false)
+            }}
             testID="save-artwork-icon"
           >
-            {!!isSaved ? (
-              <Flex
-                style={{
-                  width: HEART_CIRCLE_SIZE,
-                  height: HEART_CIRCLE_SIZE,
-                  borderRadius: HEART_CIRCLE_SIZE,
-                  backgroundColor: color("black5"),
-                  justifyContent: "center",
-                  alignItems: "center",
-                }}
-              >
+            <Flex
+              flexDirection="row"
+              alignItems="center"
+              justifyContent="center"
+              style={{
+                width: HEART_CIRCLE_SIZE + 40,
+                height: HEART_CIRCLE_SIZE,
+                borderRadius: (HEART_CIRCLE_SIZE + 30) / 2,
+                backgroundColor: color("black5"),
+                paddingHorizontal: 10,
+              }}
+            >
+              {/* when the artwork is saved */}
+              {!!isSaved ? (
+                // <Flex
+                //   style={{
+                //     width: HEART_CIRCLE_SIZE,
+                //     height: HEART_CIRCLE_SIZE,
+                //     borderRadius: HEART_CIRCLE_SIZE,
+                //     backgroundColor: color("black50"),
+                //     justifyContent: "center",
+                //     alignItems: "center",
+                //   }}
+                // >
                 <HeartFillIcon
                   testID="filled-heart-icon"
                   height={HEART_ICON_SIZE}
                   width={HEART_ICON_SIZE}
                   fill="blue100"
                 />
-              </Flex>
-            ) : (
-              <Flex
-                style={{
-                  width: HEART_CIRCLE_SIZE,
-                  height: HEART_CIRCLE_SIZE,
-                  borderRadius: HEART_CIRCLE_SIZE,
-                  backgroundColor: color("black5"),
-                  justifyContent: "center",
-                  alignItems: "center",
-                }}
-              >
+              ) : (
+                // {/* </Flex> */}
+                // <Flex
+                //   style={{
+                //     width: HEART_CIRCLE_SIZE,
+                //     height: HEART_CIRCLE_SIZE,
+                //     borderRadius: HEART_CIRCLE_SIZE,
+                //     backgroundColor: color("black5"),
+                //     justifyContent: "center",
+                //     alignItems: "center",
+                //   }}
+                // >
                 <HeartIcon
                   testID="empty-heart-icon"
                   height={HEART_ICON_SIZE}
                   width={HEART_ICON_SIZE}
                   fill="black100"
                 />
-              </Flex>
-            )}
+                // {/* </Flex> */}
+              )}
+              <Text ml={0.5} variant="sm-display" color={isSaving ? "gray10" : "black100"}>
+                {isSaved ? "Saved" : "Save"}
+              </Text>
+            </Flex>
           </Touchable>
         </Flex>
       </Flex>


### PR DESCRIPTION
This PR resolves [DIA-1165] <!-- eg [PROJECT-XXXX] -->

### Description
Adds additional copy to the save widget for infinite discovery.

- When I encounter an unsaved artwork, I can see the word “Save” next to the heart icon
- While I’m saving that artwork, the font color of “Save” becomes grey
- When I’ve saved that artwork, I can see the word “Saved” next to the heart icon
- When I encounter a saved artwork, I can see the word “Saved” next to the heart icon
- While I’m un-saving that artwork, the font color of “Saved” becomes grey
- When I’ve un-saved that artwork, I can see the word “Save” next to the heart icon

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

https://github.com/user-attachments/assets/4cb7974e-5647-4b0b-bb0e-c52d0c4c066d

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Adds additional copy to the save widget for infinite discovery.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1165]: https://artsyproduct.atlassian.net/browse/DIA-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ