### PR TITLE
fix: search term highlighting only showing first few characters

### DIFF
--- a/src/app/Components/AutosuggestResults/AutosuggestResults.tsx
+++ b/src/app/Components/AutosuggestResults/AutosuggestResults.tsx
@@ -171,15 +171,19 @@ const AutosuggestResultsFlatList: React.FC<{
     )
   }, [hasMoreResults, noResults, ListFooterComponent])
 
+  // Store query in a ref so renderItem always has access to the latest value
+  const queryRef = useRef(query)
+  queryRef.current = query
+
   const renderItem: ListRenderItem<AutosuggestResult> = useCallback(({ item, index }) => {
     if (CustomListItemComponent) {
-      return <CustomListItemComponent item={item} highlight={query} />
+      return <CustomListItemComponent item={item} highlight={queryRef.current} />
     }
 
     return (
       <Flex mb={2}>
         <AutosuggestSearchResult
-          highlight={query}
+          highlight={queryRef.current}
           result={item}
           showResultType={showResultType}
           onResultPress={onResultPress}
@@ -213,6 +217,7 @@ const AutosuggestResultsFlatList: React.FC<{
         listRef={flatListRef}
         initialNumToRender={isTablet() ? 24 : 12}
         data={allNodes}
+        extraData={query}
         showsVerticalScrollIndicator={false}
         ListFooterComponent={ListFooterComponentWithLoadingIndicator}
         keyboardDismissMode="on-drag"

--- a/src/app/Scenes/Search/components/EntitySearchResults.tsx
+++ b/src/app/Scenes/Search/components/EntitySearchResults.tsx
@@ -63,8 +63,21 @@ export const EntitySearchResults: React.FC<SearchResultsProps> = ({ query, selec
     }
   }, [query])
 
+  // Store query and selectedPill in refs so renderItem always has access to the latest values
+  const queryRef = useRef(query)
+  queryRef.current = query
+  const selectedPillRef = useRef(selectedPill)
+  selectedPillRef.current = selectedPill
+
   const renderItem: ListRenderItem<SearchResultInterface> = useCallback(({ item, index }) => {
-    return <SearchResult result={item} selectedPill={selectedPill} query={query} position={index} />
+    return (
+      <SearchResult
+        result={item}
+        selectedPill={selectedPillRef.current}
+        query={queryRef.current}
+        position={index}
+      />
+    )
   }, [])
 
   return (
@@ -78,6 +91,7 @@ export const EntitySearchResults: React.FC<SearchResultsProps> = ({ query, selec
         paddingBottom: space(6),
       }}
       data={hits}
+      extraData={{ query, selectedPill }}
       keyExtractor={(item, index) => item.internalID ?? index.toString()}
       renderItem={renderItem}
       estimatedItemSize={ESTIMATED_ITEM_SIZE}


### PR DESCRIPTION
### Description

Fixed issue where search results were only highlighting the first 2-3 characters of the search query instead of the full matching text.

The renderItem callbacks had empty dependency arrays, causing them to capture stale query values. Now using refs to store current values and FlashList's extraData prop to trigger re-renders when values change.

Jira: [ONYX-2023](https://artsyproduct.atlassian.net/browse/ONYX-2023)

## Screen Recordings

| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/33ca7bdc-f410-4258-89ab-b8f85350028a" width="400" /> | <video src="https://github.com/user-attachments/assets/86b36f17-3f53-4e59-b571-1a6b5c39337c" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="[xxx](https://github.com/user-attachments/assets/33ca7bdc-f410-4258-89ab-b8f85350028a)" width="400" /> | <video src="[xxx](https://github.com/user-attachments/assets/86b36f17-3f53-4e59-b571-1a6b5c39337c)" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: search term highlighting only showing first few characters

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-2023]: https://artsyproduct.atlassian.net/browse/ONYX-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ