### PR TITLE
chore(releases): make the flag message louder #trivial

### DIFF
--- a/fastlane/utility_fastlane.rb
+++ b/fastlane/utility_fastlane.rb
@@ -157,17 +157,18 @@ lane :check_flags do
 
   hidden_flags_message = ''
   hidden_flags.each do |flag_name|
-    hidden_flags_message += "\n :x: #{flag_name}"
+    hidden_flags_message += "\n :alert-orange: #{flag_name}"
   end
 
   message = <<~MSG
-    :checkered_flag: :steam_locomotive:
+    :alert-orange: :checkered_flag: :steam_locomotive: :alert-orange:
     We are getting ready for an app release!
-    Are your features ready?
+
+    *Did you forget to set readyForRelease to true :interrobang:*
     *Features HIDDEN in the upcoming release*:
     #{hidden_flags_message}
-    If a feature here should be going out this release please follow the docs here
-    ahead of release QA:
+
+    If a feature here should be going out this release please follow the docs here:
     https://github.com/artsy/eigen/blob/main/docs/developing_a_feature.md#releasing-a-feature
     @onyx-devs @phires @amber-devs @diamond-devs @emerald-devs
   MSG


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Make the flag reminder message a little louder as suggested here: https://artsy.slack.com/archives/C02BAQ5K7/p1746813024602029?thread_ts=1746795170.434749&cid=C02BAQ5K7

Example:
<img width="668" alt="Screenshot 2025-05-09 at 2 59 51 PM" src="https://github.com/user-attachments/assets/980c9b2c-36b5-48a5-a95a-b3380e47fa80" />

#nochangelog #trivial 
### PR Checklist
