### PR TITLE
fix: install node modules before determine-deployment-type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -605,7 +605,6 @@ workflows:
             branches:
               only:
                 - main
-                - brian/main-break
 
       - test-js
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
       - install-node
       - install-gems
       - setup-awscli
+      - install-node-modules
       - run:
           name: Determine Deployment Type
           command: |
@@ -284,7 +285,6 @@ jobs:
               ./scripts/deploys/expo-updates/maybe-notify-beta-needed
               circleci-agent step halt
             fi
-      - install-node-modules
       - run-relay-compiler
       # - run:
       #     name: Handle Deployment for expo updates
@@ -605,6 +605,7 @@ workflows:
             branches:
               only:
                 - main
+                - brian/main-break
 
       - test-js
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Fixes failure in main due to fingerprint dep not being available.

Successful job:
https://app.circleci.com/pipelines/github/artsy/eigen/70377/workflows/09500dc8-7ea3-48bd-b96a-0179b8c37735/jobs/245395

### Follow-ups
- [ ] Migrate ci tools to bin pattern to avoid needing to install all node modules

#nochangelog 

