### PR TITLE
fix(tests): after merging AREnableFavoritesTab

### DIFF
--- a/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileHeader.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyProfileHeaderTestQuery } from "__generated__/MyProfileHeaderTestQuery.graphql"
 import { MyProfileHeader } from "app/Scenes/MyProfile/MyProfileHeader"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -27,7 +28,55 @@ describe("MyProfileHeader", () => {
     expect(navigate).toHaveBeenCalledWith("/my-profile/edit")
   })
 
-  describe("settings screen", () => {
+  describe("with AREnableFavoritesTab feature flag disabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableFavoritesTab: false })
+    })
+
+    describe("settings screen", () => {
+      it("renders settings screen", async () => {
+        renderWithRelay({
+          Me: () => ({
+            name: "Collector Collectorson",
+            location: {
+              display: "The Shire, Farthing",
+            },
+            counts: {
+              followedArtists: 1,
+              savedArtworks: 2,
+              savedSearches: 3,
+            },
+          }),
+        })
+
+        expect(screen.getByText("The Shire, Farthing")).toBeOnTheScreen()
+        expect(screen.getByText("1")).toBeOnTheScreen()
+        expect(screen.getByText("Follow")).toBeOnTheScreen()
+        expect(screen.getByText("2")).toBeOnTheScreen()
+        expect(screen.getByText("Saves")).toBeOnTheScreen()
+        expect(screen.getByText("3")).toBeOnTheScreen()
+        expect(screen.getByText("Alerts")).toBeOnTheScreen()
+      })
+
+      it("navigates to the other screens from the links", () => {
+        renderWithRelay()
+
+        fireEvent.press(screen.getByText("Follows"))
+        expect(navigate).toHaveBeenLastCalledWith("favorites")
+
+        fireEvent.press(screen.getByText("Saves"))
+        expect(navigate).toHaveBeenLastCalledWith("favorites/saves")
+
+        fireEvent.press(screen.getByText("Alerts"))
+        expect(navigate).toHaveBeenLastCalledWith("favorites/alerts")
+      })
+    })
+  })
+
+  describe("with AREnableFavoritesTab feature flag enabled", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableFavoritesTab: true })
+    })
     it("renders settings screen", async () => {
       renderWithRelay({
         Me: () => ({
@@ -44,25 +93,12 @@ describe("MyProfileHeader", () => {
       })
 
       expect(screen.getByText("The Shire, Farthing")).toBeOnTheScreen()
-      expect(screen.getByText("1")).toBeOnTheScreen()
-      expect(screen.getByText("Follow")).toBeOnTheScreen()
-      expect(screen.getByText("2")).toBeOnTheScreen()
-      expect(screen.getByText("Saves")).toBeOnTheScreen()
-      expect(screen.getByText("3")).toBeOnTheScreen()
-      expect(screen.getByText("Alerts")).toBeOnTheScreen()
-    })
-
-    it("navigates to the other screens from the links", () => {
-      renderWithRelay()
-
-      fireEvent.press(screen.getByText("Follows"))
-      expect(navigate).toHaveBeenLastCalledWith("favorites")
-
-      fireEvent.press(screen.getByText("Saves"))
-      expect(navigate).toHaveBeenLastCalledWith("favorites/saves")
-
-      fireEvent.press(screen.getByText("Alerts"))
-      expect(navigate).toHaveBeenLastCalledWith("favorites/alerts")
+      expect(screen.queryByText("1")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Follow")).not.toBeOnTheScreen()
+      expect(screen.queryByText("2")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Saves")).not.toBeOnTheScreen()
+      expect(screen.queryByText("3")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Alerts")).not.toBeOnTheScreen()
     })
   })
 })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes the tests in main eigen that were broken due to enabling the flag in echo.

Surprised that the `run-eigen-tests` test job didn't catch that but it was probably due to having `AREnableFavoritesTab` duplicate in echo for a bit with both false and true values.


#nochangelog