### PR TITLE
fix: Re-prefetch queries when they have been garbage collected

### DIFF
--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -3,7 +3,7 @@ import { navigate } from "app/system/navigation/navigate"
 import { Sentinel } from "app/utils/Sentinel"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { usePrefetch } from "app/utils/queryPrefetching"
-import React, { useState } from "react"
+import React from "react"
 import { GestureResponderEvent } from "react-native"
 import { Variables } from "relay-runtime"
 
@@ -31,8 +31,6 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   hasChildTouchable,
   ...restProps
 }) => {
-  const [isPrefetched, setIsPrefetched] = useState(false)
-
   const prefetchUrl = usePrefetch()
   const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
 
@@ -51,9 +49,8 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   }
 
   const handleVisible = (isVisible: boolean) => {
-    if (isPrefetchingEnabled && isVisible && !isPrefetched) {
+    if (isPrefetchingEnabled && isVisible) {
       prefetchUrl(to, prefetchVariables)
-      setIsPrefetched(true)
     }
   }
 

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -63,9 +63,6 @@ const prefetchQuery = async ({
 
   return fetchQuery(environment, query, variables ?? {}, {
     fetchPolicy: "store-or-network",
-    networkCacheConfig: {
-      force: false,
-    },
   }).subscribe({
     complete: () => {
       if (logPrefetching)


### PR DESCRIPTION
This PR resolves [ONYX-1621] <!-- eg [PROJECT-XXXX] -->

### Description

Currently links don't get prefetched again when the prefetched query has been garbage collected by Relay. This PR removes this behavior.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Re-prefetch queries when they have been garbage collected - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1621]: https://artsyproduct.atlassian.net/browse/ONYX-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ