### PR TITLE
fix: Increase Splash screen duration

### DIFF
--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -6,7 +6,7 @@ import { useEffect } from "react"
 import { Linking } from "react-native"
 import RNBootSplash from "react-native-bootsplash"
 
-const HOME_VIEW_SPLASH_SCREEN_DELAY = 1500
+const HOME_VIEW_SPLASH_SCREEN_DELAY = 1200
 
 export const useHideSplashScreen = () => {
   const { flagsReady: unleashFlagsReady, flagsError: unleashError } = useFlagsStatus()

--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -6,7 +6,7 @@ import { useEffect } from "react"
 import { Linking } from "react-native"
 import RNBootSplash from "react-native-bootsplash"
 
-const HOME_VIEW_SPLASH_SCREEN_DELAY = 500
+const HOME_VIEW_SPLASH_SCREEN_DELAY = 1500
 
 export const useHideSplashScreen = () => {
   const { flagsReady: unleashFlagsReady, flagsError: unleashError } = useFlagsStatus()


### PR DESCRIPTION
Related PR: https://github.com/artsy/eigen/pull/10951

### Description

The currently added delay of 500 ms that the splash screen keeps visible after the home screen has rendered does not seem to be enough anymore to hide the initial loading skeleton and layout shifts (explained in https://github.com/artsy/eigen/pull/10951). This PR updates the timeout to 1200 milliseconds. 

I assume that the initial home screen query has gotten slower since we're also fetching experiments (https://github.com/artsy/eigen/issues/11048).


### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Increase Splash screen duration to hide Home screen loading skeletons - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
