### PR TITLE
feat: Prefetch Search screen rail links

### DIFF
--- a/src/app/Scenes/Search/CuratedCollectionItem.tsx
+++ b/src/app/Scenes/Search/CuratedCollectionItem.tsx
@@ -31,8 +31,8 @@ export const CuratedCollectionItem: React.FC<CuratedCollectionItemProps> = ({
   }
 
   return (
-    <RouterLink to={`/collection/${item.slug}`} hasChildTouchable>
-      <CardRailCard onPress={onPress}>
+    <RouterLink to={`/collection/${item.slug}`} onPress={onPress} hasChildTouchable>
+      <CardRailCard>
         <Box>
           <ThreeUpImageLayout imageURLs={availableArtworkImageURLs} />
           <CardRailMetadataContainer>

--- a/src/app/Scenes/Search/CuratedCollectionItem.tsx
+++ b/src/app/Scenes/Search/CuratedCollectionItem.tsx
@@ -4,7 +4,7 @@ import { Box, Text, TextProps } from "@artsy/palette-mobile"
 import { CuratedCollectionItem_collection$key } from "__generated__/CuratedCollectionItem_collection.graphql"
 import { CardRailCard, CardRailMetadataContainer } from "app/Components/CardRail/CardRailCard"
 import { ThreeUpImageLayout } from "app/Components/ThreeUpImageLayout"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { compact } from "lodash"
 import { isTablet } from "react-native-device-info"
@@ -28,24 +28,24 @@ export const CuratedCollectionItem: React.FC<CuratedCollectionItemProps> = ({
 
   const onPress = () => {
     tracking.trackEvent(trackingEvent.tappedCollectionGroup(item.internalID, item.slug, position))
-
-    navigate(`/collection/${item.slug}`)
   }
 
   return (
-    <CardRailCard onPress={onPress}>
-      <Box>
-        <ThreeUpImageLayout imageURLs={availableArtworkImageURLs} />
-        <CardRailMetadataContainer>
-          <Text variant={textVariant} numberOfLines={1}>
-            {item.title}
-          </Text>
-          <Text variant={textVariant} numberOfLines={1} color="black60">
-            Collection
-          </Text>
-        </CardRailMetadataContainer>
-      </Box>
-    </CardRailCard>
+    <RouterLink to={`/collection/${item.slug}`} hasChildTouchable>
+      <CardRailCard onPress={onPress}>
+        <Box>
+          <ThreeUpImageLayout imageURLs={availableArtworkImageURLs} />
+          <CardRailMetadataContainer>
+            <Text variant={textVariant} numberOfLines={1}>
+              {item.title}
+            </Text>
+            <Text variant={textVariant} numberOfLines={1} color="black60">
+              Collection
+            </Text>
+          </CardRailMetadataContainer>
+        </Box>
+      </CardRailCard>
+    </RouterLink>
   )
 }
 

--- a/src/app/Scenes/Search/CuratedCollections.tests.tsx
+++ b/src/app/Scenes/Search/CuratedCollections.tests.tsx
@@ -72,6 +72,8 @@ describe("CuratedCollections", () => {
 
     fireEvent.press(getByText("Blue-Chip Artists"))
 
+    expect(navigate).toHaveBeenCalledWith(`/collection/blue-chip-artists`)
+
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       [
         {

--- a/src/app/Scenes/Search/TrendingArtists.tsx
+++ b/src/app/Scenes/Search/TrendingArtists.tsx
@@ -5,7 +5,6 @@ import { TrendingArtists_query$key } from "__generated__/TrendingArtists_query.g
 import { CardRailFlatList } from "app/Components/CardRail/CardRailFlatList"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { ArtistCardContainer as ArtistCard } from "app/Scenes/HomeView/Components/ArtistRails/ArtistCard"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { isTablet } from "react-native-device-info"
 import { graphql, usePaginationFragment } from "react-relay"
@@ -53,7 +52,6 @@ export const TrendingArtists: React.FC<TrendingArtistsProps> = ({ data, ...boxPr
         renderItem={({ item, index }) => {
           const onPress = () => {
             if (item.href) {
-              navigate(item.href)
               tracking.trackEvent(tracks.tappedArtistGroup(item.internalID, item.slug, index))
             }
           }

--- a/src/app/Scenes/Search/components/TrendingArtistCard.tsx
+++ b/src/app/Scenes/Search/components/TrendingArtistCard.tsx
@@ -1,8 +1,8 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { TrendingArtistCard_artist$key } from "__generated__/TrendingArtistCard_artist.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
-import { TouchableHighlight } from "react-native"
-import { useFragment, graphql } from "react-relay"
+import { RouterLink } from "app/system/navigation/RouterLink"
+import { graphql, useFragment } from "react-relay"
 
 interface TrendingArtistCardProps {
   artist: TrendingArtistCard_artist$key
@@ -16,11 +16,7 @@ export const TrendingArtistCard: React.FC<TrendingArtistCardProps> = ({ artist, 
   const data = useFragment(TrendingArtistCardFragment, artist)
 
   return (
-    <TouchableHighlight
-      underlayColor="transparent"
-      style={{ width: CARD_WIDTH, overflow: "hidden" }}
-      onPress={onPress}
-    >
+    <RouterLink to={data.href} style={{ width: CARD_WIDTH, overflow: "hidden" }} onPress={onPress}>
       <Flex>
         <ImageWithFallback
           src={data.coverArtwork?.image?.url}
@@ -40,7 +36,7 @@ export const TrendingArtistCard: React.FC<TrendingArtistCardProps> = ({ artist, 
           )}
         </Flex>
       </Flex>
-    </TouchableHighlight>
+    </RouterLink>
   )
 }
 


### PR DESCRIPTION
This PR resolves [ONYX-1591] <!-- eg [PROJECT-XXXX] -->

### Description

Prefetch Search screen rail links.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prefetch Search screen rail links - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1591]: https://artsyproduct.atlassian.net/browse/ONYX-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ