### PR TITLE
chore: show content on empty follow option state

### DIFF
--- a/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
@@ -35,6 +35,7 @@ export const FollowedArtists: React.FC<Props> = ({ me }) => {
   if (data.followsAndSaves?.artistsConnection?.totalCount === 0) {
     return (
       <Screen.ScrollView refreshControl={RefreshControl}>
+        <FollowOptionPicker />
         <ZeroState
           title="You haven’t followed any artists yet"
           subtitle="When you’ve found an artist you like, follow them to get updates on new works that become available."

--- a/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
@@ -136,7 +136,7 @@ export const FollowedArtistsQueryRenderer = withSuspense({
     return (
       <LoadFailureView
         onRetry={fallbackProps.resetErrorBoundary}
-        showBackButton={true}
+        showBackButton={false}
         useSafeArea={false}
         error={fallbackProps.error}
         trackErrorBoundary={false}

--- a/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
@@ -132,7 +132,7 @@ export const FollowedGalleriesQueryRenderer = withSuspense({
     return (
       <LoadFailureView
         onRetry={fallbackProps.resetErrorBoundary}
-        showBackButton={true}
+        showBackButton={false}
         useSafeArea={false}
         error={fallbackProps.error}
         trackErrorBoundary={false}

--- a/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
@@ -35,6 +35,7 @@ export const FollowedGalleries: React.FC<Props> = ({ me }) => {
   if (galleries.length === 0) {
     return (
       <Screen.ScrollView refreshControl={RefreshControl}>
+        <FollowOptionPicker />
         <ZeroState
           title="You haven’t followed any galleries yet"
           subtitle="When you save galleries, they will show up here."

--- a/src/app/Scenes/Favorites/Components/FollowedShows.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedShows.tsx
@@ -31,6 +31,7 @@ export const FollowedShows: React.FC<Props> = ({ me }) => {
   if (shows.length === 0) {
     return (
       <Screen.ScrollView refreshControl={RefreshControl}>
+        <FollowOptionPicker />
         <ZeroState
           title="You haven’t saved any shows yet"
           subtitle="When you save shows, they will show up here for future use."

--- a/src/app/Scenes/Favorites/Components/FollowedShows.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedShows.tsx
@@ -118,7 +118,7 @@ export const FollowedShowsQueryRenderer = withSuspense({
     return (
       <LoadFailureView
         onRetry={fallbackProps.resetErrorBoundary}
-        showBackButton={true}
+        showBackButton={false}
         useSafeArea={false}
         error={fallbackProps.error}
         trackErrorBoundary={false}

--- a/src/app/Scenes/Favorites/Favorites.tsx
+++ b/src/app/Scenes/Favorites/Favorites.tsx
@@ -8,6 +8,7 @@ import {
   Spacer,
   Text,
   useScreenDimensions,
+  useSpace,
 } from "@artsy/palette-mobile"
 import { useScreenScrollContext } from "@artsy/palette-mobile/dist/elements/Screen/ScreenScrollContext"
 import { BOTTOM_TABS_HEIGHT } from "@artsy/palette-mobile/dist/elements/Screen/StickySubHeader"
@@ -119,6 +120,7 @@ const FavoritesHeaderTapBar: React.FC<MaterialTopTabBarProps> = ({ state, naviga
 export const FavoriteTopNavigator = createMaterialTopTabNavigator()
 
 const Content = () => {
+  const space = useSpace()
   const { currentScrollYAnimated } = useScreenScrollContext()
   const { headerHeight } = FavoritesContextStore.useStoreState((state) => state)
   const { height: screenHeight } = useScreenDimensions()
@@ -135,7 +137,7 @@ const Content = () => {
   }))
 
   return (
-    <Animated.View style={[animatedStyles, { height: screenHeight + headerHeight }]}>
+    <Animated.View style={[animatedStyles, { height: screenHeight + headerHeight + space(1) }]}>
       <Screen.Body fullwidth>
         <FavoriteTopNavigator.Navigator
           tabBar={FavoritesHeaderTapBar}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

this PR adds the follow option picker to the favorites tab.

<img width="350" src="https://github.com/user-attachments/assets/3891488a-a263-4904-ad9f-1c4663cebff4" /> 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [X] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- show content on empty follow option state - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
