### PR TITLE
fix: stop firing experiment_viewed event when search screen is rendered

### DIFF
--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -177,14 +177,6 @@ export const SearchScreenQuery = graphql`
 type SearchScreenProps = StackScreenProps<any>
 
 const SearchScreenInner: React.FC<SearchScreenProps> = () => {
-  const { trackExperiment } = useExperimentVariant("diamond_discover-tab")
-
-  useEffect(() => {
-    trackExperiment({
-      context_owner_type: OwnerType.search,
-    })
-  }, [])
-
   return (
     <>
       <Screen>


### PR DESCRIPTION
This PR removes an unnecessary tracking event that was being fired when the Search screen was first rendered.