### PR TITLE
chore: prep for 8.71.0

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
   "appName": "eigen",
-  "version": "8.70.0",
+  "version": "8.71.0",
   "isAndroidBeta": false
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps version to 8.71.0 and triggers an iOS beta from main. Reason that the automatic one failed is that when nightly run the app wasn't approved yet

#nochangelog