### PR TITLE
feat: Prefetch all links on Partner screen

### DIFF
--- a/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
+++ b/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
@@ -1,8 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedShowGroup } from "@artsy/cohesion"
-import { Touchable } from "@artsy/palette-mobile"
 import { ArtistShow_show$data, ArtistShow_show$key } from "__generated__/ArtistShow_show.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { hrefForPartialShow } from "app/utils/router"
 import { View, ViewStyle } from "react-native"
@@ -32,14 +31,13 @@ export const ArtistShow: React.FC<Props> = ({ styles, show, index, imageDimensio
 
   const handleTap = () => {
     tracking.trackEvent(tracks.tappedShowGroup(data, index))
-    navigate(hrefForPartialShow(data))
   }
 
   const image = data.coverImage
   const imageURL = image && image.url
 
   return (
-    <Touchable onPress={handleTap} haptic>
+    <RouterLink onPress={handleTap} to={hrefForPartialShow(data)} haptic>
       <View style={[styles?.container]}>
         <View style={[styles?.imageMargin]}>
           <ImageWithFallback
@@ -55,7 +53,7 @@ export const ArtistShow: React.FC<Props> = ({ styles, show, index, imageDimensio
           <Metadata show={data} style={!!styles && styles.metadata} />
         </View>
       </View>
-    </Touchable>
+    </RouterLink>
   )
 }
 

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -33,7 +33,7 @@ import {
 import { ArtistArticlesQueryRenderer } from "app/Scenes/ArtistArticles/ArtistArticles"
 import { ArtistSeriesQueryRenderer } from "app/Scenes/ArtistSeries/ArtistSeries"
 import { ArtistSeriesFullArtistSeriesListQueryRenderer } from "app/Scenes/ArtistSeries/ArtistSeriesFullArtistSeriesList"
-import { ArtistShows2QueryRenderer } from "app/Scenes/ArtistShows/ArtistShows2"
+import { ArtistShowsQueryRenderer } from "app/Scenes/ArtistShows/ArtistShows"
 import { ArtworkScreen, ArtworkScreenQuery } from "app/Scenes/Artwork/Artwork"
 import { BrowseSimilarWorksQueryRenderer } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks"
 import { CertificateOfAuthenticity } from "app/Scenes/Artwork/Components/CertificateAuthenticity"
@@ -114,7 +114,10 @@ import { NewWorksFromGalleriesYouFollowScreen } from "app/Scenes/NewWorksFromGal
 import { OrderDetailsQueryRender } from "app/Scenes/OrderHistory/OrderDetails/Components/OrderDetails"
 import { OrderHistoryQueryRender } from "app/Scenes/OrderHistory/OrderHistory"
 import { PartnerQueryRenderer } from "app/Scenes/Partner/Partner"
-import { PartnerLocationsQueryRenderer } from "app/Scenes/Partner/Screens/PartnerLocations"
+import {
+  PartnerLocationsQueryRenderer,
+  PartnerLocationsScreenQuery,
+} from "app/Scenes/Partner/Screens/PartnerLocations"
 import { PartnerOfferContainer } from "app/Scenes/PartnerOffer/PartnerOfferContainer"
 import { PriceDatabase } from "app/Scenes/PriceDatabase/PriceDatabase"
 import { PrivacyRequest } from "app/Scenes/PrivacyRequest/PrivacyRequest"
@@ -413,7 +416,7 @@ export const artsyDotNetRoutes = defineRoutes([
   {
     path: "/artist/:artistID/shows",
     name: "ArtistShows",
-    Component: ArtistShows2QueryRenderer,
+    Component: ArtistShowsQueryRenderer,
   },
   // Routes `/artist/:artistID/*` and `"/:profile_id_ignored/artist/:artistID"`
   // MUST go together The following two
@@ -1148,6 +1151,7 @@ export const artsyDotNetRoutes = defineRoutes([
     path: "/partner-locations/:partnerID",
     name: "PartnerLocations",
     Component: PartnerLocationsQueryRenderer,
+    queries: [PartnerLocationsScreenQuery],
   },
   {
     path: "/partner-offer/:partnerOfferID/checkout",

--- a/src/app/Scenes/ArtistShows/ArtistShows.tests.tsx
+++ b/src/app/Scenes/ArtistShows/ArtistShows.tests.tsx
@@ -1,20 +1,20 @@
 import { Text } from "@artsy/palette-mobile"
-import { ArtistShows2TestsQuery } from "__generated__/ArtistShows2TestsQuery.graphql"
+import { ArtistShowsTestsQuery } from "__generated__/ArtistShowsTestsQuery.graphql"
 import { ArtistShow } from "app/Components/Artist/ArtistShows/ArtistShow"
 import { extractText } from "app/utils/tests/extractText"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { FlatList } from "react-native"
 import { graphql } from "react-relay"
-import { ArtistShows2PaginationContainer } from "./ArtistShows2"
+import { ArtistShowsPaginationContainer } from "./ArtistShows"
 
-describe("ArtistShows2", () => {
-  const { renderWithRelay } = setupTestWrapper<ArtistShows2TestsQuery>({
-    Component: (props) => <ArtistShows2PaginationContainer artist={props.artist!} />,
+describe("ArtistShows", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtistShowsTestsQuery>({
+    Component: (props) => <ArtistShowsPaginationContainer artist={props.artist!} />,
     query: graphql`
-      query ArtistShows2TestsQuery($artistID: String!) @relay_test_operation {
+      query ArtistShowsTestsQuery($artistID: String!) @relay_test_operation {
         artist(id: $artistID) {
           slug
-          ...ArtistShows2_artist
+          ...ArtistShows_artist
         }
       }
     `,

--- a/src/app/Scenes/ArtistShows/ArtistShows.tsx
+++ b/src/app/Scenes/ArtistShows/ArtistShows.tsx
@@ -1,6 +1,6 @@
-import { Spacer, Flex, Text, Spinner } from "@artsy/palette-mobile"
-import { ArtistShows2Query } from "__generated__/ArtistShows2Query.graphql"
-import { ArtistShows2_artist$data } from "__generated__/ArtistShows2_artist.graphql"
+import { Flex, Spacer, Spinner, Text } from "@artsy/palette-mobile"
+import { ArtistShowsQuery } from "__generated__/ArtistShowsQuery.graphql"
+import { ArtistShows_artist$data } from "__generated__/ArtistShows_artist.graphql"
 import { ArtistShow } from "app/Components/Artist/ArtistShows/ArtistShow"
 import { PAGE_SIZE } from "app/Components/constants"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -14,11 +14,11 @@ import { Animated, StyleSheet, View, ViewStyle } from "react-native"
 import { createPaginationContainer, graphql, QueryRenderer, RelayPaginationProp } from "react-relay"
 
 interface Props {
-  artist: ArtistShows2_artist$data
+  artist: ArtistShows_artist$data
   relay: RelayPaginationProp
 }
 
-const ArtistShows2: React.FC<Props> = ({ artist, relay }) => {
+const ArtistShows: React.FC<Props> = ({ artist, relay }) => {
   const top = 60
   const [isFetchingMoreData, setIsFetchingMoreData] = useState(false)
   const pastShows = extractNodes(artist.pastShows)
@@ -99,11 +99,11 @@ const showStyles = StyleSheet.create({
   imageMargin: ViewStyle
 }
 
-export const ArtistShows2PaginationContainer = createPaginationContainer(
-  ArtistShows2,
+export const ArtistShowsPaginationContainer = createPaginationContainer(
+  ArtistShows,
   {
     artist: graphql`
-      fragment ArtistShows2_artist on Artist
+      fragment ArtistShows_artist on Artist
       @argumentDefinitions(
         count: { type: "Int", defaultValue: 10 }
         status: { type: "String", defaultValue: "closed" }
@@ -112,7 +112,7 @@ export const ArtistShows2PaginationContainer = createPaginationContainer(
         slug
         name
         pastShows: showsConnection(status: $status, first: $count, after: $cursor)
-          @connection(key: "ArtistShows2_pastShows") {
+          @connection(key: "ArtistShows_pastShows") {
           edges {
             node {
               id
@@ -139,35 +139,35 @@ export const ArtistShows2PaginationContainer = createPaginationContainer(
 
     query: graphql`
       # Here is the query to fetch any specific page
-      query ArtistShows2PastShowsQuery(
+      query ArtistShowsPastShowsQuery(
         $count: Int!
         $cursor: String
         $artistID: String!
         $status: String!
       ) {
         artist(id: $artistID) {
-          ...ArtistShows2_artist @arguments(count: $count, cursor: $cursor, status: $status)
+          ...ArtistShows_artist @arguments(count: $count, cursor: $cursor, status: $status)
         }
       }
     `,
   }
 )
 
-export const ArtistShows2QueryRenderer: React.FC<{ artistID: string }> = ({ artistID }) => {
+export const ArtistShowsQueryRenderer: React.FC<{ artistID: string }> = ({ artistID }) => {
   return (
-    <QueryRenderer<ArtistShows2Query>
+    <QueryRenderer<ArtistShowsQuery>
       cacheConfig={{ force: true }}
       environment={getRelayEnvironment()}
       query={graphql`
-        query ArtistShows2Query($artistID: String!) {
+        query ArtistShowsQuery($artistID: String!) {
           artist(id: $artistID) {
             slug
-            ...ArtistShows2_artist
+            ...ArtistShows_artist
           }
         }
       `}
       render={renderWithPlaceholder({
-        Container: ArtistShows2PaginationContainer,
+        Container: ArtistShowsPaginationContainer,
         renderPlaceholder: LoadingSkeleton,
       })}
       variables={{ artistID }}

--- a/src/app/Scenes/Partner/Components/PartnerLocationSection.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerLocationSection.tsx
@@ -1,6 +1,6 @@
-import { Spacer, Text, Button } from "@artsy/palette-mobile"
+import { Button, Spacer, Text } from "@artsy/palette-mobile"
 import { PartnerLocationSection_partner$data } from "__generated__/PartnerLocationSection_partner.graphql"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { get } from "app/utils/get"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -28,10 +28,6 @@ export const createLocationsString = (partner: PartnerLocationSection_partner$da
 }
 
 export const PartnerLocationSection: React.FC<PartnerLocationSectionProps> = ({ partner }) => {
-  const handleSeeAllLocations = () => {
-    navigate(`/partner-locations/${partner.slug}`)
-  }
-
   const cities = get(partner, (p) => p.cities)
 
   if (!cities) {
@@ -62,15 +58,11 @@ export const PartnerLocationSection: React.FC<PartnerLocationSectionProps> = ({ 
         .
       </Text>
       <Spacer y={2} />
-      <Button
-        variant="fillGray"
-        size="large"
-        block
-        width="100%"
-        onPress={() => handleSeeAllLocations()}
-      >
-        See all location details
-      </Button>
+      <RouterLink to={`/partner-locations/${partner.slug}`} hasChildTouchable>
+        <Button variant="fillGray" size="large" block width="100%">
+          See all location details
+        </Button>
+      </RouterLink>
       <Spacer y={4} />
     </>
   )

--- a/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
@@ -1,8 +1,8 @@
-import { Flex, Spacer, Text, Touchable, useScreenDimensions } from "@artsy/palette-mobile"
+import { Flex, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
 import { PartnerShowRailItem_show$data } from "__generated__/PartnerShowRailItem_show.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
 import { exhibitionDates } from "app/Scenes/Map/exhibitionPeriodParser"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { Schema } from "app/utils/track"
 import { first } from "lodash"
 import React from "react"
@@ -19,7 +19,6 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
 
   const onPress = () => {
     tracking.trackEvent(tracks.tapPartnerShowRailItem(props.show.internalID, props.show.slug))
-    navigate(`/show/${props.show.slug}`)
   }
 
   const { show } = props
@@ -29,7 +28,7 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
   const sectionWidth = windowWidth - 100
 
   return (
-    <Touchable onPress={onPress}>
+    <RouterLink onPress={onPress} to={`/show/${props.show.slug}`}>
       <Flex my="15px" mr={2} width={sectionWidth}>
         <ImageWithFallback
           height={200}
@@ -47,7 +46,7 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
           </Text>
         )}
       </Flex>
-    </Touchable>
+    </RouterLink>
   )
 }
 

--- a/src/app/Scenes/Partner/Components/PartnerShows.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerShows.tsx
@@ -1,9 +1,9 @@
-import { Box, Flex, Spacer, Tabs, Text, Touchable, useSpace } from "@artsy/palette-mobile"
+import { Box, Flex, Spacer, Tabs, Text, useSpace } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import { PartnerShows_partner$data } from "__generated__/PartnerShows_partner.graphql"
 import { TabEmptyState } from "app/Components/TabEmptyState"
 
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { useState } from "react"
 import { ActivityIndicator, ImageBackground } from "react-native"
@@ -26,16 +26,13 @@ const ShowGridItem: React.FC<ShowGridItemProps> = (props) => {
   const { show, itemIndex } = props
   const space = useSpace()
 
-  const onPress = () => {
-    navigate(`/show/${show.slug}`)
-  }
-
   const showImageURL = show?.coverImage?.url
 
   const styles = itemIndex % 2 === 0 ? { paddingRight: space(1) } : { paddingLeft: space(1) }
+
   return (
     <GridItem key={show.id}>
-      <Touchable onPress={onPress}>
+      <RouterLink to={`/show/${show.slug}`}>
         <Box style={styles}>
           {showImageURL ? (
             <BackgroundImage key={show.id} resizeMode="cover" source={{ uri: showImageURL }} />
@@ -48,7 +45,7 @@ const ShowGridItem: React.FC<ShowGridItemProps> = (props) => {
             {show.exhibitionPeriod}
           </Text>
         </Box>
-      </Touchable>
+      </RouterLink>
       <Spacer y={2} />
     </GridItem>
   )
@@ -78,7 +75,7 @@ export const PartnerShows: React.FC<{
       key: "past_shows_header",
       content: (
         <Flex mb={2}>
-          <Text variant="sm-display">Past shows</Text>
+          <Text variant="sm-display">Past Shows</Text>
         </Flex>
       ),
     })

--- a/src/app/Scenes/Partner/Components/PartnerShowsRail.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerShowsRail.tsx
@@ -38,7 +38,7 @@ const PartnerShowsRail: React.FC<{
 
   return (
     <Flex mb={2}>
-      <Text variant="sm-display">Current and upcoming shows</Text>
+      <Text variant="sm-display">Current and Upcoming Shows</Text>
       <FlatList
         horizontal
         onScroll={isCloseToEdge(fetchNextPage)}

--- a/src/app/Scenes/Partner/Screens/PartnerLocations.tsx
+++ b/src/app/Scenes/Partner/Screens/PartnerLocations.tsx
@@ -1,4 +1,4 @@
-import { Spacer, Box, Text } from "@artsy/palette-mobile"
+import { Box, Spacer, Text } from "@artsy/palette-mobile"
 import { PartnerLocationsQuery } from "__generated__/PartnerLocationsQuery.graphql"
 import { PartnerLocations_partner$data } from "__generated__/PartnerLocations_partner.graphql"
 import { PartnerMapContainer as PartnerMap } from "app/Scenes/Partner/Components/PartnerMap"
@@ -101,15 +101,17 @@ export const PartnerLocationsQueryRenderer: React.FC<{ partnerID: string }> = ({
   return (
     <QueryRenderer<PartnerLocationsQuery>
       environment={getRelayEnvironment()}
-      query={graphql`
-        query PartnerLocationsQuery($partnerID: String!) {
-          partner(id: $partnerID) {
-            ...PartnerLocations_partner
-          }
-        }
-      `}
+      query={PartnerLocationsScreenQuery}
       variables={{ partnerID }}
       render={renderWithLoadProgress(PartnerLocationsContainer)}
     />
   )
 }
+
+export const PartnerLocationsScreenQuery = graphql`
+  query PartnerLocationsQuery($partnerID: String!) {
+    partner(id: $partnerID) {
+      ...PartnerLocations_partner
+    }
+  }
+`


### PR DESCRIPTION
This PR resolves [ONYX-1595] <!-- eg [PROJECT-XXXX] -->

### Description

Prefetch all links on Partner screen.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prefetch all links on Partner screen - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1595]: https://artsyproduct.atlassian.net/browse/ONYX-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ