### PR TITLE
chore: add regression testing to withSuspense

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheetFooter.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryBottomSheetFooter.tsx
@@ -180,7 +180,6 @@ export const InfiniteDiscoveryBottomSheetFooterQueryRenderer: FC<InfiniteDiscove
     ErrorFallback: (_errorProps, props) => {
       return <InfiniteDiscoveryBottomSheetFooterErrorFallback {...props} />
     },
-    disableFadeIn: true,
   })
 
 const InfiniteDiscoveryBottomSheetFooterErrorFallback: React.FC<

--- a/src/app/store/__tests__/withSuspense.tests.tsx
+++ b/src/app/store/__tests__/withSuspense.tests.tsx
@@ -1,0 +1,18 @@
+import { render } from "@testing-library/react-native"
+import { NoFallback, SpinnerFallback, withSuspense } from "app/utils/hooks/withSuspense"
+import { View } from "react-native"
+
+const TestRenderer = () => <View testID="test-id"></View>
+
+describe("withSuspense", () => {
+  it("directly renders the component without any wrappers", () => {
+    const WrappedComponent = withSuspense({
+      Component: TestRenderer,
+      LoadingFallback: SpinnerFallback,
+      ErrorFallback: NoFallback,
+    })
+
+    const { root } = render(<WrappedComponent />)
+    expect(root.props.testID).toBe("test-id")
+  })
+})

--- a/src/app/utils/hooks/withSuspense.tsx
+++ b/src/app/utils/hooks/withSuspense.tsx
@@ -1,9 +1,11 @@
 import { Flex, Spinner } from "@artsy/palette-mobile"
 import { captureException } from "@sentry/react-native"
+import { BottomSheetModalAwareView } from "app/Components/BottomSheetAwareView"
 import { FadeIn } from "app/Components/FadeIn"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ReactElement, Suspense } from "react"
 import { ErrorBoundary, FallbackProps } from "react-error-boundary"
+import { View } from "react-native"
 
 /**
  * A symbol used to indicate that no error fallback should be rendered.
@@ -89,13 +91,7 @@ export const withSuspense = <T extends Object | any>({
             </ProvidePlaceholderContext>
           }
         >
-          {disableFadeIn ? (
-            <Component {...props} />
-          ) : (
-            <FadeIn style={{ flex: 1 }} slide={false}>
-              <Component {...props} />
-            </FadeIn>
-          )}
+          <Component {...props} />
         </Suspense>
       </ErrorBoundary>
     )

--- a/src/app/utils/hooks/withSuspense.tsx
+++ b/src/app/utils/hooks/withSuspense.tsx
@@ -1,11 +1,8 @@
 import { Flex, Spinner } from "@artsy/palette-mobile"
 import { captureException } from "@sentry/react-native"
-import { BottomSheetModalAwareView } from "app/Components/BottomSheetAwareView"
-import { FadeIn } from "app/Components/FadeIn"
 import { ProvidePlaceholderContext } from "app/utils/placeholders"
 import { ReactElement, Suspense } from "react"
 import { ErrorBoundary, FallbackProps } from "react-error-boundary"
-import { View } from "react-native"
 
 /**
  * A symbol used to indicate that no error fallback should be rendered.
@@ -37,12 +34,6 @@ type WithSuspenseOptions<T> = {
   ErrorFallback:
     | ((props: FallbackProps, componentProps: T) => ReactElement | null)
     | typeof NoFallback
-
-  /**
-   * Skip the FadeIn animation for components that manage their own opacity/animation.
-   * Useful for components like BottomSheet footers that have conflicting animations.
-   */
-  disableFadeIn?: boolean
 }
 
 const DefaultLoadingFallback: React.FC = () => (
@@ -65,7 +56,6 @@ export const withSuspense = <T extends Object | any>({
   Component,
   LoadingFallback,
   ErrorFallback,
-  disableFadeIn = false,
 }: WithSuspenseOptions<T>): React.FC<T> => {
   const LoadingFallbackComponent =
     LoadingFallback === SpinnerFallback ? DefaultLoadingFallback : LoadingFallback


### PR DESCRIPTION
### Description

This PR is a follow-up to https://github.com/artsy/eigen/pull/12785

In this PR I added a test to make sure the same regression doesn't happen again  + I removed the Fade from the wrapper to do that case by case in the future.


https://github.com/user-attachments/assets/bc911792-deac-4b12-ad37-444dde152692



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- add regression testing to withSuspense - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
