### PR TITLE
fix(NWFY): Bugs, round 2

### DIFF
--- a/src/app/Scenes/HomeViewSectionScreen/Components/HomeViewSectionScreenArtworks.tsx
+++ b/src/app/Scenes/HomeViewSectionScreen/Components/HomeViewSectionScreenArtworks.tsx
@@ -212,7 +212,7 @@ export const HomeViewSectionScreenArtworks: React.FC<ArtworksScreenHomeSection> 
               offset: width * index,
             }
           }}
-          initialNumToRender={4}
+          removeClippedSubviews={false}
           snapToInterval={width}
           snapToAlignment="start"
           snapToEnd={false}


### PR DESCRIPTION
This PR resolves [Bug1](https://www.notion.so/artsy/iOS-When-opening-the-DD-experience-and-the-first-artwork-is-already-saved-the-save-animation-is-pla-2a1cab0764a08047aba2e57ee6f64935?source=copy_link) and [Bug2](https://www.notion.so/artsy/Design-has-a-sneak-peak-of-the-artwork-before-and-after-in-the-carousel-Has-that-been-cut-from-scop-2a1cab0764a080efa62deffab1721181?source=copy_link) by the commits, respectively.

### Description

Fixes:
- Animation triggered on entering the NWFY screen with a saved artwork
- Android not showing next/previous cards when they should be visible

cc @artsy/onyx-devs 

| Patform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/a9c6d201-cc44-42dc-84c1-6e9d91960c94" width="400" /> | <video src="https://github.com/user-attachments/assets/0d930467-9a51-4b42-8418-f48f3e1e26b1" width="400" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: save animation triggered when entering the screen, Android not showing the next/previous cards

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
