### PR TITLE
feat: allow which-build to show earliest or latest tag for a commit

### DIFF
--- a/scripts/deploys/which-build
+++ b/scripts/deploys/which-build
@@ -2,7 +2,7 @@
 
 # which-build: Find commits and their corresponding builds across iOS and Android platforms
 #
-# This script helps identify which commits are included in which builds by showing the latest tag
+# This script helps identify which commits are included in which builds by showing the latest or earliest tag
 # for each platform (iOS and Android) that contains a specific commit. Useful for tracking
 # beta and release status of recent changes.
 #
@@ -12,6 +12,8 @@
 #   ./scripts/deploys/which-build --submission              # Shows submission builds only
 #   ./scripts/deploys/which-build --since="2023-01-01" --submission  # Shows submission builds since Jan 1, 2023
 #   ./scripts/deploys/which-build --author="Jane Doe"       # Shows builds with commits by Jane Doe from the last 2 weeks
+#   ./scripts/deploys/which-build --version=earliest        # Shows the earliest tag that contains each commit
+#   ./scripts/deploys/which-build --version=latest          # Shows the latest tag that contains each commit (default)
 
 # Default --since value
 SINCE="2 weeks ago"
@@ -21,6 +23,9 @@ SUBMISSION=false
 
 # Default --author value (empty means all authors)
 AUTHOR=""
+
+# Default --version value
+VERSION="latest"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -45,10 +50,26 @@ while [[ $# -gt 0 ]]; do
       SUBMISSION=true
       shift
       ;;
+    --version=*)
+      VERSION="${1#*=}"
+      if [[ "$VERSION" != "latest" && "$VERSION" != "earliest" ]]; then
+        echo "Error: --version must be either 'latest' or 'earliest'"
+        exit 1
+      fi
+      shift
+      ;;
+    --version)
+      VERSION="$2"
+      if [[ "$VERSION" != "latest" && "$VERSION" != "earliest" ]]; then
+        echo "Error: --version must be either 'latest' or 'earliest'"
+        exit 1
+      fi
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $(basename "$0") [--since=\"time spec\"] [--author=\"author name\"] [--submission]"
-      echo "Example: $(basename "$0") --since=\"4 weeks ago\" --author=\"Jane Doe\" --submission"
+      echo "Usage: $(basename "$0") [--since=\"time spec\"] [--author=\"author name\"] [--submission] [--version=latest|earliest]"
+      echo "Example: $(basename "$0") --since=\"4 weeks ago\" --author=\"Jane Doe\" --submission --version=earliest"
       exit 1
       ;;
   esac
@@ -68,12 +89,20 @@ fi
 # iterate over SHAs
 for sha in $SHAS; do
   git show -s --pretty="%C(yellow)%s %C(white)%h %C(green)%aN %C(blue)%ar%C(reset)" $sha
-  # find the latest tag for each platform that includes that commit
+  # find the latest or earliest tag for each platform that includes that commit
   for e in ios android; do
     if [ "$SUBMISSION" = true ]; then
-      git tag --list "$e-*-submission" --contains $sha | sort -Vr | head -1
+      if [ "$VERSION" = "earliest" ]; then
+        git tag --list "$e-*-submission" --contains $sha | sort -V | head -1
+      else
+        git tag --list "$e-*-submission" --contains $sha | sort -Vr | head -1
+      fi
     else
-      git tag --list "$e-*" --contains $sha | grep -v '-expo-' | sort -Vr | head -1
+      if [ "$VERSION" = "earliest" ]; then
+        git tag --list "$e-*" --contains $sha | grep -v '-expo-' | sort -V | head -1
+      else
+        git tag --list "$e-*" --contains $sha | grep -v '-expo-' | sort -Vr | head -1
+      fi
     fi
   done
 done


### PR DESCRIPTION
### Description

Follow-up to [this comment](https://github.com/artsy/eigen/pull/12140#issuecomment-2967863156) 

Adds the ability for `yarn which-build` to take a new optional argument which controls whether you see the _earliest_ build for a given commit or the _latest_ one (the default behavior).

With `yarn which-build --version=earliest` you'll see the first tagged build that contains that commit, as shown on the right below:

<img width="2560" alt="version" src="https://github.com/user-attachments/assets/7119c6d6-c6d0-4c7c-98b5-5c05cb4b0740" />


### PR Checklist

- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Allow which-build script to show earliest or latest build for each commit

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
