### PR TITLE
feat(auctions): update Auctions home screen header and whitespace

### DIFF
--- a/src/app/Components/LatestAuctionResultsRail.tsx
+++ b/src/app/Components/LatestAuctionResultsRail.tsx
@@ -1,12 +1,9 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
-import { Flex } from "@artsy/palette-mobile"
+import { Flex, Spacer } from "@artsy/palette-mobile"
 import { LatestAuctionResultsRail_me$key } from "__generated__/LatestAuctionResultsRail_me.graphql"
 import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { CardRailFlatList } from "app/Components/CardRail/CardRailFlatList"
-import {
-  AuctionResultListItemFragmentContainer,
-  AuctionResultListSeparator,
-} from "app/Components/Lists/AuctionResultListItem"
+import { AuctionResultListItemFragmentContainer } from "app/Components/Lists/AuctionResultListItem"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { AUCTION_RESULT_CARD_WIDTH } from "app/Scenes/HomeView/Sections/HomeViewSectionAuctionResults"
 import {
@@ -47,13 +44,14 @@ export const LatestAuctionResultsRail: React.FC<Props> = ({ me }) => {
         initialNumToRender={HORIZONTAL_FLATLIST_INTIAL_NUMBER_TO_RENDER_DEFAULT}
         windowSize={HORIZONTAL_FLATLIST_WINDOW_SIZE}
         showsHorizontalScrollIndicator={false}
-        ItemSeparatorComponent={AuctionResultListSeparator}
+        ItemSeparatorComponent={() => <Spacer x={2} />}
         renderItem={({ item, index }) => {
           return (
             <AuctionResultListItemFragmentContainer
               showArtistName
               auctionResult={item}
               width={AUCTION_RESULT_CARD_WIDTH}
+              withHorizontalPadding={false}
               onPress={() => {
                 trackEvent(tracks.tappedThumbnail(item.internalID, index))
               }}

--- a/src/app/Scenes/Sales/CurrentlyRunningAuctions.tsx
+++ b/src/app/Scenes/Sales/CurrentlyRunningAuctions.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@artsy/palette-mobile"
+import { Box, Flex } from "@artsy/palette-mobile"
 import { CurrentlyRunningAuctionsRefetchQuery } from "__generated__/CurrentlyRunningAuctionsRefetchQuery.graphql"
 import { CurrentlyRunningAuctions_viewer$key } from "__generated__/CurrentlyRunningAuctions_viewer.graphql"
 
@@ -42,11 +42,11 @@ export const CurrentlyRunningAuctions: React.FC<CurrentlyRunningAuctionsProps> =
   }, [nodes])
 
   return (
-    <>
+    <Flex>
       {!!liveAuctions.length && <SaleList title="Current Live Auctions" sales={liveAuctions} />}
       {!!liveAuctions.length && !!timedAuctions.length && <Box pb={4} />}
       {!!timedAuctions.length && <SaleList title="Current Timed Auctions" sales={timedAuctions} />}
-    </>
+    </Flex>
   )
 }
 

--- a/src/app/Scenes/Sales/Sales.tests.tsx
+++ b/src/app/Scenes/Sales/Sales.tests.tsx
@@ -1,7 +1,8 @@
-import { act, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { act, fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { CurrentlyRunningAuctions } from "./CurrentlyRunningAuctions"
-import { SalesScreen } from "./Sales"
+import { SalesScreen, SUPPORT_ARTICLE_URL } from "./Sales"
 import { UpcomingAuctions } from "./UpcomingAuctions"
 
 describe("Sales", () => {
@@ -57,6 +58,21 @@ describe("Sales", () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId("SalePlaceholder"))
 
     expect(screen.getByText("Latest Auction Results")).toBeOnTheScreen()
+  })
+
+  it("tracks article tap with the correct event data", async () => {
+    renderWithRelay()
+    await waitForElementToBeRemoved(() => screen.queryByTestId("SalePlaceholder"))
+
+    const learnMoreLink = screen.getByText("Learn more about bidding on Artsy.")
+    fireEvent.press(learnMoreLink)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "tappedLink",
+      context_module: "header",
+      context_screen_owner_type: "auctions",
+      destination_path: SUPPORT_ARTICLE_URL,
+    })
   })
 })
 

--- a/src/app/Scenes/Sales/Sales.tsx
+++ b/src/app/Scenes/Sales/Sales.tsx
@@ -1,21 +1,26 @@
-import { OwnerType } from "@artsy/cohesion"
-import { Flex, Screen, Spinner } from "@artsy/palette-mobile"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { Box, Flex, LinkText, Screen, Spinner, Text } from "@artsy/palette-mobile"
 import { SalesQuery } from "__generated__/SalesQuery.graphql"
 import { LatestAuctionResultsRail } from "app/Components/LatestAuctionResultsRail"
 import { RecommendedAuctionLotsRail } from "app/Scenes/HomeView/Components/RecommendedAuctionLotsRail"
 import { SaleListActiveBids } from "app/Scenes/Sales/Components/SaleListActiveBids"
-import { goBack } from "app/system/navigation/navigate"
+// eslint-disable-next-line no-restricted-imports
+import { goBack, navigate } from "app/system/navigation/navigate"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { Suspense, useRef, useState } from "react"
 import { RefreshControl } from "react-native"
 import { graphql, useLazyLoadQuery } from "react-relay"
+import { useTracking } from "react-tracking"
 import { ZeroState } from "./Components/ZeroState"
 import {
   CurrentlyRunningAuctions,
   CurrentlyRunningAuctionsRefetchType,
 } from "./CurrentlyRunningAuctions"
 import { UpcomingAuctions, UpcomingAuctionsRefetchType } from "./UpcomingAuctions"
+
+export const SUPPORT_ARTICLE_URL =
+  "https://support.artsy.net/s/article/The-Complete-Guide-to-Auctions-on-Artsy"
 
 export const SalesScreenQuery = graphql`
   query SalesQuery {
@@ -72,6 +77,17 @@ export const Sales: React.FC = () => {
 
   const totalSalesCount = currentSalesCount + upcomingSalesCount
 
+  const { trackEvent } = useTracking()
+
+  const trackArticleTap = () => {
+    trackEvent({
+      action: ActionType.tappedLink,
+      context_module: ContextModule.header,
+      context_screen_owner_type: OwnerType.auctions,
+      destination_path: SUPPORT_ARTICLE_URL,
+    })
+  }
+
   if (totalSalesCount < 1) {
     return <ZeroState />
   }
@@ -85,7 +101,24 @@ export const Sales: React.FC = () => {
         testID="Sales-Screen-ScrollView"
         refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
       >
-        <Flex py={2} gap={4}>
+        <Flex pb={2} gap={4}>
+          <Box mx={2}>
+            <Text variant="sm-display">
+              Bid on works you love with Artsy’s daily auctions.{" "}
+              <LinkText
+                variant="sm-display"
+                accessibilityRole="link"
+                accessibilityHint="Redirects to Artsy auctions guide"
+                onPress={() => {
+                  trackArticleTap()
+                  navigate(SUPPORT_ARTICLE_URL)
+                }}
+              >
+                Learn more about bidding on Artsy.
+              </LinkText>
+            </Text>
+          </Box>
+
           <SaleListActiveBids me={data.me} />
 
           <RecommendedAuctionLotsRail

--- a/src/app/Scenes/Sales/UpcomingAuctions.tsx
+++ b/src/app/Scenes/Sales/UpcomingAuctions.tsx
@@ -1,6 +1,5 @@
 import { UpcomingAuctionsRefetchQuery } from "__generated__/UpcomingAuctionsRefetchQuery.graphql"
 import { UpcomingAuctions_viewer$key } from "__generated__/UpcomingAuctions_viewer.graphql"
-import { Stack } from "app/Components/Stack"
 import { extractNodes } from "app/utils/extractNodes"
 import React, { useEffect } from "react"
 import { graphql, RefetchFnDynamic, useRefetchableFragment } from "react-relay"
@@ -38,11 +37,7 @@ export const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
     setSalesCountOnParent(nodes.length)
   }, [nodes.length])
 
-  return (
-    <Stack py={2} spacing={4}>
-      <SaleList title="Upcoming Auctions" sales={nodes} />
-    </Stack>
-  )
+  return <SaleList title="Upcoming Auctions" sales={nodes} />
 }
 
 export const upcomingSalesFragment = graphql`


### PR DESCRIPTION
This PR resolves [ONYX-1722]

### Description

Applies a few updates to the Auctions screen as part of the updates for auction-engaged users ([see Figma](https://www.figma.com/design/3LYkzfvfTPcYAIgzkaOM1C/Personalization?node-id=39-7842&m=dev))

- New header text and link to auctions guide
- Left-aligned images in **Latest Auction Results** rail
- Consistent spacing between rails, e.g. before **Upcoming Auctions** auctions 

<br>

| Before                                                                                                                                   | After (iOS)                                                                                                                             | After (Android)                                                                                                                               |
|------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
| <img alt="header before" height="400" src="https://github.com/user-attachments/assets/0bc5d417-fee5-4eff-8124-0f6b5343a5b4">            | <img alt="header after" height="400" src="https://github.com/user-attachments/assets/7e23ceca-bc7a-44b7-86ae-c1488ab9903e">            | <img alt="android header after" height="400" src="https://github.com/user-attachments/assets/6276a0e1-b130-4427-a1f1-a09420be1fbe">            |
| <img alt="space before" height="400" src="https://github.com/user-attachments/assets/30a831aa-ba2a-4203-b743-d36b3c37ba73">            | <img alt="space after" height="400" src="https://github.com/user-attachments/assets/2636e33f-6c6e-43ac-bdbe-45faa15963b8">            | <img alt="android space after" height="400" src="https://github.com/user-attachments/assets/554c62b8-f97e-46fa-a154-3520a8aee0db">            |



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Updates Auction screen and links to support document

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1722]: https://artsyproduct.atlassian.net/browse/ONYX-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ