### PR TITLE
fix: Android deeplinking regression after react-native 83.6

### DIFF
--- a/src/app/utils/fetchMarketingURL.ts
+++ b/src/app/utils/fetchMarketingURL.ts
@@ -17,6 +17,34 @@ const captureFetchError = (errorMessage: string, url: string, status?: number) =
   }
 }
 
+/**
+ * Recover the resolved destination URL from a landing page's HTML.
+ *
+ * On Android (RN 0.83), `Response.url` returns the original pre-redirect URL instead of the
+ * final one (a regression in RN's prebuilt NetworkingModule, commit 3cf6bff2 — and not fixable
+ * via a node_modules patch since RN Android ships as a prebuilt AAR). The redirect IS followed,
+ * so the response body is the destination page; we read its canonical / og:url meta tag to get
+ * the resolved URL. Note: these tags usually omit query params (e.g. utm_*), which is fine for
+ * routing since `matchRoute` keys off the path.
+ */
+const extractResolvedURLFromBody = (html: string): string | null => {
+  const canonical =
+    html.match(/<link[^>]+rel=["']canonical["'][^>]*href=["']([^"']+)["']/i) ||
+    html.match(/<link[^>]+href=["']([^"']+)["'][^>]*rel=["']canonical["']/i)
+  if (canonical?.[1]) {
+    return canonical[1]
+  }
+
+  const ogURL =
+    html.match(/<meta[^>]+property=["']og:url["'][^>]*content=["']([^"']+)["']/i) ||
+    html.match(/<meta[^>]+content=["']([^"']+)["'][^>]*property=["']og:url["']/i)
+  if (ogURL?.[1]) {
+    return ogURL[1]
+  }
+
+  return null
+}
+
 export const fetchMarketingURL = async (url: string) => {
   try {
     const response = await fetch(url)
@@ -26,7 +54,19 @@ export const fetchMarketingURL = async (url: string) => {
       captureFetchError(errorMessage, url, response.status)
       return null
     }
-    return response.url
+
+    let resolved = response.url
+
+    // Android fallback: when `response.url` didn't pick up the redirect, recover the
+    // destination from the landing page body (see extractResolvedURLFromBody).
+    if (!resolved || resolved === url) {
+      const fromBody = extractResolvedURLFromBody(await response.text())
+      if (fromBody) {
+        resolved = fromBody
+      }
+    }
+
+    return resolved
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     captureFetchError(errorMessage, url)


### PR DESCRIPTION
This PR resolves [PHIRE-3157] <!-- eg [PROJECT-XXXX] -->

### Description

Realised as I was working on improving the e2e tests that we have that the marketing deeplinks started failing on android.

**What & why:**

Marketing-link deeplinks (`click.artsy.net`, `email-link.artsy.net`) stopped working on Android only after the Expo 55 / RN 0.83.6 upgrade (#13576). They open the app but never navigate to the destination screen. iOS is unaffected but the changes here also work for iOS as well.

These domains are redirect wrappers that aren't in our route domain map, so `fetchMarketingURL` resolves them by following the redirect with fetch(url) and reading response.url. On Android + RN 0.83, response.url comes back as the original pre-redirect URL instead of the resolved artsy.net one — so useDeepLinks hits its targetURL === url guard and silently bails.

**Root cause**

This is a React Native Android regression, not something in our code. The redirect is followed (HTTP 200, body is the real landing page) — RN's native NetworkingModule just reports the wrong URL back to JS. iOS uses response.URL (the final URL) and works correctly. Verified with a minimal repro against a public redirect endpoint, and traced to RN commit 3cf6bff2, which refactored NetworkEventUtil.onResponseReceived to pass the original request URL instead of deriving the final one from the OkHttp response.

**We can't patch it in node_modules**: RN Android is consumed as the prebuilt com.facebook.react:react-android AAR, so the Kotlin source there is never recompiled. (RN issue to be filed upstream; link to follow.)

**Resolution**

Add an Android-only fallback in fetchMarketingURL: when response.url is empty or unchanged from the request, recover the destination from the already-downloaded landing-page HTML via its <link rel="canonical"> (falling back to og:url). iOS keeps using `response.url` and never reads the body — no behavior change or extra cost there.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

- 

#### Dev changes

- android deeplinking regression after react-native 83.6

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3157]: https://artsyproduct.atlassian.net/browse/PHIRE-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ