### PR TITLE
refactor: import icons from @artsy/icons

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
@@ -1,7 +1,5 @@
-import { ArrowUpRightIcon } from "@artsy/icons/native"
-// TODO: MOPRAT-846
-// eslint-disable-next-line local-rules/no-palette-icon-imports
-import { Box, FireIcon, Text } from "@artsy/palette-mobile"
+import { ArrowUpRightIcon, FireIcon } from "@artsy/icons/native"
+import { Box, Text } from "@artsy/palette-mobile"
 import { ArtworkSocialSignal_collectorSignals$key } from "__generated__/ArtworkSocialSignal_collectorSignals.graphql"
 import { graphql, useFragment } from "react-relay"
 

--- a/src/app/Scenes/Artwork/Components/ArtworkDetailsCollectorSignal.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkDetailsCollectorSignal.tsx
@@ -1,7 +1,5 @@
-import { ArrowUpRightIcon } from "@artsy/icons/native"
-// TODO: MOPRAT-837 & MOPRAT-846
-// eslint-disable-next-line local-rules/no-palette-icon-imports
-import { bullet, FairIcon, FireIcon, Flex, LinkText, Text } from "@artsy/palette-mobile"
+import { ArrowUpRightIcon, FireIcon, FairIcon } from "@artsy/icons/native"
+import { bullet, Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { ArtworkDetailsCollectorSignal_artwork$key } from "__generated__/ArtworkDetailsCollectorSignal_artwork.graphql"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { DateTime } from "luxon"

--- a/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
+++ b/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
@@ -1,10 +1,9 @@
 import {
-  ArrowUpCircleFillIcon,
-  ArrowDownCircleFillIcon,
-  ExclamationMarkCircleFill,
-  BookmarkFill,
-  Text,
-} from "@artsy/palette-mobile"
+  ArrowheadUpCircleFillIcon,
+  ArrowheadDownCircleFillIcon,
+  BookmarkFillIcon,
+} from "@artsy/icons/native"
+import { ExclamationMarkCircleFill, Text } from "@artsy/palette-mobile"
 
 export const ReserveNotMet = () => (
   <>
@@ -18,7 +17,7 @@ export const ReserveNotMet = () => (
 
 export const HighestBid = () => (
   <>
-    <ArrowUpCircleFillIcon fill="green100" />
+    <ArrowheadUpCircleFillIcon fill="green100" />
     <Text variant="xs" color="green100">
       {" "}
       Highest bid
@@ -28,7 +27,7 @@ export const HighestBid = () => (
 
 export const Outbid = () => (
   <>
-    <ArrowDownCircleFillIcon fill="red100" />
+    <ArrowheadDownCircleFillIcon fill="red100" />
     <Text variant="xs" color="red100">
       {" "}
       Outbid
@@ -65,7 +64,7 @@ export const BiddingLiveNow = () => (
 
 export const Watching = () => (
   <>
-    <BookmarkFill />
+    <BookmarkFillIcon />
     <Text variant="xs" color="mono60">
       {" "}
       Watching

--- a/src/app/Scenes/MyBids/Components/SaleInfo.tsx
+++ b/src/app/Scenes/MyBids/Components/SaleInfo.tsx
@@ -1,4 +1,5 @@
-import { BoltFill, IconProps, Stopwatch, Flex, Box, Text } from "@artsy/palette-mobile"
+import { BoltFillIcon } from "@artsy/icons/native"
+import { IconProps, Stopwatch, Flex, Box, Text } from "@artsy/palette-mobile"
 import { TimelySale } from "app/Scenes/MyBids/helpers/timely"
 import { DateTime } from "luxon"
 import ordinal from "ordinal"
@@ -8,7 +9,7 @@ export const SaleInfo = ({
 }: {
   sale: { liveStartAt?: string | null; endAt?: string | null; status?: string | null }
 }) => {
-  let Icon: React.ComponentType<IconProps>
+  let Icon: React.ComponentType<IconProps> | typeof BoltFillIcon
   let noteColor: string
   let line1: string
   let line2: string | undefined
@@ -57,7 +58,7 @@ export const SaleInfo = ({
   }
 
   if (tSale.isLAI) {
-    Icon = BoltFill
+    Icon = BoltFillIcon
     line2 = line2Message("Opens", endMoment)
     if (tSale.isLiveBiddingNow()) {
       noteColor = "blue100"

--- a/src/app/Scenes/MyBids/SaleInfo.tests.tsx
+++ b/src/app/Scenes/MyBids/SaleInfo.tests.tsx
@@ -1,4 +1,5 @@
-import { BoltFill, Stopwatch, Text } from "@artsy/palette-mobile"
+import { BoltFillIcon } from "@artsy/icons/native"
+import { Stopwatch, Text } from "@artsy/palette-mobile"
 import { extractText } from "app/utils/tests/extractText"
 import { renderWithWrappersLEGACY } from "app/utils/tests/renderWithWrappers"
 import { merge } from "lodash"
@@ -26,7 +27,7 @@ describe(SaleInfo, () => {
       expect(
         renderWithWrappersLEGACY(
           <SaleInfo sale={saleFixture({ liveStartAt: "2020-08-01T15:00:00+00:00" })} />
-        ).root.findAllByType(BoltFill).length
+        ).root.findAllByType(BoltFillIcon).length
       ).toEqual(1)
     })
 
@@ -39,7 +40,7 @@ describe(SaleInfo, () => {
         )
       })
       it("has a blue100 icon + note if live bidding is active, mono60 otherwise", () => {
-        expect(tree.root.findByType(BoltFill).props.fill).toMatch("blue100")
+        expect(tree.root.findByType(BoltFillIcon).props.fill).toMatch("blue100")
       })
       it("has blue100 text", () => {
         expect(tree.root.findByType(Text).props.color).toEqual("blue100")


### PR DESCRIPTION
This PR resolves [MOPRAT-844],[MOPRAT-845],[MOPRAT-846],[MOPRAT-847],[MOPRAT-840],[MOPRAT-841]

Follow up to https://github.com/artsy/icons/pull/84, https://github.com/artsy/icons/pull/85, https://github.com/artsy/icons/pull/86, https://github.com/artsy/icons/pull/87

### Description

Updates imports for the following migrated icons:

- ArrowheadDownCircleFillIcon
- ArrowheadUpCircleFillIcon
- BoltFillIcon
- FairIcon
- FireIcon
- ArrowUpRightIcon
- BookmarkFillIcon

|Before|After|
|---|---|
| <img width="786" alt="Up-before" src="https://github.com/user-attachments/assets/513b2acf-52ee-4284-ba4d-5f4abe890f47" /> | <img width="786" alt="Up-after" src="https://github.com/user-attachments/assets/51087728-49f6-4af3-81d6-9f6dc91b1db3" /> |
| <img width="786" alt="Down-before" src="https://github.com/user-attachments/assets/d1a1a280-68d4-449c-8eed-55250e0314c0" /> | <img width="786" alt="Down-after" src="https://github.com/user-attachments/assets/3682a7be-a8cc-4b6d-bf78-569be06694c1" /> |
| <img width="786" alt="Bolt-before" src="https://github.com/user-attachments/assets/c4fdbcf7-fcd6-4bf4-baec-77ebde75b4df" /> | <img width="786" alt="Bolt-after" src="https://github.com/user-attachments/assets/16e77395-2781-4540-9d72-1a70e605896f" /> |
| <img width="786" alt="Fair-before" src="https://github.com/user-attachments/assets/722a0932-8ffd-459c-afa4-1aa1760fffe1" /> | <img width="786" alt="Fair-after" src="https://github.com/user-attachments/assets/fa588508-6738-45db-aed1-342ab9dec576" /> |
| <img width="786" alt="Fire-before" src="https://github.com/user-attachments/assets/e99b1751-4b89-4657-87f0-78f5dd57f735" /> | <img width="786" alt="Fire-after" src="https://github.com/user-attachments/assets/7aa453ac-4871-4832-ab6e-e55e1306138c" /> |
| <img width="786" alt="Increase-before" src="https://github.com/user-attachments/assets/d27b05cb-ea0a-4b10-a6a4-cab8298662ee" /> | <img width="786" alt="Increase-after" src="https://github.com/user-attachments/assets/ca6e9ae3-ec3b-4304-9c07-9d44cedba6a7" /> |
| <img width="786" alt="Fire item-before" src="https://github.com/user-attachments/assets/e63aeaa1-fffb-4513-9701-e12758338ba3" /> | <img width="786" alt="Fire item-after" src="https://github.com/user-attachments/assets/c0db86f9-1c21-42a3-802c-c76e3c35e3e0" /> |
| <img width="786" alt="Increase item-before" src="https://github.com/user-attachments/assets/4061c7e5-f9f9-45e2-941a-f2771f88bffd" /> | <img width="786" alt="Increase item-after" src="https://github.com/user-attachments/assets/5f11303d-4303-48dc-b78b-8bf7533da135" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Update icon imports

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[MOPRAT-844]: https://artsyproduct.atlassian.net/browse/MOPRAT-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPRAT-845]: https://artsyproduct.atlassian.net/browse/MOPRAT-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPRAT-846]: https://artsyproduct.atlassian.net/browse/MOPRAT-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPRAT-847]: https://artsyproduct.atlassian.net/browse/MOPRAT-847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPRAT-840]: https://artsyproduct.atlassian.net/browse/MOPRAT-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOPRAT-841]: https://artsyproduct.atlassian.net/browse/MOPRAT-841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ