### PR TITLE
fix: sentry cli not found in time during fastlane deploy

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -491,7 +491,7 @@ lane :deploy_to_expo_updates do |options|
       popd > /dev/null")
   build_folder = File.expand_path("../dist/")
 
-  sh("./scripts/setup/instal-bin")
+  sh("yarn add @sentry/cli -D")
   sentry_cli_path = 'bin/node_modules/@sentry/cli/bin/sentry-cli'
 
   upload_expo_sourcemaps(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -491,6 +491,7 @@ lane :deploy_to_expo_updates do |options|
       popd > /dev/null")
   build_folder = File.expand_path("../dist/")
 
+  sh("./scripts/setup/instal-bin")
   sentry_cli_path = 'bin/node_modules/@sentry/cli/bin/sentry-cli'
 
   upload_expo_sourcemaps(

--- a/fastlane/sentry_fastlane.rb
+++ b/fastlane/sentry_fastlane.rb
@@ -5,7 +5,8 @@ lane :upload_sentry_artifacts do |options|
   sentry_release_name = options[:sentry_release_name]
   platform = options[:platform]
   dist_version = options[:dist_version]
-  sentry_cli_path="./bin/node_modules/@sentry/cli/bin/sentry-cli"
+  sh("yarn add @sentry/cli -D")
+  sentry_cli_path="node_modules/@sentry/cli/bin/sentry-cli"
 
   project_slug = 'eigen'
   org_slug = 'artsynet'


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Brings back `sh("yarn add @sentry/cli -D")`. It was removed [here](https://github.com/artsy/eigen/pull/12256/files#diff-f93431d15b5981ca9a3ef1538b1bad0a059b541c31ba42500ef6da9e40638982L8)

Reasoning: 

Creating a release for sentry will **always** fail unless you are on the latest `@sentry/cli` version. The reason we are getting these messages [here](https://artsy.slack.com/archives/C02BAQ5K7/p1749797086500379) is because we moved sentry-cli to the `./bin` directory. 

Sentry cli is used only on this fastlane file and IMO it's gonna be way better to install it there only on demand vs having it on the bin file because it is always gonna have the latest version.

If we dont do that the feedback loop is gonna be like so:
- we get similar sentry cli is outdated and creating the sentry release failed errors in slack
- we need to go and open a pr with a dependency bump 
- trigger a new beta with the upgraded sentry-cli version

More context on when we moved sentry-cli installation in the fastlane file [here](https://github.com/artsy/eigen/pull/10767)

Followup of https://github.com/artsy/eigen/pull/12256

#nochangelog