### PR TITLE
fix: add missing suspense to Favorites

### DIFF
--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -7,6 +7,7 @@ import { SavesTab } from "app/Scenes/Favorites/SavesTab"
 
 const Content: React.FC = () => {
   const activeTab = FavoritesContextStore.useStoreState((state) => state.activeTab)
+
   switch (activeTab) {
     case "saves":
       return <SavesTab />


### PR DESCRIPTION
### Description
This PR fixes an issue with DX on favorites tab. This is happening because we didn't have suspense wrapping the favorites screen query.



**Before**

https://github.com/user-attachments/assets/23b6974b-9204-4230-9f5a-26954eae291d


**After**

https://github.com/user-attachments/assets/2c0f7ee3-5ba0-4f2e-a3f5-b43fe6747143


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- missing suspense on favorites tab - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
