### PR TITLE
chore: update S3 presign screenshot url expiration to 15 days in report-maestro-test-failure script

### DIFF
--- a/scripts/ci/report-maestro-test-failure
+++ b/scripts/ci/report-maestro-test-failure
@@ -22,7 +22,10 @@ for screenshot in "$SCREENSHOTS_DIR"/*.png; do
   S3_PATH="s3://artsy-citadel/eigen/screenshots/$LATEST/$BASENAME"
 
   aws s3 cp "$screenshot" "$S3_PATH"
-  URL=$(aws s3 presign "$S3_PATH" --expires-in 86400)
+  # 15 days × 24 hours/day × 60 min/hour × 60 sec/min
+  EXPIRES_IN=$((15 * 24 * 60 * 60))  # → 1296000 seconds
+
+  URL=$(aws s3 presign "$S3_PATH" --expires-in "$EXPIRES_IN")
 
   bundle exec fastlane report_maestro_failure s3_url:$URL error_message:"$ERROR_MESSAGE" flow_name:"$FLOW_NAME"
 done


### PR DESCRIPTION
This PR resolves [PHIRE-1877] <!-- eg [PROJECT-XXXX] -->

### Description

Bumps the S3 presign screenshot url expiration for e2e tests from 1 day  to 15 days for easier debugging.

FYI the screenshots are already persisted for longer time than this so no further changes are needed

#nochangelog

[PHIRE-1877]: https://artsyproduct.atlassian.net/browse/PHIRE-1877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ