### PR TITLE
fix: missing tappedCardGroup event on home screen

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
@@ -72,12 +72,15 @@ export const HomeViewSectionCardsChips: React.FC<HomeViewSectionCardsChipsProps>
 
               return (
                 <Flex minWidth={CHIP_WIDTH} key={`collectionChips-row-${index}`}>
-                  <RouterLink to={item.href} hasChildTouchable>
+                  <RouterLink
+                    to={item.href}
+                    hasChildTouchable
+                    onPress={() => handleOnChipPress(item, index)}
+                  >
                     <Chip
                       key={item.href}
                       title={item.title}
                       subtitle={item.subtitle as string | undefined}
-                      onPress={() => handleOnChipPress(item, index)}
                     />
                   </RouterLink>
                 </Flex>

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCardsChips.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCardsChips.tests.tsx
@@ -2,11 +2,26 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { HomeViewSectionCardsChipsTestsQuery } from "__generated__/HomeViewSectionCardsChipsTestsQuery.graphql"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionCardsChips } from "app/Scenes/HomeView/Sections/HomeViewSectionCardsChips"
+import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
+jest.mock("app/Scenes/HomeView/hooks/useHomeViewTracking", () => ({
+  useHomeViewTracking: jest.fn(),
+}))
+
 describe("HomeViewSectionCardsChips", () => {
+  const mockUseHomeViewTracking = useHomeViewTracking as jest.Mock
+  const mockTracking = {
+    tappedCardGroup: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseHomeViewTracking.mockReturnValue(mockTracking)
+  })
+
   const { renderWithRelay } = setupTestWrapper<HomeViewSectionCardsChipsTestsQuery>({
     Component: (props) => {
       return (
@@ -48,5 +63,6 @@ describe("HomeViewSectionCardsChips", () => {
     expect(screen.getByText("Discover Something New")).toBeOnTheScreen()
     fireEvent.press(screen.getByText("Figurative Art"))
     expect(navigate).toHaveBeenCalledWith("/figurative-art")
+    expect(mockTracking.tappedCardGroup).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION
This PR addresses an issue raised by the Data team. When users tap on a chip in the Discover Something New home view section, a `tappedCardGroup` event should be fired, but it hasn't been, so it looks like no users are engaging with it.

| Before | After |
|-------|-------|
| https://github.com/user-attachments/assets/2d5483ac-3dd2-4407-ad23-d7e1c25a722b | https://github.com/user-attachments/assets/97f1ee8c-6215-475f-9d64-1e572797aca5 |

### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
