### PR TITLE
fix: Use Palettes Touchable component for RouterLinks

### DIFF
--- a/src/app/Scenes/Articles/News/ArticlesCards.tsx
+++ b/src/app/Scenes/Articles/News/ArticlesCards.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedNewsSection } from "@artsy/cohesion"
 import { Flex, Separator, Text, Touchable } from "@artsy/palette-mobile"
 import { ArticlesCards_viewer$key } from "__generated__/ArticlesCards_viewer.graphql"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -17,9 +18,8 @@ export const ArticlesCards: React.FC<ArticleNewsProps> = ({ viewer }) => {
     return null
   }
 
-  const handleOnPress = (href: string) => {
+  const handleArticlePress = () => {
     tracking.trackEvent(tracks.tappedNewsSection())
-    navigate(href)
   }
 
   return (
@@ -30,13 +30,13 @@ export const ArticlesCards: React.FC<ArticleNewsProps> = ({ viewer }) => {
       </Flex>
       {data.articles.map((article, index) => (
         <Flex key={index} gap={2}>
-          <Touchable onPress={() => handleOnPress(article.href ?? "")}>
+          <RouterLink to={article.href} onPress={handleArticlePress}>
             <Flex flexDirection="row" alignItems="center">
               <Text variant="sm-display" numberOfLines={3}>
                 {article.title}
               </Text>
             </Flex>
-          </Touchable>
+          </RouterLink>
           {index !== data.articles.length - 1 && <Separator />}
         </Flex>
       ))}

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -1,10 +1,10 @@
-import { TouchableProps } from "@artsy/palette-mobile"
+import { Touchable, TouchableProps } from "@artsy/palette-mobile"
 import { navigate } from "app/system/navigation/navigate"
 import { Sentinel } from "app/utils/Sentinel"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import React, { useState } from "react"
-import { GestureResponderEvent, TouchableOpacity } from "react-native"
+import { GestureResponderEvent } from "react-native"
 import { Variables } from "relay-runtime"
 
 export interface RouterLinkProps {
@@ -64,13 +64,13 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   }
 
   if (!isPrefetchingEnabled) {
-    return <TouchableOpacity {...touchableProps} children={children} />
+    return <Touchable {...touchableProps} children={children} />
   }
 
   if (!hasChildTouchable) {
     return (
       <Sentinel onChange={handleVisible}>
-        <TouchableOpacity {...touchableProps}>{children}</TouchableOpacity>
+        <Touchable {...touchableProps}>{children}</Touchable>
       </Sentinel>
     )
   }


### PR DESCRIPTION
This PR resolves [ONYX-1517] <!-- eg [PROJECT-XXXX] -->

* Related Palette-Mobile PR: https://github.com/artsy/palette-mobile/pull/315

### Description

After the fix from https://github.com/artsy/palette-mobile/pull/315, we can now use Palette's [Touchable](https://github.com/artsy/palette-mobile/blob/a5acc4fef5d2892de608b0b45d522ca0a975222c/src/elements/Touchable/Touchable.tsx#L63) component for `RouterLink`'s.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Use Palette's Touchable component for all RouterLink's - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Use Palette's Touchable component for all RouterLink's (there shouldn't be a visible difference) - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1517]: https://artsyproduct.atlassian.net/browse/ONYX-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ