### PR TITLE
feat: Add logged-out browsing mode [SPIKE]

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
@@ -4,7 +4,7 @@ import { SavedSearchButtonV2 } from "app/Components/Artist/ArtistArtworks/SavedS
 import { useShowArtworksFilterModal } from "app/Components/Artist/ArtistArtworks/hooks/useShowArtworksFilterModal"
 import { useSelectedFiltersCount } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { ArtworksFilterHeader } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtistArtworksFilterProps {
@@ -28,7 +28,6 @@ export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = (
 
   const appliedFiltersCount = useSelectedFiltersCount()
   const { openFilterArtworksModal } = useShowArtworksFilterModal({ artist: data })
-  const requireAuth = useRequireAuth()
 
   return (
     <Flex backgroundColor="background">
@@ -39,16 +38,13 @@ export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = (
         selectedFiltersCount={appliedFiltersCount}
         childrenPosition="left"
       >
-        <SavedSearchButtonV2
-          artistId={data.internalID}
-          artistSlug={data.slug}
-          onPress={requireAuth(
-            () => {
-              showCreateAlertModal()
-            },
-            { intent: "create_alert" }
-          )}
-        />
+        <RequireAuth intent="create_alert">
+          <SavedSearchButtonV2
+            artistId={data.internalID}
+            artistSlug={data.slug}
+            onPress={showCreateAlertModal}
+          />
+        </RequireAuth>
       </ArtworksFilterHeader>
     </Flex>
   )

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworksFilterHeader.tsx
@@ -4,6 +4,7 @@ import { SavedSearchButtonV2 } from "app/Components/Artist/ArtistArtworks/SavedS
 import { useShowArtworksFilterModal } from "app/Components/Artist/ArtistArtworks/hooks/useShowArtworksFilterModal"
 import { useSelectedFiltersCount } from "app/Components/ArtworkFilter/useArtworkFilters"
 import { ArtworksFilterHeader } from "app/Components/ArtworkGrids/ArtworksFilterHeader"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { graphql, useFragment } from "react-relay"
 
 interface ArtistArtworksFilterProps {
@@ -27,6 +28,7 @@ export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = (
 
   const appliedFiltersCount = useSelectedFiltersCount()
   const { openFilterArtworksModal } = useShowArtworksFilterModal({ artist: data })
+  const requireAuth = useRequireAuth()
 
   return (
     <Flex backgroundColor="background">
@@ -40,9 +42,12 @@ export const ArtistArtworksFilterHeader: React.FC<ArtistArtworksFilterProps> = (
         <SavedSearchButtonV2
           artistId={data.internalID}
           artistSlug={data.slug}
-          onPress={() => {
-            showCreateAlertModal()
-          }}
+          onPress={requireAuth(
+            () => {
+              showCreateAlertModal()
+            },
+            { intent: "create_alert" }
+          )}
         />
       </ArtworksFilterHeader>
     </Flex>

--- a/src/app/Components/Artist/ArtistHeaderNavRight.tsx
+++ b/src/app/Components/Artist/ArtistHeaderNavRight.tsx
@@ -3,6 +3,7 @@ import { Flex, FollowButton, Screen, useSpace } from "@artsy/palette-mobile"
 import { ArtistHeaderNavRightQuery } from "__generated__/ArtistHeaderNavRightQuery.graphql"
 import { ArtistHeaderNavRight_artist$key } from "__generated__/ArtistHeaderNavRight_artist.graphql"
 import { useFollowArtist } from "app/Components/Artist/useFollowArtist"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { useShareSheet } from "app/Components/ShareSheet/ShareSheetContext"
 import { ACCESSIBLE_DEFAULT_ICON_SIZE } from "app/Components/constants"
 import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
@@ -69,12 +70,14 @@ export const ArtistHeaderNavRight: React.FC<ArtistHeaderNavRightProps> = ({
       py={1}
     >
       <MotiView style={[followButtonStyle, { marginRight: space(0.5) }]}>
-        <FollowButton
-          haptic
-          isFollowed={isFollowed}
-          followCount={artist?.counts.follows}
-          onPress={() => setIsFollowed(!isFollowed)}
-        />
+        <RequireAuth intent="follow_artist">
+          <FollowButton
+            haptic
+            isFollowed={isFollowed}
+            followCount={artist?.counts.follows}
+            onPress={() => setIsFollowed(!isFollowed)}
+          />
+        </RequireAuth>
       </MotiView>
 
       <TouchableOpacity

--- a/src/app/Components/Artist/RelatedArtistsRailCell.tsx
+++ b/src/app/Components/Artist/RelatedArtistsRailCell.tsx
@@ -8,6 +8,7 @@ import {
   RelatedArtistsRailCell_relatedArtist$data,
   RelatedArtistsRailCell_relatedArtist$key,
 } from "__generated__/RelatedArtistsRailCell_relatedArtist.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { useFollowArtist } from "app/utils/mutations/useFollowArtist"
 import { graphql, useFragment } from "react-relay"
@@ -76,7 +77,9 @@ export const RelatedArtistsRailCell: React.FC<RelatedArtistsRailCellProps> = ({
             {relatedArtistData.formattedNationalityAndBirthday}
           </Text>
         </Flex>
-        <FollowButton isFollowed={!!relatedArtistData.isFollowed} onPress={handleOnFollow} />
+        <RequireAuth intent="follow_artist">
+          <FollowButton isFollowed={!!relatedArtistData.isFollowed} onPress={handleOnFollow} />
+        </RequireAuth>
       </Flex>
     </RouterLink>
   )

--- a/src/app/Components/ArtistFollowButton.tsx
+++ b/src/app/Components/ArtistFollowButton.tsx
@@ -2,6 +2,7 @@ import { FollowButton } from "@artsy/palette-mobile"
 import { ArtistFollowButtonQuery } from "__generated__/ArtistFollowButtonQuery.graphql"
 import { ArtistFollowButton_artist$key } from "__generated__/ArtistFollowButton_artist.graphql"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowArtist } from "app/utils/mutations/useFollowArtist"
 import { ActionNames, ActionTypes, OwnerEntityTypes } from "app/utils/track/schema"
 import { FC } from "react"
@@ -17,28 +18,32 @@ export const ArtistFollowButton: FC<ArtistFollowButtonProps> = ({ artist }) => {
   const [commitMutation, isInFlight] = useFollowArtist()
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
+  const requireAuth = useRequireAuth()
 
   if (!data) {
     return null
   }
 
-  const handleOnPress = () => {
-    commitMutation({
-      variables: { input: { artistID: data.internalID, unfollow: data.isFollowed } },
-      updater: (store) => {
-        store.get(data.internalID)?.setValue(!data.isFollowed, "isFollowed")
-      },
-    })
-
-    trackEvent(
-      tracks.trackFollowUnfollow({
-        analytics,
-        isFollowed: data.isFollowed,
-        internalID: data.internalID,
-        slug: data.slug,
+  const handleOnPress = requireAuth(
+    () => {
+      commitMutation({
+        variables: { input: { artistID: data.internalID, unfollow: data.isFollowed } },
+        updater: (store) => {
+          store.get(data.internalID)?.setValue(!data.isFollowed, "isFollowed")
+        },
       })
-    )
-  }
+
+      trackEvent(
+        tracks.trackFollowUnfollow({
+          analytics,
+          isFollowed: data.isFollowed,
+          internalID: data.internalID,
+          slug: data.slug,
+        })
+      )
+    },
+    { intent: "follow_artist" }
+  )
 
   return <FollowButton isFollowed={data.isFollowed} onPress={handleOnPress} loading={isInFlight} />
 }

--- a/src/app/Components/ArtistFollowButton.tsx
+++ b/src/app/Components/ArtistFollowButton.tsx
@@ -1,8 +1,8 @@
 import { FollowButton } from "@artsy/palette-mobile"
 import { ArtistFollowButtonQuery } from "__generated__/ArtistFollowButtonQuery.graphql"
 import { ArtistFollowButton_artist$key } from "__generated__/ArtistFollowButton_artist.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowArtist } from "app/utils/mutations/useFollowArtist"
 import { ActionNames, ActionTypes, OwnerEntityTypes } from "app/utils/track/schema"
 import { FC } from "react"
@@ -18,34 +18,34 @@ export const ArtistFollowButton: FC<ArtistFollowButtonProps> = ({ artist }) => {
   const [commitMutation, isInFlight] = useFollowArtist()
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
-  const requireAuth = useRequireAuth()
 
   if (!data) {
     return null
   }
 
-  const handleOnPress = requireAuth(
-    () => {
-      commitMutation({
-        variables: { input: { artistID: data.internalID, unfollow: data.isFollowed } },
-        updater: (store) => {
-          store.get(data.internalID)?.setValue(!data.isFollowed, "isFollowed")
-        },
+  const handleOnPress = () => {
+    commitMutation({
+      variables: { input: { artistID: data.internalID, unfollow: data.isFollowed } },
+      updater: (store) => {
+        store.get(data.internalID)?.setValue(!data.isFollowed, "isFollowed")
+      },
+    })
+
+    trackEvent(
+      tracks.trackFollowUnfollow({
+        analytics,
+        isFollowed: data.isFollowed,
+        internalID: data.internalID,
+        slug: data.slug,
       })
+    )
+  }
 
-      trackEvent(
-        tracks.trackFollowUnfollow({
-          analytics,
-          isFollowed: data.isFollowed,
-          internalID: data.internalID,
-          slug: data.slug,
-        })
-      )
-    },
-    { intent: "follow_artist" }
+  return (
+    <RequireAuth intent="follow_artist">
+      <FollowButton isFollowed={data.isFollowed} onPress={handleOnPress} loading={isInFlight} />
+    </RequireAuth>
   )
-
-  return <FollowButton isFollowed={data.isFollowed} onPress={handleOnPress} loading={isInFlight} />
 }
 
 const fragment = graphql`

--- a/src/app/Components/ArtistListItem.tsx
+++ b/src/app/Components/ArtistListItem.tsx
@@ -3,13 +3,14 @@ import {
   AvatarSize,
   EntityHeader,
   Flex,
-  FollowButton,
   Text,
   Touchable,
   useColor,
+  FollowButton,
 } from "@artsy/palette-mobile"
 import { ArtistListItemFollowArtistMutation } from "__generated__/ArtistListItemFollowArtistMutation.graphql"
 import { ArtistListItem_artist$data } from "__generated__/ArtistListItem_artist.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
 import { pluralize } from "app/utils/pluralize"
@@ -185,12 +186,14 @@ const ArtistListItem: React.FC<Props> = ({
         )}
         {!!showFollowButton && (
           <Flex>
-            <FollowButton
-              testID="follow-artist-button"
-              haptic
-              isFollowed={!!is_followed}
-              onPress={handleFollowArtist}
-            />
+            <RequireAuth intent="follow_artist">
+              <FollowButton
+                testID="follow-artist-button"
+                haptic
+                isFollowed={!!is_followed}
+                onPress={handleFollowArtist}
+              />
+            </RequireAuth>
           </Flex>
         )}
       </Flex>

--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -3,6 +3,7 @@ import { useArtworkListContext } from "app/Components/ArtworkLists/ArtworkListCo
 import { ArtworkListsStore } from "app/Components/ArtworkLists/ArtworkListsStore"
 import { ArtworkEntity } from "app/Components/ArtworkLists/types"
 import { useArtworkListToast } from "app/Components/ArtworkLists/useArtworkListsToast"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { SaveArtworkOptions, useSaveArtwork } from "app/utils/mutations/useSaveArtwork"
 import { graphql, useFragment } from "react-relay"
 
@@ -18,6 +19,7 @@ export const useSaveArtworkToArtworkLists = (options: Options) => {
   const openSelectArtworkListsView = ArtworkListsStore.useStoreActions(
     (actions) => actions.openSelectArtworkListsView
   )
+  const requireAuth = useRequireAuth()
 
   const artwork = useFragment(ArtworkFragment, artworkFragmentRef)
 
@@ -78,19 +80,22 @@ export const useSaveArtworkToArtworkLists = (options: Options) => {
     openSelectArtworkListsView(artworkEntity)
   }
 
-  const saveArtworkToLists = () => {
-    if (options.saveToDefaultCollectionOnly) {
+  const saveArtworkToLists = requireAuth(
+    () => {
+      if (options.saveToDefaultCollectionOnly) {
+        saveArtworkToDefaultArtworkList()
+        return
+      }
+
+      if (artworkListID || isSavedToCustomArtworkLists) {
+        openSelectArtworkListsForArtworkView()
+        return
+      }
+
       saveArtworkToDefaultArtworkList()
-      return
-    }
-
-    if (artworkListID || isSavedToCustomArtworkLists) {
-      openSelectArtworkListsForArtworkView()
-      return
-    }
-
-    saveArtworkToDefaultArtworkList()
-  }
+    },
+    { intent: "save_artwork" }
+  )
 
   return {
     isSaved,

--- a/src/app/Components/AuthBottomSheet/AuthBottomSheetContent.tsx
+++ b/src/app/Components/AuthBottomSheet/AuthBottomSheetContent.tsx
@@ -1,0 +1,35 @@
+import { Flex, Text } from "@artsy/palette-mobile"
+import { BottomSheetView } from "@gorhom/bottom-sheet"
+import { AuthIntent } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+import { AuthContext } from "app/Scenes/Onboarding/Screens/Auth/AuthContext"
+import { AuthScenes } from "app/Scenes/Onboarding/Screens/Auth/AuthScenes"
+
+const INTENT_COPY: Record<AuthIntent, string> = {
+  save_artwork: "Sign up or log in to save artworks",
+  follow_artist: "Sign up or log in to follow artists",
+  contact_gallery: "Sign up or log in to contact the gallery",
+  make_offer: "Sign up or log in to make an offer",
+  bid: "Sign up or log in to place a bid",
+  purchase: "Sign up or log in to purchase",
+  create_alert: "Sign up or log in to create an alert",
+  generic: "Sign up or log in",
+}
+
+interface AuthBottomSheetContentProps {
+  intent: AuthIntent
+}
+
+export const AuthBottomSheetContent: React.FC<AuthBottomSheetContentProps> = ({ intent }) => {
+  return (
+    <BottomSheetView>
+      <AuthContext.Provider>
+        <Flex px={2} pt={2}>
+          <Text variant="sm-display" textAlign="center">
+            {INTENT_COPY[intent]}
+          </Text>
+        </Flex>
+        <AuthScenes />
+      </AuthContext.Provider>
+    </BottomSheetView>
+  )
+}

--- a/src/app/Components/AuthBottomSheet/AuthBottomSheetContent.tsx
+++ b/src/app/Components/AuthBottomSheet/AuthBottomSheetContent.tsx
@@ -1,8 +1,13 @@
 import { Flex, Text } from "@artsy/palette-mobile"
 import { BottomSheetView } from "@gorhom/bottom-sheet"
+import { NavigationContainer, NavigationIndependentTree } from "@react-navigation/native"
+import { createStackNavigator } from "@react-navigation/stack"
+import { ArtsyWebViewPage } from "app/Components/ArtsyWebView"
 import { AuthIntent } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+import { useNavigationTheme } from "app/Navigation/useNavigationTheme"
 import { AuthContext } from "app/Scenes/Onboarding/Screens/Auth/AuthContext"
 import { AuthScenes } from "app/Scenes/Onboarding/Screens/Auth/AuthScenes"
+import type { OnboardingWebViewRoute } from "app/Scenes/Onboarding/Screens/OnboardingWebView"
 
 const INTENT_COPY: Record<AuthIntent, string> = {
   save_artwork: "Sign up or log in to save artworks",
@@ -15,21 +20,45 @@ const INTENT_COPY: Record<AuthIntent, string> = {
   generic: "Sign up or log in",
 }
 
+type AuthSheetStack = {
+  AuthMain: undefined
+  OnboardingWebView: { url: OnboardingWebViewRoute }
+}
+
+const Stack = createStackNavigator<AuthSheetStack>()
+
 interface AuthBottomSheetContentProps {
   intent: AuthIntent
 }
 
 export const AuthBottomSheetContent: React.FC<AuthBottomSheetContentProps> = ({ intent }) => {
+  const theme = useNavigationTheme()
+
   return (
-    <BottomSheetView>
-      <AuthContext.Provider>
-        <Flex px={2} pt={2}>
-          <Text variant="sm-display" textAlign="center">
-            {INTENT_COPY[intent]}
-          </Text>
-        </Flex>
-        <AuthScenes />
-      </AuthContext.Provider>
-    </BottomSheetView>
+    <NavigationIndependentTree>
+      <NavigationContainer theme={theme}>
+        <Stack.Navigator screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="AuthMain">
+            {() => (
+              <BottomSheetView>
+                <AuthContext.Provider>
+                  <Flex px={2} pt={2}>
+                    <Text variant="sm-display" textAlign="center">
+                      {INTENT_COPY[intent]}
+                    </Text>
+                  </Flex>
+                  <AuthScenes />
+                </AuthContext.Provider>
+              </BottomSheetView>
+            )}
+          </Stack.Screen>
+          <Stack.Screen name="OnboardingWebView">
+            {({ route, navigation }) => (
+              <ArtsyWebViewPage url={route.params.url} backAction={() => navigation.goBack()} />
+            )}
+          </Stack.Screen>
+        </Stack.Navigator>
+      </NavigationContainer>
+    </NavigationIndependentTree>
   )
 }

--- a/src/app/Components/AuthBottomSheet/AuthBottomSheetProvider.tsx
+++ b/src/app/Components/AuthBottomSheet/AuthBottomSheetProvider.tsx
@@ -5,15 +5,7 @@ import {
 } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { GlobalStore } from "app/store/GlobalStore"
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 
 interface AuthBottomSheetContextValue {
   present: (options?: AuthBottomSheetPresentOptions) => void
@@ -56,7 +48,7 @@ export const AuthBottomSheetProvider: React.FC<React.PropsWithChildren> = ({ chi
     [present, dismiss]
   )
 
-  // Auto-dismiss when the user becomes authenticated (signIn flips userID).
+  // // Auto-dismiss when the user becomes authenticated (signIn flips userID).
   useEffect(() => {
     if (visible && userID) {
       setVisible(false)

--- a/src/app/Components/AuthBottomSheet/AuthBottomSheetProvider.tsx
+++ b/src/app/Components/AuthBottomSheet/AuthBottomSheetProvider.tsx
@@ -1,0 +1,103 @@
+import { AuthBottomSheetContent } from "app/Components/AuthBottomSheet/AuthBottomSheetContent"
+import {
+  AuthBottomSheetPresentOptions,
+  AuthIntent,
+} from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
+import { GlobalStore } from "app/store/GlobalStore"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+interface AuthBottomSheetContextValue {
+  present: (options?: AuthBottomSheetPresentOptions) => void
+  dismiss: () => void
+}
+
+const AuthBottomSheetContext = createContext<AuthBottomSheetContextValue | null>(null)
+
+// Module-level ref so imperative callers (e.g. navigate()) can present the sheet
+// without needing to be inside the React context.
+export const authBottomSheetRef: { current: AuthBottomSheetContextValue | null } = {
+  current: null,
+}
+
+export const presentAuthBottomSheet = (options?: AuthBottomSheetPresentOptions) => {
+  authBottomSheetRef.current?.present(options)
+}
+
+export const dismissAuthBottomSheet = () => {
+  authBottomSheetRef.current?.dismiss()
+}
+
+export const AuthBottomSheetProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [visible, setVisible] = useState(false)
+  const [intent, setIntent] = useState<AuthIntent>("generic")
+  const previousVisibleRef = useRef(false)
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
+
+  const present = useCallback((options?: AuthBottomSheetPresentOptions) => {
+    setIntent(options?.intent ?? "generic")
+    setVisible(true)
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setVisible(false)
+  }, [])
+
+  const value = useMemo<AuthBottomSheetContextValue>(
+    () => ({ present, dismiss }),
+    [present, dismiss]
+  )
+
+  // Auto-dismiss when the user becomes authenticated (signIn flips userID).
+  useEffect(() => {
+    if (visible && userID) {
+      setVisible(false)
+    }
+  }, [userID, visible])
+
+  // Track the previous visible state for the imperative ref consumers.
+  useEffect(() => {
+    previousVisibleRef.current = visible
+  }, [visible])
+
+  // Sync the module-level ref so non-React callers can drive the sheet.
+  useEffect(() => {
+    authBottomSheetRef.current = value
+    return () => {
+      if (authBottomSheetRef.current === value) {
+        authBottomSheetRef.current = null
+      }
+    }
+  }, [value])
+
+  return (
+    <AuthBottomSheetContext.Provider value={value}>
+      {children}
+      <AutomountedBottomSheetModal visible={visible} onDismiss={dismiss}>
+        <AuthBottomSheetContent intent={intent} />
+      </AutomountedBottomSheetModal>
+    </AuthBottomSheetContext.Provider>
+  )
+}
+
+export const useAuthBottomSheet = (): AuthBottomSheetContextValue => {
+  const ctx = useContext(AuthBottomSheetContext)
+  if (!ctx) {
+    // Provide a safe no-op fallback so callers don't crash when the provider
+    // is absent (e.g. during isolated tests). Real callers should be wrapped
+    // by AuthBottomSheetProvider via app/Providers.tsx.
+    return {
+      present: presentAuthBottomSheet,
+      dismiss: dismissAuthBottomSheet,
+    }
+  }
+  return ctx
+}

--- a/src/app/Components/AuthBottomSheet/AuthBottomSheetTypes.ts
+++ b/src/app/Components/AuthBottomSheet/AuthBottomSheetTypes.ts
@@ -1,0 +1,13 @@
+export type AuthIntent =
+  | "save_artwork"
+  | "follow_artist"
+  | "contact_gallery"
+  | "make_offer"
+  | "bid"
+  | "purchase"
+  | "create_alert"
+  | "generic"
+
+export interface AuthBottomSheetPresentOptions {
+  intent?: AuthIntent
+}

--- a/src/app/Components/AuthBottomSheet/LoggedOutTabPlaceholder.tsx
+++ b/src/app/Components/AuthBottomSheet/LoggedOutTabPlaceholder.tsx
@@ -1,0 +1,39 @@
+import { Button, Flex, Screen, Text } from "@artsy/palette-mobile"
+import { useAuthBottomSheet } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
+import { AuthIntent } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+
+interface LoggedOutTabPlaceholderProps {
+  title: string
+  body: string
+  ctaLabel?: string
+  intent?: AuthIntent
+}
+
+export const LoggedOutTabPlaceholder: React.FC<LoggedOutTabPlaceholderProps> = ({
+  title,
+  body,
+  ctaLabel = "Sign up or log in",
+  intent = "generic",
+}) => {
+  const { present } = useAuthBottomSheet()
+
+  return (
+    <Screen>
+      <Screen.Body>
+        <Flex flex={1} alignItems="center" justifyContent="center" px={2}>
+          <Text variant="lg-display" textAlign="center">
+            {title}
+          </Text>
+          <Text variant="sm" textAlign="center" color="mono60" mt={1}>
+            {body}
+          </Text>
+          <Flex mt={2} width="100%">
+            <Button block onPress={() => present({ intent })}>
+              {ctaLabel}
+            </Button>
+          </Flex>
+        </Flex>
+      </Screen.Body>
+    </Screen>
+  )
+}

--- a/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
+++ b/src/app/Components/BottomSheet/AutomountedBottomSheetModal.tsx
@@ -17,11 +17,13 @@ export interface AutomountedBottomSheetModalProps extends BottomSheetModalProps 
 export const AutomountedBottomSheetModal: FC<AutomountedBottomSheetModalProps> = ({
   visible,
   closeOnBackdropClick = true,
+  onDismiss: onDismissProp,
   ...rest
 }) => {
   const color = useColor()
   const ref = useRef<BottomSheetModal>(null)
   const [modalIsPresented, setModalIsPresented] = useState(false)
+  const isPresentedRef = useRef(false)
   const { height: screenHeight, safeAreaInsets } = useScreenDimensions()
 
   // dismiss modal on back button press on Android
@@ -36,17 +38,20 @@ export const AutomountedBottomSheetModal: FC<AutomountedBottomSheetModalProps> =
   }, [modalIsPresented, visible])
 
   const handlePresent = () => {
+    isPresentedRef.current = true
     setModalIsPresented(true)
   }
 
   const handleDismiss = () => {
+    isPresentedRef.current = false
     setModalIsPresented(false)
+    onDismissProp?.()
   }
 
   useEffect(() => {
     if (visible) {
       ref.current?.present()
-    } else {
+    } else if (isPresentedRef.current) {
       ref.current?.dismiss()
     }
   }, [visible])

--- a/src/app/Components/PartnerFollowButton.tsx
+++ b/src/app/Components/PartnerFollowButton.tsx
@@ -2,6 +2,7 @@ import { FollowButton } from "@artsy/palette-mobile"
 import { PartnerFollowButtonQuery } from "__generated__/PartnerFollowButtonQuery.graphql"
 import { PartnerFollowButton_partner$key } from "__generated__/PartnerFollowButton_partner.graphql"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
 import { ActionNames, ActionTypes, OwnerEntityTypes } from "app/utils/track/schema"
 import { FC } from "react"
@@ -21,15 +22,19 @@ export const PartnerFollowButton: FC<PartnerFollowButtonProps> = ({ partner }) =
     internalID: data?.profile.internalID ?? "",
     isFollowed: !!data?.profile.isFollowed,
   })
+  const requireAuth = useRequireAuth()
 
   if (!data) {
     return null
   }
 
-  const handleOnPress = () => {
-    followProfile()
-    trackEvent(tracks.trackFollowPartner(data.internalID, analytics))
-  }
+  const handleOnPress = requireAuth(
+    () => {
+      followProfile()
+      trackEvent(tracks.trackFollowPartner(data.internalID, analytics))
+    },
+    { intent: "follow_artist" }
+  )
 
   return (
     <FollowButton

--- a/src/app/Components/PartnerFollowButton.tsx
+++ b/src/app/Components/PartnerFollowButton.tsx
@@ -1,8 +1,8 @@
 import { FollowButton } from "@artsy/palette-mobile"
 import { PartnerFollowButtonQuery } from "__generated__/PartnerFollowButtonQuery.graphql"
 import { PartnerFollowButton_partner$key } from "__generated__/PartnerFollowButton_partner.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
 import { ActionNames, ActionTypes, OwnerEntityTypes } from "app/utils/track/schema"
 import { FC } from "react"
@@ -22,26 +22,23 @@ export const PartnerFollowButton: FC<PartnerFollowButtonProps> = ({ partner }) =
     internalID: data?.profile.internalID ?? "",
     isFollowed: !!data?.profile.isFollowed,
   })
-  const requireAuth = useRequireAuth()
-
   if (!data) {
     return null
   }
 
-  const handleOnPress = requireAuth(
-    () => {
-      followProfile()
-      trackEvent(tracks.trackFollowPartner(data.internalID, analytics))
-    },
-    { intent: "follow_artist" }
-  )
+  const handleOnPress = () => {
+    followProfile()
+    trackEvent(tracks.trackFollowPartner(data.internalID, analytics))
+  }
 
   return (
-    <FollowButton
-      isFollowed={!!data.profile.isFollowed}
-      onPress={handleOnPress}
-      loading={isInFlight}
-    />
+    <RequireAuth intent="follow_artist">
+      <FollowButton
+        isFollowed={!!data.profile.isFollowed}
+        onPress={handleOnPress}
+        loading={isInFlight}
+      />
+    </RequireAuth>
   )
 }
 

--- a/src/app/Components/RequireAuth.tsx
+++ b/src/app/Components/RequireAuth.tsx
@@ -1,0 +1,47 @@
+import { AuthIntent } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
+import { cloneElement, ReactElement } from "react"
+
+interface RequireAuthProps {
+  children: ReactElement<{ onPress?: (...args: any[]) => any }>
+  intent?: AuthIntent
+  /**
+   * The action to run when authenticated. If omitted, the child's own
+   * onPress is used instead, so you can wrap any existing button without
+   * touching its props.
+   */
+  onPress?: (...args: any[]) => any
+}
+
+/**
+ * Wraps a single child's onPress with auth-gating. If the user is not
+ * logged in the auth bottom sheet is shown instead of running the action.
+ *
+ * @example — override child's onPress:
+ *   <RequireAuth intent="create_alert" onPress={() => openModal()}>
+ *     <Button>Create Alert</Button>
+ *   </RequireAuth>
+ *
+ * @example — guard the child's existing onPress in-place:
+ *   <RequireAuth intent="follow_artist">
+ *     <FollowButton isFollowed={false} onPress={handleFollow} />
+ *   </RequireAuth>
+ */
+export const RequireAuth: React.FC<RequireAuthProps> = ({
+  children,
+  intent = "generic",
+  onPress,
+}) => {
+  const requireAuth = useRequireAuth()
+  const childOnPress = children.props.onPress
+  const action =
+    onPress && childOnPress
+      ? (...args: any[]) => {
+          onPress(...args)
+          childOnPress(...args)
+        }
+      : onPress ?? childOnPress
+  return cloneElement(children, {
+    onPress: action ? requireAuth(action, { intent }) : undefined,
+  })
+}

--- a/src/app/Navigation/AuthenticatedRoutes/FavoritesTab.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/FavoritesTab.tsx
@@ -1,8 +1,22 @@
+import { LoggedOutTabPlaceholder } from "app/Components/AuthBottomSheet/LoggedOutTabPlaceholder"
 import { registerScreen, StackNavigator } from "app/Navigation/AuthenticatedRoutes/StackNavigator"
 import { sharedRoutes } from "app/Navigation/AuthenticatedRoutes/sharedRoutes"
 import { modules } from "app/Navigation/utils/modules"
+import { GlobalStore } from "app/store/GlobalStore"
 
 export const FavoritesTab: React.FC = () => {
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
+
+  if (!userID) {
+    return (
+      <LoggedOutTabPlaceholder
+        title="Favorites"
+        body="Save artworks you love. Sign up or log in to start your collection."
+        intent="save_artwork"
+      />
+    )
+  }
+
   return (
     <StackNavigator.Navigator screenOptions={{ headerShown: false }} initialRouteName="Favorites">
       {registerScreen({

--- a/src/app/Navigation/AuthenticatedRoutes/InboxTab.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/InboxTab.tsx
@@ -1,8 +1,21 @@
+import { LoggedOutTabPlaceholder } from "app/Components/AuthBottomSheet/LoggedOutTabPlaceholder"
 import { registerScreen, StackNavigator } from "app/Navigation/AuthenticatedRoutes/StackNavigator"
 import { sharedRoutes } from "app/Navigation/AuthenticatedRoutes/sharedRoutes"
 import { modules } from "app/Navigation/utils/modules"
+import { GlobalStore } from "app/store/GlobalStore"
 
 export const InboxTab: React.FC = () => {
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
+
+  if (!userID) {
+    return (
+      <LoggedOutTabPlaceholder
+        title="Inbox"
+        body="Sign up or log in to message galleries and track your orders."
+      />
+    )
+  }
+
   return (
     <StackNavigator.Navigator screenOptions={{ headerShown: false }} initialRouteName="Inbox">
       {registerScreen({

--- a/src/app/Navigation/AuthenticatedRoutes/ProfileTab.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/ProfileTab.tsx
@@ -1,21 +1,8 @@
-import { LoggedOutTabPlaceholder } from "app/Components/AuthBottomSheet/LoggedOutTabPlaceholder"
 import { registerScreen, StackNavigator } from "app/Navigation/AuthenticatedRoutes/StackNavigator"
 import { sharedRoutes } from "app/Navigation/AuthenticatedRoutes/sharedRoutes"
 import { modules } from "app/Navigation/utils/modules"
-import { GlobalStore } from "app/store/GlobalStore"
 
 export const ProfileTab: React.FC = () => {
-  const userID = GlobalStore.useAppState((state) => state.auth.userID)
-
-  if (!userID) {
-    return (
-      <LoggedOutTabPlaceholder
-        title="Profile"
-        body="Sign up or log in to access your collection, orders, and settings."
-      />
-    )
-  }
-
   return (
     <StackNavigator.Navigator screenOptions={{ headerShown: false }} initialRouteName="MyProfile">
       {registerScreen({

--- a/src/app/Navigation/AuthenticatedRoutes/ProfileTab.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/ProfileTab.tsx
@@ -1,8 +1,21 @@
+import { LoggedOutTabPlaceholder } from "app/Components/AuthBottomSheet/LoggedOutTabPlaceholder"
 import { registerScreen, StackNavigator } from "app/Navigation/AuthenticatedRoutes/StackNavigator"
 import { sharedRoutes } from "app/Navigation/AuthenticatedRoutes/sharedRoutes"
 import { modules } from "app/Navigation/utils/modules"
+import { GlobalStore } from "app/store/GlobalStore"
 
 export const ProfileTab: React.FC = () => {
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
+
+  if (!userID) {
+    return (
+      <LoggedOutTabPlaceholder
+        title="Profile"
+        body="Sign up or log in to access your collection, orders, and settings."
+      />
+    )
+  }
+
   return (
     <StackNavigator.Navigator screenOptions={{ headerShown: false }} initialRouteName="MyProfile">
       {registerScreen({

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -207,8 +207,10 @@ export const AuthenticatedRoutesStack = createNativeStackNavigator()
 
 export const AuthenticatedRoutes: React.FC = () => {
   const onboardingState = GlobalStore.useAppState((state) => state.onboarding.onboardingState)
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
 
-  if (onboardingState === "incomplete") {
+  // Anonymous (logged-out browsing) users never see the onboarding quiz.
+  if (!!userID && onboardingState === "incomplete") {
     return <OnboardingQuiz />
   }
 

--- a/src/app/Navigation/Navigation.tsx
+++ b/src/app/Navigation/Navigation.tsx
@@ -4,6 +4,7 @@ import { NavigationContainer, NavigationContainerRef } from "@react-navigation/n
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { useReactNavigationDevTools } from "@rozenite/react-navigation-plugin"
 import { addBreadcrumb } from "@sentry/react-native"
+import { AuthBottomSheetProvider } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
 import { FPSCounter } from "app/Components/FPSCounter"
 import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import {
@@ -114,8 +115,10 @@ export const Navigation = () => {
           }
         }}
       >
-        {!showAuthedRoutes && <OnboardingWelcomeScreens />}
-        {!!showAuthedRoutes && <AuthenticatedRoutes />}
+        <AuthBottomSheetProvider>
+          {!showAuthedRoutes && <OnboardingWelcomeScreens />}
+          {!!showAuthedRoutes && <AuthenticatedRoutes />}
+        </AuthBottomSheetProvider>
       </NavigationContainer>
       {!!fpsCounter && <FPSCounter style={{ bottom: Platform.OS === "ios" ? 40 : undefined }} />}
     </Fragment>

--- a/src/app/Navigation/Navigation.tsx
+++ b/src/app/Navigation/Navigation.tsx
@@ -37,7 +37,10 @@ export const Navigation = () => {
 
   useReactNavigationDevTools({ ref: internal_navigationRef })
 
-  const isLoggedIn = GlobalStore.useAppState((state) => state.auth.userID)
+  const userID = GlobalStore.useAppState((state) => state.auth.userID)
+  const skippedOnboarding = GlobalStore.useAppState((state) => state.auth.skippedOnboarding)
+  const loggedOutEnabled = useFeatureFlag("AREnableLoggedOutMode")
+  const showAuthedRoutes = !!userID || (loggedOutEnabled && skippedOnboarding)
   const fpsCounter = useDevToggle("DTFPSCounter")
 
   const theme = useNavigationTheme()
@@ -111,8 +114,8 @@ export const Navigation = () => {
           }
         }}
       >
-        {!isLoggedIn && <OnboardingWelcomeScreens />}
-        {!!isLoggedIn && <AuthenticatedRoutes />}
+        {!showAuthedRoutes && <OnboardingWelcomeScreens />}
+        {!!showAuthedRoutes && <AuthenticatedRoutes />}
       </NavigationContainer>
       {!!fpsCounter && <FPSCounter style={{ bottom: Platform.OS === "ios" ? 40 : undefined }} />}
     </Fragment>

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -255,6 +255,10 @@ import { GraphQLTaggedNode } from "react-relay"
 export interface ViewOptions {
   alwaysPresentModally?: boolean
   hidesBottomTabs?: boolean
+  // Mark routes that should never open without an authenticated user. When
+  // logged-out browsing is enabled, navigate() short-circuits these and
+  // presents the auth bottom sheet instead.
+  authRequired?: boolean
   // If this module is the root view of a particular tab, name it here
   isRootViewForTabName?: BottomTabType
   // If this module should only be shown in one particular tab, name it here
@@ -801,6 +805,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "Conversation",
     Component: ConversationQueryRenderer,
     options: {
+      authRequired: true,
       onlyShowInTabName: "inbox",
       screenOptions: {
         headerShown: false,
@@ -991,6 +996,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "Inbox",
     Component: InboxScreen,
     options: {
+      authRequired: true,
       isRootViewForTabName: "inbox",
       onlyShowInTabName: "inbox",
       screenOptions: {
@@ -1074,6 +1080,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "MyAccount",
     Component: MyAccountQueryRenderer,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Account Settings",
         headerShown: false,
@@ -1149,6 +1156,7 @@ export const artsyDotNetRoutes = defineRoutes([
     Component: MyCollectionQueryRenderer,
     queries: [myCollectionArtworksQuery],
     options: {
+      authRequired: true,
       screenOptions: {
         headerShown: false,
       },
@@ -1261,6 +1269,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "CompleteMyProfile",
     Component: CompleteMyProfile,
     options: {
+      authRequired: true,
       hidesBottomTabs: true,
       screenOptions: {
         headerShown: false,
@@ -1285,6 +1294,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "MyProfileEditForm",
     Component: MyProfileEditFormScreen,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Edit Profile",
       },
@@ -1296,6 +1306,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "MyProfilePayment",
     Component: MyProfilePaymentQueryRenderer,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Payment",
         headerShown: false,
@@ -1384,6 +1395,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "OrderHistory",
     Component: OrderHistoryQueryRender,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Order History",
       },
@@ -1690,6 +1702,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "Conversation",
     Component: ConversationQueryRenderer,
     options: {
+      authRequired: true,
       onlyShowInTabName: "inbox",
       screenOptions: {
         headerShown: false,
@@ -1702,6 +1715,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "OrderDetail",
     Component: OrderDetailsQR,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Order Details",
       },
@@ -1712,6 +1726,7 @@ export const artsyDotNetRoutes = defineRoutes([
     name: "OrderDetails",
     Component: OrderDetailsQR,
     options: {
+      authRequired: true,
       screenOptions: {
         headerTitle: "Order Details",
       },

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -3,7 +3,6 @@ import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { PortalProvider } from "@gorhom/portal"
 import FlagProvider from "@unleash/proxy-client-react"
 import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsStore"
-import { AuthBottomSheetProvider } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
 import { ShareSheetProvider } from "app/Components/ShareSheet/ShareSheetContext"
 import { WrappedFlagProvider } from "app/system/flags/Components/WrappedFlagProvider"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -48,7 +47,6 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       ToastProvider, // uses: GlobalStoreProvider
       GravityWebsocketContextProvider, // uses GlobalStoreProvider
       ArtworkListsProvider,
-      AuthBottomSheetProvider, // uses BottomSheetProvider (provided by ArtworkListsProvider)
       ShareSheetProvider, // uses BottomSheetProvider
       KeyboardControllerProvider,
     ],

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -3,6 +3,7 @@ import { ActionSheetProvider } from "@expo/react-native-action-sheet"
 import { PortalProvider } from "@gorhom/portal"
 import FlagProvider from "@unleash/proxy-client-react"
 import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsStore"
+import { AuthBottomSheetProvider } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
 import { ShareSheetProvider } from "app/Components/ShareSheet/ShareSheetContext"
 import { WrappedFlagProvider } from "app/system/flags/Components/WrappedFlagProvider"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -47,6 +48,7 @@ export const Providers: React.FC<{ children: React.ReactNode }> = ({ children })
       ToastProvider, // uses: GlobalStoreProvider
       GravityWebsocketContextProvider, // uses GlobalStoreProvider
       ArtworkListsProvider,
+      AuthBottomSheetProvider, // uses BottomSheetProvider (provided by ArtworkListsProvider)
       ShareSheetProvider, // uses BottomSheetProvider
       KeyboardControllerProvider,
     ],

--- a/src/app/Scenes/Activity/components/ArticleFeaturedArtistNotification.tsx
+++ b/src/app/Scenes/Activity/components/ArticleFeaturedArtistNotification.tsx
@@ -3,6 +3,7 @@ import { ArticleCard_article$data } from "__generated__/ArticleCard_article.grap
 import { ArticleFeaturedArtistNotificationFollowArtistMutation } from "__generated__/ArticleFeaturedArtistNotificationFollowArtistMutation.graphql"
 import { ArticleFeaturedArtistNotification_notification$key } from "__generated__/ArticleFeaturedArtistNotification_notification.graphql"
 import { ArticleCard } from "app/Components/ArticleCard"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { ActivityErrorScreen } from "app/Scenes/Activity/components/ActivityErrorScreen"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { goBack } from "app/system/navigation/navigate"
@@ -73,11 +74,13 @@ export const ArticleFeaturedArtistNotification: React.FC<
 
               {artists.length === 1 && (
                 <>
-                  <FollowButton
-                    haptic
-                    isFollowed={!!artists[0].isFollowed}
-                    onPress={handleFollowArtist}
-                  />
+                  <RequireAuth intent="follow_artist">
+                    <FollowButton
+                      haptic
+                      isFollowed={!!artists[0].isFollowed}
+                      onPress={handleFollowArtist}
+                    />
+                  </RequireAuth>
                   <Spacer y={2} />
                 </>
               )}

--- a/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
+++ b/src/app/Scenes/Activity/components/ArtworkPublishedNotification.tsx
@@ -2,6 +2,7 @@ import { ChevronRightIcon } from "@artsy/icons/native"
 import { Flex, FollowButton, Screen, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkPublishedNotificationFollowArtistMutation } from "__generated__/ArtworkPublishedNotificationFollowArtistMutation.graphql"
 import { ArtworkPublishedNotification_notification$key } from "__generated__/ArtworkPublishedNotification_notification.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { ActivityErrorScreen } from "app/Scenes/Activity/components/ActivityErrorScreen"
 import { NotificationArtworkList } from "app/Scenes/Activity/components/NotificationArtworkList"
 import { RouterLink } from "app/system/navigation/RouterLink"
@@ -64,7 +65,9 @@ export const ArtworkPublishedNotification: FC<ArtworkPublishedNotificationProps>
 
           <Spacer y={2} />
 
-          <FollowButton haptic isFollowed={!!artist.isFollowed} onPress={handleFollowArtist} />
+          <RequireAuth intent="follow_artist">
+            <FollowButton haptic isFollowed={!!artist.isFollowed} onPress={handleFollowArtist} />
+          </RequireAuth>
         </Flex>
 
         <NotificationArtworkList artworksConnection={artworksConnection} />

--- a/src/app/Scenes/Activity/components/PartnerShowOpenedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerShowOpenedNotification.tsx
@@ -1,5 +1,6 @@
 import { Flex, FollowButton, Screen, Spacer, Text } from "@artsy/palette-mobile"
 import { PartnerShowOpenedNotification_notification$key } from "__generated__/PartnerShowOpenedNotification_notification.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { ShowItem } from "app/Components/ShowItem"
 import { ActivityErrorScreen } from "app/Scenes/Activity/components/ActivityErrorScreen"
 import { goBack } from "app/system/navigation/navigate"
@@ -43,13 +44,15 @@ export const PartnerShowOpenedNotification: FC<PartnerShowOpenedNotificationProp
 
           <Spacer y={1} />
 
-          <FollowButton
-            haptic
-            isFollowed={!!profile?.isFollowed}
-            onPress={followProfile}
-            disabled={isInFlight}
-            mr={1}
-          />
+          <RequireAuth intent="follow_artist">
+            <FollowButton
+              haptic
+              isFollowed={!!profile?.isFollowed}
+              onPress={followProfile}
+              disabled={isInFlight}
+              mr={1}
+            />
+          </RequireAuth>
 
           <Spacer y={4} />
 

--- a/src/app/Scenes/Activity/components/ViewingRoomPublishedNotification.tsx
+++ b/src/app/Scenes/Activity/components/ViewingRoomPublishedNotification.tsx
@@ -1,5 +1,6 @@
 import { Flex, FollowButton, Screen, Spacer, Text } from "@artsy/palette-mobile"
 import { ViewingRoomPublishedNotification_notification$key } from "__generated__/ViewingRoomPublishedNotification_notification.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { ViewingRoomPublishedNotificationsList } from "app/Scenes/Activity/components/ViewingRoomPublishedNotificationsList"
 import { goBack } from "app/system/navigation/navigate"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
@@ -45,13 +46,15 @@ export const ViewingRoomPublishedNotification: React.FC<ViewingRoomPublishedNoti
         <Flex mx={2} mt={2} mb={4}>
           <Text variant="lg-display">{headline}</Text>
           <Spacer y={2} />
-          <FollowButton
-            haptic
-            isFollowed={!!profile?.isFollowed}
-            onPress={handleFollowPartner}
-            disabled={isInFlight}
-            mr={1}
-          />
+          <RequireAuth intent="follow_artist">
+            <FollowButton
+              haptic
+              isFollowed={!!profile?.isFollowed}
+              onPress={handleFollowPartner}
+              disabled={isInFlight}
+              mr={1}
+            />
+          </RequireAuth>
           <Spacer y={4} />
           <ViewingRoomPublishedNotificationsList
             viewingRoomsConnection={item?.viewingRoomsConnection}

--- a/src/app/Scenes/Artwork/Artwork.tsx
+++ b/src/app/Scenes/Artwork/Artwork.tsx
@@ -71,7 +71,7 @@ import { ShippingAndTaxesFragmentContainer } from "./Components/ShippingAndTaxes
 interface ArtworkProps {
   artworkAboveTheFold: Artwork_artworkAboveTheFold$data | null | undefined
   artworkBelowTheFold: Artwork_artworkBelowTheFold$data | null | undefined
-  me: Artwork_me$data
+  me: Artwork_me$data | null
   isVisible: boolean
   relay: RelayRefetchProp
   tracking?: TrackingProp
@@ -389,7 +389,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
         })
       }
 
-      if (shouldRenderPartner()) {
+      if (shouldRenderPartner() && !!me) {
         sections.push({
           key: "partnerCard",
           element: (
@@ -475,7 +475,7 @@ export const Artwork: React.FC<ArtworkProps> = (props) => {
       })
     }
 
-    if (!artworkAboveTheFold?.isUnlisted && shouldRenderPartner()) {
+    if (!artworkAboveTheFold?.isUnlisted && shouldRenderPartner() && !!me) {
       sections.push({
         key: "partnerCard",
         element: (
@@ -852,17 +852,13 @@ export const ArtworkScreen: React.FC<ArtworkScreenProps> = ({
       render={{
         renderPlaceholder: () => <AboveTheFoldPlaceholder artworkID={artworkID} />,
         renderComponent: ({ above, below }) => {
-          if (
-            // Make sure that the artwork exists
-            above.artworkResult?.__typename === "Artwork" &&
-            above.me
-          ) {
+          if (above.artworkResult?.__typename === "Artwork") {
             return (
               <ArtworkContainer
                 {...others}
                 artworkAboveTheFold={above.artworkResult}
                 artworkBelowTheFold={below?.artworkResult ?? null}
-                me={above.me}
+                me={above.me ?? null}
               />
             )
           }

--- a/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
@@ -3,11 +3,11 @@ import { BellStrokeIcon } from "@artsy/icons/native"
 import { Button, Flex, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtworkAuctionCreateAlertHeader_artwork$key } from "__generated__/ArtworkAuctionCreateAlertHeader_artwork.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
 import { useCreateAlertTracking } from "app/Scenes/SavedSearchAlert/useCreateAlertTracking"
 import { RouterLink } from "app/system/navigation/RouterLink"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { FC, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -51,8 +51,6 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
     contextScreenOwnerSlug: slug,
     contextModule: ContextModule.artworkClosedLotHeader,
   })
-  const requireAuth = useRequireAuth()
-
   if (!displayAuctionCreateAlertHeader) {
     return null
   }
@@ -101,22 +99,21 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
             </Button>
           </RouterLink>
         ) : (
-          <Button
-            size="large"
-            variant="fillDark"
-            haptic
-            onPress={requireAuth(
-              () => {
+          <RequireAuth intent="create_alert">
+            <Button
+              size="large"
+              variant="fillDark"
+              haptic
+              onPress={() => {
                 trackCreateAlertTap()
                 setShowCreateArtworkAlertModal(true)
-              },
-              { intent: "create_alert" }
-            )}
-            icon={<BellStrokeIcon fill="mono0" />}
-            block
-          >
-            Create Alert
-          </Button>
+              }}
+              icon={<BellStrokeIcon fill="mono0" />}
+              block
+            >
+              Create Alert
+            </Button>
+          </RequireAuth>
         )}
 
         {!!hasArtworksSuggestions && (

--- a/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/app/Scenes/Artwork/ArtworkAuctionCreateAlertHeader.tsx
@@ -7,6 +7,7 @@ import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
 import { useCreateAlertTracking } from "app/Scenes/SavedSearchAlert/useCreateAlertTracking"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { FC, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -50,6 +51,7 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
     contextScreenOwnerSlug: slug,
     contextModule: ContextModule.artworkClosedLotHeader,
   })
+  const requireAuth = useRequireAuth()
 
   if (!displayAuctionCreateAlertHeader) {
     return null
@@ -103,10 +105,13 @@ export const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeader
             size="large"
             variant="fillDark"
             haptic
-            onPress={() => {
-              trackCreateAlertTap()
-              setShowCreateArtworkAlertModal(true)
-            }}
+            onPress={requireAuth(
+              () => {
+                trackCreateAlertTap()
+                setShowCreateArtworkAlertModal(true)
+              },
+              { intent: "create_alert" }
+            )}
             icon={<BellStrokeIcon fill="mono0" />}
             block
           >

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -7,6 +7,7 @@ import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
 import { useCreateAlertTracking } from "app/Scenes/SavedSearchAlert/useCreateAlertTracking"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -38,6 +39,7 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
     contextScreenOwnerSlug: slug,
     contextModule: "ArtworkScreenHeader" as ContextModule,
   })
+  const requireAuth = useRequireAuth()
 
   if (!!displayCreateAlertHeader || !isEligibleToCreateAlert) {
     return null
@@ -49,10 +51,13 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
         size="small"
         variant={isForSale ? "outline" : "fillDark"}
         haptic
-        onPress={() => {
-          trackCreateAlertTap()
-          setShowCreateArtworkAlertModal(true)
-        }}
+        onPress={requireAuth(
+          () => {
+            trackCreateAlertTap()
+            setShowCreateArtworkAlertModal(true)
+          },
+          { intent: "create_alert" }
+        )}
         icon={<BellStrokeIcon fill={isForSale ? "mono100" : "mono0"} />}
       >
         Create Alert

--- a/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
+++ b/src/app/Scenes/Artwork/Components/ArtworkScreenHeaderCreateAlert.tsx
@@ -3,11 +3,11 @@ import { BellStrokeIcon } from "@artsy/icons/native"
 import { Button, Flex } from "@artsy/palette-mobile"
 import { ArtworkScreenHeaderCreateAlert_artwork$key } from "__generated__/ArtworkScreenHeaderCreateAlert_artwork.graphql"
 import { CreateArtworkAlertModal } from "app/Components/Artist/ArtistArtworks/CreateArtworkAlertModal"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { hasBiddingEnded } from "app/Scenes/Artwork/utils/hasBiddingEnded"
 import { isLotClosed } from "app/Scenes/Artwork/utils/isLotClosed"
 import { useCreateAlertTracking } from "app/Scenes/SavedSearchAlert/useCreateAlertTracking"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -39,29 +39,26 @@ export const ArtworkScreenHeaderCreateAlert: React.FC<ArtworkScreenHeaderCreateA
     contextScreenOwnerSlug: slug,
     contextModule: "ArtworkScreenHeader" as ContextModule,
   })
-  const requireAuth = useRequireAuth()
-
   if (!!displayCreateAlertHeader || !isEligibleToCreateAlert) {
     return null
   }
 
   return (
     <Flex>
-      <Button
-        size="small"
-        variant={isForSale ? "outline" : "fillDark"}
-        haptic
-        onPress={requireAuth(
-          () => {
+      <RequireAuth intent="create_alert">
+        <Button
+          size="small"
+          variant={isForSale ? "outline" : "fillDark"}
+          haptic
+          onPress={() => {
             trackCreateAlertTap()
             setShowCreateArtworkAlertModal(true)
-          },
-          { intent: "create_alert" }
-        )}
-        icon={<BellStrokeIcon fill={isForSale ? "mono100" : "mono0"} />}
-      >
-        Create Alert
-      </Button>
+          }}
+          icon={<BellStrokeIcon fill={isForSale ? "mono100" : "mono0"} />}
+        >
+          Create Alert
+        </Button>
+      </RequireAuth>
 
       <CreateArtworkAlertModal
         artwork={artwork}

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/BidButton.tsx
@@ -4,8 +4,10 @@ import { BidButton_artwork$data } from "__generated__/BidButton_artwork.graphql"
 import { BidButton_me$data } from "__generated__/BidButton_me.graphql"
 import { AuctionTimerState } from "app/Components/Bidding/Components/Timer"
 import { ThemeAwareClassTheme } from "app/Components/DarkModeClassTheme"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { bidderNeedsIdentityVerification } from "app/utils/auction/bidderNeedsIdentityVerification"
+import { useRequireAuthGuard } from "app/utils/hooks/useRequireAuth"
 import { Schema } from "app/utils/track"
 import React from "react"
 import { createFragmentContainer, graphql, RelayProp } from "react-relay"
@@ -47,6 +49,7 @@ const IdentityVerificationRequiredMessage: React.FC<TextProps> = ({
 export const BidButton: React.FC<BidButtonProps> = (props) => {
   const { artwork, me, auctionState, variant } = props
   const { trackEvent } = useTracking()
+  const requireAuth = useRequireAuthGuard()
 
   const redirectToIdentityVerificationFAQ = () => {
     trackEvent({
@@ -58,6 +61,10 @@ export const BidButton: React.FC<BidButtonProps> = (props) => {
   }
 
   const redirectToRegister = () => {
+    if (!requireAuth("bid")) {
+      return
+    }
+
     trackEvent({
       action_name: Schema.ActionNames.RegisterToBid,
       action_type: Schema.ActionTypes.Tap,
@@ -91,6 +98,10 @@ export const BidButton: React.FC<BidButtonProps> = (props) => {
   }
 
   const redirectToBid = (firstIncrement: number) => {
+    if (!requireAuth("bid")) {
+      return
+    }
+
     const myLotStanding = getMyLotStanding(artwork)
     const hasBid = getHasBid(myLotStanding)
 

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/BuyNowButton.tsx
@@ -8,6 +8,7 @@ import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getTimer } from "app/utils/getTimer"
+import { useRequireAuthGuard } from "app/utils/hooks/useRequireAuth"
 import { useEffect, useRef, useState } from "react"
 import { Alert } from "react-native"
 import { graphql, useFragment } from "react-relay"
@@ -45,6 +46,7 @@ export const BuyNowButton = ({
   const { saleMessage, internalID } = useFragment(artworkFragment, artwork)
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
+  const requireAuth = useRequireAuthGuard()
 
   const [partnerOfferTimer, setPartnerOfferTimer] = useState(
     partnerOffer?.endAt ? getTimer(partnerOffer.endAt) : null
@@ -134,6 +136,10 @@ export const BuyNowButton = ({
   }
 
   const handleCreateOrder = async () => {
+    if (!requireAuth("purchase")) {
+      return
+    }
+
     if (isCommittingCreateOrderMutation) {
       return
     }

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -13,6 +13,7 @@ import {
   CollectorSignals,
   getArtworkSignalTrackingFields,
 } from "app/utils/getArtworkSignalTrackingFields"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import React from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -31,16 +32,22 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
 
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
+  const requireAuth = useRequireAuth()
 
   return (
     <ArtworkInquiryStateProvider>
       <ArtworkInquiryContext.Consumer>
         {({ dispatch }) => (
           <Button
-            onPress={() => {
-              trackEvent(tracks.trackTappedContactGallery(analytics, artworkData.collectorSignals))
-              dispatch({ type: "setInquiryModalVisible", payload: true })
-            }}
+            onPress={requireAuth(
+              () => {
+                trackEvent(
+                  tracks.trackTappedContactGallery(analytics, artworkData.collectorSignals)
+                )
+                dispatch({ type: "setInquiryModalVisible", payload: true })
+              },
+              { intent: "contact_gallery" }
+            )}
             haptic
             {...rest}
           >

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton.tsx
@@ -3,6 +3,7 @@ import { ButtonProps, Button } from "@artsy/palette-mobile"
 import { ContactGalleryButton_artwork$key } from "__generated__/ContactGalleryButton_artwork.graphql"
 import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
 import { useSendInquiry_me$key } from "__generated__/useSendInquiry_me.graphql"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { InquiryModal } from "app/Scenes/Artwork/Components/CommercialButtons/InquiryModal"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
 import {
@@ -13,7 +14,6 @@ import {
   CollectorSignals,
   getArtworkSignalTrackingFields,
 } from "app/utils/getArtworkSignalTrackingFields"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import React from "react"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -32,27 +32,25 @@ export const ContactGalleryButton: React.FC<ContactGalleryButtonProps> = ({
 
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
-  const requireAuth = useRequireAuth()
 
   return (
     <ArtworkInquiryStateProvider>
       <ArtworkInquiryContext.Consumer>
         {({ dispatch }) => (
-          <Button
-            onPress={requireAuth(
-              () => {
+          <RequireAuth intent="contact_gallery">
+            <Button
+              onPress={() => {
                 trackEvent(
                   tracks.trackTappedContactGallery(analytics, artworkData.collectorSignals)
                 )
                 dispatch({ type: "setInquiryModalVisible", payload: true })
-              },
-              { intent: "contact_gallery" }
-            )}
-            haptic
-            {...rest}
-          >
-            Contact Gallery
-          </Button>
+              }}
+              haptic
+              {...rest}
+            >
+              Contact Gallery
+            </Button>
+          </RequireAuth>
         )}
       </ArtworkInquiryContext.Consumer>
       <InquiryModal artwork={artworkData} me={me} />

--- a/src/app/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
+++ b/src/app/Scenes/Artwork/Components/CommercialButtons/MakeOfferButton.tsx
@@ -3,7 +3,9 @@ import { Button, ButtonProps } from "@artsy/palette-mobile"
 import { MakeOfferButtonOrderMutation } from "__generated__/MakeOfferButtonOrderMutation.graphql"
 import { MakeOfferButton_artwork$data } from "__generated__/MakeOfferButton_artwork.graphql"
 import { useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
+import { useRequireAuthGuard } from "app/utils/hooks/useRequireAuth"
 
 import React, { useState } from "react"
 import { Alert } from "react-native"
@@ -30,6 +32,7 @@ export const MakeOfferButton: React.FC<MakeOfferButtonProps> = (props) => {
 
   const tracking = useTracking()
   const analytics = useAnalyticsContext()
+  const requireAuth = useRequireAuthGuard()
 
   // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
   const onMutationError = (error) => {
@@ -53,6 +56,10 @@ export const MakeOfferButton: React.FC<MakeOfferButtonProps> = (props) => {
   }
 
   const handleCreateOfferOrder = () => {
+    if (!requireAuth("make_offer")) {
+      return
+    }
+
     tracking.trackEvent({
       action: ActionType.tappedMakeOffer,
       context_module: analytics.contextModule,

--- a/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
+++ b/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
@@ -1,11 +1,11 @@
 import { Flex, FollowButton, Text, useScreenDimensions, useSpace } from "@artsy/palette-mobile"
 import { PartnerListItem_partner$key } from "__generated__/PartnerListItem_partner.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { sortByDistance } from "app/Scenes/GalleriesForYou/helpers"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { Location } from "app/utils/hooks/useLocation"
-import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
 import { pluralize } from "app/utils/pluralize"
 import { isTablet } from "react-native-device-info"
@@ -49,14 +49,9 @@ export const PartnerListItem: React.FC<PartnerListItemProps> = ({
     isFollowed: !!profile?.isFollowed,
     onCompleted: onFollow,
   })
-  const requireAuth = useRequireAuth()
-
-  const handleFollowPartner = requireAuth(
-    () => {
-      followProfile()
-    },
-    { intent: "follow_artist" }
-  )
+  const handleFollowPartner = () => {
+    followProfile()
+  }
 
   if (!profile) {
     return null
@@ -105,12 +100,14 @@ export const PartnerListItem: React.FC<PartnerListItemProps> = ({
             </Flex>
 
             <Flex mt={0.5}>
-              <FollowButton
-                haptic
-                isFollowed={!!profile?.isFollowed}
-                onPress={handleFollowPartner}
-                disabled={isInFlight}
-              />
+              <RequireAuth intent="follow_artist">
+                <FollowButton
+                  haptic
+                  isFollowed={!!profile?.isFollowed}
+                  onPress={handleFollowPartner}
+                  disabled={isInFlight}
+                />
+              </RequireAuth>
             </Flex>
           </Flex>
         </Flex>

--- a/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
+++ b/src/app/Scenes/GalleriesForYou/Components/PartnerListItem.tsx
@@ -5,6 +5,7 @@ import { sortByDistance } from "app/Scenes/GalleriesForYou/helpers"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { Location } from "app/utils/hooks/useLocation"
+import { useRequireAuth } from "app/utils/hooks/useRequireAuth"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
 import { pluralize } from "app/utils/pluralize"
 import { isTablet } from "react-native-device-info"
@@ -48,10 +49,14 @@ export const PartnerListItem: React.FC<PartnerListItemProps> = ({
     isFollowed: !!profile?.isFollowed,
     onCompleted: onFollow,
   })
+  const requireAuth = useRequireAuth()
 
-  const handleFollowPartner = () => {
-    followProfile()
-  }
+  const handleFollowPartner = requireAuth(
+    () => {
+      followProfile()
+    },
+    { intent: "follow_artist" }
+  )
 
   if (!profile) {
     return null

--- a/src/app/Scenes/HomeView/Components/ArtistRails/ArtistCard.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistRails/ArtistCard.tsx
@@ -2,6 +2,7 @@ import { CloseIcon } from "@artsy/icons/native"
 import { Flex, FollowButton, Image, Text, Touchable, useColor } from "@artsy/palette-mobile"
 import { ArtistCard_artist$data } from "__generated__/ArtistCard_artist.graphql"
 import { useFollowArtist } from "app/Components/Artist/useFollowArtist"
+import { RequireAuth } from "app/Components/RequireAuth"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { extractNodes } from "app/utils/extractNodes"
 import { memo } from "react"
@@ -62,10 +63,12 @@ export const ArtistCard: React.FC<ArtistCardProps> = memo(
             </Flex>
             {!!(onFollow || showDefaultFollowButton) && (
               <Flex>
-                <FollowButton
-                  isFollowed={!!artist.isFollowed}
-                  onPress={onFollow ?? handleFollowToggle}
-                />
+                <RequireAuth intent="follow_artist">
+                  <FollowButton
+                    isFollowed={!!artist.isFollowed}
+                    onPress={onFollow ?? handleFollowToggle}
+                  />
+                </RequireAuth>
               </Flex>
             )}
           </Flex>

--- a/src/app/Scenes/MyProfile/Components/UserAccountHeader/LoggedOutAccountHeader.tsx
+++ b/src/app/Scenes/MyProfile/Components/UserAccountHeader/LoggedOutAccountHeader.tsx
@@ -1,0 +1,68 @@
+import { PersonIcon } from "@artsy/icons/native"
+import { Button, Flex, Join, Spacer, Text, useColor } from "@artsy/palette-mobile"
+import { useAuthBottomSheet } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
+
+const PROFILE_IMAGE_SIZE = 70
+
+interface LoggedOutAccountHeaderProps {
+  showBorder?: boolean
+}
+
+export const LoggedOutAccountHeader: React.FC<LoggedOutAccountHeaderProps> = ({ showBorder }) => {
+  const color = useColor()
+  const { present } = useAuthBottomSheet()
+
+  const Wrapper = showBorder
+    ? ({ children }: React.PropsWithChildren) => (
+        <Flex
+          minHeight={200}
+          borderRadius={20}
+          borderColor="mono10"
+          borderWidth={1}
+          alignItems="center"
+          justifyContent="center"
+          p={2}
+          mx={2}
+          mt={2}
+        >
+          {children}
+        </Flex>
+      )
+    : ({ children }: React.PropsWithChildren) => (
+        <Flex borderRadius={20} alignItems="center" px={2} pb={1} mb={2}>
+          {children}
+        </Flex>
+      )
+
+  return (
+    <Wrapper>
+      <Join separator={<Spacer y={2} />}>
+        <Flex
+          height={PROFILE_IMAGE_SIZE}
+          width={PROFILE_IMAGE_SIZE}
+          borderRadius={PROFILE_IMAGE_SIZE / 2}
+          backgroundColor={color("mono5")}
+          borderWidth={1}
+          borderColor={color("mono10")}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <PersonIcon width={18} height={18} />
+        </Flex>
+
+        <Flex alignItems="center" px={2}>
+          <Text variant="md" textAlign="center">
+            Sign up or log in
+          </Text>
+          <Text variant="sm" color="mono60" textAlign="center" mt={0.5}>
+            Save artworks, follow artists, and access your collection across devices.
+          </Text>
+        </Flex>
+
+        <Button block onPress={() => present({ intent: "generic" })}>
+          Sign up or log in
+        </Button>
+      </Join>
+    </Wrapper>
+  )
+}

--- a/src/app/Scenes/MyProfile/MyProfileSettings.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileSettings.tsx
@@ -10,6 +10,7 @@ import { Flex, Join, LinkText, Screen, Spacer, Text, Touchable } from "@artsy/pa
 import * as Sentry from "@sentry/react-native"
 import { DarkModeIcon } from "app/Components/Icons/DarkModeIcon"
 import { MenuItem } from "app/Components/MenuItem"
+import { LoggedOutAccountHeader } from "app/Scenes/MyProfile/Components/UserAccountHeader/LoggedOutAccountHeader"
 import { UserAccountHeaderQueryRenderer } from "app/Scenes/MyProfile/Components/UserAccountHeader/UserAccountHeader"
 import { GlobalStore } from "app/store/GlobalStore"
 import { AnalyticsContextProvider } from "app/system/analytics/AnalyticsContext"
@@ -34,6 +35,7 @@ const MyProfileSettingsContent: React.FC = () => {
   const appVersion = getAppVersion()
   const { updateTapCount } = useSetDevMode()
   const { value: userIsDev } = GlobalStore.useAppState((store) => store.artsyPrefs.userIsDev)
+  const isLoggedIn = GlobalStore.useAppState((state) => !!state.auth.userID)
   const tracking = useTracking()
 
   const scrollableRef = useBottomTabsScrollToTop() as React.RefObject<ScrollView>
@@ -43,57 +45,71 @@ const MyProfileSettingsContent: React.FC = () => {
       <Screen.Body fullwidth>
         <Sentry.TimeToInitialDisplay record>
           <ScrollView ref={scrollableRef}>
-            <UserAccountHeaderQueryRenderer
-              showBorder
-              showMyCollectionPreview
-              tappable
-              showCompleteProfile
-              onAvatarPress={() => {
-                tracking.trackEvent(tracks.trackTappedEditedProfile())
-              }}
-              onCardPress={() => {
-                tracking.trackEvent(tracks.trackTappedMyCollection())
-              }}
-            />
+            {isLoggedIn ? (
+              <UserAccountHeaderQueryRenderer
+                showBorder
+                showMyCollectionPreview
+                tappable
+                showCompleteProfile
+                onAvatarPress={() => {
+                  tracking.trackEvent(tracks.trackTappedEditedProfile())
+                }}
+                onCardPress={() => {
+                  tracking.trackEvent(tracks.trackTappedMyCollection())
+                }}
+              />
+            ) : (
+              <LoggedOutAccountHeader showBorder />
+            )}
 
             <Text variant="lg-display" px={2} mt={4}>
               Account
             </Text>
             <Join separator={<Spacer y={4} />}>
-              <>
-                <Text variant="xs" color="mono60" px={2} mt={2}>
-                  Transactions
-                </Text>
+              {!!isLoggedIn && (
+                <>
+                  <Text variant="xs" color="mono60" px={2} mt={2}>
+                    Transactions
+                  </Text>
 
-                <MenuItem title="Your Orders" href="/orders" icon={<BagIcon />} />
-              </>
+                  <MenuItem title="Your Orders" href="/orders" icon={<BagIcon />} />
+                </>
+              )}
 
               <>
                 <Text variant="xs" color="mono60" px={2} mt={2}>
                   Preferences
                 </Text>
 
-                <MenuItem
-                  title="Artwork Budget"
-                  href="/my-account/edit-price-range"
-                  icon={<MoneyBackIcon />}
-                />
+                {!!isLoggedIn && (
+                  <MenuItem
+                    title="Artwork Budget"
+                    href="/my-account/edit-price-range"
+                    icon={<MoneyBackIcon />}
+                  />
+                )}
                 <MenuItem title="Dark Mode" href="/my-account/dark-mode" icon={<DarkModeIcon />} />
               </>
 
-              <>
-                <Text variant="xs" color="mono60" px={2}>
-                  Account
-                </Text>
+              {!!isLoggedIn && (
+                <>
+                  <Text variant="xs" color="mono60" px={2}>
+                    Account
+                  </Text>
 
-                <MenuItem title="Login and Security" href="my-account" icon={<LockIcon />} />
-                <MenuItem title="Payments" href="my-profile/payment" icon={<CreditCardIcon />} />
-                <MenuItem
-                  title="Notifications"
-                  href="my-profile/push-notifications"
-                  icon={<MobileIcon />}
-                />
-              </>
+                  <MenuItem title="Login and Security" href="my-account" icon={<LockIcon />} />
+                  <MenuItem
+                    title="Payments"
+                    href="my-profile/payment"
+                    icon={<CreditCardIcon />}
+                  />
+                  <MenuItem
+                    title="Notifications"
+                    href="my-profile/push-notifications"
+                    icon={<MobileIcon />}
+                  />
+                </>
+              )}
 
               <>
                 <Text variant="xs" color="mono60" px={2}>
@@ -134,9 +150,11 @@ const MyProfileSettingsContent: React.FC = () => {
               </>
 
               <Flex justifyContent="center" px={2} pb={2}>
-                <LinkText onPress={confirmLogout} variant="sm">
-                  Log out
-                </LinkText>
+                {!!isLoggedIn && (
+                  <LinkText onPress={confirmLogout} variant="sm">
+                    Log out
+                  </LinkText>
+                )}
                 <Spacer y={4} />
                 <Touchable
                   accessibilityRole="button"

--- a/src/app/Scenes/MyProfile/__tests__/MyProfileSettings.tests.tsx
+++ b/src/app/Scenes/MyProfile/__tests__/MyProfileSettings.tests.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { MyProfileSettings } from "app/Scenes/MyProfile/MyProfileSettings"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { Alert, Linking } from "react-native"
@@ -10,6 +11,7 @@ jest.spyOn(Alert, "alert")
 describe("MyProfileSettings", () => {
   beforeEach(() => {
     jest.spyOn(Linking, "openURL").mockImplementation(() => Promise.resolve())
+    __globalStoreTestUtils__?.injectState({ auth: { userID: "user-id" } })
   })
 
   it("renders Transactions section", () => {

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
@@ -8,6 +8,7 @@ import {
   LinkText,
   Spacer,
   Text,
+  Touchable,
   useTheme,
 } from "@artsy/palette-mobile"
 import { NavigationProp, useNavigation } from "@react-navigation/native"
@@ -20,6 +21,7 @@ import { useInputAutofocus } from "app/Scenes/Onboarding/Screens/Auth/hooks/useI
 import { OnboardingNavigationStack } from "app/Scenes/Onboarding/Screens/Onboarding"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useSocialLogin } from "app/utils/auth/socialSignInHelpers"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { osMajorVersion } from "app/utils/platformUtil"
 import { Formik, useFormikContext } from "formik"
 import { MotiView } from "moti"
@@ -131,6 +133,7 @@ const LoginWelcomeStepForm: React.FC = () => {
   const setModalExpanded = AuthContext.useStoreActions((actions) => actions.setModalExpanded)
   const isModalExpanded = AuthContext.useStoreState((state) => state.isModalExpanded)
   const isLoading = GlobalStore.useAppState((state) => state.auth.sessionState.isLoading)
+  const loggedOutEnabled = useFeatureFlag("AREnableLoggedOutMode")
 
   const { color } = useTheme()
   const { handleChange, handleSubmit, isSubmitting, isValid, resetForm, values } =
@@ -251,6 +254,23 @@ const LoginWelcomeStepForm: React.FC = () => {
             </LinkText>
             .
           </Text>
+
+          {!!loggedOutEnabled && (
+            <>
+              <Spacer y={2} />
+              <Touchable
+                onPress={() => {
+                  GlobalStore.actions.auth.setSkippedOnboarding(true)
+                }}
+                accessibilityHint="Continue browsing without signing in"
+                accessibilityLabel="Continue without an account"
+              >
+                <Text variant="xs" textAlign="center" underline>
+                  Continue without an account
+                </Text>
+              </Touchable>
+            </>
+          )}
         </MotiView>
       )}
     </Flex>

--- a/src/app/store/AuthModel.ts
+++ b/src/app/store/AuthModel.ts
@@ -121,12 +121,14 @@ export interface AuthModel {
   xApptokenExpiresIn: string | null
   userEmail: string | null
   previousSessionUserID: string | null
+  skippedOnboarding: boolean
 
   userHasArtsyEmail: Computed<this, boolean, GlobalStoreModel>
 
   // Actions
   setState: Action<this, Partial<StateMapper<this>>>
   setSessionState: Action<this, Partial<SessionState>>
+  setSkippedOnboarding: Action<this, boolean>
   getXAppToken: Thunk<this, void, {}, GlobalStoreModel, Promise<string>>
   getUser: Thunk<this, { accessToken: string }, {}, GlobalStoreModel>
   signIn: Thunk<
@@ -212,11 +214,15 @@ export const getAuthModel = (): AuthModel => ({
   xApptokenExpiresIn: null,
   userEmail: null,
   previousSessionUserID: null,
+  skippedOnboarding: false,
   userHasArtsyEmail: computed((state) => isArtsyEmail(state.userEmail ?? "")),
 
   setState: action((state, payload) => Object.assign(state, payload)),
   setSessionState: action((state, payload) => {
     state.sessionState = { ...state.sessionState, ...payload }
+  }),
+  setSkippedOnboarding: action((state, payload) => {
+    state.skippedOnboarding = payload
   }),
   getXAppToken: thunk(async (actions, _payload, context) => {
     const xAppToken = context.getState().xAppToken
@@ -351,6 +357,7 @@ export const getAuthModel = (): AuthModel => ({
         userAccessTokenExpiresIn: expires_in,
         userID: user.id,
         userEmail: email,
+        skippedOnboarding: false,
       })
 
       GlobalStore.actions.onboarding.setOnboardingState("complete")

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -44,6 +44,11 @@ export type FeatureDescriptor = (
 export type FeatureName = keyof typeof features
 
 export const features = {
+  AREnableLoggedOutMode: {
+    readyForRelease: false,
+    showInDevMenu: true,
+    description: "Allow browsing the app without an account",
+  },
   ARDarkModeSupport: {
     readyForRelease: true,
     showInDevMenu: true,

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -68,9 +68,10 @@ export const Versions = {
   AddHasSavedArtworksToInfiniteDiscoveryModel: 55,
   AddPreviouslySelectedCitySlugToUserPrefsModel: 56,
   RemovePendingPushNotificationModel: 57,
+  AddSkippedOnboardingToAuthModel: 58,
 }
 
-export const CURRENT_APP_VERSION = Versions.RemovePendingPushNotificationModel
+export const CURRENT_APP_VERSION = Versions.AddSkippedOnboardingToAuthModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -383,6 +384,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.RemovePendingPushNotificationModel]: (state) => {
     delete state.pendingPushNotification
+  },
+  [Versions.AddSkippedOnboardingToAuthModel]: (state) => {
+    state.auth.skippedOnboarding = false
   },
 }
 

--- a/src/app/system/navigation/__tests__/navigate.tests.tsx
+++ b/src/app/system/navigation/__tests__/navigate.tests.tsx
@@ -18,6 +18,7 @@ jest.mock("app/store/GlobalStore", () => ({
   }),
   unsafe_getFeatureFlag: jest.fn(),
   unsafe_getDevToggle: jest.fn().mockReturnValue(false),
+  unsafe_getUserAccessToken: jest.fn().mockReturnValue("user-access-token"),
   GlobalStore: {
     actions: {
       bottomTabs: {

--- a/src/app/system/navigation/navigate.ts
+++ b/src/app/system/navigation/navigate.ts
@@ -1,10 +1,15 @@
 import { EventEmitter } from "events"
 import { CommonActions, StackActions, TabActions } from "@react-navigation/native"
+import { presentAuthBottomSheet } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
 import { tabsTracks } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { modules } from "app/Navigation/utils/modules"
 import { BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
-import { GlobalStore } from "app/store/GlobalStore"
+import {
+  GlobalStore,
+  unsafe_getFeatureFlag,
+  unsafe_getUserAccessToken,
+} from "app/store/GlobalStore"
 import { getValidTargetURL } from "app/system/navigation/utils/getValidTargetURL"
 import { matchRoute } from "app/system/navigation/utils/matchRoute"
 import { postEventToProviders } from "app/utils/track/providers"
@@ -62,6 +67,15 @@ export async function navigate(url: string, options: NavigateOptions = {}) {
   const module = modules[result.module]
 
   if (shouldQuit(options, targetURL)) {
+    return
+  }
+
+  if (
+    module.options?.authRequired &&
+    !unsafe_getUserAccessToken() &&
+    unsafe_getFeatureFlag("AREnableLoggedOutMode")
+  ) {
+    presentAuthBottomSheet({ intent: "generic" })
     return
   }
 

--- a/src/app/utils/hooks/useRequireAuth.ts
+++ b/src/app/utils/hooks/useRequireAuth.ts
@@ -1,0 +1,52 @@
+import { useAuthBottomSheet } from "app/Components/AuthBottomSheet/AuthBottomSheetProvider"
+import { AuthIntent } from "app/Components/AuthBottomSheet/AuthBottomSheetTypes"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useCallback } from "react"
+
+interface RequireAuthOptions {
+  intent?: AuthIntent
+}
+
+/**
+ * Wraps a handler so it runs as-is when authenticated, and presents the auth
+ * bottom sheet when not. Use for synchronous event handlers (Save, Follow, …).
+ *
+ * When the logged-out browsing flag is off, this is a pass-through — callers
+ * keep their pre-pilot behavior (the handler always runs).
+ */
+export const useRequireAuth = () => {
+  const isLoggedIn = GlobalStore.useAppState((state) => !!state.auth.userID)
+  const loggedOutEnabled = useFeatureFlag("AREnableLoggedOutMode")
+  const { present } = useAuthBottomSheet()
+
+  return useCallback(
+    <T extends (...args: any[]) => any>(handler: T, opts?: RequireAuthOptions): T =>
+      ((...args: Parameters<T>) => {
+        if (isLoggedIn || !loggedOutEnabled) return handler(...args)
+        present({ intent: opts?.intent ?? "generic" })
+        return undefined
+      }) as T,
+    [isLoggedIn, loggedOutEnabled, present]
+  )
+}
+
+/**
+ * Imperative guard: returns true if authenticated (or if the logged-out
+ * browsing flag is off, preserving pre-pilot behavior), otherwise presents
+ * the auth sheet and returns false.
+ */
+export const useRequireAuthGuard = () => {
+  const isLoggedIn = GlobalStore.useAppState((state) => !!state.auth.userID)
+  const loggedOutEnabled = useFeatureFlag("AREnableLoggedOutMode")
+  const { present } = useAuthBottomSheet()
+
+  return useCallback(
+    (intent: AuthIntent = "generic"): boolean => {
+      if (isLoggedIn || !loggedOutEnabled) return true
+      present({ intent })
+      return false
+    },
+    [isLoggedIn, loggedOutEnabled, present]
+  )
+}


### PR DESCRIPTION
### Description

This PR implements a logged-out browsing mode that allows users to explore the app without authentication. When the `AREnableLoggedOutMode` feature flag is enabled, unauthenticated users can:

- Browse the app and access most features
- See placeholder screens for auth-required tabs (Inbox, Favorites, Profile)
- Trigger an auth bottom sheet when attempting auth-required actions
- Skip onboarding and continue browsing without signing in

**Key changes:**

1. **Auth Bottom Sheet System**
   - New `AuthBottomSheetProvider` component that manages presentation of auth UI via context and imperative refs
   - `AuthBottomSheetContent` displays intent-specific messaging (e.g., "Sign up or log in to save artworks")
   - Supports 8 different auth intents (save_artwork, follow_artist, contact_gallery, make_offer, bid, purchase, create_alert, generic)

2. **Auth Requirement Hooks**
   - `useRequireAuth()`: Wraps event handlers to require authentication before execution
   - `useRequireAuthGuard()`: Imperative guard that returns boolean and presents auth sheet if needed
   - Both respect the feature flag and pass through when logged-out mode is disabled

3. **Navigation & Route Protection**
   - Added `authRequired` flag to route options for routes that should never open without auth
   - `navigate()` now checks this flag and presents auth sheet instead of navigating when logged-out
   - Updated Conversation and Inbox routes as auth-required

4. **Tab Placeholders**
   - New `LoggedOutTabPlaceholder` component for auth-required tabs
   - Inbox, Favorites, and Profile tabs show placeholders when user is logged out
   - Each placeholder has intent-specific messaging and CTA

5. **Feature Integration**
   - Wrapped auth-required actions in: ArtistFollowButton, PartnerFollowButton, ContactGalleryButton, BidButton, MakeOfferButton, BuyNowButton, SaveArtwork, CreateAlert, SavedSearch
   - Added "Continue without an account" option to login screen when feature is enabled
   - Added `skippedOnboarding` state to AuthModel to track users who skip auth

6. **State & Migration**
   - Added `skippedOnboarding` boolean to AuthModel
   - Added migration v58 to initialize the new state field
   - New feature flag `AREnableLoggedOutMode` (disabled by default)

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
  - Changes are behind `AREnableLoggedOutMode` feature flag
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
  - Added migration v58 for `skippedOnboarding` field
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add logged-out browsing mode behind `AREnableLoggedOutMode` feature flag
- Add auth bottom sheet system for presenting authentication UI on demand
- Add `useRequireAuth()` and `useRequireAuthGuard()` hooks for protecting auth-required actions
- Add `LoggedOutTabPlaceholder` component for auth-required tabs
- Add `authRequired` route option for protecting navigation routes

</details>

https://claude.ai/code/session_016zXaTUqg5yWgdKPPLJ8YWw