### PR TITLE
fix: hide back button on first artwork of art quiz

### DIFF
--- a/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
+++ b/src/app/Scenes/ArtQuiz/ArtQuizArtworks.tsx
@@ -10,7 +10,8 @@ import { FancySwiper, FancySwiperArtworkCard } from "app/Components/FancySwiper/
 import { usePopoverMessage } from "app/Components/PopoverMessage/popoverMessageHooks"
 import { ArtQuizLoader } from "app/Scenes/ArtQuiz/ArtQuizLoader"
 import { GlobalStore } from "app/store/GlobalStore"
-import { goBack, navigate } from "app/system/navigation/navigate"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
 import { isEmpty } from "lodash"
 import { Suspense, useEffect, useMemo, useState } from "react"
@@ -106,9 +107,7 @@ const ArtQuizArtworksScreen = () => {
 
   const handleOnBack = () => {
     popoverMessage.hide()
-    if (activeCardIndex === 0) {
-      goBack()
-    } else {
+    if (activeCardIndex !== 0) {
       const previousArtwork = artworks[activeCardIndex - 1]
 
       setActiveCardIndex(activeCardIndex - 1)
@@ -169,6 +168,7 @@ const ArtQuizArtworksScreen = () => {
     <Screen>
       <Screen.Header
         onBack={handleOnBack}
+        hideLeftElements={activeCardIndex === 0}
         title={`${activeCardIndex + 1}/${artworks.length}`}
         rightElements={
           <Touchable accessibilityRole="button" haptic="impactLight" onPress={handleOnSkip}>


### PR DESCRIPTION
This PR resolves [PHIRE-2406] <!-- eg [PROJECT-XXXX] -->

### Description

Steps to repro:
```
1. Open Artsy app
2. Complete Sign Up flow (Email. Password, Full Name)
3. On the flow, tap on "Get Started" 
4. Select "Yes, I love collecting art"  (and tap on Next button)
5. Select "Developing my art tastes" (and tap on Next button)
6. Select "The Art Taste Quiz" (and tap on Next button)
7. Tap on "Start the Quiz"
8. Tap on back arrow on the top left of the screen
```

Expected Result:

User should not be able to go back when on the first artwork, they can only tap close and dismiss the artquiz or proceed with it.

Actual Result:

User is able to go back when on the first artwork, and a blank screen is appearing

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/ffa8f7a6-8cd0-4dd2-814b-ba5c447fa904" width="400" /> | <video src="https://github.com/user-attachments/assets/f1be6128-fad6-4ae9-ac8e-1bad904e1931" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-  hide back button on first artwork of art quiz

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2406]: https://artsyproduct.atlassian.net/browse/PHIRE-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ