### PR TITLE
fix: handle artist bio text and credit as separate fields

### DIFF
--- a/src/app/Components/Artist/Biography.tsx
+++ b/src/app/Components/Artist/Biography.tsx
@@ -4,7 +4,7 @@ import { HTML } from "app/Components/HTML"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
-const MAX_CHARS = 250
+export const MAX_CHARS = 250
 export const MAX_WIDTH_BIO = 650
 
 interface BiographyProps {
@@ -20,7 +20,8 @@ export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) 
     return null
   }
 
-  const text = data.biographyBlurb.text
+  const credit = data.biographyBlurb.credit
+  const text = !!credit ? `${data.biographyBlurb.text} ${credit}` : data.biographyBlurb.text
   const truncatedText = text.slice(0, MAX_CHARS)
   const canExpand = text.length > MAX_CHARS
 
@@ -44,8 +45,9 @@ export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) 
 
 const query = graphql`
   fragment Biography_artist on Artist {
-    biographyBlurb(format: HTML, partnerBio: false) {
+    biographyBlurb(format: HTML) {
       text
+      credit
     }
   }
 `

--- a/src/app/Components/Artist/__tests__/Biography.tests.tsx
+++ b/src/app/Components/Artist/__tests__/Biography.tests.tsx
@@ -1,0 +1,211 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { BiographyTestsQuery } from "__generated__/BiographyTestsQuery.graphql"
+import { Biography, MAX_CHARS } from "app/Components/Artist/Biography"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("Biography", () => {
+  const { renderWithRelay } = setupTestWrapper<BiographyTestsQuery>({
+    Component: ({ artist }) => <Biography artist={artist!} />,
+    query: graphql`
+      query BiographyTestsQuery($artistID: String!) @relay_test_operation {
+        artist(id: $artistID) {
+          ...Biography_artist
+        }
+      }
+    `,
+    variables: { artistID: "test-artist-id" },
+  })
+
+  describe("when no biography text exists", () => {
+    it("returns null and does not render", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: null,
+        }),
+      })
+
+      expect(screen.toJSON()).toBeNull()
+    })
+
+    it("returns null when text is empty", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: "",
+            credit: null,
+          },
+        }),
+      })
+
+      expect(screen.toJSON()).toBeNull()
+    })
+  })
+
+  describe("when biography text exists without credit", () => {
+    it("renders biography text without credit", () => {
+      const biographyText = "This is a short biography about the artist."
+
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: biographyText,
+            credit: null,
+          },
+        }),
+      })
+
+      expect(screen.getByText(biographyText)).toBeOnTheScreen()
+    })
+
+    it("renders biography text when credit is empty string", () => {
+      const biographyText = "This is a short biography about the artist."
+
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: biographyText,
+            credit: "",
+          },
+        }),
+      })
+
+      expect(screen.getByText(biographyText)).toBeOnTheScreen()
+    })
+  })
+
+  describe("when biography text exists with credit", () => {
+    it("renders biography text with credit appended with space", () => {
+      const biographyText = "This is a biography about the artist."
+      const credit = "Source: Museum of Modern Art"
+
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: biographyText,
+            credit: credit,
+          },
+        }),
+      })
+
+      expect(screen.getByText(`${biographyText} ${credit}`, { exact: false })).toBeOnTheScreen()
+    })
+  })
+
+  describe("truncation behavior", () => {
+    const longText = "a".repeat(MAX_CHARS + 20)
+
+    it("shows Read More button when text is longer than MAX_CHARS", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: null,
+          },
+        }),
+      })
+
+      expect(screen.getByText("Read More")).toBeOnTheScreen()
+    })
+
+    it("does not show Read More button when text is shorter than MAX_CHARS", () => {
+      const shortText = "Short biography text"
+
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: shortText,
+            credit: null,
+          },
+        }),
+      })
+
+      expect(screen.queryByText("Read More")).toBeNull()
+    })
+
+    it("shows truncated text initially when text is long", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: null,
+          },
+        }),
+      })
+
+      const truncatedText = longText.slice(0, MAX_CHARS)
+      expect(screen.getByText(truncatedText, { exact: false })).toBeOnTheScreen()
+    })
+  })
+
+  describe("expand/collapse functionality", () => {
+    const longText = "a".repeat(MAX_CHARS + 20)
+
+    it("expands text when Read More is pressed", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: null,
+          },
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Read More"))
+
+      expect(screen.getByText("Read Less")).toBeOnTheScreen()
+      expect(screen.getByText(longText)).toBeOnTheScreen()
+    })
+
+    it("collapses text when Read Less is pressed", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: null,
+          },
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Read More"))
+      fireEvent.press(screen.getByText("Read Less"))
+
+      expect(screen.getByText("Read More")).toBeOnTheScreen()
+      const truncatedText = longText.slice(0, 250)
+      expect(screen.getByText(truncatedText, { exact: false })).toBeOnTheScreen()
+    })
+  })
+
+  describe("credit with long text", () => {
+    const longText = "a".repeat(MAX_CHARS - 20)
+    const credit = "Museum of Modern Art"
+
+    it("includes credit in expanded state when text is long", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: credit,
+          },
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Read More"))
+
+      expect(screen.getByText(credit, { exact: false })).toBeOnTheScreen()
+    })
+
+    it("shows Read More button when text with credit exceeds MAX_CHARS", () => {
+      renderWithRelay({
+        Artist: () => ({
+          biographyBlurb: {
+            text: longText,
+            credit: credit,
+          },
+        }),
+      })
+
+      expect(screen.getByText("Read More")).toBeOnTheScreen()
+    })
+  })
+})


### PR DESCRIPTION
This PR updates the artist about tab to be aware of partner bios by handling the `text` and `credit` fields of a `biographyBlurb` as separate items. Before this change that tab expected both items to be included in the `text`.

It also adds basic tests for the artist biography component that did not exist before.

cc: @artsy/diamond-devs 

| iOS | Android |
|----|----------|
| ![Screenshot_1751919605](https://github.com/user-attachments/assets/17dc9dd6-3510-4882-91b8-bbda971fe775) | ![Simulator Screenshot - iPhone 16 Plus - 2025-07-07 at 16 20 10](https://github.com/user-attachments/assets/cd906eda-438b-4325-86a4-eb2cad8241d0) |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fetch and display artist bio credits separately from bio text

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
