### PR TITLE
fix(DIA-1423): remove withSuspense overlapping the screen

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignalsBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignalsBottomSheet.tsx
@@ -1,15 +1,13 @@
 import { useColor } from "@artsy/palette-mobile"
 import BottomSheet from "@gorhom/bottom-sheet"
 import { InfiniteDiscoveryNegativeSignalsBottomSheetQuery } from "__generated__/InfiniteDiscoveryNegativeSignalsBottomSheetQuery.graphql"
-import { LoadFailureView } from "app/Components/LoadFailureView"
 import { InfiniteDiscoveryBottomSheetBackdrop } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheetBackdrop"
 import {
   InfiniteDiscoveryNegativeSignals,
   InfiniteDiscoveryNegativeSignalsPlaceholder,
 } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignals"
 import { GlobalStore } from "app/store/GlobalStore"
-import { withSuspense } from "app/utils/hooks/withSuspense"
-import { FC, useRef } from "react"
+import { FC, Suspense, useRef } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 
 interface NegativeSignalsBottomSheetProps {
@@ -43,51 +41,44 @@ interface InfiniteDiscoveryNegativeSignalsBottomSheetProps {
   artworkID: string
 }
 
-export const InfiniteDiscoveryNegativeSignalsBottomSheet =
-  withSuspense<InfiniteDiscoveryNegativeSignalsBottomSheetProps>({
-    Component: ({ artworkID }) => {
-      const color = useColor()
-      const ref = useRef<BottomSheet>(null)
-      const moreInfoSheetVisible = GlobalStore.useAppState(
-        (state) => state.infiniteDiscovery.sessionState.moreInfoSheetVisible
-      )
-      const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
+export const InfiniteDiscoveryNegativeSignalsBottomSheet: FC<
+  InfiniteDiscoveryNegativeSignalsBottomSheetProps
+> = ({ artworkID }) => {
+  const color = useColor()
+  const ref = useRef<BottomSheet>(null)
+  const moreInfoSheetVisible = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.moreInfoSheetVisible
+  )
+  const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
 
-      const handleOnSheetChange = (index: number) => {
-        if (index === 0 && moreInfoSheetVisible) {
-          setMoreInfoSheetVisible(false)
-        }
-      }
+  const handleOnSheetChange = (index: number) => {
+    if (index === 0 && moreInfoSheetVisible) {
+      setMoreInfoSheetVisible(false)
+    }
+  }
 
-      if (!moreInfoSheetVisible) {
-        return null
-      }
+  if (!moreInfoSheetVisible) {
+    return null
+  }
 
-      return (
-        <BottomSheet
-          ref={ref}
-          enableDynamicSizing={false}
-          enablePanDownToClose={true}
-          snapPoints={[1, 260]}
-          onChange={handleOnSheetChange}
-          index={1}
-          backgroundStyle={{
-            backgroundColor: color("mono0"),
-          }}
-          backdropComponent={(props) => (
-            <InfiniteDiscoveryBottomSheetBackdrop
-              {...props}
-              disappearsOnIndex={0}
-              appearsOnIndex={1}
-            />
-          )}
-        >
-          <NegativeSignalsBottomSheet artworkID={artworkID} />
-        </BottomSheet>
-      )
-    },
-    LoadingFallback: InfiniteDiscoveryNegativeSignalsPlaceholder,
-    ErrorFallback: () => {
-      return <LoadFailureView />
-    },
-  })
+  return (
+    <BottomSheet
+      ref={ref}
+      enableDynamicSizing={false}
+      enablePanDownToClose={true}
+      snapPoints={[1, 260]}
+      onChange={handleOnSheetChange}
+      index={1}
+      backgroundStyle={{
+        backgroundColor: color("mono0"),
+      }}
+      backdropComponent={(props) => (
+        <InfiniteDiscoveryBottomSheetBackdrop {...props} disappearsOnIndex={0} appearsOnIndex={1} />
+      )}
+    >
+      <Suspense fallback={<InfiniteDiscoveryNegativeSignalsPlaceholder />}>
+        <NegativeSignalsBottomSheet artworkID={artworkID} />
+      </Suspense>
+    </BottomSheet>
+  )
+}


### PR DESCRIPTION
This PR resolves [DIA-1423] <!-- eg [PROJECT-XXXX] -->

### Description

The discover daily screen was getting an overlay from `withSuspense` implementation, blocking the cards and not allowing swipe on iOS. I've time-boxed it and couldn't find the culprit for that(also checked if the bottom sheet wasn't being rendered by accident, and it looks like it isn't). Removing the withSuspense and using a normal `Suspense` fixes the issue.

cc @artsy/diamond-devs 

| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/277133e9-f9c2-449a-9dc4-218d27217218" width="400" /> | <video src="https://github.com/user-attachments/assets/855bb617-7aad-415a-a9ce-b25f10b00bca" width="400" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: discover daily blocked by a strange overlay

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1423]: https://artsyproduct.atlassian.net/browse/DIA-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ