### PR TITLE
feat: hide fair date for specific Artsy Edition Shop instance

### DIFF
--- a/src/app/Scenes/Fair/Components/FairHeader.tsx
+++ b/src/app/Scenes/Fair/Components/FairHeader.tsx
@@ -15,6 +15,7 @@ export const FairHeader: FC<FairHeaderProps> = ({ fair }) => {
     return null
   }
 
+  const isArtsyEditionShop = data.slug === "the-artsy-edition-shop"
   const profileImageUrl = data.profile?.icon?.imageUrl
 
   return (
@@ -44,10 +45,16 @@ export const FairHeader: FC<FairHeaderProps> = ({ fair }) => {
         </Flex>
       ) : null}
       <Flex px={2} pointerEvents="none">
-        <Text variant="lg-display" py={2}>
+        <Text variant="lg-display" pt={2} pb={isArtsyEditionShop ? 0 : 2}>
           {data.name}
         </Text>
-        <FairTiming fair={data} />
+        {isArtsyEditionShop ? (
+          <Text variant="sm" pb={2} color="mono60">
+            Your Chance to Own an Icon
+          </Text>
+        ) : (
+          <FairTiming fair={data} />
+        )}
       </Flex>
     </Flex>
   )
@@ -56,6 +63,7 @@ export const FairHeader: FC<FairHeaderProps> = ({ fair }) => {
 const fragment = graphql`
   fragment FairHeader_fair on Fair {
     name
+    slug
     profile {
       icon {
         imageUrl: url(version: "untouched-png")

--- a/src/app/Scenes/Fair/__tests__/FairHeader.tests.tsx
+++ b/src/app/Scenes/Fair/__tests__/FairHeader.tests.tsx
@@ -51,4 +51,26 @@ describe("FairHeader", () => {
 
     expect(screen.getByText("Closed")).toBeOnTheScreen()
   })
+
+  it("does not render the timing info for the Artsy Edition Shop instance", () => {
+    renderWithRelay({
+      Fair: () => ({
+        slug: "the-artsy-edition-shop",
+        endAt: "2020-09-19T08:00:00+00:00",
+      }),
+    })
+
+    expect(screen.queryByText("Closed")).not.toBeOnTheScreen()
+  })
+
+  it("displays a custom subheader", () => {
+    renderWithRelay({
+      Fair: () => ({
+        slug: "the-artsy-edition-shop",
+        endAt: "2020-09-19T08:00:00+00:00",
+      }),
+    })
+
+    expect(screen.getByText("Your Chance to Own an Icon")).toBeOnTheScreen()
+  })
 })


### PR DESCRIPTION
### Description

Part of a set of requests from Marketing to tweak the design of the fair experience to support the use of these surfaces for a persistent "online shop", sourcing works directly from various gallery partners.

Long-term, we intend to plan out the introduction of a separate "Shop" concept, which can borrow from some fair behavior (like sourcing directly from partners via CMS) but shed some of the time-specific requirements fairs currently have.

This PR resolves [ONYX-1873](https://artsyproduct.atlassian.net/browse/ONYX-187) 🔒 

| Platform | Before | After |
|---|---|---|
| iOS | <img width="400" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 14 34 36" src="https://github.com/user-attachments/assets/29266a0c-75bf-44fd-a8fe-2285aa886d62" /> | <img width="400" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 22 34 03" src="https://github.com/user-attachments/assets/e7a23ae4-29af-4ba6-8c56-8c5651a62a7b" /> |
| iOS | <img width="400" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 22 31 36" src="https://github.com/user-attachments/assets/3f5ac6d0-11c3-41e9-a503-c861b569fc44" /> | <img width="400" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 22 33 29" src="https://github.com/user-attachments/assets/9f6754ce-db57-4931-a46a-fdc7a065c924" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: hide fair date for specific Artsy Edition Shop instance

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1873]: https://artsyproduct.atlassian.net/browse/ONYX-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ