### PR TITLE
fix: broken edit saved search

### DIFF
--- a/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/EditSavedSearchAlert.tsx
@@ -250,7 +250,6 @@ export const EditSavedSearchAlertQueryRenderer: React.FC<EditSavedSearchAlertBas
               environment={getRelayEnvironment()}
               query={EditSavedSearchAlertDetailsScreenQuery}
               variables={{ artistIDs: relayProps.me?.alert?.artistIDs as string[] }}
-              fetchPolicy="store-and-network"
               render={renderWithPlaceholder({
                 Container: EditSavedSearchAlertRefetchContainer,
                 renderPlaceholder: () => <EditSavedSearchFormPlaceholder />,

--- a/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
+++ b/src/app/Scenes/SavedSearchAlert/SavedSearchAlert.tsx
@@ -6,33 +6,39 @@ export const SavedSearchAlertScreenQuery = graphql`
   query SavedSearchAlertQuery($savedSearchAlertId: String!) {
     me {
       alert(id: $savedSearchAlertId) {
-        acquireable
-        additionalGeneIDs
-        artistIDs
-        artistSeriesIDs
-        atAuction
-        attributionClass
-        colors
-        dimensionRange
-        displayName
-        sizes
-        height
-        inquireableOnly
-        locationCities
-        majorPeriods
-        materialsTerms
-        offerable
-        partnerIDs
-        priceRange
-        settings {
-          email
-          name
-          push
-          details
-        }
-        width
+        ...SavedSearchAlert_alert @relay(mask: false)
       }
     }
+  }
+`
+
+export const alertFragment = graphql`
+  fragment SavedSearchAlert_alert on Alert {
+    acquireable
+    additionalGeneIDs
+    artistIDs
+    artistSeriesIDs
+    atAuction
+    attributionClass
+    colors
+    dimensionRange
+    displayName
+    sizes
+    height
+    inquireableOnly
+    locationCities
+    majorPeriods
+    materialsTerms
+    offerable
+    partnerIDs
+    priceRange
+    settings {
+      email
+      name
+      push
+      details
+    }
+    width
   }
 `
 
@@ -51,7 +57,6 @@ export const SavedSearchAlertQueryRenderer: React.FC<SearchCriteriaAlertBaseProp
   return (
     <QueryRenderer<SavedSearchAlertQuery>
       environment={getRelayEnvironment()}
-      fetchPolicy="store-and-network"
       query={SavedSearchAlertScreenQuery}
       render={render}
       variables={{ savedSearchAlertId }}

--- a/src/app/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
+++ b/src/app/Scenes/SavedSearchAlert/mutations/updateSavedSearchAlert.ts
@@ -27,6 +27,7 @@ export const updateSavedSearchAlert = (
                   settings {
                     name
                   }
+                  ...SavedSearchAlert_alert
                 }
               }
             }


### PR DESCRIPTION
This PR resolves [ONYX-1738] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the broken edit on saved search.

**Debugging process:**
![Untitled-2024-10-09-2321](https://github.com/user-attachments/assets/03f9d28a-abf5-428f-af14-55418a35b1c6)

We have a few possible solutions if we want to keep things as they are:

- When the user updates an alert, mutate the store value 
- Update the store value when the network request is done. This isn't straightforward - so we better just make the query `network-only` 
>> I initially did this but removed it because the solution above was enough for the alert. It remains however fragile in case we query for another interface at some point. I would say we cross that bridge when we reach it but I am open to your thoughts here.

https://github.com/user-attachments/assets/db351dff-3ead-495f-9762-7778abf57c0b


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: broken edit saved search - mounir


#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1738]: https://artsyproduct.atlassian.net/browse/ONYX-1738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ