### PR TITLE
fix: sentry sourcemaps after expo integration

### DIFF
--- a/scripts/hermes/hermes-android-bundle.sh
+++ b/scripts/hermes/hermes-android-bundle.sh
@@ -3,7 +3,7 @@
 NODE_OPTIONS=--max_old_space_size=8192
 BUNDLE_DIR="android/app/src/main/assets"
 
-react-native bundle \
+npx expo export:embed \
 --dev false \
 --platform android \
 --entry-file index.android.js \

--- a/scripts/hermes/hermes-ios-bundle.sh
+++ b/scripts/hermes/hermes-ios-bundle.sh
@@ -3,7 +3,7 @@
 NODE_OPTIONS=--max_old_space_size=8192
 BUNDLE_DIR="dist"
 
-react-native bundle \
+npx expo export:embed \
 --dev false \
 --platform ios \
 --entry-file index.ios.js \


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Attempt to fix broken sourcemaps after the expo integration, this PR resolves https://www.notion.so/artsy/Sentry-test-error-showing-wrong-source-code-problem-with-sourcemaps-1e0cab0764a080c486f1c985ae8ca292?pvs=4

#nochangelog