### PR TITLE
feat: update notifications screen to use new UI

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -136,7 +136,10 @@ import { MyAccountDeleteAccountQueryRenderer } from "app/Scenes/MyAccount/MyAcco
 import { MyAccountEditEmailQueryRenderer } from "app/Scenes/MyAccount/MyAccountEditEmail"
 import { MyAccountEditPassword } from "app/Scenes/MyAccount/MyAccountEditPassword"
 import { MyAccountEditPhoneQueryRenderer } from "app/Scenes/MyAccount/MyAccountEditPhone"
-import { MyAccountEditPriceRangeQueryRenderer } from "app/Scenes/MyAccount/MyAccountEditPriceRange"
+import {
+  myAccountEditPriceRangeQuery,
+  MyAccountEditPriceRangeQueryRenderer,
+} from "app/Scenes/MyAccount/MyAccountEditPriceRange"
 import {
   MyCollectionQueryRenderer,
   MyCollectionScreenQuery,
@@ -165,7 +168,10 @@ import {
   MyProfilePaymentScreenQuery,
 } from "app/Scenes/MyProfile/MyProfilePayment"
 import { MyProfilePaymentNewCreditCard } from "app/Scenes/MyProfile/MyProfilePaymentNewCreditCard"
-import { MyProfilePreferencesQueryRenderer } from "app/Scenes/MyProfile/MyProfilePreferences"
+import {
+  myProfilePreferencesQuery,
+  MyProfilePreferencesQueryRenderer,
+} from "app/Scenes/MyProfile/MyProfilePreferences"
 import { MyProfilePrivacy } from "app/Scenes/MyProfile/MyProfilePrivacy"
 import { MyProfilePushNotificationsQueryRenderer } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
@@ -1046,6 +1052,7 @@ export const artsyDotNetRoutes = defineRoutes([
     path: "/my-account/edit-price-range",
     name: "MyAccountEditPriceRange",
     Component: MyAccountEditPriceRangeQueryRenderer,
+    queries: [myAccountEditPriceRangeQuery],
     options: {
       screenOptions: {
         headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
@@ -1220,6 +1227,7 @@ export const artsyDotNetRoutes = defineRoutes([
     path: "/my-profile/preferences",
     name: "MyProfilePreferences",
     Component: MyProfilePreferencesQueryRenderer,
+    queries: [myProfilePreferencesQuery],
     options: {
       screenOptions: {
         headerShown: false,

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -168,6 +168,7 @@ import { MyProfilePaymentNewCreditCard } from "app/Scenes/MyProfile/MyProfilePay
 import { MyProfilePreferencesQueryRenderer } from "app/Scenes/MyProfile/MyProfilePreferences"
 import { MyProfilePushNotificationsQueryRenderer } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
+import { MyProfileTermsAndConditions } from "app/Scenes/MyProfile/MyProfileTermsAndConditions"
 import { NewWorksForYouQueryRenderer } from "app/Scenes/NewWorksForYou/NewWorksForYou"
 import { NewWorksFromGalleriesYouFollowScreenQuery } from "app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow"
 import { NewWorksFromGalleriesYouFollowScreen } from "app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow"
@@ -1235,6 +1236,16 @@ export const artsyDotNetRoutes = defineRoutes([
     },
   },
   {
+    path: "/my-profile/terms-and-conditions",
+    name: "MyProfileTermsAndConditions",
+    Component: MyProfileTermsAndConditions,
+    options: {
+      screenOptions: {
+        headerShown: false,
+      },
+    },
+  },
+  {
     path: "/news",
     name: "News",
     Component: NewsScreen,
@@ -1670,6 +1681,12 @@ export const artsyDotNetRoutes = defineRoutes([
   }),
   webViewRoute({
     path: "/terms",
+    config: {
+      alwaysPresentModally: true,
+    },
+  }),
+  webViewRoute({
+    path: "/supplemental-cos",
     config: {
       alwaysPresentModally: true,
     },

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -1207,6 +1207,7 @@ export const artsyDotNetRoutes = defineRoutes([
     Component: MyProfilePushNotificationsQueryRenderer,
     options: {
       screenOptions: {
+        headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
         headerTitle: "Push Notifications",
       },
     },

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -165,7 +165,7 @@ import {
   MyProfilePaymentScreenQuery,
 } from "app/Scenes/MyProfile/MyProfilePayment"
 import { MyProfilePaymentNewCreditCard } from "app/Scenes/MyProfile/MyProfilePaymentNewCreditCard"
-import { MyProfilePreferences } from "app/Scenes/MyProfile/MyProfilePreferences"
+import { MyProfilePreferencesQueryRenderer } from "app/Scenes/MyProfile/MyProfilePreferences"
 import { MyProfilePushNotificationsQueryRenderer } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
 import { NewWorksForYouQueryRenderer } from "app/Scenes/NewWorksForYou/NewWorksForYou"
@@ -1046,6 +1046,7 @@ export const artsyDotNetRoutes = defineRoutes([
     Component: MyAccountEditPriceRangeQueryRenderer,
     options: {
       screenOptions: {
+        headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
         headerTitle: "Price Range",
       },
     },
@@ -1216,7 +1217,7 @@ export const artsyDotNetRoutes = defineRoutes([
   {
     path: "/my-profile/preferences",
     name: "MyProfilePreferences",
-    Component: MyProfilePreferences,
+    Component: MyProfilePreferencesQueryRenderer,
     options: {
       screenOptions: {
         headerShown: false,
@@ -1505,6 +1506,7 @@ export const artsyDotNetRoutes = defineRoutes([
     Component: DarkModeSettings,
     options: {
       screenOptions: {
+        headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
         headerTitle: "Dark Mode",
       },
     },

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -165,6 +165,7 @@ import {
   MyProfilePaymentScreenQuery,
 } from "app/Scenes/MyProfile/MyProfilePayment"
 import { MyProfilePaymentNewCreditCard } from "app/Scenes/MyProfile/MyProfilePaymentNewCreditCard"
+import { MyProfilePreferences } from "app/Scenes/MyProfile/MyProfilePreferences"
 import { MyProfilePushNotificationsQueryRenderer } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
 import { NewWorksForYouQueryRenderer } from "app/Scenes/NewWorksForYou/NewWorksForYou"
@@ -1209,6 +1210,16 @@ export const artsyDotNetRoutes = defineRoutes([
       screenOptions: {
         headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
         headerTitle: "Push Notifications",
+      },
+    },
+  },
+  {
+    path: "/my-profile/preferences",
+    name: "MyProfilePreferences",
+    Component: MyProfilePreferences,
+    options: {
+      screenOptions: {
+        headerShown: false,
       },
     },
   },

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -166,6 +166,7 @@ import {
 } from "app/Scenes/MyProfile/MyProfilePayment"
 import { MyProfilePaymentNewCreditCard } from "app/Scenes/MyProfile/MyProfilePaymentNewCreditCard"
 import { MyProfilePreferencesQueryRenderer } from "app/Scenes/MyProfile/MyProfilePreferences"
+import { MyProfilePrivacy } from "app/Scenes/MyProfile/MyProfilePrivacy"
 import { MyProfilePushNotificationsQueryRenderer } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
 import { MyProfileTermsAndConditions } from "app/Scenes/MyProfile/MyProfileTermsAndConditions"
@@ -1236,6 +1237,16 @@ export const artsyDotNetRoutes = defineRoutes([
     },
   },
   {
+    path: "/my-profile/privacy",
+    name: "MyProfilePrivacy",
+    Component: MyProfilePrivacy,
+    options: {
+      screenOptions: {
+        headerShown: false,
+      },
+    },
+  },
+  {
     path: "/my-profile/terms-and-conditions",
     name: "MyProfileTermsAndConditions",
     Component: MyProfileTermsAndConditions,
@@ -1371,6 +1382,7 @@ export const artsyDotNetRoutes = defineRoutes([
     Component: PrivacyRequest,
     options: {
       screenOptions: {
+        headerShown: !unsafe_getFeatureFlag("AREnableRedesignedSettings"),
         headerTitle: "Personal Data Request",
       },
     },

--- a/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tests.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tests.tsx
@@ -3,12 +3,9 @@ import { MyAccountEditPriceRangeTestsQuery } from "__generated__/MyAccountEditPr
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
-import {
-  MyAccountEditPriceRangeContainer,
-  MyAccountEditPriceRangeQueryRenderer,
-} from "./MyAccountEditPriceRange"
+import { MyAccountEditPriceRange } from "./MyAccountEditPriceRange"
 
-describe(MyAccountEditPriceRangeQueryRenderer, () => {
+describe("MyAccountEditPriceRangeQueryRenderer", () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -16,7 +13,7 @@ describe(MyAccountEditPriceRangeQueryRenderer, () => {
   const { renderWithRelay } = setupTestWrapper<MyAccountEditPriceRangeTestsQuery>({
     Component: (props) => {
       if (props?.me) {
-        return <MyAccountEditPriceRangeContainer me={props.me} />
+        return <MyAccountEditPriceRange me={props.me} />
       }
       return null
     },

--- a/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useState } from "react"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { updateMyUserProfile } from "./updateMyUserProfile"
 
-const MyAccountEditPriceRange: React.FC<{
+export const MyAccountEditPriceRange: React.FC<{
   me: MyAccountEditPriceRange_me$key
 }> = (props) => {
   const enableRedesignedSettings = useFeatureFlag("AREnableRedesignedSettings")

--- a/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
@@ -1,25 +1,30 @@
 import { Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { MyAccountEditPriceRangeQuery } from "__generated__/MyAccountEditPriceRangeQuery.graphql"
-import { MyAccountEditPriceRange_me$data } from "__generated__/MyAccountEditPriceRange_me.graphql"
+import { MyAccountEditPriceRange_me$key } from "__generated__/MyAccountEditPriceRange_me.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
 import { Select, SelectOption } from "app/Components/Select"
+import { MyProfileScreenWrapper } from "app/Scenes/MyProfile/Components/MyProfileScreenWrapper"
 import { goBack } from "app/system/navigation/navigate"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { PlaceholderBox } from "app/utils/placeholders"
-import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
 import React, { useEffect, useState } from "react"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { updateMyUserProfile } from "./updateMyUserProfile"
 
 const MyAccountEditPriceRange: React.FC<{
-  me: MyAccountEditPriceRange_me$data
-}> = ({ me }) => {
-  const navigation = useNavigation()
+  me: MyAccountEditPriceRange_me$key
+}> = (props) => {
+  const enableRedesignedSettings = useFeatureFlag("AREnableRedesignedSettings")
+  const me = useFragment(meFragment, props.me)
+  const [isLoading, setIsLoading] = useState(false)
 
   const [receivedError, setReceivedError] = useState<string | undefined>(undefined)
   const [priceRange, setPriceRange] = useState<string>(me.priceRange ?? "")
   const [priceRangeMax, setPriceRangeMax] = useState<number | null | undefined>(me.priceRangeMax)
   const [priceRangeMin, setPriceRangeMin] = useState<number | null | undefined>(me.priceRangeMin)
+  const navigation = useNavigation()
 
   useEffect(() => {
     setReceivedError(undefined)
@@ -28,31 +33,43 @@ const MyAccountEditPriceRange: React.FC<{
   useEffect(() => {
     const isValid = !!priceRange && priceRange !== me.priceRange
 
-    navigation.setOptions({
-      headerRight: () => {
-        return (
-          <Touchable onPress={handleSave} disabled={!isValid}>
-            <Text variant="xs" color={!!isValid ? "mono100" : "mono60"}>
-              Save
-            </Text>
-          </Touchable>
-        )
-      },
-    })
-  }, [navigation, priceRange, me.priceRange])
+    if (enableRedesignedSettings) {
+      navigation.setOptions({
+        headerRight: () => {
+          return (
+            <Touchable onPress={handleSave} disabled={!isValid}>
+              <Text variant="xs" color={!!isValid ? "mono100" : "mono60"}>
+                Save
+              </Text>
+            </Touchable>
+          )
+        },
+      })
+    }
+  }, [navigation, priceRange, me.priceRange, enableRedesignedSettings])
 
   const handleSave = async () => {
     try {
+      setIsLoading(true)
       await updateMyUserProfile({ priceRangeMin, priceRangeMax })
       goBack()
     } catch (e: any) {
       setReceivedError(e)
+    } finally {
+      setIsLoading(false)
     }
   }
 
-  return (
-    <>
-      <Flex p={2}>
+  const isValid = !!priceRange && priceRange !== me.priceRange
+
+  if (enableRedesignedSettings) {
+    return (
+      <MyProfileScreenWrapper
+        title="Price Range"
+        onPress={handleSave}
+        isValid={isValid}
+        loading={isLoading}
+      >
         <Select
           title="Price Range"
           options={PRICE_BUCKETS}
@@ -60,56 +77,89 @@ const MyAccountEditPriceRange: React.FC<{
           value={priceRange}
           onSelectValue={(value) => {
             setPriceRange(value)
-
-            // We don't actually accept a priceRange,
-            // so have to split it into min/max
             const [priceRangeMinFin, priceRangeMaxFin] = value
               .split(":")
               .map((n) => parseInt(n, 10))
-
             setPriceRangeMin(priceRangeMinFin)
             setPriceRangeMax(priceRangeMaxFin)
           }}
           hasError={!!receivedError}
         />
-      </Flex>
-    </>
+      </MyProfileScreenWrapper>
+    )
+  }
+
+  return (
+    <Flex p={2}>
+      <Select
+        title="Price Range"
+        options={PRICE_BUCKETS}
+        enableSearch={false}
+        value={priceRange}
+        onSelectValue={(value) => {
+          setPriceRange(value)
+          const [priceRangeMinFin, priceRangeMaxFin] = value.split(":").map((n) => parseInt(n, 10))
+          setPriceRangeMin(priceRangeMinFin)
+          setPriceRangeMax(priceRangeMaxFin)
+        }}
+        hasError={!!receivedError}
+      />
+    </Flex>
   )
 }
 
-const MyAccountEditPriceRangePlaceholder: React.FC<{}> = ({}) => {
+const MyAccountEditPriceRangePlaceholder: React.FC<{}> = () => {
+  const enableRedesignedSettings = useFeatureFlag("AREnableRedesignedSettings")
+
+  if (enableRedesignedSettings) {
+    return (
+      <MyProfileScreenWrapper title="Price Range">
+        <PlaceholderBox height={40} />
+      </MyProfileScreenWrapper>
+    )
+  }
+
   return <PlaceholderBox height={40} />
 }
 
-export const MyAccountEditPriceRangeContainer = createFragmentContainer(MyAccountEditPriceRange, {
-  me: graphql`
-    fragment MyAccountEditPriceRange_me on Me {
-      priceRange
-      priceRangeMin
-      priceRangeMax
-    }
-  `,
-})
+const meFragment = graphql`
+  fragment MyAccountEditPriceRange_me on Me {
+    priceRange
+    priceRangeMin
+    priceRangeMax
+  }
+`
 
-export const MyAccountEditPriceRangeQueryRenderer: React.FC<{}> = () => {
-  return (
-    <QueryRenderer<MyAccountEditPriceRangeQuery>
-      environment={getRelayEnvironment()}
-      query={graphql`
-        query MyAccountEditPriceRangeQuery {
-          me {
-            ...MyAccountEditPriceRange_me
-          }
-        }
-      `}
-      render={renderWithPlaceholder({
-        Container: MyAccountEditPriceRangeContainer,
-        renderPlaceholder: () => <MyAccountEditPriceRangePlaceholder />,
-      })}
-      variables={{}}
-    />
-  )
-}
+const myAccountEditPriceRangeQuery = graphql`
+  query MyAccountEditPriceRangeQuery {
+    me {
+      ...MyAccountEditPriceRange_me
+    }
+  }
+`
+
+export const MyAccountEditPriceRangeQueryRenderer: React.FC<{}> = withSuspense({
+  Component: ({}) => {
+    const data = useLazyLoadQuery<MyAccountEditPriceRangeQuery>(myAccountEditPriceRangeQuery, {})
+
+    if (!data?.me) {
+      return null
+    }
+
+    return <MyAccountEditPriceRange me={data.me} />
+  },
+  LoadingFallback: MyAccountEditPriceRangePlaceholder,
+  ErrorFallback: (fallbackProps) => {
+    return (
+      <LoadFailureView
+        onRetry={fallbackProps.resetErrorBoundary}
+        useSafeArea={false}
+        error={fallbackProps.error}
+        trackErrorBoundary={false}
+      />
+    )
+  },
+})
 
 export const PRICE_BUCKETS: Array<SelectOption<string>> = [
   { label: "Select a price range", value: "" },

--- a/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
+++ b/src/app/Scenes/MyAccount/MyAccountEditPriceRange.tsx
@@ -130,7 +130,7 @@ const meFragment = graphql`
   }
 `
 
-const myAccountEditPriceRangeQuery = graphql`
+export const myAccountEditPriceRangeQuery = graphql`
   query MyAccountEditPriceRangeQuery {
     me {
       ...MyAccountEditPriceRange_me

--- a/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
+++ b/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
@@ -1,6 +1,6 @@
 import { Button, Flex, Screen, useSpace } from "@artsy/palette-mobile"
 import { goBack } from "app/system/navigation/navigate"
-import { ViewStyle } from "react-native"
+import { RefreshControlProps, ViewStyle } from "react-native"
 
 export interface MyProfileScreenWrapperProps {
   title: string
@@ -9,7 +9,7 @@ export interface MyProfileScreenWrapperProps {
   loading?: boolean
   hideLeftElements?: boolean
   contentContainerStyle?: ViewStyle
-  RefreshControl?: JSX.Element
+  RefreshControl?: React.ReactElement<RefreshControlProps>
 }
 export const MyProfileScreenWrapper: React.FC<MyProfileScreenWrapperProps> = ({
   children,

--- a/src/app/Scenes/MyProfile/DarkModeSettings.tsx
+++ b/src/app/Scenes/MyProfile/DarkModeSettings.tsx
@@ -1,38 +1,54 @@
 import { Flex, Join, RadioButton, Spacer, Text } from "@artsy/palette-mobile"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ScrollView, TouchableOpacity } from "react-native"
+import { MyProfileScreenWrapper } from "./Components/MyProfileScreenWrapper"
 
 export const DarkModeSettings: React.FC<{}> = () => {
   const darkModeOption = GlobalStore.useAppState((state) => state.devicePrefs.darkModeOption)
   const setDarkModeOption = GlobalStore.actions.devicePrefs.setDarkModeOption
+  const enableRedesignedSettings = useFeatureFlag("AREnableRedesignedSettings")
+
+  const content = (
+    <Flex px={2}>
+      <Join separator={<Spacer y={2} />}>
+        <RadioMenuItem
+          title="Sync with system"
+          selected={darkModeOption === "system"}
+          onPress={() => {
+            setDarkModeOption("system")
+          }}
+        />
+        <RadioMenuItem
+          title="On"
+          selected={darkModeOption === "on"}
+          onPress={() => {
+            setDarkModeOption("on")
+          }}
+        />
+        <RadioMenuItem
+          title="Off"
+          selected={darkModeOption === "off"}
+          onPress={() => {
+            setDarkModeOption("off")
+          }}
+        />
+      </Join>
+    </Flex>
+  )
+
+  if (enableRedesignedSettings) {
+    return (
+      <MyProfileScreenWrapper title="Dark Mode" contentContainerStyle={{ paddingHorizontal: 0 }}>
+        {content}
+      </MyProfileScreenWrapper>
+    )
+  }
 
   return (
     <ScrollView>
-      <Flex px={2} mt={2}>
-        <Join separator={<Spacer y={2} />}>
-          <RadioMenuItem
-            title="Sync with system"
-            selected={darkModeOption === "system"}
-            onPress={() => {
-              setDarkModeOption("system")
-            }}
-          />
-          <RadioMenuItem
-            title="On"
-            selected={darkModeOption === "on"}
-            onPress={() => {
-              setDarkModeOption("on")
-            }}
-          />
-          <RadioMenuItem
-            title="Off"
-            selected={darkModeOption === "off"}
-            onPress={() => {
-              setDarkModeOption("off")
-            }}
-          />
-        </Join>
-      </Flex>
+      <Spacer y={2} />
+      {content}
     </ScrollView>
   )
 }

--- a/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
@@ -38,7 +38,7 @@ const myProfilePreferencesFragment = graphql`
   }
 `
 
-const myProfilePreferencesQuery = graphql`
+export const myProfilePreferencesQuery = graphql`
   query MyProfilePreferencesQuery {
     me {
       ...MyProfilePreferences_me

--- a/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
@@ -1,0 +1,69 @@
+import { MyProfilePreferencesQuery } from "__generated__/MyProfilePreferencesQuery.graphql"
+import { MyProfilePreferences_me$key } from "__generated__/MyProfilePreferences_me.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
+import { MenuItem } from "app/Components/MenuItem"
+import { navigate } from "app/system/navigation/navigate"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
+import { MyProfileScreenWrapper } from "./Components/MyProfileScreenWrapper"
+
+export const MyProfilePreferences = (props: { me?: MyProfilePreferences_me$key }) => {
+  const data = useFragment(myProfilePreferencesFragment, props.me)
+
+  return (
+    <MyProfileScreenWrapper title="Preferences" contentContainerStyle={{ paddingHorizontal: 0 }}>
+      <MenuItem
+        title="Price Range"
+        value={data?.priceRange}
+        onPress={() => {
+          navigate("/my-account/edit-price-range")
+        }}
+      />
+      <MenuItem
+        title="Dark Mode"
+        onPress={() => {
+          navigate("/settings/dark-mode")
+        }}
+      />
+    </MyProfileScreenWrapper>
+  )
+}
+
+const myProfilePreferencesFragment = graphql`
+  fragment MyProfilePreferences_me on Me {
+    priceRange
+    priceRangeMin
+    priceRangeMax
+  }
+`
+
+const myProfilePreferencesQuery = graphql`
+  query MyProfilePreferencesQuery {
+    me {
+      ...MyProfilePreferences_me
+    }
+  }
+`
+
+export const MyAccountEditEmailQueryRenderer: React.FC<{}> = withSuspense({
+  Component: ({}) => {
+    const data = useLazyLoadQuery<MyProfilePreferencesQuery>(myProfilePreferencesQuery, {})
+
+    if (!data?.me) {
+      return null
+    }
+
+    return <MyProfilePreferences me={data?.me} />
+  },
+  LoadingFallback: MyProfilePreferences,
+  ErrorFallback: (fallbackProps) => {
+    return (
+      <LoadFailureView
+        onRetry={fallbackProps.resetErrorBoundary}
+        useSafeArea={false}
+        error={fallbackProps.error}
+        trackErrorBoundary={false}
+      />
+    )
+  },
+})

--- a/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePreferences.tsx
@@ -2,6 +2,7 @@ import { MyProfilePreferencesQuery } from "__generated__/MyProfilePreferencesQue
 import { MyProfilePreferences_me$key } from "__generated__/MyProfilePreferences_me.graphql"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { MenuItem } from "app/Components/MenuItem"
+import { PRICE_BUCKETS } from "app/Scenes/MyAccount/MyAccountEditPriceRange"
 import { navigate } from "app/system/navigation/navigate"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
@@ -14,7 +15,7 @@ export const MyProfilePreferences = (props: { me?: MyProfilePreferences_me$key }
     <MyProfileScreenWrapper title="Preferences" contentContainerStyle={{ paddingHorizontal: 0 }}>
       <MenuItem
         title="Price Range"
-        value={data?.priceRange}
+        value={PRICE_BUCKETS.find((bucket) => bucket.value === data?.priceRange)?.label}
         onPress={() => {
           navigate("/my-account/edit-price-range")
         }}
@@ -45,7 +46,7 @@ const myProfilePreferencesQuery = graphql`
   }
 `
 
-export const MyAccountEditEmailQueryRenderer: React.FC<{}> = withSuspense({
+export const MyProfilePreferencesQueryRenderer: React.FC<{}> = withSuspense({
   Component: ({}) => {
     const data = useLazyLoadQuery<MyProfilePreferencesQuery>(myProfilePreferencesQuery, {})
 

--- a/src/app/Scenes/MyProfile/MyProfilePrivacy.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePrivacy.tsx
@@ -1,0 +1,11 @@
+import { MenuItem } from "app/Components/MenuItem"
+import { MyProfileScreenWrapper } from "./Components/MyProfileScreenWrapper"
+
+export const MyProfilePrivacy: React.FC<{}> = () => {
+  return (
+    <MyProfileScreenWrapper title="Privacy" contentContainerStyle={{ paddingHorizontal: 0 }}>
+      <MenuItem title="Privacy Policy" href="/privacy" />
+      <MenuItem title="Personal Data Request" href="/privacy-request" />
+    </MyProfileScreenWrapper>
+  )
+}

--- a/src/app/Scenes/MyProfile/MyProfileSettings.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileSettings.tsx
@@ -115,7 +115,7 @@ export const MyProfileSettings: React.FC = () => {
             <MenuItem
               title="Privacy"
               onPress={() => {
-                navigate("my-profile/terms-and-conditions")
+                navigate("my-profile/privacy")
               }}
             />
           </>

--- a/src/app/Scenes/MyProfile/MyProfileTermsAndConditions.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileTermsAndConditions.tsx
@@ -1,0 +1,14 @@
+import { MenuItem } from "app/Components/MenuItem"
+import { MyProfileScreenWrapper } from "./Components/MyProfileScreenWrapper"
+
+export const MyProfileTermsAndConditions: React.FC<{}> = () => {
+  return (
+    <MyProfileScreenWrapper
+      title="Terms & Conditions"
+      contentContainerStyle={{ paddingHorizontal: 0 }}
+    >
+      <MenuItem title="Terms & Conditions" href="/terms" />
+      <MenuItem title="Auction Conditions of Sale" href="/supplemental-cos" />
+    </MyProfileScreenWrapper>
+  )
+}

--- a/src/app/Scenes/PrivacyRequest/PrivacyRequest.tsx
+++ b/src/app/Scenes/PrivacyRequest/PrivacyRequest.tsx
@@ -1,12 +1,28 @@
-import { Box, Button, Join, LinkText, Spacer, Text } from "@artsy/palette-mobile"
+import { Box, Button, Flex, Join, LinkText, Spacer, Text } from "@artsy/palette-mobile"
 import { presentEmailComposer } from "app/NativeModules/presentEmailComposer"
+import { MyProfileScreenWrapper } from "app/Scenes/MyProfile/Components/MyProfileScreenWrapper"
 import { navigate } from "app/system/navigation/navigate"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import React from "react"
-import { View } from "react-native"
 
 export const PrivacyRequest: React.FC = () => {
+  const enableRedesignedSettings = useFeatureFlag("AREnableRedesignedSettings")
+
+  if (enableRedesignedSettings) {
+    return (
+      <MyProfileScreenWrapper
+        title="Personal Data Request"
+        contentContainerStyle={{ paddingHorizontal: 0 }}
+      >
+        <Content />
+      </MyProfileScreenWrapper>
+    )
+  }
+  return <Content />
+}
+export const Content: React.FC = () => {
   return (
-    <View style={{ flex: 1 }}>
+    <Flex flex={1}>
       <Spacer y={1} />
       <Box mx={2}>
         <Join separator={<Spacer y={2} />}>
@@ -40,6 +56,6 @@ export const PrivacyRequest: React.FC = () => {
           </Button>
         </Join>
       </Box>
-    </View>
+    </Flex>
   )
 }


### PR DESCRIPTION
This PR resolves [ONYX-1642]

### Description

This PR updates the notifications screen to use the new UI.

| screen | screenshots |
|--------|--------|
| Notifications | <img width="597" alt="Screenshot 2025-04-25 at 10 53 12" src="https://github.com/user-attachments/assets/3509e75b-641f-449a-9c10-dc80ba582141" /> |
| Terms and Conditions screen | <img width="586" alt="Screenshot 2025-04-25 at 11 53 18" src="https://github.com/user-attachments/assets/88feb794-e54a-4fbb-98dd-4f12f7162a12" /> | 
| Terms and Conditions webview | <img width="592" alt="Screenshot 2025-04-25 at 11 53 24" src="https://github.com/user-attachments/assets/e68e7596-c093-4b6d-83d5-4d1934b1bca7" /> | 
| Supplementar auctions | <img width="596" alt="Screenshot 2025-04-25 at 11 53 33" src="https://github.com/user-attachments/assets/d3584336-433e-415e-b562-c873cc8ec842" /> | 
| Privacy | <img width="591" alt="Screenshot 2025-04-25 at 11 59 33" src="https://github.com/user-attachments/assets/b7666a5f-fd77-4e8f-baec-f6c2de0062ee" /> | 
| Privacy policy webview | <img width="598" alt="Screenshot 2025-04-25 at 11 59 39" src="https://github.com/user-attachments/assets/100cd99a-9c13-4193-9fad-0cba2898a07a" /> | 
| Personal Data Request | <img width="594" alt="Screenshot 2025-04-25 at 11 59 46" src="https://github.com/user-attachments/assets/c7f213e0-010e-48b6-8091-44da78d51f14" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- update notifications screen to use new UI - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1642]: https://artsyproduct.atlassian.net/browse/ONYX-1642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ