### PR TITLE
fix(DIA-1364): curator's pick subtitle copy in onboarding

### DIFF
--- a/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingCuratedArtworks.tsx
+++ b/src/app/Scenes/Onboarding/OnboardingQuiz/OnboardingCuratedArtworks.tsx
@@ -4,7 +4,7 @@ export const OnboardingCuratedArtworks: React.FC = () => {
   return (
     <OnboardingMarketingCollectionScreen
       slug="curators-picks-emerging"
-      description="The best works on Artsy each week, all available now."
+      description="Fresh, standout works handpicked by our chief curator."
     />
   )
 }


### PR DESCRIPTION
This PR makes a small copy change to the onboarding step where users are shown the Curator's Picks collection.

A similar copy change was made on the Home feed Curator's Picks section by updating the text in Gravity's `SiteHeroUnit` model like so:

```ruby
shu = SiteHeroUnit.find 'curators-picks-emerging-app'
shu.update!(app_description: "Fresh, standout works handpicked by our chief curator.")
```