### PR TITLE
feat(DI-349): experience-based onboarding flow (shell)

### DIFF
--- a/src/app/Components/AnimatedFadingPill/AnimatedFadingPill.tsx
+++ b/src/app/Components/AnimatedFadingPill/AnimatedFadingPill.tsx
@@ -1,6 +1,8 @@
-import { IconProps } from "@artsy/icons/native"
-import { Pill, PillVariant } from "@artsy/palette-mobile"
+import { CheckmarkFillIcon, IconProps } from "@artsy/icons/native"
+import { Flex, Pill, PillVariant } from "@artsy/palette-mobile"
+import { ACCESSIBLE_DEFAULT_ICON_SIZE } from "app/Components/constants"
 import { MotiPressableProps } from "moti/interactions"
+import { Platform } from "react-native"
 import Animated, { FadeInUp, FadeOutDown, Layout } from "react-native-reanimated"
 
 interface FadingPillProps {
@@ -14,6 +16,20 @@ interface FadingPillProps {
 }
 
 export const FADE_OUT_PILL_ANIMATION_DURATION = 500
+
+export const PillCheckmarkIcon = () => (
+  <Flex pr={Platform.OS === "android" ? 1 : 0} mr={0.5}>
+    <CheckmarkFillIcon
+      fill="mono0"
+      height={ACCESSIBLE_DEFAULT_ICON_SIZE}
+      width={ACCESSIBLE_DEFAULT_ICON_SIZE}
+    />
+  </Flex>
+)
+
+export const PillIconPlaceholder = () => (
+  <Flex width={0} height={ACCESSIBLE_DEFAULT_ICON_SIZE} overflow="hidden" />
+)
 
 export const AnimatedFadingPill: React.FC<React.PropsWithChildren<FadingPillProps>> = ({
   isVisible,

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -18,8 +18,10 @@ import { useBottomTabsBadges } from "app/Navigation/utils/useBottomTabsBadges"
 import { BottomTabOption, BottomTabType } from "app/Scenes/BottomTabs/BottomTabType"
 import { BottomTabsIcon } from "app/Scenes/BottomTabs/BottomTabsIcon"
 import { bottomTabsConfig } from "app/Scenes/BottomTabs/bottomTabsConfig"
+import { Onboarding } from "app/Scenes/Onboarding/Screens/Onboarding/Onboarding"
 import { OnboardingQuiz } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingQuiz"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useIsStaging } from "app/utils/hooks/useIsStaging"
 import { postEventToProviders } from "app/utils/track/providers"
 import { useCallback } from "react"
@@ -207,9 +209,10 @@ export const AuthenticatedRoutesStack = createNativeStackNavigator()
 
 export const AuthenticatedRoutes: React.FC = () => {
   const onboardingState = GlobalStore.useAppState((state) => state.onboarding.onboardingState)
+  const isExperienceOnboardingEnabled = useFeatureFlag("AREnableExperienceBasedOnboarding")
 
   if (onboardingState === "incomplete") {
-    return <OnboardingQuiz />
+    return isExperienceOnboardingEnabled ? <Onboarding /> : <OnboardingQuiz />
   }
 
   return (

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -257,6 +257,9 @@ export const HomeView: React.FC = memo(() => {
 
 const HomeViewScreenComponent: React.FC = () => {
   const artQuizState = GlobalStore.useAppState((state) => state.onboarding.onboardingArtQuizState)
+  const onboardingDestination = GlobalStore.useAppState(
+    (state) => state.onboarding.onboardingDestination
+  )
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const theme = GlobalStore.useAppState((state) => state.devicePrefs.colorScheme)
 
@@ -280,6 +283,14 @@ const HomeViewScreenComponent: React.FC = () => {
     }
   }, [artQuizState, isNavigationReady])
 
+  useEffect(() => {
+    if (onboardingDestination === "infinite-discovery" && isNavigationReady) {
+      requestAnimationFrame(() => {
+        navigate("/infinite-discovery")
+      })
+    }
+  }, [onboardingDestination, isNavigationReady])
+
   // We want to avoid rendering the home view when the user comes back from a deep link
   // Because it triggers a lot of queries that affect the user's experience and can be avoided
   if (isDeepLink !== false) {
@@ -287,6 +298,10 @@ const HomeViewScreenComponent: React.FC = () => {
   }
 
   if (artQuizState === "incomplete") {
+    return null
+  }
+
+  if (onboardingDestination === "infinite-discovery") {
     return null
   }
 

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -285,6 +285,7 @@ const HomeViewScreenComponent: React.FC = () => {
 
   useEffect(() => {
     if (onboardingDestination === "infinite-discovery" && isNavigationReady) {
+      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
       requestAnimationFrame(() => {
         navigate("/infinite-discovery")
       })

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -280,24 +280,21 @@ const HomeViewScreenComponent: React.FC = () => {
   }, [theme])
 
   useEffect(() => {
-    if (artQuizState === "incomplete" && isNavigationReady) {
+    if (!isNavigationReady) return
+
+    if (artQuizState === "incomplete") {
       // Wait for react-navigation to start drawing the screen before navigating to ArtQuiz
       requestAnimationFrame(() => {
         navigate("/art-quiz")
       })
-      return
-    }
-  }, [artQuizState, isNavigationReady])
-
-  useEffect(() => {
-    if (onboardingDestination === "infinite-discovery" && isNavigationReady) {
+    } else if (onboardingDestination === "infinite-discovery") {
       GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
       GlobalStore.actions.onboarding.setOnboardingDestination(null)
       requestAnimationFrame(() => {
         navigate("/infinite-discovery")
       })
     }
-  }, [onboardingDestination, isNavigationReady])
+  }, [artQuizState, onboardingDestination, isNavigationReady])
 
   // We want to avoid rendering the home view when the user comes back from a deep link
   // Because it triggers a lot of queries that affect the user's experience and can be avoided

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -260,8 +260,14 @@ const HomeViewScreenComponent: React.FC = () => {
   const onboardingDestination = GlobalStore.useAppState(
     (state) => state.onboarding.onboardingDestination
   )
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  )
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const theme = GlobalStore.useAppState((state) => state.devicePrefs.colorScheme)
+
+  const isNavigatingToInfiniteDiscovery =
+    onboardingDestination === "infinite-discovery" || isOnboardingSession
 
   const showPlayground = useDevToggle("DTShowPlayground")
 
@@ -286,6 +292,7 @@ const HomeViewScreenComponent: React.FC = () => {
   useEffect(() => {
     if (onboardingDestination === "infinite-discovery" && isNavigationReady) {
       GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+      GlobalStore.actions.onboarding.setOnboardingDestination(null)
       requestAnimationFrame(() => {
         navigate("/infinite-discovery")
       })
@@ -302,7 +309,7 @@ const HomeViewScreenComponent: React.FC = () => {
     return null
   }
 
-  if (onboardingDestination === "infinite-discovery") {
+  if (isNavigatingToInfiniteDiscovery) {
     return null
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -45,17 +45,12 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
-
-  const onboardingDestination = GlobalStore.useAppState(
-    (state) => state.onboarding.onboardingDestination
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
   )
-  const isComingFromOnboardingRef = useRef(onboardingDestination === "infinite-discovery")
 
   const handleDismiss = () => {
     setIsVisible(false)
-    if (isComingFromOnboardingRef.current) {
-      GlobalStore.actions.onboarding.setOnboardingDestination(null)
-    }
   }
 
   useEffect(() => {
@@ -66,7 +61,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
     }
   }, [isVisible])
   useEffect(() => {
-    const delay = isComingFromOnboardingRef.current ? 0 : 1000
+    const delay = isOnboardingSession ? 0 : 1000
     setTimeout(() => {
       if (!hasInteractedWithOnboarding) {
         setIsVisible(true)
@@ -77,7 +72,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
         }, 1500)
       }
     }, delay)
-  }, [hasInteractedWithOnboarding])
+  }, [hasInteractedWithOnboarding, isOnboardingSession])
 
   useEffect(() => {
     if (isVisible) {
@@ -200,23 +195,35 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
                   <Spacer y={1} />
 
-                  <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
-                    Start{" "}
-                    <Text variant="lg-display" fontWeight="500">
-                      swiping
-                    </Text>{" "}
-                    to discover art, and{" "}
-                    <Text variant="lg-display" fontWeight="500">
-                      save
-                    </Text>{" "}
-                    the works you love.
-                  </Text>
+                  {isOnboardingSession ? (
+                    <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
+                      Save{" "}
+                      <Text variant="lg-display" fontWeight="500">
+                        5 different artworks
+                      </Text>{" "}
+                      to build your taste profile.
+                    </Text>
+                  ) : (
+                    <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
+                      Start{" "}
+                      <Text variant="lg-display" fontWeight="500">
+                        swiping
+                      </Text>{" "}
+                      to discover art, and{" "}
+                      <Text variant="lg-display" fontWeight="500">
+                        save
+                      </Text>{" "}
+                      the works you love.
+                    </Text>
+                  )}
 
                   <Spacer y={2} />
 
                   <MotiView animate={{ opacity: enableTapToDismiss ? 1 : 0 }}>
                     <Flex alignItems="flex-end">
-                      <LinkText onPress={handleDismiss}>Tap to get started</LinkText>
+                      <LinkText onPress={handleDismiss}>
+                        {isOnboardingSession ? "Tap to start swiping" : "Tap to get started"}
+                      </LinkText>
                     </Flex>
                   </MotiView>
                 </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -46,6 +46,18 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
 
+  const onboardingDestination = GlobalStore.useAppState(
+    (state) => state.onboarding.onboardingDestination
+  )
+  const isComingFromOnboardingRef = useRef(onboardingDestination === "infinite-discovery")
+
+  const handleDismiss = () => {
+    setIsVisible(false)
+    if (isComingFromOnboardingRef.current) {
+      GlobalStore.actions.onboarding.setOnboardingDestination(null)
+    }
+  }
+
   useEffect(() => {
     if (isVisible) {
       setTimeout(() => {
@@ -54,6 +66,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
     }
   }, [isVisible])
   useEffect(() => {
+    const delay = isComingFromOnboardingRef.current ? 0 : 1000
     setTimeout(() => {
       if (!hasInteractedWithOnboarding) {
         setIsVisible(true)
@@ -63,7 +76,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
           setEnableTapToDismiss(true)
         }, 1500)
       }
-    }, 1000)
+    }, delay)
   }, [hasInteractedWithOnboarding])
 
   useEffect(() => {
@@ -115,14 +128,14 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
       animationType="fade"
       visible={isVisible}
       transparent
-      onRequestClose={() => setIsVisible(false)}
+      onRequestClose={handleDismiss}
       presentationStyle="overFullScreen"
     >
       <TouchableWithoutFeedback
         accessibilityRole="button"
         onPress={() => {
           if (enableTapToDismiss) {
-            setIsVisible(false)
+            handleDismiss()
           }
         }}
       >
@@ -203,13 +216,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
                   <MotiView animate={{ opacity: enableTapToDismiss ? 1 : 0 }}>
                     <Flex alignItems="flex-end">
-                      <LinkText
-                        onPress={() => {
-                          setIsVisible(false)
-                        }}
-                      >
-                        Tap to get started
-                      </LinkText>
+                      <LinkText onPress={handleDismiss}>Tap to get started</LinkText>
                     </Flex>
                   </MotiView>
                 </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -49,10 +49,6 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
     (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
   )
 
-  const handleDismiss = () => {
-    setIsVisible(false)
-  }
-
   useEffect(() => {
     if (isVisible) {
       setTimeout(() => {
@@ -123,14 +119,14 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
       animationType="fade"
       visible={isVisible}
       transparent
-      onRequestClose={handleDismiss}
+      onRequestClose={() => setIsVisible(false)}
       presentationStyle="overFullScreen"
     >
       <TouchableWithoutFeedback
         accessibilityRole="button"
         onPress={() => {
           if (enableTapToDismiss) {
-            handleDismiss()
+            setIsVisible(false)
           }
         }}
       >
@@ -199,9 +195,9 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
                       Save{" "}
                       <Text variant="lg-display" fontWeight="500">
-                        5 different artworks
+                        5
                       </Text>{" "}
-                      to build your taste profile.
+                      different artworks to build your taste profile.
                     </Text>
                   ) : (
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
@@ -221,7 +217,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
                   <MotiView animate={{ opacity: enableTapToDismiss ? 1 : 0 }}>
                     <Flex alignItems="flex-end">
-                      <LinkText onPress={handleDismiss}>
+                      <LinkText onPress={() => setIsVisible(false)}>
                         {isOnboardingSession ? "Tap to start swiping" : "Tap to get started"}
                       </LinkText>
                     </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -42,7 +42,6 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   )
 
   useEffect(() => {
-    GlobalStore.actions.onboarding.setOnboardingDestination(null)
     return () => {
       GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
     }

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -41,6 +41,21 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
 
+  const onboardingDestination = GlobalStore.useAppState(
+    (state) => state.onboarding.onboardingDestination
+  )
+
+  useEffect(() => {
+    if (onboardingDestination === "infinite-discovery") {
+      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+      GlobalStore.actions.onboarding.setOnboardingDestination(null)
+    }
+    return () => {
+      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const [topArtworkId, setTopArtworkId] = useState<string | null>(null)
   const topArtwork = useMemo(
     () => artworks.find((artwork) => artwork.internalID === topArtworkId),

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -41,19 +41,11 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
 
-  const onboardingDestination = GlobalStore.useAppState(
-    (state) => state.onboarding.onboardingDestination
-  )
-
   useEffect(() => {
-    if (onboardingDestination === "infinite-discovery") {
-      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
-      GlobalStore.actions.onboarding.setOnboardingDestination(null)
-    }
+    GlobalStore.actions.onboarding.setOnboardingDestination(null)
     return () => {
       GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const [topArtworkId, setTopArtworkId] = useState<string | null>(null)

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscoveryQueryRenderer.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscoveryQueryRenderer.tsx
@@ -38,7 +38,6 @@ export const InfiniteDiscoveryQueryRenderer = withSuspense({
     const prefetch = usePrefetch()
 
     const { resetSavedArtworksCount } = GlobalStore.actions.infiniteDiscovery
-
     const initialArtworks = extractNodes(data.discoverArtworks)
     const [artworks, setArtworks] = useState<InfiniteDiscoveryArtwork[]>(initialArtworks)
 

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscoveryQueryRenderer.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscoveryQueryRenderer.tsx
@@ -38,6 +38,7 @@ export const InfiniteDiscoveryQueryRenderer = withSuspense({
     const prefetch = usePrefetch()
 
     const { resetSavedArtworksCount } = GlobalStore.actions.infiniteDiscovery
+
     const initialArtworks = extractNodes(data.discoverArtworks)
     const [artworks, setArtworks] = useState<InfiniteDiscoveryArtwork[]>(initialArtworks)
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -1,0 +1,50 @@
+import { Flex } from "@artsy/palette-mobile"
+import { useScreenDimensions } from "app/utils/hooks"
+import { MotiView } from "moti"
+import { useEffect } from "react"
+import { Image } from "react-native"
+import { Easing } from "react-native-reanimated"
+
+const IMG_DISPLAY_DURATION = 500
+const LAST_IMG_DISPLAY_DURATION = 600
+
+const ONBOARDING_IMAGES = [
+  require("images/OnboardingImage0AdesinaPaintingOfRechel.webp"),
+  require("images/OnboardingImage1KatzYellowFlags.webp"),
+  require("images/OnboardingImage2SuperFutureKidHazyDaisy2022.webp"),
+  require("images/OnboardingImage3WangTheSnowflakeThatComesAlive.webp"),
+  require("images/OnboardingImage4AndyWarholCow.webp"),
+]
+
+const ARTWORKS_DURATION =
+  ONBOARDING_IMAGES.length * IMG_DISPLAY_DURATION + LAST_IMG_DISPLAY_DURATION
+
+interface ArtworkMontageStepProps {
+  onNext: () => void
+}
+
+export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }) => {
+  const { width: screenWidth } = useScreenDimensions()
+
+  useEffect(() => {
+    const timer = setTimeout(onNext, ARTWORKS_DURATION)
+    return () => clearTimeout(timer)
+  }, [onNext])
+
+  return (
+    <Flex flex={1} backgroundColor="mono100">
+      {ONBOARDING_IMAGES.map((image, index) => (
+        <MotiView
+          key={index}
+          from={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          delay={index * IMG_DISPLAY_DURATION}
+          transition={{ type: "timing", duration: IMG_DISPLAY_DURATION, easing: Easing.linear }}
+          style={{ position: "absolute", height: "100%", width: screenWidth }}
+        >
+          <Image source={image} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
+        </MotiView>
+      ))}
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
@@ -1,0 +1,43 @@
+import { Button, Flex, Text } from "@artsy/palette-mobile"
+import Animated, { Easing, FadeInRight } from "react-native-reanimated"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Logo } from "./Logo"
+
+const AnimatedFlex = Animated.createAnimatedComponent(Flex)
+
+const BUTTONS_ENTERING_DURATION = 500
+const BUTTONS_ENTERING_DELAY = 300
+
+interface BrowsePromptStepProps {
+  onNext: () => void
+  onSkip: () => void
+}
+
+export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext, onSkip }) => {
+  const { bottom } = useSafeAreaInsets()
+
+  return (
+    <Flex flex={1} px={2} backgroundColor="mono100">
+      <Logo />
+      <Flex flex={1} justifyContent="center">
+        <Text variant="xl" color="mono0">
+          Try our artwork browsing tool to start developing your tastes.
+        </Text>
+      </Flex>
+      <AnimatedFlex
+        pb={`${bottom}px`}
+        gap={1}
+        entering={FadeInRight.duration(BUTTONS_ENTERING_DURATION)
+          .delay(BUTTONS_ENTERING_DELAY)
+          .easing(Easing.out(Easing.quad))}
+      >
+        <Button variant="fillLight" block onPress={onNext}>
+          Start browsing
+        </Button>
+        <Button variant="fillDark" block onPress={onSkip}>
+          Skip to homepage
+        </Button>
+      </AnimatedFlex>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
@@ -1,0 +1,14 @@
+import { ArtsyLogoIcon } from "@artsy/icons/native"
+import { Box } from "@artsy/palette-mobile"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+const LOGO_TOP_OFFSET = 44
+
+export const Logo: React.FC = () => {
+  const { top } = useSafeAreaInsets()
+  return (
+    <Box position="absolute" top={`${top + LOGO_TOP_OFFSET}px`} left={2}>
+      <ArtsyLogoIcon height={32} width={94} fill="mono0" />
+    </Box>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -1,0 +1,79 @@
+import { Button, Flex, Spacer, Screen, Text } from "@artsy/palette-mobile"
+import {
+  AnimatedFadingPill,
+  FADE_OUT_PILL_ANIMATION_DURATION,
+  PillCheckmarkIcon,
+  PillIconPlaceholder,
+} from "app/Components/AnimatedFadingPill/AnimatedFadingPill"
+import { useState } from "react"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+export type Experience = "experienced" | "beginner"
+
+const EXPERIENCE_OPTIONS: { label: string; experience: Experience }[] = [
+  { label: "I have collected many works (4 or more)", experience: "experienced" },
+  { label: "I have collected a few works (1-3)", experience: "experienced" },
+  { label: "I'm just starting out but have something in mind", experience: "beginner" },
+  { label: "I'm just starting out and want to explore", experience: "beginner" },
+]
+
+const SHOW_TICK_DELAY = FADE_OUT_PILL_ANIMATION_DURATION + 200
+const NAVIGATE_DELAY = SHOW_TICK_DELAY + 500
+
+interface QuestionStepProps {
+  onSelect: (experience: Experience) => void
+}
+
+export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null)
+  const [hideUnselectedPills, setHideUnselectedPills] = useState(false)
+  const [showPillTick, setShowPillTick] = useState(false)
+  const { bottom } = useSafeAreaInsets()
+
+  const handleContinue = () => {
+    const option = EXPERIENCE_OPTIONS.find((o) => o.label === selectedLabel)
+    if (!option) return
+
+    setHideUnselectedPills(true)
+    setTimeout(() => setShowPillTick(true), SHOW_TICK_DELAY)
+    setTimeout(() => onSelect(option.experience), NAVIGATE_DELAY)
+  }
+
+  return (
+    <Screen>
+      <Screen.Body>
+        <Flex flex={1} flexDirection="column">
+          <Spacer y={2} />
+          <Text variant="lg-display">What is your art collecting experience?</Text>
+          <Spacer y={2} />
+          {EXPERIENCE_OPTIONS.map(({ label }) => {
+            const isSelected = selectedLabel === label
+            const isVisible = !hideUnselectedPills || isSelected
+            const Icon = showPillTick && isSelected ? PillCheckmarkIcon : PillIconPlaceholder
+
+            return (
+              <Flex key={label}>
+                <AnimatedFadingPill
+                  isVisible={isVisible}
+                  selected={isSelected}
+                  Icon={Icon}
+                  onPress={() => !hideUnselectedPills && setSelectedLabel(label)}
+                >
+                  <Text variant="sm" lineHeight="16px" color={isSelected ? "mono0" : "mono100"}>
+                    {label}
+                  </Text>
+                </AnimatedFadingPill>
+                {!!isVisible && <Spacer y={2} />}
+              </Flex>
+            )
+          })}
+        </Flex>
+        <Flex pb={`${bottom}px`}>
+          <Button block disabled={!selectedLabel || hideUnselectedPills} onPress={handleContinue}>
+            Continue
+          </Button>
+        </Flex>
+      </Screen.Body>
+    </Screen>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/WelcomeStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/WelcomeStep.tsx
@@ -1,0 +1,55 @@
+import { Flex, Spinner, Text } from "@artsy/palette-mobile"
+import { WelcomeStepQuery } from "__generated__/WelcomeStepQuery.graphql"
+import { Suspense, useEffect } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { Logo } from "./Logo"
+
+const WELCOME_DISPLAY_DURATION = 3000
+
+interface WelcomeStepProps {
+  onNext: () => void
+}
+
+const WelcomeStepContent: React.FC<WelcomeStepProps> = ({ onNext }) => {
+  const { me } = useLazyLoadQuery<WelcomeStepQuery>(
+    WelcomeStepScreenQuery,
+    {},
+    { fetchPolicy: "network-only" }
+  )
+
+  useEffect(() => {
+    const timer = setTimeout(onNext, WELCOME_DISPLAY_DURATION)
+    return () => clearTimeout(timer)
+  }, [onNext])
+
+  return (
+    <Flex flex={1} justifyContent="center" px={2} backgroundColor="mono100">
+      <Logo />
+      <Text variant="xl" color="mono0">
+        Welcome{"\n"}to Artsy,{"\n"}
+        {me?.name}
+      </Text>
+    </Flex>
+  )
+}
+
+const Placeholder: React.FC = () => (
+  <Flex flex={1} justifyContent="center" alignItems="center" backgroundColor="mono100">
+    <Logo />
+    <Spinner color="mono0" />
+  </Flex>
+)
+
+export const WelcomeStep: React.FC<WelcomeStepProps> = ({ onNext }) => (
+  <Suspense fallback={<Placeholder />}>
+    <WelcomeStepContent onNext={onNext} />
+  </Suspense>
+)
+
+const WelcomeStepScreenQuery = graphql`
+  query WelcomeStepQuery {
+    me {
+      name
+    }
+  }
+`

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -1,0 +1,46 @@
+import { Button, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
+import { GlobalStore } from "app/store/GlobalStore"
+import { useState } from "react"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+const MIN_FOLLOWED = 3
+
+export const FollowArtists: React.FC = () => {
+  const { bottom } = useSafeAreaInsets()
+  const [count, setCount] = useState(0)
+
+  return (
+    <Screen>
+      <Screen.Body>
+        <Flex flex={1} justifyContent="center" alignItems="center">
+          <Flex flexDirection="row" alignItems="center" gap={4}>
+            <Touchable
+              accessibilityRole="button"
+              onPress={() => setCount((c) => Math.max(0, c - 1))}
+              disabled={count === 0}
+            >
+              <Text variant="xxl" fontWeight="bold" color={count === 0 ? "mono30" : "mono100"}>
+                −
+              </Text>
+            </Touchable>
+            <Text variant="xxl">{count}</Text>
+            <Touchable accessibilityRole="button" onPress={() => setCount((c) => c + 1)}>
+              <Text variant="xxl" fontWeight="bold">
+                +
+              </Text>
+            </Touchable>
+          </Flex>
+        </Flex>
+        <Flex pb={`${bottom}px`}>
+          <Button
+            block
+            disabled={count < MIN_FOLLOWED}
+            onPress={() => GlobalStore.actions.onboarding.setOnboardingState("complete")}
+          >
+            Continue to Artsy
+          </Button>
+        </Flex>
+      </Screen.Body>
+    </Screen>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -1,0 +1,105 @@
+import { Flex } from "@artsy/palette-mobile"
+import { useNavigation } from "@react-navigation/native"
+import { NativeStackNavigationProp } from "@react-navigation/native-stack"
+import { GlobalStore } from "app/store/GlobalStore"
+import { WorkflowEngine } from "app/utils/WorkflowEngine/WorkflowEngine"
+import { AnimatePresence, MotiView } from "moti"
+import { useCallback, useRef, useState } from "react"
+import { ArtworkMontageStep } from "./Components/ArtworkMontageStep"
+import { BrowsePromptStep } from "./Components/BrowsePromptStep"
+import { Experience, QuestionStep } from "./Components/QuestionStep"
+import { WelcomeStep } from "./Components/WelcomeStep"
+import { NavigationStack } from "./Onboarding"
+
+const STEP_QUESTION = "question"
+const STEP_BROWSE_PROMPT = "browse_prompt"
+const STEP_ARTWORK_MONTAGE = "artwork_montage"
+const STEP_WELCOME = "welcome"
+const CHECK_EXPERIENCE = "check_experience"
+
+export const Introduction: React.FC = () => {
+  const { navigate } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
+  const experienceRef = useRef<Experience | null>(null)
+
+  const workflowEngine = useRef(
+    new WorkflowEngine({
+      workflow: [
+        STEP_QUESTION,
+        {
+          [CHECK_EXPERIENCE]: {
+            beginner: [STEP_BROWSE_PROMPT, STEP_ARTWORK_MONTAGE, STEP_WELCOME],
+            experienced: [STEP_ARTWORK_MONTAGE, STEP_WELCOME],
+          },
+        },
+      ],
+      conditions: {
+        [CHECK_EXPERIENCE]: () => experienceRef.current ?? "experienced",
+      },
+    })
+  )
+
+  // `workflowEngine.current` is the value of the ref - a WorkflowEngine instance.
+  // `workflowEngine.current.current()` is the current step of that WorkflowEngine instance.
+  const [currentStep, setCurrentStep] = useState(workflowEngine.current.current())
+
+  const handleDone = useCallback(() => {
+    if (experienceRef.current === "beginner") {
+      GlobalStore.actions.onboarding.setOnboardingDestination("infinite-discovery")
+      GlobalStore.actions.onboarding.setOnboardingState("complete")
+    } else {
+      navigate("FollowArtists")
+    }
+  }, [navigate])
+
+  const next = useCallback(() => {
+    if (workflowEngine.current.isEnd()) {
+      handleDone()
+      return
+    }
+    const nextStep = workflowEngine.current.next()
+    if (nextStep) setCurrentStep(nextStep)
+  }, [handleDone])
+
+  const handleSkipToHome = useCallback(() => {
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
+  }, [])
+
+  const renderStep = () => {
+    switch (currentStep) {
+      case STEP_QUESTION:
+        return (
+          <QuestionStep
+            onSelect={(experience) => {
+              experienceRef.current = experience
+              next()
+            }}
+          />
+        )
+      case STEP_BROWSE_PROMPT:
+        return <BrowsePromptStep onNext={next} onSkip={handleSkipToHome} />
+      case STEP_ARTWORK_MONTAGE:
+        return <ArtworkMontageStep onNext={next} />
+      case STEP_WELCOME:
+        return <WelcomeStep onNext={next} />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <Flex flex={1} backgroundColor="background">
+      <AnimatePresence>
+        <MotiView
+          key={currentStep}
+          from={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ type: "timing", duration: 300 }}
+          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+        >
+          {renderStep()}
+        </MotiView>
+      </AnimatePresence>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -2,79 +2,46 @@ import { Flex } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { GlobalStore } from "app/store/GlobalStore"
-import { WorkflowEngine } from "app/utils/WorkflowEngine/WorkflowEngine"
 import { AnimatePresence, MotiView } from "moti"
-import { useCallback, useRef, useState } from "react"
+import { useCallback } from "react"
 import { ArtworkMontageStep } from "./Components/ArtworkMontageStep"
 import { BrowsePromptStep } from "./Components/BrowsePromptStep"
 import { Experience, QuestionStep } from "./Components/QuestionStep"
 import { WelcomeStep } from "./Components/WelcomeStep"
 import { NavigationStack } from "./Onboarding"
-
-const STEP_QUESTION = "question"
-const STEP_BROWSE_PROMPT = "browse_prompt"
-const STEP_ARTWORK_MONTAGE = "artwork_montage"
-const STEP_WELCOME = "welcome"
-const CHECK_EXPERIENCE = "check_experience"
+import {
+  STEP_ARTWORK_MONTAGE,
+  STEP_BROWSE_PROMPT,
+  STEP_QUESTION,
+  STEP_WELCOME,
+  useConfig,
+} from "./config"
 
 export const Introduction: React.FC = () => {
   const { navigate } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
-  const experienceRef = useRef<Experience | null>(null)
 
-  const workflowEngine = useRef(
-    new WorkflowEngine({
-      workflow: [
-        STEP_QUESTION,
-        {
-          [CHECK_EXPERIENCE]: {
-            beginner: [STEP_BROWSE_PROMPT, STEP_ARTWORK_MONTAGE, STEP_WELCOME],
-            experienced: [STEP_ARTWORK_MONTAGE, STEP_WELCOME],
-          },
-        },
-      ],
-      conditions: {
-        [CHECK_EXPERIENCE]: () => experienceRef.current ?? "experienced",
-      },
-    })
+  const handleDone = useCallback(
+    (experience: Experience) => {
+      if (experience === "beginner") {
+        GlobalStore.actions.onboarding.setOnboardingDestination("infinite-discovery")
+        GlobalStore.actions.onboarding.setOnboardingState("complete")
+      } else {
+        navigate("FollowArtists")
+      }
+    },
+    [navigate]
   )
-
-  // `workflowEngine.current` is the value of the ref - a WorkflowEngine instance.
-  // `workflowEngine.current.current()` is the current step of that WorkflowEngine instance.
-  const [currentStep, setCurrentStep] = useState(workflowEngine.current.current())
-
-  const handleDone = useCallback(() => {
-    if (experienceRef.current === "beginner") {
-      GlobalStore.actions.onboarding.setOnboardingDestination("infinite-discovery")
-      GlobalStore.actions.onboarding.setOnboardingState("complete")
-    } else {
-      navigate("FollowArtists")
-    }
-  }, [navigate])
-
-  const next = useCallback(() => {
-    if (workflowEngine.current.isEnd()) {
-      handleDone()
-      return
-    }
-    const nextStep = workflowEngine.current.next()
-    if (nextStep) setCurrentStep(nextStep)
-  }, [handleDone])
 
   const handleSkipToHome = useCallback(() => {
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }, [])
 
+  const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
+
   const renderStep = useCallback(() => {
     switch (currentStep) {
       case STEP_QUESTION:
-        return (
-          <QuestionStep
-            onSelect={(experience) => {
-              experienceRef.current = experience
-              next()
-            }}
-          />
-        )
+        return <QuestionStep onSelect={selectExperience} />
       case STEP_BROWSE_PROMPT:
         return <BrowsePromptStep onNext={next} onSkip={handleSkipToHome} />
       case STEP_ARTWORK_MONTAGE:
@@ -84,7 +51,7 @@ export const Introduction: React.FC = () => {
       default:
         return null
     }
-  }, [currentStep, next, handleSkipToHome])
+  }, [currentStep, next, selectExperience, handleSkipToHome])
 
   return (
     <Flex flex={1} backgroundColor="background">

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -64,7 +64,7 @@ export const Introduction: React.FC = () => {
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }, [])
 
-  const renderStep = () => {
+  const renderStep = useCallback(() => {
     switch (currentStep) {
       case STEP_QUESTION:
         return (
@@ -84,7 +84,7 @@ export const Introduction: React.FC = () => {
       default:
         return null
     }
-  }
+  }, [currentStep, next, handleSkipToHome])
 
   return (
     <Flex flex={1} backgroundColor="background">

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Onboarding.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Onboarding.tsx
@@ -1,0 +1,27 @@
+import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { defaultScreenOrientation } from "app/utils/screenOrientation"
+import { FollowArtists } from "./FollowArtists"
+import { Introduction } from "./Introduction"
+
+export type NavigationStack = {
+  Introduction: undefined
+  FollowArtists: undefined
+}
+
+const Stack = createNativeStackNavigator<NavigationStack>()
+
+export const Onboarding: React.FC = () => {
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        animation: "slide_from_right",
+        headerShown: false,
+        gestureEnabled: false,
+        orientation: defaultScreenOrientation,
+      }}
+    >
+      <Stack.Screen name="Introduction" component={Introduction} />
+      <Stack.Screen name="FollowArtists" component={FollowArtists} />
+    </Stack.Navigator>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockNavigate } from "app/utils/tests/navigationMocks"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+jest.mock("../Components/QuestionStep", () => {
+  const { Text } = require("react-native")
+  return {
+    QuestionStep: ({ onSelect }: { onSelect: (e: "beginner" | "experienced") => void }) => (
+      <>
+        <Text onPress={() => onSelect("beginner")}>Select beginner</Text>
+        <Text onPress={() => onSelect("experienced")}>Select experienced</Text>
+      </>
+    ),
+  }
+})
+
+jest.mock("../Components/BrowsePromptStep", () => {
+  const { Text } = require("react-native")
+  return {
+    BrowsePromptStep: ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => (
+      <>
+        <Text onPress={onNext}>Browse next</Text>
+        <Text onPress={onSkip}>Browse skip</Text>
+      </>
+    ),
+  }
+})
+
+jest.mock("../Components/ArtworkMontageStep", () => {
+  const { Text } = require("react-native")
+  return {
+    ArtworkMontageStep: ({ onNext }: { onNext: () => void }) => (
+      <Text onPress={onNext}>Montage next</Text>
+    ),
+  }
+})
+
+jest.mock("../Components/WelcomeStep", () => {
+  const { Text } = require("react-native")
+  return {
+    WelcomeStep: ({ onNext }: { onNext: () => void }) => <Text onPress={onNext}>Welcome next</Text>,
+  }
+})
+
+describe("Introduction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("shows the question step initially", () => {
+    renderWithWrappers(<Introduction />)
+    expect(screen.getByText("Select beginner")).toBeOnTheScreen()
+    expect(screen.getByText("Select experienced")).toBeOnTheScreen()
+  })
+
+  describe("beginner path", () => {
+    it("routes through BrowsePromptStep → ArtworkMontageStep → WelcomeStep in order", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Select beginner"))
+      expect(screen.getByText("Browse next")).toBeOnTheScreen()
+
+      fireEvent.press(screen.getByText("Browse next"))
+      expect(screen.getByText("Montage next")).toBeOnTheScreen()
+
+      fireEvent.press(screen.getByText("Montage next"))
+      expect(screen.getByText("Welcome next")).toBeOnTheScreen()
+    })
+
+    it("sets onboardingDestination and completes onboarding when done", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Select beginner"))
+      fireEvent.press(screen.getByText("Browse next"))
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
+
+      const state = __globalStoreTestUtils__?.getCurrentState()
+      expect(state?.onboarding.onboardingDestination).toBe("infinite-discovery")
+      expect(state?.onboarding.onboardingState).toBe("complete")
+    })
+
+    it("completes onboarding when skipping to home from BrowsePromptStep", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Select beginner"))
+      fireEvent.press(screen.getByText("Browse skip"))
+
+      const state = __globalStoreTestUtils__?.getCurrentState()
+      expect(state?.onboarding.onboardingState).toBe("complete")
+    })
+  })
+
+  describe("experienced path", () => {
+    it("skips BrowsePromptStep and routes ArtworkMontageStep → WelcomeStep", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Select experienced"))
+      expect(screen.getByText("Montage next")).toBeOnTheScreen()
+
+      fireEvent.press(screen.getByText("Montage next"))
+      expect(screen.getByText("Welcome next")).toBeOnTheScreen()
+    })
+
+    it("navigates to FollowArtists when done", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Select experienced"))
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
+
+      expect(mockNavigate).toHaveBeenCalledWith("FollowArtists")
+    })
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/config.ts
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/config.ts
@@ -1,0 +1,56 @@
+import { WorkflowEngine } from "app/utils/WorkflowEngine/WorkflowEngine"
+import { useCallback, useRef, useState } from "react"
+import { Experience } from "./Components/QuestionStep"
+
+export const STEP_QUESTION = "question"
+export const STEP_BROWSE_PROMPT = "browse_prompt"
+export const STEP_ARTWORK_MONTAGE = "artwork_montage"
+export const STEP_WELCOME = "welcome"
+
+const CHECK_EXPERIENCE = "check_experience"
+
+interface UseConfigProps {
+  onDone: (experience: Experience) => void
+}
+
+export const useConfig = ({ onDone }: UseConfigProps) => {
+  const experienceRef = useRef<Experience | null>(null)
+
+  const workflowEngine = useRef(
+    new WorkflowEngine({
+      workflow: [
+        STEP_QUESTION,
+        {
+          [CHECK_EXPERIENCE]: {
+            beginner: [STEP_BROWSE_PROMPT, STEP_ARTWORK_MONTAGE, STEP_WELCOME],
+            experienced: [STEP_ARTWORK_MONTAGE, STEP_WELCOME],
+          },
+        },
+      ],
+      conditions: {
+        [CHECK_EXPERIENCE]: () => experienceRef.current ?? "experienced",
+      },
+    })
+  )
+
+  const [currentStep, setCurrentStep] = useState(workflowEngine.current.current())
+
+  const next = useCallback(() => {
+    if (workflowEngine.current.isEnd()) {
+      onDone(experienceRef.current ?? "experienced")
+      return
+    }
+    const nextStep = workflowEngine.current.next()
+    if (nextStep) setCurrentStep(nextStep)
+  }, [onDone])
+
+  const selectExperience = useCallback(
+    (experience: Experience) => {
+      experienceRef.current = experience
+      next()
+    },
+    [next]
+  )
+
+  return { currentStep, next, selectExperience }
+}

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Components/OnboardingQuestionTemplate.tsx
@@ -11,6 +11,10 @@ import {
   DEFAULT_HIT_SLOP,
 } from "@artsy/palette-mobile"
 import { useFocusEffect, useNavigation } from "@react-navigation/native"
+import {
+  AnimatedFadingPill,
+  FADE_OUT_PILL_ANIMATION_DURATION,
+} from "app/Components/AnimatedFadingPill/AnimatedFadingPill"
 import { ACCESSIBLE_DEFAULT_ICON_SIZE } from "app/Components/constants"
 import {
   OnboardingContextAction,
@@ -21,7 +25,6 @@ import { useBackHandler } from "app/utils/hooks/useBackHandler"
 import { debounce } from "lodash"
 import React, { FC, useCallback, useState } from "react"
 import { LayoutAnimation, Platform } from "react-native"
-import { AnimatedFadingPill, FADE_OUT_PILL_ANIMATION_DURATION } from "./AnimatedFadingPill"
 
 interface OnboardingQuestionTemplateProps {
   answers?: string[]

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -6,6 +6,7 @@ export interface InfiniteDiscoveryModel {
   savedArtworksCount: number
   sessionState: {
     moreInfoSheetVisible: boolean
+    isOnboardingSession: boolean
   }
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
@@ -13,6 +14,7 @@ export interface InfiniteDiscoveryModel {
   setHasInteractedWithOnboarding: Action<this, boolean>
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
+  setIsOnboardingSession: Action<this, boolean>
 }
 
 export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
@@ -21,6 +23,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   savedArtworksCount: 0,
   sessionState: {
     moreInfoSheetVisible: false,
+    isOnboardingSession: false,
   },
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
@@ -39,5 +42,8 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   setMoreInfoSheetVisible: action((state, payload) => {
     state.sessionState.moreInfoSheetVisible = payload
+  }),
+  setIsOnboardingSession: action((state, payload) => {
+    state.sessionState.isOnboardingSession = payload
   }),
 })

--- a/src/app/store/OnboardingModel.ts
+++ b/src/app/store/OnboardingModel.ts
@@ -2,21 +2,28 @@ import { Action, action } from "easy-peasy"
 
 type OnboardingState = "incomplete" | "complete"
 type OnboardingArtQuizState = "none" | "incomplete" | "complete"
+type OnboardingDestination = "infinite-discovery" | null
 
 export interface OnboardingModel {
   onboardingState: OnboardingState
   onboardingArtQuizState: OnboardingArtQuizState
+  onboardingDestination: OnboardingDestination
   setArtQuizState: Action<this, OnboardingArtQuizState>
   setOnboardingState: Action<this, OnboardingState>
+  setOnboardingDestination: Action<this, OnboardingDestination>
 }
 
 export const getOnboardingModel = (): OnboardingModel => ({
   onboardingState: "incomplete",
   onboardingArtQuizState: "none",
+  onboardingDestination: null,
   setArtQuizState: action((state, artQuizState) => {
     state.onboardingArtQuizState = artQuizState
   }),
   setOnboardingState: action((state, onboardingState) => {
     state.onboardingState = onboardingState
+  }),
+  setOnboardingDestination: action((state, destination) => {
+    state.onboardingDestination = destination
   }),
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -68,9 +68,10 @@ export const Versions = {
   AddHasSavedArtworksToInfiniteDiscoveryModel: 55,
   AddPreviouslySelectedCitySlugToUserPrefsModel: 56,
   RemovePendingPushNotificationModel: 57,
+  AddOnboardingDestinationToOnboardingModel: 58,
 }
 
-export const CURRENT_APP_VERSION = Versions.RemovePendingPushNotificationModel
+export const CURRENT_APP_VERSION = Versions.AddOnboardingDestinationToOnboardingModel
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -383,6 +384,9 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.RemovePendingPushNotificationModel]: (state) => {
     delete state.pendingPushNotification
+  },
+  [Versions.AddOnboardingDestinationToOnboardingModel]: (state) => {
+    state.onboarding.onboardingDestination = null
   },
 }
 


### PR DESCRIPTION
This PR adds the foundation for a new onboarding flow that will offer a different experience depending on the new user's art collecting experience.

The new onboarding flow is enabled when the "experienced-based onboarding" feature flag is enabled and a new user account is created.

- It begins when `onboardingStatus` is "incomplete" when a user is authenticated.
- A `WorkflowManager` is used to show a question that tells us what the user's collecting experience is. Based on their answer, the user will see a different sequence of the welcome introduction sequence.
- If the user is an **experienced** collector, we will show them a screen to follow artists. The goal of this screen is to get the users to follow 3 artists. (Note: In this PR the onboarding flow just closes when the user increases a counter above 3 and clicks the complete button. In the future it will persist the avatars of the artists that were followed and show them in a modal dialog on the home screen.)
- If the user is a **beginner** collector, we will take them to Infinite Discovery in "onboarding mode." The goal of this will be to get the users to save 5 artworks. (Note: The onboarding flow is closed when we open Infinite Discovery, but 
it will use a global state variable to know that it is in "onboarding mode". In the future it will persist thumbnails of the artworks that were saved and show them in an animation on the home screen.)

| Experienced Collector | Beginner Collector |
|-|-|
| <video src="https://github.com/user-attachments/assets/21d04713-d5bf-48eb-b8dd-41d9a98a9cca" width="400" /> | <video src="https://github.com/user-attachments/assets/4e4d41bd-bba2-4bef-9d21-7d111c4a1cc2" width="400" /> |


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add experience-based onboarding shell behind `AREnableExperienceBasedOnboarding` flag
- Promote `AnimatedFadingPill` to `app/Components` (shared); remove local copy from `OnboardingQuiz`
- `InfiniteDiscovery` onboarding overlay now skips 1s delay when navigated from the new onboarding flow

<!-- end_changelog_updates -->

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

> This change is related to [DI-349](https://www.notion.so/375cab0764a08003bfdafabe66e40090)