### PR TITLE
fix(ONYX-1778): pagination is broken on long grids, decrease onEndReachedThreshold

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -35,6 +35,7 @@ import { convertSavedSearchCriteriaToFilterParams } from "app/Components/Artwork
 import { SearchCriteriaAttributes } from "app/Components/ArtworkFilter/SavedSearch/types"
 import { useArtworkFilters } from "app/Components/ArtworkFilter/useArtworkFilters"
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
+import { HEADER_HEIGHT } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
 import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { Props as InfiniteScrollGridProps } from "app/Components/ArtworkGrids/InfiniteScrollArtworksGrid"
 import { LoadFailureView, LoadFailureViewProps } from "app/Components/LoadFailureView"
@@ -501,29 +502,30 @@ export const ArtistArtworksQueryRenderer = withSuspense<ArtistArtworksQueryRende
   },
 })
 
-const SUB_TAB_BAR_HEIGHT = 70
-
 const ArtistArtworksPlaceholder = () => {
   const space = useSpace()
 
   const { height } = useHeaderMeasurements()
   // Tabs.ScrollView paddingTop is not working on Android, so we need to set it manually
-  const paddingTop = Platform.OS === "android" ? SUB_TAB_BAR_HEIGHT + height : space(2)
+  const paddingTop = Platform.OS === "android" ? height + HEADER_HEIGHT + space(1) : space(1)
 
   return (
     <Tabs.ScrollView
-      contentContainerStyle={{ paddingHorizontal: 0, paddingTop: paddingTop }}
+      contentContainerStyle={{
+        paddingHorizontal: 0,
+        paddingTop: paddingTop,
+      }}
       scrollEnabled={false}
     >
-      <Flex px={2} testID="ArtistArtworksPlaceholder" gap={2}>
+      <Flex px={2} testID="ArtistArtworksPlaceholder" gap={1}>
         <Flex flexDirection="row" justifyContent="space-between">
-          <SkeletonText>Create Alert</SkeletonText>
-          <SkeletonText>Sort & Filter</SkeletonText>
+          <SkeletonText variant="sm">Create Alert</SkeletonText>
+          <SkeletonText variant="sm">Sort & Filter</SkeletonText>
         </Flex>
 
-        <Flex borderBottomWidth={1} borderBottomColor="mono100" mx={-2} />
+        <Flex borderBottomWidth={1} borderBottomColor="mono30" mx={-2} />
 
-        <SkeletonText variant="xs">XX Artworks</SkeletonText>
+        <SkeletonText variant="sm">XX Artworks</SkeletonText>
 
         <PlaceholderGrid mx={0} />
       </Flex>
@@ -536,7 +538,7 @@ const ArtistArtworksError: React.FC<LoadFailureViewProps> = (fallbackProps) => {
 
   const { height } = useHeaderMeasurements()
   // Tabs.ScrollView paddingTop is not working on Android, so we need to set it manually
-  const paddingTop = Platform.OS === "android" ? SUB_TAB_BAR_HEIGHT + height : space(2)
+  const paddingTop = Platform.OS === "android" ? height + HEADER_HEIGHT + space(2) : space(2)
 
   return (
     <Tabs.ScrollView contentContainerStyle={{ paddingHorizontal: 0, paddingTop: paddingTop }}>

--- a/src/app/Components/ArtworkGrids/ArtworksFilterHeader.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworksFilterHeader.tsx
@@ -11,7 +11,7 @@ interface FilterHeaderProps {
   showSeparator?: boolean
 }
 
-const HEADER_HEIGHT = 50
+export const HEADER_HEIGHT = 50
 
 export const ArtworksFilterHeader: React.FC<FilterHeaderProps> = ({
   children,

--- a/src/app/Components/constants.ts
+++ b/src/app/Components/constants.ts
@@ -20,6 +20,7 @@ export const ICON_HIT_SLOP = {
 }
 export const BACK_BUTTON_SIZE_SIZE = 40
 export const SCROLLVIEW_PADDING_BOTTOM_OFFSET = 80
+export const SCROLLVIEW_SEARCH_RESULTS_PADDING_BOTTOM_OFFSET = 120
 
 // This is the default value of iOS transition duration
 export const DEFAULT_SCREEN_ANIMATION_DURATION = 350

--- a/src/app/Scenes/Search/SearchArtworksGrid.tsx
+++ b/src/app/Scenes/Search/SearchArtworksGrid.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   quoteLeft,
   quoteRight,
-  Spinner,
   Text,
   useScreenDimensions,
   useTheme,
@@ -19,13 +18,14 @@ import {
 } from "app/Components/ArtworkFilter/useArtworkFilters"
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { ArtworksFilterHeader } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
-import { SCROLLVIEW_PADDING_BOTTOM_OFFSET } from "app/Components/constants"
+import { SCROLLVIEW_SEARCH_RESULTS_PADDING_BOTTOM_OFFSET } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import {
   ESTIMATED_MASONRY_ITEM_SIZE,
   NUM_COLUMNS_MASONRY,
   ON_END_REACHED_THRESHOLD_MASONRY,
 } from "app/utils/masonryHelpers"
+import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 
 import { Schema } from "app/utils/track"
 import { OwnerEntityTypes, PageNames } from "app/utils/track/schema"
@@ -133,9 +133,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
           onEndReached={loadMore}
           onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
           ListFooterComponent={
-            <Flex alignItems="center" my={4}>
-              {shouldDisplaySpinner ? <Spinner /> : null}
-            </Flex>
+            <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
           }
           renderItem={({ item, index, columnIndex }) => {
             const imgAspectRatio = item.image?.aspectRatio ?? 1
@@ -160,7 +158,7 @@ const SearchArtworksGrid: React.FC<SearchArtworksGridProps> = ({ viewer, relay, 
               </Flex>
             )
           }}
-          contentContainerStyle={{ paddingBottom: SCROLLVIEW_PADDING_BOTTOM_OFFSET }}
+          contentContainerStyle={{ paddingBottom: SCROLLVIEW_SEARCH_RESULTS_PADDING_BOTTOM_OFFSET }}
         />
       </Flex>
     </>

--- a/src/app/utils/masonryHelpers/index.tsx
+++ b/src/app/utils/masonryHelpers/index.tsx
@@ -6,7 +6,7 @@ export const ESTIMATED_MASONRY_ITEM_SIZE = 272
 
 export const NUM_COLUMNS_MASONRY = isTablet() ? 3 : 2
 
-export const ON_END_REACHED_THRESHOLD_MASONRY = 2
+export const ON_END_REACHED_THRESHOLD_MASONRY = 1.2
 
 export const MASONRY_LIST_PAGE_SIZE = 10
 


### PR DESCRIPTION
This PR resolves [ONYX-1778] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Pagination on screens with long artwork grids is not working properly - the screen either freezes on a loading state or does not show all available results. It looks like `onEndReached` fails to be called every time when `onEndReachedThreshold` is too high

I noticed that decreasing the `onEndReachedThreshold` value solves the issue without harming the performance - the lists are still rendering fairly quickly, without freezing and showing all available results

We can experiment with the `onEndReachedThreshold`, I notised that anything below 1.6 is an improvement, but I found 1.2 performing best

I’m also wondering if lowering the onEndReachedThreshold is actually the right way to address this issue. The discussion in this PR got me thinking: https://github.com/artsy/eigen/pull/11745 

| Platform | Before | After |
| --- | --- | --- |
| Android | <video src="https://github.com/user-attachments/assets/844725a6-c4fe-4143-8972-aaa7bd7b136f" width="300" /> | <video src="https://github.com/user-attachments/assets/6a2bad98-59e4-4b78-abf2-a4a37fcd1f1c" width="300" /> |
| iOS | <video src="https://github.com/user-attachments/assets/dbe5f878-b4aa-442c-bcd2-19624e11e8e7" width="300" /> | <video src="https://github.com/user-attachments/assets/b4e7e8af-dc64-4927-93ad-6557d8f83c32" width="300" /> |

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- pagination is broken on long grids, decrease onEndReachedThreshold

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
