### PR TITLE
fix(hotfix): missing commercial actions in discover daily

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheetFooter.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheetFooter.tsx
@@ -180,6 +180,7 @@ export const InfiniteDiscoveryBottomSheetFooterQueryRenderer: FC<InfiniteDiscove
     ErrorFallback: (_errorProps, props) => {
       return <InfiniteDiscoveryBottomSheetFooterErrorFallback {...props} />
     },
+    disableFadeIn: true,
   })
 
 const InfiniteDiscoveryBottomSheetFooterErrorFallback: React.FC<

--- a/src/app/utils/hooks/withSuspense.tsx
+++ b/src/app/utils/hooks/withSuspense.tsx
@@ -35,6 +35,12 @@ type WithSuspenseOptions<T> = {
   ErrorFallback:
     | ((props: FallbackProps, componentProps: T) => ReactElement | null)
     | typeof NoFallback
+
+  /**
+   * Skip the FadeIn animation for components that manage their own opacity/animation.
+   * Useful for components like BottomSheet footers that have conflicting animations.
+   */
+  disableFadeIn?: boolean
 }
 
 const DefaultLoadingFallback: React.FC = () => (
@@ -57,6 +63,7 @@ export const withSuspense = <T extends Object | any>({
   Component,
   LoadingFallback,
   ErrorFallback,
+  disableFadeIn = false,
 }: WithSuspenseOptions<T>): React.FC<T> => {
   const LoadingFallbackComponent =
     LoadingFallback === SpinnerFallback ? DefaultLoadingFallback : LoadingFallback
@@ -82,9 +89,13 @@ export const withSuspense = <T extends Object | any>({
             </ProvidePlaceholderContext>
           }
         >
-          <FadeIn style={{ flex: 1 }} slide={false}>
+          {disableFadeIn ? (
             <Component {...props} />
-          </FadeIn>
+          ) : (
+            <FadeIn style={{ flex: 1 }} slide={false}>
+              <Component {...props} />
+            </FadeIn>
+          )}
         </Suspense>
       </ErrorBoundary>
     )


### PR DESCRIPTION
This PR fixes a bug where the commercial action buttons were not appearing in the footer of the Discover Daily "swipe up" bottom sheet.

The `FadeIn` component starts with `opacity: 0` (from `showing.value = 0`) and animates to `opacity: 1`. When this wraps the footer component, it creates a conflicting opacity animation with the footer's own reversedOpacityStyle opacity.

The footer's `InfiniteDiscoveryBottomSheetFooterQueryRenderer` is wrapped by `withSuspense`, so it gets the `FadeIn` treatment, which starts invisible and fades in - but this interferes with the footer's own visibility logic.

| Before | After |
|-|-|
| <img width="1080" height="2340" alt="before" src="https://github.com/user-attachments/assets/ca5a3e04-340f-4712-a8fe-f81f8d8672a7" /> | <img width="1080" height="2340" alt="after" src="https://github.com/user-attachments/assets/018cc4c7-7418-43d4-9349-e6b0bb92922b" /> |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-25 at 10 58 00" src="https://github.com/user-attachments/assets/515a39a4-8caa-46ba-884d-a9b358f42c1d" /> | <img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-09-25 at 13 24 59" src="https://github.com/user-attachments/assets/3d7e8928-25d7-4efb-bc8a-b8082ab48a5c" /> |


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixes a bug that prevented users from purchasing artworks in Discover Daily

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
