### PR TITLE
chore: update references to artwork large_rectangle

### DIFF
--- a/src/app/Scenes/Artwork/Components/__tests__/ContextCard.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/__tests__/ContextCard.tests.tsx
@@ -97,7 +97,7 @@ const auctionContextArtwork = {
     isAuction: true,
     formattedStartDateTime: "Ended Oct 25, 2018",
     coverImage: {
-      url: "https://d32dm0rphc51dk.cloudfront.net/bMu0vqXOVlpABBsWVxVIJA/large_rectangle.jpg",
+      url: "https://d32dm0rphc51dk.cloudfront.net/bMu0vqXOVlpABBsWVxVIJA/main.jpg",
     },
   },
   shows: [],


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/DIAM-208

(Semi-automated PR)

Updates references to `Artwork` `Image` fields where a version of `large_rectangle` is requested.

In this case, only in specs. So no user-facing change that would require a release cycle before continuing with Gemini cleanup

<details><summary>Changelog updates</summary>

#### Dev changes

- remove references to artwork large_rectangle image
</details>