### PR TITLE
chore: remove unused @types/react-native-push-notification dep & stale hack entries

### DIFF
--- a/HACKS.md
+++ b/HACKS.md
@@ -28,16 +28,6 @@ There was a case where echo returns 401 when a user asks for the latest echo opt
 
 After a few months we should be safe to return to the old name if we want. If we decide to do that, we should make sure to remove the old file that might have been sitting on users' phones.
 
-## Delay modal display after LoadingModal is dismissed
-
-#### When can we remove this:
-
-Doesn't really need to be removed but can be if view hierarchy issue is fixed in RN or our LoadingModal see PR for more details: https://github.com/artsy/eigen/pull/4283
-
-#### Explanation/Context:
-
-We have a modal for showing a loading state and a onDismiss call that optionally displays an alert message, on iOS 14 we came across an issue where the alert was not displaying because when onDismiss was called the LoadingModal was still in the view hierarchy. The delay is a workaround.
-
 ## android Input placeholder measuring hack
 
 #### When can we remove this:
@@ -49,18 +39,6 @@ Once https://github.com/facebook/react-native/pull/29664 is merged or https://gi
 As you can see in the PR and issue, android doesn't use ellipsis on the placeholder of a TextInput. That makes for a funky cut-off.
 
 We added a workaround on Input, to accept an array of placeholders, from longest to shortest, so that android can measure which one fits in the TextInput as placeholder, and it uses that. When android can handle a long placeholder and use ellipsis or if we don't use long placeholders anymore, this can go.
-
-## `react-native-push-notification` Requiring unknown module on ios
-
-#### When can we remove this:
-
-Once we want to use react-native-push-notification on iOS
-
-#### Explanation/Context:
-
-This is happening because react-native-push-notification requires @react-native-community/push-notification-ios. We are not
-adding this dependency at this time because it is unnecessary and we do not use react-native-push-notification on iOS. Also,
-we do not want unnecessary conflicts between our native push notification implementation and @react-native-community/push-notification-ios's.
 
 ## `PropsStore` pass functions as props inside navigate() on iOS
 
@@ -240,27 +218,6 @@ When Rozenite stable release is published and no longer requires this resolution
 #### Explanation/Context:
 
 This resolution was added to fix Rozenite integration issues. Rozenite was unable to display its dev tools tabs because it couldn't properly detect whether we were using Expo CLI or React Native CLI, causing confusion in its tooling detection logic. The resolution ensures Rozenite can correctly identify our development environment and render its interface properly.
-
-## patch for react-native-reanimated
-
-#### Explanation/Context:
-
-This patch was added to support 16KB page size on Android. It's a copy paste from here https://github.com/software-mansion/react-native-reanimated/pull/7037
-
-#### When can we remove it
-
-It can be removed once we upgrade to any version past 3.17
-
-## Patch for react-native-reanimated (CellRendererComponent)
-
-#### When can we remove this:
-
-When we can update the reanimated flatlist CellRendererComponent or it's style, or when this PR gets merged:
-https://github.com/software-mansion/react-native-reanimated/pull/6573
-
-#### Explanation/Context:
-
-In the HomeView Tasks, we want to update the FlatList's `CellRendererComponent` to update the `zIndex` of the rendered elements so they can be on top of each other, and to animate them we need to use Reanimated's FlatList, but it doesn't support updating the `CellRendererComponent` prop since they have their own implementation, so we added this patch to update the style of the component in Reanimated's FlatList.
 
 ## patch for react-native RCTEventEmitter
 

--- a/HACKS.md
+++ b/HACKS.md
@@ -40,42 +40,6 @@ As you can see in the PR and issue, android doesn't use ellipsis on the placehol
 
 We added a workaround on Input, to accept an array of placeholders, from longest to shortest, so that android can measure which one fits in the TextInput as placeholder, and it uses that. When android can handle a long placeholder and use ellipsis or if we don't use long placeholders anymore, this can go.
 
-## `PropsStore` pass functions as props inside navigate() on iOS
-
-#### When can we remove this:
-
-Once we no longer use our native implementation of pushView on iOS
-
-#### Explanation/Context:
-
-We cannot pass functions as props because `navigate.ts` on ios uses the native obj-c definition of pushView in `ARScreenPresenterModule.m`.
-React native is not able to convert js functions so this is passed as null to the underlying native method
-See what can be converted: https://github.com/facebook/react-native/blob/main/React/Base/RCTConvert.h
-
-PropsStore allows us to temporarily hold on the props and reinject them back into the destination view or module.
-
-## `ORStackView` patch (add UIKit import)
-
-#### When can we remove this:
-
-Once we remove ORStackView or the upstream repo adds the import. May want to proactively open a PR for this.
-
-#### Explanation/Context:
-
-The Pod does not compile when imported as is without hack due to missing symbols from UIKit.
-
-## `Map` manual prop update in `PageWrapper`
-
-#### When can we remove this:
-
-We should see if it is still necessary when we remove the old native navigation on iOS. To check: go into City Guide, leave, enter again and then try to change the city. If it works without this code it can be removed.
-If it is still an issue with old native navigation gone this can either be removed when we remove or rebuild City Guide or if we change how props are saved in PageWrapper.
-
-#### Explanation/Context:
-
-City Guide is a mixture of native components and react components, prop updates from the native side are not updating the component on the react native side without this manual check and update. See the PR here for the change in the AppRegistry:
-https://github.com/artsy/eigen/pull/6348
-
 ## `React-Native-Image-Crop-Picker` App restarting when photo is taken. Fix is in `ArtsyNativeModule.clearCache`.
 
 #### When can we remove this:
@@ -90,13 +54,13 @@ The app restarts when the user takes a picture to pass to `react-native-image-cr
 
 #### When can we remove this:
 
-To remove this, we need to change our InfiniteScrollArtworksGrid to use a FlatList or any VirtualizedList. We haven't done that yet, because we need the masonry layout.
-We either need to find a library that gives us masonry layout using a VirtualizedList, or we need to make our own version of this.
+When all `InfiniteScrollArtworksGrid` callers have been migrated to `MasonryFlashList` (from `@shopify/flash-list`), at which point `ParentAwareScrollView` and `InfiniteScrollArtworksGrid`'s ScrollView path become unused and can be deleted.
 
 #### Explanation/Context:
 
-Currently our masonry layout (in InfiniteScrollArtworksGrid `render()`) is using a ScrollView, which is not a VirtualizedList.
-Also, currently, the parent that is the FlatList, comes from StickyTabPageFlatList.
+`InfiniteScrollArtworksGrid` renders its masonry layout inside a `ScrollView` (not a `VirtualizedList`), and on Android wraps it in `ParentAwareScrollView` to detect when it's nested inside an outer scroll view of the same orientation and forward scroll events accordingly.
+
+`MasonryFlashList` now provides a virtualized masonry layout, and several scenes have migrated to it, but `InfiniteScrollArtworksGrid` is still used in ~40 places.
 
 ## Podfile postinstall code_signing_required = NO
 
@@ -131,17 +95,6 @@ patch.
 
 This package includes a `setPageName` method on `SiftReactNative`, but no corresponding type.
 I patched it to add the type.
-
-## Patch for @react-navigation/native
-
-#### When we can remove this:
-
-When we upgrade to 6.0.14 or higher, should do shortly but requires fixing a fair few type issues.
-
-### Explanation/Context
-
-React native removed removeEventListener which this library uses and causes jest tests to fail with type errors. This commit fixes the issue:
-https://github.com/react-navigation/react-navigation/commit/6e9da7304127a7c33cda2da2fa9ea1740ef56604
 
 ## Artsy fork of Interstellar in Podfile
 
@@ -209,16 +162,6 @@ This patch allows us to animate the appearance of the bottom tabs. This is curre
 
 See https://github.com/artsy/eigen/pull/12249 for more details.
 
-## Resolutions @react-native/dev-middleware
-
-#### When can we remove this:
-
-When Rozenite stable release is published and no longer requires this resolution
-
-#### Explanation/Context:
-
-This resolution was added to fix Rozenite integration issues. Rozenite was unable to display its dev tools tabs because it couldn't properly detect whether we were using Expo CLI or React Native CLI, causing confusion in its tooling detection logic. The resolution ensures Rozenite can correctly identify our development environment and render its interface properly.
-
 ## patch for react-native RCTEventEmitter
 
 #### Explanation/Context:
@@ -232,17 +175,20 @@ It can be removed once if we stop using the singleton pattern or get rid of ARNo
 
 ## react-native-reanimated package.json flags and react-native patch
 
-### USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS
-
 #### Explanation/Context:
 
-This feature flag was added to fix performance issues with scrolling. See https://docs.swmansion.com/react-native-reanimated/docs/guides/performance/#%EF%B8%8F-lower-fps-while-scrolling
+`package.json` sets the following reanimated `staticFeatureFlags` to fix scroll performance. See https://docs.swmansion.com/react-native-reanimated/docs/guides/performance/#%EF%B8%8F-lower-fps-while-scrolling
 
-We also added a patch to react-native to support this flag and temporarily enabled preventShadowTreeCommitExhaustion and enableCppPropsIteratorSetter flags to fix performance issues.
+- `USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS`
+- `DISABLE_COMMIT_PAUSING_MECHANISM`
+- `ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS`
+- `IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS`
+
+We also patch `react-native` (`ReactNativeFeatureFlagsDefaults.h`) to flip `preventShadowTreeCommitExhaustion()` to return `true`, which is required for these flags to behave correctly.
 
 #### When can we remove this:
 
-When reanimated adopts this by default.
+When reanimated adopts these by default.
 
 ## react-native-webview passing constant for decelerationRate prop
 

--- a/package.json
+++ b/package.json
@@ -258,7 +258,6 @@
     "@types/qs": "6.9.7",
     "@types/query-string": "5.0.1",
     "@types/react": "19.1.0",
-    "@types/react-native-push-notification": "8.1.1",
     "@types/react-relay": "18.2.0",
     "@types/react-test-renderer": "19.1.0",
     "@types/react-tracking": "8.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9648,13 +9648,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-native-push-notification@npm:8.1.1":
-  version: 8.1.1
-  resolution: "@types/react-native-push-notification@npm:8.1.1"
-  checksum: 10c0/94ada0802844070a08b578a64fcfcb3f82eb868fb9e290bab71ec78ae6bb23872815ad844eaa48f68871996a834bb1b7bbebb9d31ea17fb3a3177f946dc66a49
-  languageName: node
-  linkType: hard
-
 "@types/react-relay@npm:18.2.0":
   version: 18.2.0
   resolution: "@types/react-relay@npm:18.2.0"
@@ -13394,7 +13387,6 @@ __metadata:
     "@types/qs": "npm:6.9.7"
     "@types/query-string": "npm:5.0.1"
     "@types/react": "npm:19.1.0"
-    "@types/react-native-push-notification": "npm:8.1.1"
     "@types/react-relay": "npm:18.2.0"
     "@types/react-test-renderer": "npm:19.1.0"
     "@types/react-tracking": "npm:8.1.6"


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Removes `@types/react-native-push-notification` stale dependency

Updates on hacks.md entries:

Deleted entries (9):

  - 🧹 🧼 🫧 Delay modal display after LoadingModal is dismissed — workaround code (setTimeout(..., 150) inside LoadingModal's onDismiss) lived in MyAccountFieldEditScreen.tsx, which
   has been removed from the codebase; no remaining LoadingModal usage has the delay pattern.
  - 🧹 🧼 🫧 react-native-push-notification Requiring unknown module on ios — entry described why we don't add a dep we never adopted on iOS; there's no actual hack in the code to
  document.
  - 🧹 🧼 🫧 patch for react-native-reanimated — patch was for 16KB Android page-size support; reanimated has since shipped a version (>3.17) that includes the fix natively, so the
  patch was already removed.
  - 🧹 🧼 🫧 Patch for react-native-reanimated (CellRendererComponent) — patch enabled custom CellRendererComponent on reanimated's FlatList; the HomeView Tasks code that needed it
  has changed shape and the patch is no longer applied.
  - 🧹 🧼 🫧 PropsStore pass functions as props inside navigate() on iOS — premise was a native pushView bridge in ARScreenPresenterModule.m that dropped JS function props; that
  bridge method no longer exists (the renamed ARTNativeScreenPresenterModule only exposes AR-related methods now), and PropsStore.ts has zero callers.
  - 🧹 🧼 🫧 ORStackView patch (add UIKit import) — ios/patches/ORStackView+2.0.3.diff and the cocoapods-patch plugin were removed in commit 8cc0de6abb (Dec 2024) during the Expo
  migration; ORStackView still compiles fine without the patch.
  - 🧹 🧼 🫧 Map manual prop update in PageWrapper — PageWrapper no longer exists in src/; City Guide is now a pure React Native screen (<MapRenderer /> driven by a hook), with no
  native bridge passing props in.
  - 🧹 🧼 🫧 Patch for @react-navigation/native — no @react-navigation/native patch exists in .yarn/patches/, and the removal condition (upgrade to 6.0.14+) was satisfied long ago —
  we're on 7.1.18, two majors past it.
  - 🧹 🧼 🫧 Resolutions @react-native/dev-middleware — no such resolution exists in package.json; the 9 entries in the resolutions block don't include @react-native/dev-middleware.

  Refreshed wording (2):

  - ✏️ ParentAwareScrollView — dropped dead StickyTabPageFlatList reference (no matches in src/); reframed removal condition around MasonryFlashList migration progress, since
  @shopify/flash-list's virtualized masonry now exists and is the path forward.
  - ✏️ react-native-reanimated package.json flags and react-native patch — listed the actual 4 staticFeatureFlags we set (USE_COMMIT_HOOK_ONLY_FOR_REACT_COMMITS,
  DISABLE_COMMIT_PAUSING_MECHANISM, ANDROID_SYNCHRONOUSLY_UPDATE_UI_PROPS, IOS_SYNCHRONOUSLY_UPDATE_UI_PROPS), removed the inaccurate enableCppPropsIteratorSetter mention (not
  present in our config or patches), kept the preventShadowTreeCommitExhaustion note since that flip is in the RN patch.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- cleanup hacks.md

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
