### PR TITLE
refactor: LiveAuctions more defensive

### DIFF
--- a/ios/Artsy/Models/API_Models/Live/LiveSale.m
+++ b/ios/Artsy/Models/API_Models/Live/LiveSale.m
@@ -41,8 +41,19 @@
 + (NSValueTransformer *)saleArtworksJSONTransformer
 {
     // Mantle doesn't have a clean way to handle data in the shape of a connection.
-    return [MTLValueTransformer transformerWithBlock:^id(NSDictionary *connection) {
+    // We need to be defensive here in case the API returns unexpected data
+    return [MTLValueTransformer transformerWithBlock:^id(id connection) {
+        // Handle nil or unexpected types gracefully
+        if (![connection isKindOfClass:[NSDictionary class]]) {
+            return @[];
+        }
+
         NSArray *edges = connection[@"edges"];
+        // If edges is not an array, return empty array to prevent crashes
+        if (![edges isKindOfClass:[NSArray class]]) {
+            return @[];
+        }
+
         return [edges map:^id(NSDictionary *edge) {
             return [LiveAuctionLot modelWithJSON:edge[@"node"]];
         }];

--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionSalesPerson.swift
@@ -68,7 +68,9 @@ class LiveAuctionsSalesPerson: NSObject, LiveAuctionsSalesPersonType {
          auctionViewModelCreator: AuctionViewModelCreator = LiveAuctionsSalesPerson.defaultAuctionViewModelCreator()) {
 
         self.sale = sale
-        self.lots = sale.saleArtworks.map { LiveAuctionLotViewModel(lot: $0, bidderCredentials: biddingCredentials) }
+        // Defensive check: saleArtworks can be nil if the API response doesn't have the expected structure
+        // In such cases, we default to an empty array to prevent crashes
+        self.lots = (sale.saleArtworks ?? []).map { LiveAuctionLotViewModel(lot: $0, bidderCredentials: biddingCredentials) }
         self.bidderCredentials = biddingCredentials
 
         let host = ARRouter.baseCausalitySocketURLString()!


### PR DESCRIPTION
This PR resolves [PHIRE-2452] <!-- eg [PROJECT-XXXX] -->

### Description

Attempt to make live auctions more defensive to prevent crashes like [this sentry crash](https://artsynet.sentry.io/issues/5509017273/?project=5867225) when 

The crash occurred on line 72 of LiveAuctionSalesPerson.swiftin the initializer:

```
self.lots = sale.saleArtworks.map { ... }
```

When `sale.saleArtworks` was nil (due to unexpected API response structure or error or timeout), calling .map() on a nil value caused the crash. The issue originated from the Mantle JSON transformer in LiveSale.m.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix auction crash

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2452]: https://artsyproduct.atlassian.net/browse/PHIRE-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ