### PR TITLE
fix(DI-337): show validation errors for email and password login

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginPasswordStep.tsx
@@ -9,7 +9,6 @@ import {
   Touchable,
   useTheme,
 } from "@artsy/palette-mobile"
-import { useToast } from "app/Components/Toast/toastHook"
 import {
   useAuthNavigation,
   useAuthScreen,
@@ -28,7 +27,6 @@ export interface LoginPasswordStepFormValues {
 export const LoginPasswordStep: React.FC = () => {
   const screen = useAuthScreen()
   const navigation = useAuthNavigation()
-  const toast = useToast()
 
   return (
     <Formik<LoginPasswordStepFormValues>
@@ -66,13 +64,7 @@ export const LoginPasswordStep: React.FC = () => {
 
         switch (true) {
           case res === "failure": {
-            toast.show(
-              "Something went wrong. Please try again, or contact support@artsy.net",
-              "bottom",
-              {
-                backgroundColor: "red100",
-              }
-            )
+            setErrors({ password: "Incorrect email or password" }) // pragma: allowlist secret
             break
           }
           case res === "auth_blocked": {
@@ -100,12 +92,14 @@ export const LoginPasswordStep: React.FC = () => {
 const LoginPasswordStepForm: React.FC = () => {
   const {
     errors,
+    handleBlur,
     handleChange,
     handleSubmit,
     isSubmitting,
     isValid,
     resetForm,
     submitCount,
+    touched,
     values,
   } = useFormikContext<LoginPasswordStepFormValues>()
 
@@ -141,7 +135,9 @@ const LoginPasswordStepForm: React.FC = () => {
         importantForAutofill="yes"
         autoCorrect={false}
         blurOnSubmit={false}
-        error={submitCount > 0 ? errors.password : undefined}
+        error={
+          (touched.password || submitCount > 0) && errors.password ? errors.password : undefined
+        }
         placeholderTextColor={color("mono30")}
         ref={passwordRef}
         returnKeyType="done"
@@ -149,6 +145,7 @@ const LoginPasswordStepForm: React.FC = () => {
         testID="password"
         title="Password"
         value={values.password}
+        onBlur={handleBlur("password")}
         onChangeText={(text) => {
           handleChange("password")(text)
         }}

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/LoginWelcomeStep.tsx
@@ -133,8 +133,17 @@ const LoginWelcomeStepForm: React.FC = () => {
   const isLoading = GlobalStore.useAppState((state) => state.auth.sessionState.isLoading)
 
   const { color } = useTheme()
-  const { handleChange, handleSubmit, isSubmitting, isValid, resetForm, values } =
-    useFormikContext<LoginEmailFormValues>()
+  const {
+    handleBlur,
+    handleChange,
+    handleSubmit,
+    isSubmitting,
+    isValid,
+    resetForm,
+    values,
+    errors,
+    touched,
+  } = useFormikContext<LoginEmailFormValues>()
 
   const navigation = useNavigation<NavigationProp<OnboardingNavigationStack>>()
   const emailRef = useRef<Input>(null)
@@ -178,6 +187,7 @@ const LoginWelcomeStepForm: React.FC = () => {
         importantForAutofill="yes"
         autoCorrect={false}
         blurOnSubmit={false}
+        error={touched.email && errors.email ? errors.email : undefined}
         placeholderTextColor={color("mono30")}
         ref={emailRef}
         spellCheck={false}
@@ -185,6 +195,7 @@ const LoginWelcomeStepForm: React.FC = () => {
         returnKeyType="next"
         title="Email"
         defaultValue={values.email}
+        onBlur={handleBlur("email")}
         onKeyPress={(e) => {
           // Avoid spaces from being submitted
           if (e.nativeEvent.key === "Space") {

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginPasswordStep.tests.tsx
@@ -78,19 +78,14 @@ describe("LoginPasswordStep", () => {
     )
   })
 
-  it("shows a toast when login fails", async () => {
+  it("shows an inline error when login fails", async () => {
     jest.spyOn(GlobalStore.actions.auth, "signIn").mockResolvedValue("failure")
     const toastSpy = jest.spyOn(GlobalStore.actions.toast, "add")
     renderWithWrappers(<LoginPasswordStep />)
     fireEvent.changeText(screen.getByA11yHint("Enter your password"), "Password1")
     fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
-    await waitFor(() =>
-      expect(toastSpy).toHaveBeenCalledWith({
-        message: "Something went wrong. Please try again, or contact support@artsy.net",
-        placement: "bottom",
-        options: { backgroundColor: "red100" },
-      })
-    )
+    expect(toastSpy).not.toHaveBeenCalled()
+    await screen.findByText("Incorrect email or password")
   })
 
   describe("when showLoginLink param is true", () => {

--- a/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Auth/scenes/__tests__/LoginWelcomeStep.tests.tsx
@@ -239,6 +239,21 @@ describe("LoginWelcomeStep", () => {
       expect(refreshTokenSpy).toHaveBeenCalled()
       expect(navigateSpy).not.toHaveBeenCalled()
     })
+
+    it("shows an inline error for invalid email format", async () => {
+      renderExpandedWelcomeStep()
+      fireEvent.changeText(screen.getByA11yHint("Enter your email address"), "invalidemail")
+
+      // eslint-disable-next-line testing-library/no-unnecessary-act
+      await act(async () => {
+        fireEvent.press(screen.getByA11yHint("Continue to the next screen"))
+      })
+
+      act(() => {
+        jest.runAllTimers()
+      })
+      expect(screen.getByText("Please provide a valid email address")).toBeTruthy()
+    })
   })
 
   it("shows the Sign in with Apple button on iOS versions >= 13 ", () => {


### PR DESCRIPTION
This PR resolves [DI-337](https://www.notion.so/373cab0764a081a2a91dd2b06e0c1956) <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
We found that users entering invalid credentials on the login screen received no feedback about what was wrong. When an invalid email format was entered (for example missing @) or the password field was left empty, the Continue button would grey out (good) but there would be no error message explaining why. This left users confused during onboarding.

This PR adds inline validation error messages to the login flow for both email and password. It also adds blur handling so errors now appear whether users tap away from a field or use keyboard navigation.

Also updated authentication error handling. Before, the wrong credentials triggered a generic toast notification ("Something went wrong"). Now they show "Incorrect email or password" inline under the password field, and actual network/system failures still show the toast if needed. 

<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

#### Before: 
(no error messages if email is or password are invalid or missing)

https://github.com/user-attachments/assets/09af425d-a402-4d61-afba-95901acf862c

#### After: 
(validation messages for for invalid and/or missing email or password)

https://github.com/user-attachments/assets/4e269b07-00fd-4a3f-8349-4bfcdc9acd91



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add inline validation error messages to login email and password inputs

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
