### PR TITLE
chore: bottom tabs hiding animation

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -316,3 +316,9 @@ https://github.com/expo/expo/pull/36893
 #### Explanation/Context:
 
 Expo updates was not returning the reason an update failed to be available on iOS making debugging difficult.
+
+## patch-package for react-navigation/bottom-tabs
+
+This patch allows us to animate the appearance of the bottom tabs. This is currently not supported by @react-navigation/bottom-tabs but it's something they do when the user shows/hides the keyboard.
+
+See https://github.com/artsy/eigen/pull/12249 for more details.

--- a/patches/@react-navigation+bottom-tabs+7.3.3.patch
+++ b/patches/@react-navigation+bottom-tabs+7.3.3.patch
@@ -1,0 +1,37 @@
+diff --git a/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js b/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
+index 8f0fb1c..755fce8 100644
+--- a/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
++++ b/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
+@@ -131,6 +131,7 @@ function BottomTabBar({
+     tabBarShowLabel,
+     tabBarLabelPosition,
+     tabBarHideOnKeyboard = false,
++    tabBarVisible = false,
+     tabBarVisibilityAnimationConfig,
+     tabBarVariant = 'uikit',
+     tabBarStyle,
+@@ -149,7 +150,7 @@ function BottomTabBar({
+   const dimensions = (0, _reactNativeSafeAreaContext.useSafeAreaFrame)();
+   const isKeyboardShown = (0, _useIsKeyboardShown.useIsKeyboardShown)();
+   const onHeightChange = _react.default.useContext(_BottomTabBarHeightCallbackContext.BottomTabBarHeightCallbackContext);
+-  const shouldShowTabBar = !(tabBarHideOnKeyboard && isKeyboardShown);
++  const shouldShowTabBar = !(tabBarHideOnKeyboard && isKeyboardShown) && !tabBarVisible;
+   const visibilityAnimationConfigRef = _react.default.useRef(tabBarVisibilityAnimationConfig);
+   _react.default.useEffect(() => {
+     visibilityAnimationConfigRef.current = tabBarVisibilityAnimationConfig;
+diff --git a/node_modules/@react-navigation/bottom-tabs/src/types.tsx b/node_modules/@react-navigation/bottom-tabs/src/types.tsx
+index 02f7119..01dfabc 100644
+--- a/node_modules/@react-navigation/bottom-tabs/src/types.tsx
++++ b/node_modules/@react-navigation/bottom-tabs/src/types.tsx
+@@ -224,6 +224,11 @@ export type BottomTabNavigationOptions = HeaderOptions & {
+    */
+   tabBarHideOnKeyboard?: boolean;
+ 
++  /**
++   * Whether the tab bar gets hidden when the screen is focused. Defaults to `false`.
++   */
++  tabBarVisible?: boolean;
++
+   /**
+    * Animation config for showing and hiding the tab bar when the keyboard is shown/hidden.
+    */

--- a/scripts/deploys/expo-updates/deploy-to-expo-updates
+++ b/scripts/deploys/expo-updates/deploy-to-expo-updates
@@ -37,6 +37,9 @@ if [ -n "$rollout" ]; then
 else
   bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:ios
   bundle exec fastlane deploy_to_expo_updates deployment_name:$deployment description:"$description" platform:android
+  # reset changes made to app.json
+  git checkout app.json
+  git checkout dist/.gitkeep
 fi
 
 echo "Release to $deployment deployment successful."

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -18,7 +18,7 @@ import { goBack } from "app/system/navigation/navigate"
 import { memo } from "react"
 import { Platform } from "react-native"
 import { isTablet } from "react-native-device-info"
-import Animated, { Easing, withTiming } from "react-native-reanimated"
+import Animated, { Easing, useAnimatedStyle, withTiming } from "react-native-reanimated"
 
 export const StackNavigator = createNativeStackNavigator<AuthenticatedRoutesParams>()
 
@@ -102,16 +102,24 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const tabBarHeight = hidesBottomTabs ? 0 : useBottomTabBarHeight()
 
+    const animatedStyle = useAnimatedStyle(() => {
+      return {
+        paddingBottom: withTiming(hidesBottomTabs ? 0 : tabBarHeight, {
+          duration: TAB_BAR_ANIMATION_DURATION,
+          easing: Easing.inOut(Easing.ease),
+        }),
+      }
+    })
+
     return (
       <RetryErrorBoundary>
         <Animated.View
-          style={{
-            flex: 1,
-            paddingBottom: withTiming(hidesBottomTabs ? 0 : tabBarHeight, {
-              duration: TAB_BAR_ANIMATION_DURATION,
-              easing: Easing.inOut(Easing.ease),
-            }),
-          }}
+          style={[
+            {
+              flex: 1,
+            },
+            animatedStyle,
+          ]}
         >
           {children}
         </Animated.View>

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -15,10 +15,11 @@ import {
 import { AppModule, ModuleDescriptor } from "app/Navigation/routes"
 import { isModalScreen } from "app/Navigation/utils/isModalScreen"
 import { goBack } from "app/system/navigation/navigate"
+import { MotiView } from "moti"
 import { memo } from "react"
 import { Platform } from "react-native"
 import { isTablet } from "react-native-device-info"
-import Animated, { Easing, useAnimatedStyle, withTiming } from "react-native-reanimated"
+import { Easing, useAnimatedStyle, withTiming } from "react-native-reanimated"
 
 export const StackNavigator = createNativeStackNavigator<AuthenticatedRoutesParams>()
 
@@ -113,7 +114,7 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
 
     return (
       <RetryErrorBoundary>
-        <Animated.View
+        <MotiView
           style={[
             {
               flex: 1,
@@ -122,7 +123,7 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
           ]}
         >
           {children}
-        </Animated.View>
+        </MotiView>
       </RetryErrorBoundary>
     )
   }

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -2,20 +2,23 @@ import {
   ArrowLeftIcon,
   CloseIcon,
   DEFAULT_HIT_SLOP,
-  Flex,
   THEMES,
   Touchable,
 } from "@artsy/palette-mobile"
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
-import { AuthenticatedRoutesParams } from "app/Navigation/AuthenticatedRoutes/Tabs"
+import {
+  AuthenticatedRoutesParams,
+  TAB_BAR_ANIMATION_DURATION,
+} from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { AppModule, ModuleDescriptor } from "app/Navigation/routes"
 import { isModalScreen } from "app/Navigation/utils/isModalScreen"
 import { goBack } from "app/system/navigation/navigate"
 import { memo } from "react"
 import { Platform } from "react-native"
 import { isTablet } from "react-native-device-info"
+import Animated, { Easing, withTiming } from "react-native-reanimated"
 
 export const StackNavigator = createNativeStackNavigator<AuthenticatedRoutesParams>()
 
@@ -101,14 +104,17 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
 
     return (
       <RetryErrorBoundary>
-        <Flex
-          flex={1}
+        <Animated.View
           style={{
-            paddingBottom: hidesBottomTabs ? 0 : tabBarHeight,
+            flex: 1,
+            paddingBottom: withTiming(hidesBottomTabs ? 0 : tabBarHeight, {
+              duration: TAB_BAR_ANIMATION_DURATION,
+              easing: Easing.inOut(Easing.ease),
+            }),
           }}
         >
           {children}
-        </Flex>
+        </Animated.View>
       </RetryErrorBoundary>
     )
   }

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -91,6 +91,10 @@ const AppTabs: React.FC = () => {
     <Tab.Navigator
       screenOptions={({ route }) => {
         const currentRoute = internal_navigationRef.current?.getCurrentRoute()?.name
+
+        const hidesBottomTabs =
+          currentRoute && modules[currentRoute as AppModule]?.options?.hidesBottomTabs
+
         return {
           animation: "fade",
           headerShown: false,
@@ -98,13 +102,11 @@ const AppTabs: React.FC = () => {
             animate: true,
             position: "absolute",
             height: BOTTOM_TABS_HEIGHT + insets.bottom,
-            display:
-              currentRoute && modules[currentRoute as AppModule]?.options?.hidesBottomTabs
-                ? "none"
-                : "flex",
+
             ...(isStaging ? stagingTabBarStyle : {}),
           },
           tabBarHideOnKeyboard: true,
+          tabBarVisible: hidesBottomTabs,
           tabBarIcon: ({ focused }) => {
             return (
               <Flex pt={1}>

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -21,7 +21,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { useIsStaging } from "app/utils/hooks/useIsStaging"
 import { postEventToProviders } from "app/utils/track/providers"
 import { useCallback } from "react"
-import { InteractionManager, PixelRatio, Platform } from "react-native"
+import { Easing, InteractionManager, PixelRatio, Platform } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 if (Platform.OS === "ios") {
@@ -47,6 +47,7 @@ type TabRoutesParams = {
 const Tab = createBottomTabNavigator<TabRoutesParams>()
 
 const BOTTOM_TABS_HEIGHT = PixelRatio.getFontScale() < 1.5 ? 65 : 85
+export const TAB_BAR_ANIMATION_DURATION = 250
 
 const AppTabs: React.FC = () => {
   const { tabsBadges } = useBottomTabsBadges()
@@ -107,6 +108,22 @@ const AppTabs: React.FC = () => {
           },
           tabBarHideOnKeyboard: true,
           tabBarVisible: hidesBottomTabs,
+          tabBarVisibilityAnimationConfig: {
+            show: {
+              animation: "timing",
+              config: {
+                duration: TAB_BAR_ANIMATION_DURATION,
+                easing: Easing.inOut(Easing.ease),
+              },
+            },
+            hide: {
+              animation: "timing",
+              config: {
+                duration: TAB_BAR_ANIMATION_DURATION,
+                easing: Easing.inOut(Easing.ease),
+              },
+            },
+          },
           tabBarIcon: ({ focused }) => {
             return (
               <Flex pt={1}>


### PR DESCRIPTION
### Description

This PR allows us to animate the appearance of the bottom tab. This is unfortunately something that react-navigation doesn't support yet, it however is a behaviour that is available in most apps and is quick to implement on the native side.


This helps us making transition between screens smoother and makes our experiene closer to a native experience.


**Before**

<video src="https://github.com/user-attachments/assets/6be76ed5-cb1c-4455-9e0e-e91ad79f62a5"  width="400"></video>

___

**After**

| Android | iOS |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fda4cf4e-58f0-43f4-b532-7e62383b2b06" /> | <video src="https://github.com/user-attachments/assets/7c555d00-d6ec-4f1a-8f7a-9cbedac01ea9" /> | 



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- animate bottom tabs appearance/disappearance - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
