### PR TITLE
refactor(InfiniteDiscoveryMoreWorksTab): add "Show more" button for loading artworks on Android

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
@@ -1,11 +1,10 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { SimpleMessage, Tabs, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
+import { Button, SimpleMessage, Tabs, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { ListRenderItem } from "@shopify/flash-list"
 import { InfiniteDiscoveryMoreWorksTabQuery } from "__generated__/InfiniteDiscoveryMoreWorksTabQuery.graphql"
 import { InfiniteDiscoveryMoreWorksTab_artworks$key } from "__generated__/InfiniteDiscoveryMoreWorksTab_artworks.graphql"
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
-import { FilteredArtworkGridZeroState } from "app/Components/ArtworkGrids/FilteredArtworkGridZeroState"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
 import { withSuspense } from "app/utils/hooks/withSuspense"
@@ -28,11 +27,11 @@ export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => 
 
   const artworks = extractNodes(data.artworksConnection)
 
-  const loadMore = () => {
-    if (!!hasNext && !isLoadingNext) {
+  const loadMore = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
       loadNext(PAGE_SIZE)
     }
-  }
+  }, [hasNext, isLoadingNext, loadNext])
 
   const renderItem: ListRenderItem<ExtractNodeType<typeof data.artworksConnection>> = useCallback(
     ({ item, index }) => {
@@ -62,11 +61,32 @@ export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => 
       keyboardShouldPersistTaps="handled"
       contentContainerStyle={{ paddingHorizontal: space(1) }}
       keyExtractor={(item) => item?.internalID}
-      ListEmptyComponent={<FilteredArtworkGridZeroState />}
-      ListFooterComponent={() => (
-        <AnimatedMasonryListFooter shouldDisplaySpinner={!!hasNext && !!isLoadingNext} />
-      )}
-      onEndReached={loadMore}
+      ListEmptyComponent={<SimpleMessage m={2}>There are no available works.</SimpleMessage>}
+      // Android: this Masonry is nested inside <BottomSheetScrollView>, which makes the inner
+      // list believe it is fully visible on mount and fires onEndReached immediately regardless
+      // of onEndReachedThreshold. We replace auto-pagination with an explicit "Show more" button
+      // so loading more remains user-initiated on Android.
+      ListFooterComponent={() =>
+        Platform.OS === "android" ? (
+          hasNext ? (
+            <Button
+              mt={2}
+              mb={4}
+              variant="fillGray"
+              size="large"
+              block
+              onPress={loadMore}
+              loading={isLoadingNext}
+            >
+              Show more
+            </Button>
+          ) : null
+        ) : (
+          <AnimatedMasonryListFooter shouldDisplaySpinner={!!hasNext && !!isLoadingNext} />
+        )
+      }
+      // no-op on Android; see ListFooterComponent comment above
+      onEndReached={Platform.OS === "ios" ? loadMore : undefined}
       onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
       renderItem={renderItem}
     />
@@ -80,7 +100,7 @@ const fragment = graphql`
   fragment InfiniteDiscoveryMoreWorksTab_artworks on Query
   @refetchable(queryName: "InfiniteDiscoveryMoreWorksQuery")
   @argumentDefinitions(
-    count: { type: "Int", defaultValue: 12 }
+    count: { type: "Int", defaultValue: 10 }
     cursor: { type: "String" }
     artistIDs: { type: "[String!]" }
   ) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Refactors InfiniteDiscoveryMoreWorksTab **on android only** (functionality for iOS does not change at all) to prevent an issue that we had.

Due to the Tabs.Masonry being wrapped with a BottomSheetScrollView that was added due to a bug there (without it we weren't able to interact with the list on android) on render we were calling the onEndReached function all the time and as a result we were getting some crashes due to infinite loops of the onEndReached function being called.

With this refactor on Android we are adding an explicit load more button on the end of the list in order to prevent this.



|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/51236a6b-de43-4bd9-827e-52a22e0394a0" width="300" />|<video src="https://github.com/user-attachments/assets/02293e97-1fcf-4d2f-a3e0-4d56ccc0a71b" width="300" />|








<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- refactor(InfiniteDiscoveryMoreWorksTab): add "Show more" button for loading artworks on Android

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

https://github.com/user-attachments/assets/c1cb11d2-1ef4-4e2a-92fd-52dafdf68090

