### PR TITLE
spike: discover tab experiment

### DIFF
--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -10,10 +10,11 @@ import { GlobalSearchInput } from "app/Components/GlobalSearchInput/GlobalSearch
 import { SearchPills } from "app/Scenes/Search/SearchPills"
 import { useRefetchWhenQueryChanged } from "app/Scenes/Search/useRefetchWhenQueryChanged"
 import { useSearchQuery } from "app/Scenes/Search/useSearchQuery"
+import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
 import { Schema } from "app/utils/track"
-import { memo, Suspense, useEffect, useRef, useState } from "react"
-import { KeyboardAvoidingView, Platform, ScrollView } from "react-native"
+import React, { memo, Suspense, useEffect, useRef, useState } from "react"
+import { KeyboardAvoidingView, Platform, ScrollView, Text, View } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -41,6 +42,28 @@ export const searchQueryDefaultVariables: SearchQuery$variables = {
 }
 
 export const Search: React.FC = () => {
+  const { variant, trackExperiment } = useExperimentVariant("diamond_discover-tab")
+
+  trackExperiment({
+    context_owner_type: OwnerType.search,
+  })
+
+  if (variant.enabled) {
+    if (variant.name === "control") {
+      return <LegacySearch />
+    } else if (variant.name === "variant-a") {
+      return (
+        <View>
+          <Text>Hello, World</Text>
+        </View>
+      )
+    }
+  }
+
+  return <LegacySearch />
+}
+
+export const LegacySearch: React.FC = () => {
   const searchPillsRef = useRef<ScrollView>(null)
   const [searchQuery, setSearchQuery] = useState<string>("")
   const [selectedPill, setSelectedPill] = useState<PillType>(TOP_PILL)

--- a/src/app/system/flags/experiments.ts
+++ b/src/app/system/flags/experiments.ts
@@ -5,6 +5,10 @@ export type ExperimentDescriptor = {
 }
 
 export const experiments = {
+  "diamond_discover-tab": {
+    description: "Discover tab experiment",
+    variantSuggestions: ["control", "variant-a"],
+  },
   "eigen-new-works-for-you-recommendations-model": {
     description: "value controlling which model to use for new works for you recs",
   },


### PR DESCRIPTION
This is a PR to document how to set up an A/B test experiment with the tooling that's available.

| Text | Screenshot |
|-----|-----|
| Testers can choose which variant they are seeing by accessing the Experiments section in the Dev Menu. Note that tracking events are not fired when users have chosen a variant themselves. | ![Simulator Screenshot - iPhone 16 Plus - 2025-04-22 at 10 25 06](https://github.com/user-attachments/assets/8d9298cf-2cad-4756-83e5-a393ad648997) |
| To hide home view sections in Metaphysics, we can follow this pattern. Remember to pass the user's ID so that the same variant is used in Eigen. | <img width="1193" alt="Screenshot 2025-04-22 at 12 07 15 PM" src="https://github.com/user-attachments/assets/0fa5c15b-1d40-4117-946f-badb61e836d8" /> |

