### PR TITLE
chore: Introduce `RouterButton` component

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -12,8 +12,23 @@ The [RouterLink] component wraps `Touchable` and enables navigation to a specifi
 </RouterLink>
 ```
 
-Alternatively, [navigate] can be used to programmatically navigate to a given route.
+For buttons, [RouterButton] can be used, which wraps `Button`:
+
+```typescript
+<RouterButton to="/my-route">
+  {children}
+</RouterButton>
+```
+
+Alternatively, [navigate] can be used to programmatically navigate to a given route:
+
+```typescript
+<Touchable onPress={() => navigate("/my-route")}>
+  {children}
+</Touchable>
+```
 
 [routes.tsx]: /src/app/Navigation/routes.tsx
 [RouterLink]: /src/app/system/navigation/RouterLink.tsx
+[RouterButton]: /src/app/system/navigation/RouterButton.tsx
 [navigate]: /src/app/system/navigation/navigate.ts

--- a/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
@@ -4,7 +4,7 @@ import { ArtworkAuctionCreateAlertHeader_artwork$key } from "__generated__/Artwo
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterButton } from "app/system/navigation/RouterButton"
 import { FC, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -79,18 +79,16 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
         <Spacer y={2} />
 
         {hasLostBid ? (
-          <Button
+          <RouterButton
             size="large"
             variant="outline"
             haptic
-            onPress={() => {
-              navigate("/favorites/alerts")
-            }}
+            to="/favorites/alerts"
             icon={<BellIcon fill="black100" />}
             block
           >
             Manage your Alerts
-          </Button>
+          </RouterButton>
         ) : (
           <Button
             size="large"
@@ -105,19 +103,19 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
         )}
 
         {!!hasArtworksSuggestions && (
-          <Button
+          <RouterButton
             size="large"
             variant="outline"
             haptic
             onPress={() => {
               tracking.trackEvent(tracks.tappedBrowseSimilarWorksHeaderButton(internalID, slug))
-              navigate(`/artwork/${internalID}/browse-similar-works`)
             }}
+            to={`/artwork/${internalID}/browse-similar-works`}
             block
             mt={1}
           >
             Browse Similar Artworks
-          </Button>
+          </RouterButton>
         )}
       </Flex>
     </>

--- a/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
@@ -4,7 +4,7 @@ import { ArtworkAuctionCreateAlertHeader_artwork$key } from "__generated__/Artwo
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
-import { RouterButton } from "app/system/navigation/RouterButton"
+import { navigate } from "app/system/navigation/navigate"
 import { FC, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -79,16 +79,18 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
         <Spacer y={2} />
 
         {hasLostBid ? (
-          <RouterButton
+          <Button
             size="large"
             variant="outline"
             haptic
-            to="/favorites/alerts"
+            onPress={() => {
+              navigate("/favorites/alerts")
+            }}
             icon={<BellIcon fill="black100" />}
             block
           >
             Manage your Alerts
-          </RouterButton>
+          </Button>
         ) : (
           <Button
             size="large"
@@ -103,19 +105,19 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
         )}
 
         {!!hasArtworksSuggestions && (
-          <RouterButton
+          <Button
             size="large"
             variant="outline"
             haptic
             onPress={() => {
               tracking.trackEvent(tracks.tappedBrowseSimilarWorksHeaderButton(internalID, slug))
+              navigate(`/artwork/${internalID}/browse-similar-works`)
             }}
-            to={`/artwork/${internalID}/browse-similar-works`}
             block
             mt={1}
           >
             Browse Similar Artworks
-          </RouterButton>
+          </Button>
         )}
       </Flex>
     </>

--- a/src/app/system/navigation/RouterButton.tsx
+++ b/src/app/system/navigation/RouterButton.tsx
@@ -1,0 +1,40 @@
+import { Button, ButtonProps } from "@artsy/palette-mobile"
+import { RouterLinkProps, usePrefetchOnVisible } from "app/system/navigation/RouterLink"
+import { Sentinel } from "app/utils/Sentinel"
+import React from "react"
+
+export type RouterButtonProps = RouterLinkProps & ButtonProps
+/**
+ * `Button` wrapper component that enables navigation when pressed, using the `to` prop.
+ * It supports optional prefetching.
+ */
+export const RouterButton: React.FC<RouterButtonProps> = ({
+  disablePrefetch,
+  to,
+  prefetchVariables,
+  onPress,
+  navigationProps,
+  children,
+
+  ...restProps
+}) => {
+  const { isPrefetchingEnabled, handlePress, handleVisible } = usePrefetchOnVisible({
+    to,
+    disablePrefetch,
+    onPress,
+    navigationProps,
+    prefetchVariables,
+  })
+
+  if (!isPrefetchingEnabled) {
+    return <Button onPress={handlePress} {...restProps} children={children} />
+  }
+
+  return (
+    <Sentinel onChange={handleVisible}>
+      <Button {...restProps} onPress={handlePress}>
+        {children}
+      </Button>
+    </Sentinel>
+  )
+}

--- a/src/app/system/navigation/RouterButton.tsx
+++ b/src/app/system/navigation/RouterButton.tsx
@@ -1,40 +1,13 @@
 import { Button, ButtonProps } from "@artsy/palette-mobile"
-import { RouterLinkProps, usePrefetchOnVisible } from "app/system/navigation/RouterLink"
-import { Sentinel } from "app/utils/Sentinel"
+import { RouterLinkComponent, RouterLinkComponentProps } from "app/system/navigation/RouterLink"
 import React from "react"
 
-export type RouterButtonProps = RouterLinkProps & ButtonProps
+export type RouterButtonProps = RouterLinkComponentProps & ButtonProps
+
 /**
  * `Button` wrapper component that enables navigation when pressed, using the `to` prop.
  * It supports optional prefetching.
  */
-export const RouterButton: React.FC<RouterButtonProps> = ({
-  disablePrefetch,
-  to,
-  prefetchVariables,
-  onPress,
-  navigationProps,
-  children,
-
-  ...restProps
-}) => {
-  const { isPrefetchingEnabled, handlePress, handleVisible } = usePrefetchOnVisible({
-    to,
-    disablePrefetch,
-    onPress,
-    navigationProps,
-    prefetchVariables,
-  })
-
-  if (!isPrefetchingEnabled) {
-    return <Button onPress={handlePress} {...restProps} children={children} />
-  }
-
-  return (
-    <Sentinel onChange={handleVisible}>
-      <Button {...restProps} onPress={handlePress}>
-        {children}
-      </Button>
-    </Sentinel>
-  )
+export const RouterButton: React.FC<RouterButtonProps> = ({ ...restProps }) => {
+  return <RouterLinkComponent<ButtonProps> {...restProps} TouchableWrapper={Button} />
 }

--- a/src/app/system/navigation/__tests__/RouterButton.tests.tsx
+++ b/src/app/system/navigation/__tests__/RouterButton.tests.tsx
@@ -1,11 +1,11 @@
 import { Text } from "@artsy/palette-mobile"
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { RouterLink, RouterLinkProps } from "app/system/navigation/RouterLink"
+import { RouterButton, RouterButtonProps } from "app/system/navigation/RouterButton"
 import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useEffect } from "react"
-import { TouchableWithoutFeedback, View } from "react-native"
+import { View } from "react-native"
 
 jest.mock("app/utils/queryPrefetching", () => ({
   usePrefetch: () => mockPrefetch,
@@ -16,8 +16,7 @@ jest.mock("app/utils/Sentinel", () => ({
   Sentinel: (props: any) => <MockedVisibleSentinel {...props} />,
 }))
 
-describe("RouterLink", () => {
-  const touchableOnPress = jest.fn()
+describe("RouterButton", () => {
   beforeAll(() => {
     __globalStoreTestUtils__?.injectFeatureFlags({
       AREnableViewPortPrefetching: true,
@@ -28,34 +27,24 @@ describe("RouterLink", () => {
     jest.clearAllMocks()
   })
 
-  const TestComponent = (props: Partial<RouterLinkProps>) => (
-    <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
-      <Text>Test Link</Text>
-    </RouterLink>
+  const TestComponent = (props: Partial<RouterButtonProps>) => (
+    <RouterButton to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
+      <Text>Test Button</Text>
+    </RouterButton>
   )
-
-  const TestTouchableComponent = (props: Partial<RouterLinkProps>) => {
-    return (
-      <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
-        <TouchableWithoutFeedback onPress={touchableOnPress}>
-          <Text>Test Link</Text>
-        </TouchableWithoutFeedback>
-      </RouterLink>
-    )
-  }
 
   it("renders", () => {
     renderWithWrappers(<TestComponent />)
 
-    expect(screen.getByText("Test Link")).toBeDefined()
+    expect(screen.getByText("Test Button")).toBeDefined()
   })
 
   it("navigates to route on press (with prefetching)", async () => {
     renderWithWrappers(<TestComponent />)
 
-    fireEvent.press(screen.getByText("Test Link"))
+    fireEvent.press(screen.getByText("Test Button"))
 
-    expect(navigate).toHaveBeenCalledExactlyOnceWith("/test-route", {
+    expect(navigate).toHaveBeenCalledWith("/test-route", {
       passProps: { id: "test-id" },
     })
   })
@@ -63,7 +52,7 @@ describe("RouterLink", () => {
   it("navigates to route on press (without prefetching)", () => {
     renderWithWrappers(<TestComponent disablePrefetch />)
 
-    fireEvent.press(screen.getByText("Test Link"))
+    fireEvent.press(screen.getByText("Test Button"))
 
     expect(navigate).toHaveBeenCalledExactlyOnceWith("/test-route", {
       passProps: { id: "test-id" },
@@ -72,31 +61,11 @@ describe("RouterLink", () => {
 
   it("calls onPress on press", () => {
     const onPress = jest.fn()
-
     renderWithWrappers(<TestComponent onPress={onPress} />)
 
-    fireEvent.press(screen.getByText("Test Link"))
+    fireEvent.press(screen.getByText("Test Button"))
 
     expect(onPress).toHaveBeenCalledExactlyOnceWith()
-  })
-
-  describe("given a children with touchable element", () => {
-    it("navigates given hasChildTouchable", () => {
-      renderWithWrappers(<TestTouchableComponent hasChildTouchable />)
-
-      fireEvent.press(screen.getByText("Test Link"))
-
-      expect(navigate).toHaveBeenCalled()
-    })
-
-    it("does not navigate", () => {
-      renderWithWrappers(<TestTouchableComponent />)
-
-      fireEvent.press(screen.getByText("Test Link"))
-
-      expect(navigate).not.toHaveBeenCalled()
-      expect(touchableOnPress).toHaveBeenCalledTimes(1)
-    })
   })
 
   describe("prefetching", () => {
@@ -105,14 +74,6 @@ describe("RouterLink", () => {
 
       await waitFor(() => {
         expect(mockPrefetch).toHaveBeenCalledWith("/test-route", undefined)
-      })
-    })
-
-    it("prefetches given prefetchVariables", async () => {
-      renderWithWrappers(<TestComponent prefetchVariables={{ slug: "banksy" }} />)
-
-      await waitFor(() => {
-        expect(mockPrefetch).toHaveBeenCalledWith("/test-route", { slug: "banksy" })
       })
     })
 

--- a/src/app/system/navigation/__tests__/RouterLink.tests.tsx
+++ b/src/app/system/navigation/__tests__/RouterLink.tests.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@artsy/palette-mobile"
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { RouterLink, RouterLinkProps } from "app/system/navigation/RouterLink"
+import { RouterLink, RouterLinkComponentProps } from "app/system/navigation/RouterLink"
 import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useEffect } from "react"
@@ -28,13 +28,13 @@ describe("RouterLink", () => {
     jest.clearAllMocks()
   })
 
-  const TestComponent = (props: Partial<RouterLinkProps>) => (
+  const TestComponent = (props: Partial<RouterLinkComponentProps>) => (
     <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
       <Text>Test Link</Text>
     </RouterLink>
   )
 
-  const TestTouchableComponent = (props: Partial<RouterLinkProps>) => {
+  const TestTouchableComponent = (props: Partial<RouterLinkComponentProps>) => {
     return (
       <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
         <TouchableWithoutFeedback onPress={touchableOnPress}>


### PR DESCRIPTION
This PR resolves [ONYX-1493] <!-- eg [PROJECT-XXXX] -->

### Description

this PR introduces a `RouterButton` component (similar to [RouterLink](https://github.com/artsy/eigen/blob/14113b8c405646512ae7d89537434a4ba3c4cd8c/src/app/system/navigation/RouterLink.tsx#L24)) to support prefetching button links.

To achieve this without duplicating code, I created a generic `RouterLinkComponent` that can be adjusted to use a different Touchable wrapper.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Add `RouterButton` component to support prefetching button links - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1493]: https://artsyproduct.atlassian.net/browse/ONYX-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ