### PR TITLE
feat(EMI-2444): Add new route for the new Order Details screen

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -160,7 +160,7 @@ module.exports = {
       },
     },
     {
-      files: ["*.tests.ts", "*.tests.tsx", "src/app/system/navigation/RouterLink.tsx"],
+      files: ["*.tests.ts", "*.tests.tsx"],
       rules: {
         "no-restricted-imports": OFF,
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -160,7 +160,7 @@ module.exports = {
       },
     },
     {
-      files: ["*.tests.ts", "*.tests.tsx"],
+      files: ["*.tests.ts", "*.tests.tsx", "src/app/system/navigation/RouterLink.tsx"],
       rules: {
         "no-restricted-imports": OFF,
       },

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -179,6 +179,7 @@ import { MyProfileTermsAndConditions } from "app/Scenes/MyProfile/MyProfileTerms
 import { NewWorksForYouQueryRenderer } from "app/Scenes/NewWorksForYou/NewWorksForYou"
 import { NewWorksFromGalleriesYouFollowScreenQuery } from "app/Scenes/NewWorksFromGalleriesYouFollow/Components/NewWorksFromGalleriesYouFollow"
 import { NewWorksFromGalleriesYouFollowScreen } from "app/Scenes/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollow"
+import { OrderDetailQR } from "app/Scenes/OrderHistory/OrderDetail/OrderDetail"
 import { OrderDetailsQueryRender } from "app/Scenes/OrderHistory/OrderDetails/Components/OrderDetails"
 import { OrderHistoryQueryRender } from "app/Scenes/OrderHistory/OrderHistory"
 import { PartnerQueryRenderer, PartnerScreenQuery } from "app/Scenes/Partner/Partner"
@@ -1626,6 +1627,20 @@ export const artsyDotNetRoutes = defineRoutes([
     },
     queries: [ConversationScreenQuery],
   },
+  ...(unsafe_getFeatureFlag("AREnableNewOrderDetails")
+    ? [
+        {
+          path: "/orders/:orderID/details",
+          name: "OrderDetail",
+          Component: OrderDetailQR,
+          options: {
+            screenOptions: {
+              headerTitle: "Order Details",
+            },
+          },
+        },
+      ]
+    : []),
   {
     path: "/user/purchases/:orderID",
     name: "OrderDetails",

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -37,10 +37,7 @@ const mockOrder = {
 describe("OrderHistoryRow", () => {
   const { renderWithRelay } = setupTestWrapper<OrderHistoryRowTestsQuery>({
     Component: (props) => {
-      if (props?.commerceOrder) {
-        return <OrderHistoryRowContainer order={props.commerceOrder} />
-      }
-      return null
+      return <OrderHistoryRowContainer order={props.commerceOrder} />
     },
     query: graphql`
       query OrderHistoryRowTestsQuery @relay_test_operation {

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tests.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { OrderHistoryRowTestsQuery } from "__generated__/OrderHistoryRowTestsQuery.graphql"
 import { navigate } from "app/system/navigation/navigate"
-import { extractText } from "app/utils/tests/extractText"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 import { OrderHistoryRowContainer } from "./OrderHistoryRow"
@@ -82,7 +81,7 @@ describe("OrderHistoryRow", () => {
     it("displays the image", () => {
       renderWithRelay({ CommerceOrder: () => mockOrder })
 
-      expect(screen.getByTestId("image")).toBeTruthy()
+      expect(screen.getByTestId("image")).toBeOnTheScreen()
     })
 
     it("displays a gray box unless there is an image", () => {
@@ -108,7 +107,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.getByTestId("image-box")).toBeTruthy()
+      expect(screen.getByTestId("image-box")).toBeOnTheScreen()
     })
   })
 
@@ -131,7 +130,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.getByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeOnTheScreen()
     })
 
     it("is visible when a tracking number is provided", () => {
@@ -152,7 +151,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.getByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeOnTheScreen()
     })
 
     it("is visible when a tracking ID is provided", () => {
@@ -173,7 +172,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.getByTestId("track-package-button")).toBeTruthy()
+      expect(screen.getByTestId("track-package-button")).toBeOnTheScreen()
     })
 
     it("is not visible unless tracking information is provided", () => {
@@ -194,7 +193,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.queryByTestId("track-package-button")).toBeNull()
+      expect(screen.queryByTestId("track-package-button")).not.toBeOnTheScreen()
     })
   })
 
@@ -211,7 +210,7 @@ describe("OrderHistoryRow", () => {
       screen.getByText("payment failed")
 
       const button = screen.getByTestId("update-payment-button")
-      expect(button).toBeVisible()
+      expect(button).toBeOnTheScreen()
 
       fireEvent.press(button!)
 
@@ -230,7 +229,7 @@ describe("OrderHistoryRow", () => {
       })
 
       const button = screen.queryByTestId("update-payment-button")
-      expect(button).toBeNull()
+      expect(button).not.toBeOnTheScreen()
     })
   })
 
@@ -243,7 +242,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.getByTestId("view-order-button")).toBeTruthy()
+      expect(screen.getByTestId("view-order-button")).toBeOnTheScreen()
     })
 
     it("is not visible when the order is canceled", () => {
@@ -254,7 +253,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.queryByTestId("view-order-button")).toBeNull()
+      expect(screen.queryByTestId("view-order-button")).not.toBeOnTheScreen()
     })
 
     it("is not visible when the order is refunded", () => {
@@ -265,7 +264,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(screen.queryByTestId("view-order-button")).toBeNull()
+      expect(screen.queryByTestId("view-order-button")).not.toBeOnTheScreen()
     })
 
     it("shows 'view order' when the order is submitted", () => {
@@ -277,7 +276,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Order")
+      expect(screen.getByTestId("view-order-button")).toHaveTextContent("View Order")
     })
 
     it("shows 'view offer' when the order has a submitted offer", () => {
@@ -289,7 +288,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Offer")
+      expect(screen.getByTestId("view-order-button")).toHaveTextContent("View Offer")
     })
 
     it("shows 'view offer' when the order has an approved offer", () => {
@@ -301,7 +300,7 @@ describe("OrderHistoryRow", () => {
         }),
       })
 
-      expect(extractText(screen.getByTestId("view-order-button"))).toContain("View Offer")
+      expect(screen.getByTestId("view-order-button")).toHaveTextContent("View Offer")
     })
 
     it("navigates to the counteroffer when the order has a submitted offer", () => {
@@ -314,7 +313,7 @@ describe("OrderHistoryRow", () => {
           buyerAction: "OFFER_RECEIVED",
         }),
       })
-      const button = screen.UNSAFE_getByProps({ testID: "counteroffer-button" })
+      const button = screen.getByTestId("counteroffer-button")
 
       fireEvent.press(button)
 

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -7,6 +7,8 @@ import {
   CommerceOrderModeEnum,
 } from "__generated__/OrderHistoryRow_order.graphql"
 import { RouterLink } from "app/system/navigation/RouterLink"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { getOrderStatus } from "app/utils/getOrderStatus"
 import { getTrackingUrl } from "app/utils/getTrackingUrl"
@@ -45,35 +47,36 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
   switch (displayState) {
     case "PAYMENT_FAILED":
       return (
-        <RouterLink
-          hasChildTouchable
-          to={`/orders/${orderId}/payment/new`}
-          isWebView
-          navigationProps={{ orderID: orderId, title: "Update Payment Details" }}
+        <Button
+          block
+          variant="fillDark"
           onPress={() => {
             tracks.tappedChangePaymentMethod({ id: orderId })
+            navigate(`/orders/${orderId}/payment/new`, {
+              modal: true,
+              passProps: { orderID: orderId, title: "Update Payment Details" },
+            })
           }}
           testID="update-payment-button"
         >
-          <Button block variant="fillDark">
-            Update Payment Method
-          </Button>
-        </RouterLink>
+          Update Payment Method
+        </Button>
       )
 
     case "OFFER_RECEIVED":
       return (
-        <RouterLink
-          hasChildTouchable
-          to={`/orders/${orderId}`}
-          isWebView
-          navigationProps={{ orderID: orderId, title: "Review Offer" }}
-          testID="counteroffer-button"
+        <Button
+          block
+          variant="fillDark"
+          onPress={() =>
+            navigate(`/orders/${orderId}`, {
+              modal: true,
+              passProps: { orderID: orderId, title: "Review Offer" },
+            })
+          }
         >
-          <Button block variant="fillDark">
-            Respond to Counteroffer
-          </Button>
-        </RouterLink>
+          Respond to Counteroffer
+        </Button>
       )
     case "SUBMITTED":
     case "APPROVED":

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -7,8 +7,6 @@ import {
   CommerceOrderModeEnum,
 } from "__generated__/OrderHistoryRow_order.graphql"
 import { RouterLink } from "app/system/navigation/RouterLink"
-// eslint-disable-next-line no-restricted-imports
-import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { getOrderStatus } from "app/utils/getOrderStatus"
 import { getTrackingUrl } from "app/utils/getTrackingUrl"
@@ -47,36 +45,35 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
   switch (displayState) {
     case "PAYMENT_FAILED":
       return (
-        <Button
-          block
-          variant="fillDark"
+        <RouterLink
+          hasChildTouchable
+          to={`/orders/${orderId}/payment/new`}
+          isWeb
+          navigationProps={{ orderID: orderId, title: "Update Payment Details" }}
           onPress={() => {
             tracks.tappedChangePaymentMethod({ id: orderId })
-            navigate(`/orders/${orderId}/payment/new`, {
-              modal: true,
-              passProps: { orderID: orderId, title: "Update Payment Details" },
-            })
           }}
           testID="update-payment-button"
         >
-          Update Payment Method
-        </Button>
+          <Button block variant="fillDark">
+            Update Payment Method
+          </Button>
+        </RouterLink>
       )
+
     case "OFFER_RECEIVED":
       return (
-        <Button
-          block
-          variant="fillDark"
-          onPress={() =>
-            navigate(`/orders/${orderId}`, {
-              modal: true,
-              passProps: { orderID: orderId, title: "Review Offer" },
-            })
-          }
+        <RouterLink
+          hasChildTouchable
+          to={`/orders/${orderId}`}
+          isWeb
+          navigationProps={{ orderID: orderId, title: "Review Offer" }}
           testID="counteroffer-button"
         >
-          Respond to Counteroffer
-        </Button>
+          <Button block variant="fillDark">
+            Respond to Counteroffer
+          </Button>
+        </RouterLink>
       )
     case "SUBMITTED":
     case "APPROVED":
@@ -86,6 +83,7 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
     case "IN_TRANSIT":
       return (
         <RouterLink
+          hasChildTouchable
           testID="view-order-button"
           to={AREnableNewOrderDetails ? `/orders/${orderId}/details` : `/user/purchases/${orderId}`}
         >

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -86,9 +86,10 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
     case "IN_TRANSIT":
       return (
         <RouterLink
+          testID="view-order-button"
           to={AREnableNewOrderDetails ? `/orders/${orderId}/details` : `/user/purchases/${orderId}`}
         >
-          <Button block variant="fillGray" testID="view-order-button">
+          <Button block variant="fillGray">
             {mode == "OFFER" ? "View Offer" : "View Order"}
           </Button>
         </RouterLink>

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -40,6 +40,8 @@ const getStateColor = (displayState: BuyerDisplayStateEnum) => {
 }
 
 const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, orderId, mode }) => {
+  const AREnableNewOrderDetails = useFeatureFlag("AREnableNewOrderDetails")
+
   switch (displayState) {
     case "PAYMENT_FAILED":
       return (
@@ -84,7 +86,11 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
         <Button
           block
           variant="fillGray"
-          onPress={() => navigate(`/user/purchases/${orderId}`)}
+          onPress={() =>
+            navigate(
+              AREnableNewOrderDetails ? `/orders/${orderId}/details` : `/user/purchases/${orderId}`
+            )
+          }
           testID="view-order-button"
         >
           {mode == "OFFER" ? "View Offer" : "View Order"}

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -48,7 +48,7 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
         <RouterLink
           hasChildTouchable
           to={`/orders/${orderId}/payment/new`}
-          isWeb
+          isWebView
           navigationProps={{ orderID: orderId, title: "Update Payment Details" }}
           onPress={() => {
             tracks.tappedChangePaymentMethod({ id: orderId })
@@ -66,7 +66,7 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
         <RouterLink
           hasChildTouchable
           to={`/orders/${orderId}`}
-          isWeb
+          isWebView
           navigationProps={{ orderID: orderId, title: "Review Offer" }}
           testID="counteroffer-button"
         >

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -6,6 +6,8 @@ import {
   CommerceBuyerOfferActionEnum,
   CommerceOrderModeEnum,
 } from "__generated__/OrderHistoryRow_order.graphql"
+import { RouterLink } from "app/system/navigation/RouterLink"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { getOrderStatus } from "app/utils/getOrderStatus"
@@ -83,18 +85,13 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
     case "PROCESSING_APPROVAL":
     case "IN_TRANSIT":
       return (
-        <Button
-          block
-          variant="fillGray"
-          onPress={() =>
-            navigate(
-              AREnableNewOrderDetails ? `/orders/${orderId}/details` : `/user/purchases/${orderId}`
-            )
-          }
-          testID="view-order-button"
+        <RouterLink
+          to={AREnableNewOrderDetails ? `/orders/${orderId}/details` : `/user/purchases/${orderId}`}
         >
-          {mode == "OFFER" ? "View Offer" : "View Order"}
-        </Button>
+          <Button block variant="fillGray" testID="view-order-button">
+            {mode == "OFFER" ? "View Offer" : "View Order"}
+          </Button>
+        </RouterLink>
       )
     default:
       return null

--- a/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
+++ b/src/app/Scenes/OrderHistory/OrderHistoryRow.tsx
@@ -74,6 +74,7 @@ const OrderActionButton: React.FC<OrderActionButtonProps> = ({ displayState, ord
               passProps: { orderID: orderId, title: "Review Offer" },
             })
           }
+          testID="counteroffer-button"
         >
           Respond to Counteroffer
         </Button>

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -12,7 +12,6 @@ import { Variables } from "relay-runtime"
 export interface RouterLinkProps {
   disablePrefetch?: boolean
   navigationProps?: NavigateOptions["passProps"]
-  isWebView?: boolean
   to?: string | null | undefined
   // Indicates whether the child component is a touchable element, preventing duplicate touch handlers
   hasChildTouchable?: boolean
@@ -34,7 +33,6 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   navigationProps,
   children,
   hasChildTouchable,
-  isWebView,
   ...restProps
 }) => {
   const enablePrefetchingIndicator = useDevToggle("DTShowPrefetchingIndicator")
@@ -42,26 +40,15 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
   const [prefetchState, setPrefetchState] = useState<PrefetchState>(null)
 
-  const isPrefetchingEnabled = !isWebView && !disablePrefetch && enableViewPortPrefetching && to
+  const isPrefetchingEnabled = !disablePrefetch && enableViewPortPrefetching && to
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
 
     if (!to) return
 
-    const navigationOptions: NavigateOptions = {}
-
     if (navigationProps) {
-      navigationOptions.passProps = navigationProps
-    }
-
-    if (isWebView) {
-      navigationOptions.modal = true
-    }
-
-    // check if there's any navigation options
-    if (Object.keys(navigationOptions).length > 0) {
-      navigate(to, navigationOptions)
+      navigate(to, { passProps: navigationProps })
     } else {
       navigate(to)
     }

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -1,5 +1,5 @@
 import { Flex, Touchable, TouchableProps } from "@artsy/palette-mobile"
-import { navigate } from "app/system/navigation/navigate"
+import { navigate, NavigateOptions } from "app/system/navigation/navigate"
 import { Sentinel } from "app/utils/Sentinel"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -10,7 +10,8 @@ import { Variables } from "relay-runtime"
 
 export interface RouterLinkProps {
   disablePrefetch?: boolean
-  navigationProps?: Object
+  navigationProps?: NavigateOptions["passProps"]
+  isWeb?: boolean
   to?: string | null | undefined
   // Indicates whether the child component is a touchable element, preventing duplicate touch handlers
   hasChildTouchable?: boolean
@@ -32,6 +33,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   navigationProps,
   children,
   hasChildTouchable,
+  isWeb,
   ...restProps
 }) => {
   const enablePrefetchingIndicator = useDevToggle("DTShowPrefetchingIndicator")
@@ -39,18 +41,24 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
   const [prefetchState, setPrefetchState] = useState<PrefetchState>(null)
 
-  const isPrefetchingEnabled = !disablePrefetch && enableViewPortPrefetching && to
+  const isPrefetchingEnabled = !isWeb && !disablePrefetch && enableViewPortPrefetching && to
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
 
     if (!to) return
 
+    const navigationOptions: NavigateOptions = {}
+
     if (navigationProps) {
-      navigate(to, { passProps: navigationProps })
-    } else {
-      navigate(to)
+      navigationOptions.passProps = navigationProps
     }
+
+    if (isWeb) {
+      navigationOptions.modal = true
+    }
+
+    navigate(to, navigationOptions)
   }
 
   const handleVisible = (isVisible: boolean) => {

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -1,4 +1,5 @@
 import { Flex, Touchable, TouchableProps } from "@artsy/palette-mobile"
+// eslint-disable-next-line no-restricted-imports
 import { navigate, NavigateOptions } from "app/system/navigation/navigate"
 import { Sentinel } from "app/utils/Sentinel"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -12,7 +12,7 @@ import { Variables } from "relay-runtime"
 export interface RouterLinkProps {
   disablePrefetch?: boolean
   navigationProps?: NavigateOptions["passProps"]
-  isWeb?: boolean
+  isWebView?: boolean
   to?: string | null | undefined
   // Indicates whether the child component is a touchable element, preventing duplicate touch handlers
   hasChildTouchable?: boolean
@@ -34,7 +34,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   navigationProps,
   children,
   hasChildTouchable,
-  isWeb,
+  isWebView,
   ...restProps
 }) => {
   const enablePrefetchingIndicator = useDevToggle("DTShowPrefetchingIndicator")
@@ -42,7 +42,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
   const [prefetchState, setPrefetchState] = useState<PrefetchState>(null)
 
-  const isPrefetchingEnabled = !isWeb && !disablePrefetch && enableViewPortPrefetching && to
+  const isPrefetchingEnabled = !isWebView && !disablePrefetch && enableViewPortPrefetching && to
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
@@ -55,7 +55,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
       navigationOptions.passProps = navigationProps
     }
 
-    if (isWeb) {
+    if (isWebView) {
       navigationOptions.modal = true
     }
 

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -58,7 +58,12 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
       navigationOptions.modal = true
     }
 
-    navigate(to, navigationOptions)
+    // check if there's any navigation options
+    if (Object.keys(navigationOptions).length > 0) {
+      navigate(to, navigationOptions)
+    } else {
+      navigate(to)
+    }
   }
 
   const handleVisible = (isVisible: boolean) => {


### PR DESCRIPTION
This PR resolves [EMI-2444] <!-- eg [PROJECT-XXXX] -->

### Description
This PR adds a new route (behind a feature flag) for the new Order Details screen

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

| | Android | iOS |
|---|---|---|
| Routing when FF is off | <video src="https://github.com/user-attachments/assets/4574399a-3b9e-4fc4-aa01-d69151a0691f" /> | <video src="https://github.com/user-attachments/assets/67c48b51-1e31-4afa-89d7-56f5038c95f5" /> |
| Routing when FF is on | <video src="https://github.com/user-attachments/assets/6d1985af-a55a-4ca2-a07b-a7b1a495dd8d" /> |  <video src="https://github.com/user-attachments/assets/04c0991b-4160-4bfb-a26b-ae918386b881" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add route for the new Order Details screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2444]: https://artsyproduct.atlassian.net/browse/EMI-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ