### PR TITLE
fix: dismiss keyboard after tapping on create alert

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -38,7 +38,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
 import { useLocalizedUnit } from "app/utils/useLocalizedUnit"
 import { useEffect, useState } from "react"
-import { Modal, ViewProps } from "react-native"
+import { Keyboard, Modal, ViewProps } from "react-native"
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context"
 import { useTracking } from "react-tracking"
 import {
@@ -310,8 +310,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   }
 
   const handleCreateAlertPress = () => {
-    setIsCreateAlertModalVisible(true)
-    tracking.trackEvent(tracks.tappedCreateAlert(id as string, name as string))
+    Keyboard.dismiss()
+    requestAnimationFrame(() => {
+      setIsCreateAlertModalVisible(true)
+      tracking.trackEvent(tracks.tappedCreateAlert(id as string, name as string))
+    })
   }
 
   const setSelectedMetric = ArtworksFiltersStore.useStoreActions((state) => state.setSizeMetric)


### PR DESCRIPTION
### Description

This PR fixes an issue affecting release builds on android. The issue happens mainly when the user taps on the create alert while having the keyboard closed.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- dismiss keyboard after tapping on create alert - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
