### PR TITLE
chore: update bid status to show 'live auction' in grey after live auction opens

### DIFF
--- a/src/app/Scenes/Inbox/Components/ActiveBids/__tests__/ActiveBid.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/ActiveBids/__tests__/ActiveBid.tests.tsx
@@ -7,15 +7,21 @@ it("renders without throwing a error", () => {
 })
 
 it("looks right for bids in live open auctions", () => {
-  const tree = renderWithWrappersLEGACY(<ActiveBid bid={bid(true)} />)
-  expect(extractText(tree.root)).toMatch("Live bidding now open")
+  const view = renderWithWrappersLEGACY(<ActiveBid bid={bid(true, true)} />)
+  expect(extractText(view.root)).toMatch("Live bidding now open")
 })
 
-const bid = (isOpen?: boolean) => {
+it("looks right for bids in live closed auctions", () => {
+  const view = renderWithWrappersLEGACY(<ActiveBid bid={bid(false, true)} />)
+  expect(extractText(view.root)).toMatch("Live auction")
+})
+
+const bid = (isLiveOpen?: boolean, isLiveOpenHappened?: boolean) => {
   return {
     is_leading_bidder: false,
     sale: {
-      is_live_open: isOpen,
+      isLiveOpen: isLiveOpen,
+      isLiveOpenHappened: isLiveOpenHappened,
       href: "/to-the-auction",
     },
     most_recent_bid: {

--- a/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
+++ b/src/app/Scenes/MyBids/Components/ActiveLotStanding.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex, Text } from "@artsy/palette-mobile"
 import { ActiveLotStanding_saleArtwork$data } from "__generated__/ActiveLotStanding_saleArtwork.graphql"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { useScreenDimensions } from "app/utils/hooks"
 import { TouchableOpacity } from "react-native"
@@ -45,6 +46,7 @@ export const ActiveLotStanding = ({
       destination_screen_owner_id: saleArtwork?.artwork?.internalID,
       destination_screen_owner_slug: saleArtwork?.artwork?.slug,
     })
+    // eslint-disable-next-line no-restricted-imports
     navigate(saleArtwork?.artwork?.href as string)
   }
 
@@ -56,7 +58,7 @@ export const ActiveLotStanding = ({
     >
       <Flex flexDirection="row" justifyContent="space-between">
         <Lot saleArtwork={saleArtwork} isSmallScreen={isSmallScreen} />
-        {!sale.isLiveOpen && (
+        {!sale.isLiveOpenHappened && (
           <Flex>
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
@@ -90,7 +92,7 @@ export const ActiveLotStandingFragmentContainer = createFragmentContainer(Active
       isHighestBidder
       sale {
         status
-        isLiveOpen
+        isLiveOpenHappened
         liveStartAt
         endAt
       }

--- a/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
+++ b/src/app/Scenes/MyBids/Components/BiddingStatuses.tsx
@@ -57,8 +57,15 @@ export const Passed = () => (
 export const BiddingLiveNow = () => (
   <>
     <Text variant="xs" color="blue100">
-      {" "}
       Bidding live now
+    </Text>
+  </>
+)
+
+export const LiveAuction = () => (
+  <>
+    <Text variant="xs" color="mono60">
+      Live auction
     </Text>
   </>
 )

--- a/src/app/Scenes/MyBids/Components/ClosedLotStanding.tsx
+++ b/src/app/Scenes/MyBids/Components/ClosedLotStanding.tsx
@@ -3,6 +3,7 @@ import { StarCircleFillIcon } from "@artsy/icons/native"
 import { Flex, Text } from "@artsy/palette-mobile"
 import { ClosedLotStanding_saleArtwork$data } from "__generated__/ClosedLotStanding_saleArtwork.graphql"
 import { TimelySale } from "app/Scenes/MyBids/helpers/timely"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import moment from "moment-timezone"
 import { TouchableOpacity } from "react-native"
@@ -84,7 +85,7 @@ export const ClosedLotStanding = ({
     >
       <Flex flexDirection="row" justifyContent="space-between">
         <Lot saleArtwork={saleArtwork} subtitle={subtitle} ArtworkBadge={Badge} />
-        {!sale.isLiveOpen && (
+        {!sale.isLiveOpenHappened && (
           <Flex>
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
@@ -117,7 +118,7 @@ export const ClosedLotStandingFragmentContainer = createFragmentContainer(Closed
         }
       }
       sale {
-        isLiveOpen
+        isLiveOpenHappened
         endAt
         status
       }

--- a/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
+++ b/src/app/Scenes/Sale/Components/SaleActiveBidItem.tsx
@@ -5,8 +5,10 @@ import {
   Outbid,
   ReserveNotMet,
   BiddingLiveNow,
+  LiveAuction,
 } from "app/Scenes/MyBids/Components/BiddingStatuses"
 import { LotFragmentContainer } from "app/Scenes/MyBids/Components/Lot"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -32,7 +34,7 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
       <Flex flexDirection="row" justifyContent="space-between">
         <LotFragmentContainer saleArtwork={saleArtwork} />
         <Flex>
-          {!saleArtwork.sale?.isLiveOpen && (
+          {!saleArtwork.sale?.isLiveOpenHappened && (
             <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
               <Text variant="xs">{sellingPrice}</Text>
               <Text variant="xs" color="mono60">
@@ -44,6 +46,8 @@ export const SaleActiveBidItem: React.FC<SaleActiveBidItemProps> = ({ lotStandin
           <Flex flexDirection="row" alignItems="center" justifyContent="flex-end">
             {saleArtwork.sale?.isLiveOpen ? (
               <BiddingLiveNow />
+            ) : saleArtwork.sale?.isLiveOpenHappened ? (
+              <LiveAuction />
             ) : lotStanding?.activeBid?.isWinning &&
               saleArtwork.reserveStatus === "ReserveNotMet" ? (
               <ReserveNotMet />
@@ -84,6 +88,7 @@ export const SaleActiveBidItemContainer = createFragmentContainer(SaleActiveBidI
         }
         sale {
           isLiveOpen
+          isLiveOpenHappened
           slug
         }
       }


### PR DESCRIPTION
The code for all the auction displays is pretty confusing and probably needs a bigger refactor. But we are not touching it for the most part so I just attempt to do the same we do on Force. Not display bid status for live auctions after the live bidding started. We do have some 'live bidding' prompts in blue across the app - so I kept those but added additional check to see if it is past live open time and in this case just display 'Live auction' in gray in places.

Want to see if specs are passing and after fixing will adjust the PR to proper format

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
