### PR TITLE
chore: add impressions tracking to artwork sections

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -82,6 +82,7 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   /** allows for artwork to be added to recent searches */
   updateRecentSearchesOnTap?: boolean
   hideCreateAlertOnArtworkPreview?: boolean
+  enableImpressionsTracking?: boolean
 }
 
 export const Artwork: React.FC<ArtworkProps> = memo(
@@ -116,6 +117,7 @@ export const Artwork: React.FC<ArtworkProps> = memo(
     trackTap,
     updateRecentSearchesOnTap = false,
     hideCreateAlertOnArtworkPreview = false,
+    enableImpressionsTracking = false,
   }) => {
     const itemRef = useRef<any>(null)
     const disappearableRef = useRef<Disappearable>(null)
@@ -277,6 +279,12 @@ export const Artwork: React.FC<ArtworkProps> = memo(
             haptic
             underlayColor={color("mono0")}
             onPress={handleTap}
+            onVisible={() => {
+              if (enableImpressionsTracking) {
+                console.log("artwork impression", artwork.internalID)
+              }
+            }}
+            visibilityThreshold={0.7}
             // To prevent navigation when opening the long-press context menu, `onLongPress` & `delayLongPress` need to be set (https://github.com/mpiannucci/react-native-context-menu-view/issues/60)
             onLongPress={() => {
               // Adroid long press is tracked inside of the ContextMenuArtwork component

--- a/src/app/Components/ArtworkGrids/MasonryArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryArtworkGridItem.tsx
@@ -30,14 +30,15 @@ interface MasonryArtworkGridItemProps extends Omit<ArtworkProps, "artwork"> {
   contextScreenOwnerId?: string
   contextScreenOwnerSlug?: string
   contextScreenOwnerType?: ScreenOwnerType
+  enableImpressionsTracking?: boolean
+  hideSaleInfo?: boolean
+  hideSaveIcon?: boolean
   index: number
   item: Artwork
   numColumns?: number
   onPress?: (artworkID: string, artwork?: ArtworkGridItem_artwork$data) => void
   partnerOffer?: PartnerOffer | null
   priceOfferMessage?: PriceOfferMessage
-  hideSaveIcon?: boolean
-  hideSaleInfo?: boolean
 }
 
 export const MasonryArtworkGridItem: React.FC<MasonryArtworkGridItemProps> = ({

--- a/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
+++ b/src/app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid.tsx
@@ -31,13 +31,14 @@ interface MasonryInfiniteScrollArtworkGridProps extends MasonryFlashListOmittedP
   /** Do not show add to artworks list prompt */
   disableArtworksListPrompt?: boolean
   disableProgressiveOnboarding?: boolean
+  enableImpressionsTracking?: boolean
   hasMore?: boolean
   hideCreateAlertOnArtworkPreview?: boolean
   hideCuratorsPick?: boolean
   hideIncreasedInterest?: boolean
-  hideViewFollowsLink?: boolean
   hideSaleInfo?: boolean
   hideSaveIcon?: boolean
+  hideViewFollowsLink?: boolean
   isLoading?: boolean
   loadMore?: (pageSize: number) => void
   onPress?: (artworkID: string) => void
@@ -63,6 +64,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   contextScreenOwnerType,
   disableArtworksListPrompt,
   disableProgressiveOnboarding,
+  enableImpressionsTracking,
   hasMore,
   hideCreateAlertOnArtworkPreview,
   hideCuratorsPick,
@@ -71,15 +73,15 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
   hideSaveIcon,
   isLoading,
   ListEmptyComponent,
+  ListFooterComponent,
   ListHeaderComponent,
   loadMore,
   onPress,
+  onViewableItemsChanged,
   pageSize = MASONRY_LIST_PAGE_SIZE,
   partnerOffer,
   priceOfferMessage,
   refreshControl,
-  ListFooterComponent,
-  onViewableItemsChanged,
   viewabilityConfig,
   ...rest
 }) => {
@@ -112,6 +114,7 @@ export const MasonryInfiniteScrollArtworkGrid: React.FC<MasonryInfiniteScrollArt
           // Extra space between items for one column artwork grids
           paddingBottom: rest.numColumns !== 1 ? 0 : artworks.length === 1 ? space(2) : space(4),
         }}
+        enableImpressionsTracking={enableImpressionsTracking}
         partnerOffer={partnerOffer}
         priceOfferMessage={priceOfferMessage}
         onPress={onPress}

--- a/src/app/Scenes/Artwork/Components/OtherWorks/OtherWorks.tsx
+++ b/src/app/Scenes/Artwork/Components/OtherWorks/OtherWorks.tsx
@@ -1,17 +1,14 @@
-import { ContextModule } from "@artsy/cohesion"
-import { Spacer, Box, Text, useSpace, Separator, Join } from "@artsy/palette-mobile"
+import { Box, Join, Separator } from "@artsy/palette-mobile"
 import { Artwork_artworkBelowTheFold$data } from "__generated__/Artwork_artworkBelowTheFold.graphql"
 import { OtherWorks_artwork$data } from "__generated__/OtherWorks_artwork.graphql"
-import GenericGrid from "app/Components/ArtworkGrids/GenericGrid"
-import { extractNodes } from "app/utils/extractNodes"
-import { useScreenDimensions } from "app/utils/hooks"
-import { Schema } from "app/utils/track"
+import { OtherWorksSection } from "app/Scenes/Artwork/Components/OtherWorks/OtherWorksSection"
 import { filter } from "lodash"
 import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { ContextGridCTA } from "./ContextGridCTA"
 
-type OtherWorksGrid = NonNullable<NonNullable<OtherWorks_artwork$data["contextGrids"]>[number]>
+export type OtherWorksGrid = NonNullable<
+  NonNullable<OtherWorks_artwork$data["contextGrids"]>[number]
+>
 type ArtworkGrid = NonNullable<
   NonNullable<Artwork_artworkBelowTheFold$data["contextGrids"]>[number]
 >
@@ -26,8 +23,6 @@ export const populatedGrids = (grids?: ReadonlyArray<Grid | null | undefined> | 
 }
 
 const OtherWorks: React.FC<{ artwork: OtherWorks_artwork$data }> = ({ artwork }) => {
-  const { width } = useScreenDimensions()
-  const space = useSpace()
   const grids = artwork.contextGrids
   const gridsToShow = populatedGrids(grids) as ReadonlyArray<OtherWorksGrid>
 
@@ -44,25 +39,7 @@ const OtherWorks: React.FC<{ artwork: OtherWorks_artwork$data }> = ({ artwork })
       }
     >
       {gridsToShow.map((grid, index) => (
-        <React.Fragment key={`Grid-${index}`}>
-          <Text variant="md" textAlign="left">
-            {grid.title}
-          </Text>
-          <Spacer y={2} />
-          <GenericGrid
-            trackingFlow={Schema.Flow.RecommendedArtworks}
-            contextModule={grid.__typename as ContextModule}
-            artworks={extractNodes(grid.artworks)}
-            width={width - space(2)}
-          />
-          <Box mt={2}>
-            <ContextGridCTA
-              contextModule={grid.__typename}
-              href={grid.ctaHref || undefined}
-              label={grid.ctaTitle ?? ""}
-            />
-          </Box>
-        </React.Fragment>
+        <OtherWorksSection key={`Grid-${index}`} grid={grid} index={index} artwork={artwork} />
       ))}
     </Join>
   )
@@ -71,6 +48,8 @@ const OtherWorks: React.FC<{ artwork: OtherWorks_artwork$data }> = ({ artwork })
 export const OtherWorksFragmentContainer = createFragmentContainer(OtherWorks, {
   artwork: graphql`
     fragment OtherWorks_artwork on Artwork {
+      internalID
+      slug
       contextGrids {
         __typename
         title
@@ -79,7 +58,15 @@ export const OtherWorksFragmentContainer = createFragmentContainer(OtherWorks, {
         artworks: artworksConnection(first: 6) {
           edges {
             node {
-              ...GenericGrid_artworks
+              id
+              slug
+              href
+              # ...GenericGrid_artworks
+              image(includeAll: false) {
+                aspectRatio
+                blurhash
+              }
+              ...ArtworkGridItem_artwork @arguments(includeAllImages: false)
             }
           }
         }

--- a/src/app/Scenes/Artwork/Components/OtherWorks/OtherWorksSection.tsx
+++ b/src/app/Scenes/Artwork/Components/OtherWorks/OtherWorksSection.tsx
@@ -1,0 +1,54 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { Box, Flex, Spacer, Text } from "@artsy/palette-mobile"
+import { OtherWorks_artwork$data } from "__generated__/OtherWorks_artwork.graphql"
+import { MasonryInfiniteScrollArtworkGrid } from "app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid"
+import { ContextGridCTA } from "app/Scenes/Artwork/Components/OtherWorks/ContextGridCTA"
+import { OtherWorksGrid } from "app/Scenes/Artwork/Components/OtherWorks/OtherWorks"
+import { extractNodes } from "app/utils/extractNodes"
+import React from "react"
+
+// This would be better controlled from the backend
+export const GRID_TO_TRACK = "Related works"
+
+export const OtherWorksSection: React.FC<{
+  grid: OtherWorksGrid
+  index: number
+  artwork: OtherWorks_artwork$data
+}> = ({ grid, index, artwork }) => {
+  return (
+    <React.Fragment key={`Grid-${index}`}>
+      <Text variant="md" textAlign="left">
+        {grid.title}
+      </Text>
+
+      <Spacer y={2} />
+
+      <Flex
+        // We are setting a negative margin to the flex container to offset the default margin
+        // of the masonry grid items
+        mx={-2}
+      >
+        <MasonryInfiniteScrollArtworkGrid
+          artworks={extractNodes(grid.artworks)}
+          loadMore={() => {}}
+          hasMore={false}
+          numColumns={2}
+          contextModule={grid.__typename as ContextModule}
+          contextScreenOwnerType={OwnerType.artwork}
+          nestedScrollEnabled={false}
+          contextScreenOwnerId={artwork.internalID}
+          contextScreenOwnerSlug={artwork.slug}
+          enableImpressionsTracking={grid.title === GRID_TO_TRACK}
+        />
+      </Flex>
+
+      <Box mt={2}>
+        <ContextGridCTA
+          contextModule={grid.__typename}
+          href={grid.ctaHref || undefined}
+          label={grid.ctaTitle ?? ""}
+        />
+      </Box>
+    </React.Fragment>
+  )
+}


### PR DESCRIPTION
### Description

This is a first POC implementation of tracking artwork impressions on Artwork screens.

A few things are left to figure out here:
- The sticky bottom is messing up the computation logic because it's on top of the screen
- This API isn't as fancy as the viewability config pairs from RN and currently doesn't support minimum view duration. Maybe it's possible to add it though.

**Other paths tried**
I tried the viewability config pairs but because it's 2 nested scrollviews, it quickly got so complicated I got lost in the maths. 


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
