### PR TITLE
chore: adjust checkbox a11y labels to work with maestro and improve a11y

### DIFF
--- a/e2e/flows/signup.yml
+++ b/e2e/flows/signup.yml
@@ -16,6 +16,5 @@ appId: ${MAESTRO_APP_ID}
 - inputText: "Test McTest"
 - runFlow:
     commands:
-      - tapOn:
-          point: 15%,36%
+      - tapOn: Accept terms and privacy policy checkbox
 - tapOn: "Continue.*"

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/EmailSubscriptionCheckbox.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/EmailSubscriptionCheckbox.tsx
@@ -16,14 +16,17 @@ export const EmailSubscriptionCheckbox: React.FC<EmailSubscriptionCheckboxProps>
 
   return (
     <Flex pr={2} flexDirection="row">
-      <Checkbox
-        error={error}
-        checked={checked}
-        onPress={() => setChecked(!checked)}
-        mt={0.5}
-        accessibilityLabel="Agree to receive Artsy's emails checkbox"
-        accessibilityHint="Check this element to receive Artsy's emails"
-      />
+      <Flex>
+        <Checkbox
+          hitSlop={{ top: 25, bottom: 25, left: 25, right: 25 }}
+          error={error}
+          checked={checked}
+          onPress={() => setChecked(!checked)}
+          mt={0.5}
+          accessibilityLabel="Agree to receive Artsy's emails checkbox"
+          accessibilityHint="Check this element to receive Artsy's emails"
+        />
+      </Flex>
       <Flex paddingLeft={1} pt={0.5}>
         {signupLoginFusionEnabled ? (
           <Text variant="xs">

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/EmailSubscriptionCheckbox.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/EmailSubscriptionCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Text, Checkbox } from "@artsy/palette-mobile"
+import { Text, Checkbox, Flex } from "@artsy/palette-mobile"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 
 interface EmailSubscriptionCheckboxProps {
@@ -15,25 +15,28 @@ export const EmailSubscriptionCheckbox: React.FC<EmailSubscriptionCheckboxProps>
   const signupLoginFusionEnabled = useFeatureFlag("AREnableSignupLoginFusion")
 
   return (
-    <Checkbox
-      error={error}
-      checked={checked}
-      onPress={() => setChecked(!checked)}
-      mt={0.5}
-      accessibilityLabel="Agree to receive Artsy's emails"
-      accessibilityHint="Check this element to receive Artsy's emails"
-    >
-      {signupLoginFusionEnabled ? (
-        <Text variant="xs">
-          Get Artsy's emails on the art market, products, services, editorial, and promotional
-          content. Unsubscribe at any time.
-        </Text>
-      ) : (
-        <Text variant="xs">
-          Dive deeper into the art market with Artsy emails. Subscribe to hear about our products,
-          services, editorials, and other promotional content. Unsubscribe at any time.
-        </Text>
-      )}
-    </Checkbox>
+    <Flex pr={2} flexDirection="row">
+      <Checkbox
+        error={error}
+        checked={checked}
+        onPress={() => setChecked(!checked)}
+        mt={0.5}
+        accessibilityLabel="Agree to receive Artsy's emails checkbox"
+        accessibilityHint="Check this element to receive Artsy's emails"
+      />
+      <Flex paddingLeft={1} pt={0.5}>
+        {signupLoginFusionEnabled ? (
+          <Text variant="xs">
+            Get Artsy's emails on the art market, products, services, editorial, and promotional
+            content. Unsubscribe at any time.
+          </Text>
+        ) : (
+          <Text variant="xs">
+            Dive deeper into the art market with Artsy emails. Subscribe to hear about our products,
+            services, editorials, and other promotional content. Unsubscribe at any time.
+          </Text>
+        )}
+      </Flex>
+    </Flex>
   )
 }

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountName.tests.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/OnboardingCreateAccountName.tests.tsx
@@ -79,7 +79,7 @@ describe("OnboardingCreateAccountName", () => {
   describe("Checkboxes", () => {
     it("sets acceptedTerms to true when the user presses on the checkbox", async () => {
       renderWithWrappers(<Test name="Andy warhol" />)
-      const termsCheckbox = screen.getByLabelText("Accept terms and privacy policy")
+      const termsCheckbox = screen.getByLabelText("Accept terms and privacy policy checkbox")
 
       fireEvent(termsCheckbox, "setChecked")
 
@@ -89,7 +89,9 @@ describe("OnboardingCreateAccountName", () => {
     it("sets agreedToReceiveEmails to true when the user presses on the checkbox", async () => {
       renderWithWrappers(<Test name="Andy warhol" />)
 
-      const emailsSubscriptionCheckbox = screen.getByLabelText("Agree to receive Artsy's emails")
+      const emailsSubscriptionCheckbox = screen.getByLabelText(
+        "Agree to receive Artsy's emails checkbox"
+      )
       fireEvent(emailsSubscriptionCheckbox, "setChecked")
 
       expect(emailsSubscriptionCheckbox).toBeChecked()

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Text } from "@artsy/palette-mobile"
+import { Checkbox, Flex, Text } from "@artsy/palette-mobile"
 import { NavigationProp } from "@react-navigation/native"
 
 interface TermsOfServiceCheckboxProps {
@@ -15,33 +15,38 @@ export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = ({
   navigation,
 }) => {
   return (
-    <Checkbox
-      error={error}
-      checked={checked}
-      onPress={() => setChecked(!checked)}
-      mt={0.5}
-      accessibilityLabel="Accept terms and privacy policy"
-      accessibilityHint="Check this element to accept Artsy's terms and privacy policy"
-    >
-      <Text variant="xs" testID="disclaimer">
-        I accept Artsy's{" "}
-        <Text
-          onPress={() => navigation.navigate("OnboardingWebView", { url: "/terms" })}
-          variant="xs"
-          style={{ textDecorationLine: "underline" }}
-        >
-          General Terms and Conditions of Sale
-        </Text>{" "}
-        and{" "}
-        <Text
-          onPress={() => navigation.navigate("OnboardingWebView", { url: "/privacy" })}
-          variant="xs"
-          style={{ textDecorationLine: "underline" }}
-        >
-          Privacy Policy
+    <Flex flexDirection="row" alignItems="center" mr={2}>
+      <Flex>
+        <Checkbox
+          error={error}
+          checked={checked}
+          onPress={() => setChecked(!checked)}
+          mt={0.5}
+          accessibilityLabel="Accept terms and privacy policy checkbox"
+          accessibilityHint="Check this element to accept Artsy's terms and privacy policy"
+        />
+      </Flex>
+      <Flex paddingLeft={1} pt={0.5}>
+        <Text variant="xs" testID="disclaimer">
+          I accept Artsy's{" "}
+          <Text
+            onPress={() => navigation.navigate("OnboardingWebView", { url: "/terms" })}
+            variant="xs"
+            style={{ textDecorationLine: "underline" }}
+          >
+            General Terms and Conditions of Sale
+          </Text>{" "}
+          and{" "}
+          <Text
+            onPress={() => navigation.navigate("OnboardingWebView", { url: "/privacy" })}
+            variant="xs"
+            style={{ textDecorationLine: "underline" }}
+          >
+            Privacy Policy
+          </Text>
+          .
         </Text>
-        .
-      </Text>
-    </Checkbox>
+      </Flex>
+    </Flex>
   )
 }

--- a/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingCreateAccount/TermsOfServiceCheckbox.tsx
@@ -18,6 +18,7 @@ export const TermsOfServiceCheckbox: React.FC<TermsOfServiceCheckboxProps> = ({
     <Flex flexDirection="row" alignItems="center" mr={2}>
       <Flex>
         <Checkbox
+          hitSlop={{ top: 25, bottom: 25, left: 25, right: 25 }}
           error={error}
           checked={checked}
           onPress={() => setChecked(!checked)}


### PR DESCRIPTION
This PR resolves [PHIRE-1501] <!-- eg [PROJECT-XXXX] -->

### Description

- Increases hitslop on checkbox
- separate children from checkbox since they are both pressable
- updates the e2e tests accordingly to utilise the a11y label

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/1b9389b3-4202-470d-85f9-4abcf2fb2278" width="400" /> | <img src="https://github.com/user-attachments/assets/f4b64ad8-c027-4e2a-9562-1191e4abe68e" width="400" /> |
| iOS | <img src="https://github.com/user-attachments/assets/f069009c-2226-4c7b-848f-cfc83e47595d" width="400" /> | <img src="https://github.com/user-attachments/assets/250a0f98-54d9-46b2-8485-849208e89529" width="400" /> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- adjust checkbox a11y labels to work with maestro and improve a11y

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1501]: https://artsyproduct.atlassian.net/browse/PHIRE-1501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ