### PR TITLE
feat: improve favourites tab logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@react-native-google-signin/google-signin": "11.0.1",
     "@react-navigation/bottom-tabs": "7.3.3",
     "@react-navigation/elements": "2.3.1",
+    "@react-navigation/material-top-tabs": "7.2.10",
     "@react-navigation/native": "7.0.19",
     "@react-navigation/native-stack": "7.3.3",
     "@react-navigation/stack": "7.2.3",

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -109,7 +109,11 @@ const AppTabs: React.FC = () => {
           },
           tabBarHideOnKeyboard: true,
           tabBarIcon: ({ focused }) => {
-            return <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
+            return (
+              <Flex pt={1}>
+                <BottomTabsIcon tab={route.name} state={focused ? "active" : "inactive"} />
+              </Flex>
+            )
           },
           tabBarButton: (props) => (
             <PlatformPressable
@@ -125,7 +129,7 @@ const AppTabs: React.FC = () => {
                 alignItems="flex-end"
                 justifyContent="flex-end"
                 height={BOTTOM_TABS_HEIGHT}
-                pb={1}
+                pb={0.5}
               >
                 <Text variant="xxs" selectable={false} textAlign="center" color="black100">
                   {bottomTabsConfig[route.name].name}

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -243,6 +243,9 @@ export interface ViewOptions {
   // If this module should only be shown in one particular tab, name it here
   onlyShowInTabName?: BottomTabType
   screenOptions?: NativeStackNavigationOptions
+  // This route is part of a material top tab navigator
+  isTopTap?: boolean
+  topTabName?: string
 }
 // Default WebView Route Definition
 const webViewRoute = ({
@@ -545,6 +548,10 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
+      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
         headerShown: false,
       },
@@ -862,19 +869,6 @@ export const artsyDotNetRoutes = defineRoutes([
       },
     },
     queries: [featuredFairsScreenQuery],
-  },
-
-  {
-    path: "/favorites",
-    name: "Favorites",
-    Component: unsafe_getFeatureFlag("AREnableFavoritesTab") ? Favorites : LegacyFavorites,
-    options: {
-      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
-      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
-      screenOptions: {
-        headerShown: false,
-      },
-    },
   },
   {
     path: "/feature/:slug",
@@ -1379,10 +1373,26 @@ export const artsyDotNetRoutes = defineRoutes([
     queries: [SearchScreenQuery],
   },
   {
+    path: "/favorites",
+    name: "Favorites",
+    Component: unsafe_getFeatureFlag("AREnableFavoritesTab") ? Favorites : LegacyFavorites,
+    options: {
+      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      screenOptions: {
+        headerShown: false,
+      },
+    },
+  },
+  {
     path: "/favorites/alerts",
     name: "SavedSearchAlertsList",
     Component: SavedSearchAlertsListQueryRenderer,
     options: {
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "alerts" : undefined,
+      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
         headerShown: false,
       },
@@ -1412,10 +1422,30 @@ export const artsyDotNetRoutes = defineRoutes([
     },
   },
   {
+    path: "/favorites/follows",
+    name: "SavedArtworks",
+    Component: SavedArtworks,
+    options: {
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "follows" : undefined,
+      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      screenOptions: {
+        headerShown: false,
+      },
+    },
+    queries: [artworkListsQuery],
+    queryVariables: [artworkListVariables],
+  },
+  {
     path: "/favorites/saves",
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
+      isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
+      onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
         headerShown: false,
       },

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events"
-import { StackActions, TabActions } from "@react-navigation/native"
+import { CommonActions, StackActions, TabActions } from "@react-navigation/native"
 import { tabsTracks } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { modules } from "app/Navigation/utils/modules"
@@ -92,6 +92,15 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
       }
     } else {
       internal_navigationRef.current?.dispatch(StackActions.push(result.module, props))
+    }
+
+    const topTabName = module?.options?.topTabName
+    if (module.options?.isTopTap && topTabName) {
+      // We need to wait for the material top tab navigator to finish mounting
+      //  before we can navigate to it
+      setTimeout(() => {
+        internal_navigationRef.current?.dispatch(CommonActions.navigate(topTabName))
+      }, 200)
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,6 +3527,22 @@
   dependencies:
     color "^4.2.3"
 
+"@react-navigation/elements@^2.3.8":
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-2.3.8.tgz#ebf32b2f4540b5f6391a937e437ac7f4aed1f2d4"
+  integrity sha512-2ZVBtPfrkmOxzvIyDu3fPZ6aS4HcXL+TvzPDGa1znY2OP1Llo6wH14AmJHQFDquiInp2656hRMM1BkfJ3yPwew==
+  dependencies:
+    color "^4.2.3"
+
+"@react-navigation/material-top-tabs@7.2.10":
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-7.2.10.tgz#b1fd6a5350b5dcf236ffff4c4651570ebe9674a8"
+  integrity sha512-cMdCH4PZUK+HaLYrTjRJ5Ax9NO/QqXaxo9xEJBKvv6t8t2J0QSciJhmCRjSrEi8+NA9roXv42Z59mmdXtgqLww==
+  dependencies:
+    "@react-navigation/elements" "^2.3.8"
+    color "^4.2.3"
+    react-native-tab-view "^4.0.10"
+
 "@react-navigation/native-stack@7.3.3":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-7.3.3.tgz#0b05b5aea07088ce383ae1a553eb8761fc732b49"
@@ -13429,6 +13445,13 @@ react-native-svg@15.10.1:
     css-select "^5.1.0"
     css-tree "^1.1.3"
     warn-once "0.1.1"
+
+react-native-tab-view@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-4.0.10.tgz#5e11e4dd1a343cc17b17bc4d74c92d97367746cb"
+  integrity sha512-KU1ovavUURfKffqNn7F2jwgQ0tUSa2WosnHSztVYArCr22HP2nR7xHrd8DddFL4uenaT9KGXlNgx1IUPGUdZSw==
+  dependencies:
+    use-latest-callback "^0.2.1"
 
 react-native-url-polyfill@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR resolves [https://www.notion.so/artsy/The-Saves-quicklink-links-to-the-old-destination-1cfcab0764a080c58e03d3f77ece43a9?pvs=4] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates the tabs logic inside the favorites tab and fixes quick links navigation issues.

This PR brings a functionality that we wanted to have since always but were unfortunately unable to do. For a long time, we needed to inject the active tab as a prop, then within the screen, keep listening to navigation events, then after the screen is focused, we add a `useEffect` to go to a specific tab. This logic wasn't trivial to pull properly, and needed to be rewritten each time to be supported. 

**Now**, we will be able to not just navigate to those tabs by easily defining them in `routes.tsx` - and it should all magically work.
In my opinion, this work **should** be ported to every tab we have in the app, it will allow us as well to decouple further screens and support by default lazy loading and more advanced memory improvements. 

| Platform | Video | 
|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/47fdc756-a10f-48df-95b4-a348c013bbbe" width="400" /> |
| Andoird | <video src="https://github.com/user-attachments/assets/bdbd2d3d-dfc6-4f7b-9d43-3eb8d6410590" width="400" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- improve favorites tabs navigation logic - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
