### PR TITLE
fix(Fair): suspense improvement on fairartworks

### DIFF
--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -1,5 +1,5 @@
 import { OwnerType } from "@artsy/cohesion"
-import { Flex, Spinner, Tabs, Text, useSpace } from "@artsy/palette-mobile"
+import { Flex, Spinner, Tabs, useSpace } from "@artsy/palette-mobile"
 import { MasonryFlashList } from "@shopify/flash-list"
 import { FairArtworks_fair$key } from "__generated__/FairArtworks_fair.graphql"
 import { ArtworkFilterNavigator, FilterModalMode } from "app/Components/ArtworkFilter"
@@ -23,7 +23,6 @@ import {
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
 import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
-import { pluralize } from "app/utils/pluralize"
 import { Schema } from "app/utils/track"
 import React, { useCallback, useEffect, useState } from "react"
 import { graphql, usePaginationFragment } from "react-relay"
@@ -139,7 +138,6 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
   }
 
   const filteredArtworks = extractNodes(data.fairArtworks)
-  const artworksCount = data.fairArtworks?.counts?.total ?? 0
 
   return (
     <>
@@ -164,16 +162,8 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
         ListHeaderComponent={
           <>
             <Tabs.SubTabBar>
-              <HeaderArtworksFilterWithTotalArtworks
-                hideArtworksCount={true}
-                onPress={handleFilterOpen}
-              />
+              <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />
             </Tabs.SubTabBar>
-
-            <Text variant="xs" weight="medium">{`${artworksCount} ${pluralize(
-              "Artwork",
-              artworksCount
-            )}:`}</Text>
           </>
         }
         ListFooterComponent={<AnimatedMasonryListFooter shouldDisplaySpinner={isLoadingNext} />}

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import {
   Flex,
+  // eslint-disable-next-line local-rules/no-palette-icon-imports
   ShareIcon,
   Skeleton,
   SkeletonBox,
@@ -17,6 +18,7 @@ import { FairArtworks } from "app/Scenes/Fair/Components/FairArtworks"
 import { FairExhibitorsFragmentContainer } from "app/Scenes/Fair/Components/FairExhibitors"
 import { FairOverview } from "app/Scenes/Fair/FairOverview"
 import { goBack } from "app/system/navigation/navigate"
+import { PlaceholderGrid } from "app/utils/placeholderGrid"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
 import React, { Suspense } from "react"
 import { TouchableOpacity } from "react-native"
@@ -116,7 +118,19 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
 
         <Tabs.Tab name="Artworks" label="Artworks">
           <ArtworkFiltersStoreProvider>
-            <FairArtworks fair={data} />
+            <Suspense
+              fallback={
+                <Flex flex={1} alignItems="center">
+                  <Flex width="100%" justifyContent="space-between" py={2} flexDirection="row">
+                    <SkeletonText variant="xs">Showing X works</SkeletonText>
+                    <SkeletonText variant="xs">Sort & Filter</SkeletonText>
+                  </Flex>
+                  <PlaceholderGrid />
+                </Flex>
+              }
+            >
+              <FairArtworks fair={data} />
+            </Suspense>
           </ArtworkFiltersStoreProvider>
         </Tabs.Tab>
       </Tabs.TabsWithHeader>


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Improving a bit the suspense situation in FairArtworks

| Platform | Before | After |
|---|---|---|
| Android |  <video src="https://github.com/user-attachments/assets/ca84efb0-cdb2-47ff-94f0-f9fefe51045d" width="400" /> | <video src="https://github.com/user-attachments/assets/b99cd263-9f15-456b-b025-f8d3558350f4" width="400" /> |

The solution isn't perfect, but it's an improvement over before. I also tried wrapping the content in a separate <Tabs.Masonry />, but using two different <Tabs.Masonry /> components caused the suspended list to have a large top margin, creating excessive empty space that pushed the placeholder down, which didn't look great.


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- suspense improvement on fairartworks

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
