### PR TITLE
fix: change spec repo order to avoid dep confusion attacks

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,8 +1,10 @@
 require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
 # frozen_string_literal: true
 
-source 'https://cdn.cocoapods.org/'
+# Important: Artsy must come first, see here: https://github.com/artsy/eigen/issues/12584
 source 'https://github.com/artsy/Specs.git'
+source 'https://cdn.cocoapods.org/'
+
 
 require 'dotenv'
 Dotenv.load('../.env.shared')


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Change pod spec repo order so artsy takes precedence to avoid dep confusion attacks: 
https://github.com/artsy/eigen/issues/12584

#trivial 


### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- change spec repo order in Podfile to avoid dep confusion attacks - brian 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
