### PR TITLE
fix: expo updates not applying after switching channels #trivial

### DIFF
--- a/docs/debugging_expo_updates.md
+++ b/docs/debugging_expo_updates.md
@@ -24,7 +24,7 @@ Set the debug flag in terminal and reinstall pods:
 
 ```
 export EX_UPDATES_NATIVE_DEBUG=1
-npx pod-install
+bundle exec npx pod-install
 ```
 
 Set flag in project to create a js bundle on every build:
@@ -40,6 +40,10 @@ Run the application from Xcode using the Artsy (QA) scheme.
 
 Deploy an update using these [instructions](./deploy_to_expo_updates.md) and pull down using the dev menu.
 
+#### If you want to use lldb / xcode debugger
+
+The QA configuration is a release configuration, code is optimized so debugging doesn't work properly, you can change the optimization level to None in build settings if you need this.
+
 ### Known gotchas
 
 #### Code changes not auto refreshing app
@@ -49,3 +53,8 @@ The QA scheme uses bundled JS. To see any changes you will need to rebuild from 
 #### Update is not applied after fetch
 
 Expo updates has a bunch of native code checks to see if the local code is newer than the update it is trying to apply. These can be manually disabled by commenting out, or you can make sure you don't change any code after shipping an update, but this makes the feedback loop painful. Ask #product-sapphire for help if you have trouble.
+
+#### Crash on launch after switching channels
+
+In dev mode there are assertions for valid state transitions that fail after switching channels, this may be a bug worth investigating and possibly PR back to expo?
+To get arround it you can comment out the assertions in the transition function in UpdatesStateMachine.swift when debugging in dev.

--- a/ios/Artsy/Supporting/QA/ExpoQA.plist
+++ b/ios/Artsy/Supporting/QA/ExpoQA.plist
@@ -10,6 +10,11 @@
 	<true/>
 	<key>EXUpdatesLaunchWaitMs</key>
 	<integer>0</integer>
+	<key>EXUpdatesRequestHeaders</key>
+	<dict>
+		<key>expo-channel-name</key>
+		<string>staging</string>
+	</dict>
 	<key>EXUpdatesRuntimeVersion</key>
 	<string>replaced-at-build-time</string>
 	<key>EXUpdatesURL</key>

--- a/ios/Artsy/Supporting/QA/ExpoQA.plist
+++ b/ios/Artsy/Supporting/QA/ExpoQA.plist
@@ -10,11 +10,6 @@
 	<true/>
 	<key>EXUpdatesLaunchWaitMs</key>
 	<integer>0</integer>
-	<key>EXUpdatesRequestHeaders</key>
-	<dict>
-		<key>expo-channel-name</key>
-		<string>staging</string>
-	</dict>
 	<key>EXUpdatesRuntimeVersion</key>
 	<string>replaced-at-build-time</string>
 	<key>EXUpdatesURL</key>

--- a/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
+++ b/src/app/system/devTools/DevMenu/Components/ExpoUpdatesOptions.tsx
@@ -146,11 +146,9 @@ export const ExpoUpdatesOptions = () => {
                 setSelectedDeployment(deployment as ExpoDeployment)
                 const channelName = expoDeploymentChannels[deployment as ExpoDeployment]
                 Updates.setUpdateURLAndRequestHeadersOverride({
-                  updateUrl:
-                    "https://expo-updates-api.artsy.net/api/manifest?project=eigen&channel=" +
-                    channelName,
+                  updateUrl: "https://u.expo.dev/39b092dc-effa-4d59-a530-85107bdfd668",
                   requestHeaders: {
-                    "expo-channel-name": expoDeploymentChannels[deployment as ExpoDeployment],
+                    "expo-channel-name": channelName,
                   },
                 })
 
@@ -162,8 +160,10 @@ export const ExpoUpdatesOptions = () => {
                       text: "I will crash now!",
                       style: "destructive",
                       onPress: () => {
-                        // Crash the app to force a restart
-                        Sentry.nativeCrash()
+                        if (!__DEV__) {
+                          // Crash the app to force a restart
+                          Sentry.nativeCrash()
+                        }
                       },
                     },
                   ]


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

🤦 Missed this when we migrated from self hosted and only tested updates on the default channel. This should fix switching channels. 


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix expo updates not applying after switching channels

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
