### PR TITLE
feat(analytics): include context module (NWFY) and artwork id/slug fields on save events

### DIFF
--- a/src/app/Components/ArtworkCard/ArtworkCard.tsx
+++ b/src/app/Components/ArtworkCard/ArtworkCard.tsx
@@ -114,6 +114,8 @@ export const ArtworkCard: React.FC<ArtworkCardProps> = memo(
           tracks.saveOrUnsaveArtwork(!!isArtworkSaved, {
             context_module: contextModule,
             context_screen_owner_type: ownerType,
+            item_id: artwork.internalID,
+            item_slug: artwork.slug,
           })
         )
       },

--- a/src/app/Components/ArtworkCard/__tests__/ArtworkCard.tests.tsx
+++ b/src/app/Components/ArtworkCard/__tests__/ArtworkCard.tests.tsx
@@ -1,6 +1,8 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkCardTestsQuery } from "__generated__/ArtworkCardTestsQuery.graphql"
 import { ArtworkCard } from "app/Components/ArtworkCard/ArtworkCard"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -25,6 +27,7 @@ describe("ArtworkCard", () => {
       supportMultipleImages: false,
       showPager: false,
     }
+    mockTrackEvent.mockClear()
   })
 
   it("renders artwork card with basic information", () => {
@@ -159,6 +162,53 @@ describe("ArtworkCard", () => {
     fireEvent.press(saveButton)
 
     expect(screen.getByText("Saved")).toBeOnTheScreen()
+  })
+
+  it("tracks save with artwork entity id, slug, and context", () => {
+    defaultProps = {
+      ...defaultProps,
+      contextModule: ContextModule.infiniteDiscoveryArtworkCard,
+      ownerType: OwnerType.infiniteDiscoveryArtwork,
+    }
+
+    const { mockResolveLastOperation } = renderWithRelay({
+      Artwork: () => ({
+        id: "test-artwork-relay-id",
+        internalID: "test-artwork-id",
+        slug: "test-artwork-slug",
+        isSaved: false,
+      }),
+      CollectionsConnection: () => ({
+        totalCount: 0,
+      }),
+    })
+
+    fireEvent.press(screen.getByTestId("save-artwork-icon"))
+
+    mockResolveLastOperation({
+      SaveArtworkPayload: () => ({
+        artwork: {
+          id: "test-artwork-id",
+          isSaved: true,
+          collectorSignals: null,
+        },
+        me: null,
+      }),
+    })
+
+    expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+      [
+        {
+          "action": "success",
+          "action_name": "artworkSave",
+          "action_type": "success",
+          "context_module": "infiniteDiscoveryArtworkCard",
+          "context_screen_owner_type": "infiniteDiscoveryArtwork",
+          "item_id": "test-artwork-id",
+          "item_slug": "test-artwork-slug",
+        },
+      ]
+    `)
   })
 
   it("renders sale message when available", () => {

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -180,6 +180,8 @@ export const Artwork: React.FC<ArtworkProps> = memo(
         context_screen_owner_id: contextScreenOwnerId,
         context_screen_owner_slug: contextScreenOwnerSlug,
         context_screen_owner_type: contextScreenOwnerType,
+        item_id: artwork.internalID,
+        item_slug: artwork.slug,
         inquireable: isInquireable,
         offerable: isOfferable,
       }

--- a/src/app/Components/ArtworkGrids/GenericGrid.tsx
+++ b/src/app/Components/ArtworkGrids/GenericGrid.tsx
@@ -33,6 +33,7 @@ type PropsForArtwork = Omit<ArtworkProps, "artwork">
 
 export const GenericGrid: React.FC<Props & PropsForArtwork> = ({
   artworks: artworksProp,
+  contextModule,
   contextScreenOwnerId,
   contextScreenOwnerSlug,
   contextScreenOwnerType,
@@ -58,6 +59,8 @@ export const GenericGrid: React.FC<Props & PropsForArtwork> = ({
         <Flex accessibilityLabel="Artworks Content View" mx={-2}>
           <MasonryInfiniteScrollArtworkGrid
             artworks={artworks as unknown as MasonryArtworkItem[]}
+            contextModule={contextModule}
+            contextScreenOwnerType={contextScreenOwnerType}
             scrollEnabled={false}
             hidePartner={hidePartner}
             trackTap={trackTap}

--- a/src/app/Components/ArtworkGrids/__tests__/ArtworkGridItem.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/ArtworkGridItem.tests.tsx
@@ -1,4 +1,4 @@
-import { OwnerType } from "@artsy/cohesion"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkGridItemTestsQuery } from "__generated__/ArtworkGridItemTestsQuery.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
@@ -462,6 +462,57 @@ describe("ArtworkGridItem", () => {
 
         expect(screen.getByTestId("filled-heart-icon")).toBeOnTheScreen()
         expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
+      })
+
+      it("tracks save with artwork entity id, slug, and context", () => {
+        const { mockResolveLastOperation } = renderWithRelay(
+          {
+            Artwork: () => ({
+              ...artwork,
+              availability: "for sale",
+              isAcquireable: true,
+              isBiddable: false,
+              isInquireable: false,
+              isOfferable: true,
+            }),
+          },
+          {
+            contextModule: ContextModule.newWorksForYouRail,
+            contextScreenOwnerType: OwnerType.home,
+          }
+        )
+
+        fireEvent.press(screen.getByTestId("save-artwork-icon"))
+
+        mockResolveLastOperation({
+          SaveArtworkPayload: () => ({
+            artwork: {
+              id: artwork.id,
+              isSaved: true,
+              collectorSignals: null,
+            },
+            me: null,
+          }),
+        })
+
+        expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+          [
+            {
+              "acquireable": true,
+              "action": "success",
+              "action_name": "artworkSave",
+              "action_type": "success",
+              "availability": "for sale",
+              "biddable": false,
+              "context_module": "newWorksForYouRail",
+              "context_screen_owner_type": "home",
+              "inquireable": false,
+              "item_id": "abc1234",
+              "item_slug": "cool-artwork",
+              "offerable": true,
+            },
+          ]
+        `)
       })
 
       it("does not render Save CTA if hideSaveIcon is true", () => {

--- a/src/app/Components/ArtworkGrids/__tests__/GenericGrid.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/GenericGrid.tests.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType, ScreenOwnerType } from "@artsy/cohesion"
 import { screen } from "@testing-library/react-native"
 import { GenericGridTestsQuery } from "__generated__/GenericGridTestsQuery.graphql"
 import { GenericGrid } from "app/Components/ArtworkGrids/GenericGrid"
@@ -5,11 +6,39 @@ import { extractNodes } from "app/utils/extractNodes"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
+const mockMasonryInfiniteScrollArtworkGrid = jest.fn()
+
+jest.mock("app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid", () => {
+  const actual = jest.requireActual("app/Components/ArtworkGrids/MasonryInfiniteScrollArtworkGrid")
+
+  return {
+    ...actual,
+    MasonryInfiniteScrollArtworkGrid: (props: any) => {
+      mockMasonryInfiniteScrollArtworkGrid(props)
+      return <actual.MasonryInfiniteScrollArtworkGrid {...props} />
+    },
+  }
+})
+
 describe("GenericGrid", () => {
-  const { renderWithRelay } = setupTestWrapper<GenericGridTestsQuery, { isLoading?: boolean }>({
-    Component: ({ viewer, isLoading }) => {
+  const { renderWithRelay } = setupTestWrapper<
+    GenericGridTestsQuery,
+    {
+      contextModule?: ContextModule
+      contextScreenOwnerType?: ScreenOwnerType
+      isLoading?: boolean
+    }
+  >({
+    Component: ({ viewer, contextModule, contextScreenOwnerType, isLoading }) => {
       const artworks = extractNodes(viewer?.artworksConnection)
-      return <GenericGrid artworks={artworks} isLoading={isLoading} />
+      return (
+        <GenericGrid
+          artworks={artworks}
+          contextModule={contextModule}
+          contextScreenOwnerType={contextScreenOwnerType}
+          isLoading={isLoading}
+        />
+      )
     },
     query: graphql`
       query GenericGridTestsQuery @relay_test_operation {
@@ -24,6 +53,10 @@ describe("GenericGrid", () => {
         }
       }
     `,
+  })
+
+  beforeEach(() => {
+    mockMasonryInfiniteScrollArtworkGrid.mockClear()
   })
 
   it("renders without throwing an error", () => {
@@ -63,5 +96,30 @@ describe("GenericGrid", () => {
     )
 
     expect(screen.getByTestId("spinner")).toBeOnTheScreen()
+  })
+
+  it("passes analytics context through to the masonry grid", () => {
+    renderWithRelay(
+      {
+        Artwork: () => ({
+          id: "artwork-1",
+          slug: "test-artwork",
+          image: {
+            aspectRatio: 1.5,
+          },
+        }),
+      },
+      {
+        contextModule: ContextModule.newWorksForYouRail,
+        contextScreenOwnerType: OwnerType.home,
+      }
+    )
+
+    expect(mockMasonryInfiniteScrollArtworkGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextModule: ContextModule.newWorksForYouRail,
+        contextScreenOwnerType: OwnerType.home,
+      })
+    )
   })
 })

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -103,6 +103,8 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
         context_screen_owner_id: contextScreenOwnerId,
         context_screen_owner_slug: contextScreenOwnerSlug,
         context_screen_owner_type: contextScreenOwnerType,
+        item_id: artwork.internalID,
+        item_slug: artwork.slug,
         inquireable: isInquireable,
         offerable: isOfferable,
       })

--- a/src/app/Components/ArtworkRail/__tests__/ArtworkRailCard.tests.tsx
+++ b/src/app/Components/ArtworkRail/__tests__/ArtworkRailCard.tests.tsx
@@ -1,6 +1,8 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtworkRailCardTestsQuery } from "__generated__/ArtworkRailCardTestsQuery.graphql"
 import { ArtworkRailCard } from "app/Components/ArtworkRail/ArtworkRailCard"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { DateTime } from "luxon"
 import { graphql } from "react-relay"
@@ -15,6 +17,10 @@ describe("ArtworkRailCard", () => {
         }
       }
     `,
+  })
+
+  beforeEach(() => {
+    mockTrackEvent.mockClear()
   })
 
   describe("in an open sale", () => {
@@ -95,6 +101,58 @@ describe("ArtworkRailCard", () => {
 
       expect(screen.getByTestId("filled-heart-icon")).toBeOnTheScreen()
       expect(screen.queryByTestId("empty-heart-icon")).not.toBeOnTheScreen()
+    })
+
+    it("tracks save with artwork entity id, slug, and context", () => {
+      const { mockResolveLastOperation } = renderWithRelay(
+        {
+          Artwork: () => ({
+            ...artwork,
+            availability: "for sale",
+            isAcquireable: true,
+            isBiddable: false,
+            isInquireable: false,
+            isOfferable: true,
+          }),
+        },
+        {
+          contextModule: ContextModule.newWorksForYouRail,
+          contextScreenOwnerType: OwnerType.home,
+          showSaveIcon: true,
+        }
+      )
+
+      fireEvent.press(screen.getByTestId("save-artwork-icon"))
+
+      mockResolveLastOperation({
+        SaveArtworkPayload: () => ({
+          artwork: {
+            id: artwork.id,
+            isSaved: true,
+            collectorSignals: null,
+          },
+          me: null,
+        }),
+      })
+
+      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "acquireable": true,
+            "action": "success",
+            "action_name": "artworkSave",
+            "action_type": "success",
+            "availability": "for sale",
+            "biddable": false,
+            "context_module": "newWorksForYouRail",
+            "context_screen_owner_type": "home",
+            "inquireable": false,
+            "item_id": "abc1234",
+            "item_slug": "cool-artwork",
+            "offerable": true,
+          },
+        ]
+      `)
     })
 
     it("does not show heart icon when showSaveIcon is set to false", () => {

--- a/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkSaveButton.tsx
@@ -65,6 +65,8 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
           : Schema.ActionNames.ArtworkUnsave,
         action_type: Schema.ActionTypes.Success,
         context_module: Schema.ContextModules.ArtworkActions,
+        item_id: artworkData.internalID,
+        item_slug: artworkData.slug,
       })
     },
     saveToDefaultCollectionOnly,
@@ -114,6 +116,8 @@ export const ArtworkSaveButton: React.FC<ArtworkSaveButtonProps> = ({
 
 const ArtworkSaveButtonFragment = graphql`
   fragment ArtworkSaveButton_artwork on Artwork {
+    internalID
+    slug
     sale {
       isAuction
       isClosed

--- a/src/app/Scenes/Artwork/Components/__tests__/ArtworkActions.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/__tests__/ArtworkActions.tests.tsx
@@ -7,6 +7,7 @@ import {
   shareContent,
 } from "app/Scenes/Artwork/Components/ArtworkActions"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -151,11 +152,48 @@ describe("ArtworkActions", () => {
         "useSaveArtworkMutation"
       )
     })
+
+    it("tracks save with artwork entity id and slug", () => {
+      const { mockResolveLastOperation } = renderWithRelay({
+        Artwork: () => ({
+          ...artworkActionsArtwork,
+          internalID: "artwork-internal-id",
+          slug: "artwork-slug",
+          isSaved: false,
+        }),
+      })
+
+      fireEvent.press(screen.getByLabelText("Save artwork"))
+
+      mockResolveLastOperation({
+        SaveArtworkPayload: () => ({
+          artwork: {
+            id: "artwork12345",
+            isSaved: true,
+            collectorSignals: null,
+          },
+          me: null,
+        }),
+      })
+
+      expect(mockTrackEvent.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "action_name": "artworkSave",
+            "action_type": "success",
+            "context_module": "ArtworkActions",
+            "item_id": "artwork-internal-id",
+            "item_slug": "artwork-slug",
+          },
+        ]
+      `)
+    })
   })
 })
 
 const artworkActionsArtwork = {
   id: "artwork12345",
+  internalID: "artwork-internal-id",
   slug: "andreas-rod-prinzknecht",
   image: {
     url: "image.com/image",

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Button, Flex } from "@artsy/palette-mobile"
 import { ArtworkGridItem_artwork$data } from "__generated__/ArtworkGridItem_artwork.graphql"
 import { GenericGrid_artworks$key } from "__generated__/GenericGrid_artworks.graphql"
@@ -79,6 +79,8 @@ export const HomeViewSectionArtworksGrid: React.FC<HomeViewSectionArtworksGridPr
       <View ref={gridContainerRef}>
         <GenericGrid
           artworks={artworks}
+          contextModule={contextModule}
+          contextScreenOwnerType={OwnerType.home}
           onPress={onArtworkPress}
           fitToFrame
           onItemVisibilityChange={handleGridItemVisibilityChange}

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworksGrid.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworksGrid.tests.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { HomeViewSectionArtworksGrid } from "app/Scenes/HomeView/Sections/HomeViewSectionArtworksGrid"
 import HomeAnalytics from "app/Scenes/HomeView/helpers/homeAnalytics"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -84,6 +84,17 @@ describe("HomeViewSectionArtworksGrid", () => {
         contextModule: gridContextModule,
         position: 1,
         type: "artwork",
+      })
+    )
+  })
+
+  it("passes home analytics context to the artwork grid", () => {
+    renderComponent()
+
+    expect(mockGenericGrid).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextModule: gridContextModule,
+        contextScreenOwnerType: OwnerType.home,
       })
     )
   })


### PR DESCRIPTION
This PR resolves [ONYX-2097]

### Description

- Adds `item_id` and `item_slug` to artwork save/unsave events from:
  - artwork cards
  - artwork grids
  - artwork rails
  - artwork page save button
- Passes `context_screen_owner_type` through Home artwork grid save/unsave events, including the New Works for You screen.

No visual changes.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- changes to save/un-save tracking: added artwork id and slug everywhere; added missing NWFY context module 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

[ONYX-2097]: https://artsyproduct.atlassian.net/browse/ONYX-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ