### PR TITLE
fix: ensure refresh functions are called in BidResult component

### DIFF
--- a/src/app/Components/Bidding/Screens/BidResult.tsx
+++ b/src/app/Components/Bidding/Screens/BidResult.tsx
@@ -7,9 +7,10 @@ import { Markdown } from "app/Components/Markdown"
 import { NavigationHeader } from "app/Components/NavigationHeader"
 import { BiddingNavigationStackParams } from "app/Navigation/AuthenticatedRoutes/BiddingNavigator"
 import { unsafe__getEnvironment } from "app/store/GlobalStore"
+// eslint-disable-next-line no-restricted-imports
 import { dismissModal, navigate } from "app/system/navigation/navigate"
 import { useBackHandler } from "app/utils/hooks/useBackHandler"
-import React from "react"
+import { useEffect } from "react"
 import { Image, ImageRequireSource } from "react-native"
 import { graphql, useFragment } from "react-relay"
 
@@ -41,6 +42,17 @@ export const BidResult: React.FC<BidResultProps> = ({
   const setSelectedBidIndex = BidFlowContextStore.useStoreActions(
     (actions) => actions.setSelectedBidIndex
   )
+
+  useEffect(() => {
+    if (refreshBidderInfo) {
+      refreshBidderInfo()
+    }
+
+    if (refreshSaleArtwork) {
+      refreshSaleArtwork()
+    }
+  }, [refreshBidderInfo, refreshSaleArtwork])
+
   const saleArtworkData = useFragment(bidResultFragment, saleArtwork)
   const { status, messageHeader, messageDescriptionMD } = bidderPositionResult
 


### PR DESCRIPTION
This PR resolves [PHIRE-3096] <!-- eg [PROJECT-XXXX] -->

### Description

Makes sure that after bidding we refresh the `SaleArtwork` and `BidderInfo` to have the fresh state always.

There was an issue reported (see ticket) that was due to stale data, see also before and after vids:

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/65d7993a-567f-4aea-8fa4-af0eba675774" width="400" />|<video src="https://github.com/user-attachments/assets/3562457e-25e5-4767-9397-718c9414abbb" width="400" />|


<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix issue stale data preventing users from rebidding with the same card

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3096]: https://artsyproduct.atlassian.net/browse/PHIRE-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ