### PR TITLE
fix(DIA-1116): Refactored Onboarding Art Quiz header 

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -8,6 +8,8 @@ import {
   Button,
   LegacyScreen,
   Touchable,
+  CloseIcon,
+  ChevronIcon
 } from "@artsy/palette-mobile"
 import { useFocusEffect, useNavigation } from "@react-navigation/native"
 import {
@@ -15,7 +17,6 @@ import {
   State,
   useOnboardingContext,
 } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
-import { BackButton } from "app/system/navigation/BackButton"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { debounce } from "lodash"
 import React, { FC, useCallback, useState } from "react"
@@ -107,31 +108,19 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
 
   return (
     <LegacyScreen>
-      {/* <LegacyScreen.Header onBack={handleBack} onSkip={debouncedHandleSkip} /> */}
       <LegacyScreen.Body>
         <Flex
           flexDirection="row"
           alignItems="center"
           justifyContent="space-between"
-          px={2}
-          height={44}
-          zIndex={10}
-          backgroundColor="red"
+          height={40}
         >
-          {/* <Touchable onPress={handleBack} hitSlop={{ left: 20, right: 20 }}> */}
-          <Flex
-            width={44}
-            height={44}
-            alignItems="center"
-            justifyContent="center"
-            backgroundColor="blue"
-          >
-            <BackButton onPress={handleBack} />
-          </Flex>
-          {/* </Touchable> */}
+          <Touchable onPress={handleBack} hitSlop={{ left: 20, right: 20 }}>
+            <ChevronIcon direction="left"/>
+          </Touchable>
 
-          <Touchable onPress={debouncedHandleSkip} hitSlop={{ left: 20, right: 20 }}>
-            <Text variant="sm"> Skip </Text>
+          <Touchable testID="close-button" onPress={debouncedHandleSkip} hitSlop={{ left: 20, right: 20 }}>
+            <CloseIcon />
           </Touchable>
         </Flex>
 

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   Button,
   LegacyScreen,
+  Touchable,
 } from "@artsy/palette-mobile"
 import { useFocusEffect, useNavigation } from "@react-navigation/native"
 import {
@@ -14,6 +15,7 @@ import {
   State,
   useOnboardingContext,
 } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingContext"
+import { BackButton } from "app/system/navigation/BackButton"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { debounce } from "lodash"
 import React, { FC, useCallback, useState } from "react"
@@ -105,8 +107,34 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
 
   return (
     <LegacyScreen>
-      <LegacyScreen.Header onBack={handleBack} onSkip={debouncedHandleSkip} />
+      {/* <LegacyScreen.Header onBack={handleBack} onSkip={debouncedHandleSkip} /> */}
       <LegacyScreen.Body>
+        <Flex
+          flexDirection="row"
+          alignItems="center"
+          justifyContent="space-between"
+          px={2}
+          height={44}
+          zIndex={10}
+          backgroundColor="red"
+        >
+          {/* <Touchable onPress={handleBack} hitSlop={{ left: 20, right: 20 }}> */}
+          <Flex
+            width={44}
+            height={44}
+            alignItems="center"
+            justifyContent="center"
+            backgroundColor="blue"
+          >
+            <BackButton onPress={handleBack} />
+          </Flex>
+          {/* </Touchable> */}
+
+          <Touchable onPress={debouncedHandleSkip} hitSlop={{ left: 20, right: 20 }}>
+            <Text variant="sm"> Skip </Text>
+          </Touchable>
+        </Flex>
+
         <Box pt={2}>
           <ProgressBar progress={progress} />
         </Box>
@@ -164,4 +192,7 @@ const STATE_KEYS: Record<Exclude<OnboardingContextAction["type"], "RESET">, keyo
   SET_ANSWER_TWO: "questionTwo",
   SET_ANSWER_THREE: "questionThree",
   FOLLOW: "followedIds",
+}
+function useSafeAreaInsets() {
+  throw new Error("Function not implemented.")
 }

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -9,7 +9,7 @@ import {
   LegacyScreen,
   Touchable,
   CloseIcon,
-  ChevronIcon
+  ChevronIcon,
 } from "@artsy/palette-mobile"
 import { useFocusEffect, useNavigation } from "@react-navigation/native"
 import {
@@ -109,17 +109,16 @@ export const OnboardingQuestionTemplate: FC<OnboardingQuestionTemplateProps> = (
   return (
     <LegacyScreen>
       <LegacyScreen.Body>
-        <Flex
-          flexDirection="row"
-          alignItems="center"
-          justifyContent="space-between"
-          height={40}
-        >
+        <Flex flexDirection="row" alignItems="center" justifyContent="space-between" height={40}>
           <Touchable onPress={handleBack} hitSlop={{ left: 20, right: 20 }}>
-            <ChevronIcon direction="left"/>
+            <ChevronIcon direction="left" />
           </Touchable>
 
-          <Touchable testID="close-button" onPress={debouncedHandleSkip} hitSlop={{ left: 20, right: 20 }}>
+          <Touchable
+            testID="close-button"
+            onPress={debouncedHandleSkip}
+            hitSlop={{ left: 20, right: 20 }}
+          >
             <CloseIcon />
           </Touchable>
         </Flex>
@@ -181,7 +180,4 @@ const STATE_KEYS: Record<Exclude<OnboardingContextAction["type"], "RESET">, keyo
   SET_ANSWER_TWO: "questionTwo",
   SET_ANSWER_THREE: "questionThree",
   FOLLOW: "followedIds",
-}
-function useSafeAreaInsets() {
-  throw new Error("Function not implemented.")
 }

--- a/src/app/Scenes/Onboarding/OnboardingQuiz/__tests__/OnboardingQuestionTemplate.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/__tests__/OnboardingQuestionTemplate.tests.tsx
@@ -22,7 +22,7 @@ describe("onboarding question template", () => {
     useOnboardingContextMock.mockReset()
   })
 
-  it.each(["Skip", "question", "subtitle", "answer 1", "answer 2", "Next"])(
+  it.each(["question", "subtitle", "answer 1", "answer 2", "Next"])(
     "renders expected element %s",
     (text) => {
       useOnboardingContextMock.mockReturnValue(contextValue())
@@ -38,6 +38,7 @@ describe("onboarding question template", () => {
       )
 
       expect(screen.getByText(text)).toBeTruthy()
+      expect(screen.getByTestId("close-button")).toBeTruthy()
     }
   )
 


### PR DESCRIPTION
This PR resolves [DIA-1116] <!-- eg [PROJECT-XXXX] -->

### Description

This PR removes the original LegacyScreen.header that was being used for the Art Quiz and replaces it with a new header that uses a close icon instead of text. We may want to consider removing LegacyScreen altogether in a future PR. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Before:

![Screenshot 2025-03-17 at 5 17 38 PM](https://github.com/user-attachments/assets/2f24b5b9-75a7-43de-aa09-450ac62e1eee)

After:

![Screenshot 2025-03-17 at 5 01 05 PM](https://github.com/user-attachments/assets/40742244-04ad-494b-a4e9-9c48da2d1455)

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- removed the original LegacyScreen.header that was being used for the Art Quiz and replaces it with a new header that uses a close icon instead of text.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1116]: https://artsyproduct.atlassian.net/browse/DIA-1116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ