### PR TITLE
fix: sort order of artworks in other works tab

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
@@ -89,8 +89,12 @@ const fragment = graphql`
     cursor: { type: "String" }
     artistIDs: { type: "[String!]" }
   ) {
-    artworksConnection(first: $count, after: $cursor, artistIDs: $artistIDs)
-      @connection(key: "InfiniteDiscoveryMoreWorks_artworksConnection") {
+    artworksConnection(
+      first: $count
+      after: $cursor
+      artistIDs: $artistIDs
+      sort: "-decayed_merch"
+    ) @connection(key: "InfiniteDiscoveryMoreWorks_artworksConnection") {
       edges {
         node {
           ...ArtworkGridItem_artwork @arguments(includeAllImages: false)


### PR DESCRIPTION
This PR adds a sort order to the artworks listed in the "Other Works" tab of the bottom sheet in Discover Daily. This was necessary because we were seeing more sold or not-for-sale artworks appearing first.

| Before | After |
|--------|------|
| ![before](https://github.com/user-attachments/assets/8b645f69-0f14-42c3-834b-36f6347b9a04) | ![after](https://github.com/user-attachments/assets/87de87a3-6408-4dc9-a94c-150ced425f5d) |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixed sort order of artworks in Discover Daily other works tab

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
