### PR TITLE
feat(DIA-1416): add tracking to negative signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "braces": "in the resolutions - needed to resolve a security dependency issue - need to remove this when the issue is resolved and packages are updated"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.288.0",
+    "@artsy/cohesion": "4.289.0",
     "@artsy/icons": "3.47.0",
     "@artsy/palette-mobile": "17.29.0",
     "@artsy/to-title-case": "1.1.0",

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -57,7 +57,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
       return
     }
 
-    track.tappedShare(topArtwork.internalID, topArtwork.slug)
+    track.tappedShare(topArtwork.internalID, topArtwork.slug, "artwork")
 
     const url = getShareURL(
       `/artwork/${topArtwork.slug}?utm_content=discover-daily-share&utm_medium=product-share`
@@ -80,7 +80,8 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleOnRightButtonPressed = () => {
-    if (negativeSignalsEnabled) {
+    if (negativeSignalsEnabled && topArtwork) {
+      track.tappedMore(topArtwork?.internalID, topArtwork?.slug)
       setMoreInfoSheetVisible(true)
     } else {
       handleSharePressed()

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals.tsx
@@ -42,13 +42,15 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
     return null
   }
 
+  const artist = data.artists?.[0]
+
   const handleSharePressed = (
     id: string,
     slug: string,
     path: "artwork" | "artist",
     title: string
   ) => {
-    track.tappedShare(id, slug)
+    track.tappedShare(id, slug, path)
 
     const url = getShareURL(
       `/${path}/${slug}?utm_content=discover-daily-share&utm_medium=product-share`
@@ -75,9 +77,11 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
   }
 
   const handleSeeFewerArtistArtworks = () => {
-    if (isInFlight || !data.artistNames) {
+    if (isInFlight || !data.artistNames || !artist?.internalID) {
       return
     }
+
+    track.tappedSeeFewerWorks(data.internalID, data.slug, artist.internalID, NEGATIVE_SIGNAL_TEXT)
 
     Alert.alert(`Are you sure? You will no longer see works by ${data.artistNames}.`, undefined, [
       { text: "No" },
@@ -100,13 +104,12 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
             }
           })
 
+          track.tappedConfirmSeeFewerWorks(data.internalID, data.slug, artist.internalID)
           collapse()
         },
       },
     ])
   }
-
-  const artist = data.artists?.[0]
 
   return (
     <Flex p={2} flex={1} gap={2}>
@@ -178,7 +181,7 @@ export const InfiniteDiscoveryNegativeSignals: FC<InfiniteDiscoveryNegativeSigna
       >
         <Flex flexDirection="row" alignItems="center" gap={1}>
           <NoArtIcon width={ACCESSIBLE_DEFAULT_ICON_SIZE} height={ACCESSIBLE_DEFAULT_ICON_SIZE} />
-          <Text>See fewer artworks by this artist</Text>
+          <Text>{NEGATIVE_SIGNAL_TEXT}</Text>
         </Flex>
       </Touchable>
     </Flex>
@@ -251,3 +254,5 @@ export const InfiniteDiscoveryNegativeSignalsPlaceholder: FC = () => {
     </Flex>
   )
 }
+
+const NEGATIVE_SIGNAL_TEXT = "See fewer artworks by this artist"

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -26,6 +26,7 @@ const mockTrack = {
   tappedExit: jest.fn(),
   tappedSummary: jest.fn(),
   tappedShare: jest.fn(),
+  tappedMore: jest.fn(),
   share: jest.fn(),
 }
 
@@ -101,6 +102,7 @@ describe("InfiniteDiscoveryHeader", () => {
       const rightButton = screen.getByTestId("top-right-icon")
       fireEvent.press(rightButton)
 
+      expect(mockTrack.tappedMore).toHaveBeenCalledWith("artwork-id", "test-artwork")
       expect(setMoreInfoSheetVisibleSpy).toHaveBeenCalledWith(true)
     })
 
@@ -121,7 +123,7 @@ describe("InfiniteDiscoveryHeader", () => {
       const rightButton = screen.getByTestId("top-right-icon")
       fireEvent.press(rightButton)
 
-      expect(mockTrack.tappedShare).toHaveBeenCalledWith("artwork-id", "test-artwork")
+      expect(mockTrack.tappedShare).toHaveBeenCalledWith("artwork-id", "test-artwork", "artwork")
       expect(RNShare.open).toHaveBeenCalledWith({
         title: "Test Artwork",
         message:

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryNegativeSignals.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryNegativeSignals.tests.tsx
@@ -18,6 +18,16 @@ jest.mock("app/Scenes/InfiniteDiscovery/hooks/useExcludeArtistFromDiscovery", ()
 // Mock Alert.alert
 jest.spyOn(Alert, "alert").mockImplementation(jest.fn())
 
+const mockTrack = {
+  tappedShare: jest.fn(),
+  tappedSeeFewerWorks: jest.fn(),
+  tappedConfirmSeeFewerWorks: jest.fn(),
+}
+
+jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
+  useInfiniteDiscoveryTracking: () => mockTrack,
+}))
+
 describe("InfiniteDiscoveryNegativeSignals", () => {
   const { renderWithRelay } = setupTestWrapper({
     Component: InfiniteDiscoveryNegativeSignals,
@@ -82,6 +92,7 @@ describe("InfiniteDiscoveryNegativeSignals", () => {
     })
     fireEvent.press(screen.getByLabelText("Share artwork"))
 
+    expect(mockTrack.tappedShare).toHaveBeenCalledWith("artwork-id", "test-artwork", "artwork")
     expect(RNShare.open).toHaveBeenLastCalledWith({
       title: "Test Artwork",
       message:
@@ -91,6 +102,7 @@ describe("InfiniteDiscoveryNegativeSignals", () => {
 
     fireEvent.press(screen.getByLabelText("Share artist"))
 
+    expect(mockTrack.tappedShare).toHaveBeenCalledWith("artist-id", "artist-slug", "artist")
     expect(RNShare.open).toHaveBeenLastCalledWith({
       title: "Test Artist",
       message:
@@ -117,6 +129,12 @@ describe("InfiniteDiscoveryNegativeSignals", () => {
     const excludeButton = screen.getByText("See fewer artworks by this artist")
     fireEvent.press(excludeButton)
 
+    expect(mockTrack.tappedSeeFewerWorks).toHaveBeenCalledWith(
+      "artwork-id",
+      "test-artwork",
+      "artist-id",
+      "See fewer artworks by this artist"
+    )
     expect(Alert.alert).toHaveBeenCalledWith(
       "Are you sure? You will no longer see works by Test Artist.",
       undefined,
@@ -150,6 +168,11 @@ describe("InfiniteDiscoveryNegativeSignals", () => {
     const yesButton = alertCall[2]?.find((button: any) => button.text === "Yes")
     yesButton?.onPress()
 
+    expect(mockTrack.tappedConfirmSeeFewerWorks).toHaveBeenCalledWith(
+      "artwork-id",
+      "test-artwork",
+      "artist-id"
+    )
     expect(mockCommitMutation).toHaveBeenCalledWith({
       variables: { input: { artistId: "artist-id" } },
       onError: expect.any(Function),

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking.ts
@@ -1,4 +1,12 @@
-import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  Tapped3Dots,
+  TappedConfirmSeeFewerWorks,
+  TappedSeeFewerWorks,
+  TappedShare,
+} from "@artsy/cohesion"
 import { Schema } from "app/utils/track"
 import { useTracking } from "react-tracking"
 
@@ -49,25 +57,26 @@ export const useInfiniteDiscoveryTracking = () => {
         mode: "swipe",
       })
     },
-    tappedMore: () => {
-      // TODO: ActionType
-      // trackEvent({
-      //   action: ActionType.tappedMore,
-      //   context_module: ContextModule.infiniteDiscovery,
-      //   context_screen_owner_id: artworkId,
-      //   context_screen_owner_slug: artworkSlug,
-      //   context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
-      // })
+    tappedMore: (artworkId: string, artworkSlug: string) => {
+      trackEvent({
+        action: ActionType.tapped3Dots,
+        context_module: ContextModule.infiniteDiscovery,
+        context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
+        context_screen_owner_id: artworkId,
+        context_screen_owner_slug: artworkSlug,
+      } as Tapped3Dots)
     },
-    tappedShare: (id: string, slug: string) => {
-      // TODO: check if something else is necessary to differentiate Artist/Artwork share
+    tappedShare: (id: string, slug: string, type: "artwork" | "artist") => {
       trackEvent({
         action: ActionType.tappedShare,
         context_module: ContextModule.infiniteDiscovery,
         context_screen_owner_id: id,
         context_screen_owner_slug: slug,
-        context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
-      })
+        context_screen_owner_type:
+          type === "artwork"
+            ? OwnerType.infiniteDiscoveryArtwork
+            : OwnerType.infiniteDiscoveryArtist,
+      } as TappedShare)
     },
     tappedSummary: () => {
       trackEvent({
@@ -76,6 +85,32 @@ export const useInfiniteDiscoveryTracking = () => {
         context_screen_owner_type: OwnerType.home,
         subject: "Tap here to navigate to your Saves area in your profile.",
       })
+    },
+    tappedSeeFewerWorks: (
+      artworkId: string,
+      artworkSlug: string,
+      artistId: string,
+      subject: string
+    ) => {
+      trackEvent({
+        artist_id: artistId,
+        action: ActionType.tappedSeeFewerWorks,
+        context_module: ContextModule.infiniteDiscovery,
+        context_screen_owner_id: artworkId,
+        context_screen_owner_slug: artworkSlug,
+        context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
+        subject,
+      } as TappedSeeFewerWorks)
+    },
+    tappedConfirmSeeFewerWorks: (artworkId: string, artworkSlug: string, artistId: string) => {
+      trackEvent({
+        action: ActionType.tappedConfirmSeeFewerWorks,
+        context_module: ContextModule.infiniteDiscovery,
+        context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
+        context_screen_owner_id: artworkId,
+        context_screen_owner_slug: artworkSlug,
+        artist_id: artistId,
+      } as TappedConfirmSeeFewerWorks)
     },
     artworkImageSwipe: () => {
       trackEvent({

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@artsy/cohesion@4.288.0":
-  version "4.288.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.288.0.tgz#c7e5958aeeedbc792011712c86d4911582e6a9a4"
-  integrity sha512-bpygj2aZQJXls+LB3qxetwf/JK7MEe8kF0cgKuMzBu308HK00nEclOdqw8e4yfgJy+vo1mV+muiw/1IofJ+EXw==
+"@artsy/cohesion@4.289.0":
+  version "4.289.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.289.0.tgz#bdcb2f991534ff69334e1ab12ae4de9c1fc4f1da"
+  integrity sha512-TwIxeDKSctfbnaCi7vP+sUZhWOEhkq3iBFVK6B5UqcbgzVkIkPUeAPxGY7HFASMinaVderyhdDVk00DRDJp0Dg==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
This PR resolves [DIA-1416] <!-- eg [PROJECT-XXXX] -->

### Description

Adds tracking to the negative signals:
- tracks when tapping more information(Ellipsis)
- tracks when tapping to see fewer works
- tracks when confirming to see fewer works
- tracks the share of artist and artwork

cc @artsy/diamond-devs 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: add tracking to negative signals

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1416]: https://artsyproduct.atlassian.net/browse/DIA-1416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ