### PR TITLE
fix: make sure to remove backfill when auctions hub is enabled

### DIFF
--- a/src/app/Scenes/HomeView/Components/RecommendedAuctionLotsRail.tsx
+++ b/src/app/Scenes/HomeView/Components/RecommendedAuctionLotsRail.tsx
@@ -7,7 +7,7 @@ import {
   ArtworkActionTrackingProps,
   extractArtworkActionTrackingProps,
 } from "app/utils/track/ArtworkActions"
-import React, { memo, useRef } from "react"
+import { memo, useRef } from "react"
 import { View } from "react-native"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -70,8 +70,9 @@ export const RecommendedAuctionLotsRail: React.FC<RecommendedAuctionLotsRailProp
 )
 
 const artworksFragment = graphql`
-  fragment RecommendedAuctionLotsRail_artworkConnection on Viewer {
-    artworksForUser(includeBackfill: true, first: 10, onlyAtAuction: true) {
+  fragment RecommendedAuctionLotsRail_artworkConnection on Viewer
+  @argumentDefinitions(includeBackfill: { type: "Boolean!", defaultValue: true }) {
+    artworksForUser(includeBackfill: $includeBackfill, first: 10, onlyAtAuction: true) {
       edges {
         node {
           title

--- a/src/app/system/flags/experiments.ts
+++ b/src/app/system/flags/experiments.ts
@@ -22,6 +22,10 @@ export const experiments = {
   "onyx_nwfy-artworks-card-test": {
     description: "New card rail type for home view nwfy section",
   },
+  onyx_auctions_hub: {
+    description:
+      "Adds AuctionsHub Section to the home view and replaces the existing Auctions screen",
+  },
 } satisfies { [key: string]: ExperimentDescriptor }
 
 export type EXPERIMENT_NAME = keyof typeof experiments


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Addresses notions card [I only see one card group, even though I have other sections when I tap on “Discover Auctions on Artsy”](https://www.notion.so/artsy/I-only-see-one-card-group-even-though-I-have-other-sections-when-I-tap-on-Discover-Auctions-on-Art-2a3cab0764a0807aa225f2867ddb8823)

[For the auctions hub we are removing backfill](https://github.com/artsy/metaphysics/blob/84a4ec16c4c68928c0684f2f4f195e2f2140337d/src/schema/v2/homeView/sections/AuctionsHub.ts#L52). We need to make sure corresponding rails on eigen are not backfilled either

I don't include videos as for my account nothing change as I probably have enough recommendations

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: make sure to remove backfill when auctions hub is enabled -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
