### PR TITLE
chore(DIA-1307): capture sentry messages when verifyUser fails

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -1021,10 +1021,12 @@ export const getAuthModel = (): AuthModel => ({
         },
       })
     } catch (error) {
+      Sentry.captureMessage(`AuthModel verifyUser error ${error}`)
       return "something_went_wrong"
     }
 
     if (result.status !== 201) {
+      Sentry.captureMessage(`AuthModel verifyUser result status ${result.status}`)
       return "something_went_wrong"
     }
 


### PR DESCRIPTION
This PR adds calls to sentry when user verification fails during the auth flow. This is the verification that tells us whether an email address belongs to a user or not. I want to see how often this happens in production so that I can get a benchmark for any fixes that we make to the verification setup.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Added sentry messages when user verification fails.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
