### PR TITLE
fix(ArtistSeries): avoid suspending parent component when filtering

### DIFF
--- a/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeries.tsx
@@ -21,6 +21,7 @@ import { goBack } from "app/system/navigation/navigate"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { ProvideScreenTracking } from "app/utils/track"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
+import { Suspense } from "react"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
 interface ArtistSeriesProps {
@@ -53,7 +54,9 @@ export const ArtistSeries: React.FC<ArtistSeriesProps> = (props) => {
         >
           <Tabs.Tab name="Artworks" label="Artworks">
             <Tabs.Lazy>
-              <ArtistSeriesArtworks artistSeries={data} />
+              <Suspense fallback={<PlaceholderGrid />}>
+                <ArtistSeriesArtworks artistSeries={data} />
+              </Suspense>
             </Tabs.Lazy>
           </Tabs.Tab>
           <Tabs.Tab name="About" label="About">
@@ -117,11 +120,16 @@ const ArtistSeriesPlaceholder: React.FC = () => {
             <SkeletonText variant="xs">Artworks</SkeletonText>
             <SkeletonText variant="xs">About</SkeletonText>
           </Flex>
+          <Separator my={1} />
         </Skeleton>
 
-        <Separator mt={1} mb={4} />
-
-        <PlaceholderGrid />
+        <Flex flex={1} alignItems="center">
+          <Flex width="100%" justifyContent="space-between" p={2} flexDirection="row">
+            <SkeletonText variant="xs">Showing X works</SkeletonText>
+            <SkeletonText variant="xs">Sort & Filter</SkeletonText>
+          </Flex>
+          <PlaceholderGrid />
+        </Flex>
       </Screen.Body>
     </Screen>
   )


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Improving a bit the suspense situation in ArtistSeries

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/57ca0cdc-8815-48c3-ac00-9a0c346aad1c" width="400" /> | <video src="https://github.com/user-attachments/assets/db7f0b0f-2564-4788-87a0-0503b7ec3e61" width="400" /> |

The solution isn't perfect, but it's an improvement over before. I also tried wrapping the content in a separate <Tabs.Masonry />, but using two different <Tabs.Masonry /> components caused the suspended list to have a large top margin, creating excessive empty space that pushed the placeholder down, which didn't look great.


<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- avoid suspending parent component when filtering

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
