### PR TITLE
chore: remove artwork filtering feature flags

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterOptionsScreen.tsx
@@ -18,7 +18,6 @@ import {
   ArtworksFiltersStore,
 } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { GlobalStore } from "app/store/GlobalStore"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { Schema } from "app/utils/track"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
 import { compact } from "lodash"
@@ -50,10 +49,6 @@ export enum FilterModalMode {
 export const ArtworkFilterOptionsScreen: React.FC<
   StackScreenProps<ArtworkFilterNavigationStack, "FilterOptionsScreen">
 > = ({ navigation, route }) => {
-  const enableArtistSeriesFilter = useFeatureFlag("AREnableArtistSeriesFilter")
-  const enableAvailabilityFilter = useFeatureFlag("AREnableAvailabilityFilter")
-  const enableFramedFilter = useFeatureFlag("AREnableFramedFilter")
-
   const tracking = useTracking()
   const { closeModal, id, mode, slug, title = "Sort & Filter" } = route.params
 
@@ -111,13 +106,6 @@ export const ArtworkFilterOptionsScreen: React.FC<
   const sortedFilterOptions = filterOptions
     .sort(getFilterScreenSortByMode(mode, localFilterOptions))
     .filter((filterOption) => filterOption.filterType)
-    // Filter out the Artist Series filter if the feature flag is disabled
-    .filter(
-      (filterOption) =>
-        (enableArtistSeriesFilter || filterOption.filterType !== "artistSeriesIDs") &&
-        (enableAvailabilityFilter || filterOption.filterType !== "availability") &&
-        (enableFramedFilter || filterOption.filterType !== "framed")
-    )
 
   const clearAllFilters = () => {
     clearFiltersZeroStateAction()

--- a/src/app/Components/ArtworkFilter/Filters/__tests__/ArtistSeriesOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/__tests__/ArtistSeriesOptions.tests.tsx
@@ -12,10 +12,6 @@ import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe(ArtistSeriesOptionsScreen, () => {
-  beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtistSeriesFilter: true })
-  })
-
   const initialState: ArtworkFiltersState = {
     aggregations: [
       {

--- a/src/app/Components/ArtworkFilter/Filters/__tests__/AvailabilityOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/__tests__/AvailabilityOptions.tests.tsx
@@ -12,10 +12,6 @@ import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe(AvailabilityOptionsScreen, () => {
-  beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableAvailabilityFilter: true })
-  })
-
   const initialState: ArtworkFiltersState = {
     aggregations: [],
     appliedFilters: [],

--- a/src/app/Components/ArtworkFilter/Filters/__tests__/FramedOptions.tests.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/__tests__/FramedOptions.tests.tsx
@@ -12,10 +12,6 @@ import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe(FramedOptionsScreen, () => {
-  beforeEach(() => {
-    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableFramedFilter: true })
-  })
-
   const initialState: ArtworkFiltersState = {
     aggregations: [],
     appliedFilters: [],

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -92,11 +92,6 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableAlertsFiltersSizeFiltering",
   },
-  AREnableArtistSeriesFilter: {
-    description: "Enable artist series filter on Artist screen",
-    readyForRelease: true,
-    echoFlagKey: "AREnableArtistSeriesFilter",
-  },
   AREnablePartnerOffersNotificationSwitch: {
     description: "Enable partner offers notification switch",
     readyForRelease: true,
@@ -155,12 +150,6 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnablePaymentFailureBanner",
   },
-  AREnableAvailabilityFilter: {
-    description: "Enable availability filter",
-    readyForRelease: true,
-    showInDevMenu: true,
-    echoFlagKey: "AREnableAvailabilityFilter",
-  },
   AREnableViewPortPrefetching: {
     description: "Enable viewport prefetching",
     readyForRelease: true,
@@ -172,12 +161,6 @@ export const features = {
     readyForRelease: true,
     showInDevMenu: true,
     echoFlagKey: "AREnableArtworkCardContextMenuIOS",
-  },
-  AREnableFramedFilter: {
-    description: "Enable show only framed works filter",
-    readyForRelease: true,
-    showInDevMenu: true,
-    echoFlagKey: "AREnableFramedFilter",
   },
   AREnableHidingDislikedArtworks: {
     description: "Enable hiding disliked artworks",


### PR DESCRIPTION
### Description

- chore: remove artwork filtering feature flags

Remove AREnableArtistSeriesFilter, AREnableAvailabilityFilter, and
AREnableFramedFilter feature flags as they have been fully rolled out. These
filter options are now permanently enabled in the artwork filtering system.

Changes:
- Remove feature flag definitions from features.ts
- Remove feature flag checks from ArtworkFilterOptionsScreen.tsx
- Remove feature flag injections from test files
- All artwork filters (artist series, availability, framed) are now always available

The artwork filtering system now permanently includes artist series filtering,
availability filtering ("Only works for sale"), and framed works filtering
without requiring feature flag controls.

The three artwork filtering feature flags have been completely removed from the
codebase and all functionality is working correctly. All filter options are now
permanently enabled for users.

_drive-by change 🚗  – remove the unreferenced AREnableAlertsFilters flag too._

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- chore: remove artwork filtering feature flags
- chore: remove unused AREnableAlertsFilters feature flag

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
