### PR TITLE
chore(ci): attempt to make flaky test less flaky 

### DIFF
--- a/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/ForgotPasswordStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Auth2/scenes/__tests__/ForgotPasswordStep.tests.tsx
@@ -69,6 +69,7 @@ describe("ForgotPasswordStep", () => {
       renderWithWrappers(<ForgotPasswordStep />)
       fireEvent.press(screen.getByText("Send Reset Link"))
       await waitFor(() => expect(screen.queryByA11yHint("Enter your email address")).toBeNull())
+      await waitFor(() => expect(screen.getByText("Send Again")).toBeEnabled())
       fireEvent.press(screen.getByText("Send Again"))
       await waitFor(() => expect(GlobalStore.actions.auth.forgotPassword).toHaveBeenCalledTimes(2))
     })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

I can't reproduce this locally but my best guess is the second button press can happen while the first press or UI transition is still in flight leading the 2nd not to be handled. This just explicitly waits for the button to be visible and enabled. 

#nochangelog #trivial 

