### PR TITLE
feat: add custom context fields to Unleash

### DIFF
--- a/src/app/system/flags/Components/WrappedFlagProvider.tsx
+++ b/src/app/system/flags/Components/WrappedFlagProvider.tsx
@@ -3,6 +3,8 @@ import FlagProvider, { IConfig } from "@unleash/proxy-client-react"
 import { useUnleashEnvironment } from "app/system/flags/hooks/useUnleashEnvironment"
 import { useUnleashInitializer } from "app/system/flags/hooks/useUnleashInitializer"
 import { useUnleashListener } from "app/system/flags/hooks/useUnleashListener"
+import { getAppVersion } from "app/utils/appVersion"
+import { Platform } from "react-native"
 import Keys from "react-native-keys"
 
 export const WrappedFlagProvider: React.FC = ({ children }) => {
@@ -11,6 +13,12 @@ export const WrappedFlagProvider: React.FC = ({ children }) => {
   const storageName = (name: string) => `unleash-values:${name}`
 
   const config: IConfig = {
+    context: {
+      properties: {
+        appVersion: getAppVersion(),
+        appPlatformOS: Platform.OS,
+      },
+    },
     url:
       env === "production"
         ? Keys.secureFor("UNLEASH_PROXY_URL_PRODUCTION")

--- a/src/app/system/flags/Components/__tests__/WrappedFlagProvider.tests.tsx
+++ b/src/app/system/flags/Components/__tests__/WrappedFlagProvider.tests.tsx
@@ -1,0 +1,147 @@
+import { render } from "@testing-library/react-native"
+import { WrappedFlagProvider } from "app/system/flags/Components/WrappedFlagProvider"
+import { useUnleashEnvironment } from "app/system/flags/hooks/useUnleashEnvironment"
+import { useUnleashInitializer } from "app/system/flags/hooks/useUnleashInitializer"
+import { useUnleashListener } from "app/system/flags/hooks/useUnleashListener"
+import { getAppVersion } from "app/utils/appVersion"
+import { Platform } from "react-native"
+import Keys from "react-native-keys"
+
+jest.mock("@unleash/proxy-client-react", () => ({
+  __esModule: true,
+  default: ({ children, config }: any) => {
+    // Expose config for testing
+    ;(global as any).__unleashConfig = config
+    return children
+  },
+}))
+
+jest.mock("app/system/flags/hooks/useUnleashEnvironment")
+jest.mock("app/system/flags/hooks/useUnleashInitializer")
+jest.mock("app/system/flags/hooks/useUnleashListener")
+jest.mock("app/utils/appVersion")
+jest.mock("react-native-keys", () => ({
+  secureFor: jest.fn(),
+}))
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+  NativeModules: {
+    ArtsyNativeModule: {
+      gitCommitShortHash: "abc123",
+      isBetaOrDev: false,
+      clearCache: jest.fn(),
+    },
+  },
+  Text: "Text",
+}))
+
+const mockUseUnleashEnvironment = useUnleashEnvironment as jest.MockedFunction<
+  typeof useUnleashEnvironment
+>
+const mockUseUnleashInitializer = useUnleashInitializer as jest.MockedFunction<
+  typeof useUnleashInitializer
+>
+const mockUseUnleashListener = useUnleashListener as jest.MockedFunction<typeof useUnleashListener>
+const mockGetAppVersion = getAppVersion as jest.MockedFunction<typeof getAppVersion>
+const mockKeys = Keys as { secureFor: jest.MockedFunction<any> }
+
+describe("WrappedFlagProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseUnleashEnvironment.mockReturnValue({ unleashEnv: "staging" })
+    mockUseUnleashInitializer.mockReturnValue()
+    mockUseUnleashListener.mockReturnValue()
+    mockKeys.secureFor.mockReturnValue("mock-unleash-url")
+    mockGetAppVersion.mockReturnValue("1.2.3")
+    // Clear the global config
+    ;(global as any).__unleashConfig = undefined
+  })
+
+  it("provides app version and platform OS in context", () => {
+    render(
+      <WrappedFlagProvider>
+        <div>Test Child</div>
+      </WrappedFlagProvider>
+    )
+
+    const config = (global as any).__unleashConfig
+    expect(config).toBeDefined()
+    expect(config.context.properties.appVersion).toBe("1.2.3")
+    expect(config.context.properties.appPlatformOS).toBe("ios")
+    expect(mockGetAppVersion).toHaveBeenCalled()
+  })
+
+  it("uses Android platform when Platform.OS is android", () => {
+    // Mock Platform.OS for this test
+    const originalPlatform = Platform.OS
+    Object.defineProperty(Platform, "OS", {
+      value: "android",
+      configurable: true,
+    })
+
+    render(
+      <WrappedFlagProvider>
+        <div>Test Child</div>
+      </WrappedFlagProvider>
+    )
+
+    const config = (global as any).__unleashConfig
+    expect(config.context.properties.appPlatformOS).toBe("android")
+
+    // Restore original platform
+    Object.defineProperty(Platform, "OS", {
+      value: originalPlatform,
+      configurable: true,
+    })
+  })
+
+  it("calls required hooks", () => {
+    render(
+      <WrappedFlagProvider>
+        <div>Test Child</div>
+      </WrappedFlagProvider>
+    )
+
+    expect(mockUseUnleashEnvironment).toHaveBeenCalled()
+    expect(mockUseUnleashInitializer).toHaveBeenCalled()
+    expect(mockUseUnleashListener).toHaveBeenCalled()
+  })
+
+  it("configures production URL when environment is production", () => {
+    mockUseUnleashEnvironment.mockReturnValue({ unleashEnv: "production" })
+    mockKeys.secureFor.mockImplementation((key: string) => {
+      if (key === "UNLEASH_PROXY_URL_PRODUCTION") return "prod-url"
+      if (key === "UNLEASH_PROXY_CLIENT_KEY_PRODUCTION") return "prod-secret"
+      return "fallback"
+    })
+
+    render(
+      <WrappedFlagProvider>
+        <div>Test Child</div>
+      </WrappedFlagProvider>
+    )
+
+    const config = (global as any).__unleashConfig
+    expect(config.url).toBe("prod-url")
+    expect(config.clientKey).toBe("prod-secret")
+  })
+
+  it("configures staging URL when environment is staging", () => {
+    mockUseUnleashEnvironment.mockReturnValue({ unleashEnv: "staging" })
+    mockKeys.secureFor.mockImplementation((key: string) => {
+      if (key === "UNLEASH_PROXY_URL_STAGING") return "staging-url"
+      if (key === "UNLEASH_PROXY_CLIENT_KEY_STAGING") return "staging-secret"
+      return "fallback"
+    })
+
+    render(
+      <WrappedFlagProvider>
+        <div>Test Child</div>
+      </WrappedFlagProvider>
+    )
+
+    const config = (global as any).__unleashConfig
+    expect(config.url).toBe("staging-url")
+    expect(config.clientKey).toBe("staging-secret")
+  })
+})

--- a/src/app/system/flags/hooks/__tests__/useUnleashInitializer.tests.ts
+++ b/src/app/system/flags/hooks/__tests__/useUnleashInitializer.tests.ts
@@ -1,0 +1,150 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useUnleashClient } from "@unleash/proxy-client-react"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useUnleashInitializer } from "app/system/flags/hooks/useUnleashInitializer"
+import { jwtDecode } from "jwt-decode"
+
+jest.mock("@unleash/proxy-client-react")
+jest.mock("app/store/GlobalStore")
+jest.mock("jwt-decode")
+
+jest.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+  NativeModules: {
+    ArtsyNativeModule: {
+      gitCommitShortHash: "abc123",
+      isBetaOrDev: false,
+      clearCache: jest.fn(),
+    },
+  },
+}))
+
+const mockUseUnleashClient = useUnleashClient as jest.MockedFunction<typeof useUnleashClient>
+const mockJwtDecode = jwtDecode as jest.MockedFunction<typeof jwtDecode>
+
+const mockClient = {
+  getContext: jest.fn(),
+  setContextField: jest.fn(),
+  start: jest.fn(),
+  stop: jest.fn(),
+}
+
+const mockGlobalStore = {
+  useAppState: jest.fn(),
+}
+
+describe("useUnleashInitializer", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseUnleashClient.mockReturnValue(mockClient as any)
+    ;(GlobalStore as any).useAppState = mockGlobalStore.useAppState
+    mockClient.getContext.mockReturnValue({ userId: undefined })
+  })
+
+  it("does not start client when userID is not available", () => {
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: null, userAccessToken: null } }
+      return selector(state)
+    })
+
+    renderHook(() => useUnleashInitializer())
+
+    expect(mockClient.start).not.toHaveBeenCalled()
+    expect(mockClient.setContextField).not.toHaveBeenCalled()
+  })
+
+  it("starts client when userID becomes available", () => {
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: "user123", userAccessToken: null } }
+      return selector(state)
+    })
+
+    renderHook(() => useUnleashInitializer())
+
+    expect(mockClient.setContextField).toHaveBeenCalledWith("userId", "user123")
+    expect(mockClient.start).toHaveBeenCalled()
+  })
+
+  it("sets user roles from JWT token when userAccessToken is available", () => {
+    const mockToken = "<token>"
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: "user123", userAccessToken: mockToken } }
+      return selector(state)
+    })
+
+    mockJwtDecode.mockReturnValue({ roles: "admin,user" })
+
+    renderHook(() => useUnleashInitializer())
+
+    expect(mockJwtDecode).toHaveBeenCalledWith(mockToken)
+    expect(mockClient.setContextField).toHaveBeenCalledWith("userId", "user123")
+    expect(mockClient.setContextField).toHaveBeenCalledWith("userRoles", "admin,user")
+    expect(mockClient.start).toHaveBeenCalled()
+  })
+
+  it("handles missing roles in JWT token", () => {
+    const mockToken = "<token>"
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: "user123", userAccessToken: mockToken } }
+      return selector(state)
+    })
+
+    mockJwtDecode.mockReturnValue({}) // No roles field
+
+    renderHook(() => useUnleashInitializer())
+
+    expect(mockClient.setContextField).toHaveBeenCalledWith("userRoles", "")
+  })
+
+  it("does not update context if userId is already set", () => {
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: "user123", userAccessToken: null } }
+      return selector(state)
+    })
+    mockClient.getContext.mockReturnValue({ userId: "user123" })
+
+    renderHook(() => useUnleashInitializer())
+
+    expect(mockClient.setContextField).not.toHaveBeenCalled()
+    expect(mockClient.start).toHaveBeenCalled()
+  })
+
+  it("stops client on cleanup", () => {
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: { userID: "user123", userAccessToken: null } }
+      return selector(state)
+    })
+
+    const { unmount } = renderHook(() => useUnleashInitializer())
+
+    unmount()
+
+    expect(mockClient.stop).toHaveBeenCalled()
+  })
+
+  it("re-initializes when userID or userAccessToken changes", () => {
+    let authState: { userID: string; userAccessToken: null | string } = {
+      userID: "user123",
+      userAccessToken: null,
+    }
+
+    mockGlobalStore.useAppState.mockImplementation((selector) => {
+      const state = { auth: authState }
+      return selector(state)
+    })
+
+    const { rerender } = renderHook(() => useUnleashInitializer())
+
+    expect(mockClient.setContextField).toHaveBeenCalledTimes(1)
+    expect(mockClient.start).toHaveBeenCalledTimes(1)
+
+    // Change userAccessToken
+    authState = { userID: "user123", userAccessToken: "new-token" }
+    mockJwtDecode.mockReturnValue({ roles: "user" })
+
+    rerender()
+
+    expect(mockClient.setContextField).toHaveBeenCalledTimes(3) // userId + userRoles on second call
+    expect(mockClient.start).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/app/system/flags/hooks/useUnleashInitializer.ts
+++ b/src/app/system/flags/hooks/useUnleashInitializer.ts
@@ -1,15 +1,24 @@
 import { useUnleashClient } from "@unleash/proxy-client-react"
 import { GlobalStore } from "app/store/GlobalStore"
+import { jwtDecode } from "jwt-decode"
 import { useEffect } from "react"
 
 export const useUnleashInitializer = () => {
   const client = useUnleashClient()
   const userID = GlobalStore.useAppState((state) => state.auth.userID)
+  const userAccessToken = GlobalStore.useAppState((state) => state.auth.userAccessToken)
 
   useEffect(() => {
     if (userID) {
       if (client.getContext().userId !== userID) {
         client.setContextField("userId", userID)
+
+        if (userAccessToken) {
+          const decodedToken = jwtDecode(userAccessToken) as { roles: string }
+
+          const userRoles = decodedToken["roles"] ?? ""
+          client.setContextField("userRoles", userRoles)
+        }
       }
 
       client.start()
@@ -20,5 +29,5 @@ export const useUnleashInitializer = () => {
     return () => {
       client.stop()
     }
-  }, [userID])
+  }, [userID, userAccessToken])
 }


### PR DESCRIPTION
### Description

This is meant as a conversation starter – not something on the critical path for feature development.

Reflecting on recent Unleash-backed A/B experiments, it would be nice to update the targeting for an experiment so that a certain group is always given the `experiment` variant. For example the members of a specific product team or all Artsy staff members (as identified via the `team` role).

We've recently built some handling into Metaphysics (https://github.com/artsy/metaphysics/pull/6297 and https://github.com/artsy/metaphysics/pull/6465) to support returning Home View content only when the client is requesting from a supported app version. It seems like we can do similar targeting for Unleash feature flags (including experiments), if we pass along an appVersion context field.

- appPlatformOS: "ios" | "android" | "web" | # to allow targeting based on platform
- appVersion: "8.67.0" # to allow targeting based on semVer constraints
- userRoles: "user,team" # to allow targeting based on user role (for example, rolling out to all Artsy staff)

The updated API request params to the Unleash backend look a bit like this:

```
sessionId: 128917516
appName: eigen
environment: default
properties["appPlatformOS"]: ios
properties["userRoles"]: user,team
userId: <user ID>
```

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- feat: add custom context fields to Unleash

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
