### PR TITLE
fix(releases): broken version update

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "appName": "eigen",
-  "version": "8.73.0",
+  "version": "8.74.0",
   "isAndroidBeta": false,
   "slug": "eigen",
   "expo": {

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "appName": "eigen",
-  "version": "8.74.0",
+  "version": "8.73.0",
   "isAndroidBeta": false,
   "slug": "eigen",
   "expo": {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -224,6 +224,11 @@ lane :set_git_properties_ios do
   set_info_plist_value(path: absolute_path, key: 'GITRemoteOriginURL', value: GIT_REMOTE_ORIGIN_URL)
 end
 
+lane :test_next_version do
+  update_version_string(version: '8.74.0')
+  pr_url = prepare_version_update_pr(commit_message: "chore: prepare for next release")
+end
+
 desc 'Create a new version in app store connect if one does not exist'
 lane :create_next_version_if_needed do
   api_token = generate_spaceship_token

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -224,11 +224,6 @@ lane :set_git_properties_ios do
   set_info_plist_value(path: absolute_path, key: 'GITRemoteOriginURL', value: GIT_REMOTE_ORIGIN_URL)
 end
 
-lane :test_next_version do
-  update_version_string(version: '8.74.0')
-  pr_url = prepare_version_update_pr(commit_message: "chore: prepare for next release")
-end
-
 desc 'Create a new version in app store connect if one does not exist'
 lane :create_next_version_if_needed do
   api_token = generate_spaceship_token
@@ -242,7 +237,15 @@ lane :create_next_version_if_needed do
   edit_version_ready = edit_version && edit_version.app_store_state == 'PREPARE_FOR_SUBMISSION'
   live_version_ready = live_version && live_version.app_store_state == 'READY_FOR_SALE'
   if live_version_ready and !edit_version_ready then
-    UI.message("There is a live app version but there is no editable version")
+    UI.message("There is a live app version but there is no editable version ready")
+
+    non_editable_states = ['WAITING_FOR_REVIEW', 'IN_REVIEW', 'PENDING_APPLE_RELEASE', 'PROCESSING_FOR_APP_STORE']
+    if non_editable_states.include?(edit_version.app_store_state)
+      UI.message("An editable version exists but is not editable (state: #{edit_version.app_store_state})")
+      UI.message("We can't create a new version until the editable version is approved and ready")
+      next
+    end
+
     next_version = increment_version_number(live_version.version_string)
     UI.message("Creating new version #{next_version}")
     update_version_string(version: next_version)


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds some logic missing from our version update that was causing prs to open without updating version.
If the app is still in review we cannot create a new version yet.

Example failing PR: https://github.com/artsy/eigen/pull/12149/files

Now in this state will fail like this and wait until the next day:
```
[13:32:08]: There is a live app version but there is no editable version ready
[13:32:08]: An editable version exists but is not editable (state: WAITING_FOR_REVIEW)
[13:32:08]: We can't create a new version until the editable version is approved and ready
```

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix logic for version update when app in review - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
