### PR TITLE
fix: broken galleries for you for new users

### DIFF
--- a/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
+++ b/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
@@ -46,7 +46,7 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
 
   const ipLocation = queryData.requestLocation?.coordinates
 
-  const userLocation = location || { lat: ipLocation?.lat, lng: ipLocation?.lng }
+  const userLocation = location || { lat: ipLocation?.lat!, lng: ipLocation?.lng! }
 
   const RefreshControl = useRefreshControl(refetch)
 


### PR DESCRIPTION
This PR resolves [PBRW-927] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes an issue affecting new users visiting the galleries for you screen.

What's the current flow?
- When a user has no follows, we have no galleries for them
- We then trigger a **manual refetch** with `includePartnersWithFollowedArtists:false` within `useEffect`

This works fine for the initial load. However, when the user tries to pull to refresh, **we call `refetch` with the initial query params**, the ones that return nothing

![Screenshot 2025-06-24 at 10 46 18](https://github.com/user-attachments/assets/0184f309-27ad-4c6a-ac74-343e916814d4)

⭐⭐⭐  This PR fixes the pull to refresh by making sure that when we refetch in case we have no follows, we refetch with `includePartnersWithFollowedArtists` set to `false`


https://github.com/user-attachments/assets/469d9acd-9413-4596-9da5-2d2db7ce98a6



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix broken galleries for you pull to refresh for new users - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-927]: https://artsyproduct.atlassian.net/browse/PBRW-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ