### PR TITLE
fix: Sentinel component "maximum update depth exceeded" error

### DIFF
--- a/src/app/utils/Sentinel.tsx
+++ b/src/app/utils/Sentinel.tsx
@@ -38,7 +38,7 @@ const RNView = View as any
 export const Sentinel: FC<Props> = ({ children, onChange, threshold = DEFAULT_THRESHOLD }) => {
   const myView: any = useRef(null)
 
-  const [lastValue, setLastValue] = useState<boolean>(false)
+  const [isVisible, setIsVisible] = useState<boolean>(false)
 
   let interval: any = null
 
@@ -90,21 +90,21 @@ export const Sentinel: FC<Props> = ({ children, onChange, threshold = DEFAULT_TH
   const isInViewPort = (dimensions: IDimensionData) => {
     const window = Dimensions.get("window")
 
-    const isVisible =
+    const newIsVisible =
       dimensions.rectBottom != 0 &&
       dimensions.rectTop >= 0 &&
       dimensions.rectBottom - dimensions.height * (1 - threshold) <= window.height &&
       dimensions.rectWidth > 0 &&
       dimensions.rectWidth - dimensions.width * (1 - threshold) <= window.width
 
-    if (isVisible !== lastValue) {
-      setLastValue(isVisible)
+    if (newIsVisible !== isVisible) {
+      setIsVisible(newIsVisible)
     }
   }
 
   useEffect(() => {
-    onChange(lastValue)
-  }, [lastValue])
+    onChange(isVisible)
+  }, [isVisible])
 
   return (
     <RNView collapsable={false} ref={myView}>

--- a/src/app/utils/Sentinel.tsx
+++ b/src/app/utils/Sentinel.tsx
@@ -68,16 +68,14 @@ export const Sentinel: FC<Props> = ({ children, onChange, threshold = DEFAULT_TH
           pageX: number,
           pageY: number
         ) => {
-          const dimensions = {
+          isInViewPort({
             rectTop: pageY,
             rectBottom: pageY + height,
             rectWidth: pageX + width,
             rectHeight: pageY + height,
             width,
             height,
-          }
-
-          isInViewPort(dimensions)
+          })
         }
       )
     }, 1000)


### PR DESCRIPTION
This PR resolves [ONYX-1656] <!-- eg [PROJECT-XXXX] -->

### Description

This fixes the Sentinel component "Maximum update depth exceeded" error.

```
[1]  ERROR  Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```

### To Do:

- [ ] Test on Android


### iOS

Printing the rerenders with a simple `console.log` inside the component:

```tsx
let renderCount = 0

Sentinel => () => {
  renderCount += 1
  console.log("Render count:", renderCount)

  ...

  return ...
}
```

**Before:**

https://github.com/user-attachments/assets/bb861492-27e1-448e-ae7e-2e761b45c652

**After:**

https://github.com/user-attachments/assets/359aa2fa-57c1-4d85-a8a7-34ff35d77dc9






<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix Sentinel component maximum update depth exceeded error (error causing home screen crashes on Android) - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1656]: https://artsyproduct.atlassian.net/browse/ONYX-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ