### PR TITLE
fix(DIA-1162): cannot read property 'userInterestsConnection' of null

### DIFF
--- a/src/app/Scenes/MyCollection/MyCollection.tsx
+++ b/src/app/Scenes/MyCollection/MyCollection.tsx
@@ -71,7 +71,7 @@ const MyCollection: React.FC<{
 
   const toast = useToast()
 
-  const hasCollectedArtists = (me.userInterestsConnection?.totalCount ?? 0) > 0
+  const hasCollectedArtists = (me?.userInterestsConnection?.totalCount ?? 0) > 0
 
   const { showVisualClue } = useVisualClue()
   const showMyCollectionCollectedArtistsOnboarding = !!showVisualClue(


### PR DESCRIPTION
This PR attempts to resolve an Applause bug report where the tester was seeing the following error message when they accessed the profile tab:

> Error: Cannot read property 'userInterestsConnection' of null

I cannot reproduce this locally, but Sentry shows that this error happens a handful of times a day on production (search for "Unable to load in tab" and find ones that show "Unable to load in tab: profile" in the message). The stack trace of that points to something in MyCollection:

> TypeError: Cannot read property 'userInterestsConnection' of null
    at MyCollection (address at ...)

I'm adding a null access operator to the line that accesses `userInterestesConnection` in that file to see if it stops the errors.

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
