### PR TITLE
fix: Persist message text in Order Details modal

### DIFF
--- a/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsAskSpecialistModal.tsx
+++ b/src/app/Scenes/OrderHistory/OrderDetails/Components/OrderDetailsAskSpecialistModal.tsx
@@ -33,6 +33,11 @@ export const OrderDetailsAskSpecialistModal: React.FC<OrderDetailsAskSpecialistM
 
   const artworkID = orderData.lineItems[0]?.artwork?.internalID
 
+  const closeModal = () => {
+    setMessage("")
+    handleDismiss()
+  }
+
   const handleSubmit = () => {
     if (!message.trim()) {
       return
@@ -56,7 +61,7 @@ export const OrderDetailsAskSpecialistModal: React.FC<OrderDetailsAskSpecialistM
       },
       onError: () => setError(true),
       onCompleted: () => {
-        handleDismiss()
+        closeModal()
         toast.show("Your message has been sent", "bottom", {
           backgroundColor: "green100",
         })
@@ -65,14 +70,9 @@ export const OrderDetailsAskSpecialistModal: React.FC<OrderDetailsAskSpecialistM
   }
 
   return (
-    <Modal
-      onRequestClose={handleDismiss}
-      visible={visible}
-      statusBarTranslucent
-      animationType="slide"
-    >
+    <Modal onRequestClose={closeModal} visible={visible} statusBarTranslucent animationType="slide">
       <Screen>
-        <NavigationHeader useXButton onLeftButtonPress={handleDismiss}>
+        <NavigationHeader useXButton onLeftButtonPress={closeModal}>
           Send message to Artsy
         </NavigationHeader>
         {!!error && (
@@ -111,7 +111,7 @@ export const OrderDetailsAskSpecialistModal: React.FC<OrderDetailsAskSpecialistM
               placeholder="Leave your comments"
               title="Your message"
               accessibilityLabel="Your message"
-              defaultValue=""
+              defaultValue={message}
               onChangeText={setMessage}
               required
             />


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes the issue of disappearing text input value on keyboard dismiss on Android
The reason seems to be coming from a re-render on keyboard dismiss on Android, which rerenderes the `TextInput` with the `defaultValue` of an empty string `""`


### Videos
| | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/10c2de93-be07-4d9c-930c-ef466a30a654" /> | <video src="https://github.com/user-attachments/assets/1a26a070-c749-460d-bda3-76ec7765fce3" /> |
| iOS | <video src="https://github.com/user-attachments/assets/ac3cb658-62ee-4156-85a5-c0972fc43b45" /> | <video src="https://github.com/user-attachments/assets/4bea3e72-dbd9-4f47-b90a-174dfec85c97" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fix disappearing text input value in Order Details modal on Android

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
