### PR TITLE
fix: "Browse More" card navigation

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -35,7 +35,7 @@ export interface ArtworkRailProps extends ArtworkActionTrackingProps {
   itemHref?(artwork: Artwork): string
   onEndReached?: () => void
   onEndReachedThreshold?: number
-  onMoreHref?: string
+  moreHref?: string | null
   onMorePress?: () => void
   onViewableItemsChanged?: (info: { viewableItems: any[]; changed: any[] }) => void
   showSaveIcon?: boolean
@@ -57,7 +57,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
     showSaveIcon = false,
     viewabilityConfig,
     onViewableItemsChanged,
-    onMoreHref,
+    moreHref,
     onMorePress,
     hideIncreasedInterestSignal,
     hideCuratorsPickSignal,
@@ -102,10 +102,10 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
         keyExtractor={(item: Artwork) => item.internalID}
         ListFooterComponent={
           <>
-            {!!(onMorePress || onMoreHref) && (
+            {!!(onMorePress || moreHref) && (
               <BrowseMoreRailCard
                 dark={dark}
-                href={onMoreHref}
+                href={moreHref}
                 onPress={onMorePress}
                 text="Browse All Artworks"
               />

--- a/src/app/Components/BrowseMoreRailCard.tsx
+++ b/src/app/Components/BrowseMoreRailCard.tsx
@@ -16,7 +16,7 @@ export const BrowseMoreRailCard: React.FC<BrowseMoreRailCardProps> = ({
 }) => {
   return (
     <Flex flex={1} px={1} mx={2} justifyContent="center">
-      <RouterLink hasChildTouchable to={href} onPress={onPress}>
+      <RouterLink disablePrefetch hasChildTouchable to={href} onPress={onPress}>
         <Button
           variant={dark ? "outlineLight" : "outline"}
           accessibilityLabel={text ?? "Browse All Results"}

--- a/src/app/Scenes/HomeView/Components/ArtworkModuleRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtworkModuleRail.tsx
@@ -3,7 +3,6 @@ import { ArtworkModuleRail_rail$data } from "__generated__/ArtworkModuleRail_rai
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
-import { navigate } from "app/system/navigation/navigate"
 import {
   ArtworkActionTrackingProps,
   extractArtworkActionTrackingProps,
@@ -100,8 +99,6 @@ const ArtworkModuleRail: React.FC<ArtworkModuleRailProps & RailScrollProps> = ({
     if (tapEvent) {
       tracking.trackEvent(tapEvent)
     }
-
-    navigate(viewAllUrl)
   }
 
   if (artworks.length === 0) {
@@ -136,6 +133,7 @@ const ArtworkModuleRail: React.FC<ArtworkModuleRailProps & RailScrollProps> = ({
           }
         }}
         onMorePress={handlePressMore}
+        moreHref={viewAllUrl}
         showSaveIcon
       />
     </Flex>

--- a/src/app/Scenes/HomeView/Components/ArtworkRecommendationsRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtworkRecommendationsRail.tsx
@@ -5,7 +5,6 @@ import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { useItemsImpressionsTracking } from "app/Scenes/HomeView/Components/useImpressionsTracking"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { CollectorSignals } from "app/utils/getArtworkSignalTrackingFields"
 import {
@@ -53,22 +52,18 @@ export const ArtworkRecommendationsRail: React.FC<
 
   const handleMorePress = () => {
     trackEvent(tracks.tappedMore("viewAll"))
-    navigate("/artwork-recommendations")
   }
 
   const handleHeaderPress = () => {
     trackEvent(tracks.tappedMore("header"))
   }
 
+  const moreHref = "/artwork-recommendations"
+
   return (
     <Flex mb={mb}>
       <View ref={railRef}>
-        <SectionTitle
-          href="/artwork-recommendations"
-          title={title}
-          onPress={handleHeaderPress}
-          mx={2}
-        />
+        <SectionTitle href={moreHref} title={title} onPress={handleHeaderPress} mx={2} />
 
         <ArtworkRail
           {...trackingProps}
@@ -88,6 +83,7 @@ export const ArtworkRecommendationsRail: React.FC<
             )
           }}
           onMorePress={handleMorePress}
+          moreHref={moreHref}
           onViewableItemsChanged={onViewableItemsChanged}
           viewabilityConfig={viewabilityConfig}
           showSaveIcon

--- a/src/app/Scenes/HomeView/Components/RecommendedAuctionLotsRail.tsx
+++ b/src/app/Scenes/HomeView/Components/RecommendedAuctionLotsRail.tsx
@@ -2,7 +2,6 @@ import { ActionType, ContextModule, OwnerType, ScreenOwnerType } from "@artsy/co
 import { RecommendedAuctionLotsRail_artworkConnection$key } from "__generated__/RecommendedAuctionLotsRail_artworkConnection.graphql"
 import { ArtworkRail } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   ArtworkActionTrackingProps,
@@ -62,8 +61,8 @@ export const RecommendedAuctionLotsRail: React.FC<RecommendedAuctionLotsRailProp
           showSaveIcon
           onMorePress={() => {
             trackEvent(tracks.tappedMoreCard(contextScreenOwnerType))
-            navigate("/auctions/lots-for-you-ending-soon")
           }}
+          moreHref={"/auctions/lots-for-you-ending-soon"}
         />
       </View>
     )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -22,7 +22,6 @@ import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeView
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { getHomeViewSectionHref } from "app/Scenes/HomeView/helpers/getHomeViewSectionHref"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
@@ -70,7 +69,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     )
   }
 
-  const href = getHomeViewSectionHref(viewAll?.href, section)
+  const moreHref = getHomeViewSectionHref(viewAll?.href, section)
 
   const onSectionViewAll = () => {
     tracking.tappedArtworkGroupViewAll(
@@ -84,8 +83,6 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
       section.contextModule as ContextModule,
       (viewAll?.ownerType || section.ownerType) as ScreenOwnerType
     )
-
-    navigate(href)
   }
 
   // This is a temporary solution to show the long press context menu only on the first artwork section
@@ -94,10 +91,10 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
   return (
     <Flex {...flexProps}>
       <SectionTitle
-        href={href}
+        href={moreHref}
         mx={2}
         title={section.component?.title}
-        onPress={href ? onSectionViewAll : undefined}
+        onPress={moreHref ? onSectionViewAll : undefined}
       />
 
       {!!isFirstArtworkSection && <ProgressiveOnboardingLongPressContextMenu />}
@@ -108,6 +105,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
         artworks={artworks}
         onPress={handleOnArtworkPress}
         showSaveIcon
+        moreHref={moreHref}
         onMorePress={onMorePress}
       />
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -107,7 +107,7 @@ export const HomeViewSectionFeaturedCollection: React.FC<
           showPartnerName
           artworks={artworks}
           onPress={handleOnArtworkPress}
-          onMoreHref={viewAllHref}
+          moreHref={viewAllHref}
           onMorePress={onSectionViewAll}
           hideCuratorsPickSignal
           hideIncreasedInterestSignal

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -60,28 +60,39 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
     ...restProps,
   }
 
+  const cloneProps = {
+    ...restProps,
+    onPress: handlePress,
+  }
+
+  // If the child component is a touchable element, we don't add another touchable wrapper
+  if (hasChildTouchable) {
+    if (isPrefetchingEnabled) {
+      return (
+        <Sentinel onChange={handleVisible}>
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
+          )}
+        </Sentinel>
+      )
+    } else {
+      return (
+        <>
+          {React.Children.map(children, (child) =>
+            React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
+          )}
+        </>
+      )
+    }
+  }
+
   if (!isPrefetchingEnabled) {
     return <Touchable {...touchableProps} children={children} />
   }
 
-  if (!hasChildTouchable) {
-    return (
-      <Sentinel onChange={handleVisible}>
-        <Touchable {...touchableProps}>{children}</Touchable>
-      </Sentinel>
-    )
-  }
-
-  const cloneProps = {
-    onPress: handlePress,
-    ...restProps,
-  }
-
   return (
     <Sentinel onChange={handleVisible}>
-      {React.Children.map(children, (child) =>
-        React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
-      )}
+      <Touchable {...touchableProps}>{children}</Touchable>
     </Sentinel>
   )
 }

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -66,24 +66,24 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   }
 
   // If the child component is a touchable element, we don't add another touchable wrapper
-  if (hasChildTouchable) {
-    if (isPrefetchingEnabled) {
-      return (
-        <Sentinel onChange={handleVisible}>
-          {React.Children.map(children, (child) =>
-            React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
-          )}
-        </Sentinel>
-      )
-    } else {
-      return (
-        <>
-          {React.Children.map(children, (child) =>
-            React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
-          )}
-        </>
-      )
-    }
+  if (hasChildTouchable && isPrefetchingEnabled) {
+    return (
+      <Sentinel onChange={handleVisible}>
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
+        )}
+      </Sentinel>
+    )
+  }
+
+  if (hasChildTouchable && !isPrefetchingEnabled) {
+    return (
+      <>
+        {React.Children.map(children, (child) =>
+          React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
+        )}
+      </>
+    )
   }
 
   if (!isPrefetchingEnabled) {

--- a/src/app/system/navigation/__tests__/RouterLink.tests.tsx
+++ b/src/app/system/navigation/__tests__/RouterLink.tests.tsx
@@ -36,8 +36,13 @@ describe("RouterLink", () => {
 
   const TestTouchableComponent = (props: Partial<RouterLinkProps>) => {
     return (
-      <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
-        <TouchableWithoutFeedback onPress={touchableOnPress}>
+      <RouterLink
+        to="/test-route"
+        navigationProps={{ id: "test-id" }}
+        onPress={touchableOnPress}
+        {...props}
+      >
+        <TouchableWithoutFeedback>
           <Text>Test Link</Text>
         </TouchableWithoutFeedback>
       </RouterLink>
@@ -70,22 +75,40 @@ describe("RouterLink", () => {
     })
   })
 
-  describe("given a children with touchable element", () => {
-    it("navigates given hasChildTouchable", () => {
+  describe("with hasChildTouchable", () => {
+    it("navigates and calls onPress on press", () => {
       renderWithWrappers(<TestTouchableComponent hasChildTouchable />)
 
       fireEvent.press(screen.getByText("Test Link"))
 
       expect(navigate).toHaveBeenCalled()
+      expect(touchableOnPress).toHaveBeenCalled()
     })
 
-    it("does not navigate", () => {
-      renderWithWrappers(<TestTouchableComponent />)
+    describe("when prefetching is disabled", () => {
+      it("calls onPress, navigates and does not prefetch", () => {
+        renderWithWrappers(<TestTouchableComponent hasChildTouchable disablePrefetch />)
 
-      fireEvent.press(screen.getByText("Test Link"))
+        fireEvent.press(screen.getByText("Test Link"))
 
-      expect(navigate).not.toHaveBeenCalled()
-      expect(touchableOnPress).toHaveBeenCalledTimes(1)
+        expect(touchableOnPress).toHaveBeenCalled()
+        expect(navigate).toHaveBeenCalled()
+
+        expect(mockPrefetch).not.toHaveBeenCalled()
+      })
+
+      describe("when `to` is `undefined`", () => {
+        it("calls onPress and does not navigate or prefetch", () => {
+          renderWithWrappers(<TestTouchableComponent hasChildTouchable to={undefined} />)
+
+          fireEvent.press(screen.getByText("Test Link"))
+
+          expect(touchableOnPress).toHaveBeenCalled()
+
+          expect(navigate).not.toHaveBeenCalled()
+          expect(mockPrefetch).not.toHaveBeenCalled()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

### Description

`RouterLink` wasn't passing the `onPress` callback correctly to its touchable child component (with `hasTouchableChild` prop) when prefetching was disabled (e.g., no `to` prop provided).

This PR fixes the issue and adjusts the "Browse More" rail card that was affected by the issue.

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix "Browse More" rail card navigation - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
