### PR TITLE
fix: Artwork card context menu with dark background.

### DIFF
--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -177,7 +177,10 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     onPressToCall?.()
   }
 
-  const artworkPreviewComponent = (artwork: ContextMenuArtworkPreviewCard_artwork$key) => {
+  const artworkPreviewComponent = (
+    artwork: ContextMenuArtworkPreviewCard_artwork$key,
+    artworkDisplayProps: ArtworkDisplayProps | undefined
+  ) => {
     return (
       <ContextMenuArtworkPreviewCard artwork={artwork} artworkDisplayProps={artworkDisplayProps} />
     )
@@ -191,7 +194,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
       <ContextMenu
         actions={contextActions}
         onPress={handleContextPress}
-        preview={artworkPreviewComponent(artwork)}
+        preview={artworkPreviewComponent(artwork, artworkDisplayProps)}
         hideShadows={true}
         previewBackgroundColor={!!dark ? color("black100") : color("white100")}
       >
@@ -214,7 +217,7 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
     return (
       <>
         <TouchableHighlight
-          underlayColor={color("white100")}
+          underlayColor={dark ? color("black100") : color("white100")}
           activeOpacity={0.8}
           onLongPress={handleAndroidLongPress}
           delayLongPress={1200} // To avoid the context menu from opening on a (long) normal press on Android.
@@ -226,9 +229,10 @@ export const ContextMenuArtwork: React.FC<ContextMenuArtworkProps> = ({
 
         <AutoHeightBottomSheet visible={androidVisible} onDismiss={() => setAndroidVisible(false)}>
           <SafeAreaView>
-            <Flex mx={2} my={2}>
+            <Flex mx={2} mb={4}>
               <Flex ml={-1} mb={1}>
-                {artworkPreviewComponent(artwork)}
+                {/* Always show light mode on Android for the bottom sheet */}
+                {artworkPreviewComponent(artwork, { ...artworkDisplayProps, dark: false })} //
               </Flex>
 
               <Join separator={<Separator borderColor="black10" my={1} />}>


### PR DESCRIPTION
This PR resolves [ONYX-1587] <!-- eg [PROJECT-XXXX] -->

### Description

This fixes the artwork card context menu for artwork rails with a dark background. I've decided to simply give the bottom sheet a white background to keep it consistent with other bottom sheets.




| Before | After |
| --- | --- |
|![Simulator Screenshot - iPhone 16 - 2025-03-18 at 15 41 23](https://github.com/user-attachments/assets/e18d6f43-18f4-4fcc-b70c-b3d428a52883) |![Simulator Screenshot - iPhone 16 - 2025-03-18 at 15 37 27](https://github.com/user-attachments/assets/11fcc926-246f-4625-b472-d0feaa347624) |




### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix the artwork card context menu for artwork rails with a dark background on home screen -ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1587]: https://artsyproduct.atlassian.net/browse/ONYX-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ