### PR TITLE
chore(Unleash): revert "feat: render remaining providers after Unleash is initialized (or errored)"

### DIFF
--- a/src/app/system/flags/Components/WrappedFlagProvider.tsx
+++ b/src/app/system/flags/Components/WrappedFlagProvider.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import FlagProvider, { IConfig, useFlagsStatus } from "@unleash/proxy-client-react"
+import FlagProvider, { IConfig } from "@unleash/proxy-client-react"
 import { useUnleashEnvironment } from "app/system/flags/hooks/useUnleashEnvironment"
 import { useUnleashInitializer } from "app/system/flags/hooks/useUnleashInitializer"
 import { useUnleashListener } from "app/system/flags/hooks/useUnleashListener"
@@ -41,15 +41,5 @@ const UnleashInitializer: React.FC = ({ children }) => {
   useUnleashListener()
   useUnleashInitializer()
 
-  return <UnleashReady children={children} />
-}
-
-const UnleashReady: React.FC = ({ children }) => {
-  const { flagsReady: unleashFlagsReady, flagsError: unleashError } = useFlagsStatus()
-  const isUnleashReady = unleashFlagsReady || unleashError
-
-  if (!isUnleashReady) {
-    return null
-  }
   return <>{children}</>
 }


### PR DESCRIPTION
### Description

This reverts commit 0b5dbd9e119877484e740bb6e5eb984327776902.

The commit reverted here is causing Android builds to get stuck on the splash screen. Reverting this to fix those builds while we investigate further.

Related Slack thread [here](https://artsy.slack.com/archives/C02BAQ5K7/p1742559672312569).

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- revert "feat: render remaining providers after Unleash is initialized (or errored)"

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
