### PR TITLE
chore: update github action naming conventions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -509,7 +509,7 @@ parameters:
     default: "m4pro.medium"
   normal_mac_runner:
     type: string
-    default: "m4pro.medium"
+    default: "m2pro.medium"
   run_workflow_build-run-tests-for-echo:
     type: boolean
     default: false


### PR DESCRIPTION
This PR updates the github actions using duchamp workflows to match the updated naming convention changes in https://github.com/artsy/duchamp/pull/14.