### PR TITLE
fix: broken back button behaviour on android

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/__tests__/OnboardingMarketingCollection.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/__tests__/OnboardingMarketingCollection.tests.tsx
@@ -12,9 +12,11 @@ jest.mock("app/utils/Sentinel", () => ({
 }))
 
 jest.mock("@react-navigation/native", () => {
+  const { useEffect } = require("react")
   const actualNav = jest.requireActual("@react-navigation/native")
   return {
     ...actualNav,
+    useFocusEffect: useEffect,
     useNavigation: () => ({
       getId: () => "onboarding-marketing-collection-id",
       navigate: mockedNavigate,

--- a/src/app/utils/hooks/useBackHandler.tests.ts
+++ b/src/app/utils/hooks/useBackHandler.tests.ts
@@ -9,6 +9,7 @@ jest.mock("react-native", () => ({
   },
   Platform: {
     OS: "ios",
+    select: (obj: { ios: any; android: any }) => obj.ios,
   },
   NativeModules: {
     ArtsyNativeModule: {

--- a/src/app/utils/hooks/useBackHandler.ts
+++ b/src/app/utils/hooks/useBackHandler.ts
@@ -1,4 +1,5 @@
-import { useEffect } from "react"
+import { useFocusEffect } from "@react-navigation/native"
+import { useCallback } from "react"
 import { BackHandler } from "react-native"
 
 /**
@@ -9,9 +10,11 @@ import { BackHandler } from "react-native"
  * @param handler: () => boolean
  */
 export function useBackHandler(handler: () => boolean) {
-  useEffect(() => {
-    BackHandler.addEventListener("hardwareBackPress", handler)
+  useFocusEffect(
+    useCallback(() => {
+      BackHandler.addEventListener("hardwareBackPress", handler)
 
-    return () => BackHandler.removeEventListener("hardwareBackPress", handler)
-  }, [handler])
+      return () => BackHandler.removeEventListener("hardwareBackPress", handler)
+    }, [handler])
+  )
 }


### PR DESCRIPTION
This PR resolves [PBRW-812] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the broken back button behaviour on Android.

How did I identify the issue?
1. I wrapped all screens with a back button listener and saw the logged events
In our case, that's https://github.com/artsy/eigen/blob/34bd2d817e6ef78dbdc2304146884bce26fdccc4/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx#L89
2. When I am on the search tab, I saw some console logs, but I didn't get any in other tabs. Which led me to believe that we are overriding the behaviour somewhere.
3. I looked into how we override the back button usually. I met our trusted `useBackHandler`. 
4. I commented it, things worked 🎉 
5. I looked into React navigation docs and identified that we should only handle the back button if the screen is focused, because previous screens in the stack are always mounted. And that's it! 

https://github.com/user-attachments/assets/da169835-0fc8-47d8-92b1-e05bb1939605


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- broken back button behaviour - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-812]: https://artsyproduct.atlassian.net/browse/PBRW-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ