### PR TITLE
fix(PBRW-558): Fix error on tapping Make Offer

### DIFF
--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tests.tsx
@@ -668,45 +668,55 @@ describe("ArtworkCommercialButtons", () => {
     })
   })
 
-  describe("with edition sets", () => {
-    const editionSet = {
-      internalID: "editionSetID",
-      editionOf: "Edition Set One",
-      saleMessage: "$1000",
-      isAcquireable: true,
-      isOfferable: true,
-      isInquireable: false,
-    }
-    const artworkWithEditionSets = {
-      ...ArtworkFixture,
-      editionSets: [editionSet],
-      isAcquireable: true,
-      isOfferable: true,
-      isInquireable: false,
-    }
+  describe("edition sets", () => {
+    describe("with multiple edition sets", () => {
+      const editionSets = [
+        { internalID: "edition-set-one", isAcquireable: true, isOfferable: true },
+        { internalID: "edition-set-two", isAcquireable: true, isOfferable: true },
+      ]
 
-    it("renders the Purchase and Make Offer buttons when edition set is selected ", () => {
-      renderWithRelay({
-        Artwork: () => artworkWithEditionSets,
-        Me: () => meFixture,
+      const artworkWithEditionSets = {
+        ...ArtworkFixture,
+        editionSets,
+        isAcquireable: true,
+        isOfferable: true,
+        isInquireable: false,
+      }
+
+      it("does not render the Purchase and Make Offer buttons when edition set is not selected ", () => {
+        renderWithRelay({ Artwork: () => artworkWithEditionSets, Me: () => meFixture })
+
+        expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
+        expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
       })
 
-      mockArtworkStore.getActions().setSelectedEditionId(editionSet.internalID)
+      it("renders the Purchase and Make Offer buttons when edition set is selected ", () => {
+        renderWithRelay({ Artwork: () => artworkWithEditionSets, Me: () => meFixture })
 
-      expect(screen.getByText("Purchase")).toBeOnTheScreen()
-      expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+        mockArtworkStore.getActions().setSelectedEditionId(editionSets[0].internalID)
+
+        expect(screen.getByText("Purchase")).toBeOnTheScreen()
+        expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
+      })
     })
 
-    it("does not render the Purchase and Make Offer buttons when edition set is not selected ", () => {
-      renderWithRelay({
-        Artwork: () => artworkWithEditionSets,
-        Me: () => meFixture,
+    describe("with one edition set", () => {
+      const artworkWithEditionSets = {
+        ...ArtworkFixture,
+        editionSets: [{ internalID: "edition-set-one", isAcquireable: true, isOfferable: true }],
+        isAcquireable: true,
+        isOfferable: true,
+        isInquireable: false,
+      }
+
+      it("renders the Purchase and Make Offer buttons even if the edition set is not selected ", () => {
+        renderWithRelay({ Artwork: () => artworkWithEditionSets, Me: () => meFixture })
+
+        mockArtworkStore.getActions().setSelectedEditionId(null)
+
+        expect(screen.getByText("Purchase")).toBeOnTheScreen()
+        expect(screen.getByText("Make an Offer")).toBeOnTheScreen()
       })
-
-      mockArtworkStore.getActions().setSelectedEditionId(null)
-
-      expect(screen.queryByText("Purchase")).not.toBeOnTheScreen()
-      expect(screen.queryByText("Make an Offer")).not.toBeOnTheScreen()
     })
   })
 })

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -88,7 +88,7 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
     )
   }
 
-  if (!noEditions && !selectedEditionId) {
+  if ((!artworkData.editionSets || artworkData.editionSets.length > 1) && !selectedEditionId) {
     return null
   }
 

--- a/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkCommercialButtons.tsx
@@ -88,6 +88,10 @@ export const ArtworkCommercialButtons: React.FC<ArtworkCommercialButtonsProps> =
     )
   }
 
+  if (!noEditions && !selectedEditionId) {
+    return null
+  }
+
   if (artworkData.isOfferable && artworkData.isAcquireable) {
     return (
       <RowContainer>


### PR DESCRIPTION
This PR resolves [PBRW-558] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue with artworks with edition sets, where the user can create an order for the artwork before an edition set is selected, which breaks in Exchange

The fix that I implemented here was to hide the commercial buttons if the artwork has _more than one_ edition sets and an edition set is not selected



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->


| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/cc9cbeba-eb40-4e7c-ad56-9563619bc877" width="400" /> | <video src="https://github.com/user-attachments/assets/52ee5075-282a-4e8c-9a89-a70b70bc5613" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/7ab059ef-36b1-4cf1-b319-2c5e1c71a921" width="400" /> | <video src="https://github.com/user-attachments/assets/2a0fd2ae-5e09-4302-b8d2-55b429eee19d" width="400" /> |


| | Android | iOS |
|---|---|---|
| With 1 edition set | ![image](https://github.com/user-attachments/assets/601203bd-e0d3-4915-b137-57532f2a3389) | ![image](https://github.com/user-attachments/assets/ab4023bf-2986-4238-8509-6bb33a0310b6) |





### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Prevent creating an order for artworks with edition sets when the edition set is not selected

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-558]: https://artsyproduct.atlassian.net/browse/PBRW-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ