### PR TITLE
fix(crash): account for NSNull in state access

### DIFF
--- a/ios/Artsy/Emission/Core/AREmission.m
+++ b/ios/Artsy/Emission/Core/AREmission.m
@@ -84,23 +84,36 @@ static AREmission *_sharedInstance = nil;
 
 - (NSString *)stateStringForKey:(NSString *)stateKey
 {
-    NSString *result = [self.notificationsManagerModule.state valueForKey:stateKey];
-    if (result != nil && ![result isKindOfClass:NSString.class]) {
-        NSString *actualType = NSStringFromClass([result class]);
-        NSString *valueDescription = [NSString stringWithFormat:@"%@", result];
-        [NSException raise:NSInternalInconsistencyException format:@"Value for key '%@' is not a string. Type: %@, Value: %@", stateKey, actualType, valueDescription];
+    id result = [self.notificationsManagerModule.state valueForKey:stateKey];
+    if (result == nil || result == [NSNull null]) {
+        return nil;
+    }
+
+    if (![result isKindOfClass:NSString.class]) {
+        [NSException raise:NSInternalInconsistencyException
+                        format:@"Value for key '%@' is not a string. Type: %@, Value: %@",
+                                   stateKey,
+                                   NSStringFromClass([result class]),
+                                   result];
     }
     return result;
 }
 
 - (NSString *)reactStateStringForKey:(NSString *)stateKey
 {
-    NSString *result = [self.notificationsManagerModule.reactState valueForKey:stateKey];
-    if (result && ![result isKindOfClass:NSString.class]) {
-        NSString *actualType = NSStringFromClass([result class]);
-        NSString *valueDescription = [NSString stringWithFormat:@"%@", result];
-        [NSException raise:NSInternalInconsistencyException format:@"Value for key '%@' is not a string. Type: %@, Value: %@", stateKey, actualType, valueDescription];
+    id result = [self.notificationsManagerModule.reactState valueForKey:stateKey];
+    if (result == nil || result == [NSNull null]) {
+        return nil;
     }
+
+    if (![result isKindOfClass:NSString.class]) {
+        [NSException raise:NSInternalInconsistencyException
+                            format:@"Value for key '%@' is not a string. Type: %@, Value: %@",
+                                   stateKey,
+                                   NSStringFromClass([result class]),
+                                   result];
+    }
+
     return result;
 }
 


### PR DESCRIPTION
This PR resolves [PHIRE-2451] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

When we access this state we check for nil but when we clear out this state we insert NSNull, because the state is stored in a dictionary and inserting nil removes both the key and the value and we want the key to stick around. 

Accounting for NSNull in the check fixes the issue.

<img width="603" height="1311" alt="crash" src="https://github.com/user-attachments/assets/ef2bdc50-f924-4fc7-babb-4e500d3a9569" />

### Follow-ups

There is an additional little mystery here I think deserves some investigation. The only place I can see this being called is in an ancient 4 year old migration that renamed the email field, that would mean that these are users updating from a very old app version, although the crash numbers are small they are bigger then I would expect for that scenario. I **think** expo updates might be inflating these crash numbers by trying to retry launching the app when we hit a crash like this. One little piece of evidence is that the crash in sentry [shows 4x crashes vs unique users](https://artsynet.sentry.io/issues/6680714665/events/a71338e8101c424f889b0832350ed362/?project=5867225). We should confirm if that is or isn't the case. 

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix crash with NSNull email state - george, brian

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-2451]: https://artsyproduct.atlassian.net/browse/PHIRE-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ