### PR TITLE
chore: remove refetch includePartnersWithFollowedArtists

### DIFF
--- a/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
+++ b/src/app/Scenes/GalleriesForYou/GalleriesForYouScreen.tsx
@@ -15,7 +15,7 @@ import { useRefreshControl } from "app/utils/refreshHelpers"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { times } from "lodash"
-import { Suspense, useEffect, useState } from "react"
+import { Suspense } from "react"
 import { ActivityIndicator } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
@@ -47,21 +47,6 @@ export const GalleriesForYou: React.FC<GalleriesForYouProps> = ({ location }) =>
   const RefreshControl = useRefreshControl(refetch)
 
   const partners = extractNodes(data.partnersConnection)
-
-  // Refetch in case the user doesn't follow artists and there are no results
-  // This will show results even in case the user doesn't follow any artists
-  const [hasRefetched, setHasRefetched] = useState(false)
-
-  useEffect(() => {
-    if (partners.length || hasRefetched) return
-
-    refetch({
-      ...queryParams,
-      includePartnersWithFollowedArtists: false,
-    })
-
-    setHasRefetched(true)
-  }, [partners])
 
   return (
     <ProvideScreenTrackingWithCohesionSchema


### PR DESCRIPTION
### Description

Thanks to this PR https://github.com/artsy/gravity/pull/19054, `partnersConnection` will now return galleries near you regardless of you having a followed artists or not. This means that we no longer need to do this https://github.com/artsy/eigen/pull/8890 refetching anymore 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [X] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

#nochangelog