### PR TITLE
fix: wrap payment banner in error handling

### DIFF
--- a/src/app/Scenes/HomeView/Components/HomeHeader.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeHeader.tsx
@@ -4,7 +4,6 @@ import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearch
 import { PaymentFailureBanner } from "app/Scenes/HomeView/Components/PaymentFailureBanner"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { Suspense } from "react"
 import { ActivityIndicator } from "./ActivityIndicator"
 
 export const HomeHeader: React.FC = () => {
@@ -15,12 +14,7 @@ export const HomeHeader: React.FC = () => {
 
   return (
     <Flex backgroundColor="background">
-      {!!showPaymentFailureBanner && (
-        <Suspense fallback={null}>
-          <PaymentFailureBanner />
-        </Suspense>
-      )}
-
+      {!!showPaymentFailureBanner && <PaymentFailureBanner />}
       <Flex pb={1} pt={2}>
         <Flex flexDirection="row" px={2} gap={1} justifyContent="space-around" alignItems="center">
           <Flex flex={1}>

--- a/src/app/Scenes/HomeView/Components/PaymentFailureBanner.tsx
+++ b/src/app/Scenes/HomeView/Components/PaymentFailureBanner.tsx
@@ -6,95 +6,104 @@ import { PaymentFailureBanner_Fragment$key } from "__generated__/PaymentFailureB
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { useCallback, useEffect } from "react"
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay"
 
-export const PaymentFailureBanner: React.FC = () => {
-  const tracking = useHomeViewTracking()
-  const isFocused = useIsFocused()
+export const PaymentFailureBanner: React.FC = withSuspense({
+  Component: () => {
+    const tracking = useHomeViewTracking()
+    const isFocused = useIsFocused()
 
-  const initialData = useLazyLoadQuery<PaymentFailureBannerQuery>(
-    graphql`
-      query PaymentFailureBannerQuery {
-        ...PaymentFailureBanner_Fragment
-      }
-    `,
-    {}
-  )
+    const initialData = useLazyLoadQuery<PaymentFailureBannerQuery>(
+      graphql`
+        query PaymentFailureBannerQuery {
+          ...PaymentFailureBanner_Fragment
+        }
+      `,
+      {}
+    )
 
-  const [data, refetch] = useRefetchableFragment<
-    PaymentFailureBannerRefetchQuery,
-    PaymentFailureBanner_Fragment$key
-  >(
-    graphql`
-      fragment PaymentFailureBanner_Fragment on Query
-      @refetchable(queryName: "PaymentFailureBannerRefetchQuery") {
-        commerceMyOrders(first: 10, filters: [PAYMENT_FAILED]) {
-          edges {
-            node {
-              code
-              internalID
+    const [data, refetch] = useRefetchableFragment<
+      PaymentFailureBannerRefetchQuery,
+      PaymentFailureBanner_Fragment$key
+    >(
+      graphql`
+        fragment PaymentFailureBanner_Fragment on Query
+        @refetchable(queryName: "PaymentFailureBannerRefetchQuery") {
+          commerceMyOrders(first: 10, filters: [PAYMENT_FAILED]) {
+            edges {
+              node {
+                code
+                internalID
+              }
             }
           }
         }
+      `,
+      initialData
+    )
+
+    useEffect(() => {
+      if (isFocused) {
+        refetch(
+          {},
+          {
+            fetchPolicy: "store-and-network",
+          }
+        )
       }
-    `,
-    initialData
-  )
+    }, [isFocused])
 
-  useEffect(() => {
-    if (isFocused) {
-      refetch(
-        {},
-        {
-          fetchPolicy: "store-and-network",
-        }
-      )
+    const failedPayments = extractNodes(data?.commerceMyOrders)
+
+    useEffect(() => {
+      if (failedPayments.length > 0) {
+        tracking.bannerViewed(failedPayments)
+      }
+    }, [failedPayments, tracking])
+
+    const handleBannerLinkClick = useCallback(() => {
+      tracking.tappedChangePaymentMethod(failedPayments)
+
+      const route =
+        failedPayments.length === 1
+          ? `orders/${failedPayments[0].internalID}/payment/new`
+          : `orders`
+
+      navigate(route)
+    }, [failedPayments, tracking])
+
+    if (failedPayments.length === 0) {
+      return null
     }
-  }, [isFocused])
 
-  const failedPayments = extractNodes(data?.commerceMyOrders)
+    const bannerText =
+      failedPayments.length === 1
+        ? "Payment failed for your recent order."
+        : "Payment failed for your recent orders."
 
-  useEffect(() => {
-    if (failedPayments.length > 0) {
-      tracking.bannerViewed(failedPayments)
-    }
-  }, [failedPayments, tracking])
+    const linkText =
+      failedPayments.length === 1
+        ? "Update payment method."
+        : "Update payment method for each order."
 
-  const handleBannerLinkClick = useCallback(() => {
-    tracking.tappedChangePaymentMethod(failedPayments)
-
-    const route =
-      failedPayments.length === 1 ? `orders/${failedPayments[0].internalID}/payment/new` : `orders`
-
-    navigate(route)
-  }, [failedPayments, tracking])
-
-  if (failedPayments.length === 0) {
-    return null
-  }
-
-  const bannerText =
-    failedPayments.length === 1
-      ? "Payment failed for your recent order."
-      : "Payment failed for your recent orders."
-
-  const linkText =
-    failedPayments.length === 1 ? "Update payment method." : "Update payment method for each order."
-
-  return (
-    <Banner data-testid="PaymentFailureBanner" variant="error" dismissable>
-      <Text textAlign="left" variant="xs" color="white100">
-        {bannerText}
-      </Text>
-      <LinkText
-        variant="xs"
-        textAlign="left"
-        color="white100"
-        onPress={() => handleBannerLinkClick()}
-      >
-        {linkText}
-      </LinkText>
-    </Banner>
-  )
-}
+    return (
+      <Banner data-testid="PaymentFailureBanner" variant="error" dismissable>
+        <Text textAlign="left" variant="xs" color="white100">
+          {bannerText}
+        </Text>
+        <LinkText
+          variant="xs"
+          textAlign="left"
+          color="white100"
+          onPress={() => handleBannerLinkClick()}
+        >
+          {linkText}
+        </LinkText>
+      </Banner>
+    )
+  },
+  LoadingFallback: () => null,
+  ErrorFallback: () => null,
+})


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Noticed some new unable to loads in prod:
https://artsynet.sentry.io/issues/6016955555/events/934702bec8a64c029c4983aa722f7228?environment=production&project=5867225&referrer=alert-rule-issue-list

 The payment failure banner did not have an error fallback resulting in unable to loads in the home screen. 

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/46df7c32-bffc-4313-96b4-4f5817cedddc" width="400" /> | <video src="https://github.com/user-attachments/assets/4ac83d8e-d4ef-4edf-8ac7-51a4aad3ece3" width="400" /> |








### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix payment banner unable to loads - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
