### PR TITLE
build(macos containers): trial blacksmith

### DIFF
--- a/.github/workflows/build-deploy-android-firebase.yml
+++ b/.github/workflows/build-deploy-android-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-android-firebase:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-android-playstore.yml
+++ b/.github/workflows/build-deploy-android-playstore.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-android-playstore:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ github.event_name == 'schedule' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-firebase:
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: ${{ github.event_name == 'schedule' && 'macos-15' || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-firebase:
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-firebase:
-    runs-on: macos-15
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-firebase:
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-testflight:
-    runs-on: macos-15
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-testflight:
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: blacksmith-6vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-testflight:
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: ${{ github.event_name == 'schedule' && 'macos-15' || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-testflight:
-    runs-on: blacksmith-6vcpu-macos-26
+    runs-on: blacksmith-12vcpu-macos-26
     timeout-minutes: 90
 
     steps:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -257,7 +257,7 @@ end
 
 desc 'Set the build version in the iOS app plist'
 lane :set_build_version_ios do
-  bundle_version = DateTime.now.strftime('%Y.%m.%d.%H')
+  bundle_version = DateTime.now.strftime('%Y.%m.%d.%H.%M')
   IOS_TARGETS.each do |_id, meta|
     absolute_path = File.expand_path(meta[:plist_path])
     set_info_plist_value(path: absolute_path, key: 'CFBundleShortVersionString', value: $APP_JSON['version'])
@@ -515,22 +515,15 @@ end
 
 desc 'Get next android build version code'
 lane :get_next_android_build_version do
-  # Generate date-based build number in format YYYYMMDDHH (e.g., 2025111310)
-  # This matches iOS format but without dots since Google Play Console doesn't accept them
+  # Generate date-based build number in format YYYYMMDDHHMI (e.g., 202511131045)
+  # Matches iOS format but without dots since Google Play Console doesn't accept them
   now = Time.now.utc
-  next_version_code = now.strftime('%Y%m%d%H')
+  next_version_code = now.strftime('%Y%m%d%H%M')
 
   # Check if this version code already exists in the alpha track
   current_version_code = google_play_track_version_codes(
     track: 'alpha'
   ).first
-
-  # If the generated version code matches the current version code (same hour),
-  # append minutes to create a unique version (YYYYMMDDHHMI format)
-  if current_version_code && next_version_code.to_i == current_version_code.to_i
-    next_version_code = now.strftime('%Y%m%d%H%M')
-    puts "Version code conflict detected. Using extended format with minutes: #{next_version_code}"
-  end
 
   file_dir = "#{Dir.pwd}/next_version_code.txt"
   puts "Writing next version code to: #{file_dir}"


### PR DESCRIPTION
This PR resolves [PHIRE-3053] <!-- eg [PROJECT-XXXX] -->

### Description

Trialing blacksmith macos containers:

|Before|After|
|---|---|
|<img height="250" alt="Screenshot 2026-05-05 at 17 47 50" src="https://github.com/user-attachments/assets/5442df68-6d20-4043-94e7-68d2cedfd780" />|<img height="250" alt="Screenshot 2026-05-05 at 17 47 44" src="https://github.com/user-attachments/assets/3185ae8a-605b-4c93-b7b3-14f36faa910b" />|
|<img height="250" alt="Screenshot 2026-05-05 at 17 47 30" src="https://github.com/user-attachments/assets/aa07f8a4-095a-4fe8-a8cf-72cb2f80087f" />|<img height="250" alt="Screenshot 2026-05-05 at 17 47 22" src="https://github.com/user-attachments/assets/bb346158-c02f-4f64-ba7d-54dca858cdfb" />|

Testflight from ~49mins on average to 21mins
Firebase from ~49mins on average to 17mins

With some really rough calculations on android we use per month around 1494 mins 

<img width="930" height="115" alt="Screenshot 2026-05-05 at 17 55 38" src="https://github.com/user-attachments/assets/b1484f9f-a148-4317-acc4-b92456c0b7d5" />

That leaves us with 1506 mins for ios / month for free from blacksmith.sh.

Even if we surpass the limit we will pay around:

Apply 1,494 free min to Ubuntu → $0
Apply remaining 1,506 free min to macOS → 1,705 - 1,506 = 199 macOS minutes billable
199 × $0.08 = $15.92/month
Ubuntu: $0

Total after free tier: ~$15.92/month

Around 16 bucks per month for the extra macos minutes that might go down when we optimize a bit more with updating react native etc.



Also now with faster betas we update the versioning to be like so:


  - iOS (line 260): %Y.%m.%d.%H → %Y.%m.%d.%H.%M — produces 2026.05.05.15.30
  - Android (line 517–539): always uses %Y%m%d%H%M, collision-detection block removed — produces 202605051530

### Important for further savings:

- Nightly beta builds (TestFlight / Firebase / Play Store) are triggered exclusively via the GH Actions scheduled trigger and run on standard GitHub runners. Since these builds are not time-sensitive, this avoids spending minutes on the faster (and more expensive) Blacksmith runners.

- Beta builds triggered manually via `deploy-beta-ios` / `deploy-beta-android` use Blacksmith runners, since those are typically triggered by a developer waiting on the build.

With this approach the monthly runs are reduced to approx 32/36 runs monthly per beta for the fast (cause we use the free gh runners for the nightlies around 30 per month)

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- trial blacksmith macos containers

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3053]: https://artsyproduct.atlassian.net/browse/PHIRE-3053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ