### PR TITLE
feat(devx): add `which-build` script for tracing commits to beta or submission builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
     "test:debug": "node --inspect node_modules/.bin/jest --runInBand",
     "test:watch": "jest --watch",
     "type-check": "yarn relay; yarn tsc",
+    "which-build": "./scripts/deploys/which-build",
+    "which-submission": "./scripts/deploys/which-build --submission",
     "update-metaphysics": "node scripts/update-metaphysics.js"
   },
   "repository": {

--- a/scripts/deploys/which-build
+++ b/scripts/deploys/which-build
@@ -57,7 +57,7 @@ for sha in $SHAS; do
     if [ "$SUBMISSION" = true ]; then
       git tag --list "$e-*-submission" --contains $sha | sort -Vr | head -1
     else
-      git tag --list "$e-*" --contains $sha | sort -Vr | head -1
+      git tag --list "$e-*" --contains $sha | grep -v '-expo-' | sort -Vr | head -1
     fi
   done
 done

--- a/scripts/deploys/which-build
+++ b/scripts/deploys/which-build
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# which-build: Find commits and their corresponding builds across iOS and Android platforms
+#
+# This script helps identify which commits are included in which builds by showing the latest tag
+# for each platform (iOS and Android) that contains a specific commit. Useful for tracking
+# beta and release status of recent changes.
+#
+# Usage examples:
+#   ./scripts/deploys/which-build                           # Default: Shows all builds from the last 2 weeks
+#   ./scripts/deploys/which-build --since="1 month ago"     # Shows all builds from the last month
+#   ./scripts/deploys/which-build --submission              # Shows submission builds only
+#   ./scripts/deploys/which-build --since="2023-01-01" --submission  # Shows submission builds since Jan 1, 2023
+
+# Default --since value
+SINCE="2 weeks ago"
+
+# Default --submission value
+SUBMISSION=false
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since=*)
+      SINCE="${1#*=}"
+      shift
+      ;;
+    --since)
+      SINCE="$2"
+      shift 2
+      ;;
+    --submission)
+      SUBMISSION=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $(basename "$0") [--since=\"time spec\"] [--submission]"
+      echo "Example: $(basename "$0") --since=\"4 weeks ago\" --submission"
+      exit 1
+      ;;
+  esac
+done
+
+# update tags from remotes
+git fetch --all > /dev/null
+
+# get SHAs for relevant commits
+# by default: all non MP, non-deps commits from the last month
+SHAS=$(git log --format="%H %s" --since="$SINCE" | grep -v 'chore: update metaphysics' | grep -v 'chore(deps)' | cut -c 1-40)
+
+# iterate over SHAs
+for sha in $SHAS; do
+  git show -s --pretty="%C(yellow)%s %C(white)%h %C(green)%aN %C(blue)%ar%C(reset)" $sha
+  # find the latest tag for each platform that includes that commit
+  for e in ios android; do
+    if [ "$SUBMISSION" = true ]; then
+      git tag --list "$e-*-submission" --contains $sha | sort -Vr | head -1
+    else
+      git tag --list "$e-*" --contains $sha | sort -Vr | head -1
+    fi
+  done
+done

--- a/scripts/deploys/which-build
+++ b/scripts/deploys/which-build
@@ -11,12 +11,16 @@
 #   ./scripts/deploys/which-build --since="1 month ago"     # Shows all builds from the last month
 #   ./scripts/deploys/which-build --submission              # Shows submission builds only
 #   ./scripts/deploys/which-build --since="2023-01-01" --submission  # Shows submission builds since Jan 1, 2023
+#   ./scripts/deploys/which-build --author="Jane Doe"       # Shows builds with commits by Jane Doe from the last 2 weeks
 
 # Default --since value
 SINCE="2 weeks ago"
 
 # Default --submission value
 SUBMISSION=false
+
+# Default --author value (empty means all authors)
+AUTHOR=""
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -29,14 +33,22 @@ while [[ $# -gt 0 ]]; do
       SINCE="$2"
       shift 2
       ;;
+    --author=*)
+      AUTHOR="${1#*=}"
+      shift
+      ;;
+    --author)
+      AUTHOR="$2"
+      shift 2
+      ;;
     --submission)
       SUBMISSION=true
       shift
       ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $(basename "$0") [--since=\"time spec\"] [--submission]"
-      echo "Example: $(basename "$0") --since=\"4 weeks ago\" --submission"
+      echo "Usage: $(basename "$0") [--since=\"time spec\"] [--author=\"author name\"] [--submission]"
+      echo "Example: $(basename "$0") --since=\"4 weeks ago\" --author=\"Jane Doe\" --submission"
       exit 1
       ;;
   esac
@@ -47,7 +59,11 @@ git fetch --all > /dev/null
 
 # get SHAs for relevant commits
 # by default: all non MP, non-deps commits from the last month
-SHAS=$(git log --format="%H %s" --since="$SINCE" | grep -v 'chore: update metaphysics' | grep -v 'chore(deps)' | cut -c 1-40)
+if [ -n "$AUTHOR" ]; then
+  SHAS=$(git log --format="%H %s" --since="$SINCE" --author="$AUTHOR" | grep -v 'chore: update metaphysics' | grep -v 'chore(deps)' | cut -c 1-40)
+else
+  SHAS=$(git log --format="%H %s" --since="$SINCE" | grep -v 'chore: update metaphysics' | grep -v 'chore(deps)' | cut -c 1-40)
+fi
 
 # iterate over SHAs
 for sha in $SHAS; do


### PR DESCRIPTION
Lil #FF to polish up and share something that I had been using myself this week.

### Description

When trying to identify which Eigen build to point stakeholders to for QA purposes (e.g. in our [Onyx QA scripts](https://www.notion.so/artsy/App-Auction-segment-personalization-1f2cab0764a080fd8a23f6f16b2d79eb?pvs=4#1f2cab0764a08062a685ea34101c2fd6)), it can be a little tedious and fiddly to find the right build number.

So this adds two convenient methods for automating that.

(h/t @brainbicycle for [inspo](https://artsy.slack.com/archives/C02BAQ5K7/p1646324958299619) a while back)

```sh
# Show recent commits along with the most recent beta build that contains them
yarn which-build
```

```sh
# Show recent commits along with the most recent *submission* build that contains them
yarn which-submission
```

Output is as follows:

| `yarn which-build` | `yarn which-submission` |
|--------|--------|
| <img alt="which-build" src="https://github.com/user-attachments/assets/20c83fb5-fbf3-4670-8693-5c0a433f0f94" /> | <img alt="which-submission" src="https://github.com/user-attachments/assets/3d3c4a90-8fbf-40d3-b74b-84beddf1f43a" /> | 

Output can be customized by choosing a different time span:

```sh
yarn which-build --since="1 day ago"
yarn which-build --since="1 week ago"
yarn which-submission --since="1 month ago"
```

And/or a specific git author:

```
yarn which-build --author=anandaroop
yarn which-submission --author=iskounen --since="3 weeks ago"
```



### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
