### PR TITLE
fix: unable to load in favorites tab - alerts

### DIFF
--- a/src/app/utils/Sentinel.tsx
+++ b/src/app/utils/Sentinel.tsx
@@ -9,8 +9,7 @@
  */
 
 import { Flex } from "@artsy/palette-mobile"
-import { useFocusEffect } from "@react-navigation/native"
-import { FC, ReactNode, useCallback, useEffect, useRef, useState } from "react"
+import { FC, ReactNode, useEffect, useRef, useState } from "react"
 import { Dimensions, View } from "react-native"
 
 const DEFAULT_THRESHOLD = 1
@@ -42,12 +41,10 @@ export const Sentinel: FC<Props> = ({ children, onChange, threshold = DEFAULT_TH
 
   let interval: any = null
 
-  useFocusEffect(
-    useCallback(() => {
-      startWatching()
-      return stopWatching
-    }, [])
-  )
+  useEffect(() => {
+    startWatching()
+    return stopWatching
+  }, [])
 
   const startWatching = () => {
     if (interval) {


### PR DESCRIPTION
This PR resolves [PBRW-759] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

We are using useFocusEffect in the Sentinel component used by RouterLink, useFocusEffect needs a navigation context to work and it doesn't have one in the AutomountedModal. 

I think we can just use useEffect here but defer to experts on the RouterLink 
This was changed here but not sure if it was required?: https://github.com/artsy/eigen/pull/10849/files

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/6db4e979-b6db-4e17-8e49-d4927bad3888" width="400" /> | <img src="https://github.com/user-attachments/assets/e1dd060a-81dc-44eb-906b-3c99d4210932" width="400" /> |
| iOS | <img src="https://github.com/user-attachments/assets/ea37343c-984b-4112-bb79-e2909f325fd5" width="400" /> | <img src="https://github.com/user-attachments/assets/0b6442a9-87d3-475e-b42b-4ec8edb3be83" width="400" /> |

### Follow-ups
- [ ] This is bubbling up to app wide error boundary, I believe bc the modal is outside navigation, we should wrap in ErrorBoundary

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix unable to load in favorites tab (adjust routerlink behavior) - brian 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-759]: https://artsyproduct.atlassian.net/browse/PBRW-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ