### PR TITLE
feat(EMI-2489): Add order summary in Order Details

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection.tsx
@@ -1,0 +1,26 @@
+import { ShieldIcon } from "@artsy/icons/native"
+import { Flex, LinkText, Message, Text } from "@artsy/palette-mobile"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
+
+const BUYER_GUARANTEE_LINK = "https://support.artsy.net/s/article/The-Artsy-Guarantee"
+
+export const OrderDetailBuyerProtection: React.FC = () => {
+  return (
+    <Message variant="default" containerStyle={{ px: 1 }}>
+      <Flex flexDirection="row" alignItems="flex-start">
+        <ShieldIcon fill="mono100" mr={0.5} mt="2px" />
+
+        <Flex flex={1}>
+          <Text variant="xs">
+            Your purchase is protected with{" "}
+            <LinkText onPress={() => navigate(BUYER_GUARANTEE_LINK)} variant="xs">
+              Artsy’s buyer protection
+            </LinkText>
+            .
+          </Text>
+        </Flex>
+      </Flex>
+    </Message>
+  )
+}

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Image, Spacer, Text, useScreenDimensions } from "@artsy/pale
 import { OrderDetailMetadata_order$key } from "__generated__/OrderDetailMetadata_order.graphql"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { sizeToFit } from "app/utils/useSizeToFit"
+import { Text as RNText } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
 interface OrderDetailMetadataProps {
@@ -49,11 +50,15 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
       <Spacer y={1} />
 
       {/* Metadata */}
-      <Text variant="sm">{artworkVersion?.artistNames}</Text>
+      <RNText numberOfLines={1}>
+        <Text variant="sm">{artworkVersion?.artistNames}</Text>
+      </RNText>
       <Flex flexDirection="row" alignItems="center">
-        <Text variant="sm" color="mono60" style={{ flex: 1 }} numberOfLines={1}>
-          {artworkVersion?.title}
-        </Text>
+        <RNText numberOfLines={1} style={{ flexShrink: 1 }}>
+          <Text variant="sm" color="mono60">
+            {artworkVersion?.title}
+          </Text>
+        </RNText>
         <Text variant="sm" color="mono60">
           {artworkVersion?.date ? `, ${artworkVersion.date}` : ""}
         </Text>

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -22,6 +22,14 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
   const artworkVersion = orderData.lineItems?.[0]?.artworkVersion
   const artworkImage = artworkVersion?.image
 
+  const artworkOrEditionSet = orderData.lineItems[0]?.artworkOrEditionSet
+  const isArtworkOrEditionSet =
+    !!artworkOrEditionSet &&
+    (artworkOrEditionSet.__typename === "Artwork" ||
+      artworkOrEditionSet?.__typename === "EditionSet")
+  const dimensions = isArtworkOrEditionSet ? artworkOrEditionSet.dimensions : null
+  const price = isArtworkOrEditionSet ? artworkOrEditionSet.price : null
+
   const { height, width } = sizeToFit(
     {
       height: artworkImage?.height ?? imageContainer.height,
@@ -90,9 +98,9 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
       <Text variant="sm" color="mono60">
         {artwork?.partner?.name}
       </Text>
-      {!!orderData.totalListPrice && (
+      {!!price && (
         <Text variant="sm" color="mono60">
-          List price: {orderData.totalListPrice.display}
+          List price: {price}
         </Text>
       )}
 
@@ -104,9 +112,9 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
         </Text>
       )}
 
-      {!!artworkVersion?.dimensions && (
+      {!!dimensions && (
         <Text variant="sm" color="mono60">
-          {artworkVersion.dimensions.in} | {artworkVersion.dimensions.cm}
+          {dimensions.in} | {dimensions.cm}
         </Text>
       )}
 
@@ -117,9 +125,6 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
 
 const fragment = graphql`
   fragment OrderDetailMetadata_order on Order {
-    totalListPrice {
-      display
-    }
     lineItems {
       artwork {
         partner {
@@ -135,16 +140,29 @@ const fragment = graphql`
         attributionClass {
           shortDescription
         }
-        dimensions {
-          in
-          cm
-        }
         image {
           blurhash
           url(version: ["larger", "large", "medium", "small", "square"])
           aspectRatio
           height
           width
+        }
+      }
+      artworkOrEditionSet {
+        __typename
+        ... on Artwork {
+          price
+          dimensions {
+            in
+            cm
+          }
+        }
+        ... on EditionSet {
+          price
+          dimensions {
+            in
+            cm
+          }
         }
       }
     }

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -81,9 +81,11 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
             {artworkVersion?.title}
           </Text>
         </RNText>
-        <Text variant="sm" color="mono60">
-          {artworkVersion?.date ? `, ${artworkVersion.date}` : ""}
-        </Text>
+        {!!artworkVersion?.date && (
+          <Text variant="sm" color="mono60">
+            , {artworkVersion.date}
+          </Text>
+        )}
       </Flex>
       <Text variant="sm" color="mono60">
         {artwork?.partner?.name}

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -91,15 +91,6 @@ const fragment = graphql`
     totalListPrice {
       display
     }
-    itemsTotal {
-      display
-    }
-    shippingTotal {
-      display
-    }
-    taxTotal {
-      display
-    }
     lineItems {
       artwork {
         partner {

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -1,0 +1,123 @@
+import { Box, Flex, Image, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
+import { OrderDetailMetadata_order$key } from "__generated__/OrderDetailMetadata_order.graphql"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { sizeToFit } from "app/utils/useSizeToFit"
+import { graphql, useFragment } from "react-relay"
+
+interface OrderDetailMetadataProps {
+  order: OrderDetailMetadata_order$key
+}
+
+const IMAGE_MAX_HEIGHT = 380
+
+export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order }) => {
+  const { width: screenWidth } = useScreenDimensions()
+
+  const orderData = useFragment(fragment, order)
+  const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
+
+  // const artwork = orderData.lineItems?.[0]?.artwork
+  const artworkVersion = orderData.lineItems?.[0]?.artworkVersion
+  const artworkImage = artworkVersion?.image
+
+  const { height, width } = sizeToFit(
+    { height: artworkImage?.height ?? 0, width: artworkImage?.width ?? 0 },
+    { height: IMAGE_MAX_HEIGHT, width: screenWidth - 40 }
+  )
+
+  return (
+    <Box>
+      <Box py={1}>
+        {/* Image */}
+        {!!artworkImage?.url && (
+          <Flex alignItems="center">
+            <Image
+              accessible
+              accessibilityRole="image"
+              accessibilityLabel={artworkVersion?.title || "Artwork image"}
+              src={artworkImage.url}
+              aspectRatio={artworkImage.aspectRatio ?? 1}
+              width={width}
+              height={height}
+              blurhash={showBlurhash ? artworkImage.blurhash : undefined}
+              geminiResizeMode="fit"
+              resizeMode="contain"
+            />
+          </Flex>
+        )}
+      </Box>
+
+      <Spacer y={1} />
+
+      {/* Metadata */}
+      <Text variant="sm">{artworkVersion?.artistNames}</Text>
+      <Flex flexDirection="row" alignItems="center">
+        <Text variant="sm" color="mono60" style={{ flex: 1 }} numberOfLines={1}>
+          {artworkVersion?.title}
+        </Text>
+        <Text variant="sm" color="mono60">
+          {artworkVersion?.date ? `, ${artworkVersion.date}` : ""}
+        </Text>
+      </Flex>
+      {!!orderData.totalListPrice && (
+        <Text variant="sm" color="mono60">
+          List price: {orderData.totalListPrice.display}
+        </Text>
+      )}
+
+      <Spacer y={1} />
+
+      {!!artworkVersion?.attributionClass?.shortDescription && (
+        <Text variant="sm" color="mono60">
+          {artworkVersion.attributionClass.shortDescription}
+        </Text>
+      )}
+
+      {!!artworkVersion?.dimensions && (
+        <Text variant="sm" color="mono60">
+          {artworkVersion.dimensions.in} | {artworkVersion.dimensions.cm}
+        </Text>
+      )}
+
+      <Spacer y={1} />
+    </Box>
+  )
+}
+
+const fragment = graphql`
+  fragment OrderDetailMetadata_order on Order {
+    totalListPrice {
+      display
+    }
+    itemsTotal {
+      display
+    }
+    shippingTotal {
+      display
+    }
+    taxTotal {
+      display
+    }
+    lineItems {
+      artworkVersion {
+        title
+        artistNames
+        date
+        attributionClass {
+          shortDescription
+        }
+        dimensions {
+          in
+          cm
+        }
+        image {
+          blurhash
+          url(version: ["larger", "large", "medium", "small", "square"])
+          aspectRatio
+          height
+          width
+        }
+      }
+    }
+  }
+`

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -12,11 +12,10 @@ const IMAGE_MAX_HEIGHT = 380
 
 export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order }) => {
   const { width: screenWidth } = useScreenDimensions()
-
   const orderData = useFragment(fragment, order)
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
 
-  // const artwork = orderData.lineItems?.[0]?.artwork
+  const artwork = orderData.lineItems?.[0]?.artwork
   const artworkVersion = orderData.lineItems?.[0]?.artworkVersion
   const artworkImage = artworkVersion?.image
 
@@ -59,6 +58,9 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
           {artworkVersion?.date ? `, ${artworkVersion.date}` : ""}
         </Text>
       </Flex>
+      <Text variant="sm" color="mono60">
+        {artwork?.partner?.name}
+      </Text>
       {!!orderData.totalListPrice && (
         <Text variant="sm" color="mono60">
           List price: {orderData.totalListPrice.display}
@@ -99,6 +101,11 @@ const fragment = graphql`
       display
     }
     lineItems {
+      artwork {
+        partner {
+          name
+        }
+      }
       artworkVersion {
         title
         artistNames

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -13,6 +13,7 @@ const IMAGE_MAX_HEIGHT = 380
 
 export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order }) => {
   const { width: screenWidth } = useScreenDimensions()
+  const imageContainer = { height: IMAGE_MAX_HEIGHT, width: screenWidth - 40 }
   const orderData = useFragment(fragment, order)
   const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
 
@@ -21,8 +22,11 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
   const artworkImage = artworkVersion?.image
 
   const { height, width } = sizeToFit(
-    { height: artworkImage?.height ?? 0, width: artworkImage?.width ?? 0 },
-    { height: IMAGE_MAX_HEIGHT, width: screenWidth - 40 }
+    {
+      height: artworkImage?.height ?? imageContainer.height,
+      width: artworkImage?.width ?? imageContainer.width,
+    },
+    imageContainer
   )
 
   return (

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Image, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
 import { OrderDetailMetadata_order$key } from "__generated__/OrderDetailMetadata_order.graphql"
+import { RouterLink } from "app/system/navigation/RouterLink"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { Text as RNText } from "react-native"
@@ -35,18 +36,35 @@ export const OrderDetailMetadata: React.FC<OrderDetailMetadataProps> = ({ order 
         {/* Image */}
         {!!artworkImage?.url && (
           <Flex alignItems="center">
-            <Image
-              accessible
-              accessibilityRole="image"
-              accessibilityLabel={artworkVersion?.title || "Artwork image"}
-              src={artworkImage.url}
-              aspectRatio={artworkImage.aspectRatio ?? 1}
-              width={width}
-              height={height}
-              blurhash={showBlurhash ? artworkImage.blurhash : undefined}
-              geminiResizeMode="fit"
-              resizeMode="contain"
-            />
+            {!!artwork?.slug && artwork.published ? (
+              <RouterLink to={`/artwork/${artwork.slug}`}>
+                <Image
+                  accessible
+                  accessibilityRole="image"
+                  accessibilityLabel={artworkVersion?.title || "Artwork image"}
+                  src={artworkImage.url}
+                  aspectRatio={artworkImage.aspectRatio ?? 1}
+                  width={width}
+                  height={height}
+                  blurhash={showBlurhash ? artworkImage.blurhash : undefined}
+                  geminiResizeMode="fit"
+                  resizeMode="contain"
+                />
+              </RouterLink>
+            ) : (
+              <Image
+                accessible
+                accessibilityRole="image"
+                accessibilityLabel={artworkVersion?.title || "Artwork image"}
+                src={artworkImage.url}
+                aspectRatio={artworkImage.aspectRatio ?? 1}
+                width={width}
+                height={height}
+                blurhash={showBlurhash ? artworkImage.blurhash : undefined}
+                geminiResizeMode="fit"
+                resizeMode="contain"
+              />
+            )}
           </Flex>
         )}
       </Box>
@@ -105,6 +123,8 @@ const fragment = graphql`
         partner {
           name
         }
+        slug
+        published
       }
       artworkVersion {
         title

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown.tsx
@@ -3,7 +3,8 @@ import {
   OrderDetailPriceBreakdown_order$data,
   OrderDetailPriceBreakdown_order$key,
 } from "__generated__/OrderDetailPriceBreakdown_order.graphql"
-import { RouterLink } from "app/system/navigation/RouterLink"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
 import { graphql, useFragment } from "react-relay"
 
 interface OrderDetailPriceBreakdownProps {
@@ -80,19 +81,13 @@ export const OrderDetailPriceBreakdown: React.FC<OrderDetailPriceBreakdownProps>
 
       <Spacer y={2} />
 
-      <Flex flexDirection="row" alignItems="center">
-        <Text variant="xs" color="mono60">
-          *Additional duties and taxes{" "}
-        </Text>
-        <RouterLink to={IMPORT_TAX_URL} hasChildTouchable>
-          <LinkText variant="xs" color="mono60">
-            may apply at import
-          </LinkText>
-        </RouterLink>
-        <Text variant="xs" color="mono60">
-          .
-        </Text>
-      </Flex>
+      <Text variant="xs" color="mono60">
+        *Additional duties and taxes{" "}
+        <LinkText onPress={() => navigate(IMPORT_TAX_URL)} variant="xs" color="mono60">
+          may apply at import
+        </LinkText>
+        .
+      </Text>
     </Box>
   )
 }

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown.tsx
@@ -1,0 +1,171 @@
+import { Box, Flex, LinkText, Spacer, Text } from "@artsy/palette-mobile"
+import {
+  OrderDetailPriceBreakdown_order$data,
+  OrderDetailPriceBreakdown_order$key,
+} from "__generated__/OrderDetailPriceBreakdown_order.graphql"
+import { RouterLink } from "app/system/navigation/RouterLink"
+import { graphql, useFragment } from "react-relay"
+
+interface OrderDetailPriceBreakdownProps {
+  order: OrderDetailPriceBreakdown_order$key
+}
+
+const IMPORT_TAX_URL =
+  "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
+
+type PriceBreakdownLine = OrderDetailPriceBreakdown_order$data["pricingBreakdownLines"][number]
+
+export const OrderDetailPriceBreakdown: React.FC<OrderDetailPriceBreakdownProps> = ({ order }) => {
+  const { pricingBreakdownLines } = useFragment(fragment, order)
+
+  const renderBreakdownLines = (line: PriceBreakdownLine, index: number) => {
+    if (!line) {
+      return null
+    }
+
+    switch (line.__typename) {
+      case "SubtotalLine":
+        return (
+          <PriceBreakdownLine
+            key={index}
+            amount={line.amount ? `${line.amount.currencySymbol}${line.amount.amount}` : ""}
+            label={line.displayName}
+          />
+        )
+
+      case "ShippingLine":
+        return (
+          <PriceBreakdownLine
+            key={index}
+            amount={
+              line.amount
+                ? `${line.amount.currencySymbol}${line.amount.amount}`
+                : (line.amountFallbackText as string)
+            }
+            label={line.displayName}
+          />
+        )
+
+      case "TaxLine":
+        return (
+          <PriceBreakdownLine
+            key={index}
+            amount={
+              line.amount
+                ? `${line.amount.currencySymbol}${line.amount.amount}`
+                : (line.amountFallbackText as string)
+            }
+            label={`${line.displayName}*`}
+          />
+        )
+
+      case "TotalLine":
+        return (
+          <PriceBreakdownLine
+            key={index}
+            isTotal
+            amount={line.amount?.display || line.amountFallbackText || ""}
+            label={line.displayName}
+          />
+        )
+
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Box my={1}>
+      {pricingBreakdownLines.map(renderBreakdownLines)}
+
+      <Spacer y={2} />
+
+      <Flex flexDirection="row" alignItems="center">
+        <Text variant="xs" color="mono60">
+          *Additional duties and taxes{" "}
+        </Text>
+        <RouterLink to={IMPORT_TAX_URL} hasChildTouchable>
+          <LinkText variant="xs" color="mono60">
+            may apply at import
+          </LinkText>
+        </RouterLink>
+        <Text variant="xs" color="mono60">
+          .
+        </Text>
+      </Flex>
+    </Box>
+  )
+}
+
+const fragment = graphql`
+  fragment OrderDetailPriceBreakdown_order on Order {
+    pricingBreakdownLines {
+      __typename
+      ... on ShippingLine {
+        displayName
+        amountFallbackText
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+      ... on TaxLine {
+        displayName
+        amountFallbackText
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+      ... on SubtotalLine {
+        displayName
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+      ... on TotalLine {
+        displayName
+        amountFallbackText
+        amount {
+          display
+        }
+      }
+    }
+  }
+`
+
+interface PriceBreakdownLineProps {
+  label: string
+  amount: string
+  isTotal?: boolean
+}
+
+const PriceBreakdownLine: React.FC<PriceBreakdownLineProps> = ({
+  amount,
+  label,
+  isTotal = false,
+}) => {
+  return (
+    <>
+      {!!isTotal && <Spacer y={0.5} />}
+
+      <Flex flexDirection="row" justifyContent="space-between">
+        <Text
+          variant="sm"
+          color={isTotal ? "mono100" : "mono60"}
+          fontWeight={isTotal ? "bold" : "normal"}
+        >
+          {label}
+        </Text>
+        <Text
+          variant="sm"
+          color={isTotal ? "mono100" : "mono60"}
+          fontWeight={isTotal ? "bold" : "normal"}
+        >
+          {amount}
+        </Text>
+      </Flex>
+    </>
+  )
+}

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailBuyerProtection.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailBuyerProtection.tests.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { OrderDetailBuyerProtection } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection"
+import { navigate } from "app/system/navigation/navigate"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("OrderDetailBuyerProtection", () => {
+  it("renders the Artsy buyer protection section", () => {
+    renderWithWrappers(<OrderDetailBuyerProtection />)
+
+    expect(screen.getByText("Artsy’s buyer protection")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText("Artsy’s buyer protection"))
+
+    expect(navigate).toBeCalledWith("https://support.artsy.net/s/article/The-Artsy-Guarantee")
+  })
+})

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
@@ -1,5 +1,6 @@
-import { screen } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import { OrderDetailMetadata } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata"
+import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -23,6 +24,11 @@ describe("OrderDetailMetadata", () => {
         totalListPrice: { display: "€1,242" },
         lineItems: [
           {
+            artwork: {
+              partner: {
+                name: "Commerce Test Partner",
+              },
+            },
             artworkVersion: {
               artistNames: "Pablo Picasso",
               title: "Guernica",
@@ -40,8 +46,27 @@ describe("OrderDetailMetadata", () => {
     expect(screen.getByText("Pablo Picasso")).toBeOnTheScreen()
     expect(screen.getByText("Guernica")).toBeOnTheScreen()
     expect(screen.getByText(/1936/)).toBeOnTheScreen()
+    expect(screen.getByText("Commerce Test Partner")).toBeOnTheScreen()
     expect(screen.getByText("Unique work")).toBeOnTheScreen()
     expect(screen.getByText("List price: €1,242")).toBeOnTheScreen()
     expect(screen.getByText("24 × 36 in | 61 × 91.4 cm")).toBeOnTheScreen()
+  })
+
+  it("navigates to the artwork screen", () => {
+    renderWithRelay({
+      Order: () => ({
+        lineItems: [
+          {
+            artwork: { slug: "artwork-id", published: true },
+            artworkVersion: { image: { url: "https://example.com/artwork.jpg" } },
+          },
+        ],
+      }),
+    })
+
+    expect(screen.getByRole("image")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByRole("image"))
+    expect(navigate).toBeCalledWith("/artwork/artwork-id")
   })
 })

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
@@ -1,0 +1,47 @@
+import { screen } from "@testing-library/react-native"
+import { OrderDetailMetadata } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("OrderDetailMetadata", () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: (props: any) => <OrderDetailMetadata order={props.me.order} />,
+    query: graphql`
+      query OrderDetailMetadataTestsQuery @relay_test_operation {
+        me {
+          order(id: "test-order") {
+            ...OrderDetailMetadata_order
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders artwork image and metadata", () => {
+    renderWithRelay({
+      Order: () => ({
+        totalListPrice: { display: "€1,242" },
+        lineItems: [
+          {
+            artworkVersion: {
+              artistNames: "Pablo Picasso",
+              title: "Guernica",
+              date: "1936",
+              attributionClass: { shortDescription: "Unique work" },
+              dimensions: { in: "24 × 36 in", cm: "61 × 91.4 cm" },
+              image: { url: "https://example.com/artwork.jpg" },
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(screen.getByRole("image")).toBeOnTheScreen()
+    expect(screen.getByText("Pablo Picasso")).toBeOnTheScreen()
+    expect(screen.getByText("Guernica")).toBeOnTheScreen()
+    expect(screen.getByText(/1936/)).toBeOnTheScreen()
+    expect(screen.getByText("Unique work")).toBeOnTheScreen()
+    expect(screen.getByText("List price: €1,242")).toBeOnTheScreen()
+    expect(screen.getByText("24 × 36 in | 61 × 91.4 cm")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailMetadata.tests.tsx
@@ -34,8 +34,12 @@ describe("OrderDetailMetadata", () => {
               title: "Guernica",
               date: "1936",
               attributionClass: { shortDescription: "Unique work" },
-              dimensions: { in: "24 × 36 in", cm: "61 × 91.4 cm" },
               image: { url: "https://example.com/artwork.jpg" },
+            },
+            artworkOrEditionSet: {
+              __typename: "Artwork",
+              price: "€1,242",
+              dimensions: { in: "24 × 36 in", cm: "61 × 91.4 cm" },
             },
           },
         ],

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailPriceBreakdown.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailPriceBreakdown.tests.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { OrderDetailPriceBreakdown } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown"
+import { navigate } from "app/system/navigation/navigate"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("OrderDetailPriceBreakdown", () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: (props: any) => <OrderDetailPriceBreakdown order={props.me.order} />,
+    query: graphql`
+      query OrderDetailPriceBreakdownTestsQuery @relay_test_operation {
+        me {
+          order(id: "test-order") {
+            ...OrderDetailPriceBreakdown_order
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders pricing breakdown lines", () => {
+    renderWithRelay({
+      Order: () => ({
+        pricingBreakdownLines: [
+          {
+            __typename: "SubtotalLine",
+            displayName: "Price",
+            amount: { amount: "1000", currencySymbol: "$" },
+          },
+          {
+            __typename: "ShippingLine",
+            displayName: "Standard Shipping",
+            amount: { amount: "42.99", currencySymbol: "$" },
+          },
+          {
+            __typename: "TaxLine",
+            displayName: "Tax",
+            amount: { amount: "99.58", currencySymbol: "$" },
+          },
+          {
+            __typename: "TotalLine",
+            displayName: "Total",
+            amount: { display: "US$1052.57" },
+          },
+        ],
+      }),
+    })
+
+    // Subtotal
+    expect(screen.getByText("Price")).toBeOnTheScreen()
+    expect(screen.getByText("$1000")).toBeOnTheScreen()
+
+    // Shipping
+    expect(screen.getByText("Standard Shipping")).toBeOnTheScreen()
+    expect(screen.getByText("$42.99")).toBeOnTheScreen()
+
+    // Tax
+    expect(screen.getByText("Tax*")).toBeOnTheScreen()
+    expect(screen.getByText("$99.58")).toBeOnTheScreen()
+
+    // Total
+    expect(screen.getByText("Total")).toBeOnTheScreen()
+    expect(screen.getByText("US$1052.57")).toBeOnTheScreen()
+  })
+
+  it("renders import tax disclaimer with link", () => {
+    renderWithRelay()
+
+    expect(screen.getByText("*Additional duties and taxes")).toBeOnTheScreen()
+    expect(screen.getByText("may apply at import")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText("may apply at import"))
+
+    expect(navigate).toHaveBeenCalledWith(
+      "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
+    )
+  })
+})

--- a/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailPriceBreakdown.tests.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/Components/__tests__/OrderDetailPriceBreakdown.tests.tsx
@@ -66,7 +66,7 @@ describe("OrderDetailPriceBreakdown", () => {
   it("renders import tax disclaimer with link", () => {
     renderWithRelay()
 
-    expect(screen.getByText("*Additional duties and taxes")).toBeOnTheScreen()
+    expect(screen.getByText("*Additional duties and taxes may apply at import.")).toBeOnTheScreen()
     expect(screen.getByText("may apply at import")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("may apply at import"))

--- a/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
@@ -2,14 +2,12 @@ import { ShieldIcon } from "@artsy/icons/native"
 import {
   Box,
   Flex,
-  Image,
   LinkText,
   Message,
   Screen,
   Spacer,
   Text,
   useColor,
-  useScreenDimensions,
   useSpace,
 } from "@artsy/palette-mobile"
 import { OrderDetailQuery } from "__generated__/OrderDetailQuery.graphql"
@@ -17,35 +15,23 @@ import { OrderDetail_order$key } from "__generated__/OrderDetail_order.graphql"
 import { OrderDetailFulfillment } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailFulfillment"
 import { OrderDetailHelpLinks } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailHelpLinks"
 import { OrderDetailMessage } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMessage"
+import { OrderDetailMetadata } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata"
 import { OrderDetailPaymentInfo } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPaymentInfo"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { NoFallback, SpinnerFallback, withSuspense } from "app/utils/hooks/withSuspense"
-import { sizeToFit } from "app/utils/useSizeToFit"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
 interface OrderDetailProps {
   order: OrderDetail_order$key
 }
 
-const IMAGE_MAX_HEIGHT = 380
-
 const OrderDetail: React.FC<OrderDetailProps> = ({ order }) => {
-  const { width: screenWidth } = useScreenDimensions()
   const space = useSpace()
   const color = useColor()
-  const showBlurhash = useFeatureFlag("ARShowBlurhashImagePlaceholder")
   const orderData = useFragment(orderDetailFragment, order)
 
   if (!orderData) {
     return null
   }
-
-  const orderArtwork = orderData.lineItems?.[0]?.artwork
-
-  const { height, width } = sizeToFit(
-    { height: orderArtwork?.image?.height ?? 0, width: orderArtwork?.image?.width ?? 0 },
-    { height: IMAGE_MAX_HEIGHT, width: screenWidth - 40 }
-  )
 
   return (
     <Screen.ScrollView
@@ -68,43 +54,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({ order }) => {
         <Spacer y={4} />
 
         {/* 3rd Part: Artwork image and metadata */}
-        <Box>
-          <Box backgroundColor="mono5" py={1}>
-            {/* Image */}
-            {!!orderArtwork?.image?.url && (
-              <Flex alignItems="center">
-                <Image
-                  src={orderArtwork.image.url}
-                  aspectRatio={orderArtwork.image.aspectRatio ?? 1}
-                  width={width}
-                  height={height}
-                  blurhash={showBlurhash ? orderArtwork.image.blurhash : undefined}
-                  geminiResizeMode="fit"
-                  resizeMode="contain"
-                />
-              </Flex>
-            )}
-          </Box>
-
-          <Spacer y={1} />
-
-          {/* Metadata */}
-          <Text variant="sm">Marina Savashynskaya Dunbar</Text>
-          <Text variant="sm" color="mono60">
-            Wayfinding, 2023
-          </Text>
-          <Text variant="sm" color="mono60">
-            List price: $15,000
-          </Text>
-          <Spacer y={1} />
-          <Text variant="sm" color="mono60">
-            Part of a limited edition set
-          </Text>
-          <Text variant="sm" color="mono60">
-            9 2/5 x 11 4/5 in | 24 x 30 cm
-          </Text>
-          <Spacer y={1} />
-        </Box>
+        <OrderDetailMetadata order={orderData} />
 
         {/* 4th Part: Artwork price breakdown */}
         <Box my={1}>
@@ -205,18 +155,7 @@ const orderDetailFragment = graphql`
     ...OrderDetailMessage_order
     ...OrderDetailPaymentInfo_order
     ...OrderDetailFulfillment_order
-
-    lineItems {
-      artwork {
-        image {
-          blurhash
-          url(version: ["larger", "large", "medium", "small", "square"])
-          aspectRatio
-          height
-          width
-        }
-      }
-    }
+    ...OrderDetailMetadata_order
   }
 `
 

--- a/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
@@ -17,6 +17,7 @@ import { OrderDetailHelpLinks } from "app/Scenes/OrderHistory/OrderDetail/Compon
 import { OrderDetailMessage } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMessage"
 import { OrderDetailMetadata } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMetadata"
 import { OrderDetailPaymentInfo } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPaymentInfo"
+import { OrderDetailPriceBreakdown } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailPriceBreakdown"
 import { NoFallback, SpinnerFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
@@ -57,54 +58,7 @@ const OrderDetail: React.FC<OrderDetailProps> = ({ order }) => {
         <OrderDetailMetadata order={orderData} />
 
         {/* 4th Part: Artwork price breakdown */}
-        <Box my={1}>
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Text variant="sm" color="mono60">
-              Price
-            </Text>
-            <Text variant="sm" color="mono60">
-              $15,000
-            </Text>
-          </Flex>
-
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Text variant="sm" color="mono60">
-              Standard shipping
-            </Text>
-            <Text variant="sm" color="mono60">
-              $0
-            </Text>
-          </Flex>
-
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Text variant="sm" color="mono60">
-              Tax*
-            </Text>
-            <Text variant="sm" color="mono60">
-              $100
-            </Text>
-          </Flex>
-
-          <Spacer y={0.5} />
-
-          <Flex flexDirection="row" justifyContent="space-between">
-            <Text variant="sm" fontWeight="bold">
-              Total
-            </Text>
-            <Text variant="sm" fontWeight="bold">
-              $15,100
-            </Text>
-          </Flex>
-
-          <Spacer y={2} />
-          <Text variant="xs" color="mono60">
-            *Additional duties and taxes{" "}
-            <LinkText variant="xs" color="mono60">
-              may apply at import
-            </LinkText>
-            .
-          </Text>
-        </Box>
+        <OrderDetailPriceBreakdown order={data} />
 
         <Spacer y={2} />
 
@@ -156,6 +110,7 @@ const orderDetailFragment = graphql`
     ...OrderDetailPaymentInfo_order
     ...OrderDetailFulfillment_order
     ...OrderDetailMetadata_order
+    ...OrderDetailPriceBreakdown_order
   }
 `
 

--- a/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetail/OrderDetail.tsx
@@ -1,17 +1,7 @@
-import { ShieldIcon } from "@artsy/icons/native"
-import {
-  Box,
-  Flex,
-  LinkText,
-  Message,
-  Screen,
-  Spacer,
-  Text,
-  useColor,
-  useSpace,
-} from "@artsy/palette-mobile"
+import { Box, Screen, Spacer, Text, useColor, useSpace } from "@artsy/palette-mobile"
 import { OrderDetailQuery } from "__generated__/OrderDetailQuery.graphql"
 import { OrderDetail_order$key } from "__generated__/OrderDetail_order.graphql"
+import { OrderDetailBuyerProtection } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailBuyerProtection"
 import { OrderDetailFulfillment } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailFulfillment"
 import { OrderDetailHelpLinks } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailHelpLinks"
 import { OrderDetailMessage } from "app/Scenes/OrderHistory/OrderDetail/Components/OrderDetailMessage"
@@ -58,23 +48,12 @@ const OrderDetail: React.FC<OrderDetailProps> = ({ order }) => {
         <OrderDetailMetadata order={orderData} />
 
         {/* 4th Part: Artwork price breakdown */}
-        <OrderDetailPriceBreakdown order={data} />
+        <OrderDetailPriceBreakdown order={orderData} />
 
         <Spacer y={2} />
 
         {/* 5th Part: Artsy Buyer Protection */}
-        <Message variant="default" containerStyle={{ px: 1 }}>
-          <Flex flexDirection="row" alignItems="flex-start">
-            <ShieldIcon fill="mono100" mr={0.5} mt="2px" />
-
-            <Flex flex={1}>
-              <Text variant="xs">
-                Your purchase is protected with{" "}
-                <LinkText variant="xs">Artsy’s buyer protection</LinkText>.
-              </Text>
-            </Flex>
-          </Flex>
-        </Message>
+        <OrderDetailBuyerProtection />
       </Box>
 
       <Spacer y={2} />


### PR DESCRIPTION
This PR resolves [EMI-2489] <!-- eg [PROJECT-XXXX] -->

> [!NOTE]
> This change is hidden behind `AREnableNewOrderDetails` feature flag

### Description
This PR adds the order summary to the new Order Detail screen

### Screenshots

| | Android | iOS |
|---|---|---|
| Order Details | ![image](https://github.com/user-attachments/assets/c5dbfcff-eaca-4a62-88e8-1063f6d4cfbe) | ![image](https://github.com/user-attachments/assets/900750df-889f-4691-ab6d-6d0ef12e9f0d) |
| Long artist names | ![image](https://github.com/user-attachments/assets/a54c8edf-c44c-43f0-ba26-4082012c0da2) | ![image](https://github.com/user-attachments/assets/bbc410fa-51fb-4ab1-95ae-18a648ccc5f8) |
| Long artwork name | ![image](https://github.com/user-attachments/assets/03c83b07-eaed-4516-9723-9d48a11672c3) | ![image](https://github.com/user-attachments/assets/2e0590f0-0291-4371-bf3e-67c91a2816a0) |
| Tall artwork | ![image](https://github.com/user-attachments/assets/c7161f0d-a5a9-430f-b8d3-d1f68c176ae2) | ![image](https://github.com/user-attachments/assets/916c6616-e3a4-462d-bdba-b95bebe00db3) |
| Short artwork | ![image](https://github.com/user-attachments/assets/9334add4-f520-4bf0-a1b3-59c60313a9e6) | ![image](https://github.com/user-attachments/assets/f180d9dd-5c1c-49a1-bb0c-ea57c9730a72) |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add order summary in Order Details screen

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[EMI-2489]: https://artsyproduct.atlassian.net/browse/EMI-2489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ