### PR TITLE
chore: update Order History row tests

### DIFF
--- a/src/app/Scenes/OrderHistory/__tests__/OrderHistoryRow.tests.tsx
+++ b/src/app/Scenes/OrderHistory/__tests__/OrderHistoryRow.tests.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { OrderHistoryRowTestsQuery } from "__generated__/OrderHistoryRowTestsQuery.graphql"
 import { OrderHistoryRowContainer } from "app/Scenes/OrderHistory/OrderHistoryRow"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -323,19 +324,26 @@ describe("OrderHistoryRow", () => {
       })
     })
 
-    it("navigates to the purchase summary when the order has a processing offer", () => {
-      renderWithRelay({
-        CommerceOrder: () => ({
-          ...mockOrder,
-          internalID: "internal-id",
-          displayState: "PROCESSING",
-          mode: "OFFER",
-        }),
-      })
+    describe.each([
+      [true, "/orders/internal-id/details"],
+      [false, "/user/purchases/internal-id"],
+    ])("when AREnableNewOrderDetails is %s", (featureFlagValue, navigateUrl) => {
+      it("navigates to the correct order details", () => {
+        __globalStoreTestUtils__?.injectFeatureFlags({ AREnableNewOrderDetails: featureFlagValue })
 
-      const button = screen.getByTestId("view-order-button")
-      fireEvent.press(button)
-      expect(navigate).toHaveBeenCalledWith("/orders/internal-id/details")
+        renderWithRelay({
+          CommerceOrder: () => ({
+            ...mockOrder,
+            internalID: "internal-id",
+            displayState: "PROCESSING",
+            mode: "OFFER",
+          }),
+        })
+
+        fireEvent.press(screen.getByTestId("view-order-button"))
+
+        expect(navigate).toHaveBeenCalledWith(navigateUrl)
+      })
     })
   })
 })


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR updates the Order History Row tests to include both states of the AREnableNewOrderDetails feature flag

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
