### PR TITLE
fix: native screen presenter not finding window

### DIFF
--- a/ios/Artsy/AppDelegate.h
+++ b/ios/Artsy/AppDelegate.h
@@ -7,8 +7,10 @@
 @interface ARAppDelegate : EXAppDelegateWrapper
 
 + (ARAppDelegate *)sharedInstance;
++ (void)setSharedInstanceForTesting:(ARAppDelegate *)instance;
 + (Braze *)braze;
 - (NSURL *)bundleURL;
+
 
 @property (strong, nonatomic) ARWindow *window;
 @property (strong, nonatomic) UIViewController *viewController;

--- a/ios/Artsy/AppDelegate.mm
+++ b/ios/Artsy/AppDelegate.mm
@@ -40,11 +40,21 @@
 
 @implementation ARAppDelegate
 
+static ARAppDelegate *_sharedInstanceOverride = nil;
+
 + (ARAppDelegate *)sharedInstance
 {
+    if (_sharedInstanceOverride) {
+        return _sharedInstanceOverride;
+    }
     id delegate = [UIApplication sharedApplication].delegate;
     NSAssert([delegate isKindOfClass:[ARAppDelegate class]], @"Unexpected app delegate class");
     return (ARAppDelegate *)delegate;
+}
+
+// To allow overrides in testing
++ (void)setSharedInstanceForTesting:(ARAppDelegate *)instance {
+    _sharedInstanceOverride = instance;
 }
 
 // Because we‘ve locked the launch screen on iPhone to portrait mode, we now have to unlock all of them again such that

--- a/ios/Artsy/AppDelegate.mm
+++ b/ios/Artsy/AppDelegate.mm
@@ -40,16 +40,11 @@
 
 @implementation ARAppDelegate
 
-static ARAppDelegate *_sharedInstance = nil;
-
-+ (void)load
-{
-    _sharedInstance = [[self alloc] init];
-}
-
 + (ARAppDelegate *)sharedInstance
 {
-    return _sharedInstance;
+    id delegate = [UIApplication sharedApplication].delegate;
+    NSAssert([delegate isKindOfClass:[ARAppDelegate class]], @"Unexpected app delegate class");
+    return (ARAppDelegate *)delegate;
 }
 
 // Because we‘ve locked the launch screen on iPhone to portrait mode, we now have to unlock all of them again such that

--- a/ios/ArtsyTests/App_Tests/AppDelegate+ContinuationTests.m
+++ b/ios/ArtsyTests/App_Tests/AppDelegate+ContinuationTests.m
@@ -51,7 +51,8 @@ describe(@"concerning loading a VC from a URL and reporting analytics", ^{
         emissionMock = [OCMockObject partialMockForObject:[AREmission sharedInstance]];
         [[emissionMock expect] navigate:@"/artwork/andy-warhol-tree-frog"];
 
-        appDelegateMock = [OCMockObject partialMockForObject:[ARAppDelegate sharedInstance]];
+        ARAppDelegate *delegate = [[ARAppDelegate alloc] init];
+        appDelegateMock = [OCMockObject partialMockForObject:delegate];
 
         apiMock = [OCMockObject mockForClass:ArtsyAPI.class];
     });

--- a/ios/ArtsyTests/App_Tests/AppDelegate+NotificationsTests.m
+++ b/ios/ArtsyTests/App_Tests/AppDelegate+NotificationsTests.m
@@ -32,7 +32,6 @@ describe(@"receiveRemoteNotification", ^{
         @"url": @"http://artsy.net/works-for-you",
     };
 
-    __block UIApplication *app = nil;
     __block ARAppDelegate *delegate = nil;
     __block UIApplicationState appState = -1;
     __block id mockEmissionSharedInstance = nil;
@@ -41,14 +40,15 @@ describe(@"receiveRemoteNotification", ^{
     __block void (^completionHandler)(UNNotificationPresentationOptions) = ^(UNNotificationPresentationOptions options) {};
 
     beforeEach(^{
-        app = [UIApplication sharedApplication];
-        delegate = [ARAppDelegate sharedInstance];
+        delegate = [[ARAppDelegate alloc] init];
+        [ARAppDelegate setSharedInstanceForTesting:delegate];
 
         mockEmissionSharedInstance = [OCMockObject partialMockForObject:AREmission.sharedInstance];;
     });
 
     afterEach(^{
         [mockEmissionSharedInstance stopMocking];
+        [ARAppDelegate setSharedInstanceForTesting:nil];
     });
 
     sharedExamplesFor(@"when receiving a notification", ^(NSDictionary *prefs) {

--- a/ios/ArtsyTests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
+++ b/ios/ArtsyTests/View_Controller_Tests/Web_Browsing/ARInternalMobileWebViewControllerTests.m
@@ -5,6 +5,7 @@
 #import "ARNetworkConstants.h"
 #import "ARInternalShareValidator.h"
 #import "AREmission.h"
+#import "AppDelegate.h"
 
 
 static WKNavigationAction *StubNavActionForRequest(NSURLRequest *request, WKNavigationType type)
@@ -156,7 +157,13 @@ describe(@"unauthenticated", ^{
         __block ARInternalMobileWebViewController *controller;
 
         beforeEach(^{
+            ARAppDelegate *delegate = [[ARAppDelegate alloc] init];
+            [ARAppDelegate setSharedInstanceForTesting:delegate];
             controller = [[ARInternalMobileWebViewController alloc] initWithURL:[NSURL URLWithString:@""]];
+        });
+
+        afterAll(^{
+            [ARAppDelegate setSharedInstanceForTesting:nil];
         });
 
         it(@"handles a non-native internal link being clicked", ^{
@@ -201,9 +208,16 @@ describe(@"sharing", ^{
 
     beforeEach(^{
         controller = [[ARInternalMobileWebViewController alloc] initWithURL:[NSURL URLWithString:@""]];
+        ARAppDelegate *delegate = [[ARAppDelegate alloc] init];
+        [ARAppDelegate setSharedInstanceForTesting:delegate];
         shareValidator = [OCMockObject niceMockForClass:[ARInternalShareValidator class]];
         controller.shareValidator = shareValidator;
     });
+
+    afterAll(^{
+        [ARAppDelegate setSharedInstanceForTesting:nil];
+    });
+
 
     it(@"redirects sharing link taps to the shareValidator", ^{
         [[[shareValidator stub] andReturnValue:@(YES)] isSocialSharingURL:OCMOCK_ANY];


### PR DESCRIPTION
This PR resolves [PHIRE-1802] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

First raised here: https://github.com/artsy/eigen/pull/12079

This broke with the expo integration, likely the AppDelegate changed how it was instantiated breaking our sharedInstance (which to be fair is not a standard way to do things). The result was that our sharedInstance pointed to the wrong appDelegate which didn't have an instantiated window resulting in native screens not presenting and likely other more subtle and bad things. We don't really need the sharedInstance anyway because we can get the shared appdelegate from the sharedApplication method. 

This doesn't affect Android so leaving screenshots off!

<!--  Please include screenshots or videos for visual changes, at least on Android -->

| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/69a0b91f-eb79-49c7-a23c-44d96a49c0d2" width="400" /> | <video src="https://github.com/user-attachments/assets/5b799a1d-da87-42e3-a0a3-f4ac4f089085" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/1e361d2b-d709-445b-bb2f-f6e01ab6ee2f" width="400" /> | <video src="https://github.com/user-attachments/assets/5328e2b7-fe9c-4d6e-8624-02b61ae23e0d" width="400" /> |



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix native screen presentation - brian 

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1802]: https://artsyproduct.atlassian.net/browse/PHIRE-1802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ