### PR TITLE
fix: reverse the fetched data to match what the deck expects

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -322,12 +322,11 @@ export const InfiniteDiscoveryQueryRenderer = withSuspense({
   Component: () => {
     const data = useLazyLoadQuery<InfiniteDiscoveryQuery>(
       infiniteDiscoveryQuery,
-      infiniteDiscoveryVariables,
-      { fetchPolicy: "store-and-network" }
+      infiniteDiscoveryVariables
     )
 
     const { resetSavedArtworksCount } = GlobalStore.actions.infiniteDiscovery
-    const initialArtworks = extractNodes(data.discoverArtworks)
+    const initialArtworks = [...extractNodes(data.discoverArtworks).reverse()]
     const [artworks, setArtworks] = useState<InfiniteDiscoveryArtwork[]>(initialArtworks)
 
     const fetchMoreArtworks = async (excludeArtworkIds: string[], isRetry = false) => {
@@ -335,14 +334,10 @@ export const InfiniteDiscoveryQueryRenderer = withSuspense({
         const response = await fetchQuery<InfiniteDiscoveryQuery>(
           getRelayEnvironment(),
           infiniteDiscoveryQuery,
-          {
-            excludeArtworkIds,
-          },
-          {
-            fetchPolicy: "network-only",
-          }
+          { excludeArtworkIds },
+          { fetchPolicy: "network-only" }
         ).toPromise()
-        const newArtworks = extractNodes(response?.discoverArtworks)
+        const newArtworks = [...extractNodes(response?.discoverArtworks).reverse()]
         if (newArtworks.length) {
           setArtworks((previousArtworks) => newArtworks.concat(previousArtworks))
         }


### PR DESCRIPTION
This PR resolves [DIA-1256] <!-- eg [PROJECT-XXXX] -->

### Description

Before we were:
- fetching the first batch and showing the last Artwork on top
- when fetching more doing the same thing

Now we:
- fetch the first batch and reverse the batch to show the first Artwork on top
- the same ☝️ when fetching more artworks

No visual changes expected.

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: infinite discovery artworks order

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1256]: https://artsyproduct.atlassian.net/browse/DIA-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ