### PR TITLE
feat: convert activity dots to blue

### DIFF
--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -22,7 +22,7 @@ export const useBottomTabsBadges = () => {
   const tabsBadges: Record<string, BadgeProps> = {}
 
   const visualClueStyles = {
-    backgroundColor: color("red50"),
+    backgroundColor: color("blue100"),
     top: 2,
     minWidth: VISUAL_CLUE_HEIGHT,
     maxHeight: VISUAL_CLUE_HEIGHT,
@@ -75,7 +75,7 @@ export const useBottomTabsBadges = () => {
           tabsBadges[tab] = {
             tabBarBadge: unreadConversationsCount,
             tabBarBadgeStyle: {
-              backgroundColor: color("red50"),
+              ...visualClueStyles,
             },
           }
         }

--- a/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
@@ -35,7 +35,7 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = (props) => {
               right={0}
               accessibilityLabel="Unseen Notifications Indicator"
             >
-              <VisualClueDot diameter={8} color="red50" />
+              <VisualClueDot diameter={8} />
             </Box>
           )}
         </>


### PR DESCRIPTION
This PR resolves [ONYX-1776]

### Description

This follows up https://github.com/artsy/eigen/pull/11319 by converting all the activity dots from red to blue.

| <nobr>Platform</nobr> | Before | After |
|---|---|---|
| Android | <img height=400 alt="red" src="https://github.com/user-attachments/assets/f4214009-5a21-4c56-8aaf-985394f6ea5f" /> | <img height=400 alt="blue" src="https://github.com/user-attachments/assets/c76f8042-febf-4e07-a6d6-f06d529777af" /> |
| iOS | <img height=400 alt="red" src="https://github.com/user-attachments/assets/1120ae0e-180e-4525-b548-69c8780ea6a3" /> | <img  height=400 alt="blue" src="https://github.com/user-attachments/assets/30498682-9509-433f-8059-785271afa40b" /> |



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Convert activity indicator dots from red to blue

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1776]: https://artsyproduct.atlassian.net/browse/ONYX-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ