### PR TITLE
chore: improve splash screen hiding logic

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingQuiz.tsx
@@ -1,4 +1,3 @@
-import { NavigationContainer, NavigationIndependentTree } from "@react-navigation/native"
 import { createStackNavigator, TransitionPresets } from "@react-navigation/stack"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -48,55 +47,42 @@ export const OnboardingQuiz = () => {
 
   return (
     <OnboardingProvider onDone={handleDone}>
-      <NavigationIndependentTree>
-        <NavigationContainer>
-          <StackNavigator.Navigator
-            screenOptions={{
-              ...TransitionPresets.DefaultTransition,
-              headerShown: false,
-              headerMode: "screen",
-              gestureEnabled: false,
-            }}
-          >
-            <StackNavigator.Screen
-              name="OnboardingWelcomeScreen"
-              component={OnboardingWelcomeScreen}
-            />
-            <StackNavigator.Screen name="OnboardingQuestionOne" component={OnboardingQuestionOne} />
-            <StackNavigator.Screen name="OnboardingQuestionTwo" component={OnboardingQuestionTwo} />
-            <StackNavigator.Screen
-              name="OnboardingQuestionThree"
-              component={OnboardingQuestionThree}
-            />
+      <StackNavigator.Navigator
+        screenOptions={{
+          ...TransitionPresets.DefaultTransition,
+          headerShown: false,
+          headerMode: "screen",
+          gestureEnabled: false,
+        }}
+      >
+        <StackNavigator.Screen name="OnboardingWelcomeScreen" component={OnboardingWelcomeScreen} />
+        <StackNavigator.Screen name="OnboardingQuestionOne" component={OnboardingQuestionOne} />
+        <StackNavigator.Screen name="OnboardingQuestionTwo" component={OnboardingQuestionTwo} />
+        <StackNavigator.Screen name="OnboardingQuestionThree" component={OnboardingQuestionThree} />
 
-            <StackNavigator.Screen
-              name="OnboardingTopAuctionLots"
-              component={OnboardingTopAuctionLots}
-            />
-            <StackNavigator.Screen
-              name="OnboardingArtistsOnTheRise"
-              component={OnboardingArtistsOnTheRise}
-            />
-            <StackNavigator.Screen
-              name="OnboardingCuratedArtworks"
-              component={OnboardingCuratedArtworks}
-            />
+        <StackNavigator.Screen
+          name="OnboardingTopAuctionLots"
+          component={OnboardingTopAuctionLots}
+        />
+        <StackNavigator.Screen
+          name="OnboardingArtistsOnTheRise"
+          component={OnboardingArtistsOnTheRise}
+        />
+        <StackNavigator.Screen
+          name="OnboardingCuratedArtworks"
+          component={OnboardingCuratedArtworks}
+        />
 
-            <StackNavigator.Screen
-              name="OnboardingFollowArtists"
-              component={OnboardingFollowArtists}
-            />
-            <StackNavigator.Screen
-              name="OnboardingFollowGalleries"
-              component={OnboardingFollowGalleries}
-            />
-            <StackNavigator.Screen
-              name="OnboardingPostFollowLoadingScreen"
-              component={OnboardingPostFollowLoadingScreen}
-            />
-          </StackNavigator.Navigator>
-        </NavigationContainer>
-      </NavigationIndependentTree>
+        <StackNavigator.Screen name="OnboardingFollowArtists" component={OnboardingFollowArtists} />
+        <StackNavigator.Screen
+          name="OnboardingFollowGalleries"
+          component={OnboardingFollowGalleries}
+        />
+        <StackNavigator.Screen
+          name="OnboardingPostFollowLoadingScreen"
+          component={OnboardingPostFollowLoadingScreen}
+        />
+      </StackNavigator.Navigator>
     </OnboardingProvider>
   )
 }

--- a/src/app/utils/useHideSplashScreen.ts
+++ b/src/app/utils/useHideSplashScreen.ts
@@ -44,6 +44,9 @@ export const useHideSplashScreen = () => {
       }
     }
 
-    hideSplashScreen()
+    // As a fallback, hide the splash screen after 3 seconds in case the above logic fails
+    setTimeout(() => {
+      hideSplashScreen()
+    }, 3000)
   }, [isHydrated, isLoggedIn, isNavigationReady, isUnleashReady])
 }


### PR DESCRIPTION
### Description

When QA'ng the App, I noticed that the splash screen is getting dismissed almost immediately. This started to happen after this [fix](https://github.com/artsy/eigen/pull/12180) that we shipped recently. The previous fix is still important for us as a safeguard in case some initialisation logic breaks. 

**Adjustments made:**
- Hide the splash screen after a timeout of 3 seconds, this is much less than the `HomeViewQuery` average, so hopefully we never hit it.

- **Main reason why `isNavigationReady` was `false`:** It turned out the onboarding screens where using an `IndependentNavigationContainer`. Since it's the first container inside the main `NavigationContainer`, we can never tell that it's done. The fix was to simply not use an independent navigation tree. 


https://github.com/user-attachments/assets/97254003-0a58-4618-9cdf-1ba53aae5efd


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- improve splash screen hiding logic - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
