### PR TITLE
feat: allow Echo to control switch to blue activity dot

### DIFF
--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -1,6 +1,7 @@
 import { useColor } from "@artsy/palette-mobile"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useVisualClue } from "app/utils/hooks/useVisualClue"
 import { useTabBarBadge } from "app/utils/useTabBarBadge"
 import { StyleProp, TextStyle } from "react-native"
@@ -15,6 +16,7 @@ type BadgeProps = { tabBarBadge?: string | number; tabBarBadgeStyle: StyleProp<T
  */
 export const useBottomTabsBadges = () => {
   const color = useColor()
+  const showBlueDots = useFeatureFlag("AREnableBlueActivityDots")
 
   const { showVisualClue } = useVisualClue()
   const { unreadConversationsCount, hasUnseenNotifications } = useTabBarBadge()
@@ -22,7 +24,7 @@ export const useBottomTabsBadges = () => {
   const tabsBadges: Record<string, BadgeProps> = {}
 
   const visualClueStyles = {
-    backgroundColor: color("blue100"),
+    backgroundColor: showBlueDots ? color("blue100") : color("red50"),
     top: 2,
     minWidth: VISUAL_CLUE_HEIGHT,
     maxHeight: VISUAL_CLUE_HEIGHT,
@@ -75,7 +77,7 @@ export const useBottomTabsBadges = () => {
           tabsBadges[tab] = {
             tabBarBadge: unreadConversationsCount,
             tabBarBadgeStyle: {
-              backgroundColor: color("blue100"),
+              backgroundColor: showBlueDots ? color("blue100") : color("red50"),
             },
           }
         }

--- a/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
@@ -3,6 +3,7 @@ import { Box, VisualClueDot } from "@artsy/palette-mobile"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import React from "react"
 
 interface ActivityIndicatorProps {
@@ -12,6 +13,7 @@ interface ActivityIndicatorProps {
 export const ActivityIndicator: React.FC<ActivityIndicatorProps> = (props) => {
   const { hasUnseenNotifications } = props
   const tracking = useHomeViewTracking()
+  const showBlueDots = useFeatureFlag("AREnableBlueActivityDots")
 
   const navigateToActivityPanel = () => {
     tracking.tappedNotificationBell()
@@ -35,7 +37,7 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = (props) => {
               right={0}
               accessibilityLabel="Unseen Notifications Indicator"
             >
-              <VisualClueDot diameter={8} />
+              <VisualClueDot diameter={8} color={showBlueDots ? "blue100" : "red50"} />
             </Box>
           )}
         </>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -188,6 +188,12 @@ export const features = {
     description: "Enable new order details screen",
     echoFlagKey: "AREnableNewOrderDetails",
   },
+  AREnableBlueActivityDots: {
+    readyForRelease: true,
+    showInDevMenu: true,
+    description: "Enable blue activity dots",
+    echoFlagKey: "AREnableBlueActivityDots",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [ONYX-1799]

### Description

See discussion: [Slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1751911124874829?thread_ts=1751391999.907869&cid=C05EQL4R5N0)

This PR:
- takes the previously approved [blue dot work ](https://github.com/artsy/eigen/pull/12391)
- puts it behind an [Echo flag](https://github.com/artsy/echo/pull/840) 
- so that we can independently enable it after the completion of a [home view experiment](https://github.com/artsy/metaphysics/pull/6892) that we are launching shortly

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Put blue dots behind a feature flag

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
