### PR TITLE
fix(InfiniteDiscovery): optimistic save counter

### DIFF
--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
@@ -5,6 +5,7 @@ import { useArtworkListToast } from "app/Components/ArtworkLists/useArtworkLists
 import { ArtworkListOfferSettingsView } from "app/Components/ArtworkLists/views/ArtworkListOfferSettingsView/ArtworkListOfferSettingsView"
 import { CreateNewArtworkListView } from "app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView"
 import { SelectArtworkListsForArtworkView } from "app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView"
+import { GlobalStore } from "app/store/GlobalStore"
 import { createContext, FC, useCallback, useContext, useReducer } from "react"
 import {
   ArtworkEntity,
@@ -131,6 +132,9 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
   }
 
   const onSave = (result: SaveResult) => {
+    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
+      GlobalStore.actions.infiniteDiscovery
+
     dispatch({ type: "SET_UNSAVED_CHANGES", payload: false })
 
     if (!result.artwork) {
@@ -167,6 +171,7 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
     }
 
     if (result.action === ResultAction.SavedToDefaultArtworkList) {
+      incrementSavedArtworksCount()
       toast.savedToDefaultArtworkList({
         onToastPress: () => openSelectArtworkListsForArtworkView(result.artwork as ArtworkEntity),
         isInAuction: !!result.artwork.isInAuction,
@@ -175,6 +180,7 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
     }
 
     if (result.action === ResultAction.RemovedFromDefaultArtworkList) {
+      decrementSavedArtworksCount()
       toast.removedFromDefaultArtworkList()
 
       return

--- a/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
+++ b/src/app/Components/ArtworkLists/ArtworkListsContext.tsx
@@ -5,7 +5,6 @@ import { useArtworkListToast } from "app/Components/ArtworkLists/useArtworkLists
 import { ArtworkListOfferSettingsView } from "app/Components/ArtworkLists/views/ArtworkListOfferSettingsView/ArtworkListOfferSettingsView"
 import { CreateNewArtworkListView } from "app/Components/ArtworkLists/views/CreateNewArtworkListView/CreateNewArtworkListView"
 import { SelectArtworkListsForArtworkView } from "app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/SelectArtworkListsForArtworkView"
-import { GlobalStore } from "app/store/GlobalStore"
 import { createContext, FC, useCallback, useContext, useReducer } from "react"
 import {
   ArtworkEntity,
@@ -132,9 +131,6 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
   }
 
   const onSave = (result: SaveResult) => {
-    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
-      GlobalStore.actions.infiniteDiscovery
-
     dispatch({ type: "SET_UNSAVED_CHANGES", payload: false })
 
     if (!result.artwork) {
@@ -171,7 +167,6 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
     }
 
     if (result.action === ResultAction.SavedToDefaultArtworkList) {
-      incrementSavedArtworksCount()
       toast.savedToDefaultArtworkList({
         onToastPress: () => openSelectArtworkListsForArtworkView(result.artwork as ArtworkEntity),
         isInAuction: !!result.artwork.isInAuction,
@@ -180,7 +175,6 @@ export const ArtworkListsProvider: FC<ArtworkListsProviderProps> = ({
     }
 
     if (result.action === ResultAction.RemovedFromDefaultArtworkList) {
-      decrementSavedArtworksCount()
       toast.removedFromDefaultArtworkList()
 
       return

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
@@ -90,12 +90,12 @@ export const HomeViewSectionCard: React.FC<HomeViewSectionCardProps> = ({
               />
               <LinearGradient
                 colors={["rgba(0, 0, 0, 0)", "rgba(0, 0, 0, 1)"]}
-                start={{ x: 0, y: 0 }}
+                start={{ x: 0, y: 0.3 }}
                 end={{ x: 0, y: 1 }}
                 style={{
                   position: "absolute",
                   width: "100%",
-                  height: "40%",
+                  height: "100%",
                   bottom: 0,
                 }}
               />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -52,8 +52,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const { trackEvent } = useTracking()
     const color = useColor()
-    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
-      GlobalStore.actions.infiniteDiscovery
 
     const artworkData = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
       infiniteDiscoveryArtworkCardFragment,
@@ -76,12 +74,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           context_screen_owner_slug: artwork.slug,
           context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
         })
-
-        if (isArtworkSaved) {
-          incrementSavedArtworksCount()
-        } else {
-          decrementSavedArtworksCount()
-        }
       },
     })
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -52,6 +52,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const { trackEvent } = useTracking()
     const color = useColor()
+    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
+      GlobalStore.actions.infiniteDiscovery
 
     const artworkData = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
       infiniteDiscoveryArtworkCardFragment,
@@ -74,6 +76,21 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           context_screen_owner_slug: artwork.slug,
           context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
         })
+      },
+      onError: () => {
+        /**
+         * This logic assumes that the saved artworks count was optimistically incremented or decremented when the save button was pressed.
+         * If the save operation fails, we need to revert the saved artworks count to its previous state.
+         * This is needed because the optimisticUpdater callback in useSaveArtworkToArtworkLists performs some actions that can take severel seconds to complete,
+         * and as a result the saved artworks count can be out of sync with the actual state of the artwork.
+         */
+        if (isSaved) {
+          // if the artwork is currently saved, we optimistically decremented the count, so increment it back
+          incrementSavedArtworksCount()
+        } else {
+          // if the artwork is currently unsaved, we optimistically incremented the count, so decrement it back
+          decrementSavedArtworksCount()
+        }
       },
     })
 
@@ -183,6 +200,14 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                 setHasSavedArtwors(true)
               }
               saveArtworkToLists()
+
+              if (isSaved) {
+                // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
+                decrementSavedArtworksCount()
+              } else {
+                // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
+                incrementSavedArtworksCount()
+              }
             }}
             testID="save-artwork-icon"
           >

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -199,7 +199,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
               if (!hasSavedArtworks) {
                 setHasSavedArtwors(true)
               }
-              saveArtworkToLists()
 
               if (isSaved) {
                 // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
@@ -208,6 +207,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                 // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
                 incrementSavedArtworksCount()
               }
+
+              saveArtworkToLists()
             }}
             testID="save-artwork-icon"
           >


### PR DESCRIPTION
This PR changes how we increment and decrement the number of artworks that are saved during an Infinite Discovery session. We used to increment and decrement this number after the artwork was saved in the backend and some artwork list context management was completed. This created a noticeable (2-3 seconds) delay between when a user taps the save button and when that count gets incremented. The effect of this is that users would receive the wrong number of saved artworks in the toast that users see when they close Infinite Discovery.

![image](https://github.com/user-attachments/assets/15138be5-7721-4c1c-aa6a-d06092e3d014)

As a bonus, this PR also updates the gradient on the Infinite Discovery so that the copy is easier for users to read against the background images.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Optimistically count saved artworks in an Infinite Discovery session

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
