### PR TITLE
fix(QA): discover tab a/b test event tracking

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,6 @@ import { GlobalStore, unsafe__getEnvironment, unsafe_getDevToggle } from "app/st
 import { DevMenuWrapper } from "app/system/devTools/DevMenu/DevMenuWrapper"
 import { useRageShakeDevMenu } from "app/system/devTools/useRageShakeDevMenu"
 import { setupSentry } from "app/system/errorReporting/setupSentry"
-import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 import { usePurgeCacheOnAppUpdate } from "app/system/relay/usePurgeCacheOnAppUpdate"
 import { addTrackingProvider } from "app/utils/track"
 import {
@@ -66,9 +65,6 @@ if (UIManager.setLayoutAnimationEnabledExperimental) {
 const Main = () => {
   useRageShakeDevMenu()
 
-  const { trackExperiment: trackDiscoverTabExperiment } =
-    useExperimentVariant("diamond_discover-tab")
-
   useEffect(() => {
     const oss = Keys.OSS
     if (oss === "true") {
@@ -78,8 +74,6 @@ const Main = () => {
       webClientId: "673710093763-hbj813nj4h3h183c4ildmu8vvqc0ek4h.apps.googleusercontent.com",
     })
     Settings.initializeSDK()
-
-    trackDiscoverTabExperiment()
   }, [])
   const isHydrated = GlobalStore.useAppState((state) => state.sessionState.isHydrated)
   const isUserIdentified = GlobalStore.useAppState(

--- a/src/app/Scenes/HomeView/Components/HomeViewSectionCardsCard.tsx
+++ b/src/app/Scenes/HomeView/Components/HomeViewSectionCardsCard.tsx
@@ -3,6 +3,7 @@ import { Flex, Image, SkeletonBox, Text, useSpace } from "@artsy/palette-mobile"
 import { HomeViewSectionCardsCard_card$key } from "__generated__/HomeViewSectionCardsCard_card.graphql"
 import { HomeViewSectionCardsCard_section$key } from "__generated__/HomeViewSectionCardsCard_section.graphql"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
+import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { FC } from "react"
 import { graphql, useFragment } from "react-relay"
@@ -26,6 +27,9 @@ export const HomeViewSectionCardsCard: FC<HomeViewSectionCardsCardProps> = ({
   const card = useFragment(cardFragment, _card)
   const section = useFragment(sectionFragment, _section)
   const tracking = useHomeViewTracking()
+
+  const { variant } = useExperimentVariant("diamond_discover-tab")
+  const isDiscoverVariant = variant.name === "variant-a" && variant.enabled
 
   if (!card || !section) {
     return null
@@ -51,7 +55,9 @@ export const HomeViewSectionCardsCard: FC<HomeViewSectionCardsCardProps> = ({
         card.entityType as ScreenOwnerType,
         href,
         section.contextModule as ContextModule,
-        index
+        index,
+        // TODO: remove the screenOwnerType parameter when the A/B test is dismantled
+        isDiscoverVariant ? OwnerType.search : OwnerType.home
       )
     }
   }

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -20,6 +20,7 @@ import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracki
 import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useBottomTabsScrollToTop } from "app/utils/bottomTabsHelper"
@@ -65,9 +66,12 @@ export const HomeView: React.FC = memo(() => {
   const { trackExperiment: trackQuickLinksExperiment } = useExperimentVariant(
     "onyx_quick-links-experiment"
   )
+  const { trackExperiment: trackDiscoverTabExperiment } =
+    useExperimentVariant("diamond_discover-tab")
   const enableNavigationPills = useFeatureFlag("AREnableHomeViewQuickLinks")
 
   useEffect(() => {
+    trackDiscoverTabExperiment()
     trackInternalTestingExperiment()
 
     if (enableNavigationPills) {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
@@ -1,4 +1,4 @@
-import { ContextModule, ScreenOwnerType } from "@artsy/cohesion"
+import { ContextModule, OwnerType, ScreenOwnerType } from "@artsy/cohesion"
 import { Chip, Flex, Skeleton, SkeletonBox, Spacer, useSpace } from "@artsy/palette-mobile"
 import { HomeViewSectionCardsChipsQuery } from "__generated__/HomeViewSectionCardsChipsQuery.graphql"
 import { HomeViewSectionCardsChips_section$key } from "__generated__/HomeViewSectionCardsChips_section.graphql"
@@ -49,7 +49,9 @@ export const HomeViewSectionCardsChips: React.FC<HomeViewSectionCardsChipsProps>
         card.entityType as ScreenOwnerType,
         card.href,
         section.contextModule as ContextModule,
-        index
+        index,
+        // TODO: remove the screenOwnerType parameter when the A/B test is dismantled
+        isDiscoverVariant ? OwnerType.search : OwnerType.home
       )
     }
   }

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -40,6 +40,9 @@ export const Section: React.FC<SectionProps> = ({ section, ...rest }) => {
   const { variant: quickLinksExperimentVariant } = useExperimentVariant(
     "onyx_quick-links-experiment"
   )
+  const { variant: discoverTabExperimentVariant } = useExperimentVariant("diamond_discover-tab")
+  const isDiscoverVariant =
+    discoverTabExperimentVariant.name === "variant-a" && discoverTabExperimentVariant.enabled
 
   if (!section.internalID) {
     if (__DEV__) {
@@ -56,6 +59,10 @@ export const Section: React.FC<SectionProps> = ({ section, ...rest }) => {
     case "ArticlesCard":
       return <HomeViewSectionArticlesCardsQueryRenderer sectionID={section.internalID} {...rest} />
     case "Chips":
+      if (section.internalID === "home-view-section-discover-something-new" && isDiscoverVariant) {
+        return null
+      }
+
       return <HomeViewSectionCardsChipsQueryRenderer sectionID={section.internalID} {...rest} />
   }
 
@@ -77,6 +84,10 @@ export const Section: React.FC<SectionProps> = ({ section, ...rest }) => {
     case "HomeViewSectionHeroUnits":
       return <HomeViewSectionHeroUnitsQueryRenderer sectionID={section.internalID} {...rest} />
     case "HomeViewSectionCards":
+      if (section.internalID === "home-view-section-explore-by-category" && isDiscoverVariant) {
+        return null
+      }
+
       return <HomeViewSectionCardsQueryRenderer sectionID={section.internalID} {...rest} />
     case "HomeViewSectionFairs":
       return <HomeViewSectionFairsQueryRenderer sectionID={section.internalID} {...rest} />

--- a/src/app/Scenes/HomeView/hooks/useHomeViewTracking.ts
+++ b/src/app/Scenes/HomeView/hooks/useHomeViewTracking.ts
@@ -286,12 +286,13 @@ export const useHomeViewTracking = () => {
       entityType: ScreenOwnerType,
       href: string,
       contextModule: ContextModule,
-      index: number
+      index: number,
+      screenOwnerType: ScreenOwnerType
     ) => {
       const payload: TappedCardGroup = {
         action: ActionType.tappedCardGroup,
         context_module: contextModule,
-        context_screen_owner_type: OwnerType.home,
+        context_screen_owner_type: screenOwnerType,
         destination_screen_owner_type: entityType,
         destination_path: href,
         destination_screen_owner_id: entityID,


### PR DESCRIPTION
This PR fixes two issues found with event tracking for the "diamond_discover-tab" experiment.

1. `experiment_viewed` event was not being fired when users logged-in or signed-up (it was only being fired on cold starts when the user was already logged-in).
2. `tapped_card_group` event was being fired with "home" as the context owner type instead of "search" for users in variant A

It also moves the responsibility of hiding home view components for the control group from Metaphysics to Eigen. This was done so that older versions of the app would continue serving those home view components.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Fixed QA bugs with event tracking for diamond_discover-tab

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
