### PR TITLE
fix: view in room works for artworks with diameters

### DIFF
--- a/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
+++ b/src/app/Components/ContextMenu/ContextMenuArtwork.tsx
@@ -78,12 +78,14 @@ export const ContextMenuArtwork: React.FC<React.PropsWithChildren<ContextMenuArt
   })
 
   const openViewInRoom = () => {
-    if (artwork?.widthCm == null || artwork?.heightCm == null || image?.url == null) {
+    if (!((artwork.widthCm && artwork.heightCm) || artwork.diameterCm) || image?.url == null) {
       return
     }
 
-    const heightIn = cm2in(artwork.heightCm)
-    const widthIn = cm2in(artwork.widthCm)
+    const artworkWidth = (artwork.widthCm || artwork.diameterCm) as number
+    const artworkHeight = (artwork.heightCm || artwork.diameterCm) as number
+    const heightIn = cm2in(artworkHeight)
+    const widthIn = cm2in(artworkWidth)
 
     trackEvent({
       action_name: Schema.ActionNames.ViewInRoom,
@@ -292,6 +294,7 @@ const artworkFragment = graphql`
     }
     heightCm
     widthCm
+    diameterCm
   }
 `
 

--- a/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkActions.tsx
@@ -40,19 +40,21 @@ export const shareContent = (
 }
 
 export const ArtworkActions: React.FC<ArtworkActionsProps> = ({ artwork, shareOnPress }) => {
-  const { image, id, slug, heightCm, widthCm, isHangable, sale } = artwork
+  const { image, id, slug, heightCm, widthCm, diameterCm, isHangable, sale } = artwork
   const { trackEvent } = useTracking()
   const space = useSpace()
 
   const openOrUpcomingSale = isOpenOrUpcomingSale(sale)
 
   const openViewInRoom = () => {
-    if (image?.url == null || heightCm == null || widthCm == null) {
+    if (image?.url == null || !((widthCm && heightCm) || diameterCm)) {
       return
     }
 
-    const heightIn = cm2in(heightCm)
-    const widthIn = cm2in(widthCm)
+    const artworkWidth = (widthCm || diameterCm) as number
+    const artworkHeight = (heightCm || diameterCm) as number
+    const heightIn = cm2in(artworkHeight)
+    const widthIn = cm2in(artworkWidth)
 
     trackEvent({
       action_name: Schema.ActionNames.ViewInRoom,
@@ -127,6 +129,7 @@ export const ArtworkActionsFragmentContainer = createFragmentContainer(ArtworkAc
       }
       widthCm
       heightCm
+      diameterCm
       sale {
         isAuction
         isClosed

--- a/src/app/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
+++ b/src/app/Scenes/ViewingRoom/ViewingRoomArtwork.tsx
@@ -45,11 +45,13 @@ export const ViewingRoomArtwork: React.FC<ViewingRoomArtworkProps> = (props) => 
   const viewInAR = () => {
     if (
       !!selectedArtwork.isHangable &&
-      !!selectedArtwork?.widthCm &&
-      !!selectedArtwork?.heightCm &&
+      ((selectedArtwork.widthCm && selectedArtwork.heightCm) || selectedArtwork.diameterCm) &&
       !!selectedArtwork?.image?.url
     ) {
-      const [widthIn, heightIn] = [selectedArtwork.widthCm, selectedArtwork.heightCm].map(cm2in)
+      const artworkWidth = (selectedArtwork.widthCm || selectedArtwork.diameterCm) as number
+      const artworkHeight = (selectedArtwork.heightCm || selectedArtwork.diameterCm) as number
+
+      const [widthIn, heightIn] = [artworkWidth, artworkHeight].map(cm2in)
 
       LegacyNativeModules.ARTNativeScreenPresenterModule.presentAugmentedRealityVIR(
         selectedArtwork.image.url,
@@ -275,6 +277,7 @@ const selectedArtworkFragmentSpec = graphql`
     isHangable
     widthCm
     heightCm
+    diameterCm
     id
     figures {
       ...ImageCarousel_figures @relay(mask: false) # We need this because ImageCarousel uses regular react-relay and we have relay-hooks here.


### PR DESCRIPTION
This PR resolves [ONYX-1925]

### Description

"View in Room" feature never works with round artworks - they lack `widthCm` and `heightCm` fields and only have `diameterCm`. This PR adds support for it. I made same change in Force before: https://github.com/artsy/force/pull/16143

Not attaching a video recording, since this feature doesn't work in simulator (at least in mine). But I confirm that everything works with a debugger.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: view in room works for artworks with diameters

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1925]: https://artsyproduct.atlassian.net/browse/ONYX-1925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ