### PR TITLE
fix: bottom icon height on new architecture

### DIFF
--- a/src/app/Navigation/utils/useBottomTabsBadges.ts
+++ b/src/app/Navigation/utils/useBottomTabsBadges.ts
@@ -24,8 +24,11 @@ export const useBottomTabsBadges = () => {
   const visualClueStyles = {
     backgroundColor: color("blue100"),
     top: 2,
+    // We are defining both max and min width and height to ensure the badge is a circle on the new architecture
     minWidth: VISUAL_CLUE_HEIGHT,
+    maxWidth: VISUAL_CLUE_HEIGHT,
     maxHeight: VISUAL_CLUE_HEIGHT,
+    minHeight: VISUAL_CLUE_HEIGHT,
     borderRadius: VISUAL_CLUE_HEIGHT / 2,
     borderColor: color("mono0"),
     borderWidth: 1,


### PR DESCRIPTION
This PR resolves [PHIRE-2390] <!-- eg [PROJECT-XXXX] -->

### Description

On the new architecture, we have a problem with the bottom icons style when there is a notification.

**On the new architecture**
| Before | After |
|--------|--------|
| <img width="259" height="607" alt="Screenshot 2025-10-10 at 15 09 34" src="https://github.com/user-attachments/assets/85f1e39e-eeb8-4dd4-a114-6e4798294179" /> | <img width="267" height="646" alt="Screenshot 2025-10-10 at 15 09 53" src="https://github.com/user-attachments/assets/b3ae833a-ae51-4b9a-99e9-1f9302b2a619" /> | 


___

| The old Architecture |
|--------|
| <img width="500" src="https://github.com/user-attachments/assets/b6886c9c-a6fe-4c69-a693-aa62990b928b" /> | 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix - bottom icon height on new architecture - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2390]: https://artsyproduct.atlassian.net/browse/PHIRE-2390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ