### PR TITLE
Revert "fix: use own node install"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,17 +57,10 @@ commands:
           command: scripts/setup/setup-awscli
   install-node-modules:
     steps:
-      - restore_cache:
-          keys:
-            - << pipeline.parameters.node_modules_cache_key >>
-      - run:
-          name: Install Dependencies
-          command: yarn install --immutable
-      - save_cache:
-          key: << pipeline.parameters.node_modules_cache_key >>
-          paths:
-            - node_modules
-            - .yarn/cache
+      - node/install-packages:
+          check-cache: always
+          pkg-manager: yarn
+          cache-version: << pipeline.parameters.node_modules_cache_key >>
   run-relay-compiler:
     steps:
       - run:
@@ -523,7 +516,7 @@ parameters:
   # Update Manually these versions below in order to hard overwrite the caches
   node_modules_cache_key:
     type: string
-    default: v26-node_modules-{{ checksum ".manifests/node_modules" }}
+    default: v25-node_modules-{{ checksum ".manifests/node_modules" }}
   gems_cache_key:
     type: string
     default: v13-gems-{{ checksum "Gemfile.lock" }}-{{ arch }}


### PR DESCRIPTION
Although the previous PR succeded on its own branch, it broke main

Reverts artsy/eigen#12910
