### PR TITLE
fix: the ArtworkRailCardMeta component is cut off hiding collector(urgency) signals and action timer components

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
@@ -23,7 +23,7 @@ export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
     case curatorsPick && !hideCuratorsPick:
       return (
         <Box alignItems="center" flexDirection="row">
-          <FireIcon fill="mono100" />
+          <FireIcon fill={primaryColor} />
           <Text color={primaryColor} variant="xs" textAlign="center">
             {" "}
             Curators’ Pick
@@ -34,8 +34,8 @@ export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
     case increasedInterest && !hideIncreasedInterest:
       return (
         <Box flexDirection="row" alignItems="center">
-          <ArrowUpRightIcon fill="mono100" />
-          <Text color={primaryColor} variant="xs">
+          <ArrowUpRightIcon fill={primaryColor} />
+          <Text color={primaryColor} variant="xs" textAlign="center">
             {" "}
             Increased Interest
           </Text>

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -1,8 +1,10 @@
-import { Flex, HeartFillIcon, HeartIcon, Text, Touchable } from "@artsy/palette-mobile"
+import { HeartFillIcon, HeartStrokeIcon } from "@artsy/icons/native"
+import { Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { ArtworkRailCardMeta_artwork$key } from "__generated__/ArtworkRailCardMeta_artwork.graphql"
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
 import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT } from "app/Components/ArtworkRail/ArtworkRailCard"
 import { useMetaDataTextColor } from "app/Components/ArtworkRail/ArtworkRailUtils"
 import { ArtworkSaleMessage } from "app/Components/ArtworkRail/ArtworkSaleMessage"
 import { HEART_ICON_SIZE } from "app/Components/constants"
@@ -115,7 +117,11 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
     !sale?.isAuction && !displayLimitedTimeOfferSignal && !!collectorSignals
 
   return (
-    <Flex flexDirection="row" justifyContent="space-between">
+    <Flex
+      flexDirection="row"
+      justifyContent="space-between"
+      height={ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT}
+    >
       <Flex flex={1}>
         {!!lotLabel && (
           <Text lineHeight="20px" color={secondaryColor} numberOfLines={1}>
@@ -215,7 +221,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
                 fill="blue100"
               />
             ) : (
-              <HeartIcon
+              <HeartStrokeIcon
                 testID="empty-heart-icon"
                 height={HEART_ICON_SIZE}
                 width={HEART_ICON_SIZE}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

CollectorSignals and ArtworkAuctionTimer takes some time to load for some reason. In combination with using the FlashList component on iOS we have the following:
1. flash list component is being rendered with the data it receives first and sets the height of the component accordingly
2. later, we receive the CollectorSignals or data, but the FlashList component is not re-rendering in order to adjust the height (FlatList would)

A simple solution would be to set the height if the meta data component. 

Follow-up required for a more robust solution (WIP)

| Before | After |
| --- | --- | 
| ![image](https://github.com/user-attachments/assets/f62574f1-efbd-4b03-b1bd-3da71bf499d5) | ![image](https://github.com/user-attachments/assets/6655ebba-a04d-4d77-bfa1-f89f260189cb) | 
<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes
 
- fix: the ArtworkRailCardMeta component is cut off hiding collector(urgency) signals and action timer components

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
