### PR TITLE
fix(DIA-1411): National Gallery of Art, Washington, D.C.

### DIFF
--- a/src/app/Components/Artist/ArtistAbout/ArtistCareerHighlights.tsx
+++ b/src/app/Components/Artist/ArtistAbout/ArtistCareerHighlights.tsx
@@ -29,15 +29,20 @@ export const ArtistCareerHighlights: React.FC<ArtistCareerHighlightsProps> = ({ 
         return (
           <Expandable label={label} key={`expandable-highlight-${index}`}>
             <Text color="mono60" my={1}>
-              {entities.length > 0
-                ? entities.join(", ").replace(/,\s([^,]+)$/, ", and $1")
-                : description}
+              {entities.length > 0 ? formatList(entities) : description}
             </Text>
           </Expandable>
         )
       })}
     </Flex>
   )
+}
+
+const formatList = (entities: readonly string[]) => {
+  if (entities.length === 0) return ""
+  if (entities.length === 1) return entities[0]
+  if (entities.length === 2) return entities.join(" and ")
+  return entities.slice(0, -1).join(", ") + ", and " + entities[entities.length - 1]
 }
 
 const fragment = graphql`

--- a/src/app/Components/Artist/ArtistAbout/__tests__/ArtistCareerHighlights.tests.tsx
+++ b/src/app/Components/Artist/ArtistAbout/__tests__/ArtistCareerHighlights.tests.tsx
@@ -30,16 +30,16 @@ describe("ArtistCareerHighlights", () => {
     expect(screen.queryByText("GH, IJ, and KL")).not.toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Highlight 1"))
-    expect(screen.queryByText("AB, CD, and EF")).toBeOnTheScreen()
+    expect(screen.getByText("AB, CD, and EF")).toBeOnTheScreen()
     expect(screen.queryByText("GH, IJ, and KL")).not.toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Highlight 2"))
-    expect(screen.queryByText("AB, CD, and EF")).toBeOnTheScreen()
-    expect(screen.queryByText("GH, IJ, and KL")).toBeOnTheScreen()
+    expect(screen.getByText("AB, CD, and EF")).toBeOnTheScreen()
+    expect(screen.getByText("GH, IJ, and KL")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Highlight 1"))
     expect(screen.queryByText("AB, CD, and EF")).not.toBeOnTheScreen()
-    expect(screen.queryByText("GH, IJ, and KL")).toBeOnTheScreen()
+    expect(screen.getByText("GH, IJ, and KL")).toBeOnTheScreen()
 
     fireEvent.press(screen.getByText("Highlight 2"))
     expect(screen.queryByText("AB, CD, and EF")).not.toBeOnTheScreen()
@@ -55,9 +55,82 @@ describe("ArtistCareerHighlights", () => {
 
     expect(screen.queryByText("element 1")).not.toBeOnTheScreen()
     expect(screen.queryByText("element 2")).not.toBeOnTheScreen()
-    expect(screen.queryByText("element 3")).toBeOnTheScreen()
-    expect(screen.queryByText("element 4")).toBeOnTheScreen()
-    expect(screen.queryByText("element 5")).toBeOnTheScreen()
+    expect(screen.getByText("element 3")).toBeOnTheScreen()
+    expect(screen.getByText("element 4")).toBeOnTheScreen()
+    expect(screen.getByText("element 5")).toBeOnTheScreen()
+  })
+
+  describe("formatList function", () => {
+    it("returns empty string for empty array", () => {
+      renderWithRelay({
+        Artist: () => ({
+          insights: [{ entities: [], label: "Test", description: "fallback" }],
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Test"))
+      expect(screen.getByText("fallback")).toBeOnTheScreen()
+    })
+
+    it("returns single item for array with one element", () => {
+      renderWithRelay({
+        Artist: () => ({
+          insights: [{ entities: ["Single Item"], label: "Test", description: "fallback" }],
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Test"))
+      expect(screen.getByText("Single Item")).toBeOnTheScreen()
+    })
+
+    it("formats two items with 'and'", () => {
+      renderWithRelay({
+        Artist: () => ({
+          insights: [{ entities: ["First", "Second"], label: "Test", description: "fallback" }],
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Test"))
+      expect(screen.getByText("First and Second")).toBeOnTheScreen()
+    })
+
+    it("formats multiple items with commas and 'and'", () => {
+      renderWithRelay({
+        Artist: () => ({
+          insights: [
+            { entities: ["First", "Second", "Third"], label: "Test", description: "fallback" },
+          ],
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Test"))
+      expect(screen.getByText("First, Second, and Third")).toBeOnTheScreen()
+    })
+
+    it("handles items with commas correctly", () => {
+      renderWithRelay({
+        Artist: () => ({
+          insights: [
+            {
+              entities: [
+                "Museum of Modern Art, New York",
+                "Whitney Museum, New York",
+                "Tate Modern, London",
+              ],
+              label: "Test",
+              description: "fallback",
+            },
+          ],
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Test"))
+      expect(
+        screen.getByText(
+          "Museum of Modern Art, New York, Whitney Museum, New York, and Tate Modern, London"
+        )
+      ).toBeOnTheScreen()
+    })
   })
 })
 


### PR DESCRIPTION
This PR fixes a bug that was reported in the artist career highlights where "National Gallery of Art, Washington, D.C." was being formatted as "National Gallery of Art, Washington, and D.C." when it was the last item in the list of collecting institutions.

This was happening because in order to render a list of institutions, the template was concatenating the institution names separated by a comma, and replacing the last comma with ", and". When the National Gallery of Art in Washington, D.C. was the last (or only) institution in that list, it would incorrectly identify "D.C." as the last institution.

The solution was to replace the last comma with ", and" outside of the concatenation.

(This is a duplicate of artsy/force#15848)

| BEFORE | AFTER |
|---------|--------|
| <img width="1080" height="2400" alt="Screenshot_1752688040" src="https://github.com/user-attachments/assets/3100b776-d3ff-499e-b5ee-6a0d19c05f54" /> | <img width="1080" height="2400" alt="Screenshot_1752688508" src="https://github.com/user-attachments/assets/52409fdf-b9ae-4255-b14c-1735c4380588" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixed a bug where artist career highlights were formatted incorrectly

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
