### PR TITLE
fix: cascading end times banner text color

### DIFF
--- a/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
+++ b/src/app/Scenes/Artwork/Components/CascadingEndTimesBanner.tsx
@@ -1,5 +1,6 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { Text as RNText } from "react-native"
 
 interface CascadingEndTimesBannerProps {
   cascadingEndTimeInterval: number
@@ -17,15 +18,15 @@ export const CascadingEndTimesBanner: React.FC<CascadingEndTimesBannerProps> = (
 
   return (
     <Flex backgroundColor="blue100" p={2}>
-      <Text color="mono0" style={{ textAlign: "center" }}>
+      <Text color="mono0" style={{ textAlign: "left" }}>
         {canBeExtended
           ? "Closing times may be extended due to last-minute competitive bidding. "
           : `Lots will close at ${cascadingEndTimeInterval}-minute intervals. `}
 
         <RouterLink to={CASCADING_AUCTION_HELP_ARTICLE_LINK} hasChildTouchable>
-          <Text style={{ textDecorationLine: "underline" }}>
+          <RNText style={{ textDecorationLine: "underline" }}>
             Learn more about cascading end times
-          </Text>
+          </RNText>
         </RouterLink>
       </Text>
     </Flex>


### PR DESCRIPTION
**Context:** https://artsy.slack.com/archives/C02BAQ5K7/p1753259925400769?thread_ts=1752833057.249479&cid=C02BAQ5K7

### Description

This PR fixes the color issues on cascading end times banner inside the auction screen

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-23 at 10 37 53" src="https://github.com/user-attachments/assets/7f4053c2-fbe1-469a-a4a0-17f2f6f9fbf9" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-23 at 12 28 32" src="https://github.com/user-attachments/assets/83e1f3c2-5a9c-4edd-80f9-5b126a162b00" /> | 



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: cascading end times banner color - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
