### PR TITLE
chore: remove pull to refresh from the saved lists modal

### DIFF
--- a/src/app/Components/ArtworkLists/components/ArtworkLists.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkLists.tsx
@@ -154,7 +154,8 @@ const ArtworkListsFragment = graphql`
     includeArtwork: { type: "Boolean", defaultValue: true }
     count: { type: "Int", defaultValue: 20 }
     after: { type: "String" }
-  ) {
+  )
+  @refetchable(queryName: "ArtworkLists_meRefetch") {
     savedArtworksArtworkList: collection(id: "saved-artwork") {
       internalID
       isSavedArtwork(artworkID: $artworkID) @include(if: $includeArtwork)

--- a/src/app/Components/ArtworkLists/components/ArtworkLists.tsx
+++ b/src/app/Components/ArtworkLists/components/ArtworkLists.tsx
@@ -5,7 +5,7 @@ import { ArtworkListsLoadingIndicator } from "app/Components/ArtworkLists/compon
 import { ArtworkListMode, ArtworkListOfferSettingsMode } from "app/Components/ArtworkLists/types"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
-import { FC, useCallback, useEffect, useState } from "react"
+import { FC, useCallback, useEffect } from "react"
 import { graphql, usePaginationFragment } from "react-relay"
 import { ArtworkListItem, PressedArtworkListItem } from "./ArtworkListItem"
 
@@ -18,7 +18,6 @@ type ArtworkList =
   | ExtractNodeType<ArtworkLists_me$data["customArtworkLists"]>
 
 export const ArtworkLists: FC<ArtworkListsProps> = (props) => {
-  const [refreshing, setRefreshing] = useState(false)
   const {
     shareArtworkListIDs,
     keepArtworkListPrivateIDs,
@@ -26,7 +25,7 @@ export const ArtworkLists: FC<ArtworkListsProps> = (props) => {
     removingArtworkListIDs,
     dispatch,
   } = useArtworkListsContext()
-  const { data, hasNext, loadNext, isLoadingNext, refetch } = usePaginationFragment(
+  const { data, hasNext, loadNext, isLoadingNext } = usePaginationFragment(
     ArtworkListsFragment,
     props.me
   )
@@ -45,19 +44,6 @@ export const ArtworkLists: FC<ArtworkListsProps> = (props) => {
       payload: totalSelectedArtworkListsCount,
     })
   }, [totalSelectedArtworkListsCount])
-
-  const handleRefresh = () => {
-    setRefreshing(true)
-    refetch(
-      {},
-      {
-        fetchPolicy: "store-and-network",
-        onComplete: () => {
-          setRefreshing(false)
-        },
-      }
-    )
-  }
 
   const handleLoadMore = () => {
     if (!hasNext || isLoadingNext) {
@@ -145,8 +131,6 @@ export const ArtworkLists: FC<ArtworkListsProps> = (props) => {
     <BottomSheetFlatList
       data={artworkLists}
       keyExtractor={(item) => item.internalID}
-      onRefresh={handleRefresh}
-      refreshing={refreshing}
       renderItem={({ item }) => {
         return (
           <ArtworkListItem
@@ -170,8 +154,7 @@ const ArtworkListsFragment = graphql`
     includeArtwork: { type: "Boolean", defaultValue: true }
     count: { type: "Int", defaultValue: 20 }
     after: { type: "String" }
-  )
-  @refetchable(queryName: "ArtworkLists_meRefetch") {
+  ) {
     savedArtworksArtworkList: collection(id: "saved-artwork") {
       internalID
       isSavedArtwork(artworkID: $artworkID) @include(if: $includeArtwork)


### PR DESCRIPTION
This PR resolves [PBRW-612] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Resolves [Notion card](https://www.notion.so/artsy/Saved-lists-the-list-of-saves-on-the-bottom-sheet-modal-can-be-refreshed-on-pull-let-s-remove-it-1c4cab0764a0803f8d88f644e0685de1?pvs=4) 
[Saved lists] the list of saves on the bottom sheet modal can be refreshed on pull - let’s remove it?
 
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/a9d5dcdb-7aaa-47e1-a1ba-857d0f9f4964" /> | <video src="https://github.com/user-attachments/assets/7e2b8c4f-7808-4052-bb2d-da6a15d6fe6d" /> |


### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- remove pull to refresh from the saved lists modal

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-612]: https://artsyproduct.atlassian.net/browse/PBRW-612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ