### PR TITLE
feat(Artist): Adjust header to respond only to shared values from scroll

### DIFF
--- a/src/app/Components/Artist/ArtistHeaderNavRight.tsx
+++ b/src/app/Components/Artist/ArtistHeaderNavRight.tsx
@@ -10,12 +10,7 @@ import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { MotiView } from "moti"
 import { useCallback, useState } from "react"
 import { PixelRatio, TouchableOpacity } from "react-native"
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useDerivedValue,
-  withTiming,
-} from "react-native-reanimated"
+import { Easing, useAnimatedStyle, useDerivedValue, withTiming } from "react-native-reanimated"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import useDebounce from "react-use/lib/useDebounce"
 
@@ -79,6 +74,9 @@ export const ArtistHeaderNavRight: React.FC<ArtistHeaderNavRightProps> = ({
     }),
     [followAreaDeltaX]
   )
+  const spacerStyle = useAnimatedStyle(() => ({
+    width: withTiming(spacerWidth.value, { duration: 200 }),
+  }))
   const followButtonStyle = useAnimatedStyle(() => ({
     opacity: withTiming(followButtonOpacity.value, { duration: 200 }),
   }))
@@ -114,7 +112,7 @@ export const ArtistHeaderNavRight: React.FC<ArtistHeaderNavRightProps> = ({
           <ShareIcon width={ACCESSIBLE_DEFAULT_ICON_SIZE} height={ACCESSIBLE_DEFAULT_ICON_SIZE} />
         </TouchableOpacity>
 
-        <Animated.View style={{ width: spacerWidth }} />
+        <MotiView style={spacerStyle} />
 
         <MotiView style={followButtonStyle}>
           <FollowButton


### PR DESCRIPTION
### Description

Related to https://github.com/artsy/palette-mobile/pull/365

Removes the usage of `currentScrollY` since it's being removed from palette-mobile in favor of using only `currentScrollYAnimated`.

We can see from the videos that FPS is way more stable when scrolling now.

PS: no changes on Android, if requested I can add the videos but I added the video with FPS counter only for iOS
<!--  Please include screenshots or videos for visual changes, at least on Android -->
| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/c48e7931-dc79-436a-ad83-553aef10d29e" width="400" /> | <video src="https://github.com/user-attachments/assets/199a2201-a9a7-4ebd-8ce3-7b066f3e3916" width="400" /> |


cc @artsy/diamond-devs 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: use only shared values when listening to scroll

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
