### PR TITLE
chore: add login req to docs

### DIFF
--- a/docs/deploy_a_hotfix.md
+++ b/docs/deploy_a_hotfix.md
@@ -82,6 +82,10 @@ yarn setup:releases
 ./scripts/setup/install-bin
 ```
 
+You will need to be logged in to the `artsy_mobile` account, credentials in 1pass:
+
+`./bin/node_modules/.bin/eas login`
+
 > [!IMPORTANT]
 > If the install results in changes to Podfile.lock you must do a Native Release Hotfix, please refer to that section of the docs.
 

--- a/docs/deploy_to_expo_updates.md
+++ b/docs/deploy_to_expo_updates.md
@@ -13,6 +13,10 @@ yarn setup:releases
 ./scripts/setup/install-bin
 ```
 
+You will need to be logged in to the `artsy_mobile` account, credentials in 1pass:
+
+`./bin/node_modules/.bin/eas login`
+
 ### Deploying
 
 Make your changes in typescript, commit, and run the script to deploy.


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Add login instructions to expo updates docs, need to be logged in to correct account for this to work.

#nochangelog


