### PR TITLE
chore: fail loudly when expo update command fails

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -514,6 +514,7 @@ lane :deploy_to_expo_updates do |options|
   end
 
   sh("pushd ../ > /dev/null && \
+      set -o pipefail && \
       #{expo_command} | tail -n1 && \
       popd > /dev/null")
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->


Expo update command was failing silently making it seem like it succeeded, fail loudly instead. 

#nochangelog

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

