### PR TITLE
feat: make artist above the fold query cacheable

### DIFF
--- a/src/app/Components/Artist/__tests__/ArtistHeaderNavRight.tests.tsx
+++ b/src/app/Components/Artist/__tests__/ArtistHeaderNavRight.tests.tsx
@@ -19,13 +19,16 @@ jest.mock("app/Components/Artist/useFollowArtist", () => ({
   }),
 }))
 
-describe("ArtistHeaderNavRight", () => {
-  const mockOnSharePress = jest.fn()
+const mockShowShareSheet = jest.fn()
+jest.mock("app/Components/ShareSheet/ShareSheetContext", () => ({
+  useShareSheet: () => ({
+    showShareSheet: mockShowShareSheet,
+  }),
+}))
 
+describe("ArtistHeaderNavRight", () => {
   const { renderWithRelay } = setupTestWrapper<ArtistHeaderNavRightTestsQuery>({
-    Component: ({ artist }) => (
-      <ArtistHeaderNavRight artist={artist!} onSharePress={mockOnSharePress} />
-    ),
+    Component: ({ artist }) => <ArtistHeaderNavRight artist={artist!} />,
     query: graphql`
       query ArtistHeaderNavRightTestsQuery @relay_test_operation {
         artist(id: "artist-id") {
@@ -56,7 +59,7 @@ describe("ArtistHeaderNavRight", () => {
     const shareButton = screen.getByLabelText("Share")
     fireEvent.press(shareButton)
 
-    expect(mockOnSharePress).toHaveBeenCalledTimes(1)
+    expect(mockShowShareSheet).toHaveBeenCalledTimes(1)
   })
 
   it("renders the follow button when artist is not followed", () => {

--- a/src/app/Components/Toast/ToastComponent.tsx
+++ b/src/app/Components/Toast/ToastComponent.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Image, Text, Touchable, useColor } from "@artsy/palette-mobile"
 import { useActionSheet } from "@expo/react-native-action-sheet"
+import { BOTTOM_TABS_HEIGHT } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { modules } from "app/Navigation/utils/modules"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -16,7 +17,6 @@ const EDGE_TOAST_HEIGHT = 60
 const IMAGE_SIZE = 40
 const EDGE_TOAST_PADDING = 10
 const NAVBAR_HEIGHT = 44
-const TABBAR_HEIGHT = 50
 
 export const TOAST_DURATION_MAP: Record<ToastDuration, number> = {
   short: 2500,
@@ -64,7 +64,7 @@ export const ToastComponent = ({
   const toastBottomPadding = useMemo(() => {
     // This is needed to avoid importing modules during tests
     if (__TEST__) {
-      return TABBAR_HEIGHT
+      return BOTTOM_TABS_HEIGHT
     }
 
     const moduleName = internal_navigationRef?.current?.getCurrentRoute()
@@ -78,7 +78,7 @@ export const ToastComponent = ({
       return bottomPadding || 0
     }
 
-    return TABBAR_HEIGHT
+    return BOTTOM_TABS_HEIGHT
   }, [])
 
   if (placement === "middle") {

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -46,7 +46,7 @@ type TabRoutesParams = {
 
 const Tab = createBottomTabNavigator<TabRoutesParams>()
 
-const BOTTOM_TABS_HEIGHT = PixelRatio.getFontScale() < 1.5 ? 65 : 85
+export const BOTTOM_TABS_HEIGHT = PixelRatio.getFontScale() < 1.5 ? 65 : 85
 export const TAB_BAR_ANIMATION_DURATION = 300
 
 const AppTabs: React.FC = () => {

--- a/src/app/Scenes/Artist/Artist.tsx
+++ b/src/app/Scenes/Artist/Artist.tsx
@@ -15,7 +15,7 @@ import { ArtistBelowTheFoldQuery } from "__generated__/ArtistBelowTheFoldQuery.g
 import { ArtistAboutContainer } from "app/Components/Artist/ArtistAbout/ArtistAbout"
 import { ArtistArtworksQueryRenderer } from "app/Components/Artist/ArtistArtworks/ArtistArtworks"
 import { ArtistHeader, useArtistHeaderImageDimensions } from "app/Components/Artist/ArtistHeader"
-import { ArtistHeaderNavRight } from "app/Components/Artist/ArtistHeaderNavRight"
+import { ArtistHeaderNavRightQueryRenderer } from "app/Components/Artist/ArtistHeaderNavRight"
 import { ArtistInsightsFragmentContainer } from "app/Components/Artist/ArtistInsights/ArtistInsights"
 import {
   FilterArray,
@@ -30,7 +30,6 @@ import { getOnlyFilledSearchCriteriaValues } from "app/Components/ArtworkFilter/
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
-import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
 import { SkeletonPill } from "app/Components/SkeletonPill/SkeletonPill"
 import { SearchCriteriaQueryRenderer } from "app/Scenes/Artist/SearchCriteria"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -74,42 +73,24 @@ export const Artist: React.FC<ArtistProps> = ({
   input,
 }) => {
   const popoverMessage = usePopoverMessage()
-  const { showShareSheet } = useShareSheet()
 
   const navigation = useNavigation()
-
-  const handleSharePress = useCallback(() => {
-    if (
-      artistAboveTheFold.name &&
-      artistAboveTheFold.name &&
-      artistAboveTheFold.slug &&
-      artistAboveTheFold.href
-    ) {
-      showShareSheet({
-        type: "artist",
-        internalID: artistAboveTheFold.internalID,
-        slug: artistAboveTheFold.slug,
-        artists: [{ name: artistAboveTheFold.name ?? null }],
-        title: artistAboveTheFold.name,
-        href: artistAboveTheFold.href,
-        currentImageUrl: artistAboveTheFold.coverArtwork?.image?.url ?? undefined,
-      })
-    }
-  }, [artistAboveTheFold, showShareSheet])
 
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => {
         if (artistAboveTheFold) {
           return (
-            <ArtistHeaderNavRight artist={artistAboveTheFold} onSharePress={handleSharePress} />
+            <Flex>
+              <ArtistHeaderNavRightQueryRenderer artistID={artistAboveTheFold.internalID} />
+            </Flex>
           )
         }
 
         return null
       },
     })
-  }, [artistAboveTheFold, navigation, handleSharePress])
+  }, [artistAboveTheFold, navigation])
 
   useEffect(() => {
     if (!!fetchCriteriaError) {
@@ -199,8 +180,8 @@ interface ArtistQueryRendererProps {
 }
 
 export const ArtistScreenQuery = graphql`
-  query ArtistAboveTheFoldQuery($artistID: String!) {
-    artist(id: $artistID) @principalField {
+  query ArtistAboveTheFoldQuery($artistID: String!) @cacheable {
+    artist(id: $artistID) {
       ...ArtistHeader_artist
       ...ArtistHeaderNavRight_artist
       id
@@ -208,11 +189,6 @@ export const ArtistScreenQuery = graphql`
       slug
       href
       name
-      coverArtwork {
-        image {
-          url(version: "larger")
-        }
-      }
     }
   }
 `

--- a/src/app/Scenes/Collection/Collection.tsx
+++ b/src/app/Scenes/Collection/Collection.tsx
@@ -182,7 +182,7 @@ const CollectionPlaceholder: React.FC = () => {
 }
 
 export const CollectionScreenQuery = graphql`
-  query CollectionQuery($collectionID: String!) @cacheable {
+  query CollectionQuery($collectionID: String!) {
     collection: marketingCollection(slug: $collectionID) @principalField {
       ...Collection_collection
     }

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -230,6 +230,9 @@ export const devToggles: { [key: string]: DevToggleDescriptor } = {
   DTLocationDetectionVisialiser: {
     description: "Location detection visualiser",
   },
+  DTCacheHitsVisialiser: {
+    description: "Cache hits visualiser",
+  },
   DTShowNavigationVisualiser: {
     description: "Navigation visualiser",
   },

--- a/src/app/system/relay/middlewares/cacheHeaderMiddleware.ts
+++ b/src/app/system/relay/middlewares/cacheHeaderMiddleware.ts
@@ -1,3 +1,4 @@
+import { GlobalStore, unsafe_getDevToggle } from "app/store/GlobalStore"
 import { getCurrentURL } from "app/system/navigation/utils/getCurrentURL"
 import {
   hasNoCacheParamPresent,
@@ -65,6 +66,16 @@ export const cacheHeaderMiddleware = (): Middleware => {
     const cacheControlHeader = (() => {
       if (shouldSkipCDNCache(req as GraphQLRequest)) {
         return { "Cache-Control": "no-cache" }
+      }
+
+      if (unsafe_getDevToggle("DTCacheHitsVisialiser")) {
+        GlobalStore.actions.toast.add({
+          message: `${(req as GraphQLRequest).operation.name} hit cache 🚀`,
+          placement: "bottom",
+          options: {
+            backgroundColor: "green100",
+          },
+        })
       }
 
       return {}

--- a/src/app/utils/queryPrefetching.ts
+++ b/src/app/utils/queryPrefetching.ts
@@ -82,6 +82,9 @@ export const prefetchQuery = async ({
 
   return fetchQuery(environment, query, variables ?? {}, {
     fetchPolicy: "store-or-network",
+    networkCacheConfig: {
+      force: false,
+    },
   }).subscribe({
     complete: () => {
       if (logPrefetching) {


### PR DESCRIPTION
### Description

We are finally there!

This PR comes after two previous improvements to the artist screen 
1. Improve screen layout logic and decouple components https://github.com/artsy/eigen/pull/12370
2. decouple queries https://github.com/artsy/eigen/pull/12373

This PR comes as the cherry on the top of the previous improvements to allow us finally to take advantage of `@cacheable`. The goal is: **We don't want regular app usage to be interrupted by any skeletons. We want users to focus on buying art and not on skeletons**.
___

**Bonus:**
I added a cache hit visualizer to make it easy to tell if a query hit the cache or not
<details><summary>Screen Recording</summary>
<p>


https://github.com/user-attachments/assets/35400fc9-9077-4ee6-a2c6-527fabedb4ad


</p>
</details> 

___

### Screen Recording
**Before**
`ArtistAboveTheFoldQuery` p95 is `1100ms`, not bad, but if you are fast reader, you might see the skeleton if the query prefetching didn't finish on time. 
![Screenshot 2025-07-02 at 15 08 27](https://github.com/user-attachments/assets/b84d50f6-ab5f-4d7d-bb57-85bf69e6d6e8)

**After**
_The screenshot should be enough_
![Screenshot 2025-07-02 at 15 07 32](https://github.com/user-attachments/assets/86e8aa66-de72-4ad6-89eb-dadf7db6f30c)


**Screen Recording**

As you can see in the video, I am not using the app as a regular will use it, yet still, **I barely see skeletons**.
**Note:** there is the image loading skeleton - that's different from the query related one, but that's a problem for another day 😄 


https://github.com/user-attachments/assets/40fbe4cf-acf8-42d0-a70b-134f2babbe35


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
