### PR TITLE
fix(PBRW-1082): Fix show's Unable to Load

### DIFF
--- a/src/app/Scenes/Show/Components/ShowContextCard.tsx
+++ b/src/app/Scenes/Show/Components/ShowContextCard.tsx
@@ -3,6 +3,7 @@ import { Flex, Box, BoxProps, Text, useScreenDimensions, Image } from "@artsy/pa
 import { ShowContextCard_show$data } from "__generated__/ShowContextCard_show.graphql"
 import { SmallCard } from "app/Components/Cards"
 import { SectionTitle } from "app/Components/SectionTitle"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { TouchableOpacity } from "react-native"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -99,7 +100,13 @@ const ContextCard: React.FC<ContextCardProps> = ({
     <SmallCard images={imageUrls} /> // 3-up image layout
   ) : (
     <Flex width="100%" borderRadius={4} overflow="hidden">
-      <Image testID="main-image" width={width} aspectRatio={1.5} src={imageUrls[0]} />
+      <Image
+        testID="main-image"
+        width={width}
+        aspectRatio={1.5}
+        // we need to pass an empty string in case imageUrls is empty
+        src={imageUrls[0] || ""}
+      />
     </Flex>
   )
 


### PR DESCRIPTION
This PR resolves [PBRW-1082] <!-- eg [PROJECT-XXXX] -->

### Description
This PR resolves an unable to load in the Shows screen
It is happening due to the React Native image is getting an `undefined` in `src`, which is causing the screen to break
This PR replaces it with an empty string


### Screenshots
| | Before | After |
|---|---|---|
| Android | <img width="320" alt="image" src="https://github.com/user-attachments/assets/2142d35f-f525-4e89-9fa7-47972810f159" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/7b66af0f-1c37-4ee2-91be-b22e63b56dda" /> |
| iOS | <img width="320" alt="image" src="https://github.com/user-attachments/assets/4f156743-bd60-424a-8d4c-d3f1018c6ccf" /> | <img width="320" alt="image" src="https://github.com/user-attachments/assets/ddf1757a-15eb-4ee4-bbd1-5e8c4795a695" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix Shows screen unable to load when image is not available

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1082]: https://artsyproduct.atlassian.net/browse/PBRW-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ