### PR TITLE
fix: improve push notification permission handling and tracking

### DIFF
--- a/ios/Artsy/App/ARAppNotificationsDelegate.m
+++ b/ios/Artsy/App/ARAppNotificationsDelegate.m
@@ -77,7 +77,8 @@
 
     // Save device token for dev settings and to prevent excess calls to gravity if tokens don't change
     [[NSUserDefaults standardUserDefaults] setValue:deviceToken forKey:ARAPNSDeviceTokenKey];
-
+    [[NSUserDefaults standardUserDefaults] setValue:@YES forKey:ARAPNSHasSeenPushDialog];
+    
     [[[ARAppDelegate braze] notifications] registerDeviceToken:deviceTokenData];
 
 // We only record device tokens on the Artsy service in case of Beta or App Store builds.

--- a/ios/Artsy/App/ARAppNotificationsDelegate.m
+++ b/ios/Artsy/App/ARAppNotificationsDelegate.m
@@ -28,6 +28,8 @@
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
+    BOOL hasSeenPushDialog = [[NSUserDefaults standardUserDefaults] boolForKey:ARAPNSHasSeenPushDialog];
+    
     NSString *analyticsContext = @"";
     if (self.requestContext == ARAppNotificationsRequestContextArtistFollow) {
         analyticsContext = @"ArtistFollow";
@@ -37,11 +39,15 @@
         analyticsContext = @"Launch";
     }
     analyticsContext = [@[@"PushNotification", analyticsContext] componentsJoinedByString:@""];
-    [[AREmission sharedInstance] sendEvent:ARAnalyticsPushNotificationApple traits:@{
-        @"action_type" : @"Tap",
-        @"action_name" : @"Cancel",
-        @"context_screen"  : analyticsContext
-    }];
+    
+    if (!hasSeenPushDialog) {
+        [[AREmission sharedInstance] sendEvent:ARAnalyticsPushNotificationApple traits:@{
+            @"action_type" : @"Tap",
+            @"action_name" : @"Cancel",
+            @"context_screen"  : analyticsContext
+        }];
+    }
+    [[NSUserDefaults standardUserDefaults] setValue:@YES forKey:ARAPNSHasSeenPushDialog];
 #if (TARGET_IPHONE_SIMULATOR == 0)
     ARErrorLog(@"Error registering for remote notifications: %@", error.localizedDescription);
 #endif
@@ -49,6 +55,8 @@
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceTokenData
 {
+    BOOL hasSeenPushDialog = [[NSUserDefaults standardUserDefaults] boolForKey:ARAPNSHasSeenPushDialog];
+
     NSString *analyticsContext = @"";
     if (self.requestContext == ARAppNotificationsRequestContextArtistFollow) {
         analyticsContext = @"ArtistFollow";
@@ -58,12 +66,13 @@
         analyticsContext = @"Launch";
     }
     analyticsContext = [@[@"PushNotification", analyticsContext] componentsJoinedByString:@""];
-
-    [[AREmission sharedInstance] sendEvent:ARAnalyticsPushNotificationApple traits:@{
-        @"action_type" : @"Tap",
-        @"action_name" : @"Yes",
-        @"context_screen"  : analyticsContext
-    }];
+    if (!hasSeenPushDialog) {
+        [[AREmission sharedInstance] sendEvent:ARAnalyticsPushNotificationApple traits:@{
+            @"action_type" : @"Tap",
+            @"action_name" : @"Yes",
+            @"context_screen"  : analyticsContext
+        }];
+    }
 
     // http://stackoverflow.com/questions/9372815/how-can-i-convert-my-device-token-nsdata-into-an-nsstring
     const unsigned *tokenBytes = [deviceTokenData bytes];

--- a/ios/Artsy/Constants/ARAppConstants.h
+++ b/ios/Artsy/Constants/ARAppConstants.h
@@ -12,6 +12,7 @@ extern NSString *const AROExpiryDateKey;
 extern NSString *const ARXAppToken;
 
 extern NSString *const ARAPNSDeviceTokenKey;
+extern NSString *const ARAPNSHasSeenPushDialog;
 
 extern NSString *const ARNetworkAvailableNotification;
 extern NSString *const ARNetworkUnavailableNotification;

--- a/ios/Artsy/Constants/ARAppConstants.m
+++ b/ios/Artsy/Constants/ARAppConstants.m
@@ -23,5 +23,6 @@ NSString *const ARAuctionIDKey = @"ARAuctionID";
 NSString *const ARAuctionArtworkIDKey = @"ARAuctionArtworkID";
 
 NSString *const ARAPNSDeviceTokenKey = @"apns_device_token";
+NSString *const ARAPNSHasSeenPushDialog = @"apns_has_seen_push_dialog";
 
 BOOL ARPerformWorkAsynchronously = YES;


### PR DESCRIPTION
This PR resolves [PHIRE-1670] <!-- eg [PROJECT-XXXX] -->

### Description

We are firing analytics events related to push permissions on every app launch, this PR changes this to only fire on the first time that user sees the dialog.

|Platform|Before|After|
|---|---|---|
|iOS|<video src="https://github.com/user-attachments/assets/35156030-97df-4d1a-9e1b-a19450be8110" width="400" />|<video src="https://github.com/user-attachments/assets/6899c0d5-2acc-4db6-b82d-656d2e402658" width="400" />|
|iOS|<video src="https://github.com/user-attachments/assets/08e952a2-0b95-4910-ae94-b1ed42f75aa8" width="400" />|<video src="https://github.com/user-attachments/assets/c51b82f3-9ec4-40dc-9f41-edf3e2d710b0" width="400" />|

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

### PR Checklist

- [x] I have tested my changes on **iOS** and **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- improve push notification permission handling and tracking

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1670]: https://artsyproduct.atlassian.net/browse/PHIRE-1670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ