### PR TITLE
fix: broken bottom padding after navigating back

### DIFF
--- a/src/app/Navigation/AuthenticatedRoutes/ScreenWrapper.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/ScreenWrapper.tsx
@@ -26,7 +26,7 @@ export const ScreenWrapper: React.FC<ScreenWrapperProps> = memo(
     const navigation = useNavigation()
 
     useEffect(() => {
-      const unsubscribe = navigation.addListener("blur", () => {
+      const unsubscribe = navigation.addListener("focus", () => {
         const nextRoute = internal_navigationRef.current?.getCurrentRoute()?.name
 
         const nextRoutehidesBottomTabs = !!(


### PR DESCRIPTION
This PR resolves [[PBRW-1029](https://artsyproduct.atlassian.net/browse/PBRW-1029)]

### Description

This PR fixes the broken padding on screens after the user navigates back from a screen to another.

Why was this broken?
It looks like for quite a while, the `blur` event has been unreliable in react-navigation native stacks and the community recommends instead relying on the focus event. In our case, that's totally fine.
| Android | iOS |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f5c1c449-4d6d-4379-b02c-2a7852ea1ff1" /> | <video src="https://github.com/user-attachments/assets/caa51eb5-5219-42d5-83b6-d0c38854437f" /> | 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- broken bottom padding after navigating back - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1029]: https://artsyproduct.atlassian.net/browse/PBRW-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ