### PR TITLE
feat(prototype): Infinite Discovery save & completion animations

### DIFF
--- a/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
+++ b/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
@@ -1,7 +1,7 @@
 import { useColor } from "@artsy/palette-mobile"
 import { BOTTOM_TABS_HEIGHT } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { useEffect } from "react"
-import { Modal, PixelRatio, StyleSheet, useWindowDimensions, View } from "react-native"
+import { Image, Modal, PixelRatio, StyleSheet, useWindowDimensions, View } from "react-native"
 import Animated, {
   Easing,
   runOnJS,
@@ -67,9 +67,10 @@ const easeInOut = Easing.inOut(Easing.cubic)
 
 const PRE_DELAY_MS = 600
 
-export const InfiniteDiscoveryCompletionAnimation: React.FC<{ onComplete?: () => void }> = ({
-  onComplete,
-}) => {
+export const InfiniteDiscoveryCompletionAnimation: React.FC<{
+  artworkImageUrls?: string[]
+  onComplete?: () => void
+}> = ({ artworkImageUrls, onComplete }) => {
   const { width: W, height: H } = useWindowDimensions()
   const insets = useSafeAreaInsets()
   const color = useColor()
@@ -258,11 +259,21 @@ export const InfiniteDiscoveryCompletionAnimation: React.FC<{ onComplete?: () =>
   return (
     <Modal transparent statusBarTranslucent animationType="none" visible>
       <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
-        <Animated.View style={[styles.card, { backgroundColor: COLORS[4] }, s4]} />
-        <Animated.View style={[styles.card, { backgroundColor: COLORS[3] }, s3]} />
-        <Animated.View style={[styles.card, { backgroundColor: COLORS[2] }, s2]} />
-        <Animated.View style={[styles.card, { backgroundColor: COLORS[1] }, s1]} />
-        <Animated.View style={[styles.card, { backgroundColor: COLORS[0] }, s0]} />
+        {([4, 3, 2, 1, 0] as const).map((i, idx) => {
+          const animStyle = [s4, s3, s2, s1, s0][idx]
+          const imageUrl = artworkImageUrls?.[i]
+          return (
+            <Animated.View key={i} style={[styles.card, { backgroundColor: COLORS[i] }, animStyle]}>
+              {!!imageUrl && (
+                <Image
+                  source={{ uri: imageUrl }}
+                  style={StyleSheet.absoluteFillObject}
+                  resizeMode="cover"
+                />
+              )}
+            </Animated.View>
+          )
+        })}
 
         <Animated.View
           style={[
@@ -283,7 +294,15 @@ export const InfiniteDiscoveryCompletionAnimation: React.FC<{ onComplete?: () =>
             { left: favIconLeft, top: favIconTop, width: FAV_CARD_W, height: FAV_CARD_H },
             favStyle,
           ]}
-        />
+        >
+          {!!artworkImageUrls?.[0] && (
+            <Image
+              source={{ uri: artworkImageUrls[0] }}
+              style={StyleSheet.absoluteFillObject}
+              resizeMode="cover"
+            />
+          )}
+        </Animated.View>
       </View>
     </Modal>
   )
@@ -301,13 +320,15 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     borderWidth: 4,
     borderColor: "white",
+    overflow: "hidden",
   },
   favCard: {
     position: "absolute",
     borderRadius: 3,
     borderWidth: 3,
     borderColor: "white",
-    backgroundColor: "#0000FF",
+    backgroundColor: "#0000FF", // fallback when no image
+    overflow: "hidden",
     shadowColor: "#000",
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,

--- a/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
+++ b/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
@@ -1,0 +1,317 @@
+import { useColor } from "@artsy/palette-mobile"
+import { BOTTOM_TABS_HEIGHT } from "app/Navigation/AuthenticatedRoutes/Tabs"
+import { useEffect } from "react"
+import { Modal, PixelRatio, StyleSheet, useWindowDimensions, View } from "react-native"
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+const CARD_W = 72
+const CARD_H = 96
+
+// top → bottom: blue, yellow, red, green, orange
+const COLORS = ["#0000FF", "#FFFF00", "#FF0000", "#00FF00", "#FF8C00"] as const
+
+// Natural pile rotation angles — makes the stack look like a casually placed pile
+const PILE_ANGLES: ReadonlyArray<number> = [0, 5, -7, 8, -4]
+
+// Stack depth offsets — card 0 on top at origin; 1–4 cascade behind/below
+const STACK: ReadonlyArray<{ x: number; y: number }> = [
+  { x: 0, y: 0 },
+  { x: 2.5, y: 3 },
+  { x: 5, y: 6 },
+  { x: 7.5, y: 9 },
+  { x: 10, y: 12 },
+]
+
+// Fan spread — card 0 fans right, card 4 fans left
+const FAN_R = 160
+const FAN_ANGLES: ReadonlyArray<number> = [20, 10, 0, -10, -20]
+const toRad = (deg: number) => (deg * Math.PI) / 180
+const FAN_X = FAN_ANGLES.map((deg) => FAN_R * Math.sin(toRad(deg)))
+const FAN_Y = FAN_ANGLES.map((deg) => FAN_R * (1 - Math.cos(toRad(deg))))
+
+// Drift stagger — card 4 (leftmost) first, card 0 (rightmost/top) last
+const DRIFT_ORDER: ReadonlyArray<number> = [4, 3, 2, 1, 0]
+
+const fontScale = PixelRatio.getFontScale()
+const ICON_W = 53 * fontScale
+const ICON_H = 49 * fontScale
+const FAV_CARD_W = Math.round(23 * fontScale)
+const FAV_CARD_H = Math.round(FAV_CARD_W * (4 / 3))
+
+// Phase durations (ms)
+const T_APPEAR = 350
+const T_SPREAD = 700
+const T_HOLD = 700
+const T_STAGGER = 120
+const T_DRIFT = 450
+const T_SWAP = 150 // how fast all cards cut out / favCard cuts in when card 0 arrives
+const T_FAV_HOLD = 2000
+const T_FAV_VANISH = 400
+
+const D_SPREAD = T_APPEAR
+const D_DRIFT = D_SPREAD + T_SPREAD + T_HOLD
+// D_FAV = moment card 0 (last) arrives at the Favorites tab
+const D_FAV = D_DRIFT + 4 * T_STAGGER + T_DRIFT
+
+const easeOut = Easing.out(Easing.cubic)
+const easeInOut = Easing.inOut(Easing.cubic)
+
+const PRE_DELAY_MS = 600
+
+export const InfiniteDiscoveryCompletionAnimation: React.FC<{ onComplete?: () => void }> = ({
+  onComplete,
+}) => {
+  const { width: W, height: H } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+  const color = useColor()
+
+  const favX = W * 0.7 - W / 2
+  const favY = H / 2 - insets.bottom - BOTTOM_TABS_HEIGHT / 2
+  const targetScale = FAV_CARD_W / CARD_W
+
+  // --- Shared values (no hooks in loops) ---
+
+  const x0 = useSharedValue(STACK[0].x)
+  const x1 = useSharedValue(STACK[1].x)
+  const x2 = useSharedValue(STACK[2].x)
+  const x3 = useSharedValue(STACK[3].x)
+  const x4 = useSharedValue(STACK[4].x)
+
+  const y0 = useSharedValue(STACK[0].y)
+  const y1 = useSharedValue(STACK[1].y)
+  const y2 = useSharedValue(STACK[2].y)
+  const y3 = useSharedValue(STACK[3].y)
+  const y4 = useSharedValue(STACK[4].y)
+
+  // Rotation initialised to natural pile angles
+  const r0 = useSharedValue(PILE_ANGLES[0])
+  const r1 = useSharedValue(PILE_ANGLES[1])
+  const r2 = useSharedValue(PILE_ANGLES[2])
+  const r3 = useSharedValue(PILE_ANGLES[3])
+  const r4 = useSharedValue(PILE_ANGLES[4])
+
+  const sc0 = useSharedValue(1)
+  const sc1 = useSharedValue(1)
+  const sc2 = useSharedValue(1)
+  const sc3 = useSharedValue(1)
+  const sc4 = useSharedValue(1)
+
+  // Single shared opacity for all cards — they appear together and disappear together
+  // the instant card 0 (the "first"/top card) touches the Favorites icon.
+  const opacity = useSharedValue(0)
+  const favOpacity = useSharedValue(0)
+
+  useEffect(() => {
+    const done = () => onComplete?.()
+
+    const xs = [x0, x1, x2, x3, x4]
+    const ys = [y0, y1, y2, y3, y4]
+    const rs = [r0, r1, r2, r3, r4]
+    const scs = [sc0, sc1, sc2, sc3, sc4]
+
+    const timer = setTimeout(() => {
+      // All cards appear together, stay fully opaque through the entire animation,
+      // then cut out the instant card 0 arrives at the Favorites tab (D_FAV).
+      opacity.set(() =>
+        withSequence(
+          withTiming(1, { duration: T_APPEAR, easing: easeOut }),
+          withTiming(1, { duration: D_FAV - T_APPEAR }),
+          withTiming(0, { duration: T_SWAP })
+        )
+      )
+
+      xs.forEach((x, i) => {
+        const d = DRIFT_ORDER[i]
+        x.set(() =>
+          withDelay(
+            D_SPREAD,
+            withSequence(
+              withTiming(FAN_X[i], { duration: T_SPREAD, easing: easeOut }),
+              withTiming(FAN_X[i], { duration: T_HOLD + d * T_STAGGER }),
+              withTiming(favX, { duration: T_DRIFT, easing: easeInOut })
+            )
+          )
+        )
+      })
+
+      ys.forEach((y, i) => {
+        const d = DRIFT_ORDER[i]
+        y.set(() =>
+          withDelay(
+            D_SPREAD,
+            withSequence(
+              withTiming(FAN_Y[i], { duration: T_SPREAD, easing: easeOut }),
+              withTiming(FAN_Y[i], { duration: T_HOLD + d * T_STAGGER }),
+              withTiming(favY, { duration: T_DRIFT, easing: easeInOut })
+            )
+          )
+        )
+      })
+
+      rs.forEach((r, i) => {
+        const d = DRIFT_ORDER[i]
+        r.set(() =>
+          withDelay(
+            D_SPREAD,
+            withSequence(
+              withTiming(FAN_ANGLES[i], { duration: T_SPREAD, easing: easeOut }),
+              withTiming(FAN_ANGLES[i], { duration: T_HOLD + d * T_STAGGER }),
+              withTiming(0, { duration: T_DRIFT, easing: easeInOut })
+            )
+          )
+        )
+      })
+
+      scs.forEach((sc, i) => {
+        const d = DRIFT_ORDER[i]
+        sc.set(() =>
+          withSequence(
+            withTiming(1, { duration: T_APPEAR + T_SPREAD + T_HOLD + d * T_STAGGER }),
+            withTiming(targetScale, { duration: T_DRIFT, easing: easeInOut })
+          )
+        )
+      })
+
+      // FavCard and mask appear simultaneously with the card cut-out
+      favOpacity.set(() =>
+        withDelay(
+          D_FAV,
+          withSequence(
+            withTiming(1, { duration: T_SWAP }),
+            withTiming(1, { duration: T_FAV_HOLD }),
+            withTiming(0, { duration: T_FAV_VANISH }, () => {
+              runOnJS(done)()
+            })
+          )
+        )
+      )
+    }, PRE_DELAY_MS)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  // --- Animated styles ---
+  const s0 = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [
+      { translateX: x0.get() },
+      { translateY: y0.get() },
+      { rotate: r0.get() + "deg" },
+      { scale: sc0.get() },
+    ],
+  }))
+  const s1 = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [
+      { translateX: x1.get() },
+      { translateY: y1.get() },
+      { rotate: r1.get() + "deg" },
+      { scale: sc1.get() },
+    ],
+  }))
+  const s2 = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [
+      { translateX: x2.get() },
+      { translateY: y2.get() },
+      { rotate: r2.get() + "deg" },
+      { scale: sc2.get() },
+    ],
+  }))
+  const s3 = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [
+      { translateX: x3.get() },
+      { translateY: y3.get() },
+      { rotate: r3.get() + "deg" },
+      { scale: sc3.get() },
+    ],
+  }))
+  const s4 = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [
+      { translateX: x4.get() },
+      { translateY: y4.get() },
+      { rotate: r4.get() + "deg" },
+      { scale: sc4.get() },
+    ],
+  }))
+
+  const favStyle = useAnimatedStyle(() => ({ opacity: favOpacity.get() }))
+
+  const heartCenterX = W * 0.7 - ICON_W / 2 + 26 * fontScale
+  const heartCenterY = H - BOTTOM_TABS_HEIGHT - insets.bottom + 4 + 27 * fontScale
+  const favIconLeft = heartCenterX - FAV_CARD_W / 2
+  const favIconTop = heartCenterY - FAV_CARD_H / 2
+  const maskLeft = W * 0.7 - ICON_W / 2
+  const maskTop = H - BOTTOM_TABS_HEIGHT - insets.bottom + 4
+
+  return (
+    <Modal transparent statusBarTranslucent animationType="none" visible>
+      <View style={StyleSheet.absoluteFillObject} pointerEvents="none">
+        <Animated.View style={[styles.card, { backgroundColor: COLORS[4] }, s4]} />
+        <Animated.View style={[styles.card, { backgroundColor: COLORS[3] }, s3]} />
+        <Animated.View style={[styles.card, { backgroundColor: COLORS[2] }, s2]} />
+        <Animated.View style={[styles.card, { backgroundColor: COLORS[1] }, s1]} />
+        <Animated.View style={[styles.card, { backgroundColor: COLORS[0] }, s0]} />
+
+        <Animated.View
+          style={[
+            {
+              position: "absolute",
+              left: maskLeft,
+              top: maskTop,
+              width: ICON_W,
+              height: ICON_H,
+              backgroundColor: color("background"),
+            },
+            favStyle,
+          ]}
+        />
+        <Animated.View
+          style={[
+            styles.favCard,
+            { left: favIconLeft, top: favIconTop, width: FAV_CARD_W, height: FAV_CARD_H },
+            favStyle,
+          ]}
+        />
+      </View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    position: "absolute",
+    width: CARD_W,
+    height: CARD_H,
+    top: "50%",
+    left: "50%",
+    marginTop: -CARD_H / 2,
+    marginLeft: -CARD_W / 2,
+    borderRadius: 12,
+    borderWidth: 4,
+    borderColor: "white",
+  },
+  favCard: {
+    position: "absolute",
+    borderRadius: 3,
+    borderWidth: 3,
+    borderColor: "white",
+    backgroundColor: "#0000FF",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.2,
+    shadowRadius: 2,
+    elevation: 3,
+  },
+})

--- a/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
+++ b/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
@@ -13,8 +13,8 @@ import Animated, {
 } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
-const CARD_W = 72
-const CARD_H = 96
+const CARD_W = 56
+const CARD_H = 75
 
 // top → bottom: blue, yellow, red, green, orange
 const COLORS = ["#0000FF", "#FFFF00", "#FF0000", "#00FF00", "#FF8C00"] as const

--- a/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
+++ b/src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx
@@ -1,7 +1,7 @@
-import { useColor } from "@artsy/palette-mobile"
+import { Image, useColor } from "@artsy/palette-mobile"
 import { BOTTOM_TABS_HEIGHT } from "app/Navigation/AuthenticatedRoutes/Tabs"
 import { useEffect } from "react"
-import { Image, Modal, PixelRatio, StyleSheet, useWindowDimensions, View } from "react-native"
+import { Modal, PixelRatio, StyleSheet, useWindowDimensions, View } from "react-native"
 import Animated, {
   Easing,
   runOnJS,
@@ -68,7 +68,7 @@ const easeInOut = Easing.inOut(Easing.cubic)
 const PRE_DELAY_MS = 600
 
 export const InfiniteDiscoveryCompletionAnimation: React.FC<{
-  artworkImageUrls?: string[]
+  artworkImageUrls?: Array<{ url: string; blurhash?: string | null }>
   onComplete?: () => void
 }> = ({ artworkImageUrls, onComplete }) => {
   const { width: W, height: H } = useWindowDimensions()
@@ -266,9 +266,11 @@ export const InfiniteDiscoveryCompletionAnimation: React.FC<{
             <Animated.View key={i} style={[styles.card, { backgroundColor: COLORS[i] }, animStyle]}>
               {!!imageUrl && (
                 <Image
-                  source={{ uri: imageUrl }}
-                  style={StyleSheet.absoluteFillObject}
-                  resizeMode="cover"
+                  src={imageUrl.url}
+                  blurhash={imageUrl.blurhash ?? undefined}
+                  width={CARD_W}
+                  height={CARD_H}
+                  style={{ position: "absolute", top: 0, left: 0 }}
                 />
               )}
             </Animated.View>
@@ -297,9 +299,11 @@ export const InfiniteDiscoveryCompletionAnimation: React.FC<{
         >
           {!!artworkImageUrls?.[0] && (
             <Image
-              source={{ uri: artworkImageUrls[0] }}
-              style={StyleSheet.absoluteFillObject}
-              resizeMode="cover"
+              src={artworkImageUrls[0].url}
+              blurhash={artworkImageUrls[0].blurhash ?? undefined}
+              width={FAV_CARD_W}
+              height={FAV_CARD_H}
+              style={{ position: "absolute", top: 0, left: 0 }}
             />
           )}
         </Animated.View>

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -16,6 +16,7 @@ import { useEnableProgressiveOnboarding } from "app/Components/ProgressiveOnboar
 import { RetryErrorBoundary, useRetryErrorBoundaryContext } from "app/Components/RetryErrorBoundary"
 import { EmailConfirmationBannerFragmentContainer } from "app/Scenes/HomeView/Components/EmailConfirmationBanner"
 import { HomeHeader } from "app/Scenes/HomeView/Components/HomeHeader"
+import { InfiniteDiscoveryCompletionAnimation } from "app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation"
 import { HomeViewStore, HomeViewStoreProvider } from "app/Scenes/HomeView/HomeViewContext"
 import { Section } from "app/Scenes/HomeView/Sections/Section"
 import { useHomeViewExperimentTracking } from "app/Scenes/HomeView/hooks/useHomeViewExperimentTracking"
@@ -65,6 +66,7 @@ export const HomeView: React.FC = memo(() => {
   )
 
   const [isRefreshing, setIsRefreshing] = useState(false)
+  const [showCompletionAnimation, setShowCompletionAnimation] = useState(true)
 
   const onViewableItemsChanged = useRef(
     ({ viewableItems }: { viewableItems: ViewToken[]; changed: ViewToken[] }) => {
@@ -189,37 +191,44 @@ export const HomeView: React.FC = memo(() => {
   )
 
   return (
-    <Screen safeArea={true}>
-      <Screen.Body fullwidth>
-        <FlatList
-          automaticallyAdjustKeyboardInsets
-          keyboardDismissMode="on-drag"
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-          ref={flashlistRef as RefObject<FlatList>}
-          data={sections}
-          keyExtractor={(item) => item.internalID}
-          renderItem={renderItem}
-          onEndReached={() => loadNext(NUMBER_OF_SECTIONS_TO_LOAD)}
-          ListHeaderComponent={HomeHeader}
-          ListFooterComponent={() =>
-            hasNext ? (
-              <Flex width="100%" justifyContent="center" alignItems="center" height={200}>
-                <Spinner />
-              </Flex>
-            ) : null
-          }
-          refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
-          onEndReachedThreshold={2}
-          maxToRenderPerBatch={6}
-          stickyHeaderIndices={[0]}
-          windowSize={15}
-          viewabilityConfig={viewabilityConfig}
-          onViewableItemsChanged={onViewableItemsChanged}
+    <>
+      <Screen safeArea={true}>
+        <Screen.Body fullwidth>
+          <FlatList
+            automaticallyAdjustKeyboardInsets
+            keyboardDismissMode="on-drag"
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            ref={flashlistRef as RefObject<FlatList>}
+            data={sections}
+            keyExtractor={(item) => item.internalID}
+            renderItem={renderItem}
+            onEndReached={() => loadNext(NUMBER_OF_SECTIONS_TO_LOAD)}
+            ListHeaderComponent={HomeHeader}
+            ListFooterComponent={() =>
+              hasNext ? (
+                <Flex width="100%" justifyContent="center" alignItems="center" height={200}>
+                  <Spinner />
+                </Flex>
+              ) : null
+            }
+            refreshControl={<RefreshControl refreshing={isRefreshing} onRefresh={handleRefresh} />}
+            onEndReachedThreshold={2}
+            maxToRenderPerBatch={6}
+            stickyHeaderIndices={[0]}
+            windowSize={15}
+            viewabilityConfig={viewabilityConfig}
+            onViewableItemsChanged={onViewableItemsChanged}
+          />
+          {!!data?.me && <EmailConfirmationBannerFragmentContainer me={data.me} />}
+        </Screen.Body>
+      </Screen>
+      {!!showCompletionAnimation && (
+        <InfiniteDiscoveryCompletionAnimation
+          onComplete={() => setShowCompletionAnimation(false)}
         />
-        {!!data?.me && <EmailConfirmationBannerFragmentContainer me={data.me} />}
-      </Screen.Body>
-    </Screen>
+      )}
+    </>
   )
 })
 

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -66,7 +66,14 @@ export const HomeView: React.FC = memo(() => {
   )
 
   const [isRefreshing, setIsRefreshing] = useState(false)
-  const [showCompletionAnimation, setShowCompletionAnimation] = useState(true)
+  const [showCompletionAnimation, setShowCompletionAnimation] = useState(false)
+
+  const hasPendingCompletionAnimation = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.hasPendingCompletionAnimation
+  )
+  const savedArtworkImageUrls = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.savedArtworkImageUrls
+  )
 
   const onViewableItemsChanged = useRef(
     ({ viewableItems }: { viewableItems: ViewToken[]; changed: ViewToken[] }) => {
@@ -135,6 +142,15 @@ export const HomeView: React.FC = memo(() => {
     useCallback(() => {
       tracking.screen(OwnerType.home)
     }, [])
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      if (hasPendingCompletionAnimation) {
+        GlobalStore.actions.infiniteDiscovery.setHasPendingCompletionAnimation(false)
+        setShowCompletionAnimation(true)
+      }
+    }, [hasPendingCompletionAnimation])
   )
 
   const fetchSavedArtworksCount = async () => {
@@ -225,7 +241,11 @@ export const HomeView: React.FC = memo(() => {
       </Screen>
       {!!showCompletionAnimation && (
         <InfiniteDiscoveryCompletionAnimation
-          onComplete={() => setShowCompletionAnimation(false)}
+          artworkImageUrls={savedArtworkImageUrls}
+          onComplete={() => {
+            setShowCompletionAnimation(false)
+            GlobalStore.actions.infiniteDiscovery.resetSavedArtworkImageUrls()
+          }}
         />
       )}
     </>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -68,6 +68,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const { isSaved: isSavedToArtworkList, saveArtworkToLists } = useSaveArtworkToArtworkLists({
       artworkFragmentRef: artwork as NonNullable<InfiniteDiscoveryArtworkCard_artwork$data>,
+      // Suppresses the "saved to list" toast while the animation prototype is active
+      saveToDefaultCollectionOnly: true,
       onCompleted: (isArtworkSaved) => {
         if (!!artwork) {
           track.savedArtwork(isArtworkSaved, artwork.internalID, artwork.slug)
@@ -305,9 +307,9 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                 // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
                 incrementSavedArtworksCount()
                 setShowSaveAnimation(true)
-                const imageUrl = artwork.images[0]?.url
-                if (imageUrl) {
-                  addSavedArtworkImageUrl(imageUrl)
+                const firstImage = artwork.images[0]
+                if (firstImage?.url) {
+                  addSavedArtworkImageUrl({ url: firstImage.url, blurhash: firstImage.blurhash })
                 }
               }
 
@@ -343,7 +345,11 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
         {!!showSaveAnimation && (
           <InfiniteDiscoverySaveAnimation
-            imageUrl={artwork.images[0]?.url ?? undefined}
+            image={
+              artwork.images[0]?.url
+                ? { url: artwork.images[0].url, blurhash: artwork.images[0].blurhash }
+                : undefined
+            }
             onReachChevron={() => DeviceEventEmitter.emit("infiniteDiscovery:chevronTouch")}
             onComplete={() => setShowSaveAnimation(false)}
           />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -55,7 +55,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const track = useInfiniteDiscoveryTracking()
     const color = useColor()
-    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
+    const { incrementSavedArtworksCount, decrementSavedArtworksCount, addSavedArtworkImageUrl } =
       GlobalStore.actions.infiniteDiscovery
 
     const artwork = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
@@ -305,6 +305,10 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                 // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
                 incrementSavedArtworksCount()
                 setShowSaveAnimation(true)
+                const imageUrl = artwork.images[0]?.url
+                if (imageUrl) {
+                  addSavedArtworkImageUrl(imageUrl)
+                }
               }
 
               saveArtworkToLists()

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -9,6 +9,7 @@ import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { ArtworkSaveIconWrapper } from "app/Components/ArtworkGrids/ArtworkSaveIconWrapper"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { InfiniteDiscoveryArtworkCardPopover } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover"
+import { InfiniteDiscoverySaveAnimation } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation"
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { GlobalStore } from "app/store/GlobalStore"
@@ -85,6 +86,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const isSaved = isSavedProp !== undefined ? isSavedProp : isSavedToArtworkList
     const [showScreenTapToSave, setShowScreenTapToSave] = useState(false)
+    const [showSaveAnimation, setShowSaveAnimation] = useState(false)
 
     useEffect(() => {
       // Revert showScreenTapToSave if the artwork is not saved
@@ -296,6 +298,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
               } else {
                 // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
                 incrementSavedArtworksCount()
+                setShowSaveAnimation(true)
               }
 
               saveArtworkToLists()
@@ -327,6 +330,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             </InfiniteDiscoveryArtworkCardPopover>
           </Touchable>
         </Flex>
+
+        {!!showSaveAnimation && (
+          <InfiniteDiscoverySaveAnimation
+            imageUrl={artwork.images[0]?.url ?? undefined}
+            onComplete={() => setShowSaveAnimation(false)}
+          />
+        )}
       </Flex>
     )
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -15,7 +15,13 @@ import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks
 import { GlobalStore } from "app/store/GlobalStore"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { memo, useEffect, useRef, useState } from "react"
-import { FlatList, GestureResponderEvent, Text as RNText, ViewStyle } from "react-native"
+import {
+  DeviceEventEmitter,
+  FlatList,
+  GestureResponderEvent,
+  Text as RNText,
+  ViewStyle,
+} from "react-native"
 import Haptic from "react-native-haptic-feedback"
 import Animated, {
   Easing,
@@ -334,6 +340,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
         {!!showSaveAnimation && (
           <InfiniteDiscoverySaveAnimation
             imageUrl={artwork.images[0]?.url ?? undefined}
+            onReachChevron={() => DeviceEventEmitter.emit("infiniteDiscovery:chevronTouch")}
             onComplete={() => setShowSaveAnimation(false)}
           />
         )}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -54,6 +54,9 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
 
   const handleExitPressed = () => {
     track.tappedExit()
+    if (savedArtworksCount > 0) {
+      GlobalStore.actions.infiniteDiscovery.setHasPendingCompletionAnimation(true)
+    }
     goBack()
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
-import { DEFAULT_HIT_SLOP, Flex, Screen, Touchable } from "@artsy/palette-mobile"
+import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
@@ -7,6 +7,14 @@ import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSave
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import React from "react"
+import { DeviceEventEmitter, StyleSheet } from "react-native"
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated"
 import RNShare from "react-native-share"
 
 interface InfiniteDiscoveryHeaderProps {
@@ -18,6 +26,29 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
   const track = useInfiniteDiscoveryTracking()
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
+
+  const savedArtworksCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.savedArtworksCount
+  )
+  // Ref keeps the subscription closure from going stale without re-subscribing
+  const savedArtworksCountRef = React.useRef(savedArtworksCount)
+  savedArtworksCountRef.current = savedArtworksCount
+
+  const [badgeCount, setBadgeCount] = React.useState(0)
+  const badgeScale = useSharedValue(1)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  React.useEffect(() => {
+    const sub = DeviceEventEmitter.addListener("infiniteDiscovery:chevronTouch", () => {
+      setBadgeCount(savedArtworksCountRef.current)
+      badgeScale.set(() =>
+        withSequence(withTiming(1.4, { duration: 120 }), withTiming(1, { duration: 120 }))
+      )
+    })
+    return () => sub.remove()
+  }, [])
+
+  const badgeStyle = useAnimatedStyle(() => ({ transform: [{ scale: badgeScale.get() }] }))
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
 
@@ -75,7 +106,13 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
             hitSlop={DEFAULT_HIT_SLOP}
             haptic
           >
-            <ChevronDownIcon />
+            {badgeCount === 0 ? (
+              <ChevronDownIcon />
+            ) : (
+              <Animated.View style={[styles.badge, badgeStyle]}>
+                <Text style={styles.badgeText}>{badgeCount}</Text>
+              </Animated.View>
+            )}
           </Touchable>
         }
         hideRightElements={hideRightButton}
@@ -99,3 +136,22 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     </Flex>
   )
 }
+
+const styles = StyleSheet.create({
+  badge: {
+    minWidth: 20,
+    height: 20,
+    borderRadius: 10,
+    backgroundColor: "#1023D7", // brand blue from palette tokens
+    paddingHorizontal: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "flex-start",
+  },
+  badgeText: {
+    color: "white",
+    fontSize: 12,
+    fontWeight: "700",
+    lineHeight: 14,
+  },
+})

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-
 import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
-import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast"
+// import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast" — suppressed while animation prototype is active
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -22,7 +22,7 @@ interface InfiniteDiscoveryHeaderProps {
 }
 
 export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = ({ topArtwork }) => {
-  useSavesSummaryToast()
+  // useSavesSummaryToast() — suppressed while animation prototype is active
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
   const track = useInfiniteDiscoveryTracking()
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
@@ -1,0 +1,131 @@
+import { useEffect } from "react"
+import { Image, Modal, StyleSheet, useWindowDimensions } from "react-native"
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+const CARD_W = 56
+const CARD_H = 75
+
+// Screen.Header height (44px palette-mobile standard) + Flex mb={1} (4px) beneath it
+const HEADER_HEIGHT = 44
+const HEADER_MARGIN_BOTTOM = 4
+// ChevronDownIcon: left padding 16px + half of ~18px default icon size
+const CHEVRON_CENTER_X = 25
+// Artist section inside the artwork card: p={2} + ArtistListItemContainer ≈ 60px
+const ARTIST_SECTION_HEIGHT = 60
+
+// Phase durations (ms)
+const T_FADE_IN = 200
+const T_DRIFT = 550
+const T_FADE_OUT = 200
+
+const easeInOut = Easing.inOut(Easing.cubic)
+
+interface InfiniteDiscoverySaveAnimationProps {
+  imageUrl?: string
+  onComplete?: () => void
+}
+
+export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnimationProps> = ({
+  imageUrl,
+  onComplete,
+}) => {
+  const { width: W, height: H } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
+
+  // --- Position calculations (all relative to screen center) ---
+
+  // ChevronDown icon: top-left corner of Screen.Header, which starts at insets.top
+  // because Screen.Body has marginTop: insets.top.
+  const chevronCenterY = insets.top + HEADER_HEIGHT / 2
+  const endX = CHEVRON_CENTER_X - W / 2
+  const endY = chevronCenterY - H / 2
+
+  // Artwork image center: below header + margin, below artist section, halfway into image area
+  const imageAreaHeight = H * 0.55
+  const artworkImageCenterY =
+    insets.top + HEADER_HEIGHT + HEADER_MARGIN_BOTTOM + ARTIST_SECTION_HEIGHT + imageAreaHeight / 2
+  const startX = 0
+  const startY = artworkImageCenterY - H / 2
+
+  // --- Shared values ---
+  const translateX = useSharedValue(startX)
+  const translateY = useSharedValue(startY)
+  const opacity = useSharedValue(0)
+
+  useEffect(() => {
+    const done = () => onComplete?.()
+
+    opacity.set(() =>
+      withSequence(
+        withTiming(1, { duration: T_FADE_IN }),
+        withTiming(1, { duration: T_DRIFT }),
+        withTiming(0, { duration: T_FADE_OUT }, () => runOnJS(done)())
+      )
+    )
+
+    translateX.set(() =>
+      withSequence(
+        withTiming(startX, { duration: T_FADE_IN }),
+        withTiming(endX, { duration: T_DRIFT, easing: easeInOut }),
+        withTiming(endX, { duration: T_FADE_OUT })
+      )
+    )
+
+    translateY.set(() =>
+      withSequence(
+        withTiming(startY, { duration: T_FADE_IN }),
+        withTiming(endY, { duration: T_DRIFT, easing: easeInOut }),
+        withTiming(endY, { duration: T_FADE_OUT })
+      )
+    )
+  }, [])
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.get(),
+    transform: [{ translateX: translateX.get() }, { translateY: translateY.get() }],
+  }))
+
+  return (
+    <Modal transparent statusBarTranslucent animationType="none" visible>
+      <Animated.View style={[styles.card, style]} pointerEvents="none">
+        {!!imageUrl && (
+          <Image
+            source={{ uri: imageUrl }}
+            style={StyleSheet.absoluteFillObject}
+            resizeMode="cover"
+          />
+        )}
+      </Animated.View>
+    </Modal>
+  )
+}
+
+const styles = StyleSheet.create({
+  card: {
+    position: "absolute",
+    width: CARD_W,
+    height: CARD_H,
+    top: "50%",
+    left: "50%",
+    marginTop: -CARD_H / 2,
+    marginLeft: -CARD_W / 2,
+    borderRadius: 12,
+    borderWidth: 4,
+    borderColor: "white",
+    backgroundColor: "#C8A882", // shown while image loads, or as fallback
+    overflow: "hidden", // clips the artwork image to the card's rounded corners
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+})

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
@@ -30,11 +30,13 @@ const easeInOut = Easing.inOut(Easing.cubic)
 
 interface InfiniteDiscoverySaveAnimationProps {
   imageUrl?: string
+  onReachChevron?: () => void
   onComplete?: () => void
 }
 
 export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnimationProps> = ({
   imageUrl,
+  onReachChevron,
   onComplete,
 }) => {
   const { width: W, height: H } = useWindowDimensions()
@@ -62,6 +64,7 @@ export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnima
 
   useEffect(() => {
     const done = () => onComplete?.()
+    const touchChevron = () => onReachChevron?.()
 
     opacity.set(() =>
       withSequence(
@@ -82,7 +85,9 @@ export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnima
     translateY.set(() =>
       withSequence(
         withTiming(startY, { duration: T_FADE_IN }),
-        withTiming(endY, { duration: T_DRIFT, easing: easeInOut }),
+        withTiming(endY, { duration: T_DRIFT, easing: easeInOut }, () => {
+          runOnJS(touchChevron)()
+        }),
         withTiming(endY, { duration: T_FADE_OUT })
       )
     )

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx
@@ -1,5 +1,6 @@
+import { Image } from "@artsy/palette-mobile"
 import { useEffect } from "react"
-import { Image, Modal, StyleSheet, useWindowDimensions } from "react-native"
+import { Modal, StyleSheet, useWindowDimensions } from "react-native"
 import Animated, {
   Easing,
   runOnJS,
@@ -29,13 +30,13 @@ const T_FADE_OUT = 200
 const easeInOut = Easing.inOut(Easing.cubic)
 
 interface InfiniteDiscoverySaveAnimationProps {
-  imageUrl?: string
+  image?: { url: string; blurhash?: string | null }
   onReachChevron?: () => void
   onComplete?: () => void
 }
 
 export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnimationProps> = ({
-  imageUrl,
+  image,
   onReachChevron,
   onComplete,
 }) => {
@@ -101,11 +102,13 @@ export const InfiniteDiscoverySaveAnimation: React.FC<InfiniteDiscoverySaveAnima
   return (
     <Modal transparent statusBarTranslucent animationType="none" visible>
       <Animated.View style={[styles.card, style]} pointerEvents="none">
-        {!!imageUrl && (
+        {!!image && (
           <Image
-            source={{ uri: imageUrl }}
-            style={StyleSheet.absoluteFillObject}
-            resizeMode="cover"
+            src={image.url}
+            blurhash={image.blurhash ?? undefined}
+            width={CARD_W}
+            height={CARD_H}
+            style={{ position: "absolute", top: 0, left: 0 }}
           />
         )}
       </Animated.View>

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -4,8 +4,8 @@ export interface InfiniteDiscoveryModel {
   hasSavedArtworks: boolean
   hasInteractedWithOnboarding: boolean
   savedArtworksCount: number
-  // Image URLs of the last 5 saved artworks (most recent first) — used by the home screen animation
-  savedArtworkImageUrls: string[]
+  // Last 5 saved artworks (most recent first) — url + blurhash for the home screen animation
+  savedArtworkImageUrls: Array<{ url: string; blurhash?: string | null }>
   // Set to true when the user exits Infinite Discovery with saves — triggers home screen animation
   hasPendingCompletionAnimation: boolean
   sessionState: {
@@ -17,7 +17,7 @@ export interface InfiniteDiscoveryModel {
   setHasInteractedWithOnboarding: Action<this, boolean>
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
-  addSavedArtworkImageUrl: Action<this, string>
+  addSavedArtworkImageUrl: Action<this, { url: string; blurhash?: string | null }>
   resetSavedArtworkImageUrls: Action<this>
   setHasPendingCompletionAnimation: Action<this, boolean>
 }

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -4,6 +4,10 @@ export interface InfiniteDiscoveryModel {
   hasSavedArtworks: boolean
   hasInteractedWithOnboarding: boolean
   savedArtworksCount: number
+  // Image URLs of the last 5 saved artworks (most recent first) — used by the home screen animation
+  savedArtworkImageUrls: string[]
+  // Set to true when the user exits Infinite Discovery with saves — triggers home screen animation
+  hasPendingCompletionAnimation: boolean
   sessionState: {
     moreInfoSheetVisible: boolean
   }
@@ -13,12 +17,17 @@ export interface InfiniteDiscoveryModel {
   setHasInteractedWithOnboarding: Action<this, boolean>
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
+  addSavedArtworkImageUrl: Action<this, string>
+  resetSavedArtworkImageUrls: Action<this>
+  setHasPendingCompletionAnimation: Action<this, boolean>
 }
 
 export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   hasSavedArtworks: false,
   hasInteractedWithOnboarding: false,
   savedArtworksCount: 0,
+  savedArtworkImageUrls: [],
+  hasPendingCompletionAnimation: false,
   sessionState: {
     moreInfoSheetVisible: false,
   },
@@ -39,5 +48,14 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   setMoreInfoSheetVisible: action((state, payload) => {
     state.sessionState.moreInfoSheetVisible = payload
+  }),
+  addSavedArtworkImageUrl: action((state, url) => {
+    state.savedArtworkImageUrls = [url, ...state.savedArtworkImageUrls].slice(0, 5)
+  }),
+  resetSavedArtworkImageUrls: action((state) => {
+    state.savedArtworkImageUrls = []
+  }),
+  setHasPendingCompletionAnimation: action((state, payload) => {
+    state.hasPendingCompletionAnimation = payload
   }),
 })


### PR DESCRIPTION
## What this is

A prototype of two new animations that connect the Infinite Discovery feature to the home screen. This is not production-ready code — it is a working demo intended to validate the interaction concept and get design feedback before a full implementation.

---

## The two animations

### 1. Save animation (inside Infinite Discovery)

When a user taps **Save** on an artwork card, a miniature version of that artwork — framed like a small card with a white border — fades in at the center of the card. It then floats up toward the **close chevron** in the top-left corner of the header. When it arrives, the chevron is replaced by an Artsy-blue notification badge showing the total number of artworks saved so far in the session. Each subsequent save causes the badge to pulse and the count to increment.

The intent is to give the user a continuous sense that their saved artworks are accumulating somewhere, and to prime them for what they are about to see when they close the feature.

### 2. Completion animation (on the home screen)

When the user closes Infinite Discovery (by tapping the chevron) having saved at least one artwork, they are returned to the home screen and the completion animation plays. The last five saved artworks appear as a stacked, slightly tilted pile of cards at the center of the screen. The pile fans out into an arc — top card to the right — then each card peels off one by one from the left, drifting down toward the **Favorites tab** in the bottom navigation bar, shrinking as it goes. When the final (top) card arrives, the entire stack vanishes and a small card icon appears in place of the Favorites heart, briefly showing the top saved artwork.

The intent is to celebrate the session and visually direct the user to where their saved artworks can be found.

---

## File guide for reviewers

### New files
| File | What it does |
|---|---|
| `src/app/Scenes/HomeView/Components/InfiniteDiscoveryCompletionAnimation.tsx` | The home screen celebration animation. Self-contained; renders via a `Modal` so it floats above the tab bar. All animation logic lives here. |
| `src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoverySaveAnimation.tsx` | The per-save flying card animation inside Infinite Discovery. Also Modal-based. Accepts the artwork image + blurhash and an `onReachChevron` callback. |

### Modified files
| File | Change |
|---|---|
| `src/app/store/InfiniteDiscoveryModel.ts` | Adds `savedArtworkImageUrls` (last 5 saved artwork images), `hasPendingCompletionAnimation` (flag set on exit), and their actions. |
| `src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx` | On save: stores the artwork image URL + blurhash, triggers the save animation, and emits a `DeviceEventEmitter` event when the animation card reaches the chevron. |
| `src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx` | Reads `savedArtworksCount` via a `DeviceEventEmitter` listener; replaces the `ChevronDownIcon` with an animated Artsy-blue badge on first save arrival. Sets `hasPendingCompletionAnimation` on exit. |
| `src/app/Scenes/HomeView/HomeView.tsx` | Uses `useFocusEffect` to detect the pending animation flag when the home screen regains focus after Infinite Discovery closes. |

---

## Production considerations

**Trigger and state management**
- `hasPendingCompletionAnimation` and `savedArtworkImageUrls` are currently stored in `GlobalStore`, which persists to AsyncStorage. They should either be moved to `sessionState` (cleared on app restart) or explicitly cleared on app launch.
- The animation currently re-plays every time `useFocusEffect` fires while the flag is set. In production, add a guard so it only plays once per InfiniteDiscovery session.

**Image loading**
- Artwork images are stored as URLs from the `large` version. Consider storing a smaller version (e.g. `square`) since the cards are at most 56×75pt.
- The blurhash placeholder works well but the `palette-mobile` `Image` component requires explicit `width`/`height` props — `absoluteFillObject` alone is not sufficient. This should be documented or fixed upstream.

**Touch passthrough**
- Both animations use a `Modal` to render above the tab bar. On iOS this creates a new `UIWindow` that blocks touches for the duration (~7s for the completion animation). If touch-through is required, the overlays should instead be rendered as siblings to `AppTabs` inside `AuthenticatedRoutes` (see `src/app/Navigation/AuthenticatedRoutes/Tabs.tsx`), which would place them above the tab bar in the React tree without a native window.

**Tab bar position**
- The Favorites tab X position is estimated as `screenWidth × 0.7` (4th of 5 equal tabs). This holds for the current tab configuration but would break if the tab order or count changes. Consider measuring the actual tab element with a `ref` + `measure()` and sharing the position via context or store.

**Badge counter**
- The chevron badge uses `DeviceEventEmitter` to communicate between the save animation (inside a card) and the header. This is deliberately lightweight for the prototype. In production, this should be replaced with a proper state update — likely reading `savedArtworksCount` directly from `GlobalStore` and updating the badge whenever the animation card arrives (the event timing is correct; the bus mechanism should be more robust).
- The badge itself (`InfiniteDiscoveryHeader.tsx`) holds local `useState` for `badgeCount`. This resets if the header re-mounts. In production, the count should live in the store.

**Performance**
- Each animation declares 15–20 Reanimated shared values. These are cheap individually but worth auditing if the screen ever renders multiple animated overlays simultaneously.
- The `Modal` approach triggers a native-layer render; the completion animation in particular holds the modal open for ~7 seconds. Profile on lower-end Android devices.

**Suppressed toasts**
- Two toasts are temporarily disabled: the per-save "added to list" toast (`saveToDefaultCollectionOnly: true` in `InfiniteDiscoveryArtworkCard`) and the exit summary toast (`useSavesSummaryToast` commented out in `InfiniteDiscoveryHeader`). Both are marked with comments and should be restored — or replaced with the new animation — before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)