### PR TITLE
fix(DIA-1440): navigating without the header left button shows saves summary

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -1,14 +1,12 @@
 import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
-import { DEFAULT_HIT_SLOP, Flex, LinkText, Screen, Touchable } from "@artsy/palette-mobile"
+import { DEFAULT_HIT_SLOP, Flex, Screen, Touchable } from "@artsy/palette-mobile"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
-import { useToast } from "app/Components/Toast/toastHook"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
+import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast"
 import { GlobalStore } from "app/store/GlobalStore"
-// eslint-disable-next-line no-restricted-imports
-import { goBack, navigate } from "app/system/navigation/navigate"
+import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { pluralize } from "app/utils/pluralize"
 import RNShare from "react-native-share"
 
 interface InfiniteDiscoveryHeaderProps {
@@ -16,39 +14,15 @@ interface InfiniteDiscoveryHeaderProps {
 }
 
 export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = ({ topArtwork }) => {
+  useSavesSummaryToast()
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
-  const toast = useToast()
   const track = useInfiniteDiscoveryTracking()
-  const savedArtworksCount = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.savedArtworksCount
-  )
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
 
   const handleExitPressed = () => {
-    if (savedArtworksCount > 0) {
-      toast.show(
-        `Nice! You saved ${savedArtworksCount} ${pluralize("artwork", savedArtworksCount)}.`,
-        "bottom",
-        {
-          onPress: () => {
-            track.tappedSummary()
-            navigate("/favorites/saves")
-          },
-          backgroundColor: "green100",
-          description: (
-            <LinkText variant="xs" color="mono0" onPress={() => navigate("/favorites/saves")}>
-              Tap to see all of your saved artworks.
-            </LinkText>
-          ),
-          duration: "long",
-        }
-      )
-    }
-
     track.tappedExit()
-
     goBack()
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
@@ -1,0 +1,48 @@
+import { LinkText } from "@artsy/palette-mobile"
+import { useNavigation } from "@react-navigation/native"
+import { useToast } from "app/Components/Toast/toastHook"
+import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
+import { GlobalStore } from "app/store/GlobalStore"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
+import { pluralize } from "app/utils/pluralize"
+import { useCallback, useEffect } from "react"
+
+export const useSavesSummaryToast = () => {
+  const { addListener } = useNavigation()
+  const toast = useToast()
+  const savedArtworksCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.savedArtworksCount
+  )
+  const track = useInfiniteDiscoveryTracking()
+
+  const showSavedCountToast = useCallback(() => {
+    if (savedArtworksCount > 0) {
+      toast.show(
+        `Nice! You saved ${savedArtworksCount} ${pluralize("artwork", savedArtworksCount)}.`,
+        "bottom",
+        {
+          onPress: () => {
+            track.tappedSummary()
+            navigate("/favorites/saves")
+          },
+          backgroundColor: "green100",
+          description: (
+            <LinkText variant="xs" color="mono0" onPress={() => navigate("/favorites/saves")}>
+              Tap to see all of your saved artworks.
+            </LinkText>
+          ),
+          duration: "long",
+        }
+      )
+    }
+  }, [toast, savedArtworksCount, track])
+
+  useEffect(() => {
+    const unsubscribe = addListener("beforeRemove", showSavedCountToast)
+
+    return unsubscribe
+  }, [addListener, showSavedCountToast])
+
+  return { showSavedCountToast }
+}


### PR DESCRIPTION
This PR resolves [DIA-1440] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes back events, pressing the back button on Android and other means wouldn't show the save summary toast. Now they do.

@artsy/diamond-devs 

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/1b8bebe3-f3ad-4e1f-b734-366c9b34ef30" width="400" /> | <video src="https://github.com/user-attachments/assets/52d0ff4d-3260-4572-ad9b-e99e0114f5e9" width="400" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: handle back behaviour better to show the toast 

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIA-1440]: https://artsyproduct.atlassian.net/browse/DIA-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ