### PR TITLE
fix: More Home view prefetching and better test coverage

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -394,7 +394,7 @@
         "filename": "src/app/Scenes/HomeView/Components/ShowsRail.tests.tsx",
         "hashed_secret": "8cf54e3fea51ec0c6e138c7a1f07e7516c1b47d9",
         "is_verified": false,
-        "line_number": 77
+        "line_number": 102
       }
     ],
     "src/app/Scenes/MyCollection/MyCollection.tests.tsx": [
@@ -1150,5 +1150,5 @@
       }
     ]
   },
-  "generated_at": "2025-04-07T21:56:25Z"
+  "generated_at": "2025-04-09T09:23:02Z"
 }

--- a/src/app/Components/Cards/CardWithMetaData.tsx
+++ b/src/app/Components/Cards/CardWithMetaData.tsx
@@ -1,17 +1,18 @@
 import {
+  Box,
   Flex,
   Image,
+  Screen,
   SkeletonBox,
   SkeletonText,
   Spacer,
   Text,
-  useTheme,
-  Screen,
   useScreenDimensions,
-  Box,
+  useTheme,
 } from "@artsy/palette-mobile"
 import { CARD_WIDTH } from "app/Components/CardRail/CardRailCard"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { goBack } from "app/system/navigation/navigate"
 import {
   PlaceholderBox,
   ProvidePlaceholderContext,
@@ -120,7 +121,7 @@ export const CardsWithMetaDataListPlaceholder: React.FC<CardsWithMetaDataListPla
 
   return (
     <Screen>
-      <Screen.AnimatedHeader title={title} />
+      <Screen.AnimatedHeader onBack={goBack} title={title} />
       <Screen.Body fullwidth>
         <ProvidePlaceholderContext>
           <Flex testID={testID} flexDirection="column" justifyContent="space-between" height="100%">

--- a/src/app/Scenes/HomeView/Components/ActivityRail.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityRail.tests.tsx
@@ -33,7 +33,7 @@ describe("ActivityRail", () => {
     expect(screen.getByText(/mock-value-for-field-"headline"/)).toBeOnTheScreen()
   })
 
-  it("handles header tap", () => {
+  it("handles header press", () => {
     renderWithRelay({
       Viewer: () => ({
         notificationsConnection: {
@@ -61,7 +61,7 @@ describe("ActivityRail", () => {
     })
   })
 
-  it("handles See All tap", () => {
+  it("handles See All press", () => {
     renderWithRelay({
       Viewer: () => ({
         notificationsConnection: {
@@ -89,7 +89,7 @@ describe("ActivityRail", () => {
     })
   })
 
-  it("handles item tap", () => {
+  it("handles item press", () => {
     renderWithRelay({
       Viewer: () => ({
         notificationsConnection: {

--- a/src/app/Scenes/HomeView/Components/ActivityRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityRail.tsx
@@ -4,10 +4,10 @@ import { SectionTitle } from "app/Components/SectionTitle"
 import { shouldDisplayNotification } from "app/Scenes/Activity/utils/shouldDisplayNotification"
 import { ActivityRailItem } from "app/Scenes/HomeView/Components/ActivityRailItem"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { matchRoute } from "app/system/navigation/utils/matchRoute"
 import { extractNodes } from "app/utils/extractNodes"
-import { FlatList, TouchableOpacity } from "react-native"
+import { FlatList } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -36,8 +36,6 @@ export const ActivityRail: React.FC<ActivityRailProps> = ({ title, viewer }) => 
 
   const handleMorePress = () => {
     trackEvent(HomeAnalytics.activityViewAllTapEvent())
-
-    navigate("/notifications")
   }
 
   return (
@@ -109,21 +107,23 @@ const notificationsConnectionFragment = graphql`
 interface SeeAllCardProps {
   onPress: () => void
   buttonText?: string | null
+  href?: string
 }
 
-export const SeeAllCard: React.FC<SeeAllCardProps> = ({ buttonText, onPress }) => {
+export const SeeAllCard: React.FC<SeeAllCardProps> = ({ buttonText, href, onPress }) => {
   const { space } = useTheme()
 
   return (
     <Flex flex={1} px={1} mx={4} justifyContent="center">
-      <TouchableOpacity
+      <RouterLink
         onPress={onPress}
+        to={href}
         hitSlop={{ top: space(1), bottom: space(1), left: space(1), right: space(1) }}
       >
         <Text accessibilityLabel="See All" fontWeight="bold">
           {buttonText ?? "See All"}
         </Text>
-      </TouchableOpacity>
+      </RouterLink>
     </Flex>
   )
 }

--- a/src/app/Scenes/HomeView/Components/HeroUnit.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/HeroUnit.tests.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { HeroUnit } from "app/Scenes/HomeView/Components/HeroUnit"
+import { navigate } from "app/system/navigation/navigate"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("HeroUnit", () => {
+  const mockItem = {
+    internalID: "hero-unit-id",
+    title: "Test Hero Unit",
+    body: "This is a test hero unit",
+    imageSrc: "https://example.com/image.jpg",
+    url: "/test-url",
+    buttonText: "Learn More",
+  }
+  const mockOnPress = jest.fn()
+
+  it("renders", () => {
+    renderWithWrappers(<HeroUnit item={mockItem} onPress={mockOnPress} />)
+
+    // Verify component renders correctly
+    expect(screen.getByText("Test Hero Unit")).toBeOnTheScreen()
+    expect(screen.getByText("This is a test hero unit")).toBeOnTheScreen()
+    expect(screen.getByText("Learn More")).toBeOnTheScreen()
+  })
+
+  it("handles press events", () => {
+    renderWithWrappers(<HeroUnit item={mockItem} onPress={mockOnPress} />)
+
+    fireEvent.press(screen.getByText("Test Hero Unit"))
+
+    expect(mockOnPress).toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith("/test-url")
+  })
+
+  it("handles button press events", () => {
+    renderWithWrappers(<HeroUnit item={mockItem} onPress={mockOnPress} />)
+
+    fireEvent.press(screen.getByText("Learn More"))
+
+    expect(mockOnPress).toHaveBeenCalled()
+    expect(navigate).toHaveBeenCalledWith("/test-url")
+  })
+})

--- a/src/app/Scenes/HomeView/Components/HeroUnit.tsx
+++ b/src/app/Scenes/HomeView/Components/HeroUnit.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Flex, Image, Text, Touchable } from "@artsy/palette-mobile"
+import { Box, Button, Flex, Image, Text } from "@artsy/palette-mobile"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { useScreenDimensions } from "app/utils/hooks"
 import { PixelRatio } from "react-native"
 
@@ -23,26 +24,31 @@ const CARD_IMAGE_WIDTH = 125
 const DESCRIPTION_LINES = fontScale > 1 ? 4 : 3
 
 export const HeroUnit: React.FC<HeroUnitItemProps> = ({ item, onPress }) => {
-  const { internalID, title, imageSrc, body, buttonText } = item
+  const { internalID, title, imageSrc, body, buttonText, url } = item
   const { width: screenWidth } = useScreenDimensions()
   const cardImageWidth = screenWidth > 700 ? screenWidth / 2 : CARD_IMAGE_WIDTH
 
   return (
-    <Touchable key={internalID} onPress={onPress} haptic="impactLight">
+    <RouterLink key={internalID} to={url} onPress={onPress} haptic="impactLight">
       <Flex bg="black100" flexDirection="row" height={HERO_UNIT_CARD_HEIGHT} width={screenWidth}>
         <Image height={HERO_UNIT_CARD_HEIGHT} src={imageSrc} width={cardImageWidth} />
+
         <Box p={2} width={screenWidth - cardImageWidth}>
           <Text color="white100" mb={1} numberOfLines={2} variant="lg-display">
             {title}
           </Text>
+
           <Text color="white100" mb={2} numberOfLines={DESCRIPTION_LINES}>
             {body}
           </Text>
-          <Button size="small" variant="outlineLight" onPress={onPress}>
-            {buttonText}
-          </Button>
+
+          <RouterLink hasChildTouchable to={url} onPress={onPress}>
+            <Button size="small" variant="outlineLight">
+              {buttonText}
+            </Button>
+          </RouterLink>
         </Box>
       </Flex>
-    </Touchable>
+    </RouterLink>
   )
 }

--- a/src/app/Scenes/HomeView/Components/HeroUnit.tsx
+++ b/src/app/Scenes/HomeView/Components/HeroUnit.tsx
@@ -29,13 +29,7 @@ export const HeroUnit: React.FC<HeroUnitItemProps> = ({ item, onPress }) => {
   const cardImageWidth = screenWidth > 700 ? screenWidth / 2 : CARD_IMAGE_WIDTH
 
   return (
-    <RouterLink
-      key={internalID}
-      to={url}
-      onPress={onPress}
-      haptic="impactLight"
-      activeOpacity={0.8}
-    >
+    <RouterLink key={internalID} to={url} onPress={onPress} haptic="impactLight">
       <Flex bg="black100" flexDirection="row" height={HERO_UNIT_CARD_HEIGHT} width={screenWidth}>
         <Image height={HERO_UNIT_CARD_HEIGHT} src={imageSrc} width={cardImageWidth} />
 

--- a/src/app/Scenes/HomeView/Components/HeroUnit.tsx
+++ b/src/app/Scenes/HomeView/Components/HeroUnit.tsx
@@ -29,7 +29,13 @@ export const HeroUnit: React.FC<HeroUnitItemProps> = ({ item, onPress }) => {
   const cardImageWidth = screenWidth > 700 ? screenWidth / 2 : CARD_IMAGE_WIDTH
 
   return (
-    <RouterLink key={internalID} to={url} onPress={onPress} haptic="impactLight">
+    <RouterLink
+      key={internalID}
+      to={url}
+      onPress={onPress}
+      haptic="impactLight"
+      activeOpacity={0.8}
+    >
       <Flex bg="black100" flexDirection="row" height={HERO_UNIT_CARD_HEIGHT} width={screenWidth}>
         <Image height={HERO_UNIT_CARD_HEIGHT} src={imageSrc} width={cardImageWidth} />
 

--- a/src/app/Scenes/HomeView/Components/ShowsRail.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/ShowsRail.tests.tsx
@@ -1,5 +1,8 @@
 import Geolocation from "@react-native-community/geolocation"
+import { fireEvent } from "@testing-library/react-native"
+import { navigate } from "app/system/navigation/navigate"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
 import mockFetch from "jest-fetch-mock"
 import "react-native"
@@ -21,7 +24,7 @@ describe("ShowsRailContainer", () => {
   describe("with location enabled", () => {
     const environment = createMockEnvironment()
 
-    it("renders the title and the shows", async () => {
+    it("renders the title and the shows and handles title press", async () => {
       const { getByText } = renderWithHookWrappersTL(
         <ShowsRailContainer title="Shows for You" />,
         environment
@@ -39,13 +42,24 @@ describe("ShowsRailContainer", () => {
       expect(getByText("Shows for You")).toBeDefined()
 
       expect(getByText("Leeum Collection: Beyond Space")).toBeDefined()
+
+      fireEvent.press(getByText("Shows for You"))
+
+      expect(navigate).toHaveBeenCalledWith("/shows-for-you")
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "tappedShowGroup",
+        context_module: "showsRail",
+        context_screen_owner_type: "home",
+        destination_screen_owner_type: "show",
+        type: "header",
+      })
     })
   })
 
   describe("with location disabled", () => {
     const environment = createMockEnvironment()
 
-    it("renders the title and the shows", async () => {
+    it("renders the title and the shows and handles title press", async () => {
       const { getByText } = renderWithHookWrappersTL(
         <ShowsRailContainer title="Shows for You" disableLocation />,
         environment
@@ -63,6 +77,17 @@ describe("ShowsRailContainer", () => {
       expect(getByText("Shows for You")).toBeDefined()
 
       expect(getByText("Leeum Collection: Beyond Space")).toBeDefined()
+
+      fireEvent.press(getByText("Shows for You"))
+
+      expect(navigate).toHaveBeenCalledWith("/shows-for-you")
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "tappedShowGroup",
+        context_module: "showsRail",
+        context_screen_owner_type: "home",
+        destination_screen_owner_type: "show",
+        type: "header",
+      })
     })
   })
 })

--- a/src/app/Scenes/HomeView/Components/ShowsRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ShowsRail.tsx
@@ -12,7 +12,6 @@ import {
   HORIZONTAL_FLATLIST_INTIAL_NUMBER_TO_RENDER_DEFAULT,
   HORIZONTAL_FLATLIST_WINDOW_SIZE,
 } from "app/Scenes/HomeView/helpers/constants"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { Location, useLocation } from "app/utils/hooks/useLocation"
@@ -62,8 +61,8 @@ export const ShowsRail: React.FC<ShowsRailProps> = memo(
         <SectionTitle
           title={title}
           mx={2}
+          href="/shows-for-you"
           onPress={() => {
-            navigate("/shows-for-you")
             tracking.trackEvent(tracks.tappedHeader())
           }}
         />

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionActivity.tsx
@@ -17,7 +17,6 @@ import {
   HORIZONTAL_FLATLIST_WINDOW_SIZE,
 } from "app/Scenes/HomeView/helpers/constants"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { useMemoizedRandom } from "app/utils/placeholders"
@@ -50,26 +49,17 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
 
   const href = viewAll?.href || "/notifications"
 
-  const onHeaderPress = () => {
+  const onMorePress = () => {
     tracking.tappedActivityGroupViewAll(
       section.contextModule as ContextModule,
       (viewAll?.ownerType || OwnerType.activities) as ScreenOwnerType
     )
-  }
-
-  const onSectionViewAll = () => {
-    tracking.tappedActivityGroupViewAll(
-      section.contextModule as ContextModule,
-      (viewAll?.ownerType || OwnerType.activities) as ScreenOwnerType
-    )
-
-    navigate(href)
   }
 
   return (
     <Flex {...flexProps}>
       <Flex px={2}>
-        <SectionTitle href={href} title={section.component?.title} onPress={onHeaderPress} />
+        <SectionTitle href={href} title={section.component?.title} onPress={onMorePress} />
       </Flex>
 
       <FlatList
@@ -78,7 +68,7 @@ export const HomeViewSectionActivity: React.FC<HomeViewSectionActivityProps> = (
         ListHeaderComponent={() => <Spacer x={2} />}
         ListFooterComponent={
           viewAll
-            ? () => <SeeAllCard buttonText={viewAll.buttonText} onPress={onSectionViewAll} />
+            ? () => <SeeAllCard buttonText={viewAll.buttonText} onPress={onMorePress} href={href} />
             : undefined
         }
         ItemSeparatorComponent={() => <Spacer x={2} />}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards.tsx
@@ -7,7 +7,6 @@ import {
   SkeletonBox,
   SkeletonText,
   Text,
-  Touchable,
 } from "@artsy/palette-mobile"
 import { HomeViewSectionArticlesCardsQuery } from "__generated__/HomeViewSectionArticlesCardsQuery.graphql"
 import {
@@ -17,7 +16,7 @@ import {
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { ExtractNodeType } from "app/utils/relayHelpers"
@@ -53,8 +52,6 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
         section.contextModule as ContextModule,
         index
       )
-
-      navigate(article.href)
     }
   }
 
@@ -64,8 +61,6 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
         section.contextModule as ContextModule,
         viewAll?.ownerType as ScreenOwnerType
       )
-
-      navigate(viewAll.href)
     }
   }
 
@@ -78,22 +73,22 @@ export const HomeViewSectionArticlesCards: React.FC<HomeViewSectionArticlesCards
         </Flex>
         {articles.map((article, index) => (
           <Flex key={index} gap={2}>
-            <Touchable onPress={() => onItemPress(article, index)}>
+            <RouterLink onPress={() => onItemPress(article, index)} to={article.href}>
               <Flex flexDirection="row" alignItems="center">
                 <Text variant="sm-display" numberOfLines={3}>
                   {article.title}
                 </Text>
               </Flex>
-            </Touchable>
+            </RouterLink>
             {index !== articles.length - 1 && <Separator />}
           </Flex>
         ))}
         {!!viewAll && (
-          <Touchable onPress={onViewAllPress}>
+          <RouterLink onPress={onViewAllPress} to={viewAll.href}>
             <Flex flexDirection="row" justifyContent="flex-end">
               <Text variant="sm-display">{viewAll.buttonText}</Text>
             </Flex>
-          </Touchable>
+          </RouterLink>
         )}
       </Flex>
 

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCard.tsx
@@ -6,7 +6,6 @@ import {
   Skeleton,
   SkeletonBox,
   Text,
-  Touchable,
   useColor,
   useScreenDimensions,
   useSpace,
@@ -18,7 +17,7 @@ import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeView
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { GlobalStore } from "app/store/GlobalStore"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { memo } from "react"
@@ -60,10 +59,6 @@ export const HomeViewSectionCard: React.FC<HomeViewSectionCardProps> = ({
 
   const onPress = () => {
     tracking.tappedShowMore(buttonText, section.contextModule as ContextModule)
-
-    if (route) {
-      navigate(route)
-    }
   }
 
   return (
@@ -80,7 +75,7 @@ export const HomeViewSectionCard: React.FC<HomeViewSectionCardProps> = ({
           onPress={onPress}
         />
       ) : (
-        <Touchable onPress={onPress} haptic="impactLight">
+        <RouterLink onPress={onPress} to={route} haptic="impactLight">
           {!!hasImage && (
             <Flex position="absolute">
               <FastImage
@@ -130,19 +125,20 @@ export const HomeViewSectionCard: React.FC<HomeViewSectionCardProps> = ({
 
               {!!route && (
                 <Flex mt={0.5} maxWidth={150}>
-                  <Button
-                    variant={hasImage && theme !== "dark" ? "outlineLight" : "fillDark"}
-                    size="small"
-                    onPress={onPress}
-                    iconPosition="right"
-                  >
-                    {buttonText}
-                  </Button>
+                  <RouterLink hasChildTouchable onPress={onPress} to={route}>
+                    <Button
+                      variant={hasImage && theme !== "dark" ? "outlineLight" : "fillDark"}
+                      size="small"
+                      iconPosition="right"
+                    >
+                      {buttonText}
+                    </Button>
+                  </RouterLink>
                 </Flex>
               )}
             </Flex>
           </Flex>
-        </Touchable>
+        </RouterLink>
       )}
 
       <HomeViewSectionSentinel

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionHeroUnits.tsx
@@ -11,7 +11,6 @@ import {
   HORIZONTAL_FLATLIST_WINDOW_SIZE,
 } from "app/Scenes/HomeView/helpers/constants"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { useScreenDimensions } from "app/utils/hooks"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
@@ -79,9 +78,6 @@ export const HomeViewSectionHeroUnits: React.FC<HomeViewSectionHeroUnitsProps> =
                 section.contextModule as ContextModule,
                 index
               )
-              if (item.link.url) {
-                navigate(item.link.url)
-              }
             }}
           />
         )}

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollections.tsx
@@ -7,6 +7,7 @@ import {
   SkeletonBox,
   SkeletonText,
   Spacer,
+  Touchable,
 } from "@artsy/palette-mobile"
 import { HomeViewSectionMarketingCollectionsQuery } from "__generated__/HomeViewSectionMarketingCollectionsQuery.graphql"
 import {
@@ -22,10 +23,7 @@ import {
 } from "app/Components/FiveUpImageLayout"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { HomeViewSectionSentinel } from "app/Scenes/HomeView/Components/HomeViewSectionSentinel"
-import {
-  CollectionCard,
-  HomeViewSectionMarketingCollectionsItem,
-} from "app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem"
+import { HomeViewSectionMarketingCollectionsItem } from "app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem"
 import { SectionSharedProps } from "app/Scenes/HomeView/Sections/Section"
 import {
   HORIZONTAL_FLATLIST_INTIAL_NUMBER_TO_RENDER_DEFAULT,
@@ -151,7 +149,7 @@ const HomeViewSectionMarketingCollectionsPlaceholder: React.FC<FlexProps> = (fle
           <Flex flexDirection="row">
             <Join separator={<Spacer x="15px" />}>
               {times(2 + randomValue * 10).map((index) => (
-                <CollectionCard key={index}>
+                <Touchable key={index}>
                   <Flex>
                     <Flex flexDirection="row">
                       <SkeletonBox
@@ -198,7 +196,7 @@ const HomeViewSectionMarketingCollectionsPlaceholder: React.FC<FlexProps> = (fle
                       <SkeletonText>21 works</SkeletonText>
                     </Flex>
                   </Flex>
-                </CollectionCard>
+                </Touchable>
               ))}
             </Join>
           </Flex>

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionMarketingCollectionsItem.tsx
@@ -1,18 +1,16 @@
 import { Flex, Text } from "@artsy/palette-mobile"
-import themeGet from "@styled-system/theme-get"
 import {
   HomeViewSectionMarketingCollectionsItem_marketingCollection$data,
   HomeViewSectionMarketingCollectionsItem_marketingCollection$key,
 } from "__generated__/HomeViewSectionMarketingCollectionsItem_marketingCollection.graphql"
 
 import { FiveUpImageLayout } from "app/Components/FiveUpImageLayout"
-import { navigate } from "app/system/navigation/navigate"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { pluralize } from "app/utils/pluralize"
 import { compact } from "lodash"
 import { FC } from "react"
 import { graphql, useFragment } from "react-relay"
-import styled from "styled-components/native"
 
 interface HomeViewSectionMarketingCollectionsItemProps {
   marketingCollection: HomeViewSectionMarketingCollectionsItem_marketingCollection$key
@@ -35,16 +33,16 @@ export const HomeViewSectionMarketingCollectionsItem: FC<
   const artworksCount = marketingCollection.artworksConnection?.counts?.total || 0
 
   return (
-    <CollectionCard
-      testID={`collections-rail-card-${marketingCollection.slug}`}
+    <RouterLink
       onPress={
         marketingCollection?.slug
           ? () => {
               onPress?.(marketingCollection)
-              navigate(`/collection/${marketingCollection.slug}`)
             }
           : undefined
       }
+      testID={`collections-rail-card-${marketingCollection.slug}`}
+      to={`/collection/${marketingCollection.slug}`}
     >
       <Flex>
         <FiveUpImageLayout imageURLs={artworkImageURLs} />
@@ -63,7 +61,7 @@ export const HomeViewSectionMarketingCollectionsItem: FC<
           </Text>
         </Flex>
       </Flex>
-    </CollectionCard>
+    </RouterLink>
   )
 }
 
@@ -86,8 +84,3 @@ const fragment = graphql`
     }
   }
 `
-
-export const CollectionCard = styled.TouchableHighlight.attrs(() => ({
-  underlayColor: themeGet("colors.white100"),
-  activeOpacity: 0.8,
-}))``

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionActivity.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionActivity.tests.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen } from "@testing-library/react-native"
 import { HomeViewSectionActivityTestsQuery } from "__generated__/HomeViewSectionActivityTestsQuery.graphql"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionActivity } from "app/Scenes/HomeView/Sections/HomeViewSectionActivity"
+import { navigate } from "app/system/navigation/navigate"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -44,6 +45,42 @@ describe("HomeViewSectionActivity", () => {
     expect(toJSON()).toBeNull()
   })
 
+  it("renders header and handles header press", () => {
+    renderWithRelay({
+      HomeViewSectionActivity: () => ({
+        internalID: "home-view-section-latest-activity",
+        component: {
+          title: "Latest Activity",
+        },
+        notificationsConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "id-1",
+                notificationType: "ARTWORK_ALERT",
+                headline: "artwork alert",
+                targetHref: "/artwork-room/id-1",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(screen.getByText("Latest Activity")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText("Latest Activity"))
+
+    expect(navigate).toHaveBeenCalledWith('<mock-value-for-field-"href">')
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedActivityGroup",
+      context_module: '<mock-value-for-field-"contextModule">',
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: '<mock-value-for-field-"ownerType">',
+      type: "viewAll",
+    })
+  })
+
   it("renders a list of activities", () => {
     renderWithRelay({
       HomeViewSectionActivity: () => ({
@@ -79,6 +116,7 @@ describe("HomeViewSectionActivity", () => {
 
     fireEvent.press(screen.getByText(/viewing room published/))
 
+    expect(navigate).toHaveBeenCalledWith("/notification/id-2")
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticlesCards.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticlesCards.tests.tsx
@@ -1,11 +1,17 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { HomeViewSectionArticlesCardsTestsQuery } from "__generated__/HomeViewSectionArticlesCardsTestsQuery.graphql"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionArticlesCards } from "app/Scenes/HomeView/Sections/HomeViewSectionArticlesCards"
+import { navigate } from "app/system/navigation/navigate"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
 describe("HomeViewSectionArticlesCards", () => {
+  // afterEach(() => {
+  //   mockTrackEvent.mockClear()
+  // })
+
   const { renderWithRelay } = setupTestWrapper<HomeViewSectionArticlesCardsTestsQuery>({
     Component: (props) => {
       if (!props.homeView.section) {
@@ -41,28 +47,7 @@ describe("HomeViewSectionArticlesCards", () => {
           },
         },
       }),
-      ArticleConnection: () => ({
-        edges: [
-          {
-            node: {
-              title: "The first news item",
-              href: "/article/one",
-            },
-          },
-          {
-            node: {
-              title: "The second news item",
-              href: "/article/two",
-            },
-          },
-          {
-            node: {
-              title: "The third news item",
-              href: "/article/three",
-            },
-          },
-        ],
-      }),
+      ArticleConnection: () => mockArticleconnection,
     })
 
     expect(screen.getByText(/Some news items/)).toBeOnTheScreen()
@@ -71,4 +56,89 @@ describe("HomeViewSectionArticlesCards", () => {
     expect(screen.getByText(/The third news item/)).toBeOnTheScreen()
     expect(screen.getByText(/All the news/)).toBeOnTheScreen()
   })
+
+  it("handles item press", () => {
+    renderWithRelay({
+      HomeViewComponent: () => ({
+        title: "Some news items",
+        behaviors: {
+          viewAll: {
+            href: "/articles",
+            buttonText: "All the news",
+          },
+        },
+      }),
+      ArticleConnection: () => mockArticleconnection,
+    })
+
+    expect(screen.getByText(/Some news items/)).toBeOnTheScreen()
+    expect(screen.getByText(/The first news item/)).toBeOnTheScreen()
+    expect(screen.getByText(/The second news item/)).toBeOnTheScreen()
+    expect(screen.getByText(/The third news item/)).toBeOnTheScreen()
+    expect(screen.getByText(/All the news/)).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText(/The first news item/))
+
+    expect(navigate).toHaveBeenCalledWith("/article/one")
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedArticleGroup",
+      context_module: '<mock-value-for-field-"contextModule">',
+      context_screen_owner_type: "home",
+      destination_screen_owner_id: "<Article-mock-id-2>",
+      destination_screen_owner_slug: '<mock-value-for-field-"slug">',
+      destination_screen_owner_type: "article",
+      horizontal_slide_position: 0,
+      module_height: "double",
+      type: "thumbnail",
+    })
+  })
+
+  it("handles title press", () => {
+    renderWithRelay({
+      HomeViewComponent: () => ({
+        title: "Some news items",
+        behaviors: {
+          viewAll: {
+            href: "/articles",
+            buttonText: "All the news",
+          },
+        },
+      }),
+      ArticleConnection: () => mockArticleconnection,
+    })
+
+    fireEvent.press(screen.getByText(/All the news/))
+
+    expect(navigate).toHaveBeenCalledWith("/articles")
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedArticleGroup",
+      context_module: '<mock-value-for-field-"contextModule">',
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: '<mock-value-for-field-"ownerType">',
+      type: "viewAll",
+    })
+  })
 })
+
+const mockArticleconnection = {
+  edges: [
+    {
+      node: {
+        title: "The first news item",
+        href: "/article/one",
+      },
+    },
+    {
+      node: {
+        title: "The second news item",
+        href: "/article/two",
+      },
+    },
+    {
+      node: {
+        title: "The third news item",
+        href: "/article/three",
+      },
+    },
+  ],
+}

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticlesCards.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArticlesCards.tests.tsx
@@ -8,9 +8,9 @@ import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
 describe("HomeViewSectionArticlesCards", () => {
-  // afterEach(() => {
-  //   mockTrackEvent.mockClear()
-  // })
+  afterEach(() => {
+    mockTrackEvent.mockClear()
+  })
 
   const { renderWithRelay } = setupTestWrapper<HomeViewSectionArticlesCardsTestsQuery>({
     Component: (props) => {

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCard.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionCard.tests.tsx
@@ -46,7 +46,7 @@ describe("HomeViewSectionCard", () => {
     `,
   })
 
-  it("renders the section properly", async () => {
+  it("renders the section properly and handles button press", async () => {
     renderWithRelay({
       HomeViewSectionCard: () => ({
         internalID: "home-view-section-a-single-card-section",

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionHeroUnits.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionHeroUnits.tests.tsx
@@ -95,6 +95,7 @@ describe("HomeViewSectionHeroUnits", () => {
     })
 
     fireEvent.press(screen.getByText("See Collection"))
+
     expect(navigate).toHaveBeenCalledWith("/collection/collection-1")
     expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
      [

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionMarketingCollections.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionMarketingCollections.tests.tsx
@@ -75,6 +75,13 @@ describe("HomeViewSectionMarketingCollections", () => {
     fireEvent.press(screen.getByText("Marketing Collections"))
 
     expect(navigate).toHaveBeenCalledWith("/collections")
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedCollectionGroup",
+      context_module: '<mock-value-for-field-"contextModule">',
+      context_screen_owner_type: "home",
+      destination_screen_owner_type: '<mock-value-for-field-"ownerType">',
+      type: "viewAll",
+    })
   })
 
   it("navigates and tracks clicks on an individual collection", () => {


### PR DESCRIPTION
This PR resolves [ONYX-1493] <!-- eg [PROJECT-XXXX] -->

### Description

This PR converts a few more `Touchable`s to `RouterLink` on the home view (to enable prefetching) and improves the test coverage for the updated components.

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Home view prefetching fix and improved test coverage - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1493]: https://artsyproduct.atlassian.net/browse/ONYX-1493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ