### PR TITLE
fix: broken recent searches animation

### DIFF
--- a/src/app/Scenes/Search/RecentSearches.tsx
+++ b/src/app/Scenes/Search/RecentSearches.tsx
@@ -1,18 +1,11 @@
 import { SimpleMessage, Spacer } from "@artsy/palette-mobile"
 import { SectionTitle } from "app/Components/SectionTitle"
 import { GlobalStore } from "app/store/GlobalStore"
-import { useState } from "react"
-import { Platform } from "react-native"
-import Animated, { LinearTransition } from "react-native-reanimated"
+import { FlatList } from "react-native"
 import { useRecentSearches } from "./SearchModel"
 import { AutosuggestSearchResult } from "./components/AutosuggestSearchResult"
 
-const IS_ANDROID = Platform.OS === "android"
-
 export const RecentSearches: React.FC = () => {
-  // TODO: remove this when this reanimated issue gets fixed
-  // https://github.com/software-mansion/react-native-reanimated/issues/5728
-  const [flatlistHeight, setFlatlistHeight] = useState<number>()
   const recentSearches = useRecentSearches()
 
   return (
@@ -20,20 +13,12 @@ export const RecentSearches: React.FC = () => {
       <SectionTitle title="Recent Searches" />
 
       {recentSearches.length ? (
-        <Animated.FlatList
-          onLayout={(event) => {
-            if (IS_ANDROID) {
-              setFlatlistHeight(event.nativeEvent.layout.height)
-            }
-          }}
-          style={IS_ANDROID ? { height: flatlistHeight } : {}}
-          contentContainerStyle={IS_ANDROID ? { flex: 1, height: flatlistHeight } : {}}
+        <FlatList
           data={recentSearches}
           ItemSeparatorComponent={() => <Spacer y={2} />}
           scrollEnabled={false}
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
-          itemLayoutAnimation={LinearTransition}
           keyExtractor={(item, index) => item.props.internalID ?? index.toString()}
           renderItem={({ item }) => (
             <AutosuggestSearchResult


### PR DESCRIPTION
### Description

This PR replaces `Animated.Flatlist` with `Flatlist` inside the recent searches component.

**Note:** The animation was actually broken on iOS so we had no reason to keep it 😄 


| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/91a8a361-89ee-49d8-9ffe-6a9d4e0be872" /> | <video src="https://github.com/user-attachments/assets/38ecaa92-488d-4f81-918e-383fde98a848" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

-

#### Android user-facing changes

- broken recent searches animation - mounir

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
