### PR TITLE
fix(DIAM-152): blank explore by rails

### DIFF
--- a/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
+++ b/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
@@ -43,11 +43,11 @@ export const CollectionRail: FC<CollectionRailProps> = ({
 
   return (
     <>
-      <Flex pl={2}>
+      <Flex>
         <SectionTitle
           href={`/collection/${collection.slug}`}
           onPress={handleTitlePress}
-          pr={2}
+          px={2}
           RightButtonContent={() => <ChevronRightIcon fill="mono60" ml={0.5} />}
           title={collection.title}
           titleVariant="md"
@@ -56,7 +56,6 @@ export const CollectionRail: FC<CollectionRailProps> = ({
         <ArtworkRail
           onPress={handleArtworkPress}
           artworks={artworks}
-          ListHeaderComponent={null}
           showSaveIcon
           showPartnerName
         />

--- a/src/app/Scenes/CollectionsByCategory/Components/CollectionsByCategoryArtworksWithFiltersRail.tsx
+++ b/src/app/Scenes/CollectionsByCategory/Components/CollectionsByCategoryArtworksWithFiltersRail.tsx
@@ -41,11 +41,11 @@ export const CollectionsByCategoryArtworksWithFiltersRail: FC<
 
   return (
     <>
-      <Flex pl={2}>
+      <Flex>
         <SectionTitle
           href={hrefWithParams(href, title)}
-          pr={2}
           onPress={handleTitlePress}
+          px={2}
           RightButtonContent={() => <ChevronRightIcon fill="mono60" ml={0.5} />}
           title={title}
           titleVariant="md"
@@ -54,7 +54,6 @@ export const CollectionsByCategoryArtworksWithFiltersRail: FC<
         <ArtworkRail
           onPress={handleArtworkPress}
           artworks={artworks}
-          ListHeaderComponent={null}
           showSaveIcon
           showPartnerName
         />

--- a/src/app/Scenes/CollectionsByCategory/Components/CollectionsByCategoryBody.tsx
+++ b/src/app/Scenes/CollectionsByCategory/Components/CollectionsByCategoryBody.tsx
@@ -1,5 +1,4 @@
-import { Flex, Separator, Skeleton, SkeletonText, Text } from "@artsy/palette-mobile"
-import { FlashList } from "@shopify/flash-list"
+import { Flex, Join, Separator, Skeleton, SkeletonText, Text } from "@artsy/palette-mobile"
 import { CollectionsByCategoryBodyQuery } from "__generated__/CollectionsByCategoryBodyQuery.graphql"
 import { CollectionsByCategoryBody_viewer$key } from "__generated__/CollectionsByCategoryBody_viewer.graphql"
 import {
@@ -66,38 +65,32 @@ export const CollectionsByCategoryBody: React.FC<CollectionsByCategoryBodyProps>
       <Separator borderColor="mono10" />
 
       {discoveryCategory.__typename === "DiscoveryMarketingCollection" && (
-        <FlashList
-          estimatedItemSize={ESTIMATED_ITEM_SIZE}
-          data={discoveryCategory.marketingCollections}
-          keyExtractor={(item) => `artwork_rail_${item?.slug}`}
-          ItemSeparatorComponent={() => <Separator borderColor="mono10" my={4} />}
-          renderItem={({ item, index }) => {
+        <Join separator={<Separator borderColor="mono10" my={1} />}>
+          {discoveryCategory.marketingCollections.map((item, index) => {
             return (
               <CollectionRailWithSuspense
+                key={`artwork_rail_${item?.slug}`}
                 slug={item?.slug ?? ""}
                 lastElement={index === discoveryCategory.marketingCollections.length - 1}
               />
             )
-          }}
-        />
+          })}
+        </Join>
       )}
 
       {!!filtersForArtworks && (
-        <FlashList
-          estimatedItemSize={ESTIMATED_ITEM_SIZE}
-          data={filtersForArtworks}
-          keyExtractor={(item) => `artwork_filter_rail_${item?.href}`}
-          ItemSeparatorComponent={() => <Separator borderColor="mono10" my={4} />}
-          renderItem={({ item, index }) => {
+        <Join separator={<Separator borderColor="mono10" my={1} />}>
+          {filtersForArtworks.map((item, index) => {
             return (
               <CollectionsByCategoryArtworksWithFiltersRailWithSuspense
                 {...item}
                 filterSlug={item.slug}
+                key={`artwork_filter_rail_${item?.href}`}
                 lastElement={index === filtersForArtworks.length - 1}
               />
             )
-          }}
-        />
+          })}
+        </Join>
       )}
     </Flex>
   )


### PR DESCRIPTION
This PR resolves [DIAM-152]

### Description

This PR attempts to fix an issue where the artwork rails nested in _Explore by Category_ cards were appearing blank. This happens intermittently and was more noticeable in iOS build 2025.10.24.12, so it is difficult to say if this fix addresses it, but @MounirDhahri and I found some opportunities to improve the performance of these rails by rendering them directly in the top-level ScrollView instead of in a nested FlashList (which also contains a ScrollView). This should cause the bug to be even harder to reproduce in the future.

<img width="412" height="897" alt="Screenshot 2025-10-28 at 11 52 53 AM" src="https://github.com/user-attachments/assets/cbfad3fe-c022-4fee-91ea-fd309c351f6a" />

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixed a bug where explore by rails were appearing blank

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[DIAM-152]: https://artsyproduct.atlassian.net/browse/DIAM-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ