### PR TITLE
feat: make header favorites tab header non sticky

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -243,9 +243,15 @@ export interface ViewOptions {
   // If this module should only be shown in one particular tab, name it here
   onlyShowInTabName?: BottomTabType
   screenOptions?: NativeStackNavigationOptions
+<<<<<<< HEAD
   topTabsNavigatorOptions?: {
     topTabName: string
   }
+=======
+  // This route is part of a material top tab navigator
+  isTopTap?: boolean
+  topTabName?: string
+>>>>>>> 227e444deb (feat: update top tabs logic)
 }
 // Default WebView Route Definition
 const webViewRoute = ({
@@ -548,11 +554,16 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
+<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "saves",
           }
         : undefined,
+=======
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
+>>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1392,11 +1403,16 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedSearchAlertsList",
     Component: SavedSearchAlertsListQueryRenderer,
     options: {
+<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "alerts",
           }
         : undefined,
+=======
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "alerts" : undefined,
+>>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1432,11 +1448,16 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
+<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "follows",
           }
         : undefined,
+=======
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "follows" : undefined,
+>>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1451,11 +1472,16 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
+<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "saves",
           }
         : undefined,
+=======
+      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
+      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
+>>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -243,15 +243,9 @@ export interface ViewOptions {
   // If this module should only be shown in one particular tab, name it here
   onlyShowInTabName?: BottomTabType
   screenOptions?: NativeStackNavigationOptions
-<<<<<<< HEAD
   topTabsNavigatorOptions?: {
     topTabName: string
   }
-=======
-  // This route is part of a material top tab navigator
-  isTopTap?: boolean
-  topTabName?: string
->>>>>>> 227e444deb (feat: update top tabs logic)
 }
 // Default WebView Route Definition
 const webViewRoute = ({
@@ -554,16 +548,11 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
-<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "saves",
           }
         : undefined,
-=======
-      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
-      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
->>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1403,16 +1392,11 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedSearchAlertsList",
     Component: SavedSearchAlertsListQueryRenderer,
     options: {
-<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "alerts",
           }
         : undefined,
-=======
-      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
-      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "alerts" : undefined,
->>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1448,16 +1432,11 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
-<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "follows",
           }
         : undefined,
-=======
-      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
-      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "follows" : undefined,
->>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {
@@ -1472,16 +1451,11 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "SavedArtworks",
     Component: SavedArtworks,
     options: {
-<<<<<<< HEAD
       topTabsNavigatorOptions: unsafe_getFeatureFlag("AREnableFavoritesTab")
         ? {
             topTabName: "saves",
           }
         : undefined,
-=======
-      isTopTap: unsafe_getFeatureFlag("AREnableFavoritesTab"),
-      topTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "saves" : undefined,
->>>>>>> 227e444deb (feat: update top tabs logic)
       isRootViewForTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       onlyShowInTabName: unsafe_getFeatureFlag("AREnableFavoritesTab") ? "favorites" : undefined,
       screenOptions: {

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -8,6 +8,7 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette-mobile"
+import { useScreenScrollContext } from "@artsy/palette-mobile/dist/elements/Screen/ScreenScrollContext"
 import {
   createMaterialTopTabNavigator,
   MaterialTopTabBarProps,
@@ -23,6 +24,7 @@ import { SavesTab } from "app/Scenes/Favorites/SavesTab"
 import { useFavoritesTracking } from "app/Scenes/Favorites/useFavoritesTracking"
 import { prefetchQuery } from "app/utils/queryPrefetching"
 import { useEffect } from "react"
+import Animated, { useAnimatedStyle } from "react-native-reanimated"
 
 const Pills: {
   Icon: React.FC<{ fill: string }>
@@ -49,52 +51,66 @@ const Pills: {
 const FavoritesHeaderTapBar: React.FC<MaterialTopTabBarProps> = ({ state, navigation }) => {
   const setActiveTab = FavoritesContextStore.useStoreActions((actions) => actions.setActiveTab)
   const { trackTappedNavigationTab } = useFavoritesTracking()
+  const { currentScrollYAnimated } = useScreenScrollContext()
 
   const activeRoute = state.routes[state.index].name
 
+  const animatedStyles = useAnimatedStyle(() => ({
+    height:
+      currentScrollYAnimated.value >= 150 ? 0 : 150 - Math.max(currentScrollYAnimated.value, 0),
+    transform: [
+      {
+        translateY:
+          currentScrollYAnimated.value >= 150 ? -150 : Math.min(-currentScrollYAnimated.value, 0),
+      },
+    ],
+  }))
+
   return (
-    <Flex mx={2}>
-      <Flex alignItems="flex-end" mb={2}>
-        <FavoritesLearnMore />
+    <Animated.View style={animatedStyles}>
+      <Flex mx={2}>
+        <Flex alignItems="flex-end" mb={2}>
+          <FavoritesLearnMore />
+        </Flex>
+
+        <Text variant="xl">Favorites</Text>
+
+        <Spacer y={2} />
+        <Flex flexDirection="row" gap={0.5} mb={2}>
+          {Pills.map(({ Icon, title, key }) => {
+            const isActive = activeRoute === key
+            return (
+              <Pill
+                selected={isActive}
+                onPress={() => {
+                  setActiveTab(key)
+
+                  // We are manually emitting the tabPress event here because
+                  // the navigation library doesn't emit it when we use the
+                  // navigation.navigate() method.
+                  navigation.emit({
+                    type: "tabPress",
+                    target: key,
+                    canPreventDefault: true,
+                  })
+
+                  navigation.navigate(key)
+                  trackTappedNavigationTab(key)
+                }}
+                Icon={() => (
+                  <Flex mr={0.5} justifyContent="center" bottom="1px">
+                    <Icon fill={isActive ? "white100" : "black100"} />
+                  </Flex>
+                )}
+                key={key}
+              >
+                {title}
+              </Pill>
+            )
+          })}
+        </Flex>
       </Flex>
-
-      <Text variant="xl">Favorites</Text>
-
-      <Spacer y={2} />
-      <Flex flexDirection="row" gap={0.5} mb={2}>
-        {Pills.map(({ Icon, title, key }) => {
-          const isActive = activeRoute === key
-          return (
-            <Pill
-              selected={isActive}
-              onPress={() => {
-                setActiveTab(key)
-
-                // We are manually emitting the tabPress event here because
-                // the navigation library doesn't emit it when we use the
-                // navigation.navigate() method.
-                navigation.emit({
-                  type: "tabPress",
-                  target: key,
-                  canPreventDefault: true,
-                })
-
-                navigation.navigate(key)
-                trackTappedNavigationTab(key)
-              }}
-              Icon={() => (
-                <Flex mr={0.5} justifyContent="center" bottom="1px">
-                  <Icon fill={isActive ? "white100" : "black100"} />
-                </Flex>
-              )}
-              key={key}
-            >
-              {title}
-            </Pill>
-          )
-        })}
-      </Flex>
-    </Flex>
+    </Animated.View>
   )
 }
 
@@ -123,6 +139,7 @@ export const Favorites = () => {
             screenOptions={{
               swipeEnabled: false,
             }}
+            initialRouteName="follows"
           >
             <FavoriteTopNavigator.Screen name="saves" navigationKey="saves" component={SavesTab} />
             <FavoriteTopNavigator.Screen

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -139,7 +139,6 @@ const Content = () => {
           screenOptions={{
             swipeEnabled: false,
           }}
-          initialRouteName="follows"
         >
           <FavoriteTopNavigator.Screen name="saves" navigationKey="saves" component={SavesTab} />
           <FavoriteTopNavigator.Screen

--- a/src/app/Scenes/Favorites/FavoritesContextStore.tsx
+++ b/src/app/Scenes/Favorites/FavoritesContextStore.tsx
@@ -4,12 +4,19 @@ export type FavoritesTab = "saves" | "follows" | "alerts"
 
 export interface FavoritesContextStoreModel {
   activeTab: FavoritesTab
+  headerHeight: number
+
   setActiveTab: Action<this, FavoritesTab>
+  setHeaderHeight: Action<this, number>
 }
 
 export const FavoritesContextStore = createContextStore<FavoritesContextStoreModel>({
   activeTab: "saves",
+  headerHeight: 0,
   setActiveTab: action((state, payload) => {
     state.activeTab = payload
+  }),
+  setHeaderHeight: action((state, payload) => {
+    state.headerHeight = payload
   }),
 })


### PR DESCRIPTION
This PR resolves [ONYX-1652] <!-- eg [PROJECT-XXXX] -->

### Description

This PR makes the favorites tab header non sticky. The idea is as follows:
- On initial render, measure the `headerHeight`
- Whenever the user scrolls, translate the content down or up based on the scroll position. 
  - **Here** the secret is to translate the **entire content of the screen**, instead of just the header. This way, the content and the header are **never out of sync** by design.

**What comes next?**
Bring the same approach (translating the entire content instead of just the header), to `StickySubHeader` and `AnimatedHeader` inside palette.

| Platform | Video |
|---|---|
| Android | <video src="https://github.com/user-attachments/assets/de914f32-28f6-4ec0-9a83-ab16927c6ee2" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/6c8b16ac-092c-45ee-9f8c-f9d1e30a62ab" width="400" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- make favorites tab header non sticky - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1652]: https://artsyproduct.atlassian.net/browse/ONYX-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ