### PR TITLE
fix: tests after AREnableRedirectForVideoFeatureType ff addition

### DIFF
--- a/src/app/Scenes/Feature/__tests__/Feature.tests.tsx
+++ b/src/app/Scenes/Feature/__tests__/Feature.tests.tsx
@@ -1,5 +1,6 @@
 import { act, screen } from "@testing-library/react-native"
 import { FeatureQueryRenderer } from "app/Scenes/Feature/Feature"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { getMockRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
@@ -12,6 +13,10 @@ describe(FeatureQueryRenderer, () => {
   })
 
   it("renders without failing", async () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({
+      AREnableRedirectForVideoFeatureType: false,
+    })
+
     renderWithWrappers(<FeatureQueryRenderer slug="anything" />)
 
     await act(async () => {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

After the deployment of [echo](https://github.com/artsy/echo/pull/873) the Features.tests.tsx started failing, this PR addresses this issue for now but we need to add another test covering the case for when the feature flag is enabled.

Also created a ticket to fix the behavior of echo and `run-eigen-tests` to respect the new featureflags

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix tests after AREnableRedirectForVideoFeatureType ff addition

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
