### PR TITLE
fix: save button remains grayed out after correcting card details

### DIFF
--- a/src/app/Components/Bidding/Screens/CreditCardForm.tsx
+++ b/src/app/Components/Bidding/Screens/CreditCardForm.tsx
@@ -126,6 +126,7 @@ export const CreditCardForm: React.FC<CreditCardFormProps> = ({
       <KeyboardAwareForm
         bottomOffset={bottomOffset}
         contentContainerStyle={{ padding: space(2), paddingBottom: space(4) }}
+        keyboardShouldPersistTaps="handled"
       >
         <Flex>
           <>
@@ -170,11 +171,7 @@ export const CreditCardForm: React.FC<CreditCardFormProps> = ({
             defaultValue={values.addressLine2}
             error={showError("addressLine2")}
             optional
-            placeholder={[
-              "Add your apt, floor, suite, etc.",
-              "Add your apt, floor, etc.",
-              "Add your apt, etc.",
-            ]}
+            placeholder="Add your apt, floor, suite, etc."
             onChangeText={handleChange("addressLine2")}
             onBlur={handleBlur("addressLine2")}
             returnKeyType="next"

--- a/src/app/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
+++ b/src/app/Scenes/MyProfile/MyProfilePaymentNewCreditCard.tsx
@@ -223,11 +223,7 @@ export const MyProfilePaymentNewCreditCard: React.FC<{}> = ({}) => {
           ref={addressLine2Ref}
           title="Address line 2"
           optional
-          placeholder={[
-            "Add your apt, floor, suite, etc.",
-            "Add your apt, floor, etc.",
-            "Add your apt, etc.",
-          ]}
+          placeholder="Add your apt, floor, suite, etc."
           onChangeText={actions.fields.addressLine2.setValue}
           defaultValue={state.fields.addressLine2.value ?? ""}
           returnKeyType="next"


### PR DESCRIPTION
This PR resolves [PHIRE-3110] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes an issue that let the save button grayed out even when adding correct details.

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/2b7d5d1c-0933-4054-a4b9-b89cb800c2d6" width="400" />|<video src="https://github.com/user-attachments/assets/3e86b3bd-74b2-4727-a78b-6e3207221d55" width="400" />|

Also fixed a bonus bug - replaced the array style placeholder that was throwing errors:

<img width="250" alt="Screenshot_1780409773" src="https://github.com/user-attachments/assets/f07c0166-e012-41ad-8ff6-31a6d93d282a" />

after removing them error went away, also we never basically display any of the placeholder values but we display the title instead.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix save button remains grayed out after correcting card details

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3110]: https://artsyproduct.atlassian.net/browse/PHIRE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ