### PR TITLE
fix: collect screen breaks on empty state

### DIFF
--- a/src/app/Scenes/Collect/Collect.tsx
+++ b/src/app/Scenes/Collect/Collect.tsx
@@ -113,7 +113,7 @@ export const CollectContent: React.FC<CollectContentProps> = ({ viewer }) => {
         contextScreenOwnerType={OwnerType.collect}
         contextScreen={OwnerType.collect}
         ListEmptyComponent={
-          <Flex mx={2}>
+          <Flex>
             <CollectHeader
               appliedFiltersCount={appliedFiltersCount}
               setIsArtworksFilterModalVisible={setIsArtworksFilterModalVisible}

--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
@@ -81,7 +81,7 @@ export const HomeViewSectionScreenArtworks: React.FC<ArtworksScreenHomeSection> 
           disableAutoLayout
           pageSize={PAGE_SIZE}
           ListEmptyComponent={
-            <SimpleMessage m={2}>Nothing yet. Please check back later.</SimpleMessage>
+            <SimpleMessage my={2}>Nothing yet. Please check back later.</SimpleMessage>
           }
           refreshControl={RefreshControl}
           hasMore={hasNext}


### PR DESCRIPTION
### Description

This PR fixes an issue affecting masonry artwork grids in App. When a user selects a set of filters with no results, they get an error instead of the empty state. This usually works fine in most cases, except in the case where one changes the number of columns. 

We had a first go at fixing this [here](https://github.com/artsy/eigen/pull/10319) which did the trick for a long time. But we didn't notice back then is that it wouldn't be enough in case where the artworks are dynamic, which is the case for the first time within the Collect screen.

**Suggested Solution**
Instead of returning a single `Flashlist` handling the case of artworks and no artworks, we would return two separate Flashlists sharing all props, except the dynamic `numColumns`.   

**How's that different from what we have now?**
By making `numColumns` static in the case where there are no artworks, the Flashlist won't complain if the `numColumn` prop changed, because it thinks it didn't change. This is fine in our case because the empty state is the same regardless of the view mode (masonry grid/list)


**When can we remove this logic?**
When the issue is fixed inside Flashlist
https://github.com/Shopify/flash-list/issues/1219

Tbh, I tried to solve this in a reasonable amount of time but wasn't able, I wanted to keep `numColumns` as a ref but it felt worse as a tech debt than this approach.


| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/e0270dbb-845e-40e8-8bee-20339c012efd" > | <video src="https://github.com/user-attachments/assets/2f4f0568-3c32-4ada-8304-476e9158fba3" > |
| iOS | <video src="https://github.com/user-attachments/assets/e2aa61eb-6e66-4481-ae28-2ea4e9cc76c1" > | <video src="https://github.com/user-attachments/assets/891b011f-8ca5-49ed-b189-1ff1bff0ff7c" > |




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- collect screen breaks on empty state - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
