### PR TITLE
fix: FullScreenLoadingImage text color in dark mode

### DIFF
--- a/src/app/Components/FullScreenLoadingImage.tsx
+++ b/src/app/Components/FullScreenLoadingImage.tsx
@@ -1,4 +1,4 @@
-import { Spacer, SpacerProps, Flex, Text } from "@artsy/palette-mobile"
+import { Flex, Spacer, SpacerProps, Text } from "@artsy/palette-mobile"
 import { CircularSpinner } from "app/Components/CircularSpinner"
 import { ImageBackground, ImageSourcePropType, StyleSheet } from "react-native"
 
@@ -20,11 +20,12 @@ export const FullScreenLoadingImage: React.FC<FullScreenLoadingImageProps> = ({
       source={imgSource}
     >
       <Flex flex={1} alignItems="center" justifyContent="center">
-        <CircularSpinner color="mono0" size="large" />
+        <CircularSpinner color="white" size="large" />
 
         <Spacer y={spacerHeight} />
 
-        <Text variant="sm-display" color="mono0" textAlign="center">
+        {/* Setting the text color to white in light and dark mode because of the background image. */}
+        <Text variant="sm-display" color="white" textAlign="center">
           {loadingText}
         </Text>
       </Flex>


### PR DESCRIPTION
https://www.notion.so/artsy/Low-contrast-for-text-on-onboarding-loading-screen-header-1eacab0764a080b08cabc1f31330ee84?pvs=4
 <!-- eg [PROJECT-XXXX] -->

### Description

FullScreenLoadingImage text color in dark mode.

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: FullScreenLoadingImage text color in dark mode - ole

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
