### PR TITLE
fix: staging indicator on android

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -83,7 +83,7 @@ const AppTabs: React.FC = () => {
   )
 
   const stagingTabBarStyle = {
-    borderTopColor: color("devpurple"),
+    borderColor: color("devpurple"),
     borderTopWidth: 1,
   }
 
@@ -104,7 +104,6 @@ const AppTabs: React.FC = () => {
               currentRoute && modules[currentRoute as AppModule]?.options?.hidesBottomTabs
                 ? "none"
                 : "flex",
-
             ...(isStaging ? stagingTabBarStyle : {}),
           },
           tabBarHideOnKeyboard: true,


### PR DESCRIPTION
### Description

This PR fixes an issue with Android where the staging indicator isn't visible on android.

**Before**
<img src="https://github.com/user-attachments/assets/6bcbc543-f182-41ae-b4aa-462b92291050" width="400" />
___

**After**
<img width="765" alt="Screenshot 2025-04-14 at 10 41 14" src="https://github.com/user-attachments/assets/b1860b46-7435-4f56-bfe6-5261af11dab2" />



### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- show staging indicator - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
