### PR TITLE
chore(infinite-discovery): Add some polish on swipe back

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper.tsx
@@ -125,7 +125,7 @@ export const Swiper = forwardRef<SwiperRefProps, SwiperProps>(
         lastSwipedCardKey = cards[_activeIndex.value + 1].internalID
       }
 
-      swipedCardX.value = withTiming(0, { duration: 200, easing: Easing.linear }, () => {
+      swipedCardX.value = withTiming(0, { duration: 400, easing: Easing.out(Easing.cubic) }, () => {
         if (hasSwipedCards) {
           swipedKeys.value = swipedKeys.value.slice(0, -1)
           _activeIndex.value = _activeIndex.value + 1
@@ -239,13 +239,17 @@ export const Swiper = forwardRef<SwiperRefProps, SwiperProps>(
         if (hasSwipedCards) {
           lastSwipedCardKey = cards[_activeIndex.value + 1].internalID
         }
-        swipedCardX.value = withTiming(0, { duration: 200, easing: Easing.linear }, () => {
-          if (hasSwipedCards) {
-            swipedKeys.value = swipedKeys.value.slice(0, -1)
-            _activeIndex.value = _activeIndex.value + 1
+        swipedCardX.value = withTiming(
+          0,
+          { duration: 400, easing: Easing.out(Easing.cubic) },
+          () => {
+            if (hasSwipedCards) {
+              swipedKeys.value = swipedKeys.value.slice(0, -1)
+              _activeIndex.value = _activeIndex.value + 1
+            }
+            swipedCardX.value = -width
           }
-          swipedCardX.value = -width
-        })
+        )
 
         if (!!lastSwipedCardKey) {
           runOnJS(onRewind)(lastSwipedCardKey as Key)


### PR DESCRIPTION
### Description

Was playing around with this trying to debug the missing avatar image on some artist card headers when I noticed that the swipe back was a bit abrasive due to `linear` easing. Added some natural easing to polish it out a bit. 

Re avatar image: if you swipe forward enough they 'plop' in, leading to layout shift. The only fix i could come up with was commenting out this line [here](https://github.com/artsy/palette-mobile/blob/main/src/elements/EntityHeader/EntityHeader.tsx#L96), and then to smooth out the animation to swap to use Moti). Not sure whats up tho, or why after a certain point the image data isn't accessible to the underlying card, but only after card 5 or so. I suspect it has to do with some of the null relay fragment warnings, which we should solve. 

Android 

https://github.com/user-attachments/assets/1f408a98-caa5-4e1d-afb9-ef8672fab385

iOS

https://github.com/user-attachments/assets/3fdf25a9-88e6-44e4-824b-42c9780869ff


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
