### PR TITLE
chore: persist progressive onboarding for the same user

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -364,6 +364,7 @@ export const getAuthModel = (): AuthModel => ({
 
         storeActions.search.clearRecentSearches()
         storeActions.recentPriceRanges.clearAllPriceRanges()
+        storeActions.progressiveOnboarding.reset()
       }
 
       postEventToProviders(tracks.loggedIn(oauthProvider))

--- a/src/app/store/ProgressiveOnboardingModel.ts
+++ b/src/app/store/ProgressiveOnboardingModel.ts
@@ -26,6 +26,7 @@ export interface ProgressiveOnboardingModel {
   setIsReady: Action<this, boolean>
   setActivePopover: Action<this, string | undefined>
   __clearDissmissed: Action<this>
+  reset: Action<this>
 }
 
 export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => ({
@@ -60,6 +61,10 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
   }),
   __clearDissmissed: action((state) => {
     state.dismissed = []
+  }),
+  reset: action((state) => {
+    state.dismissed = []
+    state.sessionState = { isReady: false }
   }),
 })
 


### PR DESCRIPTION
This PR resolves [ONYX-1730] <!-- eg [PROJECT-XXXX] -->

### Description

This PR allows us finally to persist the progressive onboarding values when the user signs off and signs in again using the same user id.

It also makes it slightly easier to do the same thing for future models.

_In the video below, I signed in using my account, it showed the dark model banner, and after signing in again, it no longer showed up._ 

https://github.com/user-attachments/assets/67d24735-3334-4417-8b01-9f6fc1d58e1b



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
