### PR TITLE
build(deps): bump palette mobile to latest + fix type issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "@artsy/cohesion": "4.272.2",
     "@artsy/icons": "3.39.0",
-    "@artsy/palette-mobile": "17.15.0",
+    "@artsy/palette-mobile": "17.16.0",
     "@artsy/to-title-case": "1.1.0",
     "@braze/react-native-sdk": "13.1.1",
     "@expo/react-native-action-sheet": "4.0.1",

--- a/src/app/Components/Input/INTERNALSelectAndInputCombinationBase.tsx
+++ b/src/app/Components/Input/INTERNALSelectAndInputCombinationBase.tsx
@@ -1,4 +1,4 @@
-import { Input, InputProps, InputRef } from "@artsy/palette-mobile"
+import { Input, InputComponentProps, InputRef } from "@artsy/palette-mobile"
 import { SelectModal } from "app/Components/Select/Components/SelectModal"
 import { SelectProps } from "app/Components/Select/Select"
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
@@ -25,7 +25,7 @@ export const INTERNALSelectAndInputCombinationBase = forwardRef<
     shouldDisplayLocalError?: boolean
     validate?: () => void
     displayForSelect?: string
-  } & Omit<InputProps, "onChange" | "onChangeText" | "renderLeftHandSection"> &
+  } & Omit<InputComponentProps, "onChange" | "onChangeText" | "renderLeftHandSection"> &
     TypeForSelect
 >(
   (

--- a/src/app/Components/Input/PhoneInput/PhoneInput.tsx
+++ b/src/app/Components/Input/PhoneInput/PhoneInput.tsx
@@ -1,6 +1,6 @@
 import {
   Flex,
-  InputProps,
+  InputComponentProps,
   Spacer,
   Text,
   Touchable,
@@ -27,7 +27,7 @@ export const PhoneInput = forwardRef<
     onModalFinishedClosing?: () => void
     maxModalHeight?: number
     shouldDisplayLocalError?: boolean
-  } & Omit<InputProps, "onChange">
+  } & Omit<InputComponentProps, "onChange">
 >(
   (
     {

--- a/src/app/Components/LocationAutocomplete.tsx
+++ b/src/app/Components/LocationAutocomplete.tsx
@@ -1,4 +1,5 @@
-import { Flex, Input, InputProps, MapPinIcon, Text, Touchable } from "@artsy/palette-mobile"
+import { MapPinIcon } from "@artsy/icons/native"
+import { Flex, Input, InputComponentProps, Text, Touchable } from "@artsy/palette-mobile"
 import { BottomSheetInput } from "app/Components/BottomSheetInput"
 import {
   LocationWithDetails,
@@ -10,7 +11,7 @@ import { useScreenDimensions } from "app/utils/hooks"
 import React, { useEffect, useRef, useState } from "react"
 import { TouchableWithoutFeedback } from "react-native"
 
-interface LocationAutocompleteProps extends Omit<InputProps, "onChange"> {
+interface LocationAutocompleteProps extends Omit<InputComponentProps, "onChange"> {
   floating?: boolean
   initialLocation?: LocationWithDetails | null
   displayLocation?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,10 +27,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.39.0.tgz#99ffeb84249e3f22ce801828da8696c8dfea989d"
   integrity sha512-LS7wngIX5TdN0+yPDVMu6fiXw4RE86RZ2ksBKiHNILXdd76JnCIwEla2WUamsVzKDypF1HRhlXhG2iOP7OX3AQ==
 
-"@artsy/palette-mobile@17.15.0":
-  version "17.15.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-17.15.0.tgz#96e7e9cdef703b61955d55bcc677523c666aa827"
-  integrity sha512-fgCQAJzBUOsXTv0S6uTTwj6nOw+l4xp0C15o6JSLyJTi6K1/vreT938H3+hJYvP2zAHBhU/o1tdbMe56AZbESg==
+"@artsy/palette-mobile@17.16.0":
+  version "17.16.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-mobile/-/palette-mobile-17.16.0.tgz#13fbc60e40c05040f56898887d9bd8f5bb9be69c"
+  integrity sha512-OSf4G/iAMk1zLcQ+POSFGf+SDcrNAMvFP9Z1EdpiMi8XT6jksclg5bSqEEgruDZsR/VwS7tyi/eHsGHF7tchPQ==
   dependencies:
     "@artsy/palette-tokens" "^7.0.0"
     "@shopify/flash-list" "1.7.6"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps palette mobile to latest https://github.com/artsy/palette-mobile/pull/354

and fixes type issues in eigen after the interface rename


#nochangelog