### PR TITLE
chore(ONYX-1644): Fetch home view experiments async in the background

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2681,7 +2681,7 @@ SPEC CHECKSUMS:
   CwlMachBadInstructionHandler: ea1030428925d9bf340882522af30712fb4bf356
   CwlPosixPreconditionTesting: a125dee731883f2582715f548c6b6c92c7fde145
   CwlPreconditionTesting: ccfd08aca58d14e04062b2a3dd2fd52e09857453
-  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   "Expecta+Snapshots": 7a3ac7ad2b9bae43aadb4dca08113bb495c98f3e
   FBAEMKit: 31a20c2d8744d8c57d3a5b7ae4e27b4fdd819193
@@ -2700,13 +2700,13 @@ SPEC CHECKSUMS:
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   Forgeries: 64ced144ea8341d89a7eec9d1d7986f0f1366250
   FXBlurView: db786c2561cb49a09ae98407f52460096ab8a44f
-  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
   GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
   GTMSessionFetcher: 0e876eea9782ec6462e91ab872711c357322c94f
   hermes-engine: eb4a80f6bf578536c58a44198ec93a30f6e69218
-  Interstellar: cd0c3290e249b5f156113a4c6c9c09dd0f418aaa
+  Interstellar: ab67502af03105f92100a043e178d188a1a437c9
   INTUAnimationEngine: 3a7d63738cd51af573d16848a771feedea7cc9f2
   iOSSnapshotTestCase: a670511f9ee3829c2b9c23e6e68f315fd7b6790f
   ISO8601DateFormatter: 8311a2d4e265b269b2fed7ab4db685dcb0a7ccb2
@@ -2732,7 +2732,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   Pulley: edc993fb57f7eb20541c8453d0fce10559f21dac
   Quick: ce1276c7c27ba2da3cb2fd0cde053c3648b3b22d
-  RCT-Folly: 84578c8756030547307e4572ab1947de1685c599
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
   RCTDeprecation: 7691283dd69fed46f6653d376de6fa83aaad774c
   RCTRequired: eac044a04629288f272ee6706e31f81f3a2b4bfe
   RCTTypeSafety: cfe499e127eda6dd46e5080e12d80d0bfe667228

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -85,7 +85,7 @@ export const HomeView: React.FC = memo(() => {
   useEnableProgressiveOnboarding()
 
   const prefetchUrl = usePrefetch()
-  useHomeViewExperimentTracking(queryData.homeView?.experiments)
+  useHomeViewExperimentTracking()
 
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
 
@@ -267,13 +267,6 @@ const sectionsFragment = graphql`
 
 export const homeViewScreenQuery = graphql`
   query HomeViewQuery($count: Int!, $cursor: String) {
-    homeView {
-      experiments {
-        name
-        variant
-        enabled
-      }
-    }
     viewer {
       ...HomeViewSectionsConnection_viewer @arguments(count: $count, cursor: $cursor)
     }

--- a/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
+++ b/src/app/Scenes/HomeView/__tests__/HomeView.tests.tsx
@@ -28,13 +28,6 @@ describe("HomeView", () => {
     },
     query: graphql`
       query HomeViewTestsQuery($count: Int!, $cursor: String) @relay_test_operation {
-        homeView {
-          experiments {
-            name
-            variant
-            enabled
-          }
-        }
         viewer {
           ...HomeViewSectionsConnection_viewer @arguments(count: $count, cursor: $cursor)
         }
@@ -92,7 +85,10 @@ describe("HomeView", () => {
 
   describe("home view experiments", () => {
     it("fires an experiment_viewed event for enabled experiments", () => {
-      renderWithRelay({
+      const { mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({})
+      mockResolveLastOperation({
         HomeView: () => ({
           experiments: [
             {
@@ -115,7 +111,10 @@ describe("HomeView", () => {
     })
 
     it("does not fire an experiment_viewed event for disabled experiments", () => {
-      renderWithRelay({
+      const { mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({})
+      mockResolveLastOperation({
         HomeView: () => ({
           experiments: [
             {
@@ -135,7 +134,10 @@ describe("HomeView", () => {
     })
 
     it("does not fire an experiment_viewed event when variant is missing", () => {
-      renderWithRelay({
+      const { mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({})
+      mockResolveLastOperation({
         HomeView: () => ({
           experiments: [
             {

--- a/src/app/Scenes/HomeView/hooks/useHomeViewExperimentTracking.ts
+++ b/src/app/Scenes/HomeView/hooks/useHomeViewExperimentTracking.ts
@@ -67,7 +67,7 @@ export const useHomeViewExperimentTracking = () => {
       {}
     ).subscribe({
       error: (error: any) => {
-        console.error("Unable to fetch saved artworks count.", error)
+        console.error("Unable to fetch experiments.", error)
       },
       next: (data) => {
         console.log(

--- a/src/app/Scenes/HomeView/hooks/useHomeViewExperimentTracking.ts
+++ b/src/app/Scenes/HomeView/hooks/useHomeViewExperimentTracking.ts
@@ -70,10 +70,6 @@ export const useHomeViewExperimentTracking = () => {
         console.error("Unable to fetch experiments.", error)
       },
       next: (data) => {
-        console.log(
-          "[useHomeViewExperimentTracking] Fetched experiments",
-          data.homeView?.experiments
-        )
         trackExperiments(data.homeView?.experiments)
       },
     })


### PR DESCRIPTION
Resolves [ONYX-1644](https://artsyproduct.atlassian.net/browse/ONYX-1644)
### Description

> [!NOTE]
> This might not bring much performance improvement because Metaphysics does not seem to make a request to Unleash to fetch the experiments ([code](https://github.com/artsy/metaphysics/blob/20b513b73e7ad0f58b59053c936c840042267a5f/src/schema/v2/homeView/experiments/HomeViewExperiments.ts#L19)). But it's probably good to move everything out of the query to make it smaller.

This PR defers fetching home view experiments (asynchronously and in the background) to potentially increase the time the home screen renders.

I suppose it's fine to fetch the experiments within an effect after the home screen has rendered because they are only used for tracking and don't affect any rendered components.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fching home view experiments async - ole

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1644]: https://artsyproduct.atlassian.net/browse/ONYX-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ