### PR TITLE
chore: fade bottom tabs

### DIFF
--- a/patches/@react-navigation+bottom-tabs+7.3.3.patch
+++ b/patches/@react-navigation+bottom-tabs+7.3.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js b/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
-index 8f0fb1c..755fce8 100644
+index 8f0fb1c..bfc1cfc 100644
 --- a/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
 +++ b/node_modules/@react-navigation/bottom-tabs/lib/commonjs/views/BottomTabBar.js
 @@ -131,6 +131,7 @@ function BottomTabBar({
@@ -19,6 +19,17 @@ index 8f0fb1c..755fce8 100644
    const visibilityAnimationConfigRef = _react.default.useRef(tabBarVisibilityAnimationConfig);
    _react.default.useEffect(() => {
      visibilityAnimationConfigRef.current = tabBarVisibilityAnimationConfig;
+@@ -251,6 +252,10 @@ function BottomTabBar({
+           outputRange: [layout.height + insets[tabBarPosition === 'top' ? 'top' : 'bottom'] + _reactNative.StyleSheet.hairlineWidth, 0]
+         })
+       }],
++      opacity: visible.interpolate({
++        inputRange: [0, 1],
++        outputRange: [0, 1]
++      }),
+       // Absolutely position the tab bar so that the content is below it
+       // This is needed to avoid gap at bottom when the tab bar is hidden
+       position: isTabBarHidden ? 'absolute' : undefined
 diff --git a/node_modules/@react-navigation/bottom-tabs/src/types.tsx b/node_modules/@react-navigation/bottom-tabs/src/types.tsx
 index 02f7119..01dfabc 100644
 --- a/node_modules/@react-navigation/bottom-tabs/src/types.tsx

--- a/src/app/Navigation/AuthenticatedRoutes/ScreenWrapper.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/ScreenWrapper.tsx
@@ -1,0 +1,54 @@
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
+import { useFocusEffect } from "@react-navigation/native"
+import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
+import { TAB_BAR_ANIMATION_DURATION } from "app/Navigation/AuthenticatedRoutes/Tabs"
+import { internal_navigationRef } from "app/Navigation/Navigation"
+import { AppModule } from "app/Navigation/routes"
+import { modules } from "app/Navigation/utils/modules"
+import { MotiView } from "moti"
+import { memo, useCallback } from "react"
+import { Easing, useSharedValue, withTiming } from "react-native-reanimated"
+
+export interface ScreenWrapperProps {
+  readonly hidesBottomTabs?: boolean
+}
+
+/**
+ * This component wraps all screens we have in the app.
+ */
+export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
+  ({ hidesBottomTabs: hidesBottomTabsProp = false, children }) => {
+    // We don't have the bottom tabs context on modal screens
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const tabBarHeight = hidesBottomTabsProp ? 0 : useBottomTabBarHeight()
+
+    const hideBottomTabAnimated = useSharedValue(1)
+
+    useFocusEffect(
+      useCallback(() => {
+        const currentRoute = internal_navigationRef.current?.getCurrentRoute()?.name
+        const hidesBottomTabs = !!(
+          currentRoute && modules[currentRoute as AppModule]?.options?.hidesBottomTabs
+        )
+
+        hideBottomTabAnimated.value = hidesBottomTabs ? 1 : 0
+      }, [hideBottomTabAnimated])
+    )
+
+    return (
+      <RetryErrorBoundary>
+        <MotiView
+          style={{
+            flex: 1,
+            paddingBottom: withTiming(hideBottomTabAnimated.value ? 0 : tabBarHeight, {
+              duration: TAB_BAR_ANIMATION_DURATION,
+              easing: Easing.inOut(Easing.ease),
+            }),
+          }}
+        >
+          {children}
+        </MotiView>
+      </RetryErrorBoundary>
+    )
+  }
+)

--- a/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/StackNavigator.tsx
@@ -5,20 +5,14 @@ import {
   THEMES,
   Touchable,
 } from "@artsy/palette-mobile"
-import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
-import { RetryErrorBoundary } from "app/Components/RetryErrorBoundary"
-import {
-  AuthenticatedRoutesParams,
-  TAB_BAR_ANIMATION_DURATION,
-} from "app/Navigation/AuthenticatedRoutes/Tabs"
+import { ScreenWrapper } from "app/Navigation/AuthenticatedRoutes/ScreenWrapper"
+import { AuthenticatedRoutesParams } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { AppModule, ModuleDescriptor } from "app/Navigation/routes"
 import { isModalScreen } from "app/Navigation/utils/isModalScreen"
 import { goBack } from "app/system/navigation/navigate"
-import { memo } from "react"
 import { Platform } from "react-native"
 import { isTablet } from "react-native-device-info"
-import Animated, { Easing, useAnimatedStyle, withTiming } from "react-native-reanimated"
 
 export const StackNavigator = createNativeStackNavigator<AuthenticatedRoutesParams>()
 
@@ -91,39 +85,3 @@ export const registerScreen: React.FC<StackNavigatorScreenProps> = ({ name, modu
     />
   )
 }
-
-export interface ScreenWrapperProps {
-  readonly hidesBottomTabs?: boolean
-}
-
-export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
-  ({ hidesBottomTabs = false, children }) => {
-    // We don't have the bottom tabs context on modal screens
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const tabBarHeight = hidesBottomTabs ? 0 : useBottomTabBarHeight()
-
-    const animatedStyle = useAnimatedStyle(() => {
-      return {
-        paddingBottom: withTiming(hidesBottomTabs ? 0 : tabBarHeight, {
-          duration: TAB_BAR_ANIMATION_DURATION,
-          easing: Easing.inOut(Easing.ease),
-        }),
-      }
-    })
-
-    return (
-      <RetryErrorBoundary>
-        <Animated.View
-          style={[
-            {
-              flex: 1,
-            },
-            animatedStyle,
-          ]}
-        >
-          {children}
-        </Animated.View>
-      </RetryErrorBoundary>
-    )
-  }
-)

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -47,7 +47,7 @@ type TabRoutesParams = {
 const Tab = createBottomTabNavigator<TabRoutesParams>()
 
 const BOTTOM_TABS_HEIGHT = PixelRatio.getFontScale() < 1.5 ? 65 : 85
-export const TAB_BAR_ANIMATION_DURATION = 250
+export const TAB_BAR_ANIMATION_DURATION = 300
 
 const AppTabs: React.FC = () => {
   const { tabsBadges } = useBottomTabsBadges()


### PR DESCRIPTION
**Context:** https://artsy.slack.com/archives/C05EQL4R5N0/p1749224134857029?thread_ts=1743435440.094839&cid=C05EQL4R5N0


### Description
This PR is a follow-up to https://github.com/artsy/eigen/pull/12249 and https://github.com/artsy/eigen/pull/12230


**What comes next?** 
Trigger the animation of the bottom tabs fast on go back

**Before**

<video src="https://github.com/user-attachments/assets/b62dd895-80ba-4012-a943-3a2fcde5c639"></video>


___
**After**
Please note that the animation will be smoother in device, I did my recording on the simulator/emulator.

| iOS | iOS (as well) |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/4a6148c5-c047-474b-a093-a63f6c5e4a3f" /> | <video src="https://github.com/user-attachments/assets/e4b539e7-d1a5-4efd-adff-e26e888baec6" /> | 

| Android |
|--------|
| <video src="https://github.com/user-attachments/assets/3c4fa324-0497-418e-84c0-cccca2ea7e4f" > | 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fade bottom tabs appearance/disappearance - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
