### PR TITLE
build(refactor): remove sentry cli from fastfile and sentry fastlane

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -2,7 +2,6 @@
   "name": "eigen-bin",
   "private": true,
   "devDependencies": {
-    "eas-cli": "16.9.0",
-    "@sentry/cli": "^2.46.0"
+    "eas-cli": "16.9.0"
   }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -501,10 +501,7 @@ lane :deploy_to_expo_updates do |options|
       popd > /dev/null")
   build_folder = File.expand_path("../dist/")
 
-  sentry_cli_path = 'bin/node_modules/@sentry/cli/bin/sentry-cli'
-
   upload_expo_sourcemaps(
-    sentry_cli_path: sentry_cli_path,
     org_slug: 'artsynet',
     project_slug: 'eigen',
     platform: platform,

--- a/fastlane/sentry_fastlane.rb
+++ b/fastlane/sentry_fastlane.rb
@@ -5,7 +5,6 @@ lane :upload_sentry_artifacts do |options|
   sentry_release_name = options[:sentry_release_name]
   platform = options[:platform]
   dist_version = options[:dist_version]
-  sentry_cli_path="./bin/node_modules/@sentry/cli/bin/sentry-cli"
 
   project_slug = 'eigen'
   org_slug = 'artsynet'
@@ -25,7 +24,6 @@ lane :upload_sentry_artifacts do |options|
 
   begin
     sentry_create_release(auth_token: ENV['SENTRY_UPLOAD_AUTH_KEY'],
-      sentry_cli_path: sentry_cli_path,
       org_slug: org_slug,
       project_slug: project_slug,
       version: sentry_release_name,
@@ -51,7 +49,6 @@ lane :upload_sentry_artifacts do |options|
   end
 
   upload_sentry_sourcemaps(
-    sentry_cli_path: sentry_cli_path,
     org_slug: org_slug,
     project_slug: project_slug,
     sentry_release_name: sentry_release_name,
@@ -62,7 +59,6 @@ lane :upload_sentry_artifacts do |options|
 end
 
 lane :upload_sentry_sourcemaps do |options|
-  sentry_cli_path = options[:sentry_cli_path]
   org_slug = options[:org_slug]
   project_slug = options[:project_slug]
   sentry_release_name = options[:sentry_release_name]
@@ -74,7 +70,6 @@ lane :upload_sentry_sourcemaps do |options|
   begin
     sentry_upload_sourcemap(
       auth_token: ENV['SENTRY_UPLOAD_AUTH_KEY'],
-      sentry_cli_path: sentry_cli_path,
       org_slug: org_slug,
       project_slug: project_slug,
       version: sentry_release_name,
@@ -92,7 +87,6 @@ lane :upload_sentry_sourcemaps do |options|
 end
 
 lane :upload_expo_sourcemaps do |options|
-  sentry_cli_path = options[:sentry_cli_path]
   org_slug = options[:org_slug]
   project_slug = options[:project_slug]
   sentry_release_name = options[:sentry_release_name]
@@ -111,7 +105,6 @@ lane :upload_expo_sourcemaps do |options|
   sourcemap_path = "#{file_base}.map"
 
   upload_sentry_sourcemaps(
-    sentry_cli_path: sentry_cli_path,
     org_slug: org_slug,
     project_slug: project_slug,
     sentry_release_name: sentry_release_name,
@@ -125,9 +118,8 @@ end
 private_lane :upload_dsyms_to_sentry do |options|
   org_slug = options[:org_slug]
   project_slug = options[:project_slug]
-  sentry_cli_path = options[:sentry_cli_path]
 
-  # make individual dSYM archives available to the sentry-cli tool.
+  # make individual dSYM archives available
   root = File.expand_path('..', __dir__)
   dsym_archive = File.join(root, 'Artsy.app.dSYM.zip')
   dsyms_path = File.join(root, 'dSYMs')
@@ -137,7 +129,6 @@ private_lane :upload_dsyms_to_sentry do |options|
     # No need to specify `dist` as the build number is encoded in the dSYM's Info.plist
     sentry_debug_files_upload(
       auth_token: ENV['SENTRY_UPLOAD_AUTH_KEY'],
-      sentry_cli_path: sentry_cli_path,
       org_slug: org_slug,
       project_slug: project_slug,
       path: dsym_path


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

I realized today that we **do not** need to explicitly have the `@sentry/cli` as a dependency and pass it into the sentry plugins from fastlane anymore - it was optional since it exists inside the plugins themselves.

So this PR is getting rid of it to remove also the complexity of having it break due to versions and update it 😄  (today it failed on me locally and complained that it needs updating again lol, I won't miss it)

#nochangelog