### PR TITLE
chore: [HomeView Performance] do not re-render shows

### DIFF
--- a/src/app/Components/ShowCard.tsx
+++ b/src/app/Components/ShowCard.tsx
@@ -2,6 +2,7 @@ import { toTitleCase } from "@artsy/to-title-case"
 import { ShowCard_show$data } from "__generated__/ShowCard_show.graphql"
 import { CardWithMetaData } from "app/Components/Cards/CardWithMetaData"
 import { compact } from "lodash"
+import { memo } from "react"
 import { GestureResponderEvent, ViewProps } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
 
@@ -11,7 +12,7 @@ interface ShowCardProps extends ViewProps {
   onPress?(event: GestureResponderEvent): void
 }
 
-export const ShowCard: React.FC<ShowCardProps> = ({ show, isFluid, onPress }) => {
+export const ShowCard: React.FC<ShowCardProps> = memo(({ show, isFluid, onPress }) => {
   const imageURL = show.metaImage?.url
 
   const showCity = getShowCity({
@@ -36,7 +37,7 @@ export const ShowCard: React.FC<ShowCardProps> = ({ show, isFluid, onPress }) =>
       onPress={onPress}
     />
   )
-}
+})
 
 export const getShowCity = ({
   showName,

--- a/src/app/Scenes/HomeView/Components/ShowsRail.tsx
+++ b/src/app/Scenes/HomeView/Components/ShowsRail.tsx
@@ -17,7 +17,7 @@ import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { Location, useLocation } from "app/utils/hooks/useLocation"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { times } from "lodash"
-import { Suspense, memo } from "react"
+import { Suspense, memo, useCallback } from "react"
 import { FlatList } from "react-native"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -49,6 +49,24 @@ export const ShowsRail: React.FC<ShowsRailProps> = memo(
 
     const hasShows = shows?.length
 
+    const renderItem = useCallback(
+      ({ item, index }) => (
+        <ShowCardContainer
+          show={item}
+          onPress={() => {
+            if (onTrack) {
+              return onTrack(item, index)
+            }
+
+            tracking.trackEvent(
+              tracks.tappedThumbnail(item.internalID, item.slug || "", index, contextModule)
+            )
+          }}
+        />
+      ),
+      [contextModule, onTrack, tracking]
+    )
+
     if (!hasShows) {
       return null
     }
@@ -72,22 +90,10 @@ export const ShowsRail: React.FC<ShowsRailProps> = memo(
           ListHeaderComponent={() => <Spacer x={2} />}
           ListFooterComponent={() => <Spacer x={2} />}
           ItemSeparatorComponent={() => <Spacer x={2} />}
+          disableVirtualization
           data={shows.slice(0, NUMBER_OF_SHOWS)}
           keyExtractor={(item) => `${item.internalID}`}
-          renderItem={({ item, index }) => (
-            <ShowCardContainer
-              show={item}
-              onPress={() => {
-                if (onTrack) {
-                  return onTrack(item, index)
-                }
-
-                tracking.trackEvent(
-                  tracks.tappedThumbnail(item.internalID, item.slug || "", index, contextModule)
-                )
-              }}
-            />
-          )}
+          renderItem={renderItem}
         />
       </Flex>
     )

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionShows.tsx
@@ -15,36 +15,34 @@ interface HomeViewSectionShowsProps extends FlexProps {
   index: number
 }
 
-export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = ({
-  section: sectionProp,
-  index,
-  ...flexProps
-}) => {
-  const section = useFragment(fragment, sectionProp)
-  const component = section.component
-  const tracking = useHomeViewTracking()
+export const HomeViewSectionShows: React.FC<HomeViewSectionShowsProps> = memo(
+  ({ section: sectionProp, index, ...flexProps }) => {
+    const section = useFragment(fragment, sectionProp)
+    const component = section.component
+    const tracking = useHomeViewTracking()
 
-  return (
-    <Flex>
-      <ShowsRailContainer
-        title={component?.title || "Shows"}
-        onTrack={(show, index) => {
-          tracking.tappedShowGroup(
-            show.internalID,
-            show.slug,
-            section.contextModule as ContextModule,
-            index
-          )
-        }}
-        {...flexProps}
-      />
-      <HomeViewSectionSentinel
-        contextModule={section.contextModule as ContextModule}
-        index={index}
-      />
-    </Flex>
-  )
-}
+    return (
+      <Flex>
+        <ShowsRailContainer
+          title={component?.title || "Shows"}
+          onTrack={(show, index) => {
+            tracking.tappedShowGroup(
+              show.internalID,
+              show.slug,
+              section.contextModule as ContextModule,
+              index
+            )
+          }}
+          {...flexProps}
+        />
+        <HomeViewSectionSentinel
+          contextModule={section.contextModule as ContextModule}
+          index={index}
+        />
+      </Flex>
+    )
+  }
+)
 
 const fragment = graphql`
   fragment HomeViewSectionShows_section on HomeViewSectionShows {
@@ -77,28 +75,26 @@ const homeViewSectionShowsQuery = graphql`
   }
 `
 
-export const HomeViewSectionShowsQueryRenderer: React.FC<SectionSharedProps> = memo(
-  withSuspense({
-    Component: ({ sectionID, index, ...flexProps }) => {
-      const data = useLazyLoadQuery<HomeViewSectionShowsQuery>(
-        homeViewSectionShowsQuery,
-        {
-          id: sectionID,
+export const HomeViewSectionShowsQueryRenderer: React.FC<SectionSharedProps> = withSuspense({
+  Component: ({ sectionID, index, ...flexProps }) => {
+    const data = useLazyLoadQuery<HomeViewSectionShowsQuery>(
+      homeViewSectionShowsQuery,
+      {
+        id: sectionID,
+      },
+      {
+        networkCacheConfig: {
+          force: false,
         },
-        {
-          networkCacheConfig: {
-            force: false,
-          },
-        }
-      )
-
-      if (!data.homeView.section) {
-        return null
       }
+    )
 
-      return <HomeViewSectionShows section={data.homeView.section} index={index} {...flexProps} />
-    },
-    LoadingFallback: HomeViewSectionShowsPlaceholder,
-    ErrorFallback: NoFallback,
-  })
-)
+    if (!data.homeView.section) {
+      return null
+    }
+
+    return <HomeViewSectionShows section={data.homeView.section} index={index} {...flexProps} />
+  },
+  LoadingFallback: HomeViewSectionShowsPlaceholder,
+  ErrorFallback: NoFallback,
+})


### PR DESCRIPTION
### Description

This PR improves the shows rail performance in the home view 

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/77d90f61-1002-4be7-a0f2-e020b07b9cc1" /> | <video src="https://github.com/user-attachments/assets/7942938f-3021-4e99-b1af-ae3142300263" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- [HomeView Performance] do not re-render shows - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
