### PR TITLE
refactor: reset push token on logout

### DIFF
--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -8,6 +8,7 @@ import * as Sentry from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { clearNavState } from "app/system/navigation/useReloadedDevNavigationState"
 import { _globalCacheRef } from "app/system/relay/defaultEnvironment"
+import { deleteToken } from "app/utils/PushNotification"
 import {
   handleClassicFacebookAuth,
   handleClassicFacebookAuth2,
@@ -1000,9 +1001,15 @@ export const getAuthModel = (): AuthModel => ({
       }
     }
 
-    GlobalStore.actions.artsyPrefs.pushPromptLogic.setPushPermissionsRequestedThisSession(false)
+    GlobalStore.actions.artsyPrefs.pushPromptLogic.resetPushPromptLogic()
     SiftReactNative.unsetUserId()
     SegmentTrackingProvider.identify?.(undefined, { is_temporary_user: 1 })
+
+    // Delete from the server and from Firebase before clearing local storage, so both
+    // auth token and push token are still available. Deleting the Firebase token forces
+    // a fresh registration token on the next login (triggering onTokenRefresh).
+    await deleteToken()
+    // await messaging().deleteToken()
 
     await Promise.all([
       Platform.OS === "ios"

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -28,6 +28,7 @@ import { LoginManager, LoginTracking } from "react-native-fbsdk-next"
 import Keychain from "react-native-keychain"
 import Keys from "react-native-keys"
 import SiftReactNative from "sift-react-native"
+import { v4 as uuidv4 } from "uuid"
 import { AuthError } from "./AuthError"
 import { GlobalStore, getCurrentEmissionState } from "./GlobalStore"
 import type { GlobalStoreModel } from "./GlobalStoreModel"
@@ -1004,12 +1005,14 @@ export const getAuthModel = (): AuthModel => ({
     GlobalStore.actions.artsyPrefs.pushPromptLogic.resetPushPromptLogic()
     SiftReactNative.unsetUserId()
     SegmentTrackingProvider.identify?.(undefined, { is_temporary_user: 1 })
+    // Switch to a fresh anonymous Braze user so this device no longer receives
+    // push notifications for the logged-out user. The BrazePlugin's identify()
+    // skips changeUser when userId is undefined, so we call it explicitly.
+    Braze.changeUser(uuidv4())
 
-    // Delete from the server and from Firebase before clearing local storage, so both
-    // auth token and push token are still available. Deleting the Firebase token forces
-    // a fresh registration token on the next login (triggering onTokenRefresh).
+    // Delete from the server before clearing local storage, so both
+    // auth token and push token are still available.
     await deleteToken()
-    // await messaging().deleteToken()
 
     await Promise.all([
       Platform.OS === "ios"

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -20,7 +20,6 @@ import {
 import { isArtsyEmail } from "app/utils/general"
 import { SegmentTrackingProvider } from "app/utils/track/SegmentTrackingProvider"
 import { postEventToProviders } from "app/utils/track/providers"
-
 import { Action, Computed, StateMapper, Thunk, action, computed, thunk } from "easy-peasy"
 import { stringify } from "qs"
 import { Platform } from "react-native"
@@ -28,7 +27,6 @@ import { LoginManager, LoginTracking } from "react-native-fbsdk-next"
 import Keychain from "react-native-keychain"
 import Keys from "react-native-keys"
 import SiftReactNative from "sift-react-native"
-import { v4 as uuidv4 } from "uuid"
 import { AuthError } from "./AuthError"
 import { GlobalStore, getCurrentEmissionState } from "./GlobalStore"
 import type { GlobalStoreModel } from "./GlobalStoreModel"
@@ -1005,10 +1003,10 @@ export const getAuthModel = (): AuthModel => ({
     GlobalStore.actions.artsyPrefs.pushPromptLogic.resetPushPromptLogic()
     SiftReactNative.unsetUserId()
     SegmentTrackingProvider.identify?.(undefined, { is_temporary_user: 1 })
-    // Switch to a fresh anonymous Braze user so this device no longer receives
-    // push notifications for the logged-out user. The BrazePlugin's identify()
-    // skips changeUser when userId is undefined, so we call it explicitly.
-    Braze.changeUser(uuidv4())
+    // Switch Braze to a temp user to avoid sending any more user specific
+    // events until next login, as Braze does not have an identify(null)
+    // or equivalent method
+    Braze.changeUser("00000")
 
     // Delete from the server before clearing local storage, so both
     // auth token and push token are still available.

--- a/src/app/store/PushPromptLogicModel.ts
+++ b/src/app/store/PushPromptLogicModel.ts
@@ -12,6 +12,7 @@ export interface PushPromptLogicModel {
   setPushNotificationSystemDialogRejected: Action<PushPromptLogicModel, boolean>
   setPushNotificationSystemDialogSeen: Action<PushPromptLogicModel, boolean>
   setPushNotificationDialogLastSeenTimestamp: Action<PushPromptLogicModel, number>
+  resetPushPromptLogic: Action<PushPromptLogicModel>
 }
 
 export const getPushPromptLogicModel = (): PushPromptLogicModel => ({
@@ -35,5 +36,12 @@ export const getPushPromptLogicModel = (): PushPromptLogicModel => ({
   }),
   setPushNotificationDialogLastSeenTimestamp: action((state, payload) => {
     state.pushNotificationDialogLastSeenTimestamp = payload
+  }),
+  resetPushPromptLogic: action((state) => {
+    state.pushPermissionsRequestedThisSession = false
+    state.pushNotificationSettingsPromptSeen = false
+    state.pushNotificationSystemDialogRejected = false
+    state.pushNotificationSystemDialogSeen = false
+    state.pushNotificationDialogLastSeenTimestamp = null
   }),
 })

--- a/src/app/system/notifications/__tests__/useRegisterForRemoteMessages.tests.ts
+++ b/src/app/system/notifications/__tests__/useRegisterForRemoteMessages.tests.ts
@@ -137,18 +137,17 @@ describe("useRegisterForPushNotifications", () => {
         expect(mockSaveToken).toHaveBeenCalledWith(mockToken)
       })
 
-      it("should handle null token from native module", async () => {
+      it("should handle null token from native module gracefully and keep refresh listener active", async () => {
         mockGetPushToken.mockResolvedValue(null)
-        const consoleSpy = jest.spyOn(console, "error").mockImplementation()
 
         renderHook(() => useRegisterForPushNotifications())
 
         await waitForAsync()
 
-        expect(consoleSpy).toHaveBeenCalledWith("DEBUG: Failed to obtain FCM token")
+        // No error logged — the refresh listener handles the token when APNS delivers it
         expect(mockSaveToken).not.toHaveBeenCalled()
-
-        consoleSpy.mockRestore()
+        // Refresh listener must still be set up so onTokenRefresh can save the token later
+        expect(mockOnTokenRefresh).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -162,25 +161,21 @@ describe("useRegisterForPushNotifications", () => {
 
         await waitForAsync()
 
-        expect(consoleSpy).toHaveBeenCalledWith(
-          "DEBUG: Error in registerForRemoteMessages:",
-          mockError
-        )
+        expect(consoleSpy).toHaveBeenCalledWith("Error in registerForRemoteMessages:", mockError)
         expect(mockSaveToken).not.toHaveBeenCalled()
         consoleSpy.mockRestore()
       })
 
-      it("should handle empty token", async () => {
+      it("should not call saveToken when token is empty", async () => {
         mockGetToken.mockResolvedValue("")
-        const consoleSpy = jest.spyOn(console, "error").mockImplementation()
 
         renderHook(() => useRegisterForPushNotifications())
 
         await waitForAsync()
 
-        expect(consoleSpy).toHaveBeenCalledWith("DEBUG: Failed to obtain FCM token")
         expect(mockSaveToken).not.toHaveBeenCalled()
-        consoleSpy.mockRestore()
+        // Refresh listener is still active
+        expect(mockOnTokenRefresh).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/src/app/system/notifications/useRegisterForRemoteMessages.ts
+++ b/src/app/system/notifications/useRegisterForRemoteMessages.ts
@@ -22,40 +22,30 @@ export const useRegisterForPushNotifications = () => {
 
   const registerForRemoteMessages = async () => {
     try {
-      // Register the device with FCM
       await messaging().registerDeviceForRemoteMessages()
+
+      // Register the refresh listener before attempting to get the current token.
+      // On iOS, getPushToken() can return null immediately after sign-out (clearUserData
+      // wipes the stored APNS token and re-registration is async). Without this listener
+      // in place first, we'd bail early and never capture the token once APNS delivers it.
+      const unsubscribe = messaging().onTokenRefresh(async (newToken) => {
+        await saveToken(newToken)
+      })
 
       let token = ""
       if (Platform.OS === "android") {
-        // Get the token
         token = await messaging().getToken()
       } else {
-        // Get the token
         token = (await LegacyNativeModules.ArtsyNativeModule.getPushToken()) ?? ""
       }
 
-      if (!token) {
-        console.error("DEBUG: Failed to obtain FCM token")
-        return
+      if (token) {
+        await saveToken(token)
       }
-
-      // Save the token
-      const savedToken = await saveToken(token)
-      if (!savedToken) {
-        console.error("DEBUG: Failed to save token:")
-      }
-
-      // Set up token refresh listener
-      const unsubscribe = messaging().onTokenRefresh(async (newToken) => {
-        const savedToken = await saveToken(newToken)
-        if (!savedToken) {
-          console.error("DEBUG: Failed to save refreshed token:")
-        }
-      })
 
       return unsubscribe
     } catch (error) {
-      console.error("DEBUG: Error in registerForRemoteMessages:", error)
+      console.error("Error in registerForRemoteMessages:", error)
     }
   }
 }

--- a/src/app/utils/PushNotification.ts
+++ b/src/app/utils/PushNotification.ts
@@ -93,6 +93,35 @@ export const saveToken = async (token: string) => {
   return true
 }
 
+export const deleteToken = async () => {
+  const { authenticationToken, userAgent } = getCurrentEmissionState()
+  const token = await AsyncStorage.getItem(PUSH_NOTIFICATION_TOKEN)
+
+  if (!token || !authenticationToken) {
+    return
+  }
+
+  const environment = unsafe__getEnvironment()
+  const url = `${environment.gravityURL}/api/v1/device/${token}`
+
+  const headers = {
+    "Content-Type": "application/json",
+    "X-ACCESS-TOKEN": authenticationToken,
+    "User-Agent": userAgent,
+  }
+
+  try {
+    await fetch(new Request(url, { method: "DELETE", headers }))
+  } catch (error) {
+    if (__DEV__) {
+      console.warn("Error deleting push notification token:", error)
+    } else {
+      captureMessage(`Error deleting push notification token: ${error}`, "error")
+    }
+  }
+}
+
 module.exports = {
   saveToken,
+  deleteToken,
 }

--- a/src/app/utils/requestPushNotificationsPermission.ts
+++ b/src/app/utils/requestPushNotificationsPermission.ts
@@ -140,11 +140,16 @@ export const requestPushNotificationsPermission = async () => {
 
   const permissionStatus = await getNotificationPermissionsStatus()
   if (permissionStatus === PushAuthorizationStatus.Authorized) {
-    // On iOS, we need to request the push token again to trigger the onRegister callback
+    // On iOS, re-requesting triggers the onRegister callback so the token is refreshed.
     if (Platform.OS === "ios") {
       requestSystemPermissions()
     }
-    return
+    // If the user has already seen the dialog this session, nothing left to do.
+    // If not (e.g. a different account just signed in after sign-out), fall through
+    // to the pre-prompt so the new user gets a chance to opt in.
+    if (pushNotificationSystemDialogSeen) {
+      return
+    }
   } else if (
     permissionStatus === PushAuthorizationStatus.Denied &&
     pushNotificationSystemDialogSeen

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -425,6 +425,7 @@ jest.mock("@react-native-firebase/messaging", () => ({
   default: jest.fn(() => ({
     registerDeviceForRemoteMessages: jest.fn(),
     getToken: jest.fn(),
+    deleteToken: jest.fn().mockResolvedValue(undefined),
     onMessage: jest.fn(() => jest.fn()),
     setBackgroundMessageHandler: jest.fn(),
     onTokenRefresh: jest.fn(() => jest.fn()),


### PR DESCRIPTION
This PR resolves [PHIRE-3028] <!-- eg [PROJECT-XXXX] -->

### Description

This PR is about reseting the push token anytime a user logs out of the app so multiple users can use the app without conflicts on their notifications.

Also users on logging out stop receiving notifications.

It is more of a conversation starter PR to make sure that we do want this behavior or not.

On the end of this PR we can find the latest betas that we can use in order to test this.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- reset push token on logout

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3028]: https://artsyproduct.atlassian.net/browse/PHIRE-3028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ