### PR TITLE
Revert "fix: track item impressions error"

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -119,7 +119,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
         showSaveIcon
         moreHref={moreHref}
         onMorePress={onMorePress}
-        {...(section?.trackItemImpressions
+        {...(section.trackItemImpressions
           ? {
               onViewableItemsChanged: onViewableItemsChanged,
               viewabilityConfig: viewabilityConfig,

--- a/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/HomeViewSectionScreenArtworks.tsx
@@ -99,7 +99,7 @@ export const HomeViewSectionScreenArtworks: React.FC<ArtworksScreenHomeSection> 
           onScroll={scrollHandler}
           style={{ paddingBottom: SCROLLVIEW_PADDING_BOTTOM_OFFSET }}
           contextScreenOwnerType={section.ownerType as ScreenOwnerType}
-          {...(section?.trackItemImpressions
+          {...(section.trackItemImpressions
             ? {
                 onViewableItemsChanged: onViewableItemsChanged,
                 viewabilityConfig: viewabilityConfig,


### PR DESCRIPTION
Reverts artsy/eigen#12484

Reverting because it was not solving the issue
The issue was related to Schema mismatch, more info in the thread: https://artsy.slack.com/archives/C02BC3HEJ/p1752745700591369