### PR TITLE
feat: add Typeform embed support with /typeform/:id route

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -223,6 +223,7 @@ import {
   SimilarToRecentlyViewedScreenQuery,
 } from "app/Scenes/SimilarToRecentlyViewed/SimilarToRecentlyViewed"
 import { TagQueryRenderer, TagScreenQuery } from "app/Scenes/Tag/Tag"
+import { Typeform } from "app/Scenes/Typeform/Typeform"
 import {
   VanityURLEntityRenderer,
   VanityURLEntityScreenQuery,
@@ -1635,6 +1636,18 @@ export const artsyDotNetRoutes = defineRoutes([
       },
     },
     queries: [TagScreenQuery],
+  },
+  {
+    path: "/typeform/:id",
+    name: "Typeform",
+    Component: Typeform,
+    options: {
+      alwaysPresentModally: true,
+      hidesBottomTabs: true,
+      screenOptions: {
+        headerTitle: "Survey",
+      },
+    },
   },
   {
     path: "/unlisted-artworks-faq",

--- a/src/app/Scenes/Typeform/Typeform.tsx
+++ b/src/app/Scenes/Typeform/Typeform.tsx
@@ -1,0 +1,155 @@
+import { Box, Button, Flex, Spacer, Spinner, Text } from "@artsy/palette-mobile"
+import { useNavigation, RouteProp, useRoute } from "@react-navigation/native"
+import { useSurveyTracking } from "app/Scenes/Typeform/useSurveyTracking"
+import React, { useCallback, useRef, useState } from "react"
+import { WebView, WebViewMessageEvent } from "react-native-webview"
+
+interface TypeformRouteParams {
+  id: string
+}
+
+export const Typeform: React.FC = () => {
+  const navigation = useNavigation()
+  const route = useRoute<RouteProp<{ params: TypeformRouteParams }, "params">>()
+  const { id } = route.params
+  const [loading, setLoading] = useState(true)
+  const [submitted, setSubmitted] = useState(false)
+  const hasTrackedSubmission = useRef(false)
+  const { trackSurveyViewed, trackSurveySubmitted, trackSurveyAbandoned } = useSurveyTracking()
+
+  const handleWebViewMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      const rawData = event.nativeEvent.data
+      if (typeof rawData !== "string") return
+
+      let data
+      try {
+        data = JSON.parse(rawData)
+      } catch {
+        return
+      }
+
+      if (!data?.type) return
+
+      switch (data.type) {
+        case "form-submit":
+          if (!hasTrackedSubmission.current) {
+            hasTrackedSubmission.current = true
+            trackSurveySubmitted(id)
+            setSubmitted(true)
+          }
+          break
+        case "form-ready":
+          trackSurveyViewed(id)
+          setLoading(false)
+          break
+        case "form-close":
+          trackSurveyAbandoned(id)
+          break
+      }
+    },
+    [id, trackSurveyViewed, trackSurveySubmitted, trackSurveyAbandoned]
+  )
+
+  // HTML that loads Typeform SDK and creates an embedded form
+  const html = `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+        <style>
+          * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+          }
+          html, body {
+            height: 100vh;
+            width: 100vw;
+            overflow: hidden;
+            position: fixed;
+          }
+          #typeform-container {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            width: 100%;
+            height: 100%;
+          }
+          #typeform-container iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100% !important;
+            height: 100% !important;
+          }
+          /* Hide Typeform close button */
+          button[aria-label="Close"],
+          [data-qa="close-button"] {
+            display: none !important;
+          }
+        </style>
+      </head>
+      <body>
+        <div id="typeform-container"></div>
+        <script src="https://embed.typeform.com/next/embed.js"></script>
+        <script>
+          window.tf.createWidget('${id}', {
+            container: document.getElementById('typeform-container'),
+            hideHeaders: true,
+            hideFooter: true,
+            opacity: 100,
+            width: '100%',
+            height: '100%',
+            onReady: function() {
+              window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'form-ready' }));
+            },
+            onSubmit: function() {
+              window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'form-submit' }));
+            },
+            onClose: function() {
+              window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'form-close' }));
+            }
+          });
+        </script>
+      </body>
+    </html>
+  `
+
+  if (submitted) {
+    return (
+      <Box flex={1} backgroundColor="white" justifyContent="center" alignItems="center" px={4}>
+        <Text variant="lg-display" textAlign="center">
+          Thanks for your feedback!
+        </Text>
+        <Spacer y={2} />
+        <Text variant="sm" color="black60" textAlign="center">
+          Your response has been recorded.
+        </Text>
+        <Spacer y={4} />
+        <Button block onPress={() => navigation.goBack()}>
+          Close
+        </Button>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flex={1} backgroundColor="white">
+      {!!loading && (
+        <Flex flex={1} alignItems="center" justifyContent="center">
+          <Spinner size="large" />
+        </Flex>
+      )}
+      <WebView
+        source={{ html }}
+        style={{ flex: 1, opacity: loading ? 0 : 1 }}
+        onMessage={handleWebViewMessage}
+        javaScriptEnabled={true}
+        domStorageEnabled={true}
+      />
+    </Box>
+  )
+}

--- a/src/app/Scenes/Typeform/__tests__/Typeform.tests.tsx
+++ b/src/app/Scenes/Typeform/__tests__/Typeform.tests.tsx
@@ -1,0 +1,135 @@
+import { act, screen } from "@testing-library/react-native"
+import { Typeform } from "app/Scenes/Typeform/Typeform"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+const mockTrackSurveyViewed = jest.fn()
+const mockTrackSurveySubmitted = jest.fn()
+const mockTrackSurveyAbandoned = jest.fn()
+
+jest.mock("app/Scenes/Typeform/useSurveyTracking", () => ({
+  useSurveyTracking: () => ({
+    trackSurveyViewed: mockTrackSurveyViewed,
+    trackSurveySubmitted: mockTrackSurveySubmitted,
+    trackSurveyAbandoned: mockTrackSurveyAbandoned,
+  }),
+}))
+
+let mockRouteParams: any = {
+  id: "test-form-id",
+}
+
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useRoute: () => ({
+    params: mockRouteParams,
+  }),
+  useNavigation: () => ({
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+  }),
+}))
+
+describe("Typeform", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRouteParams = {
+      id: "test-form-id",
+    }
+  })
+
+  it("renders without crashing", () => {
+    renderWithWrappers(<Typeform />)
+    expect(screen.UNSAFE_getByType(require("react-native-webview").WebView)).toBeTruthy()
+  })
+
+  it("shows loading spinner initially", () => {
+    renderWithWrappers(<Typeform />)
+    expect(screen.UNSAFE_queryByType(require("@artsy/palette-mobile").Spinner)).toBeTruthy()
+  })
+
+  it("embeds Typeform using the SDK", () => {
+    renderWithWrappers(<Typeform />)
+    const webview = screen.UNSAFE_getByType(require("react-native-webview").WebView)
+    expect(webview.props.source.html).toContain("embed.typeform.com/next/embed.js")
+    expect(webview.props.source.html).toContain("test-form-id")
+  })
+
+  it("tracks survey viewed when form is ready", async () => {
+    renderWithWrappers(<Typeform />)
+    const webview = screen.UNSAFE_getByType(require("react-native-webview").WebView)
+
+    // Simulate form ready event
+    const mockEvent = {
+      nativeEvent: {
+        data: JSON.stringify({ type: "form-ready" }),
+      },
+    }
+
+    await act(async () => {
+      webview.props.onMessage(mockEvent)
+    })
+
+    expect(mockTrackSurveyViewed).toHaveBeenCalledWith("test-form-id")
+  })
+
+  it("shows thank you message after submission", async () => {
+    renderWithWrappers(<Typeform />)
+    const webview = screen.UNSAFE_getByType(require("react-native-webview").WebView)
+
+    // Simulate form submission event from Typeform SDK
+    const mockEvent = {
+      nativeEvent: {
+        data: JSON.stringify({ type: "form-submit" }),
+      },
+    }
+
+    await act(async () => {
+      webview.props.onMessage(mockEvent)
+    })
+
+    // Should show thank you message
+    expect(screen.getByText("Thanks for your feedback!")).toBeTruthy()
+    expect(screen.getByText("Your response has been recorded.")).toBeTruthy()
+
+    // Should track submission
+    expect(mockTrackSurveySubmitted).toHaveBeenCalledWith("test-form-id")
+  })
+
+  it("does not show WebView after submission", async () => {
+    renderWithWrappers(<Typeform />)
+    const webview = screen.UNSAFE_getByType(require("react-native-webview").WebView)
+
+    // Simulate form submission
+    const mockEvent = {
+      nativeEvent: {
+        data: JSON.stringify({ type: "form-submit" }),
+      },
+    }
+
+    await act(async () => {
+      webview.props.onMessage(mockEvent)
+    })
+
+    // WebView should not be present
+    expect(screen.UNSAFE_queryByType(require("react-native-webview").WebView)).toBeNull()
+  })
+
+  it("tracks survey abandoned when form is closed", async () => {
+    renderWithWrappers(<Typeform />)
+    const webview = screen.UNSAFE_getByType(require("react-native-webview").WebView)
+
+    // Simulate form close
+    const mockEvent = {
+      nativeEvent: {
+        data: JSON.stringify({ type: "form-close" }),
+      },
+    }
+
+    await act(async () => {
+      webview.props.onMessage(mockEvent)
+    })
+
+    // Should track abandonment
+    expect(mockTrackSurveyAbandoned).toHaveBeenCalledWith("test-form-id")
+  })
+})

--- a/src/app/Scenes/Typeform/useSurveyTracking.ts
+++ b/src/app/Scenes/Typeform/useSurveyTracking.ts
@@ -1,0 +1,68 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { useTracking } from "react-tracking"
+
+// TODO: move event/property definitions to @artsy/cohesion
+
+interface SurveyViewedEvent {
+  action: ActionType
+  context_screen_owner_type: OwnerType
+  survey_id: string
+  context_module?: string
+}
+
+interface SurveySubmittedEvent {
+  action: ActionType
+  context_screen_owner_type: OwnerType
+  survey_id: string
+  context_module?: string
+}
+
+interface SurveyAbandonedEvent {
+  action: ActionType
+  context_screen_owner_type: OwnerType
+  survey_id: string
+  context_module?: string
+}
+
+export const useSurveyTracking = () => {
+  const { trackEvent } = useTracking()
+
+  const trackSurveyViewed = (surveyId: string, contextModule?: ContextModule) => {
+    const payload: SurveyViewedEvent = {
+      action: "surveyViewed" as ActionType,
+      context_screen_owner_type: "survey" as OwnerType,
+      survey_id: surveyId,
+      ...(contextModule && { context_module: contextModule }),
+    }
+
+    trackEvent(payload)
+  }
+
+  const trackSurveySubmitted = (surveyId: string, contextModule?: string) => {
+    const payload: SurveySubmittedEvent = {
+      action: "surveySubmitted" as ActionType,
+      context_screen_owner_type: "survey" as OwnerType,
+      survey_id: surveyId,
+      ...(contextModule && { context_module: contextModule }),
+    }
+
+    trackEvent(payload)
+  }
+
+  const trackSurveyAbandoned = (surveyId: string, contextModule?: string) => {
+    const payload: SurveyAbandonedEvent = {
+      action: "surveyAbandoned" as ActionType,
+      context_screen_owner_type: "survey" as OwnerType,
+      survey_id: surveyId,
+      ...(contextModule && { context_module: contextModule }),
+    }
+
+    trackEvent(payload)
+  }
+
+  return {
+    trackSurveyViewed,
+    trackSurveySubmitted,
+    trackSurveyAbandoned,
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> I'm not planning to merge this PR until we have aligned on the survey content and prompt logic.

### Description

Implements a new modal screen for displaying Typeform surveys using a customized WebView. The component integrates with analytics tracking to monitor survey engagement.

Key features:
- Embeds Typeform surveys via WebView
- Modal presentation with custom header ("Survey")
- Tracks survey viewed, submitted, and abandoned events
- Fullscreen form display with hidden Typeform branding
- Thank you screen with close button after submission
- Generic survey tracking hook for reusability

Technical implementation:
- New /typeform/:id route with alwaysPresentModally option
- Event handling via window.ReactNativeWebView.postMessage bridge
- CSS to ensure fullscreen display and hide Typeform close button

Jira: [ONYX-1984](https://artsyproduct.atlassian.net/browse/ONYX-1984) 🔒 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | After |
|---|---|
| iOS | <video src="[xxx](https://github.com/user-attachments/assets/11f30545-5434-40cc-810e-0395e60e9e1c)" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- add typeform-backed survey support

<!-- end_changelog_updates -->

</details>

### Screen Recording

| Platform | After |
|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/11f30545-5434-40cc-810e-0395e60e9e1c" width="400" /> |

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-1984]: https://artsyproduct.atlassian.net/browse/ONYX-1984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ