### PR TITLE
chore(Revert): "build(deps): bump @segment/analytics-react-native-plugin-braze to latest"

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@react-navigation/stack": "7.3.3",
     "@rnmapbox/maps": "10.1.38",
     "@segment/analytics-react-native": "2.20.3",
-    "@segment/analytics-react-native-plugin-braze": "0.8.0",
+    "@segment/analytics-react-native-plugin-braze": "0.6.1",
     "@segment/sovran-react-native": "1.1.3",
     "@sentry/react-native": "6.10.0",
     "@shopify/flash-list": "^1.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4518,10 +4518,10 @@
     "@types/geojson" "^7946.0.7"
     debounce "^1.2.0"
 
-"@segment/analytics-react-native-plugin-braze@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@segment/analytics-react-native-plugin-braze/-/analytics-react-native-plugin-braze-0.8.0.tgz#1893aaead730a31744e2646e2679a2febdaba8a7"
-  integrity sha512-ugL1J22BRFb66hPgMUVKWNfsrSqC06wOfaoQ2h304u+E0cmY1qXq/OlxiHBNun48A60RlLkwW4yqJAcJEvTCsQ==
+"@segment/analytics-react-native-plugin-braze@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@segment/analytics-react-native-plugin-braze/-/analytics-react-native-plugin-braze-0.6.1.tgz#f4c8a85852b50470a398e2b0330c6ed3d3b0e27c"
+  integrity sha512-jyksibkSHlE5CMoYc/Rs3N9m2cMjsryVz/HiZyuVZ0k+073w6ooZ3tWtwStsZHPiILCLEtLDLfM8j6NemBs3/g==
 
 "@segment/analytics-react-native@2.20.3":
   version "2.20.3"


### PR DESCRIPTION
Reverts artsy/eigen#12711

Turns out this is not needed in order to integrate rozenite so will revert since the bump broke the segment braze integration.

#nochangelog