### PR TITLE
fix: broken tracking for marketing emails

### DIFF
--- a/src/app/utils/fetchMarketingURL.ts
+++ b/src/app/utils/fetchMarketingURL.ts
@@ -1,0 +1,20 @@
+import { captureMessage } from "@sentry/react-native"
+
+export const fetchMarketingURL = async (url: string) => {
+  try {
+    const response = await fetch(url)
+    return response.url
+  } catch (error) {
+    if (__DEV__) {
+      console.warn(
+        `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`
+      )
+    } else {
+      captureMessage(
+        `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`,
+        "error"
+      )
+    }
+    return null
+  }
+}

--- a/src/app/utils/hooks/useIsDeepLink.ts
+++ b/src/app/utils/hooks/useIsDeepLink.ts
@@ -1,5 +1,7 @@
 import { useIsFocused } from "@react-navigation/native"
 import { matchRoute } from "app/system/navigation/utils/matchRoute"
+import { fetchMarketingURL } from "app/utils/fetchMarketingURL"
+import { isMarketingURL } from "app/utils/isMarketingURL"
 import { useEffect, useState } from "react"
 import { Linking } from "react-native"
 
@@ -26,13 +28,20 @@ export const useIsDeepLink = () => {
 
   useEffect(() => {
     Linking.getInitialURL()
-      .then((url) => {
+      .then(async (url) => {
         if (!url) {
           setIsDeepLink(false)
           return
         }
 
-        const result = matchRoute(url)
+        let targetURL: string | null = url
+
+        // If the url is a marketing or email-link url, we need to fetch the redirect
+        if (isMarketingURL(url)) {
+          targetURL = (await fetchMarketingURL(url)) ?? "/"
+        }
+
+        const result = matchRoute(targetURL)
         const isExternalUrl = result.type === "external_url"
         const isHomeLink = result.type === "match" && result.module === "Home"
         const shouldTreatAsDeepLink = !isHomeLink && !isExternalUrl

--- a/src/app/utils/isMarketingURL.tests.ts
+++ b/src/app/utils/isMarketingURL.tests.ts
@@ -1,0 +1,26 @@
+import { isMarketingURL } from "./isMarketingURL"
+
+describe("isMarketingURL", () => {
+  it("returns true for click.artsy.net URLs", () => {
+    expect(isMarketingURL("https://click.artsy.net/track/123")).toBe(true)
+    expect(isMarketingURL("http://click.artsy.net/abc")).toBe(true)
+    expect(isMarketingURL("https://www.click.artsy.net/xyz")).toBe(true)
+  })
+
+  it("returns true for email-link.artsy.net URLs", () => {
+    expect(isMarketingURL("https://email-link.artsy.net/track/456")).toBe(true)
+    expect(isMarketingURL("http://email-link.artsy.net/def")).toBe(true)
+    expect(isMarketingURL("https://www.email-link.artsy.net/uvw")).toBe(true)
+  })
+
+  it("returns false for non-marketing URLs", () => {
+    expect(isMarketingURL("https://www.artsy.net/some-page")).toBe(false)
+    expect(isMarketingURL("https://example.com")).toBe(false)
+    expect(isMarketingURL("https://artsynet.click.com")).toBe(false)
+    expect(isMarketingURL("https://email-link.notartsy.net")).toBe(false)
+  })
+
+  it("returns false for empty string", () => {
+    expect(isMarketingURL("")).toBe(false)
+  })
+})

--- a/src/app/utils/isMarketingURL.ts
+++ b/src/app/utils/isMarketingURL.ts
@@ -1,0 +1,8 @@
+/**
+ * Check if the url is an Artsy marketing url
+ * @param url - The url to check
+ * @returns boolean
+ */
+export const isMarketingURL = (url: string) => {
+  return url.includes("click.artsy.net") || url.includes("email-link.artsy.net")
+}

--- a/src/app/utils/useDeepLinks.ts
+++ b/src/app/utils/useDeepLinks.ts
@@ -1,7 +1,8 @@
-import { captureMessage } from "@sentry/react-native"
 import { GlobalStore } from "app/store/GlobalStore"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
+import { fetchMarketingURL } from "app/utils/fetchMarketingURL"
+import { isMarketingURL } from "app/utils/isMarketingURL"
 import { useEffect, useRef } from "react"
 import { Linking } from "react-native"
 import { useTracking } from "react-tracking"
@@ -45,24 +46,11 @@ export function useDeepLinks() {
     let targetURL
 
     // If the url is a marketing or email-link url, we need to fetch the redirect
-    if (url.includes("click.artsy.net") || url.includes("email-link.artsy.net")) {
-      try {
-        targetURL = await fetch(url)
-      } catch (error) {
-        if (__DEV__) {
-          console.warn(
-            `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`
-          )
-        } else {
-          captureMessage(
-            `[handleDeepLink] Error fetching marketing url redirect on: ${url} failed with error: ${error}`,
-            "error"
-          )
-        }
-      }
+    if (isMarketingURL(url)) {
+      targetURL = await fetchMarketingURL(url)
     }
 
-    const deepLinkUrl = targetURL?.url ?? url
+    const deepLinkUrl = targetURL ?? url
 
     // We track the deep link opened event
     trackEvent(tracks.deepLink(deepLinkUrl))


### PR DESCRIPTION
This PR resolves [ONYX-1763] <!-- eg [PROJECT-XXXX] -->

Full context: https://artsy.slack.com/archives/C02BAQ5K7/p1749662039197029

### Description

This PR fixes the broken tracking when handling links opened from a marketing email.

_As far as I can see in the code, this has been the behaviour forever._ 

**Current state?**

When the app opens from a deep link, we have a hook that checks: if the app has been opened from a valid deep link, and the deep link is a screen different than home, we don't trigger the home view tracking. Otherwise, navigate to home and trigger its tracking.

**What went wrong with NWFY email links?**
Since our marketing links are encrypted, they were getting interpreted as invalid urls, and therefore, we were triggering the tracking on the home view.

**Fix**
I added a check in case a link is a marketing link, decrypt it before making any decision.


**Next steps:**
- Whatever we do now, regardless of me adding regression tests for it, isn't the most long term solution. We should instead in the mid-term, look into updating our pipelines to expect sessions to start with a home view event. 

| iOS | Android |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/2e1721c8-0a0d-4a24-82b6-12e693bd2b3d" /> | <video src="https://github.com/user-attachments/assets/d177377a-5169-4888-9f63-e8f492be90d1" /> | 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix broken tracking for marketing emails - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
