### PR TITLE
chore: add a scroll to delay deeplink test

### DIFF
--- a/e2e/flows/deeplinks.yml
+++ b/e2e/flows/deeplinks.yml
@@ -8,8 +8,10 @@ appId: ${MAESTRO_APP_ID}
       useMaestroInit: "true"
 - assertVisible:
     id: "search-button"
-- waitFor:
-    duration: 5000 # wait 5 seconds to give OS time to verify universal link
+- scrollUntilVisible: # we do this just to give time to fetch deeplink verifications, can get rid of if we have a test run before deeplinks on same sim
+    element: "News"
+    timeout: 50000
+    speed: 60
 - killApp
 - openLink:
     link: https://www.artsy.net/artist/kaws


### PR DESCRIPTION
This PR resolves [PHIRE-2000] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Adds a scroll to expected element just to delay. Theory is that this is flaky due to not fetching the universal link verifications in time but not 100% on that. Alternatively we can have another test run on the same sim before this one and it should be enough if that is the problem. 

#nochangelog

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.


Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2000]: https://artsyproduct.atlassian.net/browse/PHIRE-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ