### PR TITLE
chore: [HomeView Performance] do not re-render artwork grid items each second

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkAuctionTimer.tsx
@@ -12,8 +12,6 @@ interface ArtworkAuctionTimerProps {
   inRailCard?: boolean
 }
 
-const INTERVAL = 1000
-
 export const ArtworkAuctionTimer: React.FC<ArtworkAuctionTimerProps> = ({
   collectorSignals,
   hideRegisterBySignal,
@@ -24,38 +22,74 @@ export const ArtworkAuctionTimer: React.FC<ArtworkAuctionTimerProps> = ({
   const { lotClosesAt, onlineBiddingExtended, registrationEndsAt } = data.auction ?? {}
 
   const lotEndAt = DateTime.fromISO(lotClosesAt ?? "")
-  const intervalId = useRef<ReturnType<typeof setInterval> | null>(null)
-  const [time, setTime] = useState(getTimer(lotClosesAt ?? "")["time"])
-
-  useEffect(() => {
-    intervalId.current = setInterval(() => {
-      const { time: timerTime } = getTimer(lotClosesAt ?? "")
-
-      setTime(timerTime)
-    }, INTERVAL)
-
-    return () => {
-      if (intervalId.current) clearInterval(intervalId.current)
-    }
-  }, [])
 
   if (
     registrationEndsAt &&
     DateTime.fromISO(registrationEndsAt).diffNow().as("seconds") > 0 &&
     !hideRegisterBySignal
   ) {
-    const formattedRegistrationEndsAt = DateTime.fromISO(registrationEndsAt).toFormat("MMM d")
-
     return (
-      <Text lineHeight={lineHeight} variant="xs" numberOfLines={1} color="mono100">
-        Register by {formattedRegistrationEndsAt}
-      </Text>
+      <AuctionTimerRegisterBy lineHeight={lineHeight} registrationEndsAt={registrationEndsAt} />
     )
   }
 
   if (!lotClosesAt || lotEndAt.diffNow().as("days") > 5 || lotEndAt.diffNow().as("seconds") <= 0) {
     return null
   }
+
+  return (
+    <AuctionTimerBid
+      lineHeight={lineHeight}
+      onlineBiddingExtended={onlineBiddingExtended}
+      lotEndAt={lotEndAt}
+      lotClosesAt={lotClosesAt}
+      inRailCard={inRailCard}
+    />
+  )
+}
+
+const AuctionTimerRegisterBy: React.FC<{
+  lineHeight: "20px" | "18px"
+  registrationEndsAt: string
+}> = ({ lineHeight, registrationEndsAt }) => {
+  const formattedRegistrationEndsAt = DateTime.fromISO(registrationEndsAt).toFormat("MMM d")
+
+  return (
+    <Text lineHeight={lineHeight} variant="xs" numberOfLines={1} color="mono100">
+      Register by {formattedRegistrationEndsAt}
+    </Text>
+  )
+}
+
+const AuctionTimerBid: React.FC<{
+  lineHeight: "20px" | "18px"
+  onlineBiddingExtended?: boolean
+  inRailCard?: boolean
+  lotEndAt: DateTime
+  lotClosesAt: string
+}> = ({ lineHeight, onlineBiddingExtended, inRailCard, lotEndAt, lotClosesAt }) => {
+  const intervalId = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [time, setTime] = useState(getTimer(lotClosesAt ?? "")["time"])
+
+  useEffect(() => {
+    // Do not update the timer if the lot is closing in longer than an hour
+    if (lotEndAt.diffNow().as("hours") > 1 && !onlineBiddingExtended) {
+      return
+    }
+
+    // Update the timer every second if the lot is closing in less than 5 minute, otherwise update every minute
+    const UPDATE_INTERVAL = lotEndAt.diffNow().as("minutes") < 5 ? 1000 : 60000
+
+    intervalId.current = setInterval(() => {
+      const { time: timerTime } = getTimer(lotClosesAt ?? "")
+
+      setTime(timerTime)
+    }, UPDATE_INTERVAL)
+
+    return () => {
+      if (intervalId.current) clearInterval(intervalId.current)
+    }
+  }, [lotClosesAt])
 
   const timerColor = lotEndAt.diffNow().as("hours") <= 1 ? "red100" : "blue100"
   const { timerCopy } = formattedTimeLeft(time)

--- a/src/app/Scenes/Activity/components/ExpiresInTimer.tsx
+++ b/src/app/Scenes/Activity/components/ExpiresInTimer.tsx
@@ -2,9 +2,8 @@ import { Stopwatch, Flex, Text } from "@artsy/palette-mobile"
 import { ActivityItem_notification$data } from "__generated__/ActivityItem_notification.graphql"
 import { formattedTimeLeft } from "app/Scenes/Activity/utils/formattedTimeLeft"
 import { Time, getTimer } from "app/utils/getTimer"
+import { DateTime } from "luxon"
 import { FC, useEffect, useRef, useState } from "react"
-
-const INTERVAL = 1000
 
 interface ExpiresInTimerProps {
   // TOFIX: this should have it's own relay fragment, no prop drilling with relay data!
@@ -27,6 +26,22 @@ export const ExpiresInTimer: FC<ExpiresInTimerProps> = ({ item }) => {
   const [hasEnded, setHasEnded] = useState(getTimer(expiresAt)["hasEnded"])
 
   useEffect(() => {
+    // Do not update the timer if the offer is expiring in longer than an hour
+    if (
+      DateTime.fromISO(expiresAt ?? "")
+        .diffNow()
+        .as("hours") > 1
+    ) {
+      return
+    }
+
+    const INTERVAL =
+      DateTime.fromISO(expiresAt ?? "")
+        .diffNow()
+        .as("minutes") < 5
+        ? 1000
+        : 60000
+
     intervalId.current = setInterval(() => {
       const { hasEnded: timerHasEnded, time: timerTime } = getTimer(expiresAt)
 


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

While profiling scroll behaviour on the `HomeView`, I noticed that we had an instance of `ArtworkAuctionTimer` being called each second. After debugging what's going on there, I found out that we are updating the components state at each second. Meaning that if we would have 20 lots shown in the home view, each of those would be updating each second, leading to potential scroll degradation. This is mostly noticeable when a lots rail shows up and a ton of js calls are being made.

**Suggested solution:**
- If a lot is finishing in 1 week, we **don't update** the timer value each second, actually we don't need to update it at all.
- If a lot is closing in 50 minutes, then we can update the timer value, but **each minute** instead of each second (anyway our UI shows minutes left in this case and does not show seconds left)
- If a lot is finishing in under one minute, **keep the same logic** and update each second

This PR fixes an issue with lots re-rendering each second because of a `setInterval`


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- [HomeView Performance] do not re-render artwork grid items each second - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
