### PR TITLE
build(deps): bump sentry cli to latest

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "devDependencies": {
     "eas-cli": "16.9.0",
-    "@sentry/cli": "2.46.0"
+    "@sentry/cli": "^2.46.0"
   }
 }


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Unrelated with [this](https://github.com/artsy/eigen/pull/12275) - we should bump sentry cli in bin/package.json eitherway