### PR TITLE
fix: refactor fair followed artists screen to fix filters being lost

### DIFF
--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -210,6 +210,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
     (state) => state.setFiltersCountAction
   )
   const counts = ArtworksFiltersStore.useStoreState((state) => state.counts)
+  const appliedFilters = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
 
   const artworks = data.fairArtworks
   const artworksTotal = artworks?.counts?.total ?? 0
@@ -229,7 +230,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
   })
 
   useEffect(() => {
-    if (initiallyAppliedFilter) {
+    if (initiallyAppliedFilter && appliedFilters.length === 0) {
       setInitialFilterStateAction(initiallyAppliedFilter)
     }
   }, [])

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -280,7 +280,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={{ paddingHorizontal: space(1) }}
         ListEmptyComponent={
-          <Flex mb={6}>
+          <Flex mb={6} mt={4}>
             <FilteredArtworkGridZeroState
               id={data.internalID}
               slug={data.slug}

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -259,15 +259,14 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
     tracking.trackEvent(tracks.trackClear(id, slug))
   }
 
-  const handleFilterToggle = () => {
-    setFilterArtworkModalVisible((prev) => {
-      if (!prev) {
-        tracking.trackEvent(tracks.openArtworksFilter(fair))
-      } else {
-        tracking.trackEvent(tracks.closeArtworksFilter(fair))
-      }
-      return !prev
-    })
+  const handleFilterOpen = () => {
+    setFilterArtworkModalVisible(true)
+    tracking.trackEvent(tracks.openArtworksFilter(fair))
+  }
+
+  const handleFilterClose = () => {
+    setFilterArtworkModalVisible(false)
+    tracking.trackEvent(tracks.closeArtworksFilter(fair))
   }
 
   const filteredArtworks = extractNodes(data.fairArtworks)
@@ -289,7 +288,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
             />
           </Flex>
         }
-        ListHeaderComponent={<HeaderArtworksFilterWithTotalArtworks onPress={handleFilterToggle} />}
+        ListHeaderComponent={<HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />}
         ListFooterComponent={() =>
           !!isLoadingNext ? (
             <Flex my={4} flexDirection="row" justifyContent="center">
@@ -321,8 +320,8 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
         id={data.internalID}
         slug={data.slug}
         mode={FilterModalMode.Fair}
-        exitModal={handleFilterToggle}
-        closeModal={handleFilterToggle}
+        exitModal={handleFilterClose}
+        closeModal={handleFilterClose}
       />
     </>
   )

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -9,6 +9,7 @@ import {
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
+import { SimpleErrorMessage } from "app/Components/ErrorView/SimpleErrorMessage"
 import { withSuspense } from "app/utils/hooks/withSuspense"
 import { PlaceholderText } from "app/utils/placeholders"
 import React from "react"
@@ -106,7 +107,7 @@ const FairAllFollowedArtistsContent = withSuspense({
     return <FairAllFollowedArtists fair={data.fair} fairForFilters={data.fairForFilters} />
   },
   LoadingFallback: () => <FairAllFollowedArtistsPlaceholder />,
-  ErrorFallback: () => null,
+  ErrorFallback: () => <SimpleErrorMessage />,
 })
 
 export const FairAllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> = ({ fairID }) => {

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -1,12 +1,7 @@
 import { Box, Flex, Separator, Spacer } from "@artsy/palette-mobile"
 import { FairAllFollowedArtistsQuery } from "__generated__/FairAllFollowedArtistsQuery.graphql"
-import { FairAllFollowedArtists_fair$data } from "__generated__/FairAllFollowedArtists_fair.graphql"
-import { FairAllFollowedArtists_fairForFilters$data } from "__generated__/FairAllFollowedArtists_fairForFilters.graphql"
-import {
-  AnimatedArtworkFilterButton,
-  ArtworkFilterNavigator,
-  FilterModalMode,
-} from "app/Components/ArtworkFilter"
+import { FairAllFollowedArtists_fair$key } from "__generated__/FairAllFollowedArtists_fair.graphql"
+import { FairAllFollowedArtists_fairForFilters$key } from "__generated__/FairAllFollowedArtists_fairForFilters.graphql"
 import {
   Aggregations,
   FilterArray,
@@ -14,27 +9,55 @@ import {
 } from "app/Components/ArtworkFilter/ArtworkFilterHelpers"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
-import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { withSuspense } from "app/utils/hooks/withSuspense"
 import { PlaceholderText } from "app/utils/placeholders"
-import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
-import React, { useState } from "react"
+import React from "react"
 import { ScrollView } from "react-native"
-import { createFragmentContainer, graphql, QueryRenderer } from "react-relay"
+import { graphql, useLazyLoadQuery, useFragment } from "react-relay"
 import { FairArtworksWithoutTabs } from "./Components/FairArtworks"
 
+const fairFragment = graphql`
+  fragment FairAllFollowedArtists_fair on Fair {
+    internalID
+    slug
+    ...FairArtworks_fair
+      @arguments(input: { includeArtworksByFollowedArtists: true, sort: "-decayed_merch" })
+  }
+`
+
+const fairForFiltersFragment = graphql`
+  fragment FairAllFollowedArtists_fairForFilters on Fair {
+    filterArtworksConnection(
+      first: 0
+      aggregations: [PARTNER, MAJOR_PERIOD, MEDIUM, FOLLOWED_ARTISTS, ARTIST]
+    ) {
+      aggregations {
+        slice
+        counts {
+          count
+          name
+          value
+        }
+      }
+
+      counts {
+        followedArtists
+      }
+    }
+  }
+`
+
 interface FairAllFollowedArtistsProps {
-  fair: FairAllFollowedArtists_fair$data
-  fairForFilters: FairAllFollowedArtists_fairForFilters$data
+  fair: FairAllFollowedArtists_fair$key
+  fairForFilters: FairAllFollowedArtists_fairForFilters$key
 }
 
 export const FairAllFollowedArtists: React.FC<FairAllFollowedArtistsProps> = ({
-  fair,
-  fairForFilters,
+  fair: fairProp,
+  fairForFilters: fairForFiltersProp,
 }) => {
-  const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
-  const handleFilterArtworksModal = () => {
-    setFilterArtworkModalVisible(!isFilterArtworksModalVisible)
-  }
+  const fair = useFragment(fairFragment, fairProp)
+  const fairForFilters = useFragment(fairForFiltersFragment, fairForFiltersProp)
 
   const initialFilter: FilterArray = [
     {
@@ -45,72 +68,18 @@ export const FairAllFollowedArtists: React.FC<FairAllFollowedArtistsProps> = ({
   ]
 
   return (
-    <ArtworkFiltersStoreProvider>
-      <ScrollView>
-        <Box px="15px">
-          <FairArtworksWithoutTabs
-            fair={fair}
-            initiallyAppliedFilter={initialFilter}
-            aggregations={fairForFilters.filterArtworksConnection?.aggregations as Aggregations}
-            followedArtistCount={fairForFilters.filterArtworksConnection?.counts?.followedArtists}
-          />
-          <ArtworkFilterNavigator
-            visible={isFilterArtworksModalVisible}
-            id={fair.internalID}
-            slug={fair.slug}
-            mode={FilterModalMode.Fair}
-            exitModal={handleFilterArtworksModal}
-            closeModal={handleFilterArtworksModal}
-          />
-        </Box>
-      </ScrollView>
-      <AnimatedArtworkFilterButton isVisible onPress={handleFilterArtworksModal} />
-    </ArtworkFiltersStoreProvider>
+    <ScrollView>
+      <Box px="15px">
+        <FairArtworksWithoutTabs
+          fair={fair}
+          initiallyAppliedFilter={initialFilter}
+          aggregations={fairForFilters.filterArtworksConnection?.aggregations as Aggregations}
+          followedArtistCount={fairForFilters.filterArtworksConnection?.counts?.followedArtists}
+        />
+      </Box>
+    </ScrollView>
   )
 }
-
-export const FairAllFollowedArtistsFragmentContainer = createFragmentContainer(
-  FairAllFollowedArtists,
-  {
-    fair: graphql`
-      fragment FairAllFollowedArtists_fair on Fair {
-        internalID
-        slug
-        ...FairArtworks_fair
-          @arguments(input: { includeArtworksByFollowedArtists: true, sort: "-decayed_merch" })
-      }
-    `,
-    /**
-     * Filter aggregations are normally dynamic according to applied filters.
-     * Because of the `includeArtworksByFollowedArtists` argument used above, the artwork grid is intially scoped to only
-     * include works by followed artists.
-     * The filter options become incomplete if that option is later disabled in the filter menu.
-     * To compensate, we are querying for the complete set below without the `includeArtworksByFollowedArtists`
-     * argument so that the complete set of filters is available.
-     */
-    fairForFilters: graphql`
-      fragment FairAllFollowedArtists_fairForFilters on Fair {
-        filterArtworksConnection(
-          first: 0
-          aggregations: [PARTNER, MAJOR_PERIOD, MEDIUM, FOLLOWED_ARTISTS, ARTIST]
-        ) {
-          aggregations {
-            slice
-            counts {
-              count
-              name
-              value
-            }
-          }
-
-          counts {
-            followedArtists
-          }
-        }
-      }
-    `,
-  }
-)
 
 export const FairAllFollowedArtistsScreenQuery = graphql`
   query FairAllFollowedArtistsQuery($fairID: String!) {
@@ -124,17 +93,27 @@ export const FairAllFollowedArtistsScreenQuery = graphql`
   }
 `
 
+const FairAllFollowedArtistsContent = withSuspense({
+  Component: ({ fairID }: { fairID: string }) => {
+    const data = useLazyLoadQuery<FairAllFollowedArtistsQuery>(FairAllFollowedArtistsScreenQuery, {
+      fairID,
+    })
+
+    if (!data.fair || !data.fairForFilters) {
+      return null
+    }
+
+    return <FairAllFollowedArtists fair={data.fair} fairForFilters={data.fairForFilters} />
+  },
+  LoadingFallback: () => <FairAllFollowedArtistsPlaceholder />,
+  ErrorFallback: () => null,
+})
+
 export const FairAllFollowedArtistsQueryRenderer: React.FC<{ fairID: string }> = ({ fairID }) => {
   return (
-    <QueryRenderer<FairAllFollowedArtistsQuery>
-      environment={getRelayEnvironment()}
-      query={FairAllFollowedArtistsScreenQuery}
-      variables={{ fairID }}
-      render={renderWithPlaceholder({
-        Container: FairAllFollowedArtistsFragmentContainer,
-        renderPlaceholder: () => <FairAllFollowedArtistsPlaceholder />,
-      })}
-    />
+    <ArtworkFiltersStoreProvider>
+      <FairAllFollowedArtistsContent fairID={fairID} />
+    </ArtworkFiltersStoreProvider>
   )
 }
 
@@ -143,7 +122,6 @@ export const FairAllFollowedArtistsPlaceholder: React.FC = () => (
     <Spacer y={2} />
     <PlaceholderText width={220} />
     <Separator my={2} />
-    {/* masonry grid */}
     <PlaceholderGrid />
   </Flex>
 )

--- a/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
+++ b/src/app/Scenes/Fair/FairAllFollowedArtists.tsx
@@ -17,37 +17,6 @@ import { ScrollView } from "react-native"
 import { graphql, useLazyLoadQuery, useFragment } from "react-relay"
 import { FairArtworksWithoutTabs } from "./Components/FairArtworks"
 
-const fairFragment = graphql`
-  fragment FairAllFollowedArtists_fair on Fair {
-    internalID
-    slug
-    ...FairArtworks_fair
-      @arguments(input: { includeArtworksByFollowedArtists: true, sort: "-decayed_merch" })
-  }
-`
-
-const fairForFiltersFragment = graphql`
-  fragment FairAllFollowedArtists_fairForFilters on Fair {
-    filterArtworksConnection(
-      first: 0
-      aggregations: [PARTNER, MAJOR_PERIOD, MEDIUM, FOLLOWED_ARTISTS, ARTIST]
-    ) {
-      aggregations {
-        slice
-        counts {
-          count
-          name
-          value
-        }
-      }
-
-      counts {
-        followedArtists
-      }
-    }
-  }
-`
-
 interface FairAllFollowedArtistsProps {
   fair: FairAllFollowedArtists_fair$key
   fairForFilters: FairAllFollowedArtists_fairForFilters$key
@@ -126,3 +95,34 @@ export const FairAllFollowedArtistsPlaceholder: React.FC = () => (
     <PlaceholderGrid />
   </Flex>
 )
+
+const fairFragment = graphql`
+  fragment FairAllFollowedArtists_fair on Fair {
+    internalID
+    slug
+    ...FairArtworks_fair
+      @arguments(input: { includeArtworksByFollowedArtists: true, sort: "-decayed_merch" })
+  }
+`
+
+const fairForFiltersFragment = graphql`
+  fragment FairAllFollowedArtists_fairForFilters on Fair {
+    filterArtworksConnection(
+      first: 0
+      aggregations: [PARTNER, MAJOR_PERIOD, MEDIUM, FOLLOWED_ARTISTS, ARTIST]
+    ) {
+      aggregations {
+        slice
+        counts {
+          count
+          name
+          value
+        }
+      }
+
+      counts {
+        followedArtists
+      }
+    }
+  }
+`

--- a/src/app/Scenes/Fair/__tests__/FairAllFollowedArtists.tests.tsx
+++ b/src/app/Scenes/Fair/__tests__/FairAllFollowedArtists.tests.tsx
@@ -1,6 +1,7 @@
 import { screen } from "@testing-library/react-native"
 import { FairAllFollowedArtistsTestsQuery } from "__generated__/FairAllFollowedArtistsTestsQuery.graphql"
-import { FairAllFollowedArtistsFragmentContainer } from "app/Scenes/Fair/FairAllFollowedArtists"
+import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { FairAllFollowedArtists } from "app/Scenes/Fair/FairAllFollowedArtists"
 import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { graphql } from "react-relay"
@@ -8,10 +9,9 @@ import { graphql } from "react-relay"
 describe("FairAllFollowedArtists", () => {
   const { renderWithRelay } = setupTestWrapper<FairAllFollowedArtistsTestsQuery>({
     Component: (props) => (
-      <FairAllFollowedArtistsFragmentContainer
-        fair={props.fair}
-        fairForFilters={props.fairForFilters}
-      />
+      <ArtworkFiltersStoreProvider>
+        <FairAllFollowedArtists fair={props.fair} fairForFilters={props.fairForFilters} />
+      </ArtworkFiltersStoreProvider>
     ),
     query: graphql`
       query FairAllFollowedArtistsTestsQuery {


### PR DESCRIPTION
This PR resolves [PBRW-1838] <!-- eg [PROJECT-XXXX] -->

### Description

This screen fires 2 queries in order to support showing initial filter "Artists You Follow" while also showing all aggregations/filters that would be present without that filter. The parent queryRenderer was also triggering a rerender when the refetchQuery when filters were applied was fired and this was causing the component to remount and lose filter state. 

This refactors to useLazyLoadQuery and withSuspense which won't trigger rerenders this way. 

(sorry my android emulator is not cooperating currently for screenshots) 

| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="https://github.com/user-attachments/assets/5e4ac283-303c-4ff2-b0b4-d89a02a61412" width="400" /> | <video src="https://github.com/user-attachments/assets/1c976693-6140-4d91-8155-1f4a13d767b3" width="400" /> |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix filters being reset in fair followed artists screen - brian

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1838]: https://artsyproduct.atlassian.net/browse/PBRW-1838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ