### PR TITLE
fix: prevent crash in Experiments menu when variant is undefined

### DIFF
--- a/src/app/system/devTools/DevMenu/Components/ExperimentFlagItem.tsx
+++ b/src/app/system/devTools/DevMenu/Components/ExperimentFlagItem.tsx
@@ -122,7 +122,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
                             setVariant("control")
                           }}
                         >
-                          control {unleashVariant.name === "control" && "(default)"}
+                          control {unleashVariant?.name === "control" && "(default)"}
                         </Pill>
                         <Pill
                           variant="badge"
@@ -130,7 +130,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
                             setVariant("experiment")
                           }}
                         >
-                          experiment {unleashVariant.name === "experiment" && "(default)"}
+                          experiment {unleashVariant?.name === "experiment" && "(default)"}
                         </Pill>
                       </Flex>
                     )}
@@ -158,7 +158,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
                               }}
                             >
                               {payloadSuggestion}{" "}
-                              {unleashVariant.payload?.value === payloadSuggestion && "(default)"}
+                              {unleashVariant?.payload?.value === payloadSuggestion && "(default)"}
                             </Pill>
                           )
                         })}
@@ -223,7 +223,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
       </Text>
       <Text>
         <Text color="mono60">Status:</Text>{" "}
-        {unleashVariant.enabled ? (
+        {unleashVariant?.enabled ? (
           <Text fontWeight="bold" color="blue100">
             enabled
           </Text>
@@ -235,7 +235,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
       </Text>
       <Text>
         <Text color="mono60">Variant:</Text>{" "}
-        <Text fontWeight="bold">{localVariantOverrides[flag] || unleashVariant.name}</Text>
+        <Text fontWeight="bold">{localVariantOverrides[flag] || unleashVariant?.name}</Text>
         <TouchableOpacity
           accessibilityRole="button"
           onPress={() => {
@@ -248,7 +248,7 @@ export const ExperimentFlagItem: React.FC<{ description: string; flag: EXPERIMEN
       <Flex flexDirection="row" flexWrap="wrap">
         <Text color="mono60">Payload: </Text>
         <Text fontWeight="bold" selectable>
-          {unleashVariant.payload?.value || "--"}
+          {unleashVariant?.payload?.value || "--"}
           <TouchableOpacity
             accessibilityRole="button"
             onPress={() => {


### PR DESCRIPTION
### Description

The app currently crashes when there's an experiment defined but the flag is disabled within Unleash. This is the case today for the `onyx_auctions_hub` feature flag. Defined [here in Eigen](https://github.com/artsy/eigen/blob/ea07f2bcd1816e083c8344a2ec0958bb1a9ac404/src/app/system/flags/experiments.ts#L15) but [disabled within Unleash here](https://unleash.artsy.net/projects/default/features/onyx_auctions_hub).

This PRs adds optional chaining to prevent a crash when an Unleash flag variant is inaccessible.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Dev changes

- fix: prevent crash in Experiments menu when variant is undefined

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
