### PR TITLE
fix: regression on message count indicator

### DIFF
--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -75,7 +75,7 @@ export const useBottomTabsBadges = () => {
           tabsBadges[tab] = {
             tabBarBadge: unreadConversationsCount,
             tabBarBadgeStyle: {
-              ...visualClueStyles,
+              backgroundColor: color("blue100"),
             },
           }
         }


### PR DESCRIPTION
### Description

In https://github.com/artsy/eigen/pull/12391 I overeagerly made all the blue dots use the same shared styles.

But that neglected the fact that the dot on the **Inbox** has special behavior to show a message count (`42` in the screencaps below).

| Platform | Before | After |
|---|---|---|
| Android | <img height="400" alt="before fix" src="https://github.com/user-attachments/assets/ba131d21-fa04-4ca8-9f38-c6b609ef4ab5" /> | <img height="400" alt="after fix" src="https://github.com/user-attachments/assets/b71173ce-446d-4ac9-b803-cd833dc350ff" /> |
| iOS | <img height="400" alt="before fix" src="https://github.com/user-attachments/assets/c0c0d0f6-13c8-46eb-8743-cde87ce53e8a" /> | <img height="400" alt="after fix" src="https://github.com/user-attachments/assets/87ea90d1-3b45-42f1-9e54-17cf6bd1813b" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix Inbox message count indicator 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
