### PR TITLE
fix: double navigation on android notifications

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1146,9 +1146,9 @@
         "filename": "src/app/utils/PushNotification.tests.ts",
         "hashed_secret": "91dfd9ddb4198affc5c194cd8ce6d338fde470e2",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 62
       }
     ]
   },
-  "generated_at": "2025-02-10T11:24:13Z"
+  "generated_at": "2025-04-01T11:38:25Z"
 }

--- a/src/app/utils/PushNotification.tests.ts
+++ b/src/app/utils/PushNotification.tests.ts
@@ -20,10 +20,6 @@ function mockFetchJsonOnce(json: object, status = 200) {
   })
 }
 
-beforeEach(() => {
-  mockFetch.mockClear()
-})
-
 describe("Push Notification Tests", () => {
   beforeEach(async () => {
     jest.clearAllMocks()
@@ -104,18 +100,6 @@ describe("Push Notification Tests", () => {
       userInteraction: true, // notification was tapped
     }
 
-    it("Saves tapped notification When a user is not logged in", () => {
-      Push.handleReceivedNotification(notification)
-      expect(
-        __globalStoreTestUtils__?.getCurrentState().pendingPushNotification.notification
-      ).toHaveProperty("tappedAt")
-      expect(
-        __globalStoreTestUtils__?.getCurrentState().pendingPushNotification.notification?.data
-      ).toEqual(notification.data)
-      // notification is not handled
-      expect(navigate).not.toHaveBeenCalled()
-    })
-
     it("Handles tapped notification instantly if user is logged in and nav is ready", async () => {
       mockFetchJsonOnce({
         xapp_token: "xapp-token",
@@ -152,6 +136,18 @@ describe("Push Notification Tests", () => {
         passProps: notification.data,
         ignoreDebounce: true,
       })
+    })
+
+    it("Saves tapped notification When a user is not logged in", () => {
+      Push.handleReceivedNotification(notification)
+      expect(
+        __globalStoreTestUtils__?.getCurrentState().pendingPushNotification.notification
+      ).toHaveProperty("tappedAt")
+      expect(
+        __globalStoreTestUtils__?.getCurrentState().pendingPushNotification.notification?.data
+      ).toEqual(notification.data)
+      // notification is not handled
+      expect(navigate).not.toHaveBeenCalled()
     })
 
     it("Pending Notification: navigates to appropriate screen when called", () => {


### PR DESCRIPTION
This PR resolves [PHIRE-1680] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes Android Braze notifications from navigating the user to the screen twice.

The reason that this was happening is that we use an outdated library and for some reason the [onNotification](https://github.com/artsy/eigen/blob/main/src/app/utils/PushNotification.ts#L255) event is getting called twice always.

We did a workaround a while ago to prevent double tracking but we didn't prevent double navigation.

This PR addresses this issue. 

> [!NOTE]  
> this is only happening on android since iOS handles notifications natively.

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/7fe4a456-7547-402c-83d0-74b74e554a7f" width="400" /> | <video src="https://github.com/user-attachments/assets/56bad87b-7ff4-46db-b559-35df68b70f9f" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- prevent notifications to navigate to surface twice

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1680]: https://artsyproduct.atlassian.net/browse/PHIRE-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ