### PR TITLE
chore: skip fixed bugs in notion export

### DIFF
--- a/scripts/utils/exportNotionTicketsToJira.ts
+++ b/scripts/utils/exportNotionTicketsToJira.ts
@@ -191,7 +191,7 @@ async function main() {
 
       const severity = page.properties["Bug Severity"]?.select?.name || null
       const team = page.properties.Team?.select?.name || null
-      const status = page.properties.Status?.select?.name || null // 👈 Add this line
+      const status = page.properties.Status?.select?.name || null
 
       // 👇 Skip bugs that are marked as Fixed/Handled
       if (status === "Fixed/Handled") {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Skips bugs marked fixed when exporting from notion

#trivial #nochangelog

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
