### PR TITLE
fix(ONYX-1817): cannot interact with items on the filter screens while the  keyboard is open

### DIFF
--- a/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
+++ b/src/app/Components/ArtworkFilter/Filters/MultiSelectOption.tsx
@@ -122,7 +122,11 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
 
       <Flex flexGrow={1}>
         {useScrollView ? (
-          <ScrollView style={{ flex: 1 }}>
+          <ScrollView
+            style={{ flex: 1 }}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
+          >
             {filteredOptions.map((option, index) => renderItem({ item: option, index }))}
             {footerComponent}
           </ScrollView>
@@ -131,6 +135,8 @@ export const MultiSelectOptionScreen: React.FC<MultiSelectOptionScreenProps> = (
             style={{ flex: 1 }}
             data={filteredOptions}
             ListFooterComponent={footerComponent}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="on-drag"
             renderItem={renderItem}
             windowSize={11}
             getItemLayout={(_, index) => ({


### PR DESCRIPTION
This PR resolves [ONYX-1817] <!-- eg [PROJECT-XXXX] -->

### Description

Fix cannot interact with items on the filter screens while the keyboard is open
Used `keyboardShouldPersistTaps="handled"` and `keyboardDismissMode="on-drag"` to make sure we can interact with child components while the keyboard is open. In this case, the keyboard will be closed `on-drag` interaction

| iOS before | iOS after | Android before | Android after |  
| --- | --- | --- | --- | 
| <video src="https://github.com/user-attachments/assets/bcaba6c4-bd9a-4726-8115-9dce12e7b77b" width="200" /> | <video src="https://github.com/user-attachments/assets/fb8e4b5a-8753-43cb-84db-b281b0bbc049" width="200" /> | <video src="https://github.com/user-attachments/assets/a6618222-4787-4b87-8083-a7a208bc061d" width="200" /> | i cannot make the keyboard open the way i want it 😮‍💨  | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: cannot interact with items on the filter screens while the  keyboard is open

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
