### PR TITLE
chore: [HomeView Performance] use optimised artwork images for rails

### DIFF
--- a/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardImage.tsx
@@ -71,7 +71,6 @@ export const ArtworkRailCardImage: React.FC<ArtworkRailCardImageProps> = ({ ...r
           height={displayImageHeight}
           aspectRatio={image.aspectRatio}
           blurhash={showBlurhash ? image.blurhash : undefined}
-          performResize={false}
           resizeMode="cover"
           testID="artwork-rail-card-image"
         />


### PR DESCRIPTION
### Description

Currently, our rails use the `larger` artwork image as preview. This is of course the best quality we provide, but it meas that sometimes, if we have multiple artwork images that are 10 or 20 mb, we would have an artwork rail that is pretty heavy for RAM. Now imagine if we have 8 or 9 of this rail, the ram would pretty fast explode: This is what is exactly happening on our home view.

In this PR, I am still keeping the high quality image, but performing resize to make sure that we are getting a more optimised image from gemini.

Fwiw, this is what we had for a long time but it's something we missed after [this](https://github.com/artsy/eigen/pull/10857) migration

**Example: (I chose a random image and I can already notice the difference)** 
**Before:**
https://d32dm0rphc51dk.cloudfront.net/JFWknRnQujX5OcuCYLqoOA/larger.jpg
**129kb**


**After:**
https://d7hftxdivxxvm.cloudfront.net/?height=645&quality=80&resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FJFWknRnQujX5OcuCYLqoOA%2Flarger.jpg&width=742&convert_to=webp
**30kb**

**Also, it's worth mentioning, without `performResize`, we use JPEGs instead of Webp, which is what we stopped doing since a long time**


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- [HomeView Performance] use optimised artwork images for rails - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
