### PR TITLE
fix(PBRW-1206): add bottom padding for infoButton component

### DIFF
--- a/src/app/Components/Artist/ArtistInsights/MarketStats.tsx
+++ b/src/app/Components/Artist/ArtistInsights/MarketStats.tsx
@@ -70,6 +70,7 @@ const MarketStats: React.FC<MarketStatsProps> = ({ priceInsightsConnection }) =>
           }}
           modalTitle="Market Signals"
           modalContent={<InfoModalContent />}
+          isPresentedModally
         />
       </Flex>
       <Text variant="xs" color="mono60" my={0.5}>

--- a/src/app/Components/Buttons/InfoButton.tsx
+++ b/src/app/Components/Buttons/InfoButton.tsx
@@ -110,7 +110,9 @@ export const AutoHeightInfoModal: React.FC<{
   const containerComponent = useMemo(() => {
     if (Platform.OS === "ios") {
       return ({ children }: { children?: React.ReactNode }) => (
-        <FullWindowOverlay>{children}</FullWindowOverlay>
+        <FullWindowOverlay>
+          <Flex height="100%">{children}</Flex>
+        </FullWindowOverlay>
       )
     }
 
@@ -143,7 +145,10 @@ export const AutoHeightInfoModal: React.FC<{
           : undefined
       }
     >
-      <SafeAreaView edges={["bottom", "top"]}>
+      <SafeAreaView
+        edges={["bottom", "top"]}
+        style={Platform.OS === "ios" ? { paddingBottom: space(2) } : {}}
+      >
         <Flex maxHeight={MAX_CONTENT_HEIGHT}>
           <Text mx={2} variant="lg-display">
             {modalTitle ?? title}

--- a/src/app/Components/Buttons/InfoButton.tsx
+++ b/src/app/Components/Buttons/InfoButton.tsx
@@ -11,7 +11,8 @@ import {
 } from "@artsy/palette-mobile"
 import { AutoHeightBottomSheet } from "app/Components/BottomSheet/AutoHeightBottomSheet"
 import { forwardRef, useImperativeHandle, useMemo, useState } from "react"
-import { Modal, Platform, ScrollView, SafeAreaView } from "react-native"
+import { Modal, Platform, ScrollView } from "react-native"
+import { SafeAreaView } from "react-native-safe-area-context"
 import { FullWindowOverlay } from "react-native-screens"
 
 interface InfoButtonProps {
@@ -108,13 +109,13 @@ export const AutoHeightInfoModal: React.FC<{
 
   const containerComponent = useMemo(() => {
     if (Platform.OS === "ios") {
-      return ({ children }: { children: React.ReactElement }) => (
+      return ({ children }: { children?: React.ReactNode }) => (
         <FullWindowOverlay>{children}</FullWindowOverlay>
       )
     }
 
     if (Platform.OS === "android" && isPresentedModally) {
-      return ({ children }: { children: React.ReactElement }) => (
+      return ({ children }: { children?: React.ReactNode }) => (
         <Modal visible={visible} transparent statusBarTranslucent>
           {children}
         </Modal>
@@ -131,7 +132,6 @@ export const AutoHeightInfoModal: React.FC<{
     <AutoHeightBottomSheet
       visible={visible}
       onDismiss={onDismiss}
-      // @ts-expect-error REACT_18_UPGRADE
       containerComponent={containerComponent}
       handleIndicatorStyle={
         // Inside modals, the gesture detector is not working on Android.
@@ -143,11 +143,7 @@ export const AutoHeightInfoModal: React.FC<{
           : undefined
       }
     >
-      <SafeAreaView
-        style={{
-          paddingBottom: space(2),
-        }}
-      >
+      <SafeAreaView edges={["bottom", "top"]}>
         <Flex maxHeight={MAX_CONTENT_HEIGHT}>
           <Text mx={2} variant="lg-display">
             {modalTitle ?? title}
@@ -161,7 +157,7 @@ export const AutoHeightInfoModal: React.FC<{
 
           <Spacer y={2} />
 
-          <Flex px={2} pb={2}>
+          <Flex px={2}>
             <Button variant="outline" block onPress={onDismiss}>
               Close
             </Button>

--- a/src/app/Components/Buttons/InfoButton.tsx
+++ b/src/app/Components/Buttons/InfoButton.tsx
@@ -110,9 +110,7 @@ export const AutoHeightInfoModal: React.FC<{
   const containerComponent = useMemo(() => {
     if (Platform.OS === "ios") {
       return ({ children }: { children?: React.ReactNode }) => (
-        <FullWindowOverlay>
-          <Flex height="100%">{children}</Flex>
-        </FullWindowOverlay>
+        <FullWindowOverlay>{children}</FullWindowOverlay>
       )
     }
 

--- a/src/app/Components/Buttons/InfoButton.tsx
+++ b/src/app/Components/Buttons/InfoButton.tsx
@@ -161,7 +161,7 @@ export const AutoHeightInfoModal: React.FC<{
 
           <Spacer y={2} />
 
-          <Flex px={2}>
+          <Flex px={2} pb={2}>
             <Button variant="outline" block onPress={onDismiss}>
               Close
             </Button>


### PR DESCRIPTION
This PR resolves [PBRW-1206] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
| Before | After iOS 1 | After iOS 2 | After Android 1 (scrolling fixed too) | After Android 2 |
| --- | --- | --- | --- | --- | 
| <img width="250"  alt="image" src="https://github.com/user-attachments/assets/b6cd4213-97d0-44c1-9060-366939355261" /> | <img width="250"  alt="image" src="https://github.com/user-attachments/assets/37c6422c-e4ba-4efc-92de-0532c1c8711d" /> | <img width="250"  alt="image" src="https://github.com/user-attachments/assets/22eeab32-2756-4319-8050-0024f0924d1f" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/c90e69ef-0e38-42a7-8747-6f818720bd92" /> | <img width="250"  alt="image" src="https://github.com/user-attachments/assets/6d6ded51-410c-4b3f-81e5-ed525e464e11" /> |
 
<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix bottom padding for infoButton component

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1206]: https://artsyproduct.atlassian.net/browse/PBRW-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ