### PR TITLE
feat: Prefetch links on Fair screen

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -67,9 +67,12 @@ import { collectionsByCategoryQuery } from "app/Scenes/CollectionsByCategory/Bod
 import { CollectionsByCategory } from "app/Scenes/CollectionsByCategory/CollectionsByCategory"
 import { CompleteMyProfile } from "app/Scenes/CompleteMyProfile/CompleteMyProfile"
 import { FairScreen, FairScreenQuery } from "app/Scenes/Fair/Fair"
-import { FairAllFollowedArtistsQueryRenderer } from "app/Scenes/Fair/FairAllFollowedArtists"
+import {
+  FairAllFollowedArtistsQueryRenderer,
+  FairAllFollowedArtistsScreenQuery,
+} from "app/Scenes/Fair/FairAllFollowedArtists"
 import { FairArticlesQueryRenderer } from "app/Scenes/Fair/FairArticles"
-import { FairMoreInfoQueryRenderer } from "app/Scenes/Fair/FairMoreInfo"
+import { FaireMoreInfoScreenQuery, FairMoreInfoQueryRenderer } from "app/Scenes/Fair/FairMoreInfo"
 import { FeaturedFairsScreen, featuredFairsScreenQuery } from "app/Scenes/Fair/FeaturedFairsScreen"
 import { Favorites, Favorites as LegacyFavorites } from "app/Scenes/Favorites/Favorites"
 import { FeatureQueryRenderer } from "app/Scenes/Feature/Feature"
@@ -760,6 +763,7 @@ export const artsyDotNetRoutes = defineRoutes([
         headerTitle: "Artworks",
       },
     },
+    queries: [FairAllFollowedArtistsScreenQuery],
   },
   {
     path: "/fair/:fairID/info",
@@ -770,6 +774,7 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
+    queries: [FaireMoreInfoScreenQuery],
   },
   {
     path: "/featured-fairs",

--- a/src/app/Scenes/Fair/Components/FairCollections.tsx
+++ b/src/app/Scenes/Fair/Components/FairCollections.tsx
@@ -4,7 +4,7 @@ import { FairCollections_fair$data } from "__generated__/FairCollections_fair.gr
 import { CARD_WIDTH } from "app/Components/CardRail/CardRailCard"
 import { CardRailFlatList } from "app/Components/CardRail/CardRailFlatList"
 import { SmallCard } from "app/Components/Cards"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { compact } from "lodash"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -54,20 +54,23 @@ export const FairCollections: React.FC<FairCollectionsProps> = ({ fair, ...rest 
           const images = compact(collection.artworks.edges.map((edge) => edge?.node?.image?.url))
 
           return (
-            <TouchableWithScale
+            <RouterLink
+              hasChildTouchable
               key={collection.slug}
+              to={`/collection/${collection.slug}`}
               onPress={() => {
                 trackTappedCollection(collection.slug, collection.slug)
-                navigate(`/collection/${collection.slug}`)
               }}
             >
-              <SmallCard
-                width={CARD_WIDTH}
-                images={images}
-                title={collection.title}
-                subtitle={collection.category}
-              />
-            </TouchableWithScale>
+              <TouchableWithScale>
+                <SmallCard
+                  width={CARD_WIDTH}
+                  images={images}
+                  title={collection.title}
+                  subtitle={collection.category}
+                />
+              </TouchableWithScale>
+            </RouterLink>
           )
         }}
       />

--- a/src/app/Scenes/Fair/Components/FairEditorial.tsx
+++ b/src/app/Scenes/Fair/Components/FairEditorial.tsx
@@ -1,5 +1,5 @@
 import { ActionType, ContextModule, OwnerType, TappedArticleGroup } from "@artsy/cohesion"
-import { Box, BoxProps, useColor, Text, Touchable, Image } from "@artsy/palette-mobile"
+import { Box, BoxProps, Image, Text } from "@artsy/palette-mobile"
 import { FairEditorial_fair$data } from "__generated__/FairEditorial_fair.graphql"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -10,7 +10,6 @@ interface FairEditorialProps extends BoxProps {
 }
 
 export const FairEditorial: React.FC<FairEditorialProps> = ({ fair, ...rest }) => {
-  const color = useColor()
   const tracking = useTracking()
 
   const trackTappedArticle = (articleID: string, articleSlug: string) => {

--- a/src/app/Scenes/Fair/Components/FairEditorial.tsx
+++ b/src/app/Scenes/Fair/Components/FairEditorial.tsx
@@ -1,7 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedArticleGroup } from "@artsy/cohesion"
 import { Box, BoxProps, useColor, Text, Touchable, Image } from "@artsy/palette-mobile"
 import { FairEditorial_fair$data } from "__generated__/FairEditorial_fair.graphql"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -44,15 +44,11 @@ export const FairEditorial: React.FC<FairEditorialProps> = ({ fair, ...rest }) =
         <Text variant="sm-display">Related Reading</Text>
 
         {(fair.articles.totalCount ?? 0) > 5 && (
-          <Touchable
-            onPress={() => {
-              navigate(`/fair/${fair.slug}/articles`)
-            }}
-          >
+          <RouterLink to={`/fair/${fair.slug}/articles`}>
             <Text variant="sm" color="black60">
               View all
             </Text>
-          </Touchable>
+          </RouterLink>
         )}
       </Box>
 
@@ -64,15 +60,14 @@ export const FairEditorial: React.FC<FairEditorialProps> = ({ fair, ...rest }) =
         const article = edge.node
 
         return (
-          <Touchable
+          <RouterLink
             key={article.id}
-            underlayColor={color("black5")}
+            to={article.href}
             onPress={() => {
               if (!article.href) {
                 return
               }
               trackTappedArticle(article.internalID, article.slug ?? "")
-              navigate(article.href)
             }}
           >
             <Box flexDirection="row" py={1} px={2}>
@@ -88,7 +83,7 @@ export const FairEditorial: React.FC<FairEditorialProps> = ({ fair, ...rest }) =
                 <Image width={90} height={50} src={article.thumbnailImage.src} />
               )}
             </Box>
-          </Touchable>
+          </RouterLink>
         )
       })}
     </Box>

--- a/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
@@ -32,9 +32,7 @@ const FairExhibitorRail: React.FC<FairExhibitorRailProps> = ({ show }) => {
           subtitle={`${count} works`}
           href={viewAllUrl}
           onPress={() => {
-            if (!viewAllUrl) {
-              return
-            }
+            if (!viewAllUrl) return
 
             trackEvent(tracks.tappedShow(show))
           }}

--- a/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
@@ -3,7 +3,6 @@ import { Flex } from "@artsy/palette-mobile"
 import { FairExhibitorRail_show$data } from "__generated__/FairExhibitorRail_show.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   CollectorSignals,
@@ -31,13 +30,13 @@ const FairExhibitorRail: React.FC<FairExhibitorRailProps> = ({ show }) => {
         <SectionTitle
           title={partnerName}
           subtitle={`${count} works`}
+          href={viewAllUrl}
           onPress={() => {
             if (!viewAllUrl) {
               return
             }
 
             trackEvent(tracks.tappedShow(show))
-            navigate(viewAllUrl)
           }}
         />
       </Flex>

--- a/src/app/Scenes/Fair/Components/FairFollowedArtistsRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairFollowedArtistsRail.tsx
@@ -3,7 +3,6 @@ import { Flex } from "@artsy/palette-mobile"
 import { FairFollowedArtistsRail_fair$data } from "__generated__/FairFollowedArtistsRail_fair.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   CollectorSignals,
@@ -29,11 +28,11 @@ export const FairFollowedArtistsRail: React.FC<FairFollowedArtistsRailProps> = (
       <Flex>
         <SectionTitle
           title="Works by artists you follow"
+          href={artworks.length > 2 ? `/fair/${fair.slug}/followedArtists` : undefined}
           onPress={
             artworks.length > 2
               ? () => {
                   trackEvent(tracks.tappedViewAll(fair))
-                  navigate(`/fair/${fair.slug}/followedArtists`)
                 }
               : undefined
           }

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Screen, Separator, Spacer } from "@artsy/palette-mobile"
+import { Box, Flex, Separator, Spacer } from "@artsy/palette-mobile"
 import { FairAllFollowedArtistsQuery } from "__generated__/FairAllFollowedArtistsQuery.graphql"
 import { FairAllFollowedArtists_fair$data } from "__generated__/FairAllFollowedArtists_fair.graphql"
 import { FairAllFollowedArtists_fairForFilters$data } from "__generated__/FairAllFollowedArtists_fairForFilters.graphql"
@@ -121,29 +121,29 @@ export const FairAllFollowedArtistsFragmentContainer = createFragmentContainer(
   }
 )
 
+export const FairAllFollowedArtistsScreenQuery = graphql`
+  query FairAllFollowedArtistsQuery($fairID: String!) {
+    fair(id: $fairID) @principalField {
+      ...FairAllFollowedArtists_fair
+    }
+
+    fairForFilters: fair(id: $fairID) {
+      ...FairAllFollowedArtists_fairForFilters
+    }
+  }
+`
+
 export const FairAllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> = ({ fairID }) => {
   return (
-    <Screen>
-      <QueryRenderer<FairAllFollowedArtistsQuery>
-        environment={getRelayEnvironment()}
-        query={graphql`
-          query FairAllFollowedArtistsQuery($fairID: String!) {
-            fair(id: $fairID) @principalField {
-              ...FairAllFollowedArtists_fair
-            }
-
-            fairForFilters: fair(id: $fairID) {
-              ...FairAllFollowedArtists_fairForFilters
-            }
-          }
-        `}
-        variables={{ fairID }}
-        render={renderWithPlaceholder({
-          Container: FairAllFollowedArtistsFragmentContainer,
-          renderPlaceholder: () => <FairAllFollowedArtistsPlaceholder />,
-        })}
-      />
-    </Screen>
+    <QueryRenderer<FairAllFollowedArtistsQuery>
+      environment={getRelayEnvironment()}
+      query={FairAllFollowedArtistsScreenQuery}
+      variables={{ fairID }}
+      render={renderWithPlaceholder({
+        Container: FairAllFollowedArtistsFragmentContainer,
+        renderPlaceholder: () => <FairAllFollowedArtistsPlaceholder />,
+      })}
+    />
   )
 }
 

--- a/src/app/Scenes/Fair/FairArticles.tsx
+++ b/src/app/Scenes/Fair/FairArticles.tsx
@@ -12,7 +12,7 @@ import {
 } from "@artsy/palette-mobile"
 import { FairArticlesQuery } from "__generated__/FairArticlesQuery.graphql"
 import { FairArticles_fair$data } from "__generated__/FairArticles_fair.graphql"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useEnvironment } from "app/utils/hooks/useEnvironment"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
@@ -69,13 +69,7 @@ export const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
     <ScrollView>
       <Box px={2} py={6}>
         <Join separator={<Spacer y={4} />}>
-          <Touchable
-            onPress={() => {
-              if (heroArticle?.href) {
-                navigate(heroArticle.href)
-              }
-            }}
-          >
+          <RouterLink to={heroArticle?.href}>
             <Box position="relative">
               {!!heroArticle?.thumbnailImage?.url && (
                 <Image
@@ -102,7 +96,7 @@ export const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
                 />
               </Box>
             </Box>
-          </Touchable>
+          </RouterLink>
 
           <FlatList<(typeof remainingArticles)[number]>
             data={remainingArticles}
@@ -110,13 +104,7 @@ export const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
             ItemSeparatorComponent={() => <Spacer y={4} />}
             renderItem={({ item: { node: article } }) => {
               return (
-                <Touchable
-                  onPress={() => {
-                    if (article?.href) {
-                      navigate(article.href)
-                    }
-                  }}
-                >
+                <RouterLink to={article?.href}>
                   {!!article?.thumbnailImage?.url && (
                     <Image
                       width={imageWidth}
@@ -142,7 +130,7 @@ export const FairArticles: React.FC<FairArticlesProps> = ({ fair, relay }) => {
                       url={`${webURL}${article?.href}`}
                     />
                   </Box>
-                </Touchable>
+                </RouterLink>
               )
             }}
           />

--- a/src/app/Scenes/Fair/FairArticles.tsx
+++ b/src/app/Scenes/Fair/FairArticles.tsx
@@ -1,14 +1,13 @@
 import {
-  Spacer,
   Box,
-  useSpace,
-  Text,
-  Join,
-  SimpleMessage,
   Button,
-  Touchable,
-  Screen,
   Image,
+  Join,
+  Screen,
+  SimpleMessage,
+  Spacer,
+  Text,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { FairArticlesQuery } from "__generated__/FairArticlesQuery.graphql"
 import { FairArticles_fair$data } from "__generated__/FairArticles_fair.graphql"

--- a/src/app/Scenes/Fair/FairMoreInfo.tsx
+++ b/src/app/Scenes/Fair/FairMoreInfo.tsx
@@ -1,15 +1,15 @@
 import { Box, LinkText, Screen, Spacer, Text, useSpace } from "@artsy/palette-mobile"
-import { FairMoreInfoQuery } from "__generated__/FairMoreInfoQuery.graphql"
 import { FairMoreInfo_fair$data } from "__generated__/FairMoreInfo_fair.graphql"
+import { FairMoreInfoQuery } from "__generated__/FairMoreInfoQuery.graphql"
 import { LocationMapContainer } from "app/Components/LocationMap/LocationMap"
 import { Markdown } from "app/Components/Markdown"
-import { goBack, navigate } from "app/system/navigation/navigate"
+import { goBack } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { defaultRules } from "app/utils/renderMarkdown"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import { compact } from "lodash"
-import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
 
 interface FairMoreInfoQueryRendererProps {
@@ -110,15 +110,9 @@ export const FairMoreInfo: React.FC<FairMoreInfoProps> = ({ fair }) => {
       title: "Ticket Links",
       content: (
         <>
-          <TouchableOpacity
-            onPress={() => {
-              if (fair.ticketsLink) {
-                navigate(fair.ticketsLink)
-              }
-            }}
-          >
+          <RouterLink to={fair.ticketsLink}>
             <LinkText>Buy Tickets</LinkText>
-          </TouchableOpacity>
+          </RouterLink>
           <Spacer y={1} />
         </>
       ),
@@ -205,17 +199,19 @@ export const FairMoreInfoFragmentContainer = createFragmentContainer(FairMoreInf
   `,
 })
 
+export const FaireMoreInfoScreenQuery = graphql`
+  query FairMoreInfoQuery($fairID: String!) {
+    fair(id: $fairID) @principalField {
+      ...FairMoreInfo_fair
+    }
+  }
+`
+
 export const FairMoreInfoQueryRenderer: React.FC<FairMoreInfoQueryRendererProps> = ({ fairID }) => {
   return (
     <QueryRenderer<FairMoreInfoQuery>
       environment={getRelayEnvironment()}
-      query={graphql`
-        query FairMoreInfoQuery($fairID: String!) {
-          fair(id: $fairID) @principalField {
-            ...FairMoreInfo_fair
-          }
-        }
-      `}
+      query={FaireMoreInfoScreenQuery}
       variables={{ fairID }}
       render={renderWithLoadProgress(FairMoreInfoFragmentContainer)}
     />

--- a/src/app/Scenes/Fair/FairOverview.tsx
+++ b/src/app/Scenes/Fair/FairOverview.tsx
@@ -1,4 +1,4 @@
-import { ChevronIcon, Flex, Spacer, Tabs, Text, Touchable, useSpace } from "@artsy/palette-mobile"
+import { ChevronIcon, Flex, Spacer, Tabs, Text, useSpace } from "@artsy/palette-mobile"
 import { FairOverview_fair$key } from "__generated__/FairOverview_fair.graphql"
 import { ReadMore } from "app/Components/ReadMore"
 import { FairCollectionsFragmentContainer } from "app/Scenes/Fair/Components/FairCollections"

--- a/src/app/Scenes/Fair/FairOverview.tsx
+++ b/src/app/Scenes/Fair/FairOverview.tsx
@@ -6,7 +6,7 @@ import { FairEditorialFragmentContainer } from "app/Scenes/Fair/Components/FairE
 import { FairEmptyStateFragmentContainer } from "app/Scenes/Fair/Components/FairEmptyState"
 import { FairFollowedArtistsRailFragmentContainer } from "app/Scenes/Fair/Components/FairFollowedArtistsRail"
 import { shouldShowLocationMap } from "app/Scenes/Fair/FairMoreInfo"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { FC } from "react"
 import { graphql, useFragment } from "react-relay"
@@ -48,12 +48,12 @@ export const FairOverview: FC<FairOverviewProps> = ({ fair }) => {
             <ReadMore textStyle="new" content={previewText} maxChars={truncatedTextLimit()} />
           )}
           {!!canShowMoreInfoLink && (
-            <Touchable onPress={() => navigate(`/fair/${data.slug}/info`)}>
+            <RouterLink to={`/fair/${data.slug}/info`}>
               <Flex pt={2} flexDirection="row" justifyContent="flex-start" alignItems="center">
                 <Text variant="sm">More info</Text>
                 <ChevronIcon mr="-5px" mt="4px" />
               </Flex>
-            </Touchable>
+            </RouterLink>
           )}
 
           {!!hasArticles && <FairEditorialFragmentContainer fair={data} />}


### PR DESCRIPTION
This PR resolves [ONYX-1597] <!-- eg [PROJECT-XXXX] -->

### Description

Prefetch links on Fair screen.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prefetch links on Fair screen - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1597]: https://artsyproduct.atlassian.net/browse/ONYX-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ