### PR TITLE
chore: fix typo when denying claude access to remote commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,7 @@
       "Read(keys.shared.json)",
       "Read(release.keystore)",
       "Bash(hokusai:*)",
-      "Bash(aws:*)]"
+      "Bash(aws:*)"
     ]
   }
 }


### PR DESCRIPTION
chore: fix typo when denying claude access to remote commands