### PR TITLE
fix: add back asset download

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,6 +423,12 @@ jobs:
           at: .
       - install-bin-modules
       - run:
+          name: Download fonts from s3
+          command: ./scripts/setup/download-fonts
+      - run:
+          name: Download android assets
+          command: ./scripts/setup/download-assets-android
+      - run:
           name: Load version code
           command: |
             VERSION_CODE=$(cat fastlane/next_version_code.txt)
@@ -441,6 +447,12 @@ jobs:
       - attach_workspace:
           at: .
       - install-bin-modules
+      - run:
+          name: Download fonts from s3
+          command: ./scripts/setup/download-fonts
+      - run:
+          name: Download android assets
+          command: ./scripts/setup/download-assets-android
       - run:
           name: Load version code
           command: |


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Android betas failing due to missing assets, possibly a bad merge, will look but adding back for now.

#trivial #nochangelog

