### PR TITLE
chore: remove Echo flagging for blue activity dot

### DIFF
--- a/src/app/Navigation/utils/__tests__/useBottomTabsBadges.tests.ts
+++ b/src/app/Navigation/utils/__tests__/useBottomTabsBadges.tests.ts
@@ -15,9 +15,6 @@ jest.mock("app/utils/hooks/useVisualClue", () => ({
 jest.mock("app/utils/useTabBarBadge", () => ({
   useTabBarBadge: jest.fn(),
 }))
-jest.mock("app/utils/hooks/useFeatureFlag", () => ({
-  useFeatureFlag: (flag: string) => flag === "AREnableBlueActivityDots",
-}))
 
 // Settings for the test
 describe("useBottomTabsBadges", () => {

--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -1,7 +1,6 @@
 import { useColor } from "@artsy/palette-mobile"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useVisualClue } from "app/utils/hooks/useVisualClue"
 import { useTabBarBadge } from "app/utils/useTabBarBadge"
 import { StyleProp, TextStyle } from "react-native"
@@ -16,7 +15,6 @@ type BadgeProps = { tabBarBadge?: string | number; tabBarBadgeStyle: StyleProp<T
  */
 export const useBottomTabsBadges = () => {
   const color = useColor()
-  const showBlueDots = useFeatureFlag("AREnableBlueActivityDots")
 
   const { showVisualClue } = useVisualClue()
   const { unreadConversationsCount, hasUnseenNotifications } = useTabBarBadge()
@@ -24,7 +22,7 @@ export const useBottomTabsBadges = () => {
   const tabsBadges: Record<string, BadgeProps> = {}
 
   const visualClueStyles = {
-    backgroundColor: showBlueDots ? color("blue100") : color("red50"),
+    backgroundColor: color("blue100"),
     top: 2,
     minWidth: VISUAL_CLUE_HEIGHT,
     maxHeight: VISUAL_CLUE_HEIGHT,
@@ -77,7 +75,7 @@ export const useBottomTabsBadges = () => {
           tabsBadges[tab] = {
             tabBarBadge: unreadConversationsCount,
             tabBarBadgeStyle: {
-              backgroundColor: showBlueDots ? color("blue100") : color("red50"),
+              backgroundColor: color("blue100"),
             },
           }
         }

--- a/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
+++ b/src/app/Scenes/HomeView/Components/ActivityIndicator.tsx
@@ -3,7 +3,6 @@ import { Box, VisualClueDot } from "@artsy/palette-mobile"
 import { ICON_HIT_SLOP } from "app/Components/constants"
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import React from "react"
 
 interface ActivityIndicatorProps {
@@ -13,7 +12,6 @@ interface ActivityIndicatorProps {
 export const ActivityIndicator: React.FC<ActivityIndicatorProps> = (props) => {
   const { hasUnseenNotifications } = props
   const tracking = useHomeViewTracking()
-  const showBlueDots = useFeatureFlag("AREnableBlueActivityDots")
 
   const navigateToActivityPanel = () => {
     tracking.tappedNotificationBell()
@@ -37,7 +35,7 @@ export const ActivityIndicator: React.FC<ActivityIndicatorProps> = (props) => {
               right={0}
               accessibilityLabel="Unseen Notifications Indicator"
             >
-              <VisualClueDot diameter={8} color={showBlueDots ? "blue100" : "red50"} />
+              <VisualClueDot diameter={8} />
             </Box>
           )}
         </>

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -188,12 +188,6 @@ export const features = {
     description: "Enable new order details screen",
     echoFlagKey: "AREnableNewOrderDetails",
   },
-  AREnableBlueActivityDots: {
-    readyForRelease: true,
-    showInDevMenu: true,
-    description: "Enable blue activity dots",
-    echoFlagKey: "AREnableBlueActivityDots",
-  },
   AREnableProgressiveOnboardingPriceRangeHome: {
     readyForRelease: false,
     showInDevMenu: true,


### PR DESCRIPTION
This PR resolves [ONYX-1845] <!-- eg [PROJECT-XXXX] -->

### Description

Removes the conditional logic added in https://github.com/artsy/eigen/pull/12428, and simply presents the blue version of the activity dots to everyone.

| iOS | Android |
|--------|--------|
| <img height="400" alt="Simulator Screenshot - iPhone 16 - 2025-07-18 at 16 36 23" src="https://github.com/user-attachments/assets/6f4e30c4-3bca-4417-8cda-f6ff7f300b8e" /> | <img height="400" alt="Screenshot_1752871022" src="https://github.com/user-attachments/assets/ef486c6b-d06f-4d33-a97c-85ce34e10630" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Remove Echo flagging for blue activity dot

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1845]: https://artsyproduct.atlassian.net/browse/ONYX-1845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ