### PR TITLE
fix: profile notification updates

### DIFF
--- a/src/app/Scenes/MyAccount/updateMyUserProfile.ts
+++ b/src/app/Scenes/MyAccount/updateMyUserProfile.ts
@@ -39,6 +39,7 @@ export const updateMyUserProfile = async (
               receiveNewWorksNotification
               receiveOutbidNotification
               receivePromotionNotification
+              receiveOrderNotification
               receivePurchaseNotification
               receiveSaleOpeningClosingNotification
               priceRangeMin

--- a/src/app/Scenes/MyAccount/updateMyUserProfile.ts
+++ b/src/app/Scenes/MyAccount/updateMyUserProfile.ts
@@ -37,9 +37,10 @@ export const updateMyUserProfile = async (
               receiveLotOpeningSoonNotification
               receiveNewSalesNotification
               receiveNewWorksNotification
-              receiveOutbidNotification
-              receivePromotionNotification
               receiveOrderNotification
+              receiveOutbidNotification
+              receivePartnerOfferNotification
+              receivePromotionNotification
               receivePurchaseNotification
               receiveSaleOpeningClosingNotification
               priceRangeMin

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -19,7 +19,6 @@ import { requestSystemPermissions } from "app/utils/requestPushNotificationsPerm
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import useAppState from "app/utils/useAppState"
-import { debounce, omit } from "lodash"
 import React, { useCallback, useEffect, useState } from "react"
 import { Alert, Linking, Platform, RefreshControl } from "react-native"
 import { graphql, useLazyLoadQuery, useRefetchableFragment } from "react-relay"
@@ -32,16 +31,7 @@ const INSTRUCTIONS = Platform.select({
   default: "",
 })
 
-export type UserPushNotificationSettings =
-  | "receiveLotOpeningSoonNotification"
-  | "receiveNewSalesNotification"
-  | "receiveNewWorksNotification"
-  | "receiveOutbidNotification"
-  | "receivePromotionNotification"
-  | "receivePurchaseNotification"
-  | "receiveSaleOpeningClosingNotification"
-  | "receiveOrderNotification"
-  | "receivePartnerOfferNotification"
+export type UserPushNotificationSettings = keyof MyProfilePushNotifications_me$data
 
 export const OpenSettingsBanner = () => (
   <>
@@ -182,21 +172,13 @@ export const MyProfilePushNotifications: React.FC<{
           [notificationType]: value,
         }
         setUserNotificationSettings(updatedUserNotificationSettings)
-        await updateNotificationPermissions(updatedUserNotificationSettings)
+        await updateMyUserProfile({ [notificationType]: value })
       } catch (error) {
         setUserNotificationSettings(userNotificationSettings)
         Alert.alert(typeof error === "string" ? error : "Something went wrong.")
       }
     },
     [userNotificationSettings]
-  )
-
-  const updateNotificationPermissions = useCallback(
-    debounce(async (updatedPermissions: MyProfilePushNotifications_me$data) => {
-      const validUpdatedPermissions = omit(updatedPermissions, "id")
-      await updateMyUserProfile(validUpdatedPermissions)
-    }, 500),
-    []
   )
 
   return (

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -31,7 +31,10 @@ const INSTRUCTIONS = Platform.select({
   default: "",
 })
 
-export type UserPushNotificationSettings = keyof MyProfilePushNotifications_me$data
+export type UserPushNotificationSettings = keyof Omit<
+  MyProfilePushNotifications_me$data,
+  "id" | " $fragmentType"
+>
 
 export const OpenSettingsBanner = () => (
   <>

--- a/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePushNotifications.tsx
@@ -35,6 +35,60 @@ export type UserPushNotificationSettings = keyof Omit<
   MyProfilePushNotifications_me$data,
   "id" | " $fragmentType"
 >
+export const NOTIFICATION_SETTINGS: Record<
+  UserPushNotificationSettings,
+  {
+    title: string
+    description: string
+    key: UserPushNotificationSettings
+  }
+> = {
+  receivePartnerOfferNotification: {
+    title: "Offers on Saved Artworks",
+    description: "Offers from galleries on artworks you saved",
+    key: "receivePartnerOfferNotification",
+  },
+  receivePurchaseNotification: {
+    title: "Messages",
+    description: "Messages from sellers on your inquiries",
+    key: "receivePurchaseNotification",
+  },
+  receiveOutbidNotification: {
+    title: "Outbid Alerts",
+    description: "Alerts for when you've been outbid",
+    key: "receiveOutbidNotification",
+  },
+  receiveOrderNotification: {
+    title: "Order Updates",
+    description: "An order you've placed has an update",
+    key: "receiveOrderNotification",
+  },
+  receiveLotOpeningSoonNotification: {
+    title: "Lot Opening Soon",
+    description: "Your lots that are opening for live bidding soon",
+    key: "receiveLotOpeningSoonNotification",
+  },
+  receiveSaleOpeningClosingNotification: {
+    title: "Lot Opening Soon",
+    description: "Your lots that are opening for live bidding soon",
+    key: "receiveLotOpeningSoonNotification",
+  },
+  receiveNewWorksNotification: {
+    title: "New Works for You",
+    description: "New works added by artists you follow",
+    key: "receiveNewWorksNotification",
+  },
+  receiveNewSalesNotification: {
+    title: "New Auctions for You",
+    description: "New auctions with artists you follow",
+    key: "receiveNewSalesNotification",
+  },
+  receivePromotionNotification: {
+    title: "Promotions",
+    description: "Updates on Artsy's latest campaigns and special offers.",
+    key: "receivePromotionNotification",
+  },
+}
 
 export const OpenSettingsBanner = () => (
   <>
@@ -115,11 +169,9 @@ const MyProfilePushNotificationsPlaceholder: React.FC<{}> = () => {
               receiveOrderNotification: false,
               receiveOutbidNotification: false,
               receivePartnerOfferNotification: false,
-              receivePartnerShowNotification: false,
               receivePromotionNotification: false,
               receivePurchaseNotification: false,
               receiveSaleOpeningClosingNotification: false,
-              receiveViewingRoomNotification: false,
             } as MyProfilePushNotifications_me$data
           }
           isLoading={true}
@@ -247,92 +299,119 @@ const Content: React.FC<ContentProps> = (props) => {
         {!!enablePartnerOffersNotificationSwitch && (
           <NotificationPermissionsBox title="Gallery Offers" isLoading={isLoading}>
             <SwitchMenu
-              title="Offers on Saved Artworks"
-              description="Offers from galleries on artworks you saved"
+              title={NOTIFICATION_SETTINGS.receivePartnerOfferNotification.title}
+              description={NOTIFICATION_SETTINGS.receivePartnerOfferNotification.description}
               value={!!userNotificationSettings.receivePartnerOfferNotification}
               disabled={isLoading}
               onChange={(value) => {
-                handleUpdateUserNotificationSettings("receivePartnerOfferNotification", value)
+                handleUpdateUserNotificationSettings(
+                  NOTIFICATION_SETTINGS.receivePartnerOfferNotification.key,
+                  value
+                )
               }}
             />
           </NotificationPermissionsBox>
         )}
         <NotificationPermissionsBox title="Purchase Updates" isLoading={isLoading}>
           <SwitchMenu
-            title="Messages"
-            description="Messages from sellers on your inquiries"
+            title={NOTIFICATION_SETTINGS.receivePurchaseNotification.title}
+            description={NOTIFICATION_SETTINGS.receivePurchaseNotification.description}
             value={!!userNotificationSettings.receivePurchaseNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receivePurchaseNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receivePurchaseNotification.key,
+                value
+              )
             }}
           />
           <SwitchMenu
-            title="Outbid Alerts"
-            description="Alerts for when you've been outbid"
+            title={NOTIFICATION_SETTINGS.receiveOutbidNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveOutbidNotification.description}
             value={!!userNotificationSettings.receiveOutbidNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveOutbidNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveOutbidNotification.key,
+                value
+              )
             }}
           />
           <SwitchMenu
-            title="Order Updates"
-            description="An order you've placed has an update"
+            title={NOTIFICATION_SETTINGS.receiveOrderNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveOrderNotification.description}
             value={!!userNotificationSettings.receiveOrderNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveOrderNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveOrderNotification.key,
+                value
+              )
             }}
           />
         </NotificationPermissionsBox>
         <NotificationPermissionsBox title="Reminders" isLoading={isLoading}>
           <SwitchMenu
-            title="Lot Opening Soon"
-            description="Your lots that are opening for live bidding soon"
+            title={NOTIFICATION_SETTINGS.receiveLotOpeningSoonNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveLotOpeningSoonNotification.description}
             value={!!userNotificationSettings.receiveLotOpeningSoonNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveLotOpeningSoonNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveLotOpeningSoonNotification.key,
+                value
+              )
             }}
           />
           <SwitchMenu
-            title="Auctions Starting and Closing"
-            description="Your registered auctions that are starting or closing soon"
+            title={NOTIFICATION_SETTINGS.receiveSaleOpeningClosingNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveSaleOpeningClosingNotification.description}
             value={!!userNotificationSettings.receiveSaleOpeningClosingNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveSaleOpeningClosingNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveSaleOpeningClosingNotification.key,
+                value
+              )
             }}
           />
         </NotificationPermissionsBox>
         <NotificationPermissionsBox title="Recommendations" isLoading={isLoading}>
           <SwitchMenu
             testID="newWorksSwitch"
-            title="New Works for You"
-            description="New works added by artists you follow"
+            title={NOTIFICATION_SETTINGS.receiveNewWorksNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveNewWorksNotification.description}
             value={!!userNotificationSettings.receiveNewWorksNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveNewWorksNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveNewWorksNotification.key,
+                value
+              )
             }}
           />
           <SwitchMenu
-            title="New Auctions for You"
-            description="New auctions with artists you follow"
+            title={NOTIFICATION_SETTINGS.receiveNewSalesNotification.title}
+            description={NOTIFICATION_SETTINGS.receiveNewSalesNotification.description}
             value={!!userNotificationSettings.receiveNewSalesNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receiveNewSalesNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receiveNewSalesNotification.key,
+                value
+              )
             }}
           />
           <SwitchMenu
-            title="Promotions"
-            description="Updates on Artsy's latest campaigns and special offers."
+            title={NOTIFICATION_SETTINGS.receivePromotionNotification.title}
+            description={NOTIFICATION_SETTINGS.receivePromotionNotification.description}
             value={!!userNotificationSettings.receivePromotionNotification}
             disabled={isLoading}
             onChange={(value) => {
-              handleUpdateUserNotificationSettings("receivePromotionNotification", value)
+              handleUpdateUserNotificationSettings(
+                NOTIFICATION_SETTINGS.receivePromotionNotification.key,
+                value
+              )
             }}
           />
         </NotificationPermissionsBox>
@@ -347,14 +426,12 @@ const meFragment = graphql`
     receiveLotOpeningSoonNotification
     receiveNewSalesNotification
     receiveNewWorksNotification
+    receiveOrderNotification
     receiveOutbidNotification
+    receivePartnerOfferNotification
     receivePromotionNotification
     receivePurchaseNotification
     receiveSaleOpeningClosingNotification
-    receiveOrderNotification
-    receiveViewingRoomNotification
-    receivePartnerShowNotification
-    receivePartnerOfferNotification
   }
 `
 

--- a/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.spec.ts
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.spec.ts
@@ -1,0 +1,21 @@
+import { updateMyUserProfileMutation } from "__generated__/updateMyUserProfileMutation.graphql"
+import {
+  NOTIFICATION_SETTINGS,
+  UserPushNotificationSettings,
+} from "app/Scenes/MyProfile/MyProfilePushNotifications"
+
+// Import the mutation type
+type MutationResponse = updateMyUserProfileMutation["response"]
+type UpdateMyUserProfile = NonNullable<MutationResponse["updateMyUserProfile"]>
+type MeObject = NonNullable<UpdateMyUserProfile["me"]>
+
+// TypeScript will error here if any UserPushNotificationSettings key is not in MeObject
+const _typeCheck = (k: UserPushNotificationSettings): keyof MeObject => {
+  return k // If this passes type-checking, the key exists on MeObject
+}
+
+// For each notification setting key, it must exist as a property on the Me object
+// TypeScript compiler will catch any missing properties
+Object.values(NOTIFICATION_SETTINGS).forEach((notification) => {
+  _typeCheck(notification.key)
+})

--- a/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
@@ -1,11 +1,9 @@
 import { Switch, Text } from "@artsy/palette-mobile"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyProfilePushNotificationsTestQuery } from "__generated__/MyProfilePushNotificationsTestQuery.graphql"
-import { updateMyUserProfileMutation } from "__generated__/updateMyUserProfileMutation.graphql"
 import { SwitchMenu } from "app/Components/SwitchMenu"
 import {
   MyProfilePushNotifications,
-  NOTIFICATION_SETTINGS,
   UserPushNotificationSettings,
 } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
@@ -185,24 +183,6 @@ describe("MyProfilePushNotificationsQueryRenderer", () => {
           },
         })
       )
-    })
-  })
-  // This is a pure type test that ensures all notification keys exist in the mutation response type
-  it("mutation response includes all UserPushNotificationSettings fields from ProfilePushNotifications", () => {
-    // Import the mutation type
-    type MutationResponse = updateMyUserProfileMutation["response"]
-    type UpdateMyUserProfile = NonNullable<MutationResponse["updateMyUserProfile"]>
-    type MeObject = NonNullable<UpdateMyUserProfile["me"]>
-
-    // TypeScript will error here if any UserPushNotificationSettings key is not in MeObject
-    const _typeCheck = (k: UserPushNotificationSettings): keyof MeObject => {
-      return k // If this passes type-checking, the key exists on MeObject
-    }
-
-    // For each notification setting key, it must exist as a property on the Me object
-    // TypeScript compiler will catch any missing properties
-    Object.values(NOTIFICATION_SETTINGS).forEach((notification) => {
-      _typeCheck(notification.key)
     })
   })
 })

--- a/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
@@ -2,7 +2,10 @@ import { Switch, Text } from "@artsy/palette-mobile"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyProfilePushNotificationsTestQuery } from "__generated__/MyProfilePushNotificationsTestQuery.graphql"
 import { SwitchMenu } from "app/Components/SwitchMenu"
-import { MyProfilePushNotifications } from "app/Scenes/MyProfile/MyProfilePushNotifications"
+import {
+  MyProfilePushNotifications,
+  UserPushNotificationSettings,
+} from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
@@ -157,12 +160,13 @@ describe("MyProfilePushNotificationsQueryRenderer", () => {
         expect.objectContaining({
           variables: {
             input: {
-              ...mockNotificationsPreferences,
               receiveNewWorksNotification: false,
             },
           },
         })
       )
+
+      await flushPromiseQueue()
 
       fireEvent(switchElement, "onValueChange", true)
 
@@ -174,7 +178,6 @@ describe("MyProfilePushNotificationsQueryRenderer", () => {
         expect.objectContaining({
           variables: {
             input: {
-              ...mockNotificationsPreferences,
               receiveNewWorksNotification: true,
             },
           },
@@ -184,7 +187,7 @@ describe("MyProfilePushNotificationsQueryRenderer", () => {
   })
 })
 
-const mockNotificationsPreferences = {
+const mockNotificationsPreferences: Record<UserPushNotificationSettings, boolean> = {
   receiveLotOpeningSoonNotification: true,
   receiveNewSalesNotification: true,
   receiveNewWorksNotification: true,

--- a/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfilePushNotifications.tests.tsx
@@ -1,9 +1,11 @@
 import { Switch, Text } from "@artsy/palette-mobile"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyProfilePushNotificationsTestQuery } from "__generated__/MyProfilePushNotificationsTestQuery.graphql"
+import { updateMyUserProfileMutation } from "__generated__/updateMyUserProfileMutation.graphql"
 import { SwitchMenu } from "app/Components/SwitchMenu"
 import {
   MyProfilePushNotifications,
+  NOTIFICATION_SETTINGS,
   UserPushNotificationSettings,
 } from "app/Scenes/MyProfile/MyProfilePushNotifications"
 import { PushAuthorizationStatus } from "app/utils/PushNotification"
@@ -185,6 +187,24 @@ describe("MyProfilePushNotificationsQueryRenderer", () => {
       )
     })
   })
+  // This is a pure type test that ensures all notification keys exist in the mutation response type
+  it("mutation response includes all UserPushNotificationSettings fields from ProfilePushNotifications", () => {
+    // Import the mutation type
+    type MutationResponse = updateMyUserProfileMutation["response"]
+    type UpdateMyUserProfile = NonNullable<MutationResponse["updateMyUserProfile"]>
+    type MeObject = NonNullable<UpdateMyUserProfile["me"]>
+
+    // TypeScript will error here if any UserPushNotificationSettings key is not in MeObject
+    const _typeCheck = (k: UserPushNotificationSettings): keyof MeObject => {
+      return k // If this passes type-checking, the key exists on MeObject
+    }
+
+    // For each notification setting key, it must exist as a property on the Me object
+    // TypeScript compiler will catch any missing properties
+    Object.values(NOTIFICATION_SETTINGS).forEach((notification) => {
+      _typeCheck(notification.key)
+    })
+  })
 })
 
 const mockNotificationsPreferences: Record<UserPushNotificationSettings, boolean> = {
@@ -196,7 +216,5 @@ const mockNotificationsPreferences: Record<UserPushNotificationSettings, boolean
   receivePurchaseNotification: true,
   receiveSaleOpeningClosingNotification: true,
   receiveOrderNotification: true,
-  receiveViewingRoomNotification: true,
-  receivePartnerShowNotification: true,
   receivePartnerOfferNotification: true,
 }


### PR DESCRIPTION
This PR resolves [ONYX-1724] <!-- eg [PROJECT-XXXX] -->

### Description

This PR is a follow up to https://github.com/artsy/eigen/pull/12174.

The above PR fixes the issues reported in [ONYX-1724], except one, the **order updates notification**.

**Why was it broken?**
- The order updates notification value wasn't accurate.
- Why? I checked the value in Insomnia and it was updated properly, it turned out that the `receiveOrderNotification` was missing in the query
- Why didn't we notice this with typescript? because we had notifications types hard typed
- What did I do?
  - I updated the type to reflect the type from GraphQL
  - I added the missing values to the query



| Android | iOS |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/cff82e14-16d1-45ba-b5ac-f87cf2d60fa3" /> | <video src="https://github.com/user-attachments/assets/d741c3b1-c7bf-4dc1-8ff7-10cef7732c8a" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix profile notifications - order details not updating - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1724]: https://artsyproduct.atlassian.net/browse/ONYX-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1724]: https://artsyproduct.atlassian.net/browse/ONYX-1724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ