### PR TITLE
chore: add beforeSend handler to Sentry for filtering non error objects

### DIFF
--- a/src/app/system/errorReporting/setupSentry.ts
+++ b/src/app/system/errorReporting/setupSentry.ts
@@ -58,6 +58,16 @@ export function setupSentry(props: SetupSentryProps = { debug: false }) {
     profilesSampleRate: props.debug ? 1.0 : 0.05,
     debug: props.debug,
     integrations: [navigationInstrumentation],
+    beforeSend(event) {
+      if (
+        typeof event.exception?.values?.[0]?.value === "string" &&
+        event.exception?.values?.[0]?.value.includes("Object captured as exception")
+      ) {
+        console.warn("Potential bad error object:", event.extra)
+        return null // Discards the event completely since it is not useful and does not result in a crash
+      }
+      return event
+    },
     ...props,
   })
 }


### PR DESCRIPTION
This PR resolves [PHIRE-1755] <!-- eg [PROJECT-XXXX] -->

### Description

When we released [ios-8.69.0-2025.04.16.18](https://artsynet.sentry.io/releases/ios-8.69.0-2025.04.16.18/?project=5867225) we started seeing in sentry [this issue](https://artsynet.sentry.io/issues/6549735723/events/113dd780ccb34febb0638fe260935f87/)

```
Error: Object captured as exception with keys: error, message, meta
  at apply(native)
  at setTimeout(/Users/distiller/project/node_modules/react-native/Libraries/Core/Timers/JSTimers.js:213:23)
  at _callTimer(/Users/distiller/project/node_modules/react-native/Libraries/Core/Timers/JSTimers.js:111:15)
  at callTimers(/Users/distiller/project/node_modules/react-native/Libraries/Core/Timers/JSTimers.js:359:17)
  at apply(native)
  at __callFunction(/Users/distiller/project/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:434:34)
  at __guard$argument_0(/Users/distiller/project/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:113:26)
  at __guard(/Users/distiller/project/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:368:11)
  at callFunctionReturnFlushedQueue(/Users/distiller/project/node_modules/react-native/Libraries/BatchedBridge/MessageQueue.js:112:17)
```

After thoroughly checking why this might happen I think that it is a result of when a non-Error object is thrown or logged in a way that Sentry doesn't recognize as a proper Error instance. Instead of a real exception, it's receiving a plain object, such as:

```
{
  error: 'Something went wrong',
  message: 'Failed to load resource',
  meta: { code: 500, endpoint: '/api/data' }
}
```

The weird thing is that is happening on iOS only.

A suggested solution would be to utilize the [beforeSend](https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-before-send) sentry function in order to filter out non error objects like this one from our reporting by returning before we report it.

I think that this is a reasonable approach but happy to get any feedback on this.

> [!NOTE]  
> This is a **handled** error - that means that it is not crashing the app in any way


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add beforeSend handler to Sentry for filtering non error objects

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1755]: https://artsyproduct.atlassian.net/browse/PHIRE-1755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ