### PR TITLE
fix(QA): stop using overrideShouldBeDisplayed for home view sections

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCards.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCards.tsx
@@ -95,9 +95,9 @@ const fragment = graphql`
 `
 
 const query = graphql`
-  query HomeViewSectionCardsQuery($id: String!, $overrideShouldBeDisplayed: Boolean = false) {
+  query HomeViewSectionCardsQuery($id: String!) {
     homeView {
-      section(id: $id, overrideShouldBeDisplayed: $overrideShouldBeDisplayed) {
+      section(id: $id) {
         ...HomeViewSectionCards_section
       }
     }
@@ -133,11 +133,10 @@ const HomeViewCardsPlaceholder: React.FC = () => {
 }
 
 export const HomeViewSectionCardsQueryRenderer = memo(
-  withSuspense<Pick<SectionSharedProps, "sectionID" | "index" | "overrideShouldBeDisplayed">>({
-    Component: ({ sectionID, index, overrideShouldBeDisplayed }) => {
+  withSuspense<Pick<SectionSharedProps, "sectionID" | "index">>({
+    Component: ({ sectionID, index }) => {
       const data = useLazyLoadQuery<HomeViewSectionCardsQuery>(query, {
         id: sectionID,
-        overrideShouldBeDisplayed,
       })
 
       if (!data?.homeView.section) {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionCardsChips.tsx
@@ -159,9 +159,9 @@ const HomeViewSectionCardsChipsPlaceholder: React.FC = () => {
 }
 
 const query = graphql`
-  query HomeViewSectionCardsChipsQuery($id: String!, $overrideShouldBeDisplayed: Boolean = false) {
+  query HomeViewSectionCardsChipsQuery($id: String!) {
     homeView {
-      section(id: $id, overrideShouldBeDisplayed: $overrideShouldBeDisplayed) {
+      section(id: $id) {
         ...HomeViewSectionCardsChips_section
       }
     }
@@ -170,10 +170,9 @@ const query = graphql`
 
 export const HomeViewSectionCardsChipsQueryRenderer: React.FC<SectionSharedProps> = memo(
   withSuspense({
-    Component: ({ sectionID, index, overrideShouldBeDisplayed, ...flexProps }) => {
+    Component: ({ sectionID, index, ...flexProps }) => {
       const data = useLazyLoadQuery<HomeViewSectionCardsChipsQuery>(query, {
         id: sectionID,
-        overrideShouldBeDisplayed,
       })
 
       if (!data?.homeView.section) {

--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -32,7 +32,6 @@ export interface SectionProps extends FlexProps {
 export interface SectionSharedProps extends FlexProps {
   index: number
   sectionID: string
-  overrideShouldBeDisplayed?: boolean
   refetchKey?: number
 }
 

--- a/src/app/Scenes/Search/Search.tsx
+++ b/src/app/Scenes/Search/Search.tsx
@@ -138,14 +138,12 @@ export const Search: React.FC = () => {
                 <HomeViewSectionCardsChipsQueryRenderer
                   sectionID="home-view-section-discover-something-new"
                   index={0}
-                  overrideShouldBeDisplayed={true}
                 />
               )}
               {!!isDiscoverVariant && (
                 <HomeViewSectionCardsQueryRenderer
                   sectionID="home-view-section-explore-by-category"
                   index={0}
-                  overrideShouldBeDisplayed={true}
                 />
               )}
 


### PR DESCRIPTION
This PR removes the `overrideShouldBeDisplayed` prop that we added to home view section queries so that sections we wanted to hide from the Home screen could be rendered in the Search screen instead for the `diamond_discover-tab` experiment.

(We want to stop using it because instead of hiding these sections in Metaphysics, we will hide them in Eigen going forward.)