### PR TITLE
fix: bottom tabs issues post navigation

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -109,11 +109,7 @@ const AppTabs: React.FC = () => {
           },
           tabBarHideOnKeyboard: true,
           tabBarIcon: ({ focused }) => {
-            return (
-              <Flex flex={1}>
-                <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
-              </Flex>
-            )
+            return <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
           },
           tabBarButton: (props) => (
             <PlatformPressable
@@ -129,6 +125,7 @@ const AppTabs: React.FC = () => {
                 alignItems="flex-end"
                 justifyContent="flex-end"
                 height={BOTTOM_TABS_HEIGHT}
+                pb={1}
               >
                 <Text variant="xxs" selectable={false} textAlign="center" color="black100">
                   {bottomTabsConfig[route.name].name}

--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -1,4 +1,4 @@
-import { useColor, useSpace } from "@artsy/palette-mobile"
+import { useColor } from "@artsy/palette-mobile"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
 import { useVisualClue } from "app/utils/hooks/useVisualClue"
@@ -15,7 +15,6 @@ type BadgeProps = { tabBarBadge?: string | number; tabBarBadgeStyle: StyleProp<T
  */
 export const useBottomTabsBadges = () => {
   const color = useColor()
-  const space = useSpace()
 
   const { showVisualClue } = useVisualClue()
   const { unreadConversationsCount, hasUnseenNotifications } = useTabBarBadge()
@@ -24,7 +23,7 @@ export const useBottomTabsBadges = () => {
 
   const visualClueStyles = {
     backgroundColor: color("red50"),
-    top: space(1),
+    top: 2,
     minWidth: VISUAL_CLUE_HEIGHT,
     maxHeight: VISUAL_CLUE_HEIGHT,
     borderRadius: VISUAL_CLUE_HEIGHT / 2,


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the bottom navigation tabs badges post react-navigation upgrade.

<img width="741" alt="Screenshot 2025-04-02 at 16 54 40" src="https://github.com/user-attachments/assets/9f076d22-d64a-4e79-ac4b-edf22aaf44ad" />


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
