### PR TITLE
fix: fit messages to viewport on tablets

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -8,8 +8,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { sortBy } from "lodash"
 import { DateTime } from "luxon"
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
-import { FlatList, RefreshControl, ViewStyle } from "react-native"
-import { isTablet } from "react-native-device-info"
+import { FlatList, RefreshControl } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
 import { MessageGroup } from "./MessageGroup"
@@ -131,13 +130,6 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
 
   const refreshControl = <RefreshControl refreshing={reloadingData} onRefresh={reload} />
 
-  const messagesStyles: Partial<ViewStyle> = isTablet()
-    ? {
-        width: 708,
-        alignSelf: "center",
-      }
-    : {}
-
   return (
     <>
       <ToastComponent
@@ -171,7 +163,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
         onEndReached={loadMore}
         onEndReachedThreshold={0.2}
         refreshControl={refreshControl}
-        style={{ ...messagesStyles, paddingHorizontal: 10, flex: 0 }}
+        style={{ paddingHorizontal: 10, flex: 0 }}
         contentContainerStyle={{ justifyContent: "flex-end", flexGrow: 1 }}
         ListFooterComponent={<LoadingIndicator animating={fetchingMoreData} hidesWhenStopped />}
       />


### PR DESCRIPTION
This PR resolves [PBRW-549] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Removes hard coded styles from conversation messages and instead fits to view port, I do not have a device the correct size but you could see how a tablet smaller then this would cause overflow. I think fitting to view port looks better generally but not clear on reason for the limit in the first place.

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/1ce09655-f51f-4961-ae9d-fa9d6bdf8446" width="400" /> | <img src="https://github.com/user-attachments/assets/6f98d23f-1702-47b0-bb8a-d6d2b9672bc6" width="400" /> |



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fit messages to viewport in conversations - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

- 

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-549]: https://artsyproduct.atlassian.net/browse/PBRW-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ