### PR TITLE
feat(DIA-1249): Multiple Artwork Images in InfiniteDiscovery

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -169,6 +169,10 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
       const rightThird = locationX > screenThird * 2
       const middleThird = !leftThird && !rightThird
 
+      // Check if the Swiper is actively swiping
+      // Note: We'll use a special technique that lets the gesture go through
+      // if it's a vertical swipe intended for the Swiper component
+
       // Handle image navigation in left/right thirds with single tap
       if (images.length > 1) {
         if (leftThird && currentImageIndex > 0) {
@@ -239,7 +243,21 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           </Animated.View>
 
           <Flex
-            onStartShouldSetResponderCapture={handleWrapperTaps}
+            // Only handle initial touches
+            onStartShouldSetResponder={(event) => {
+              // Let parent handle multi-touch gestures (like pinch zoom)
+              if (event.nativeEvent.touches && event.nativeEvent.touches.length > 1) {
+                return false
+              }
+              return true
+            }}
+            // But don't capture them from children
+            onStartShouldSetResponderCapture={() => false}
+            // Don't try to handle moves (let the Swiper handle them)
+            onMoveShouldSetResponder={() => false}
+            onMoveShouldSetResponderCapture={() => false}
+            // Handle taps on release
+            onResponderRelease={handleWrapperTaps}
             style={{
               position: "absolute",
               width: "100%",

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -13,6 +13,7 @@ import {
 import { InfiniteDiscoveryArtworkCard_artwork$key } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { GlobalStore } from "app/store/GlobalStore"
 import {
   PROGRESSIVE_ONBOARDING_INFINITE_DISCOVERY_SAVE_REMINDER_1,
@@ -142,8 +143,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     }
 
     const MAX_ARTWORK_HEIGHT = screenHeight * 0.55
-    // Define pagination dots height to subtract from available image height
-    const PAGINATION_DOTS_HEIGHT = 20
 
     const images = artwork.images || []
     const selectedImage = images[currentImageIndex]
@@ -151,10 +150,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     const width = selectedImage?.width ?? 0
     const height = selectedImage?.height ?? 0
 
-    // Adjust available height for image to account for pagination dots when multiple images exist
-    const imageMaxHeight =
-      images.length > 1 ? MAX_ARTWORK_HEIGHT - PAGINATION_DOTS_HEIGHT : MAX_ARTWORK_HEIGHT
-    const size = sizeToFit({ width, height }, { width: screenWidth, height: imageMaxHeight })
+    const size = sizeToFit({ width, height }, { width: screenWidth, height: MAX_ARTWORK_HEIGHT })
 
     const handleWrapperTaps = (event: GestureResponderEvent) => {
       const now = Date.now()
@@ -266,21 +262,21 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           />
 
           {!!src && <Image src={src} height={size.height} width={size.width} />}
-
-          {/* Show pagination bars when there are multiple images */}
-          {images.length > 1 && (
-            <Flex
-              mt={1}
-              px={2}
-              height={PAGINATION_DOTS_HEIGHT}
-              alignItems="center"
-              justifyContent="center"
-              width="100%"
-            >
-              <PaginationBars currentIndex={currentImageIndex} length={images.length} />
-            </Flex>
-          )}
         </Flex>
+
+        {/* Show pagination bars when there are multiple images */}
+        {images.length > 1 && (
+          <Flex
+            pt={2}
+            px={1}
+            height={PAGINATION_BAR_HEIGHT}
+            alignItems="center"
+            justifyContent="center"
+            width="100%"
+          >
+            <PaginationBars currentIndex={currentImageIndex} length={images.length} />
+          </Flex>
+        )}
         <Flex flexDirection="row" justifyContent="space-between" p={2} gap={1}>
           <Flex flex={1}>
             {/* TODO: remove this when we are done with the infinite discovery */}
@@ -362,31 +358,6 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     )
   }
 )
-
-// Custom pagination bars for InfiniteDiscoveryArtworkCard
-interface PaginationBarsProps {
-  currentIndex: number
-  length: number
-}
-
-const PaginationBars: React.FC<PaginationBarsProps> = ({ currentIndex, length }) => {
-  const color = useColor()
-
-  return (
-    <Flex width="100%" flexDirection="row" justifyContent="space-between">
-      {Array.from(Array(length)).map((_, index) => (
-        <Flex
-          key={index}
-          height={1}
-          flex={1}
-          mx={0.5}
-          backgroundColor={currentIndex === index ? color("black60") : color("black10")}
-        />
-      ))}
-    </Flex>
-  )
-}
-
 const FIRST_REMINDER_SWIPES_COUNT = 4
 const SECOND_REMINDER_SWIPES_COUNT = 29
 
@@ -472,3 +443,4 @@ const infiniteDiscoveryArtworkCardFragment = graphql`
 const HEART_ICON_SIZE = 18
 const HEART_CIRCLE_SIZE = 50
 const SAVE_BUTTON_WIDTH = 105
+const PAGINATION_BAR_HEIGHT = 12

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -13,6 +13,7 @@ import {
 import { InfiniteDiscoveryArtworkCard_artwork$key } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { PaginationDots } from "app/Components/PaginationDots"
 import { GlobalStore } from "app/store/GlobalStore"
 import {
   PROGRESSIVE_ONBOARDING_INFINITE_DISCOVERY_SAVE_REMINDER_1,
@@ -63,6 +64,9 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
       infiniteDiscoveryArtworkCardFragment,
       artworkProp
     )
+
+    // State to track the current image index
+    const [currentImageIndex, setCurrentImageIndex] = useState(0)
 
     const { isSaved: isSavedToArtworkList, saveArtworkToLists } = useSaveArtworkToArtworkLists({
       artworkFragmentRef: artwork,
@@ -139,12 +143,19 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     }
 
     const MAX_ARTWORK_HEIGHT = screenHeight * 0.55
+    // Define pagination dots height to subtract from available image height
+    const PAGINATION_DOTS_HEIGHT = 20
 
-    const src = artwork.images?.[0]?.url
-    const width = artwork.images?.[0]?.width ?? 0
-    const height = artwork.images?.[0]?.height ?? 0
+    const images = artwork.images || []
+    const selectedImage = images[currentImageIndex]
+    const src = selectedImage?.url
+    const width = selectedImage?.width ?? 0
+    const height = selectedImage?.height ?? 0
 
-    const size = sizeToFit({ width, height }, { width: screenWidth, height: MAX_ARTWORK_HEIGHT })
+    // Adjust available height for image to account for pagination dots when multiple images exist
+    const imageMaxHeight =
+      images.length > 1 ? MAX_ARTWORK_HEIGHT - PAGINATION_DOTS_HEIGHT : MAX_ARTWORK_HEIGHT
+    const size = sizeToFit({ width, height }, { width: screenWidth, height: imageMaxHeight })
 
     const handleWrapperTaps = () => {
       const now = Date.now()
@@ -210,6 +221,18 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           />
 
           {!!src && <Image src={src} height={size.height} width={size.width} />}
+
+          {/* Show pagination dots when there are multiple images */}
+          {images.length > 1 && (
+            <Flex
+              mt={1}
+              height={PAGINATION_DOTS_HEIGHT}
+              alignItems="center"
+              justifyContent="center"
+            >
+              <PaginationDots currentIndex={currentImageIndex} length={images.length} />
+            </Flex>
+          )}
         </Flex>
         <Flex flexDirection="row" justifyContent="space-between" p={2} gap={1}>
           <Flex flex={1}>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -13,7 +13,6 @@ import {
 import { InfiniteDiscoveryArtworkCard_artwork$key } from "__generated__/InfiniteDiscoveryArtworkCard_artwork.graphql"
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
-import { PaginationDots } from "app/Components/PaginationDots"
 import { GlobalStore } from "app/store/GlobalStore"
 import {
   PROGRESSIVE_ONBOARDING_INFINITE_DISCOVERY_SAVE_REMINDER_1,
@@ -268,15 +267,17 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
           {!!src && <Image src={src} height={size.height} width={size.width} />}
 
-          {/* Show pagination dots when there are multiple images */}
+          {/* Show pagination bars when there are multiple images */}
           {images.length > 1 && (
             <Flex
               mt={1}
+              px={2}
               height={PAGINATION_DOTS_HEIGHT}
               alignItems="center"
               justifyContent="center"
+              width="100%"
             >
-              <PaginationDots currentIndex={currentImageIndex} length={images.length} />
+              <PaginationBars currentIndex={currentImageIndex} length={images.length} />
             </Flex>
           )}
         </Flex>
@@ -361,6 +362,30 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     )
   }
 )
+
+// Custom pagination bars for InfiniteDiscoveryArtworkCard
+interface PaginationBarsProps {
+  currentIndex: number
+  length: number
+}
+
+const PaginationBars: React.FC<PaginationBarsProps> = ({ currentIndex, length }) => {
+  const color = useColor()
+
+  return (
+    <Flex width="100%" flexDirection="row" justifyContent="space-between">
+      {Array.from(Array(length)).map((_, index) => (
+        <Flex
+          key={index}
+          height={1}
+          flex={1}
+          mx={0.5}
+          backgroundColor={currentIndex === index ? color("black60") : color("black10")}
+        />
+      ))}
+    </Flex>
+  )
+}
 
 const FIRST_REMINDER_SWIPES_COUNT = 4
 const SECOND_REMINDER_SWIPES_COUNT = 29

--- a/src/app/Scenes/InfiniteDiscovery/Components/PaginationBars.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/PaginationBars.tsx
@@ -1,0 +1,25 @@
+import { Flex, useColor } from "@artsy/palette-mobile"
+import React from "react"
+
+interface PaginationBarsProps {
+  currentIndex: number
+  length: number
+}
+
+export const PaginationBars: React.FC<PaginationBarsProps> = ({ currentIndex, length }) => {
+  const color = useColor()
+
+  return (
+    <Flex width="100%" flexDirection="row" justifyContent="space-between">
+      {Array.from(Array(length)).map((_, index) => (
+        <Flex
+          key={index}
+          height={1}
+          flex={1}
+          mx={0.5}
+          backgroundColor={currentIndex === index ? color("black60") : color("black15")}
+        />
+      ))}
+    </Flex>
+  )
+}

--- a/src/app/Scenes/InfiniteDiscovery/Components/PaginationBars.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/PaginationBars.tsx
@@ -17,7 +17,7 @@ export const PaginationBars: React.FC<PaginationBarsProps> = ({ currentIndex, le
           height={1}
           flex={1}
           mx={0.5}
-          backgroundColor={currentIndex === index ? color("black60") : color("black15")}
+          backgroundColor={currentIndex === index ? color("mono60") : color("mono15")}
         />
       ))}
     </Flex>


### PR DESCRIPTION
### Summary

- Adds support for viewing and navigating between multiple artwork images in Discover Daily cards
- Adds horizontal bars indicator showing current image position
- Adds left/right tap navigation while preserving double-tap to save

### Implementation Details

- Created a dedicated PaginationBars component for consistent image navigation UI
- Added tap gesture handling to navigate through multiple images when tapping left/right sides of artwork
- Preserved existing double-tap to save functionality in the middle portion of artwork
- Fixed touch handling to avoid conflicts with existing card swipe gestures
- Added haptic feedback for better user experience when changing images


### Screenshots

https://github.com/user-attachments/assets/acd0d6f6-c85d-4524-894b-c1b61abacbd1

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Adds support for viewing and navigating between multiple artwork images in Discover Daily cards

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>