### PR TITLE
chore: Migrate Relay `{ cacheConfig: force true }` to `store-and-network` fetchPolicy

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -2,7 +2,7 @@ import { BackButton, Flex } from "@artsy/palette-mobile"
 import { NativeStackNavigationOptions } from "@react-navigation/native-stack"
 import { ArtsyWebViewConfig, ArtsyWebViewPage } from "app/Components/ArtsyWebView"
 import { BidFlow } from "app/Components/Containers/BidFlow"
-import { InboxQueryRenderer, InboxScreenQuery } from "app/Components/Containers/Inbox"
+import { InboxScreen, InboxScreenQuery } from "app/Components/Containers/Inbox"
 import { InquiryQueryRenderer } from "app/Components/Containers/Inquiry"
 import { RegistrationFlow } from "app/Components/Containers/RegistrationFlow"
 import {
@@ -60,7 +60,12 @@ import {
   ArtworkAttributionClassFAQQueryRenderer,
   ArtworkAttributionClassFAQScreenQuery,
 } from "app/Scenes/ArtworkAttributionClassFAQ/ArtworkAttributionClassFAQ"
-import { ArtworkListScreen } from "app/Scenes/ArtworkList/ArtworkList"
+import {
+  ArtworkListScreen,
+  ArtworkListScreenQuery,
+  artworkListVariables,
+} from "app/Scenes/ArtworkList/ArtworkList"
+import { artworkListsQuery } from "app/Scenes/ArtworkLists/ArtworkLists"
 import {
   ARTWORK_MEDIUM_QUERY,
   ArtworkMediumQueryRenderer,
@@ -193,7 +198,7 @@ import {
   ShowMoreInfoScreenQuery,
 } from "app/Scenes/Show/Screens/ShowMoreInfo"
 import { ShowQueryRenderer, ShowScreenQuery } from "app/Scenes/Show/Show"
-import { ShowsForYouScreen, ShowsForYouScreenQuery } from "app/Scenes/Shows/ShowsForYou"
+import { ShowsForYouScreen } from "app/Scenes/Shows/ShowsForYou"
 import {
   SimilarToRecentlyViewedScreen,
   SimilarToRecentlyViewedScreenQuery,
@@ -542,6 +547,8 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
+    queries: [artworkListsQuery],
+    queryVariables: [artworkListVariables],
   },
   {
     path: "/artwork-list/:listID",
@@ -552,6 +559,8 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
+    queries: [ArtworkListScreenQuery],
+    queryVariables: [artworkListVariables],
   },
   {
     path: "/artwork-recommendations",
@@ -715,7 +724,6 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
-    // TODO: add the query for the artworks grid
     queries: [CollectionScreenQuery],
   },
   {
@@ -907,7 +915,7 @@ export const artsyDotNetRoutes = defineRoutes([
   {
     path: "/inbox",
     name: "Inbox",
-    Component: InboxQueryRenderer,
+    Component: InboxScreen,
     options: {
       isRootViewForTabName: "inbox",
       onlyShowInTabName: "inbox",
@@ -1409,6 +1417,8 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
+    queries: [artworkListsQuery],
+    queryVariables: [artworkListVariables],
   },
   {
     path: "/favorites/saves/:listID",
@@ -1451,7 +1461,8 @@ export const artsyDotNetRoutes = defineRoutes([
         headerShown: false,
       },
     },
-    queries: [ShowsForYouScreenQuery],
+    //Not prefetching the query for now because it's dependent on the user's location.
+    queries: [],
   },
   {
     path: "/similar-to-recently-viewed",

--- a/src/app/Scenes/ArtworkList/ArtworkList.tsx
+++ b/src/app/Scenes/ArtworkList/ArtworkList.tsx
@@ -39,19 +39,20 @@ const SORT_OPTIONS: SortOption[] = [
 
 const DEFAULT_SORT_OPTION = SORT_OPTIONS[0].value as CollectionArtworkSorts
 
+export const artworkListVariables = { count: PAGE_SIZE, sort: DEFAULT_SORT_OPTION }
+
 export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   const [sortModalVisible, setSortModalVisible] = useState(false)
   const [selectedSortValue, setSelectedSortValue] = useState(DEFAULT_SORT_OPTION)
   const prevSelectedSortValue = usePrevious(selectedSortValue)
 
   const queryData = useLazyLoadQuery<ArtworkListQuery>(
-    artworkListScreenQuery,
+    ArtworkListScreenQuery,
     {
       listID,
-      count: PAGE_SIZE,
-      sort: DEFAULT_SORT_OPTION,
+      ...artworkListVariables,
     },
-    { fetchPolicy: "network-only" }
+    { fetchPolicy: "store-and-network" }
   )
 
   const { data, loadNext, hasNext, isLoadingNext, refetch } = usePaginationFragment<
@@ -126,7 +127,7 @@ export const ArtworkList: FC<ArtworkListScreenProps> = ({ listID }) => {
   )
 }
 
-export const artworkListScreenQuery = graphql`
+export const ArtworkListScreenQuery = graphql`
   query ArtworkListQuery(
     $listID: String!
     $count: Int

--- a/src/app/Scenes/ArtworkLists/ArtworkLists.tsx
+++ b/src/app/Scenes/ArtworkLists/ArtworkLists.tsx
@@ -43,11 +43,9 @@ export const ArtworkLists: React.FC<ArtworkListsProps> = ({ isTab = true }) => {
   const space = useSpace()
   const artworkListsColCount = useArtworkListsColCount()
   const [refreshing, setRefreshing] = useState(false)
-  const queryData = useLazyLoadQuery<ArtworkListsQuery>(
-    artworkListsQuery,
-    { count: PAGE_SIZE },
-    { fetchPolicy: "store-and-network" }
-  )
+  const queryData = useLazyLoadQuery<ArtworkListsQuery>(artworkListsQuery, artworkListVariables, {
+    fetchPolicy: "store-and-network",
+  })
 
   const { data, loadNext, hasNext, isLoadingNext, refetch } = usePaginationFragment<
     ArtworkListsQuery,
@@ -182,8 +180,10 @@ const artworkListsFragment = graphql`
   }
 `
 
-const artworkListsQuery = graphql`
+export const artworkListsQuery = graphql`
   query ArtworkListsQuery($count: Int!, $cursor: String) {
     ...ArtworkLists_collectionsConnection @arguments(count: $count, cursor: $cursor)
   }
 `
+
+export const artworkListVariables = { count: PAGE_SIZE }

--- a/src/app/Scenes/Collection/Collection.tsx
+++ b/src/app/Scenes/Collection/Collection.tsx
@@ -123,9 +123,7 @@ const CollectionQueryRenderer: React.FC<CollectionScreenProps> = ({ collectionID
     CollectionScreenQuery,
     { collectionID },
     {
-      networkCacheConfig: {
-        force: false,
-      },
+      fetchPolicy: "store-and-network",
     }
   )
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionTasks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionTasks.tsx
@@ -342,7 +342,6 @@ export const HomeViewSectionTasksQueryRenderer: React.FC<SectionSharedProps> = m
         {
           fetchKey: refetchKey,
           fetchPolicy: "store-and-network",
-          networkCacheConfig: { force: true },
         }
       )
 

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -323,7 +323,7 @@ export const InfiniteDiscoveryQueryRenderer = withSuspense({
     const data = useLazyLoadQuery<InfiniteDiscoveryQuery>(
       infiniteDiscoveryQuery,
       infiniteDiscoveryVariables,
-      { fetchPolicy: "store-and-network", networkCacheConfig: { force: true } }
+      { fetchPolicy: "store-and-network" }
     )
 
     const { resetSavedArtworksCount } = GlobalStore.actions.infiniteDiscovery

--- a/src/app/Scenes/MyProfile/MyProfileHeader.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tsx
@@ -286,10 +286,7 @@ export const MyProfileHeaderQueryRenderer = withSuspense({
       myProfileHeaderQuery,
       {},
       {
-        fetchPolicy: "network-only",
-        networkCacheConfig: {
-          force: true,
-        },
+        fetchPolicy: "store-and-network",
       }
     )
 

--- a/src/app/Scenes/Sales/Sales.tsx
+++ b/src/app/Scenes/Sales/Sales.tsx
@@ -43,7 +43,6 @@ export const Sales: React.FC = () => {
     {},
     {
       fetchPolicy: "store-and-network",
-      networkCacheConfig: { force: true },
     }
   )
 

--- a/src/app/Scenes/Search/SearchArtworksContainer.tsx
+++ b/src/app/Scenes/Search/SearchArtworksContainer.tsx
@@ -27,7 +27,6 @@ export const SearchArtworksQueryRenderer: React.FC<{ keyword: string }> = ({ key
           renderFallback: () => <SimpleErrorMessage />,
         })}
         variables={{ count: 10, keyword }}
-        cacheConfig={{ force: true }}
       />
     </ArtworkFiltersStoreProvider>
   )

--- a/src/app/Scenes/Shows/ShowsForYou.tsx
+++ b/src/app/Scenes/Shows/ShowsForYou.tsx
@@ -3,8 +3,8 @@ import { Flex, Screen, Spacer } from "@artsy/palette-mobile"
 import { ShowsForYouQuery } from "__generated__/ShowsForYouQuery.graphql"
 import { ShowsForYou_showsConnection$key } from "__generated__/ShowsForYou_showsConnection.graphql"
 import {
-  CardsWithMetaDataListPlaceholder as ShowsForYouPlaceholder,
   CardWithMetaDataListItem,
+  CardsWithMetaDataListPlaceholder as ShowsForYouPlaceholder,
   useNumColumns,
 } from "app/Components/Cards/CardWithMetaData"
 import { ShowCardContainer } from "app/Components/ShowCard"

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -38,7 +38,7 @@ const prefetchRoute = async <TQuery extends OperationType>(
   const queries = module.queries
 
   if (!queries) {
-    if (logPrefetching) console.error(`[queryPrefetching] Cannot not find queries for ${route}.`)
+    if (logPrefetching) console.error(`[queryPrefetching] Cannot find queries for ${route}.`)
 
     return
   }


### PR DESCRIPTION
This PR resolves [ONYX-1630] <!-- eg [PROJECT-XXXX] -->

### Description

This PR replaces Relay's `cacheConfig: force: true` with `fetchPolicy: "store-and-network"` for screens using `useLazyloadQuery`. It also adds a few more queries to routes.tsx for prefetching.

Relay's "store-and-network" fetch policy does not seem to be supported by `QueryRenderer`. During testing, the component did not run a new query when the screen opened, and the query was already cached. I will further investigate and probably migrate the remaining screens that use `QueryRenderer` to `useLazyLoadQuery`.


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Migrate Relay `{ cacheConfig: force true }` to "store-and-network" fetchPolicy (for prefetching) - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1630]: https://artsyproduct.atlassian.net/browse/ONYX-1630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ