### PR TITLE
fix: show RefreshControl beneath sticky header in Favorites screen

### DIFF
--- a/src/app/Scenes/ArtworkLists/ArtworkLists.tsx
+++ b/src/app/Scenes/ArtworkLists/ArtworkLists.tsx
@@ -43,10 +43,11 @@ interface ArtworkListsProps {
   isTab?: boolean
   isFavorites?: boolean
   style?: StyleProp<ViewStyle>
+  headerHeight?: number
 }
 
 export const ArtworkLists: React.FC<ArtworkListsProps> = withSuspense({
-  Component: ({ isTab = true, isFavorites = false, style }) => {
+  Component: ({ isTab = true, isFavorites = false, style, headerHeight }) => {
     const space = useSpace()
     const artworkListsColCount = useArtworkListsColCount()
     const [refreshing, setRefreshing] = useState(false)
@@ -118,7 +119,13 @@ export const ArtworkLists: React.FC<ArtworkListsProps> = withSuspense({
           onEndReached={handleLoadMore}
           ListFooterComponent={!!hasNext ? <LoadingIndicator /> : <Spacer x={2} />}
           ListHeaderComponent={isPartnerOfferEnabled ? <SavesTabHeader /> : null}
-          refreshControl={<RefreshControl onRefresh={handleRefresh} refreshing={refreshing} />}
+          refreshControl={
+            <RefreshControl
+              onRefresh={handleRefresh}
+              refreshing={refreshing}
+              progressViewOffset={headerHeight}
+            />
+          }
         />
       )
     }
@@ -143,7 +150,13 @@ export const ArtworkLists: React.FC<ArtworkListsProps> = withSuspense({
         ListHeaderComponent={
           isPartnerOfferEnabled ? isFavorites ? <SavesHeader /> : <SavesTabHeader /> : null
         }
-        refreshControl={<RefreshControl onRefresh={handleRefresh} refreshing={refreshing} />}
+        refreshControl={
+          <RefreshControl
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+            progressViewOffset={headerHeight}
+          />
+        }
       />
     )
   },

--- a/src/app/Scenes/Favorites/Components/AlertsList.tsx
+++ b/src/app/Scenes/Favorites/Components/AlertsList.tsx
@@ -14,6 +14,7 @@ import { SavedSearchListItem } from "app/Scenes/SavedSearchAlertsList/Components
 import { extractNodes } from "app/utils/extractNodes"
 import { RefreshEvents, SAVED_ALERT_REFRESH_KEY } from "app/utils/refreshHelpers"
 import React, { useEffect, useRef, useState } from "react"
+import { RefreshControl } from "react-native"
 import { graphql, usePaginationFragment } from "react-relay"
 
 interface AlertsListProps {
@@ -60,10 +61,15 @@ export const AlertsList: React.FC<AlertsListProps> = (props) => {
     <Screen.FlatList
       data={items.filter((item) => !item.isDeleted)}
       keyExtractor={(item) => item.internalID}
-      refreshing={isRefreshing}
       ListEmptyComponent={<EmptyMessage />}
-      onRefresh={onRefresh}
       onEndReachedThreshold={0.5}
+      refreshControl={
+        <RefreshControl
+          refreshing={isRefreshing}
+          onRefresh={onRefresh}
+          progressViewOffset={headerHeight}
+        />
+      }
       renderItem={({ item }) => {
         return (
           <SavedSearchListItem

--- a/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedArtists.tsx
@@ -30,7 +30,7 @@ export const FollowedArtists: React.FC<Props> = ({ me }) => {
 
   const artists = extractNodes(data.followsAndSaves?.artistsConnection)
 
-  const RefreshControl = useRefreshControl(refetch)
+  const RefreshControl = useRefreshControl(refetch, { progressViewOffset: headerHeight })
 
   const { trackTappedArtistFollowsGroup } = useFavoritesTracking()
 

--- a/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedGalleries.tsx
@@ -33,7 +33,7 @@ export const FollowedGalleries: React.FC<Props> = ({ me }) => {
 
   const galleries = extractNodes(data.followsAndSaves?.galleriesConnection)
 
-  const RefreshControl = useRefreshControl(refetch)
+  const RefreshControl = useRefreshControl(refetch, { progressViewOffset: headerHeight })
 
   if (galleries.length === 0) {
     return (

--- a/src/app/Scenes/Favorites/Components/FollowedShows.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedShows.tsx
@@ -29,7 +29,7 @@ export const FollowedShows: React.FC<Props> = ({ me }) => {
 
   const shows = extractNodes(data.followsAndSaves?.showsConnection)
 
-  const RefreshControl = useRefreshControl(refetch)
+  const RefreshControl = useRefreshControl(refetch, { progressViewOffset: headerHeight })
 
   if (shows.length === 0) {
     return (

--- a/src/app/Scenes/Favorites/SavesTab.tsx
+++ b/src/app/Scenes/Favorites/SavesTab.tsx
@@ -10,7 +10,12 @@ export const SavesTab = () => {
 
   return (
     <Flex flex={1}>
-      <ArtworkLists isTab={false} isFavorites={true} style={{ paddingTop: headerHeight }} />
+      <ArtworkLists
+        isTab={false}
+        isFavorites={true}
+        style={{ paddingTop: headerHeight }}
+        headerHeight={headerHeight}
+      />
     </Flex>
   )
 }

--- a/src/app/utils/refreshHelpers.tsx
+++ b/src/app/utils/refreshHelpers.tsx
@@ -43,6 +43,7 @@ export const refreshCreditCardsList = () => {
 
 interface RefreshArgs extends Record<string, any> {
   pageSize?: number
+  progressViewOffset?: number
 }
 
 /**
@@ -89,5 +90,11 @@ export const useRefreshControl = (refetch: any, args?: RefreshArgs) => {
     )
   }
 
-  return <RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />
+  return (
+    <RefreshControl
+      refreshing={isRefreshing}
+      onRefresh={handleRefresh}
+      progressViewOffset={args?.progressViewOffset}
+    />
+  )
 }


### PR DESCRIPTION
### Description

Add `progressViewOffset` to RefreshControl in all Favorites tabs (Saves, Follows, Alerts) to ensure the pull-to-refresh spinner is visible below the sticky header instead of being hidden behind it.

🤖 Generated with [Claude Code](https://claude.ai/code)

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/672b51db-809a-4509-878f-cd7da0175af2" width="400" /> | <video src="https://github.com/user-attachments/assets/9d80fee5-55bc-4d3f-ac8f-cdbab8bc3958" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/b410204a-36a4-4452-85a8-bceb90d5d657" width="400" /> | <video src="https://github.com/user-attachments/assets/611d8392-5bfe-4e24-9f2f-65bb257ec400" width="400" /> |

Jira: [ONYX-1757](https://artsyproduct.atlassian.net/browse/ONYX-1757) 🔒 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: show RefreshControl beneath sticky header in Favorites screen

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1757]: https://artsyproduct.atlassian.net/browse/ONYX-1757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ