### PR TITLE
fix: make the header of the Favorites tab static

### DIFF
--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -1,4 +1,13 @@
-import { BellIcon, Flex, HeartIcon, MultiplePersonsIcon, Pill, Screen } from "@artsy/palette-mobile"
+import {
+  BellIcon,
+  Flex,
+  HeartIcon,
+  MultiplePersonsIcon,
+  Pill,
+  Screen,
+  Spacer,
+  Text,
+} from "@artsy/palette-mobile"
 import { PAGE_SIZE } from "app/Components/constants"
 import { AlertsTab } from "app/Scenes/Favorites/AlertsTab"
 import { alertsQuery } from "app/Scenes/Favorites/Components/Alerts"
@@ -52,27 +61,37 @@ const FavoritesHeader = () => {
   const { trackTappedNavigationTab } = useFavoritesTracking()
 
   return (
-    <Flex flexDirection="row" gap={0.5} mx={2} mb={2} mt={1}>
-      {Pills.map(({ Icon, title, key }) => {
-        const isActive = activeTab === key
-        return (
-          <Pill
-            selected={isActive}
-            onPress={() => {
-              setActiveTab(key)
-              trackTappedNavigationTab(key)
-            }}
-            Icon={() => (
-              <Flex mr={0.5} justifyContent="center" bottom="1px">
-                <Icon fill={isActive ? "white100" : "black100"} />
-              </Flex>
-            )}
-            key={key}
-          >
-            {title}
-          </Pill>
-        )
-      })}
+    <Flex mx={2}>
+      <Flex alignItems="flex-end">
+        <FavoritesLearnMore />
+        <Spacer y={2} />
+      </Flex>
+
+      <Text variant="xl">Favorites</Text>
+
+      <Spacer y={2} />
+      <Flex flexDirection="row" gap={0.5} mb={2}>
+        {Pills.map(({ Icon, title, key }) => {
+          const isActive = activeTab === key
+          return (
+            <Pill
+              selected={isActive}
+              onPress={() => {
+                setActiveTab(key)
+                trackTappedNavigationTab(key)
+              }}
+              Icon={() => (
+                <Flex mr={0.5} justifyContent="center" bottom="1px">
+                  <Icon fill={isActive ? "white100" : "black100"} />
+                </Flex>
+              )}
+              key={key}
+            >
+              {title}
+            </Pill>
+          )
+        })}
+      </Flex>
     </Flex>
   )
 }
@@ -93,15 +112,7 @@ export const FavoritesScreen: React.FC = () => {
 
   return (
     <Screen>
-      <Screen.AnimatedHeader
-        title="Favorites"
-        hideLeftElements
-        rightElements={<FavoritesLearnMore />}
-      />
-
-      <Screen.StickySubHeader title="Favorites" largeTitle separatorComponent={null}>
-        <FavoritesHeader />
-      </Screen.StickySubHeader>
+      <FavoritesHeader />
 
       <Screen.Body fullwidth>
         <Content />


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Addresses a [Notion card](https://www.notion.so/artsy/In-the-designs-there-is-no-stickiness-of-the-header-component-can-we-remove-so-just-to-have-stand-1cfcab0764a080bbb6bbd2d57d22e10f?pvs=4): In the designs, there is no stickiness of the header component – can we remove so just to have standard scroll

Making the header scrollable requires a lot of refactoring and the end performance might not be what we expect. Let's try out the static header, imo it looks better than the sticky header as it reduces the noice from additional animation and makes the screen look cleaner
 
<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

| Platform |  Video |
|---|---|
| Android | <video src="https://github.com/user-attachments/assets/415a6b55-4221-48e4-abce-b0f3b5cfa192" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/d00c6d96-0b07-4306-a081-546f824c253e" width="400" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- make the header of the Favorites tab static

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
