### PR TITLE
fix: make sure the new active pills show up after refresh

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionNavigationPills.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionNavigationPills.tsx
@@ -178,16 +178,15 @@ const HomeViewSectionNavigationPillsPlaceholder: React.FC<FlexProps> = (flexProp
 
 export const HomeViewSectionNavigationPillsQueryRenderer: React.FC<SectionSharedProps> = memo(
   withSuspense({
-    Component: ({ sectionID, index, ...flexProps }) => {
+    Component: ({ sectionID, index, refetchKey, ...flexProps }) => {
       const data = useLazyLoadQuery<HomeViewSectionNavigationPillsQuery>(
         homeViewSectionNavigationPillsQuery,
         {
           id: sectionID,
         },
         {
-          networkCacheConfig: {
-            force: false,
-          },
+          fetchKey: refetchKey,
+          fetchPolicy: "store-and-network",
         }
       )
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue with the navigation pills not getting refreshed after signing up for bids.

https://github.com/user-attachments/assets/fd9281f5-9e27-4f19-ba4d-45eb03a8da03


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [X] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix make sure the new active pills show up after refresh - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
