### PR TITLE
feat(DI-356): onboarding mode for Infinite Discovery

### DIFF
--- a/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
+++ b/src/app/Components/ArtworkLists/useSaveArtworkToArtworkLists.ts
@@ -9,11 +9,12 @@ import { graphql, useFragment } from "react-relay"
 interface Options extends Pick<SaveArtworkOptions, "onCompleted" | "onError"> {
   artworkFragmentRef: useSaveArtworkToArtworkLists_artwork$key
   saveToDefaultCollectionOnly?: boolean
+  suppressToasts?: boolean
 }
 
 export const useSaveArtworkToArtworkLists = (options: Options) => {
   const toast = useArtworkListToast(null)
-  const { artworkFragmentRef, onCompleted, ...restOptions } = options
+  const { artworkFragmentRef, onCompleted, suppressToasts, ...restOptions } = options
   const { artworkListID, removedArtworkIDs } = useArtworkListContext()
   const openSelectArtworkListsView = ArtworkListsStore.useStoreActions(
     (actions) => actions.openSelectArtworkListsView
@@ -58,6 +59,10 @@ export const useSaveArtworkToArtworkLists = (options: Options) => {
       }
 
       if (options.saveToDefaultCollectionOnly) {
+        return
+      }
+
+      if (suppressToasts) {
         return
       }
 

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,0 +1,22 @@
+import { Flex, Text } from "@artsy/palette-mobile"
+
+interface OnboardingProgressBadgeProps {
+  current: number
+  total: number
+}
+
+export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = ({
+  current,
+  total,
+}) => {
+  return (
+    <Flex borderRadius={50} borderWidth={1} borderColor="mono60" px={1} py={0.5}>
+      <Text variant="xs">
+        <Text variant="xs" fontWeight="500">
+          {current}
+        </Text>
+        /{total}
+      </Text>
+    </Flex>
+  )
+}

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -13,7 +13,7 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
     <Flex borderRadius={50} borderWidth={1} borderColor="mono60" px={1} py={0.5}>
       <Text variant="xs">
         <Text variant="xs" fontWeight="500">
-          {current}
+          {Math.min(current, total)}
         </Text>
         /{total}
       </Text>

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from "@artsy/palette-mobile"
+import { Flex, Text, useTextStyleForPalette } from "@artsy/palette-mobile"
 
 interface OnboardingProgressBadgeProps {
   current: number
@@ -9,13 +9,21 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   current,
   total,
 }) => {
+  const textStyle = useTextStyleForPalette("sm-display")
+
   return (
-    <Flex borderRadius={50} borderWidth={1} borderColor="mono60" px={1} py={0.5}>
-      <Text variant="xs">
-        <Text variant="xs" fontWeight="500">
-          {Math.min(current, total)}
-        </Text>
-        /{total}
+    <Flex
+      backgroundColor="blue100"
+      borderRadius={30}
+      // 1px vertical asymmetry compensates for Unica77's font metric offset
+      style={{ paddingHorizontal: 15, paddingTop: 5, paddingBottom: 4 }}
+      alignItems="center"
+      justifyContent="center"
+      alignSelf="flex-start"
+    >
+      {/* tabular-nums keeps all digits equal width so the pill doesn't resize as the count changes */}
+      <Text color="mono0" style={{ ...textStyle, fontVariant: ["tabular-nums"] }}>
+        {Math.min(current, total)}/{total}
       </Text>
     </Flex>
   )

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text, useTextStyleForPalette } from "@artsy/palette-mobile"
+import { Flex, Text } from "@artsy/palette-mobile"
 
 interface OnboardingProgressBadgeProps {
   current: number
@@ -9,8 +9,6 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   current,
   total,
 }) => {
-  const textStyle = useTextStyleForPalette("sm-display")
-
   return (
     <Flex
       backgroundColor="blue100"
@@ -22,7 +20,7 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
       alignSelf="flex-start"
     >
       {/* tabular-nums keeps all digits equal width so the pill doesn't resize as the count changes */}
-      <Text color="mono0" style={{ ...textStyle, fontVariant: ["tabular-nums"] }}>
+      <Text color="mono0" variant="sm-display" style={{ fontVariant: ["tabular-nums"] }}>
         {Math.min(current, total)}/{total}
       </Text>
     </Flex>

--- a/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
+++ b/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
@@ -1,0 +1,23 @@
+import { screen } from "@testing-library/react-native"
+import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("OnboardingProgressBadge", () => {
+  it("renders current and total", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={2} total={5} />)
+
+    expect(screen.getByText("2/5")).toBeOnTheScreen()
+  })
+
+  it("renders zero state", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={0} total={5} />)
+
+    expect(screen.getByText("0/5")).toBeOnTheScreen()
+  })
+
+  it("caps the displayed count at total when current exceeds it", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={7} total={5} />)
+
+    expect(screen.getByText("5/5")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -260,14 +260,14 @@ const HomeViewScreenComponent: React.FC = () => {
   const onboardingDestination = GlobalStore.useAppState(
     (state) => state.onboarding.onboardingDestination
   )
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
   const isNavigationReady = GlobalStore.useAppState((state) => state.sessionState.isNavigationReady)
   const theme = GlobalStore.useAppState((state) => state.devicePrefs.colorScheme)
 
   const isNavigatingToInfiniteDiscovery =
-    onboardingDestination === "infinite-discovery" || isOnboardingSession
+    onboardingDestination === "infinite-discovery" || isNewUserOnboardingSession
 
   const showPlayground = useDevToggle("DTShowPlayground")
 
@@ -288,7 +288,7 @@ const HomeViewScreenComponent: React.FC = () => {
         navigate("/art-quiz")
       })
     } else if (onboardingDestination === "infinite-discovery") {
-      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
       GlobalStore.actions.onboarding.setOnboardingDestination(null)
       requestAnimationFrame(() => {
         navigate("/infinite-discovery")

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -63,13 +63,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     // State to track the current image index
     const [currentImageIndex, setCurrentImageIndex] = useState(0)
 
-    const isOnboardingSession = GlobalStore.useAppState(
-      (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+    const isNewUserOnboardingSession = GlobalStore.useAppState(
+      (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
     )
 
     const { isSaved: isSavedToArtworkList, saveArtworkToLists } = useSaveArtworkToArtworkLists({
       artworkFragmentRef: artwork as NonNullable<InfiniteDiscoveryArtworkCard_artwork$data>,
-      suppressToasts: isOnboardingSession,
+      suppressToasts: isNewUserOnboardingSession,
       onCompleted: (isArtworkSaved) => {
         if (!!artwork) {
           track.savedArtwork(isArtworkSaved, artwork.internalID, artwork.slug)
@@ -85,7 +85,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
         if (isSaved) {
           // if the artwork is currently saved, we optimistically decremented the count, so increment it back
           incrementSavedArtworksCount()
-          if (isOnboardingSession && artwork) {
+          if (isNewUserOnboardingSession && artwork) {
             addOnboardingSavedArtworkImage({
               internalID: artwork.internalID,
               url: artwork.images[0]?.url ?? "",
@@ -95,7 +95,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
         } else {
           // if the artwork is currently unsaved, we optimistically incremented the count, so decrement it back
           decrementSavedArtworksCount()
-          if (isOnboardingSession && artwork) {
+          if (isNewUserOnboardingSession && artwork) {
             removeOnboardingSavedArtworkImage(artwork.internalID)
           }
         }
@@ -312,13 +312,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
               if (isSaved) {
                 // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
                 decrementSavedArtworksCount()
-                if (isOnboardingSession) {
+                if (isNewUserOnboardingSession) {
                   removeOnboardingSavedArtworkImage(artwork.internalID)
                 }
               } else {
                 // if the artwork is currently unsaved, it will become saved, so optimistically increment the count
                 incrementSavedArtworksCount()
-                if (isOnboardingSession) {
+                if (isNewUserOnboardingSession) {
                   addOnboardingSavedArtworkImage({
                     internalID: artwork.internalID,
                     url: artwork.images[0]?.url ?? "",

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -48,8 +48,12 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const track = useInfiniteDiscoveryTracking()
     const color = useColor()
-    const { incrementSavedArtworksCount, decrementSavedArtworksCount } =
-      GlobalStore.actions.infiniteDiscovery
+    const {
+      incrementSavedArtworksCount,
+      decrementSavedArtworksCount,
+      addOnboardingSavedArtworkImage,
+      removeOnboardingSavedArtworkImage,
+    } = GlobalStore.actions.infiniteDiscovery
 
     const artwork = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
       infiniteDiscoveryArtworkCardFragment,
@@ -81,9 +85,19 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
         if (isSaved) {
           // if the artwork is currently saved, we optimistically decremented the count, so increment it back
           incrementSavedArtworksCount()
+          if (isOnboardingSession && artwork) {
+            addOnboardingSavedArtworkImage({
+              internalID: artwork.internalID,
+              url: artwork.images[0]?.url ?? "",
+              blurhash: artwork.images[0]?.blurhash,
+            })
+          }
         } else {
           // if the artwork is currently unsaved, we optimistically incremented the count, so decrement it back
           decrementSavedArtworksCount()
+          if (isOnboardingSession && artwork) {
+            removeOnboardingSavedArtworkImage(artwork.internalID)
+          }
         }
       },
     })
@@ -298,9 +312,19 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
               if (isSaved) {
                 // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
                 decrementSavedArtworksCount()
+                if (isOnboardingSession) {
+                  removeOnboardingSavedArtworkImage(artwork.internalID)
+                }
               } else {
-                // if the artwork is currently unsaved, it will become saved, so optimistically decrement the count
+                // if the artwork is currently unsaved, it will become saved, so optimistically increment the count
                 incrementSavedArtworksCount()
+                if (isOnboardingSession) {
+                  addOnboardingSavedArtworkImage({
+                    internalID: artwork.internalID,
+                    url: artwork.images[0]?.url ?? "",
+                    blurhash: artwork.images[0]?.blurhash,
+                  })
+                }
               }
 
               saveArtworkToLists()

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -59,8 +59,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     // State to track the current image index
     const [currentImageIndex, setCurrentImageIndex] = useState(0)
 
+    const isOnboardingSession = GlobalStore.useAppState(
+      (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+    )
+
     const { isSaved: isSavedToArtworkList, saveArtworkToLists } = useSaveArtworkToArtworkLists({
       artworkFragmentRef: artwork as NonNullable<InfiniteDiscoveryArtworkCard_artwork$data>,
+      suppressToasts: isOnboardingSession,
       onCompleted: (isArtworkSaved) => {
         if (!!artwork) {
           track.savedArtwork(isArtworkSaved, artwork.internalID, artwork.slug)

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -51,8 +51,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
     const {
       incrementSavedArtworksCount,
       decrementSavedArtworksCount,
-      addOnboardingSavedArtworkImage,
-      removeOnboardingSavedArtworkImage,
+      addNewUserOnboardingSavedArtwork,
+      removeNewUserOnboardingSavedArtwork,
     } = GlobalStore.actions.infiniteDiscovery
 
     const artwork = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
@@ -86,7 +86,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           // if the artwork is currently saved, we optimistically decremented the count, so increment it back
           incrementSavedArtworksCount()
           if (isNewUserOnboardingSession && artwork) {
-            addOnboardingSavedArtworkImage({
+            addNewUserOnboardingSavedArtwork({
               internalID: artwork.internalID,
               url: artwork.images[0]?.url ?? "",
               blurhash: artwork.images[0]?.blurhash,
@@ -96,7 +96,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
           // if the artwork is currently unsaved, we optimistically incremented the count, so decrement it back
           decrementSavedArtworksCount()
           if (isNewUserOnboardingSession && artwork) {
-            removeOnboardingSavedArtworkImage(artwork.internalID)
+            removeNewUserOnboardingSavedArtwork(artwork.internalID)
           }
         }
       },
@@ -313,13 +313,13 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
                 // if the artwork is currently saved, it will become unsaved, so optimistically decrement the count
                 decrementSavedArtworksCount()
                 if (isNewUserOnboardingSession) {
-                  removeOnboardingSavedArtworkImage(artwork.internalID)
+                  removeNewUserOnboardingSavedArtwork(artwork.internalID)
                 }
               } else {
                 // if the artwork is currently unsaved, it will become saved, so optimistically increment the count
                 incrementSavedArtworksCount()
                 if (isNewUserOnboardingSession) {
-                  addOnboardingSavedArtworkImage({
+                  addNewUserOnboardingSavedArtwork({
                     internalID: artwork.internalID,
                     url: artwork.images[0]?.url ?? "",
                     blurhash: artwork.images[0]?.blurhash,

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
@@ -21,6 +21,9 @@ export const InfiniteDiscoveryArtworkCardPopover: React.FC<
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
 
   const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  )
 
   const showSaveAlertReminder1 =
     index === FIRST_REMINDER_SWIPES_COUNT &&
@@ -45,7 +48,12 @@ export const InfiniteDiscoveryArtworkCardPopover: React.FC<
     }
   }
 
-  if (isTopCard && !hasSavedArtworks && (showSaveAlertReminder1 || showSaveAlertReminder2)) {
+  if (
+    !isOnboardingSession &&
+    isTopCard &&
+    !hasSavedArtworks &&
+    (showSaveAlertReminder1 || showSaveAlertReminder2)
+  ) {
     return (
       <Popover
         visible

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
@@ -21,8 +21,8 @@ export const InfiniteDiscoveryArtworkCardPopover: React.FC<
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
 
   const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
 
   const showSaveAlertReminder1 =
@@ -49,7 +49,7 @@ export const InfiniteDiscoveryArtworkCardPopover: React.FC<
   }
 
   if (
-    !isOnboardingSession &&
+    !isNewUserOnboardingSession &&
     isTopCard &&
     !hasSavedArtworks &&
     (showSaveAlertReminder1 || showSaveAlertReminder2)

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -21,8 +21,8 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
   const onboardingSavedArtworkCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.onboardingSavedArtworkImages.length
@@ -73,7 +73,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     }
   }
 
-  if (isOnboardingSession) {
+  if (isNewUserOnboardingSession) {
     return (
       <Flex mb={1}>
         <Screen.Header

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
-import { DEFAULT_HIT_SLOP, Flex, Screen, Touchable } from "@artsy/palette-mobile"
+import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
+import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
@@ -20,9 +21,19 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  )
+  const savedArtworksCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.savedArtworksCount
+  )
 
   const handleExitPressed = () => {
     track.tappedExit()
+    goBack()
+  }
+
+  const handleSkipPressed = () => {
     goBack()
   }
 
@@ -60,6 +71,28 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     } else {
       handleSharePressed()
     }
+  }
+
+  if (isOnboardingSession) {
+    return (
+      <Flex mb={1}>
+        <Screen.Header
+          title="Discover Daily"
+          leftElements={<OnboardingProgressBadge current={savedArtworksCount} total={5} />}
+          rightElements={
+            <Touchable
+              accessibilityRole="button"
+              accessibilityLabel="Skip onboarding"
+              onPress={handleSkipPressed}
+              hitSlop={DEFAULT_HIT_SLOP}
+              haptic
+            >
+              <Text>Skip</Text>
+            </Touchable>
+          }
+        />
+      </Flex>
+    )
   }
 
   return (

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -24,7 +24,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const isNewUserOnboardingSession = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
-  const onboardingSavedArtworkCount = GlobalStore.useAppState(
+  const newUserOnboardingSavedArtworkCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
   )
 
@@ -78,11 +78,13 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
       <Flex mb={1}>
         <Screen.Header
           title="Discover Daily"
-          leftElements={<OnboardingProgressBadge current={onboardingSavedArtworkCount} total={5} />}
+          leftElements={
+            <OnboardingProgressBadge current={newUserOnboardingSavedArtworkCount} total={5} />
+          }
           rightElements={
             <Touchable
               accessibilityRole="button"
-              accessibilityLabel="Skip onboarding"
+              accessibilityLabel="Skip new user onboarding"
               onPress={handleSkipPressed}
               hitSlop={DEFAULT_HIT_SLOP}
               haptic

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -25,7 +25,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
   const onboardingSavedArtworkCount = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.onboardingSavedArtworkImages.length
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
   )
 
   const handleExitPressed = () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -24,8 +24,8 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const isOnboardingSession = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
   )
-  const savedArtworksCount = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.savedArtworksCount
+  const onboardingSavedArtworkCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.onboardingSavedArtworkImages.length
   )
 
   const handleExitPressed = () => {
@@ -78,7 +78,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
       <Flex mb={1}>
         <Screen.Header
           title="Discover Daily"
-          leftElements={<OnboardingProgressBadge current={savedArtworksCount} total={5} />}
+          leftElements={<OnboardingProgressBadge current={onboardingSavedArtworkCount} total={5} />}
           rightElements={
             <Touchable
               accessibilityRole="button"

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -59,7 +59,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
   useEffect(() => {
     const delay = isOnboardingSession ? 0 : 1000
     setTimeout(() => {
-      if (!hasInteractedWithOnboarding) {
+      if (isOnboardingSession || !hasInteractedWithOnboarding) {
         setIsVisible(true)
         // Make sure the user can tap to dismiss the onboarding only after a delay
         // This is required to make sure they can see the onboarding content

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -45,8 +45,8 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
 
   useEffect(() => {
@@ -57,9 +57,9 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
     }
   }, [isVisible])
   useEffect(() => {
-    const delay = isOnboardingSession ? 0 : 1000
+    const delay = isNewUserOnboardingSession ? 0 : 1000
     setTimeout(() => {
-      if (isOnboardingSession || !hasInteractedWithOnboarding) {
+      if (isNewUserOnboardingSession || !hasInteractedWithOnboarding) {
         setIsVisible(true)
         // Make sure the user can tap to dismiss the onboarding only after a delay
         // This is required to make sure they can see the onboarding content
@@ -192,7 +192,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
                   <Spacer y={1} />
 
-                  {isOnboardingSession ? (
+                  {isNewUserOnboardingSession ? (
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
                       Save{" "}
                       <Text variant="lg-display" fontWeight="500">
@@ -219,7 +219,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
                   <MotiView animate={{ opacity: enableTapToDismiss ? 1 : 0 }}>
                     <Flex alignItems="flex-end">
                       <LinkText onPress={() => setIsVisible(false)}>
-                        {isOnboardingSession ? "Tap to start swiping" : "Tap to get started"}
+                        {isNewUserOnboardingSession ? "Tap to start swiping" : "Tap to get started"}
                       </LinkText>
                     </Flex>
                   </MotiView>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -68,7 +68,8 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
         }, 1500)
       }
     }, delay)
-  }, [hasInteractedWithOnboarding, isOnboardingSession])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     if (isVisible) {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -77,7 +77,7 @@ describe("InfiniteDiscoveryHeader", () => {
     jest.clearAllMocks()
     ;(mockAddListener as any).beforeRemoveCallback = undefined
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
-    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnabledDiscoverDailyNegativeSignals: false })
     ;(RNShare.open as jest.Mock).mockResolvedValue({ success: true, message: "shared" })
   })
@@ -113,7 +113,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
   describe("in onboarding mode", () => {
     beforeEach(() => {
-      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
     })
 
     it("shows the progress badge instead of the exit chevron", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -9,8 +9,8 @@ const mockGoBack = jest.fn()
 const mockNavigate = jest.fn()
 
 jest.mock("app/system/navigation/navigate", () => ({
-  goBack: mockGoBack,
-  navigate: mockNavigate,
+  goBack: (...args: any[]) => mockGoBack(...args),
+  navigate: (...args: any[]) => mockNavigate(...args),
 }))
 
 jest.mock("react-native-share", () => ({
@@ -77,6 +77,7 @@ describe("InfiniteDiscoveryHeader", () => {
     jest.clearAllMocks()
     ;(mockAddListener as any).beforeRemoveCallback = undefined
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
+    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnabledDiscoverDailyNegativeSignals: false })
     ;(RNShare.open as jest.Mock).mockResolvedValue({ success: true, message: "shared" })
   })
@@ -108,6 +109,50 @@ describe("InfiniteDiscoveryHeader", () => {
         description: expect.anything(),
       })
     )
+  })
+
+  describe("in onboarding mode", () => {
+    beforeEach(() => {
+      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+    })
+
+    it("shows the progress badge instead of the exit chevron", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      expect(screen.getByText("0/5")).toBeOnTheScreen()
+      expect(screen.queryByTestId("close-icon")).not.toBeOnTheScreen()
+    })
+
+    it("reflects the current saved artworks count in the badge", () => {
+      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      expect(screen.getByText("2/5")).toBeOnTheScreen()
+    })
+
+    it("shows a Skip button instead of the share/more button", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
+
+      expect(screen.getByText("Skip")).toBeOnTheScreen()
+      expect(screen.queryByTestId("top-right-icon")).not.toBeOnTheScreen()
+    })
+
+    it("calls goBack when Skip is pressed", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      fireEvent.press(screen.getByLabelText("Skip onboarding"))
+
+      expect(mockGoBack).toHaveBeenCalled()
+    })
+
+    it("suppresses the save summary toast when navigating away", () => {
+      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+      renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
+      ;(mockAddListener as any).beforeRemoveCallback()
+
+      expect(mockUseToast.show).not.toHaveBeenCalled()
+    })
   })
 
   describe("when negative signals feature flag is enabled", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -124,11 +124,11 @@ describe("InfiniteDiscoveryHeader", () => {
     })
 
     it("reflects the current saved artworks count in the badge", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-2",
         url: "https://example.com/2.jpg",
       })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -111,7 +111,7 @@ describe("InfiniteDiscoveryHeader", () => {
     )
   })
 
-  describe("in onboarding mode", () => {
+  describe("in new user onboarding mode", () => {
     beforeEach(() => {
       GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
     })
@@ -147,7 +147,7 @@ describe("InfiniteDiscoveryHeader", () => {
     it("calls goBack when Skip is pressed", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      fireEvent.press(screen.getByLabelText("Skip onboarding"))
+      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
 
       expect(mockGoBack).toHaveBeenCalled()
     })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -124,8 +124,14 @@ describe("InfiniteDiscoveryHeader", () => {
     })
 
     it("reflects the current saved artworks count in the badge", () => {
-      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
-      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-2",
+        url: "https://example.com/2.jpg",
+      })
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
       expect(screen.getByText("2/5")).toBeOnTheScreen()

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -1,0 +1,75 @@
+import { act, screen } from "@testing-library/react-native"
+import { InfiniteDiscoveryOnboarding } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding"
+import { GlobalStore } from "app/store/GlobalStore"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+jest.mock("app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper", () => ({
+  Swiper: () => null,
+}))
+
+jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
+  useInfiniteDiscoveryTracking: () => ({ onboardingView: jest.fn() }),
+}))
+
+describe("InfiniteDiscoveryOnboarding", () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+    GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(false)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe("in onboarding session", () => {
+    beforeEach(() => {
+      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+    })
+
+    it("shows the overlay", () => {
+      renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
+
+      act(() => {
+        jest.runAllTimers()
+      })
+
+      expect(screen.getByText("Welcome to Discover Daily")).toBeOnTheScreen()
+    })
+
+    it("shows the onboarding-specific save prompt", () => {
+      renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
+
+      act(() => {
+        jest.runAllTimers()
+      })
+
+      expect(screen.getByText(/different artworks to build your taste profile/)).toBeOnTheScreen()
+    })
+  })
+
+  describe("when not in onboarding session", () => {
+    it("shows the overlay after 1 second on first visit", () => {
+      renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
+
+      expect(screen.queryByText("Welcome to Discover Daily")).not.toBeOnTheScreen()
+
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      expect(screen.getByText("Welcome to Discover Daily")).toBeOnTheScreen()
+    })
+
+    it("does not show the overlay for a returning visitor", () => {
+      GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(true)
+      renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
+
+      act(() => {
+        jest.runAllTimers()
+      })
+
+      expect(screen.queryByText("Welcome to Discover Daily")).not.toBeOnTheScreen()
+    })
+  })
+})

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -14,7 +14,7 @@ jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () 
 describe("InfiniteDiscoveryOnboarding", () => {
   beforeEach(() => {
     jest.useFakeTimers()
-    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
     GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(false)
   })
 
@@ -24,7 +24,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
 
   describe("in onboarding session", () => {
     beforeEach(() => {
-      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(true)
+      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
     })
 
     it("shows the overlay", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -22,7 +22,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
     jest.useRealTimers()
   })
 
-  describe("in onboarding session", () => {
+  describe("in new user onboarding session", () => {
     beforeEach(() => {
       GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
     })
@@ -48,7 +48,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
     })
   })
 
-  describe("when not in onboarding session", () => {
+  describe("when not in new user onboarding session", () => {
     it("shows the overlay after 1 second on first visit", () => {
       renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
 

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -40,6 +40,9 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  )
 
   useEffect(() => {
     return () => {
@@ -158,8 +161,8 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
       return
     }
 
-    // If this is the first time the user swipes, dismiss the onboarding.
-    if (!hasInteractedWithOnboarding) {
+    // If this is the first time the user swipes (outside of new user onboarding), dismiss the onboarding (tutorial).
+    if (!hasInteractedWithOnboarding && !isOnboardingSession) {
       GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(true)
     }
 

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -40,13 +40,13 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
 
   useEffect(() => {
     return () => {
-      GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
     }
   }, [])
 
@@ -162,7 +162,7 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
     }
 
     // If this is the first time the user swipes (outside of new user onboarding), dismiss the onboarding (tutorial).
-    if (!hasInteractedWithOnboarding && !isOnboardingSession) {
+    if (!hasInteractedWithOnboarding && !isNewUserOnboardingSession) {
       GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(true)
     }
 

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
@@ -14,9 +14,13 @@ export const useSavesSummaryToast = () => {
   const savedArtworksCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.savedArtworksCount
   )
+  const isOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  )
   const track = useInfiniteDiscoveryTracking()
 
   const showSavedCountToast = useCallback(() => {
+    if (isOnboardingSession) return
     if (savedArtworksCount > 0) {
       toast.show(
         `Nice! You saved ${savedArtworksCount} ${pluralize("artwork", savedArtworksCount)}.`,
@@ -36,7 +40,7 @@ export const useSavesSummaryToast = () => {
         }
       )
     }
-  }, [toast, savedArtworksCount, track])
+  }, [toast, savedArtworksCount, isOnboardingSession, track])
 
   useEffect(() => {
     const unsubscribe = addListener("beforeRemove", showSavedCountToast)

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
@@ -14,13 +14,13 @@ export const useSavesSummaryToast = () => {
   const savedArtworksCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.savedArtworksCount
   )
-  const isOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isOnboardingSession
+  const isNewUserOnboardingSession = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
   )
   const track = useInfiniteDiscoveryTracking()
 
   const showSavedCountToast = useCallback(() => {
-    if (isOnboardingSession) return
+    if (isNewUserOnboardingSession) return
     if (savedArtworksCount > 0) {
       toast.show(
         `Nice! You saved ${savedArtworksCount} ${pluralize("artwork", savedArtworksCount)}.`,
@@ -40,7 +40,7 @@ export const useSavesSummaryToast = () => {
         }
       )
     }
-  }, [toast, savedArtworksCount, isOnboardingSession, track])
+  }, [toast, savedArtworksCount, isNewUserOnboardingSession, track])
 
   useEffect(() => {
     const unsubscribe = addListener("beforeRemove", showSavedCountToast)

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -12,7 +12,7 @@ export interface InfiniteDiscoveryModel {
   savedArtworksCount: number
   sessionState: {
     moreInfoSheetVisible: boolean
-    isOnboardingSession: boolean
+    isNewUserOnboardingSession: boolean
     onboardingSavedArtworkImages: OnboardingSavedArtworkImage[]
   }
   incrementSavedArtworksCount: Action<this>
@@ -21,7 +21,7 @@ export interface InfiniteDiscoveryModel {
   setHasInteractedWithOnboarding: Action<this, boolean>
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
-  setIsOnboardingSession: Action<this, boolean>
+  setIsNewUserOnboardingSession: Action<this, boolean>
   addOnboardingSavedArtworkImage: Action<this, OnboardingSavedArtworkImage>
   removeOnboardingSavedArtworkImage: Action<this, string>
 }
@@ -32,7 +32,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   savedArtworksCount: 0,
   sessionState: {
     moreInfoSheetVisible: false,
-    isOnboardingSession: false,
+    isNewUserOnboardingSession: false,
     onboardingSavedArtworkImages: [],
   },
   incrementSavedArtworksCount: action((state) => {
@@ -54,8 +54,8 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   setMoreInfoSheetVisible: action((state, payload) => {
     state.sessionState.moreInfoSheetVisible = payload
   }),
-  setIsOnboardingSession: action((state, payload) => {
-    state.sessionState.isOnboardingSession = payload
+  setIsNewUserOnboardingSession: action((state, payload) => {
+    state.sessionState.isNewUserOnboardingSession = payload
   }),
   addOnboardingSavedArtworkImage: action((state, payload) => {
     const { onboardingSavedArtworkImages } = state.sessionState

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -1,6 +1,6 @@
 import { Action, action } from "easy-peasy"
 
-export interface OnboardingSavedArtworkImage {
+export interface NewUserOnboardingSavedArtwork {
   internalID: string
   url: string
   blurhash?: string | null
@@ -13,7 +13,7 @@ export interface InfiniteDiscoveryModel {
   sessionState: {
     moreInfoSheetVisible: boolean
     isNewUserOnboardingSession: boolean
-    onboardingSavedArtworkImages: OnboardingSavedArtworkImage[]
+    newUserOnboardingSavedArtworks: NewUserOnboardingSavedArtwork[]
   }
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
@@ -22,8 +22,8 @@ export interface InfiniteDiscoveryModel {
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
   setIsNewUserOnboardingSession: Action<this, boolean>
-  addOnboardingSavedArtworkImage: Action<this, OnboardingSavedArtworkImage>
-  removeOnboardingSavedArtworkImage: Action<this, string>
+  addNewUserOnboardingSavedArtwork: Action<this, NewUserOnboardingSavedArtwork>
+  removeNewUserOnboardingSavedArtwork: Action<this, string>
 }
 
 export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
@@ -33,7 +33,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   sessionState: {
     moreInfoSheetVisible: false,
     isNewUserOnboardingSession: false,
-    onboardingSavedArtworkImages: [],
+    newUserOnboardingSavedArtworks: [],
   },
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
@@ -43,7 +43,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   resetSavedArtworksCount: action((state) => {
     state.savedArtworksCount = 0
-    state.sessionState.onboardingSavedArtworkImages = []
+    state.sessionState.newUserOnboardingSavedArtworks = []
   }),
   setHasInteractedWithOnboarding: action((state, payload) => {
     state.hasInteractedWithOnboarding = payload
@@ -57,17 +57,17 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   setIsNewUserOnboardingSession: action((state, payload) => {
     state.sessionState.isNewUserOnboardingSession = payload
   }),
-  addOnboardingSavedArtworkImage: action((state, payload) => {
-    const { onboardingSavedArtworkImages } = state.sessionState
-    const alreadyAdded = onboardingSavedArtworkImages.some(
+  addNewUserOnboardingSavedArtwork: action((state, payload) => {
+    const { newUserOnboardingSavedArtworks } = state.sessionState
+    const alreadyAdded = newUserOnboardingSavedArtworks.some(
       (a) => a.internalID === payload.internalID
     )
-    if (!alreadyAdded && onboardingSavedArtworkImages.length < 5) {
-      onboardingSavedArtworkImages.push(payload)
+    if (!alreadyAdded && newUserOnboardingSavedArtworks.length < 5) {
+      newUserOnboardingSavedArtworks.push(payload)
     }
   }),
-  removeOnboardingSavedArtworkImage: action((state, internalID) => {
-    state.sessionState.onboardingSavedArtworkImages =
-      state.sessionState.onboardingSavedArtworkImages.filter((a) => a.internalID !== internalID)
+  removeNewUserOnboardingSavedArtwork: action((state, internalID) => {
+    state.sessionState.newUserOnboardingSavedArtworks =
+      state.sessionState.newUserOnboardingSavedArtworks.filter((a) => a.internalID !== internalID)
   }),
 })

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -1,5 +1,11 @@
 import { Action, action } from "easy-peasy"
 
+export interface OnboardingSavedArtworkImage {
+  internalID: string
+  url: string
+  blurhash?: string | null
+}
+
 export interface InfiniteDiscoveryModel {
   hasSavedArtworks: boolean
   hasInteractedWithOnboarding: boolean
@@ -7,6 +13,7 @@ export interface InfiniteDiscoveryModel {
   sessionState: {
     moreInfoSheetVisible: boolean
     isOnboardingSession: boolean
+    onboardingSavedArtworkImages: OnboardingSavedArtworkImage[]
   }
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
@@ -15,6 +22,8 @@ export interface InfiniteDiscoveryModel {
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
   setIsOnboardingSession: Action<this, boolean>
+  addOnboardingSavedArtworkImage: Action<this, OnboardingSavedArtworkImage>
+  removeOnboardingSavedArtworkImage: Action<this, string>
 }
 
 export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
@@ -24,6 +33,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   sessionState: {
     moreInfoSheetVisible: false,
     isOnboardingSession: false,
+    onboardingSavedArtworkImages: [],
   },
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
@@ -33,6 +43,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   resetSavedArtworksCount: action((state) => {
     state.savedArtworksCount = 0
+    state.sessionState.onboardingSavedArtworkImages = []
   }),
   setHasInteractedWithOnboarding: action((state, payload) => {
     state.hasInteractedWithOnboarding = payload
@@ -45,5 +56,18 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   setIsOnboardingSession: action((state, payload) => {
     state.sessionState.isOnboardingSession = payload
+  }),
+  addOnboardingSavedArtworkImage: action((state, payload) => {
+    const { onboardingSavedArtworkImages } = state.sessionState
+    const alreadyAdded = onboardingSavedArtworkImages.some(
+      (a) => a.internalID === payload.internalID
+    )
+    if (!alreadyAdded && onboardingSavedArtworkImages.length < 5) {
+      onboardingSavedArtworkImages.push(payload)
+    }
+  }),
+  removeOnboardingSavedArtworkImage: action((state, internalID) => {
+    state.sessionState.onboardingSavedArtworkImages =
+      state.sessionState.onboardingSavedArtworkImages.filter((a) => a.internalID !== internalID)
   }),
 })

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -3,7 +3,7 @@ import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 describe("InfiniteDiscoveryModel", () => {
   beforeEach(() => {
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
-    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
   })
 
   const state = () => __globalStoreTestUtils__?.getCurrentState().infiniteDiscovery

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -1,0 +1,99 @@
+import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
+
+describe("InfiniteDiscoveryModel", () => {
+  beforeEach(() => {
+    GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
+    GlobalStore.actions.infiniteDiscovery.setIsOnboardingSession(false)
+  })
+
+  const state = () => __globalStoreTestUtils__?.getCurrentState().infiniteDiscovery
+
+  describe("addOnboardingSavedArtworkImage", () => {
+    it("adds an artwork image", () => {
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+      expect(state()?.sessionState.onboardingSavedArtworkImages[0]).toMatchObject({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+    })
+
+    it("caps at 5 artworks", () => {
+      for (let i = 1; i <= 6; i++) {
+        GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(5)
+    })
+
+    it("stores the blurhash when provided", () => {
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+        blurhash: "LGFFaS%2IV00",
+      })
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages[0].blurhash).toBe("LGFFaS%2IV00")
+    })
+  })
+
+  describe("removeOnboardingSavedArtworkImage", () => {
+    it("removes the artwork with the given internalID", () => {
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-2",
+        url: "https://example.com/2.jpg",
+      })
+
+      GlobalStore.actions.infiniteDiscovery.removeOnboardingSavedArtworkImage("artwork-1")
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+      expect(state()?.sessionState.onboardingSavedArtworkImages[0].internalID).toBe("artwork-2")
+    })
+
+    it("is a no-op when the internalID is not in the list", () => {
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+
+      GlobalStore.actions.infiniteDiscovery.removeOnboardingSavedArtworkImage("does-not-exist")
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+    })
+  })
+
+  describe("resetSavedArtworksCount", () => {
+    it("clears onboardingSavedArtworkImages", () => {
+      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+
+      GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
+
+      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(0)
+    })
+
+    it("also resets savedArtworksCount", () => {
+      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+      GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
+
+      GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
+
+      expect(state()?.savedArtworksCount).toBe(0)
+    })
+  })
+})

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -8,15 +8,15 @@ describe("InfiniteDiscoveryModel", () => {
 
   const state = () => __globalStoreTestUtils__?.getCurrentState().infiniteDiscovery
 
-  describe("addOnboardingSavedArtworkImage", () => {
+  describe("addNewUserOnboardingSavedArtwork", () => {
     it("adds an artwork image", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
-      expect(state()?.sessionState.onboardingSavedArtworkImages[0]).toMatchObject({
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(1)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks[0]).toMatchObject({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
@@ -24,67 +24,67 @@ describe("InfiniteDiscoveryModel", () => {
 
     it("caps at 5 artworks", () => {
       for (let i = 1; i <= 6; i++) {
-        GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
           internalID: `artwork-${i}`,
           url: `https://example.com/${i}.jpg`,
         })
       }
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(5)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
     })
 
     it("stores the blurhash when provided", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
         blurhash: "LGFFaS%2IV00",
       })
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages[0].blurhash).toBe("LGFFaS%2IV00")
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks[0].blurhash).toBe("LGFFaS%2IV00")
     })
   })
 
-  describe("removeOnboardingSavedArtworkImage", () => {
+  describe("removeNewUserOnboardingSavedArtwork", () => {
     it("removes the artwork with the given internalID", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-2",
         url: "https://example.com/2.jpg",
       })
 
-      GlobalStore.actions.infiniteDiscovery.removeOnboardingSavedArtworkImage("artwork-1")
+      GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
-      expect(state()?.sessionState.onboardingSavedArtworkImages[0].internalID).toBe("artwork-2")
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(1)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks[0].internalID).toBe("artwork-2")
     })
 
     it("is a no-op when the internalID is not in the list", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
 
-      GlobalStore.actions.infiniteDiscovery.removeOnboardingSavedArtworkImage("does-not-exist")
+      GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("does-not-exist")
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(1)
     })
   })
 
   describe("resetSavedArtworksCount", () => {
-    it("clears onboardingSavedArtworkImages", () => {
-      GlobalStore.actions.infiniteDiscovery.addOnboardingSavedArtworkImage({
+    it("clears newUserOnboardingSavedArtworks", () => {
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-1",
         url: "https://example.com/1.jpg",
       })
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(1)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(1)
 
       GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
 
-      expect(state()?.sessionState.onboardingSavedArtworkImages).toHaveLength(0)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(0)
     })
 
     it("also resets savedArtworksCount", () => {


### PR DESCRIPTION
This PR resolves [DI-356](https://www.notion.so/375cab0764a080fcb506cba95539b653)

| iOS | Android
|-|-|
| https://github.com/user-attachments/assets/4f7501fc-c892-475c-9225-128c4d3b901f | https://github.com/user-attachments/assets/79fe0b27-d2e5-4248-886f-74ed51dd62b7 |

### Description

When `isOnboardingSession` is true (set by the onboarding flow before navigating to Infinite Discovery), the screen switches to an onboarding-specific UI:

- The header shows a save-progress badge (`n/5`) and a **Skip** button instead of the normal exit/share controls
- Per-action save/unsave toasts are suppressed (the save animation handles feedback instead)
- The exit summary toast is suppressed
- Save-reminder popovers (at swipe 5 and 30) are suppressed

Also adds `OnboardingProgressBadge` as a shared component, to be reused in the onboarding shell ([DI-353](https://www.notion.so/375cab0764a0804c94d3db98003ca501)).

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add onboarding mode to Infinite Discovery

<!-- end_changelog_updates -->

</details>

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> This change is related to [DI-350](https://www.notion.so/375cab0764a08000bbc8fcf7d0e2e9ed)