### PR TITLE
fix: android sourcemap upload with build type support after expo 55

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -359,9 +359,10 @@ lane :ship_beta_android do |options|
     upload_sentry_artifacts(
       sentry_release_name: sentry_release_name,
       dist_version: "#{vcode}",
-      platform: 'android'
+      platform: 'android',
+      build_type: build_type
     )
-    s3_upload_android_build(app_version: vcode, app_path: "../android/app/build/outputs/bundle/release/app-release.aab")
+    s3_upload_android_build(app_version: vcode, app_path: "../android/app/build/outputs/bundle/#{build_type}/app-#{build_type}.aab")
   end
 
   deploy_android_beta(deployment_target: deployment_target)

--- a/fastlane/sentry_fastlane.rb
+++ b/fastlane/sentry_fastlane.rb
@@ -17,7 +17,8 @@ lane :upload_sentry_artifacts do |options|
     UI.user_error!("Sentry distribution version not specified")
   end
 
-  settings = platform_settings(options[:platform])
+  build_type = options[:build_type] || 'release'
+  settings = platform_settings(options[:platform], build_type: build_type)
   sourcemap_path = settings[:sourcemap_path]
   bundle_path = settings[:bundle_path]
   outfile = settings[:outfile]
@@ -99,15 +100,15 @@ lane :upload_dsyms_to_sentry do |options|
   puts "Uploaded dsyms for #{project_slug}"
 end
 
-def platform_settings(platform)
+def platform_settings(platform, build_type: 'release')
   settings = {
     ios: {
       sourcemap_path: 'dist/ios/main.jsbundle.map',
       bundle_path: 'dist/ios/main.jsbundle'
     },
     android: {
-      sourcemap_path: 'android/app/build/generated/sourcemaps/react/release/index.android.bundle.map',
-      bundle_path: 'android/app/build/generated/assets/createBundleReleaseJsAndAssets/index.android.bundle'
+      sourcemap_path: "android/app/build/generated/sourcemaps/react/#{build_type}/index.android.bundle.map",
+      bundle_path: "android/app/build/generated/assets/react/#{build_type}/index.android.bundle"
     }
   }
   settings[platform.to_sym]


### PR DESCRIPTION
This PR resolves [PHIRE-3079] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes android sourcemaps paths after the react native upgrade

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix: android sourcemap upload with build type support after expo 55

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3079]: https://artsyproduct.atlassian.net/browse/PHIRE-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ