### PR TITLE
fix: use raw flag to allow input to metro process #trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "setup:maestro:update!": "scripts/setup/update-env-for-maestro",
     "setup:releases": "./scripts/setup/setup-env-for-artsy && ./scripts/setup/setup-env-for-releases",
     "setup:releases:update!": "scripts/setup/update-env-for-releases",
-    "start": "concurrently 'yarn relay:watch' 'react-native start'",
+    "start": "concurrently --raw 'react-native start' 'yarn relay:watch'",
     "start:reset-cache": "yarn start --reset-cache",
     "sync-cities": "curl https://raw.githubusercontent.com/artsy/metaphysics/main/src/schema/city/cityDataSortedByDisplayPreference.json -o data/cityDataSortedByDisplayPreference.json",
     "sync-schema": "curl https://raw.githubusercontent.com/artsy/metaphysics/main/_schemaV2.graphql -o data/schema.graphql; yarn prettier --write --parser graphql data/schema.graphql",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Update start command to use --raw flag with concurrently to allow keyboard input to the metro process.

Specifically to fix the dev tools not opening when you type j:
```
[1]  💡 JavaScript logs have moved! They can now be viewed in React Native DevTools. Tip: Type j in the terminal to open (requires Google Chrome or Microsoft Edge).
[1] 
j
```
#nochangelog 

