### PR TITLE
chore: do not prefetch RouterLink on new architecture

### DIFF
--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -4,6 +4,7 @@ import { navigate, NavigateOptions } from "app/system/navigation/navigate"
 import { Sentinel } from "app/utils/Sentinel"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { isNewArchitectureEnabled } from "app/utils/isNewArchitectureEnabled"
 import { usePrefetch } from "app/utils/queryPrefetching"
 import React, { useState } from "react"
 import { GestureResponderEvent } from "react-native"
@@ -40,7 +41,8 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   const enableViewPortPrefetching = useFeatureFlag("AREnableViewPortPrefetching")
   const [prefetchState, setPrefetchState] = useState<PrefetchState>(null)
 
-  const isPrefetchingEnabled = !disablePrefetch && enableViewPortPrefetching && to
+  const isPrefetchingEnabled =
+    !disablePrefetch && enableViewPortPrefetching && to && !isNewArchitectureEnabled
 
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)

--- a/src/app/system/navigation/__tests__/RouterLink.tests.tsx
+++ b/src/app/system/navigation/__tests__/RouterLink.tests.tsx
@@ -7,6 +7,8 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { useEffect } from "react"
 import { TouchableWithoutFeedback, View } from "react-native"
 
+let mockIsNewArchitectureEnabled = false
+
 jest.mock("app/utils/queryPrefetching", () => ({
   usePrefetch: () => mockPrefetch,
 }))
@@ -14,6 +16,12 @@ jest.mock("app/utils/queryPrefetching", () => ({
 jest.mock("app/utils/Sentinel", () => ({
   __esModule: true,
   Sentinel: (props: any) => <MockedVisibleSentinel {...props} />,
+}))
+
+jest.mock("app/utils/isNewArchitectureEnabled", () => ({
+  get isNewArchitectureEnabled() {
+    return mockIsNewArchitectureEnabled
+  },
 }))
 
 describe("RouterLink", () => {
@@ -152,6 +160,22 @@ describe("RouterLink", () => {
 
       it("does not prefetch", () => {
         expect(mockPrefetch).not.toHaveBeenCalledWith("/test-route")
+      })
+    })
+
+    describe("when isNewArchitectureEnabled is true", () => {
+      beforeAll(() => {
+        mockIsNewArchitectureEnabled = true
+      })
+
+      afterAll(() => {
+        mockIsNewArchitectureEnabled = false
+      })
+
+      it("does not prefetch", () => {
+        renderWithWrappers(<TestComponent />)
+
+        expect(mockPrefetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/app/utils/isNewArchitectureEnabled.ts
+++ b/src/app/utils/isNewArchitectureEnabled.ts
@@ -1,0 +1,4 @@
+// Check if the global `nativeFabric` object exists.
+// Its presence indicates that Fabric is running.
+// @ts-expect-error nativeFabricUIManager is only available in the new architecture and isn't typed yet
+export const isNewArchitectureEnabled = !!global.nativeFabricUIManager


### PR DESCRIPTION
This PR resolves [PHIRE-2389] <!-- eg [PROJECT-XXXX] -->

### Description

This PR disables prefetching `RouterLink` components on the new architecture. This change is required in order to make the home view usable.

**Rationale:**
Currently, our `Sentinel` component creates an interval on `RouterLink` to measure components position. We do that so:
```typescript
useEffect(() => {
    startWatching()
    return stopWatching
  }, [])

  const startWatching = () => {
    if (interval) {
      return
    }

    interval = setInterval(() => {
      if (!myView || !myView.current) {
        return
      }

      myView.current.measure(
        async (_args) => {
          isInViewPort(_args)
        }
      )
    }, 1000)
  }
```

The latter was fine in the old architecture and didn't lead to a performance degradation, however in the new architecture, it plummeted the performance and had a big impact on the CPU load.

Hopefully, we will find a replacement to keep a similar experience and find an alternative to our `Sentinel`. I will look into doing this on a different thread later to see if we can offset the load

| After | After |
|--------|--------|
| <img width="1508" height="626" alt="Screenshot 2025-10-10 at 14 43 26" src="https://github.com/user-attachments/assets/a8e2c6e6-7554-4721-bc9a-0e2da475985e" /> | <img width="1333" height="580" alt="Screenshot 2025-10-10 at 14 43 31" src="https://github.com/user-attachments/assets/93136428-a68a-4ecc-a829-060e80508a7f" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- do not prefetch RouterLink on new architecture - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2389]: https://artsyproduct.atlassian.net/browse/PHIRE-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ