### PR TITLE
fix(DIA-1239): artist avatar is slow to load in discover daily

### DIFF
--- a/src/app/Components/ArtistListItem.tsx
+++ b/src/app/Components/ArtistListItem.tsx
@@ -144,7 +144,6 @@ const ArtistListItem: React.FC<Props> = ({
 
   return (
     <RouterLink
-      disablePrefetch
       noFeedback={!withFeedback}
       // Only navigate if there is an href and navigation is not disabled by passing `onPress` or
       to={!disableNavigation ? href : undefined}
@@ -242,7 +241,11 @@ export const ArtistListItemContainer = createFragmentContainer(ArtistListItem, {
       deathday
       coverArtwork {
         image {
-          url(version: "small")
+          # Requesting "small" causes this fragment to be refetched unexpectedly because the relay
+          # store usually contains artists with "larger" cover artworks (see ArtistScreenQuery).
+          # We can also disable prefetching on the RouterLink to avoid this, but it is better to
+          # prefetch a larger image than it is to make a additional requests for a smaller one.
+          url(version: "larger")
         }
       }
       image {

--- a/src/app/Components/ArtistListItem.tsx
+++ b/src/app/Components/ArtistListItem.tsx
@@ -144,6 +144,7 @@ const ArtistListItem: React.FC<Props> = ({
 
   return (
     <RouterLink
+      disablePrefetch
       noFeedback={!withFeedback}
       // Only navigate if there is an href and navigation is not disabled by passing `onPress` or
       to={!disableNavigation ? href : undefined}


### PR DESCRIPTION
We observed that the artist avatar that appears at the top of an artwork card in Discover Daily was slow to load after the first few swipes.

~This PR attempts to fix that by disabling prefetching on the RouterLink that wraps the contents of the ArtistListItem component that makes up the top of an artwork card.~

~I am still not sure why prefetching causes this to happen. I suspect that it has something to do with the bottom sheet also querying for the contents of an ArtistListItem, because the avatar loads correctly when the bottom sheet is commented-out.~

This PR fixes that by requesting the same cover artwork image size that the ArtworkScreenQuery requests. We noticed that prefetching caused a new request for this cover artwork that should have already been in the Relay store. It was, but using a different size version, so the cover artwork was being fetched again using that different size.

 
| Before | After |
|--------|------|
| https://github.com/user-attachments/assets/b7d18804-0c2b-466c-b5c6-8b890117dc62 | https://github.com/user-attachments/assets/94f5d84d-01d9-4ded-b579-74a7bad1ef2c |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Stopped prefetching ArtistListItem contents because it was causing visual glitches in Discover Daily

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
