### PR TITLE
fix: bring back missing artworks from collection screen

### DIFF
--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -8,7 +8,7 @@ export const NUM_COLUMNS_MASONRY = isTablet() ? 3 : 2
 
 export const ON_END_REACHED_THRESHOLD_MASONRY = 2
 
-export const MASONRY_LIST_PAGE_SIZE = 15
+export const MASONRY_LIST_PAGE_SIZE = 10
 
 export interface masonryRenderItemProps {
   item: MasonryArtworkItem


### PR DESCRIPTION
This PR resolves [ONYX-1862] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue affecting artwork grids and leading to missing artworks. After some investigation, I believe this is affecting at least 4 other screens but potentially more

### What went wrong
**1. Initial Query**
When a user initially opens an artwork screen we load 10 artworks
**2. Second Query: Pagination**
When the user reaches the end, we load 15 more artworks

The way relay does both 1 and 2 is by sending a query with `first` and `cursor` arguments . 
Inside MP, we convert `first` and `cursor` to gravity supported arguments, meaning `size`, `page` and `offset`.

Let's break down both steps
**1. Inital Query**
- We send to MP `first: 10` then `cursor:null` - meaning the first 10 artworks
- Based on the arguments we sent, we use `convertConnectionArgsToGravityArgs` giving us `page:1` and `size:10` and `offset:0`

**Second QueryL Pagination**
- We send to MP `first: 15` then `cursor:last-artwork-cursor` - meaning the next 15 artworks
- Based on the arguments we sent, we use `convertConnectionArgsToGravityArgs` giving us `page:2` and `size:15` and `offset:15`. **BUT**, becaues offset is 15! we have skipped 5 artworks since offset is computed based on `first`.

**Suggested solution**
Align count on initial query and next queries like we always did before here https://github.com/artsy/eigen/pull/11745. 

<img width="350" height="2622" alt="simulator_screenshot_BC216E3E-0003-4BF4-A59B-DDA9565698D9" src="https://github.com/user-attachments/assets/462d6225-6a26-4a34-9025-3bb5bc2177dc" />


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix bring back missing artworks from collection screen - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1862]: https://artsyproduct.atlassian.net/browse/ONYX-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ