### PR TITLE
fix: Make dark mode settings radio button pressable

### DIFF
--- a/src/app/Scenes/MyProfile/DarkModeSettings.tests.tsx
+++ b/src/app/Scenes/MyProfile/DarkModeSettings.tests.tsx
@@ -1,0 +1,91 @@
+import { RadioButton } from "@artsy/palette-mobile"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { GlobalStore, GlobalStoreProvider } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { DarkModeSettings } from "./DarkModeSettings"
+
+describe("DarkModeSettings", () => {
+  const TestWrapper = () => {
+    return (
+      <GlobalStoreProvider>
+        <DarkModeSettings />
+      </GlobalStoreProvider>
+    )
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // Reset to default state for each test
+    GlobalStore.actions.devicePrefs.setDarkModeOption("system")
+  })
+
+  it("renders dark mode settings options", () => {
+    renderWithWrappers(<TestWrapper />)
+
+    expect(screen.getByText("Sync with system")).toBeTruthy()
+    expect(screen.getByText("On")).toBeTruthy()
+    expect(screen.getByText("Off")).toBeTruthy()
+  })
+
+  it("shows correct initial state from GlobalStore", async () => {
+    GlobalStore.actions.devicePrefs.setDarkModeOption("on")
+    const { root } = renderWithWrappers(<TestWrapper />)
+
+    // The "On" option's radio button should be selected, not the others
+    const radioButtons = await root.findAllByType(RadioButton)
+    expect(radioButtons).toHaveLength(3)
+
+    expect(radioButtons[0].props.selected).toBe(false) // "Sync with system"
+    expect(radioButtons[1].props.selected).toBe(true) // "On"
+    expect(radioButtons[2].props.selected).toBe(false) // "Off"
+  })
+
+  it("changes dark mode option to 'on' when 'On' is pressed", () => {
+    const setDarkModeOptionSpy = jest.spyOn(GlobalStore.actions.devicePrefs, "setDarkModeOption")
+    renderWithWrappers(<TestWrapper />)
+
+    fireEvent.press(screen.getByText("On"))
+
+    expect(setDarkModeOptionSpy).toHaveBeenCalledWith("on")
+  })
+
+  it("changes dark mode option to 'off' when 'Off' is pressed", () => {
+    const setDarkModeOptionSpy = jest.spyOn(GlobalStore.actions.devicePrefs, "setDarkModeOption")
+    renderWithWrappers(<TestWrapper />)
+
+    fireEvent.press(screen.getByText("Off"))
+
+    expect(setDarkModeOptionSpy).toHaveBeenCalledWith("off")
+  })
+
+  it("changes dark mode option to 'system' when 'Sync with system' is pressed", () => {
+    // First set a different option so we can test changing back to system
+    GlobalStore.actions.devicePrefs.setDarkModeOption("off")
+    const setDarkModeOptionSpy = jest.spyOn(GlobalStore.actions.devicePrefs, "setDarkModeOption")
+
+    renderWithWrappers(<TestWrapper />)
+
+    fireEvent.press(screen.getByText("Sync with system"))
+
+    expect(setDarkModeOptionSpy).toHaveBeenCalledWith("system")
+  })
+
+  it("updates UI state when dark mode option changes", async () => {
+    const { root } = renderWithWrappers(<TestWrapper />)
+
+    // Initially "System" should be selected
+    let radioButtons = await root.findAllByType(RadioButton)
+    expect(radioButtons[0].props.selected).toBe(true) // "Sync with system"
+    expect(radioButtons[1].props.selected).toBe(false) // "On"
+    expect(radioButtons[2].props.selected).toBe(false) // "Off"
+
+    // Change selection to "On"
+    fireEvent.press(screen.getByText("On"))
+
+    // Now "On" should be selected
+    radioButtons = await root.findAllByType(RadioButton)
+    expect(radioButtons[0].props.selected).toBe(false) // "Sync with system"
+    expect(radioButtons[1].props.selected).toBe(true) // "On"
+    expect(radioButtons[2].props.selected).toBe(false) // "Off"
+  })
+})

--- a/src/app/Scenes/MyProfile/DarkModeSettings.tsx
+++ b/src/app/Scenes/MyProfile/DarkModeSettings.tsx
@@ -49,7 +49,7 @@ const RadioMenuItem: React.FC<{
           <Text variant="sm-display">{title}</Text>
         </Flex>
         <Flex width={40} alignItems="flex-end">
-          <RadioButton selected={selected} />
+          <RadioButton selected={selected} onPress={onPress} />
         </Flex>
       </Flex>
     </TouchableOpacity>


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Dark-mode-toggles-don-t-work-when-you-tap-the-radio-buttons-1d7cab0764a080b5afb2da3bdc34d3b4?pvs=4

### Description

This fix makes the radio button pressable on the dark mode settings screen.

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Make dark mode settings radio button pressable - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
