### PR TITLE
feat: refresh user access tokens before they expire

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -20,6 +20,7 @@ import { useDeepLinks } from "app/utils/useDeepLinks"
 import { useHideSplashScreen } from "app/utils/useHideSplashScreen"
 import { useIdentifyUser } from "app/utils/useIdentifyUser"
 import { useListenToThemeChange } from "app/utils/useListenToThemeChange"
+import { useRefreshUserAccessToken } from "app/utils/useRefreshUserAccessToken"
 import { useSiftConfig } from "app/utils/useSiftConfig"
 import { useStripeConfig } from "app/utils/useStripeConfig"
 import { useTrackAppState } from "app/utils/useTrackAppState"
@@ -106,6 +107,7 @@ const Main = () => {
   useInitializeQueryPrefetching()
   useIdentifyUser()
   useSyncNativeAuthState()
+  useRefreshUserAccessToken()
   usePushNotifications()
   usePreferredThemeTracking()
   useScreenReaderAndFontScaleTracking()

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -1112,7 +1112,7 @@ export const getAuthModel = (): AuthModel => ({
   }),
 })
 
-const REFRESH_USER_ACCESS_TOKEN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+const REFRESH_USER_ACCESS_TOKEN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000 // one week
 
 const isTokenExpired = (expiresIn: string, bufferMs = 300_000) => {
   const expirationTime = new Date(expiresIn).getTime()

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -182,6 +182,7 @@ export interface AuthModel {
     ReturnType<typeof fetch>
   >
   identifyUser: Action<this>
+  refreshUserAccessToken: Thunk<this, void, {}, GlobalStoreModel, Promise<void>>
   signOut: Thunk<this>
   verifyUser: Thunk<
     this,
@@ -986,6 +987,65 @@ export const getAuthModel = (): AuthModel => ({
     state.sessionState.isUserIdentified = true
   }),
 
+  refreshUserAccessToken: thunk(async (actions, _payload, store) => {
+    const state = store.getState()
+    const currentToken = state.userAccessToken
+    const expiresIn = state.userAccessTokenExpiresIn
+    if (!currentToken || !expiresIn) return
+
+    const expirationTime = new Date(expiresIn).getTime()
+    const withinWindow =
+      isNaN(expirationTime) || expirationTime - Date.now() < REFRESH_USER_ACCESS_TOKEN_WINDOW_MS
+    if (!withinWindow) return
+
+    try {
+      const trustResult = await actions.gravityUnauthenticatedRequest({
+        path: `/api/v1/me/trust_token`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-ACCESS-TOKEN": currentToken,
+        },
+      })
+
+      if (trustResult.status === 401 || trustResult.status === 403) {
+        await actions.signOut()
+        return
+      }
+      if (trustResult.status < 200 || trustResult.status >= 300) return
+
+      const { trust_token: trustToken } = await trustResult.json()
+      if (!trustToken) return
+
+      const tokenResult = await actions.gravityUnauthenticatedRequest({
+        path: `/oauth2/access_token`,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: {
+          grant_type: "trust_token",
+          client_id: clientKey,
+          client_secret: clientSecret,
+          code: trustToken,
+        },
+      })
+
+      if (tokenResult.status === 401 || tokenResult.status === 403) {
+        await actions.signOut()
+        return
+      }
+      if (tokenResult.status < 200 || tokenResult.status >= 300) return
+
+      const { access_token: newAccessToken, expires_in: newExpiresIn } = await tokenResult.json()
+      if (!newAccessToken) return
+
+      actions.setState({
+        userAccessToken: newAccessToken,
+        userAccessTokenExpiresIn: newExpiresIn ?? expiresIn,
+      })
+    } catch (error) {
+      Sentry.captureMessage(`AuthModel refreshUserAccessToken error ${error}`)
+    }
+  }),
   signOut: thunk(async (actions, _) => {
     const signOutGoogle = async () => {
       try {
@@ -1051,6 +1111,8 @@ export const getAuthModel = (): AuthModel => ({
     }
   }),
 })
+
+const REFRESH_USER_ACCESS_TOKEN_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
 
 const isTokenExpired = (expiresIn: string, bufferMs = 300_000) => {
   const expirationTime = new Date(expiresIn).getTime()

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -1382,6 +1382,103 @@ describe("AuthModel", () => {
     })
   })
 
+  describe("refreshUserAccessToken", () => {
+    const farFuture = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()
+    const expiringSoon = new Date(Date.now() + 60 * 1000).toISOString()
+
+    beforeEach(async () => {
+      mockFetchJsonOnce({
+        xapp_token: "my-special-token",
+        expires_in: oneWeekFromNow,
+      })
+      await GlobalStore.actions.auth.getXAppToken()
+      mockFetch.mockClear()
+    })
+
+    afterEach(() => {
+      // The 401 case calls actions.signOut(), which dirties mocks observed by
+      // later signOut tests. Reset them here.
+      ;(Cookies.clearAll as jest.Mock).mockClear()
+      ;(LegacyNativeModules.ArtsyNativeModule.clearUserData as jest.Mock).mockClear()
+      ;(LoginManager.logOut as jest.Mock).mockClear()
+    })
+
+    it("does nothing when there is no user access token", async () => {
+      await GlobalStore.actions.auth.refreshUserAccessToken()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("does nothing when the token is fresh", async () => {
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userAccessToken: "current-token",
+          userAccessTokenExpiresIn: farFuture,
+        },
+      })
+      await GlobalStore.actions.auth.refreshUserAccessToken()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("refreshes via the trust_token swap when within the refresh window", async () => {
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userAccessToken: "current-token",
+          userAccessTokenExpiresIn: expiringSoon,
+        },
+      })
+
+      mockFetchJsonOnce({ trust_token: "TT" }, 201)
+      mockFetchJsonOnce({ access_token: "fresh-token", expires_in: farFuture }, 201)
+
+      await GlobalStore.actions.auth.refreshUserAccessToken()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(mockFetch.mock.calls[0][0]).toContain("/api/v1/me/trust_token")
+      expect(mockFetch.mock.calls[0][1].headers["X-ACCESS-TOKEN"]).toBe("current-token")
+      expect(mockFetch.mock.calls[1][0]).toContain("/oauth2/access_token")
+      expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual(
+        expect.objectContaining({
+          grant_type: "trust_token",
+          code: "TT",
+        })
+      )
+      expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe("fresh-token")
+      expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessTokenExpiresIn).toBe(
+        farFuture
+      )
+    })
+
+    it("signs out when Gravity returns 401", async () => {
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userAccessToken: "current-token",
+          userAccessTokenExpiresIn: expiringSoon,
+        },
+      })
+
+      mockFetchJsonOnce({}, 401)
+
+      await GlobalStore.actions.auth.refreshUserAccessToken()
+
+      expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe(null)
+    })
+
+    it("keeps the current token on transient failures", async () => {
+      __globalStoreTestUtils__?.injectState({
+        auth: {
+          userAccessToken: "current-token",
+          userAccessTokenExpiresIn: expiringSoon,
+        },
+      })
+
+      mockFetchJsonOnce({}, 503)
+
+      await GlobalStore.actions.auth.refreshUserAccessToken()
+
+      expect(__globalStoreTestUtils__?.getCurrentState().auth.userAccessToken).toBe("current-token")
+    })
+  })
+
   describe("signOut action", () => {
     beforeEach(() => {
       __globalStoreTestUtils__?.injectState({

--- a/src/app/utils/useRefreshUserAccessToken.ts
+++ b/src/app/utils/useRefreshUserAccessToken.ts
@@ -1,0 +1,8 @@
+import { GlobalStore } from "app/store/GlobalStore"
+import { useEffect } from "react"
+
+export function useRefreshUserAccessToken() {
+  useEffect(() => {
+    void GlobalStore.actions.auth.refreshUserAccessToken()
+  }, [])
+}


### PR DESCRIPTION
This PR resolves [PHIRE-3043] <!-- eg [PROJECT-XXXX] -->

### Description

This PR updates our authentication logic to refresh the access token for users who are active. **The goal from this is to prevent active users from being signed off**


**The new flow is like so:**
- If a user has a token that is under one week **then** do nothing
- if a user has a token that is over one week    **then** refresh the token

Our current tokens expire after a year, meaning that as long as you sign in once in a year, you will not be signed off


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix: refresh user access tokens before they expire - mounir

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3043]: https://artsyproduct.atlassian.net/browse/PHIRE-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ