### PR TITLE
fix: remove echo ff from auctions hub implementation

### DIFF
--- a/src/app/Scenes/HomeView/Sections/Section.tsx
+++ b/src/app/Scenes/HomeView/Sections/Section.tsx
@@ -37,7 +37,6 @@ export interface SectionSharedProps extends FlexProps {
 
 export const Section: React.FC<SectionProps> = memo(({ section, ...rest }) => {
   const enableNavigationPills = useFeatureFlag("AREnableHomeViewQuickLinks")
-  const enableAuctionsHub = useFeatureFlag("AREnableAuctionsHubOnHomeView")
   const { variant: quickLinksExperimentVariant } = useExperimentVariant(
     "onyx_quick-links-experiment"
   )
@@ -66,11 +65,7 @@ export const Section: React.FC<SectionProps> = memo(({ section, ...rest }) => {
     case "HomeViewSectionCard":
       return <HomeViewSectionCardQueryRenderer sectionID={section.internalID} {...rest} />
     case "HomeViewSectionCards": {
-      if (section.internalID === "home-view-section-auctions-hub") {
-        if (enableAuctionsHub) {
-          return <HomeViewSectionCardsQueryRenderer sectionID={section.internalID} {...rest} />
-        } else return null
-      } else return <HomeViewSectionCardsQueryRenderer sectionID={section.internalID} {...rest} />
+      return <HomeViewSectionCardsQueryRenderer sectionID={section.internalID} {...rest} />
     }
     case "HomeViewSectionGeneric":
       return <HomeViewSectionGeneric section={section} {...rest} />

--- a/src/app/Scenes/Sales/Sales.tsx
+++ b/src/app/Scenes/Sales/Sales.tsx
@@ -7,7 +7,6 @@ import { SaleListActiveBids } from "app/Scenes/Sales/Components/SaleListActiveBi
 // eslint-disable-next-line no-restricted-imports
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 import { goBack, navigate } from "app/system/navigation/navigate"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { Suspense, useRef, useState } from "react"
@@ -45,12 +44,10 @@ export const SalesScreenQuery = graphql`
 `
 
 export const Sales: React.FC = () => {
-  const enableAuctionsHubOnHomeView = useFeatureFlag("AREnableAuctionsHubOnHomeView")
   const { variant } = useExperimentVariant("onyx_auctions_hub")
 
   // include backfill in case of not using AuctionsHub HomeView section
-  const includeBackfill =
-    !enableAuctionsHubOnHomeView || !(variant && variant.enabled && variant.name === "experiment")
+  const includeBackfill = !(variant && variant.enabled && variant.name === "experiment")
 
   const data = useLazyLoadQuery<SalesQuery>(
     SalesScreenQuery,

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -230,12 +230,6 @@ export const features = {
     description: "Enable feature videos phase 2, falls back to webview if disabled",
     echoFlagKey: "AREnableFeatureVideoPhase2Type",
   },
-  AREnableAuctionsHubOnHomeView: {
-    description: "Enable Auctions Hub on Home View",
-    readyForRelease: true,
-    showInDevMenu: true,
-    echoFlagKey: "AREnableAuctionsHubOnHomeView",
-  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

Addresses [auction rails missing in home](https://www.notion.so/artsy/auction-rails-missing-in-home-2a4cab0764a0808596dfd0e366bdb5aa)

We use conditional rendering of the Auctions hub section and a combination of echo flag and unleash experiment where the echo flag is on Eigen and Unleash experiment implementation is mostly on MP (on Eigen the Unleash experiment is only used to determine the `includeBackfill` variable). 
The bug ticket describes the case when the user is getting an "experiment" variant but the ff is turned off - in this case, the the Auctions Hub section is displayed for the user instead of other Auctions rail but the Auctions hub section is not shown because it's hidden behind a feature flag, this leads to the Auctions related sections to not be shown at all

In this PR I'm removing the echo flag from Eigen to make sure we are relying only on the Unleash implementation on MP

<video src="https://github.com/user-attachments/assets/7c3ec5c5-9768-4b8c-bf7d-74ce282553ef" width="400" />

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: remove echo ff from auctions hub implementation -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
