### PR TITLE
fix(ONYX-1789): artwork rail card layout issues

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSocialSignal.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpRightIcon, FireIcon } from "@artsy/icons/native"
 import { Box, Text } from "@artsy/palette-mobile"
 import { ArtworkSocialSignal_collectorSignals$key } from "__generated__/ArtworkSocialSignal_collectorSignals.graphql"
+import { Text as RNText } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtworkSocialSignalProps {
@@ -22,12 +23,14 @@ export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
   switch (true) {
     case curatorsPick && !hideCuratorsPick:
       return (
-        <Box alignItems="center" flexDirection="row">
+        <Box flexDirection="row" alignItems="center">
           <FireIcon fill={primaryColor} />
-          <Text color={primaryColor} variant="xs" textAlign="center">
-            {" "}
-            Curators’ Pick
-          </Text>
+          <RNText numberOfLines={1} ellipsizeMode="tail">
+            <Text color={primaryColor} variant="xs" textAlign="center">
+              {" "}
+              Curators’ Pick
+            </Text>
+          </RNText>
         </Box>
       )
 
@@ -35,10 +38,12 @@ export const ArtworkSocialSignal: React.FC<ArtworkSocialSignalProps> = ({
       return (
         <Box flexDirection="row" alignItems="center">
           <ArrowUpRightIcon fill={primaryColor} />
-          <Text color={primaryColor} variant="xs" textAlign="center">
-            {" "}
-            Increased Interest
-          </Text>
+          <RNText numberOfLines={1} ellipsizeMode="tail">
+            <Text color={primaryColor} variant="xs" textAlign="center">
+              {" "}
+              Increased Interest
+            </Text>
+          </RNText>
         </Box>
       )
 

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -1,13 +1,9 @@
-import { Flex, SkeletonBox, SkeletonText, Spacer, useSpace } from "@artsy/palette-mobile"
-import { FlashList } from "@shopify/flash-list"
+import { Flex, SkeletonBox, SkeletonText, Spacer } from "@artsy/palette-mobile"
 import {
   ArtworkRail_artworks$data,
   ArtworkRail_artworks$key,
 } from "__generated__/ArtworkRail_artworks.graphql"
-import {
-  ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT,
-  ArtworkRailCard,
-} from "app/Components/ArtworkRail/ArtworkRailCard"
+import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
   ARTWORK_RAIL_CARD_MIN_WIDTH,
@@ -16,7 +12,7 @@ import { BrowseMoreRailCard } from "app/Components/BrowseMoreRailCard"
 import { RandomWidthPlaceholderText } from "app/utils/placeholders"
 import { ArtworkActionTrackingProps } from "app/utils/track/ArtworkActions"
 import React, { memo, ReactElement, useCallback } from "react"
-import { FlatList, ListRenderItem, Platform, ViewabilityConfig } from "react-native"
+import { FlatList, ListRenderItem, ViewabilityConfig } from "react-native"
 import { isTablet } from "react-native-device-info"
 import { graphql, useFragment } from "react-relay"
 
@@ -47,7 +43,6 @@ export interface ArtworkRailProps extends ArtworkActionTrackingProps {
 
 export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
   ({
-    listRef,
     onPress,
     onEndReached,
     onEndReachedThreshold,
@@ -59,7 +54,6 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
     dark = false,
     showSaveIcon = false,
     viewabilityConfig,
-    onViewableItemsChanged,
     moreHref,
     onMorePress,
     hideIncreasedInterestSignal,
@@ -67,7 +61,6 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
     ...otherProps
   }) => {
     const artworks = useFragment(artworksFragment, otherProps.artworks)
-    const space = useSpace()
 
     const renderItem: ListRenderItem<Artwork> = useCallback(
       ({ item, index }) => {
@@ -92,22 +85,8 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
       [hideArtistName, onPress, showPartnerName]
     )
 
-    // On android we are using a flatlist to fix some image issues
-    // Context https://github.com/artsy/eigen/pull/11207
-    const ListComponent =
-      Platform.OS === "ios"
-        ? (props: any) => (
-            <FlashList
-              estimatedItemSize={
-                ARTWORK_RAIL_CARD_IMAGE_HEIGHT + ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + space(1)
-              }
-              {...props}
-            />
-          )
-        : FlatList
-
     return (
-      <ListComponent
+      <FlatList
         data={artworks}
         horizontal
         keyExtractor={(item: Artwork) => item.internalID}
@@ -125,7 +104,6 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
           </>
         }
         ListHeaderComponent={ListHeaderComponent}
-        listRef={listRef}
         onEndReached={onEndReached}
         onEndReachedThreshold={onEndReachedThreshold}
         renderItem={renderItem}

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -3,6 +3,8 @@ import { ArtworkRailCard_artwork$key } from "__generated__/ArtworkRailCard_artwo
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
 import {
   ARTWORK_RAIL_CARD_IMAGE_HEIGHT,
+  ARTWORK_RAIL_CARD_MAX_WIDTH,
+  ARTWORK_RAIL_CARD_MIN_WIDTH,
   ArtworkRailCardImage,
 } from "app/Components/ArtworkRail/ArtworkRailCardImage"
 import {
@@ -114,6 +116,8 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = ({
                 height={
                   ARTWORK_RAIL_CARD_IMAGE_HEIGHT + ARTWORK_RAIL_TEXT_CONTAINER_HEIGHT + space(1)
                 }
+                minWidth={ARTWORK_RAIL_CARD_MIN_WIDTH}
+                maxWidth={ARTWORK_RAIL_CARD_MAX_WIDTH}
                 justifyContent="flex-start"
               >
                 <ArtworkRailCardImage artwork={artwork} />


### PR DESCRIPTION
This PR resolves [ONYX-1789] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
1. add number of lined 1 to the social signals component. Use Text from React-native as a work around known Android truncation bug 
2. use FlatList instead of FlashList
3. add min and max artwork rail card to make sure the text withing the card is displayed correctly and not stretched as shown in [this bug report](https://artsy.slack.com/archives/C05EQL4R5N0/p1751452113540469?thread_ts=1751441607.453639&cid=C05EQL4R5N0)
4.  
| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/58a1e524-b413-4356-9abd-585958d59c6f" width="400" /> | <img src="https://github.com/user-attachments/assets/d4ff6511-65fd-4070-b916-1b1134561a86" width="400" /> |
| iOS | <img src="https://github.com/user-attachments/assets/f8c21181-be6f-449e-91c3-343c27164997" width="400" /> | <img src="https://github.com/user-attachments/assets/5b4b5243-1276-4530-9cca-f8f025227f15" width="400" /> |

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="https://github.com/user-attachments/assets/2d560535-167f-4549-83c5-1d9176d0d8b3" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="https://github.com/user-attachments/assets/3066f4b1-7ade-45f4-a2f8-8494ceb6daff" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix artwork rail card layout issues

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
