### PR TITLE
fix: removed additional triggered home view event

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -21,7 +21,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useIsStaging } from "app/utils/hooks/useIsStaging"
 import { postEventToProviders } from "app/utils/track/providers"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { InteractionManager, Platform } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
@@ -56,10 +56,6 @@ const AppTabs: React.FC = () => {
   const insets = useSafeAreaInsets()
 
   const selectedTab = GlobalStore.useAppState((state) => state.bottomTabs.sessionState.selectedTab)
-
-  useEffect(() => {
-    postEventToProviders(tabsTracks.tabScreenView(selectedTab))
-  }, [])
 
   const handleTabPress = useCallback(
     (e) => {

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -1,6 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Screen, Spinner } from "@artsy/palette-mobile"
 import { PortalHost } from "@gorhom/portal"
+import { useFocusEffect } from "@react-navigation/native"
 import * as Sentry from "@sentry/react-native"
 import { HomeViewFetchMeQuery } from "__generated__/HomeViewFetchMeQuery.graphql"
 import { HomeViewQuery } from "__generated__/HomeViewQuery.graphql"
@@ -14,6 +15,7 @@ import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
 import { HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewExperimentTracking } from "app/Scenes/HomeView/hooks/useHomeViewExperimentTracking"
+import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
@@ -28,7 +30,7 @@ import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import { requestPushNotificationsPermission } from "app/utils/requestPushNotificationsPermission"
 import { useMaybePromptForReview } from "app/utils/useMaybePromptForReview"
-import { memo, RefObject, Suspense, useEffect, useState } from "react"
+import { memo, RefObject, Suspense, useCallback, useEffect, useState } from "react"
 import { FlatList, Linking, RefreshControl, StatusBar } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
@@ -85,6 +87,7 @@ export const HomeView: React.FC = memo(() => {
 
   const prefetchUrl = usePrefetch()
   useHomeViewExperimentTracking(queryData.homeView?.experiments)
+  const tracking = useHomeViewTracking()
 
   useMaybePromptForReview({ contextModule: ContextModule.tabBar, contextOwnerType: OwnerType.home })
 
@@ -105,6 +108,12 @@ export const HomeView: React.FC = memo(() => {
   useEffect(() => {
     requestPushNotificationsPermission()
   }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      tracking.screen(OwnerType.home)
+    }, [])
+  )
 
   const fetchSavedArtworksCount = async () => {
     fetchQuery<HomeViewFetchMeQuery>(

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -109,11 +109,13 @@ export const HomeView: React.FC = memo(() => {
     requestPushNotificationsPermission()
   }, [])
 
-  useFocusEffect(
-    useCallback(() => {
-      tracking.screen(OwnerType.home)
-    }, [])
-  )
+  const trackHomeScreenView = useCallback(() => {
+    tracking.screen(OwnerType.home)
+  }, [tracking])
+
+  useFocusEffect(() => {
+    trackHomeScreenView()
+  })
 
   const fetchSavedArtworksCount = async () => {
     fetchQuery<HomeViewFetchMeQuery>(


### PR DESCRIPTION
### Description

This PR fixes an issue with tracking that came after https://github.com/artsy/eigen/pull/11727

The problem was that we record the home tracking event, regardless of not seeing the home view.  

https://github.com/user-attachments/assets/2e104f89-049f-4c3b-ace6-95755b22cf5e



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix: removed additional triggered home view event - mounir, leo

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
