### PR TITLE
fix(DI-107): Adds network error handling to the login flow to prevent users from getting stuck when offline.

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
@@ -18,6 +18,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
 import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
+import { Alert } from "react-native"
 import * as Yup from "yup"
 
 export interface LoginPasswordStepFormValues {
@@ -63,6 +64,10 @@ export const LoginPasswordStep: React.FC = () => {
         }
 
         switch (true) {
+          case res === "network_error": {
+            Alert.alert("Can't Connect", "Check your network and try again")
+            break
+          }
           case res === "auth_blocked": {
             showBlockedAuthError("sign in")
             break

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
@@ -9,6 +9,7 @@ import {
   Touchable,
   useTheme,
 } from "@artsy/palette-mobile"
+import { useToast } from "app/Components/Toast/toastHook"
 import {
   useAuthNavigation,
   useAuthScreen,
@@ -18,7 +19,6 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { showBlockedAuthError } from "app/utils/auth/authHelpers"
 import { Formik, useFormikContext } from "formik"
 import { useRef } from "react"
-import { Alert } from "react-native"
 import * as Yup from "yup"
 
 export interface LoginPasswordStepFormValues {
@@ -28,6 +28,7 @@ export interface LoginPasswordStepFormValues {
 export const LoginPasswordStep: React.FC = () => {
   const screen = useAuthScreen()
   const navigation = useAuthNavigation()
+  const toast = useToast()
 
   return (
     <Formik<LoginPasswordStepFormValues>
@@ -64,15 +65,24 @@ export const LoginPasswordStep: React.FC = () => {
         }
 
         switch (true) {
-          case res === "network_error": {
-            Alert.alert("Can't Connect", "Check your network and try again")
+          case res === "failure": {
+            toast.show(
+              "Something went wrong. Please try again, or contact support@artsy.net",
+              "bottom",
+              {
+                backgroundColor: "red100",
+              }
+            )
             break
           }
           case res === "auth_blocked": {
             showBlockedAuthError("sign in")
             break
           }
-          case res !== "success" && res !== "otp_missing" && res !== "on_demand_otp_missing": {
+          case res !== "success" &&
+            res !== "otp_missing" &&
+            res !== "on_demand_otp_missing" &&
+            res !== "failure": {
             setErrors({ password: "Incorrect email or password" }) // pragma: allowlist secret
             break
           }

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
@@ -10,10 +10,10 @@ import {
   Text,
   useTheme,
 } from "@artsy/palette-mobile"
-import NetInfo from "@react-native-community/netinfo"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import LoadingModal from "app/Components/Modals/LoadingModal"
 import { useRecaptcha } from "app/Components/Recaptcha/Recaptcha"
+import { useToast } from "app/Components/Toast/toastHook"
 import { AuthContext } from "app/Scenes/Onboarding/Screens/Auth/AuthContext"
 import { useAuthNavigation } from "app/Scenes/Onboarding/Screens/Auth/hooks/useAuthNavigation"
 import { useInputAutofocus } from "app/Scenes/Onboarding/Screens/Auth/hooks/useInputAutofocus"
@@ -24,7 +24,7 @@ import { osMajorVersion } from "app/utils/platformUtil"
 import { Formik, useFormikContext } from "formik"
 import { MotiView } from "moti"
 import React, { useEffect, useRef, useState } from "react"
-import { Alert, Platform } from "react-native"
+import { Platform } from "react-native"
 import { Easing } from "react-native-reanimated"
 import * as Yup from "yup"
 
@@ -37,8 +37,9 @@ export const LoginWelcomeStep: React.FC = () => {
   const isCurrentScreen = currentScreen?.name === "LoginWelcomeStep"
 
   const navigation = useAuthNavigation()
+  const toast = useToast()
 
-  const { Recaptcha, token, isTokenValid, refreshToken } = useRecaptcha({
+  const { Recaptcha, token, state, isTokenValid, refreshToken } = useRecaptcha({
     source: "authentication",
     action: "verify_email",
   })
@@ -89,15 +90,19 @@ export const LoginWelcomeStep: React.FC = () => {
         onSubmit={async ({ email }, { resetForm }) => {
           // Check if token is missing or expired
           if (!token || !isTokenValid()) {
-            const netInfo = await NetInfo.fetch()
-            if (!netInfo.isConnected) {
-              // Show alert if offline
-              Alert.alert("Can't Connect", "Check your network and try again")
+            refreshToken()
+
+            if (state === "error") {
+              toast.show(
+                "Something went wrong. Please try again, or contact support@artsy.net",
+                "bottom",
+                {
+                  backgroundColor: "red100",
+                }
+              )
               return
             }
-            // If online, wait for reCAPTCHA token (existing behavior)
             setPendingSubmission({ email, resetForm: () => resetForm({ values: { email } }) })
-            refreshToken()
             return
           }
           const res = await GlobalStore.actions.auth.verifyUser({ email, recaptchaToken: token })

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   useTheme,
 } from "@artsy/palette-mobile"
+import NetInfo from "@react-native-community/netinfo"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
 import LoadingModal from "app/Components/Modals/LoadingModal"
 import { useRecaptcha } from "app/Components/Recaptcha/Recaptcha"
@@ -23,7 +24,7 @@ import { osMajorVersion } from "app/utils/platformUtil"
 import { Formik, useFormikContext } from "formik"
 import { MotiView } from "moti"
 import React, { useEffect, useRef, useState } from "react"
-import { Platform } from "react-native"
+import { Alert, Platform } from "react-native"
 import { Easing } from "react-native-reanimated"
 import * as Yup from "yup"
 
@@ -88,11 +89,17 @@ export const LoginWelcomeStep: React.FC = () => {
         onSubmit={async ({ email }, { resetForm }) => {
           // Check if token is missing or expired
           if (!token || !isTokenValid()) {
+            const netInfo = await NetInfo.fetch()
+            if (!netInfo.isConnected) {
+              // Show alert if offline
+              Alert.alert("Can't Connect", "Check your network and try again")
+              return
+            }
+            // If online, wait for reCAPTCHA token (existing behavior)
             setPendingSubmission({ email, resetForm: () => resetForm({ values: { email } }) })
             refreshToken()
             return
           }
-
           const res = await GlobalStore.actions.auth.verifyUser({ email, recaptchaToken: token })
 
           if (res === "user_exists") {

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
@@ -86,6 +86,17 @@ describe("LoginPasswordStep", () => {
     )
   })
 
+  it("shows an alert when network error occurs", async () => {
+    jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("network_error")
+    jest.spyOn(Alert, "alert")
+    renderWithWrappers(<LoginPasswordStep />)
+    fireEvent.changeText(screen.getByA11yHint("Enter your password"), "Password1")
+    fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
+    await waitFor(() =>
+      expect(Alert.alert).toHaveBeenCalledWith("Can't Connect", "Check your network and try again")
+    )
+  })
+
   describe("when showLoginLink param is true", () => {
     beforeEach(() => {
       mockUseAuthScreen.mockReturnValue({

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
@@ -37,14 +37,6 @@ describe("LoginPasswordStep", () => {
     await waitFor(() => expect(GlobalStore.actions.auth.signIn).toHaveBeenCalled())
   })
 
-  it("shows an error when login fails", async () => {
-    jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("failure")
-    renderWithWrappers(<LoginPasswordStep />)
-    fireEvent.changeText(screen.getByA11yHint("Enter your password"), "Password2")
-    fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
-    await screen.findByText("Incorrect email or password")
-  })
-
   it("navigates to the standard OTP step with required", async () => {
     jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("otp_missing")
     renderWithWrappers(<LoginPasswordStep />)
@@ -86,14 +78,18 @@ describe("LoginPasswordStep", () => {
     )
   })
 
-  it("shows an alert when network error occurs", async () => {
-    jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("network_error")
-    jest.spyOn(Alert, "alert")
+  it("shows a toast when login fails", async () => {
+    jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("failure")
+    const toastSpy = jest.spyOn(GlobalStore.actions.toast, "add")
     renderWithWrappers(<LoginPasswordStep />)
     fireEvent.changeText(screen.getByA11yHint("Enter your password"), "Password1")
     fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
     await waitFor(() =>
-      expect(Alert.alert).toHaveBeenCalledWith("Can't Connect", "Check your network and try again")
+      expect(toastSpy).toHaveBeenCalledWith({
+        message: "Something went wrong. Please try again, or contact support@artsy.net",
+        placement: "bottom",
+        options: { backgroundColor: "red100" },
+      })
     )
   })
 

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
@@ -1,4 +1,3 @@
-import NetInfo from "@react-native-community/netinfo"
 import { act, fireEvent, screen } from "@testing-library/react-native"
 import { useRecaptcha } from "app/Components/Recaptcha/Recaptcha"
 import { AuthContext } from "app/Scenes/Onboarding/Screens/Auth/AuthContext"
@@ -8,12 +7,11 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { osMajorVersion } from "app/utils/platformUtil"
 import { mockNavigate } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { Alert, Platform } from "react-native"
+import { Platform } from "react-native"
 
 jest.mock("app/Scenes/Onboarding/Screens/Auth/hooks/useAuthNavigation")
 jest.mock("app/Scenes/Onboarding/Screens/Auth/hooks/useInputAutofocus")
 jest.mock("app/utils/platformUtil")
-jest.mock("@react-native-community/netinfo")
 jest.mock("app/Components/Recaptcha/Recaptcha", () => ({
   useRecaptcha: jest.fn().mockReturnValue({
     Recaptcha: () => {},
@@ -129,6 +127,7 @@ describe("LoginWelcomeStep", () => {
         get token() {
           return tokenValue
         },
+        state: undefined,
         isTokenValid: isTokenValidSpy,
         refreshToken: () => {
           refreshTokenSpy()
@@ -151,11 +150,7 @@ describe("LoginWelcomeStep", () => {
       // eslint-disable-next-line testing-library/no-unnecessary-act
       await act(async () => {
         fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
-      })
-
-      // Advance timers to allow async operations to complete
-      act(() => {
-        jest.advanceTimersByTime(100)
+        jest.runAllTimers()
       })
 
       expect(refreshTokenSpy).toHaveBeenCalled()
@@ -176,6 +171,7 @@ describe("LoginWelcomeStep", () => {
       mockUseRecaptcha.mockReturnValue({
         Recaptcha: () => {},
         token: "expired-token",
+        state: undefined,
         isTokenValid: isTokenValidSpy,
         refreshToken: refreshTokenSpy,
       })
@@ -195,6 +191,10 @@ describe("LoginWelcomeStep", () => {
       })
 
       act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      act(() => {
         jest.advanceTimersByTime(50)
       })
 
@@ -202,21 +202,19 @@ describe("LoginWelcomeStep", () => {
       expect(navigateSpy).not.toHaveBeenCalled()
     })
 
-    it("shows an alert when network is offline and token is missing", async () => {
+    it("shows a toast when token refresh fails", async () => {
       const refreshTokenSpy = jest.fn()
       const isTokenValidSpy = jest.fn(() => false)
 
       mockUseRecaptcha.mockReturnValue({
         Recaptcha: () => {},
         token: null,
+        state: "error",
         isTokenValid: isTokenValidSpy,
         refreshToken: refreshTokenSpy,
       })
 
-      const mockNetInfoFetch = NetInfo.fetch as jest.Mock
-      mockNetInfoFetch.mockResolvedValue({ isConnected: false })
-
-      jest.spyOn(Alert, "alert")
+      const toastSpy = jest.spyOn(GlobalStore.actions.toast, "add")
 
       const navigateSpy = jest.fn()
       mockUseAuthNavigation.mockReturnValue({
@@ -230,44 +228,14 @@ describe("LoginWelcomeStep", () => {
       // eslint-disable-next-line testing-library/no-unnecessary-act
       await act(async () => {
         fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
+        jest.runAllTimers()
       })
 
-      expect(Alert.alert).toHaveBeenCalledWith("Can't Connect", "Check your network and try again")
-      expect(refreshTokenSpy).not.toHaveBeenCalled()
-      expect(navigateSpy).not.toHaveBeenCalled()
-    })
-
-    it("continues with token refresh when network is online and token is missing", async () => {
-      const refreshTokenSpy = jest.fn()
-      const isTokenValidSpy = jest.fn(() => false)
-
-      mockUseRecaptcha.mockReturnValue({
-        Recaptcha: () => {},
-        token: null,
-        isTokenValid: isTokenValidSpy,
-        refreshToken: refreshTokenSpy,
+      expect(toastSpy).toHaveBeenCalledWith({
+        message: "Something went wrong. Please try again, or contact support@artsy.net",
+        placement: "bottom",
+        options: { backgroundColor: "red100" },
       })
-
-      const mockNetInfoFetch = NetInfo.fetch as jest.Mock
-      mockNetInfoFetch.mockResolvedValue({ isConnected: true })
-
-      jest.spyOn(Alert, "alert")
-
-      const navigateSpy = jest.fn()
-      mockUseAuthNavigation.mockReturnValue({
-        navigate: navigateSpy,
-      })
-
-      renderExpandedWelcomeStep()
-
-      fireEvent.changeText(screen.getByA11yHint("Enter your email address"), "foo@bar.baz")
-
-      // eslint-disable-next-line testing-library/no-unnecessary-act
-      await act(async () => {
-        fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
-      })
-
-      expect(Alert.alert).not.toHaveBeenCalled()
       expect(refreshTokenSpy).toHaveBeenCalled()
       expect(navigateSpy).not.toHaveBeenCalled()
     })

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
@@ -1,3 +1,4 @@
+import NetInfo from "@react-native-community/netinfo"
 import { act, fireEvent, screen } from "@testing-library/react-native"
 import { useRecaptcha } from "app/Components/Recaptcha/Recaptcha"
 import { AuthContext } from "app/Scenes/Onboarding/Screens/Auth/AuthContext"
@@ -7,11 +8,12 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { osMajorVersion } from "app/utils/platformUtil"
 import { mockNavigate } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { Platform } from "react-native"
+import { Alert, Platform } from "react-native"
 
 jest.mock("app/Scenes/Onboarding/Screens/Auth/hooks/useAuthNavigation")
 jest.mock("app/Scenes/Onboarding/Screens/Auth/hooks/useInputAutofocus")
 jest.mock("app/utils/platformUtil")
+jest.mock("@react-native-community/netinfo")
 jest.mock("app/Components/Recaptcha/Recaptcha", () => ({
   useRecaptcha: jest.fn().mockReturnValue({
     Recaptcha: () => {},
@@ -32,6 +34,7 @@ describe("LoginWelcomeStep", () => {
      * are completed before making assertions.
      */
     jest.useFakeTimers()
+    jest.clearAllMocks()
   })
 
   afterEach(() => {
@@ -195,6 +198,76 @@ describe("LoginWelcomeStep", () => {
         jest.advanceTimersByTime(50)
       })
 
+      expect(refreshTokenSpy).toHaveBeenCalled()
+      expect(navigateSpy).not.toHaveBeenCalled()
+    })
+
+    it("shows an alert when network is offline and token is missing", async () => {
+      const refreshTokenSpy = jest.fn()
+      const isTokenValidSpy = jest.fn(() => false)
+
+      mockUseRecaptcha.mockReturnValue({
+        Recaptcha: () => {},
+        token: null,
+        isTokenValid: isTokenValidSpy,
+        refreshToken: refreshTokenSpy,
+      })
+
+      const mockNetInfoFetch = NetInfo.fetch as jest.Mock
+      mockNetInfoFetch.mockResolvedValue({ isConnected: false })
+
+      jest.spyOn(Alert, "alert")
+
+      const navigateSpy = jest.fn()
+      mockUseAuthNavigation.mockReturnValue({
+        navigate: navigateSpy,
+      })
+
+      renderExpandedWelcomeStep()
+
+      fireEvent.changeText(screen.getByA11yHint("Enter your email address"), "foo@bar.baz")
+
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
+      })
+
+      expect(Alert.alert).toHaveBeenCalledWith("Can't Connect", "Check your network and try again")
+      expect(refreshTokenSpy).not.toHaveBeenCalled()
+      expect(navigateSpy).not.toHaveBeenCalled()
+    })
+
+    it("continues with token refresh when network is online and token is missing", async () => {
+      const refreshTokenSpy = jest.fn()
+      const isTokenValidSpy = jest.fn(() => false)
+
+      mockUseRecaptcha.mockReturnValue({
+        Recaptcha: () => {},
+        token: null,
+        isTokenValid: isTokenValidSpy,
+        refreshToken: refreshTokenSpy,
+      })
+
+      const mockNetInfoFetch = NetInfo.fetch as jest.Mock
+      mockNetInfoFetch.mockResolvedValue({ isConnected: true })
+
+      jest.spyOn(Alert, "alert")
+
+      const navigateSpy = jest.fn()
+      mockUseAuthNavigation.mockReturnValue({
+        navigate: navigateSpy,
+      })
+
+      renderExpandedWelcomeStep()
+
+      fireEvent.changeText(screen.getByA11yHint("Enter your email address"), "foo@bar.baz")
+
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
+      })
+
+      expect(Alert.alert).not.toHaveBeenCalled()
       expect(refreshTokenSpy).toHaveBeenCalled()
       expect(navigateSpy).not.toHaveBeenCalled()
     })

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -42,6 +42,7 @@ type SignInStatus =
   | "on_demand_otp_missing"
   | "invalid_otp"
   | "auth_blocked"
+  | "network_error"
 
 type VerifyUserStatus = "user_exists" | "user_does_not_exist" | "something_went_wrong"
 
@@ -305,28 +306,34 @@ export const getAuthModel = (): AuthModel => ({
       jwt: "jwt",
     }
 
-    const result = await actions.gravityUnauthenticatedRequest({
-      path: `/oauth2/access_token`,
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: {
-        email,
-        oauth_provider: oauthProvider,
-        otp_attempt: oauthMode === "email" ? args?.otp ?? undefined : undefined,
-        password: oauthMode === "email" ? args.password : undefined,
-        oauth_token: oauthMode === "accessToken" ? args.accessToken : undefined,
-        jwt: oauthMode === "jwt" ? args.jwt : undefined,
-        apple_uid: oauthProvider === "apple" ? args.appleUid : undefined,
-        id_token: oauthMode === "idToken" ? args.idToken : undefined,
-        grant_type: grantTypeMap[oauthMode],
-        client_id: clientKey,
-        client_secret: clientSecret,
-        scope: "offline_access",
-      },
-    })
+    let result: Response
 
+    try {
+      result = await actions.gravityUnauthenticatedRequest({
+        path: `/oauth2/access_token`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: {
+          email,
+          oauth_provider: oauthProvider,
+          otp_attempt: oauthMode === "email" ? args?.otp ?? undefined : undefined,
+          password: oauthMode === "email" ? args.password : undefined,
+          oauth_token: oauthMode === "accessToken" ? args.accessToken : undefined,
+          jwt: oauthMode === "jwt" ? args.jwt : undefined,
+          apple_uid: oauthProvider === "apple" ? args.appleUid : undefined,
+          id_token: oauthMode === "idToken" ? args.idToken : undefined,
+          grant_type: grantTypeMap[oauthMode],
+          client_id: clientKey,
+          client_secret: clientSecret,
+          scope: "offline_access",
+        },
+      })
+    } catch (error) {
+      Sentry.captureMessage(`AuthModel signIn error ${error}`)
+      return "network_error"
+    }
     if (result.status === 403) {
       return "auth_blocked"
     }

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -42,7 +42,6 @@ type SignInStatus =
   | "on_demand_otp_missing"
   | "invalid_otp"
   | "auth_blocked"
-  | "network_error"
 
 type VerifyUserStatus = "user_exists" | "user_does_not_exist" | "something_went_wrong"
 
@@ -332,7 +331,7 @@ export const getAuthModel = (): AuthModel => ({
       })
     } catch (error) {
       Sentry.captureMessage(`AuthModel signIn error ${error}`)
-      return "network_error"
+      return "failure"
     }
     if (result.status === 403) {
       return "auth_blocked"

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -159,7 +159,7 @@ describe("AuthModel", () => {
       })
       await GlobalStore.actions.auth.getXAppToken()
       mockFetch.mockClear()
-      jest.spyOn(Sentry, "captureMessage").mockImplementation(() => {})
+      jest.spyOn(Sentry, "captureMessage").mockImplementation(() => "mock-event-id")
     })
 
     afterEach(() => {

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -1,6 +1,7 @@
 import { appleAuth } from "@invertase/react-native-apple-authentication"
 import Cookies from "@react-native-cookies/cookies"
 import { GoogleSignin } from "@react-native-google-signin/google-signin"
+import * as Sentry from "@sentry/react-native"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { AuthError } from "app/store/AuthError"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
@@ -158,6 +159,11 @@ describe("AuthModel", () => {
       })
       await GlobalStore.actions.auth.getXAppToken()
       mockFetch.mockClear()
+      jest.spyOn(Sentry, "captureMessage").mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
     })
 
     it("tries to get an access token from gravity", async () => {
@@ -406,6 +412,35 @@ describe("AuthModel", () => {
         })
         expect(clearAllPriceRangesSpy).toHaveBeenCalled()
       })
+    })
+    it("returns 'network_error' when the network request fails", async () => {
+      const networkError = new Error("Network request failed")
+      mockFetch.mockRejectedValueOnce(networkError)
+
+      const result = await GlobalStore.actions.auth.signIn({
+        oauthProvider: "email",
+        oauthMode: "email",
+        email: "user@example.com",
+        password: "hunter2", // pragma: allowlist secret
+      })
+
+      expect(result).toBe("network_error")
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(`AuthModel signIn error ${networkError}`)
+    })
+
+    it("returns 'network_error' when fetch throws an error", async () => {
+      const fetchError = new TypeError("Failed to fetch")
+      mockFetch.mockRejectedValueOnce(fetchError)
+
+      const result = await GlobalStore.actions.auth.signIn({
+        oauthProvider: "email",
+        oauthMode: "email",
+        email: "user@example.com",
+        password: "hunter2", // pragma: allowlist secret
+      })
+
+      expect(result).toBe("network_error")
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(`AuthModel signIn error ${fetchError}`)
     })
   })
 

--- a/src/app/store/__tests__/AuthModel.tests.ts
+++ b/src/app/store/__tests__/AuthModel.tests.ts
@@ -413,7 +413,7 @@ describe("AuthModel", () => {
         expect(clearAllPriceRangesSpy).toHaveBeenCalled()
       })
     })
-    it("returns 'network_error' when the network request fails", async () => {
+    it("returns 'failure' when the network request fails", async () => {
       const networkError = new Error("Network request failed")
       mockFetch.mockRejectedValueOnce(networkError)
 
@@ -424,11 +424,11 @@ describe("AuthModel", () => {
         password: "hunter2", // pragma: allowlist secret
       })
 
-      expect(result).toBe("network_error")
+      expect(result).toBe("failure")
       expect(Sentry.captureMessage).toHaveBeenCalledWith(`AuthModel signIn error ${networkError}`)
     })
 
-    it("returns 'network_error' when fetch throws an error", async () => {
+    it("returns 'failure' when fetch throws an error", async () => {
       const fetchError = new TypeError("Failed to fetch")
       mockFetch.mockRejectedValueOnce(fetchError)
 
@@ -439,7 +439,7 @@ describe("AuthModel", () => {
         password: "hunter2", // pragma: allowlist secret
       })
 
-      expect(result).toBe("network_error")
+      expect(result).toBe("failure")
       expect(Sentry.captureMessage).toHaveBeenCalledWith(`AuthModel signIn error ${fetchError}`)
     })
   })


### PR DESCRIPTION
This PR resolves [DI-107](https://www.notion.so/33dcab0764a08079ad92c09555172f44) <!-- eg [PROJECT-XXXX] --> (cross listed as PBRW-1088)

### Description

Issue: 
We found that users on iPad (and other devices) would enter their credentials during login but get no feedback when network requests failed. The button would stop working with no error message, leaving users confused and unable to proceed with sign in flow. 

Solution:
I added error handling for both the password step and the email/reCAPTCHA step. 

First, I addressed the main scenario from the ticket where users enter their email but the sign-in request fails at the password step due to network issues. I added a try-catch around the network request in to catch the failures and return a `network_error` status, then show the "Can't Connect" alert in `LoginPasswordStep.tsx`.

Then while testing, I realized the same issue takes place at the very beginning of the flow -- if WiFi is off when users try to submit their email, the reCAPTCHA token can't load and they get stuck here instead. I added a network check in `LoginWelcomeStep.tsx` to check if the user is offline before trying the reCAPTCHA refresh, and then shows the same alert if needed.

Social sign-in already has proper error handling since it opens a browser, so this issue only affected email/password login.

### Before:

https://github.com/user-attachments/assets/52b65f9b-ba61-4d9a-87fb-cb8c0a5430f2



### After:

https://github.com/user-attachments/assets/c2332714-4e3c-46ee-b70f-661006da75f9



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- 

#### Android user-facing changes

-

#### Dev changes

- Adds network error handling to the login flow to prevent users from getting stuck when offline.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
