### PR TITLE
feat(Infinite-discovery): save artworks on double tap

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -138,30 +138,32 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const size = sizeToFit({ width, height }, { width: screenWidth, height: MAX_ARTWORK_HEIGHT })
 
+    const handleWrapperTaps = () => {
+      const now = Date.now()
+      const state = gestureState.current
+
+      if (now - state.lastTapTimestamp < 500) {
+        state.numTaps += 1
+      } else {
+        state.numTaps = 1
+      }
+
+      state.lastTapTimestamp = now
+
+      if (state.numTaps === 2) {
+        state.numTaps = 0
+        if (!isSaved) {
+          Haptic.trigger("impactLight")
+          setShowScreenTapToSave(true)
+          saveArtworkToLists()
+        }
+      }
+      return false
+    }
+
     return (
       <Flex
-        onStartShouldSetResponderCapture={() => {
-          const now = Date.now()
-          const state = gestureState.current
-
-          if (now - state.lastTapTimestamp < 500) {
-            state.numTaps += 1
-          } else {
-            state.numTaps = 1
-          }
-
-          state.lastTapTimestamp = now
-
-          if (state.numTaps === 2) {
-            state.numTaps = 0
-            if (!isSaved) {
-              Haptic.trigger("impactLight")
-              setShowScreenTapToSave(true)
-              saveArtworkToLists()
-            }
-          }
-          return false
-        }}
+        onStartShouldSetResponderCapture={handleWrapperTaps}
         backgroundColor="white100"
         width="100%"
         style={containerStyle || { borderRadius: 10 }}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -20,7 +20,7 @@ import {
 } from "app/store/ProgressiveOnboardingModel"
 import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
-import { memo, useEffect, useRef } from "react"
+import { memo, useEffect, useRef, useState } from "react"
 import { ViewStyle, Text as RNText } from "react-native"
 import Animated, {
   Easing,
@@ -49,6 +49,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     const saveAnimationProgress = useSharedValue(0)
     const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
     const setHasSavedArtwors = GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks
+    const gestureState = useRef({ lastTapTimestamp: 0, numTaps: 0 })
 
     const { trackEvent } = useTracking()
     const color = useColor()
@@ -86,6 +87,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     })
 
     const isSaved = isSavedProp !== undefined ? isSavedProp : isSavedToArtworkList
+    const [showScreenTapToSave, setShowScreenTapToSave] = useState(false)
 
     const animatedSaveButtonStyles = useAnimatedStyle(() => {
       return {
@@ -98,6 +100,14 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     })
 
     useEffect(() => {
+      // Revert showScreenTapToSave if the artwork is not saved
+      // This is required to make sure we show the heart overlay again
+      if (!isSaved) {
+        setShowScreenTapToSave(false)
+      }
+    }, [isSaved])
+
+    useEffect(() => {
       saveAnimationProgress.value = withTiming(isSavedProp ? 1 : 0, {
         duration: 300,
       })
@@ -105,12 +115,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const savedArtworkAnimationStyles = useAnimatedStyle(() => {
       return {
-        opacity: isSavedProp
-          ? withSequence(
-              withTiming(1, { duration: 300, easing: Easing.linear }),
-              withDelay(500, withTiming(0, { duration: 300, easing: Easing.linear }))
-            )
-          : 0,
+        opacity:
+          isSavedProp || showScreenTapToSave
+            ? withSequence(
+                withTiming(1, { duration: 300, easing: Easing.linear }),
+                withDelay(500, withTiming(0, { duration: 300, easing: Easing.linear }))
+              )
+            : 0,
       }
     })
 
@@ -127,7 +138,32 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     const size = sizeToFit({ width, height }, { width: screenWidth, height: MAX_ARTWORK_HEIGHT })
 
     return (
-      <Flex backgroundColor="white100" width="100%" style={containerStyle || { borderRadius: 10 }}>
+      <Flex
+        onStartShouldSetResponderCapture={() => {
+          const now = Date.now()
+          const state = gestureState.current
+
+          if (now - state.lastTapTimestamp < 500) {
+            state.numTaps += 1
+          } else {
+            state.numTaps = 1
+          }
+
+          state.lastTapTimestamp = now
+
+          if (state.numTaps === 2) {
+            state.numTaps = 0
+            if (!isSaved) {
+              setShowScreenTapToSave(true)
+              saveArtworkToLists()
+            }
+          }
+          return false
+        }}
+        backgroundColor="white100"
+        width="100%"
+        style={containerStyle || { borderRadius: 10 }}
+      >
         <Flex p={2}>
           <ArtistListItemContainer
             artist={artwork.artists?.[0]}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -22,6 +22,7 @@ import { Schema } from "app/utils/track"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { memo, useEffect, useRef, useState } from "react"
 import { ViewStyle, Text as RNText } from "react-native"
+import Haptic from "react-native-haptic-feedback"
 import Animated, {
   Easing,
   interpolate,
@@ -154,6 +155,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           if (state.numTaps === 2) {
             state.numTaps = 0
             if (!isSaved) {
+              Haptic.trigger("impactLight")
               setShowScreenTapToSave(true)
               saveArtworkToLists()
             }


### PR DESCRIPTION
This PR resolves [DIA-1166]

 <!-- eg [PROJECT-XXXX] -->

### Description
This PR adds an animation for when a user double taps on an artwork.


https://github.com/user-attachments/assets/7e807bbc-8218-4cfe-956b-692734d04db2


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- infinite discovery save artworks on double tap - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1166]: https://artsyproduct.atlassian.net/browse/DIA-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ