### PR TITLE
chore: use rn-launch-arguments new architecture supported version

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "react-native-in-app-review": "4.3.3",
     "react-native-keychain": "9.2.2",
     "react-native-keys": "0.7.11",
-    "react-native-launch-arguments": "4.1.0",
+    "react-native-launch-arguments": "git+https://github.com/artsy/react-native-launch-arguments.git#v4.0.1-new-arch",
     "react-native-linear-gradient": "2.8.3",
     "react-native-localize": "2.1.3",
     "react-native-pager-view": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14789,10 +14789,9 @@ react-native-keys@0.7.11:
     walk-sync "^3.0.0"
     xml2js "^0.6.2"
 
-react-native-launch-arguments@4.1.0:
+"react-native-launch-arguments@git+https://github.com/artsy/react-native-launch-arguments.git#v4.0.1-new-arch":
   version "4.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-launch-arguments/-/react-native-launch-arguments-4.1.0.tgz#7f82b00edaaf239e3210216ce99c352dd7f792c5"
-  integrity sha512-aXWULNII2XG6eK6ysPp9eUDjZVmPh65DA5i7F3pQRraRdfYnv5r6cUulqRkUk5uvA8xokurslHjEjIjAEbxa/g==
+  resolved "git+https://github.com/artsy/react-native-launch-arguments.git#b1623c84667fed965fd5a00193031f1b689e2120"
 
 react-native-linear-gradient@2.8.3:
   version "2.8.3"


### PR DESCRIPTION
## in-progress

This PR resolves [PHIRE-2084](https://artsyproduct.atlassian.net/browse/PHIRE-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates `react-native-lauch-arguments` to use our new architecture + old architecture implementation.

Fwiw, I also opened a PR to add support of the new architecture in the original repo here https://github.com/iamolegga/react-native-launch-arguments/pull/84. I had to timebox this because there were other parts in the original repo that were outdated that I didn't get to upgrade (ts and example project rn version)

**Build succeeding on new architecture on Energy**
<img width="1121" height="771" alt="Screenshot 2025-08-20 at 17 55 07" src="https://github.com/user-attachments/assets/03f7266f-a994-42e5-be14-aad44c52b3e7" />
<img width="1167" height="770" alt="Screenshot 2025-08-20 at 17 55 01" src="https://github.com/user-attachments/assets/7c37945e-153f-4556-b69d-ba517343c55a" />

### PR Checklist

- [x] I have tested my changes on the following platforms:
    - [x] **Android**.
    - [x] **iOS**.
- [x] I hid my changes behind a [**feature flag**](../blob/main/docs/developing_a_feature.md), or they don't need one.
- [x] I have included **screenshots**or **videos**at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an [**app state migration**](../blob/main/docs/adding_state_migrations.md), or my changes do not require one.
- [x] I have documented any **follow-up work**that this PR will require, or it does not require any.
- [x] I have added a **changelog entry**below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one**of the reviewers to **run**this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates









#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use rn-launch-arguments new architecture supported version - mounir



</details>

Need help with something? Have a look at our [docs](../blob/main/docs/README.md), or get in touch with us.

[PHIRE-2084]: https://artsyproduct.atlassian.net/browse/PHIRE-2084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ