### PR TITLE
build(deps): bump react-native-clipboard to latest version

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1955,7 +1955,7 @@ PODS:
     - React-Core
   - RNCAsyncStorage (2.1.2):
     - React-Core
-  - RNCClipboard (1.14.1):
+  - RNCClipboard (1.16.2):
     - React-Core
   - RNDeviceInfo (14.0.0):
     - React-Core
@@ -2933,7 +2933,7 @@ SPEC CHECKSUMS:
   RNAppleAuthentication: 98f367520bd647ea4c094dc3e133106ac523798a
   RNBootSplash: c7b7beb415eed621671ccf17c8c0e7888c84243b
   RNCAsyncStorage: b9f5f78da5d16a853fe3dc22e8268d932fc45a83
-  RNCClipboard: 4598dae0fe33e2aa130d9d213e2007be78310266
+  RNCClipboard: e1d17c9d093d8129ef50b39b63a17a0e8ccd0ade
   RNDeviceInfo: f632df5f5d9262794c03eac265e4a0f6dbb14f0a
   RNFastImage: 118468000fe3eed2a8267e610351b0291024dc28
   RNFlashList: 38e63c7f8e9ce22f765ce9b381ea8f7ced3cb88c

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@kesha-antonov/react-native-action-cable": "1.1.4",
     "@ptomasroos/react-native-multi-slider": "2.2.2",
     "@react-native-async-storage/async-storage": "2.1.2",
-    "@react-native-clipboard/clipboard": "1.14.1",
+    "@react-native-clipboard/clipboard": "1.16.2",
     "@react-native-community/geolocation": "3.0.6",
     "@react-native-community/netinfo": "11.3.2",
     "@react-native-cookies/cookies": "6.0.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3081,10 +3081,10 @@
   dependencies:
     merge-options "^3.0.4"
 
-"@react-native-clipboard/clipboard@1.14.1":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.14.1.tgz#835f82fc86881a0808a8405f2576617bb5383554"
-  integrity sha512-SM3el0A28SwoeJljVNhF217o0nI4E7RfalLmuRQcT1/7tGcxUjgFa3jyrEndYUct8/uxxK5EUNGUu1YEDqzxqw==
+"@react-native-clipboard/clipboard@1.16.2":
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/@react-native-clipboard/clipboard/-/clipboard-1.16.2.tgz#d8517eea937d336b8fe1ca44e955e691d27f5ba4"
+  integrity sha512-VqUYwVxo7DyHMz7v2LxLMaAOSu3pKFvzpqR4jQezdH0VyaudILTTcUf7dR4TroARU/lLkTU8nZA11UniTvGVXg==
 
 "@react-native-community/cli-clean@15.0.1":
   version "15.0.1"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps `react-native-clipboard` to latest


#nochangelog