### PR TITLE
chore: update notion script to use team rather than components

### DIFF
--- a/scripts/utils/exportNotionTicketsToJira.ts
+++ b/scripts/utils/exportNotionTicketsToJira.ts
@@ -68,12 +68,7 @@ async function fetchNotionDatabase(databaseId: string) {
   }
 }
 
-async function createJiraIssue(
-  issueSummary: string,
-  issueLink: string,
-  bugSeverity: string,
-  team: string
-) {
+async function createJiraIssue(issueSummary: string, issueLink: string, bugSeverity: string) {
   try {
     const auth = Buffer.from(`${JIRA_EMAIL}:${JIRA_API_TOKEN}`).toString("base64")
     const response = await fetch(`${JIRA_BASE_URL}/rest/api/3/issue`, {
@@ -214,12 +209,7 @@ async function main() {
     }
 
     for (const issue of validIssues) {
-      const issueKey = await createJiraIssue(
-        issue.summary,
-        issue.notionUrl,
-        issue.severity,
-        issue.team
-      )
+      const issueKey = await createJiraIssue(issue.summary, issue.notionUrl, issue.severity)
       if (issueKey) {
         await updateJiraLabels(issueKey, [issue.team, "mobile"])
       }

--- a/scripts/utils/exportNotionTicketsToJira.ts
+++ b/scripts/utils/exportNotionTicketsToJira.ts
@@ -72,7 +72,7 @@ async function createJiraIssue(
   issueSummary: string,
   issueLink: string,
   bugSeverity: string,
-  component: string
+  team: string
 ) {
   try {
     const auth = Buffer.from(`${JIRA_EMAIL}:${JIRA_API_TOKEN}`).toString("base64")
@@ -118,11 +118,7 @@ async function createJiraIssue(
           customfield_10130: {
             value: bugSeverity, // Bug Severity
           },
-          components: [
-            {
-              name: component,
-            },
-          ],
+          labels: [team, "mobile"],
           issuetype: {
             name: "Bug",
           },
@@ -147,7 +143,7 @@ async function createJiraIssue(
 interface ValidIssue {
   summary: string
   severity: string
-  component: string
+  team: string
   notionUrl: string
 }
 
@@ -168,10 +164,10 @@ async function main() {
       const notionPageUrl = page.url
 
       const severity = page.properties["Bug Severity"]?.select?.name || null
-      const component = page.properties.Components?.select?.name || null
+      const team = page.properties.Team?.select?.name || null
 
-      if (!severity || !component) {
-        console.error(chalk.bold.red("Missing Bug Severity or Component for page:"))
+      if (!severity || !team) {
+        console.error(chalk.bold.red("Missing Bug Severity or Team for page:"))
         console.error(chalk.bold.red(notionPageUrl))
         console.error(chalk.bold.red("Please fill in the missing fields and try again."))
         return
@@ -181,13 +177,13 @@ async function main() {
       validIssues.push({
         summary: issueSummary,
         severity: fullSeverity,
-        component,
+        team,
         notionUrl: notionPageUrl,
       })
     }
 
     for (const issue of validIssues) {
-      await createJiraIssue(issue.summary, issue.notionUrl, issue.severity, issue.component)
+      await createJiraIssue(issue.summary, issue.notionUrl, issue.severity, issue.team)
     }
   }
 }


### PR DESCRIPTION
This PR resolves [PHIRE-1913] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Updates the notion export script to add team labels directly rather than relying on components. 
Based on feedback that it was confusing which components bugs belonged to and devs generally know which teams surfaces belong to.  

Also updated the QA templates for Folio and Eigen to use this field.

Test bugs here:
https://artsyproduct.atlassian.net/browse/PBRW-999
https://artsyproduct.atlassian.net/browse/PBRW-1000
https://artsyproduct.atlassian.net/browse/PBRW-1001

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- update notion script to use teams - brian

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-1913]: https://artsyproduct.atlassian.net/browse/PHIRE-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ