### PR TITLE
fix: broken career highlights year test

### DIFF
--- a/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet.tsx
@@ -164,6 +164,8 @@ const careerHighlighsBottomSheetFragment = graphql`
   }
 `
 
+const MAX_YEAR_DIFFERENCE = 8
+export const MINIMUM_YEAR = new Date().getFullYear() - MAX_YEAR_DIFFERENCE
 /**
  * Prepares the eventDigest and creates a map of each year to the highlight kind
  * @param eventDigest
@@ -183,7 +185,7 @@ const careerHighlighsBottomSheetFragment = graphql`
 export const makeCareerHighlightMap = (
   eventDigest: string
 ): Record<number, Record<CareerHighlightKindValueType, string[]>> => {
-  const minimumYear = new Date().getFullYear() - 8
+  const minimumYear = MINIMUM_YEAR
   const result: Record<number, Record<CareerHighlightKindValueType, string[]>> = {}
   const arr = eventDigest ? eventDigest.split(";") : []
   if (!arr.length) {

--- a/src/app/Scenes/MyCollection/Screens/Insights/__tests__/CareerHighlightBottomSheet.tests.tsx
+++ b/src/app/Scenes/MyCollection/Screens/Insights/__tests__/CareerHighlightBottomSheet.tests.tsx
@@ -3,6 +3,7 @@ import { MedianSalePriceAtAuctionQuery } from "__generated__/MedianSalePriceAtAu
 import {
   CareerHighlightBottomSheet,
   makeCareerHighlightMap,
+  MINIMUM_YEAR,
 } from "app/Scenes/MyCollection/Screens/Insights/CareerHighlightBottomSheet"
 import { MedianSalePriceAtAuctionScreenQuery } from "app/Scenes/MyCollection/Screens/Insights/MedianSalePriceAtAuction"
 import {
@@ -64,16 +65,17 @@ describe(makeCareerHighlightMap, () => {
 
   it("Prepares the eventDigest and creates a map of each year to the highlight kind", () => {
     const result = makeCareerHighlightMap(
-      "2017 Group Show @ MOCA Los Angeles; 2015 Reviewed Solo Show @ The Guardian; 2015 Reviewed Solo Show @ Art in America"
+      `2020 Group Show @ MOCA Los Angeles; ${MINIMUM_YEAR} Reviewed Solo Show @ The Guardian; 2018 Reviewed Solo Show @ Art in America`
     )
 
     expect(result).toEqual({
-      2017: { "Group Show": ["MOCA Los Angeles"] },
+      [MINIMUM_YEAR]: { Review: ["The Guardian", "Art in America"] },
+      2020: { "Group Show": ["MOCA Los Angeles"] },
     })
   })
 
-  it("Returns an empty object if the year is less than 2014", async () => {
-    const result = await makeCareerHighlightMap(
+  it("Returns an empty object if the year is outside the 8-year window", () => {
+    const result = makeCareerHighlightMap(
       "2013 Group Show @ MOCA Los Angeles; 2012 Reviewed Solo Show @ The Guardian; 2011 Reviewed Solo Show @ Art in America"
     )
 
@@ -87,17 +89,17 @@ const bottomSheetDataMock = {
       {
         node: {
           eventDigest:
-            "2018 Group Show @ MOCA Los Angeles; 2015 Reviewed Solo Show @ The Guardian; 2015 Reviewed Solo Show @ Art in America; ",
+            "2020 Group Show @ MOCA Los Angeles; 2018 Reviewed Solo Show @ The Guardian; 2018 Reviewed Solo Show @ Art in America; ",
           sparkles: "0",
-          year: "year_2017",
+          year: "year_2019",
         },
       },
       {
         node: {
           eventDigest:
-            "2018 Group Show @ MOCA Los Angeles; 2015 Reviewed Solo Show @ The Guardian; 2015 Reviewed Solo Show @ Art in America; ",
+            "2020 Group Show @ MOCA Los Angeles; 2018 Reviewed Solo Show @ The Guardian; 2018 Reviewed Solo Show @ Art in America; ",
           sparkles: "10",
-          year: "year_2018",
+          year: "year_2020",
         },
       },
     ],


### PR DESCRIPTION
This PR resolves [https://app.circleci.com/pipelines/github/artsy/eigen] <!-- eg [PROJECT-XXXX] -->

### Description

This PR fixes the broken career highlights test logic.
As you can see from the last CI jobs, this test started breaking out of nothing. After looking further into it, it turned out that the logic here was hard coded instead of using a dynamic range. Which is what I did now


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [X] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix broken career highlights year test - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
