### PR TITLE
fix: Revert "fix(revert): "chore(sentry): fix firebase beta + expo update dsyms""

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,6 +112,11 @@ lane :ship_beta_ios do |options|
       dist_version: bundle_version,
       platform: 'ios'
     )
+  elsif (deployment_target == 'firebase')
+    upload_dsyms_to_sentry(
+      project_slug: 'eigen',
+      org_slug: 'artsynet'
+    )
   end
 
   deploy_ios_beta(deployment_target: deployment_target)
@@ -523,9 +528,8 @@ lane :deploy_to_expo_updates do |options|
 
   # Export environment variables for Sentry sourcemap upload
   ENV['SENTRY_RELEASE'] = "#{platform}-#{release_name_base}"
-  ENV['SENTRY_DIST'] = dist_version
 
-  puts "🔧 Uploading sourcemaps to Sentry with release: #{platform}-#{release_name_base}, dist: #{dist_version}"
+  puts "🔧 Uploading sourcemaps to Sentry with release: #{platform}-#{release_name_base}"
   sh("cd .. && npx sentry-expo-upload-sourcemaps dist")
 
   tag_and_push(tag: "#{platform}-#{release_name_base}")

--- a/fastlane/sentry_fastlane.rb
+++ b/fastlane/sentry_fastlane.rb
@@ -85,7 +85,7 @@ lane :upload_sentry_sourcemaps do |options|
   end
 end
 
-private_lane :upload_dsyms_to_sentry do |options|
+lane :upload_dsyms_to_sentry do |options|
   org_slug = options[:org_slug]
   project_slug = options[:project_slug]
 


### PR DESCRIPTION
Reverts artsy/eigen#12551

Reverts the revert in favor of https://github.com/artsy/eigen/pull/12552