### PR TITLE
fix(ONYX-1850): fix Saving Artwork screen layout

### DIFF
--- a/src/app/Components/FullScreenLoadingImage.tsx
+++ b/src/app/Components/FullScreenLoadingImage.tsx
@@ -16,7 +16,7 @@ export const FullScreenLoadingImage: React.FC<FullScreenLoadingImageProps> = ({
   return (
     <ImageBackground
       resizeMode="cover"
-      style={{ ...StyleSheet.absoluteFillObject, height: "100%", width: "100%" }}
+      style={{ ...StyleSheet.absoluteFillObject }}
       source={imgSource}
     >
       <Flex flex={1} alignItems="center" justifyContent="center">

--- a/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
+++ b/src/app/Scenes/MyCollection/Screens/ArtworkForm/MyCollectionArtworkForm.tsx
@@ -26,7 +26,8 @@ import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { refreshMyCollection, refreshMyCollectionInsights } from "app/utils/refreshHelpers"
 import { FormikProvider, useFormik } from "formik"
 import { useEffect, useRef, useState } from "react"
-import { Alert, Dimensions } from "react-native"
+import { Alert } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { useTracking } from "react-tracking"
 import { SavingArtworkModal } from "./Components/SavingArtworkModal"
 import { artworkSchema, validateArtworkSchema } from "./Form/artworkSchema"
@@ -151,7 +152,7 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
     validationSchema: artworkSchema,
   })
 
-  const { width, height } = Dimensions.get("screen")
+  const safeAreaInsets = useSafeAreaInsets()
 
   return (
     <NavigationIndependentTree>
@@ -160,7 +161,11 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           <Stack.Navigator
             screenOptions={{
               headerShown: false,
-              cardStyle: { backgroundColor: color("background") },
+              cardStyle: {
+                backgroundColor: color("background"),
+                paddingTop: safeAreaInsets.top,
+                paddingBottom: safeAreaInsets.bottom,
+              },
             }}
           >
             {mode === "add" && (
@@ -180,19 +185,9 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           </Stack.Navigator>
 
           {mode === "add" && loading ? (
-            <FadeIn style={{ position: "absolute" }} slide>
-              <Flex
-                height={height}
-                width={width}
-                left={0}
-                bottom={0}
-                top={0}
-                right={0}
-                position="absolute"
-                testID="saving-artwork-modal"
-              >
+            <FadeIn slide>
+              <Flex height="100%" width="100%" testID="saving-artwork-modal">
                 <SavingArtworkModal
-                  testID="saving-artwork-modal"
                   isVisible={loading}
                   loadingText={isArtworkSaved ? savingArtworkModalDisplayText : "Saving artwork"}
                 />
@@ -201,16 +196,8 @@ export const MyCollectionArtworkForm: React.FC<MyCollectionArtworkFormProps> = (
           ) : null}
 
           {mode === "edit" && loading ? (
-            <FadeIn style={{ position: "absolute" }} slide>
-              <Flex
-                height={height}
-                width={width}
-                left={0}
-                bottom={0}
-                top={0}
-                right={0}
-                testID="saving-artwork-modal"
-              >
+            <FadeIn slide style={{ position: "absolute", height: "100%", width: "100%" }}>
+              <Flex flex={1} testID="saving-artwork-modal">
                 <LoadingSpinner />
               </Flex>
             </FadeIn>
@@ -229,7 +216,7 @@ export const MyCollectionArtworkAdd: React.FC<{
 
 export const MyCollectionArtworkFormScreen: React.FC<MyCollectionArtworkFormProps> = (props) => {
   return (
-    <Screen>
+    <Screen safeArea={false}>
       <MyCollectionArtworkStore.Provider runtimeModel={props}>
         <MyCollectionArtworkForm {...props} />
       </MyCollectionArtworkStore.Provider>


### PR DESCRIPTION
This PR resolves [ONYX-1850] <!-- eg [PROJECT-XXXX] -->

### Description
The "saving Artwork" screen has a white space on the top which should not be there
Was fixed by disabling the `safeArea` of the `Screen` component and adding it to the screens of the stack where the safeArea is needed

| Before iOS | Before Android | After iOS (add flow) | After iOS (edit flow) | After Android (add flow) | After android (edit flow) |
| --- | --- | --- | --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/298fef88-42a9-42b6-ac6d-60a87f0c7537" width="400" /> | <img src="https://github.com/user-attachments/assets/93194d8e-419f-4035-8849-b01bea1a85b5" width="400" /> | <img src="https://github.com/user-attachments/assets/8502dbbe-5537-429f-b314-71aaeb2c4d80" width="400" /> | <img src="https://github.com/user-attachments/assets/4895ab7e-f61e-4d9c-b512-7a72839d983d" width="400" /> | <img src="https://github.com/user-attachments/assets/53b7959c-d47e-411e-8676-99bc3ae1cb06" width="400" /> | <img src="https://github.com/user-attachments/assets/d5164283-2098-42d5-a861-18de5720beea" width="400" /> | 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix extra white space on top of the "Saving Artwork" screen (add artwork ti my collection flow)

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
