### PR TITLE
feat: Decrease visibility theshold to prefetch links earlier

### DIFF
--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -77,7 +77,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   // If the child component is a touchable element, we don't add another touchable wrapper
   if (hasChildTouchable && isPrefetchingEnabled) {
     return (
-      <Sentinel onChange={handleVisible}>
+      <Sentinel onChange={handleVisible} threshold={0}>
         <Border prefetchState={prefetchState}>
           {React.Children.map(children, (child) => {
             return React.isValidElement(child) ? React.cloneElement(child, cloneProps) : child
@@ -102,7 +102,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   }
 
   return (
-    <Sentinel onChange={handleVisible}>
+    <Sentinel onChange={handleVisible} threshold={0}>
       <Border prefetchState={prefetchState}>
         <Touchable {...touchableProps}>{children}</Touchable>
       </Border>

--- a/src/app/utils/Sentinel.tests.tsx
+++ b/src/app/utils/Sentinel.tests.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react-native"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { Text } from "react-native"
+import { Sentinel } from "./Sentinel"
+
+const mockOnChange = jest.fn()
+
+const TestComponentWithSentinel = () => {
+  return (
+    <Sentinel onChange={mockOnChange}>
+      <Text testID="child-content">Test Child</Text>
+    </Sentinel>
+  )
+}
+
+describe("Sentinel", () => {
+  it("renders child components", () => {
+    renderWithWrappers(<TestComponentWithSentinel />)
+    expect(screen.getByTestId("child-content")).toBeDefined()
+  })
+})

--- a/src/app/utils/Sentinel.tsx
+++ b/src/app/utils/Sentinel.tsx
@@ -13,10 +13,15 @@ import { useFocusEffect } from "@react-navigation/native"
 import { FC, ReactNode, useCallback, useRef, useState } from "react"
 import { Dimensions, View } from "react-native"
 
+const DEFAULT_THRESHOLD = 1
+
 export interface IDimensionData {
   rectTop: number
   rectBottom: number
   rectWidth: number
+  rectHeight: number
+  width: number
+  height: number
 }
 
 export interface Props {
@@ -24,17 +29,22 @@ export interface Props {
   onChange(visible: boolean): any
   /** The component that needs to be in the viewport */
   children?: ReactNode
+  /** The value indicates the minimum percentage of the container that must be visible (vertically or horizontally). A value of 1 means 100%, 0.7 means 70%, and so forth. The default value is 1 (100%). */
+  threshold?: number
 }
 
 const RNView = View as any
 
-export const Sentinel: FC<Props> = ({ children, onChange }) => {
+export const Sentinel: FC<Props> = ({ children, onChange, threshold = DEFAULT_THRESHOLD }) => {
   const myView: any = useRef(null)
   const [lastValue, setLastValue] = useState<boolean>(false)
   const [dimensions, setDimensions] = useState<IDimensionData>({
     rectTop: 0,
     rectBottom: 0,
     rectWidth: 0,
+    rectHeight: 0,
+    width: 0,
+    height: 0,
   })
 
   let interval: any = null
@@ -71,6 +81,9 @@ export const Sentinel: FC<Props> = ({ children, onChange }) => {
             rectTop: pageY,
             rectBottom: pageY + height,
             rectWidth: pageX + width,
+            rectHeight: pageY + height,
+            width,
+            height,
           })
         }
       )
@@ -86,9 +99,9 @@ export const Sentinel: FC<Props> = ({ children, onChange }) => {
     const isVisible =
       dimensions.rectBottom != 0 &&
       dimensions.rectTop >= 0 &&
-      dimensions.rectBottom <= window.height &&
+      dimensions.rectBottom - dimensions.height * (1 - threshold) <= window.height &&
       dimensions.rectWidth > 0 &&
-      dimensions.rectWidth <= window.width
+      dimensions.rectWidth - dimensions.width * (1 - threshold) <= window.width
 
     if (lastValue !== isVisible) {
       setLastValue(isVisible)


### PR DESCRIPTION
 <!-- eg [PROJECT-XXXX] -->

## Description

This PR adds a `threshold` prop to `Sentinel` to be able to prefetch links as soon as they enter the viewport (vs. when they have fully entered the viewport).

## Screen recordings / Screenshots

### Behaviour

| Before | After |
| --- | --- |
|https://github.com/user-attachments/assets/af91a3e0-5eb0-43fc-a137-528299732137 | https://github.com/user-attachments/assets/7f0540df-d414-40d0-9f7f-c19718e5b5bd|


### Performance

| Before | After |
| --- | --- |
|https://github.com/user-attachments/assets/82728aee-1fc2-40ed-b293-4b3989b17170 | https://github.com/user-attachments/assets/4564e8a1-f2be-4455-9b8c-b9531f989cab|




### PR Checklist

- [ ] I have tested my changes on **iOS** and **Android**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prefetch links earlier (when they enter the viewport instead of when they are fully visible)- ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
