### PR TITLE
chore(releases): add jira url in output of export script, support sending slack message

### DIFF
--- a/scripts/utils/exportNotionTicketsToJira.ts
+++ b/scripts/utils/exportNotionTicketsToJira.ts
@@ -140,8 +140,13 @@ async function createJiraIssue(
     }
 
     const data = await response.json()
-    console.log(chalk.bold.green("Successfully created Jira issue:"))
-    console.log(JSON.stringify(data, null, 2))
+    const jiraUrl = `${JIRA_BASE_URL}/browse/${data.key}`
+    console.log(
+      chalk.bold.green(
+        `Successfully created Jira issue: ${data.key} — [${appName}] ${issueSummary}`
+      )
+    )
+    console.log(chalk.cyan(jiraUrl))
 
     return data.key
   } catch (error) {

--- a/scripts/utils/exportNotionTicketsToJira.ts
+++ b/scripts/utils/exportNotionTicketsToJira.ts
@@ -4,6 +4,7 @@
 "use strict"
 
 import { resolve } from "path"
+import readline from "readline"
 import chalk from "chalk"
 import { config } from "dotenv"
 import { hideBin } from "yargs/helpers"
@@ -25,6 +26,7 @@ const NOTION_API_TOKEN = process.env.NOTION_API_TOKEN
 const JIRA_BASE_URL = process.env.JIRA_BASE_URL
 const JIRA_EMAIL = process.env.JIRA_EMAIL
 const JIRA_API_TOKEN = process.env.JIRA_API_TOKEN
+const SLACK_URL = process.env.SLACK_URL
 
 if (!NOTION_API_TOKEN) {
   console.error(chalk.bold.red("Missing NOTION_API_TOKEN in environment variables."))
@@ -36,17 +38,24 @@ if (!JIRA_BASE_URL || !JIRA_EMAIL || !JIRA_API_TOKEN) {
   process.exit(1)
 }
 
-const argv = yargs(hideBin(process.argv)).option("app", {
-  describe: "App name to prepend to ticket titles",
-  choices: ["eigen", "energy"],
-  demandOption: true,
-  type: "string",
-}).argv as any
+const argv = yargs(hideBin(process.argv))
+  .option("app", {
+    describe: "App name to prepend to ticket titles",
+    choices: ["eigen", "energy"],
+    demandOption: true,
+    type: "string",
+  })
+  .option("test-slack", {
+    describe: "Preview and send the Slack message with dummy data without hitting Notion or Jira",
+    type: "boolean",
+    default: false,
+  }).argv as any
 
 const databaseId = argv._[0]
 const appName = argv.app
+const testSlack = argv["test-slack"]
 
-if (!databaseId) {
+if (!testSlack && !databaseId) {
   console.error(
     chalk.bold.red("Usage: yarn export-notion-to-jira <databaseId> --app <eigen|energy>")
   )
@@ -190,6 +199,7 @@ interface ValidIssue {
   severity: string
   team: string
   notionUrl: string
+  isLaunchBlocking: boolean
 }
 
 const severityMap = {
@@ -198,6 +208,58 @@ const severityMap = {
   P3: "P3 - Moderate",
   P4: "P4 - Low",
   P5: "P5 - Informal",
+}
+
+function formatLinkText(summary: string, maxLength = 80): string {
+  const cleaned = `${appName} ${summary}`
+    .replace(/[|<>]/g, "") // chars that break Slack's <url|text> mrkdwn format
+    .trim()
+  return cleaned.length > maxLength ? cleaned.slice(0, maxLength).trimEnd() + "…" : cleaned
+}
+
+function formatSlackLine(key: string, summary: string): string {
+  return `:red_circle: - <${JIRA_BASE_URL}/browse/${key}|${formatLinkText(summary)}>`
+}
+
+function buildSlackMessage(lines: string): string {
+  return `Thanks all for joining QA! We found the following launch blocking bugs which need volunteers - please shout if you want to work on any of them!\n${lines}`
+}
+
+function promptConfirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((resolve) => {
+    rl.question(`${question} (y/n): `, (answer) => {
+      rl.close()
+      resolve(answer.toLowerCase() === "y")
+    })
+  })
+}
+
+async function sendSlackMessage(text: string) {
+  if (!SLACK_URL) {
+    console.error(chalk.bold.red("Missing SLACK_URL in environment variables."))
+    return
+  }
+  const response = await fetch(SLACK_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed to send Slack message: ${response.status} ${response.statusText}`)
+  }
+  console.log(chalk.bold.green("Successfully sent Slack message"))
+}
+
+async function previewAndSend(slackMessage: string) {
+  console.log(chalk.bold.cyan("\n--- Launch blocker Slack message preview ---"))
+  console.log(slackMessage)
+  console.log(chalk.bold.cyan("--------------------------------------------\n"))
+
+  const shouldSend = await promptConfirm("Send this message to Slack?")
+  if (shouldSend) {
+    await sendSlackMessage(slackMessage)
+  }
 }
 
 async function main() {
@@ -231,8 +293,11 @@ async function main() {
         severity: fullSeverity,
         team,
         notionUrl: notionPageUrl,
+        isLaunchBlocking: status === "Launch Blocking",
       })
     }
+
+    const launchBlockers: Array<{ key: string; summary: string }> = []
 
     for (const issue of validIssues) {
       const issueKey = await createJiraIssue(
@@ -243,9 +308,31 @@ async function main() {
       )
       if (issueKey) {
         await updateJiraLabels(issueKey, [issue.team, "mobile"])
+        if (issue.isLaunchBlocking) {
+          launchBlockers.push({ key: issueKey, summary: issue.summary })
+        }
       }
+    }
+
+    if (launchBlockers.length > 0) {
+      const lines = launchBlockers
+        .map(({ key, summary }) => formatSlackLine(key, summary))
+        .join("\n")
+      await previewAndSend(buildSlackMessage(lines))
     }
   }
 }
 
-main().catch((err) => console.error(chalk.bold.red(err)))
+if (testSlack) {
+  const dummyBlockers = [
+    {
+      key: "PBRW-1894",
+      summary: `Inbox → Active bids - I can see Complete Registration for the bid that closes on Juna 8 4 days ago.`,
+    },
+    { key: "PBRW-1895", summary: `Android Pill text is being cut` },
+  ]
+  const lines = dummyBlockers.map(({ key, summary }) => formatSlackLine(key, summary)).join("\n")
+  previewAndSend(buildSlackMessage(lines)).catch((err) => console.error(chalk.bold.red(err)))
+} else {
+  main().catch((err) => console.error(chalk.bold.red(err)))
+}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

When exporting the notion bugs to jira we typically then send a slack message to the channel with any of the launch blockers linked. This updates the output to include jira links and adds optional slack message send after confirm.

Caveat: since the message is sent via webhook it can't be edited after the fact, which is a little unfortunate for updating statuses and assignees, but think reasonable to just copy it in thread once we have assignees and it will be editable. 

```
~/C/eigen (brian/qa-follow-ups|✚1) $ yarn export-notion-to-jira --app eigen --test-slack

--- Launch blocker Slack message preview ---
Thanks all for joining QA! We found the following launch blocking bugs which need volunteers - please shout if you want to work on any of them!
:red_circle: - <https://artsyproduct.atlassian.net/browse/PBRW-1894|eigen Inbox → Active bids - I can see Complete Registration for the bid that clo…>
:red_circle: - <https://artsyproduct.atlassian.net/browse/PBRW-1895|eigen Android Pill text is being cut>
--------------------------------------------

Send this message to Slack? (y/n): y
Successfully sent Slack message
```


<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- automate slack message for launch blockers - brian

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
