### PR TITLE
chore(releases): default to canary in dev builds #trivial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ commands:
   prep-ios-env:
     steps:
       # we can quit the macos build early if there were no native code changes
-      # and we're not on the beta branch
+      # and we're not on the beta branch.
       - run:
           name: Quit early if possible
           command: |

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -146,7 +146,7 @@ android {
             manifestPlaceholders = [
                 expoUpdatesEnabled: "false",
                 expoUpdatesCheckOnLaunch: "NEVER",
-                expoUpdatesChannel: "staging",
+                expoUpdatesChannel: "canary",
                 expoRuntimeVersion: getRuntimeVersion(),
                 expoUpdatesDisableAntibrickingMeasures: "false"
             ]
@@ -178,7 +178,7 @@ android {
             manifestPlaceholders = [
                 expoUpdatesEnabled: "true",
                 expoUpdatesCheckOnLaunch: "NEVER",
-                expoUpdatesChannel: "staging",
+                expoUpdatesChannel: "canary",
                 expoRuntimeVersion: getRuntimeVersion(),
                 expoUpdatesDisableAntibrickingMeasures: "true"
             ]

--- a/ios/Artsy/Supporting/QA/ExpoQA.plist
+++ b/ios/Artsy/Supporting/QA/ExpoQA.plist
@@ -13,7 +13,7 @@
 	<key>EXUpdatesRequestHeaders</key>
 	<dict>
 		<key>expo-channel-name</key>
-		<string>staging</string>
+		<string>canary</string>
 	</dict>
 	<key>EXUpdatesRuntimeVersion</key>
 	<string>replaced-at-build-time</string>


### PR DESCRIPTION
This PR resolves [PHIRE-1880] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Default to canary in dev builds to avoid needing to restart the app since that is the channel most devs will use for the time being. 

#trivial #nochangelog


[PHIRE-1880]: https://artsyproduct.atlassian.net/browse/PHIRE-1880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ