### PR TITLE
fix: pass the correct query to useSearchQuery refetch

### DIFF
--- a/src/app/Scenes/Search/useSearchQuery.tsx
+++ b/src/app/Scenes/Search/useSearchQuery.tsx
@@ -1,4 +1,3 @@
-import { SearchScreenQuery } from "app/Scenes/Search/Search"
 import { useState } from "react"
 import { GraphQLTaggedNode, useLazyLoadQuery, useRelayEnvironment } from "react-relay"
 import { FetchPolicy, fetchQuery, OperationType, VariablesOf } from "relay-runtime"
@@ -38,7 +37,7 @@ export function useSearchQuery<TQuery extends OperationType>(
 
     setIsRefreshing(true)
 
-    fetchQuery(environment, SearchScreenQuery, updatedVariables).subscribe({
+    fetchQuery(environment, query, updatedVariables).subscribe({
       complete: () => {
         setIsRefreshing(false)
 


### PR DESCRIPTION
This PR attempts to fix an issue that Claude Code noticed while I was debugging the Explore by Category component.

The refetch returned by that hook uses the `SearchScreenQuery` query, even when the `GlobalSearchOverlay` is using it, instead of using the same query that is passed to the hook (which is named `globalSearchInputOverlayQuery` in the case of `GlobalSearchOverlay`). 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Pass the correct query to useSearchQuery refetch

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
