### PR TITLE
build(deps): bump macos gh runners from 15 to 26

### DIFF
--- a/.github/workflows/build-deploy-ios-firebase.yml
+++ b/.github/workflows/build-deploy-ios-firebase.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-firebase:
-    runs-on: ${{ github.event_name == 'schedule' && 'macos-15' || 'blacksmith-6vcpu-macos-26' }}
+    runs-on: ${{ github.event_name == 'schedule' && 'macos-26' || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-deploy-ios-testflight.yml
+++ b/.github/workflows/build-deploy-ios-testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-deploy-ios-testflight:
-    runs-on: ${{ github.event_name == 'schedule' && 'macos-15' || 'blacksmith-6vcpu-macos-26' }}
+    runs-on: ${{ github.event_name == 'schedule' && 'macos-26' || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 90
 
     steps:

--- a/.github/workflows/build-maestro-ios.yml
+++ b/.github/workflows/build-maestro-ios.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-ios-qa:
     if: github.ref == 'refs/heads/main'
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 120
 
     steps:

--- a/.github/workflows/expo-fingerprint-check.yml
+++ b/.github/workflows/expo-fingerprint-check.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   check-fingerprint:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 10
     outputs:
       fingerprint_changed: ${{ steps.compare.outputs.changed }}

--- a/.github/workflows/ios-e2e-maestro.yml
+++ b/.github/workflows/ios-e2e-maestro.yml
@@ -1,16 +1,18 @@
 name: iOS E2E Tests (Maestro)
 
 on:
-  workflow_run:
-    workflows: ["Build iOS QA App for Maestro"]
-    types:
-      - completed
-  workflow_dispatch: # Allows you to trigger the workflow manually from the Actions tab
-
+  # workflow_run:
+  #   workflows: ["Build iOS QA App for Maestro"]
+  #   types:
+  #     - completed
+  # workflow_dispatch: # Allows you to trigger the workflow manually from the Actions tab
+  push:
+    branches:
+      - gkartalis/bump-macos-runner
 jobs:
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: macos-15 # iOS simulators require macOS runners
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: macos-26 # iOS simulators require macOS runners
     timeout-minutes: 45
     strategy:
       fail-fast: false # Don't cancel other jobs if one fails

--- a/.github/workflows/ios-e2e-maestro.yml
+++ b/.github/workflows/ios-e2e-maestro.yml
@@ -1,17 +1,15 @@
 name: iOS E2E Tests (Maestro)
 
 on:
-  # workflow_run:
-  #   workflows: ["Build iOS QA App for Maestro"]
-  #   types:
-  #     - completed
-  # workflow_dispatch: # Allows you to trigger the workflow manually from the Actions tab
-  push:
-    branches:
-      - gkartalis/bump-macos-runner
+  workflow_run:
+    workflows: ["Build iOS QA App for Maestro"]
+    types:
+      - completed
+  workflow_dispatch: # Allows you to trigger the workflow manually from the Actions tab
+
 jobs:
   e2e-tests:
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: macos-26 # iOS simulators require macOS runners
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/ios-expo-build.yml
+++ b/.github/workflows/ios-expo-build.yml
@@ -31,7 +31,7 @@ jobs:
   ios-expo-cache-build:
     needs: check-build-needed
     if: ${{ needs.check-build-needed.outputs.needs_build == 'true' }}
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
     env:
       EXPO_BUILD_CACHE_UPLOAD: 1


### PR DESCRIPTION
This PR resolves [PHIRE-3179] <!-- eg [PROJECT-XXXX] -->

### Description

Bumping gh-runners to 26 from 15.

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- bump macos gh runners from 15 to 26

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3179]: https://artsyproduct.atlassian.net/browse/PHIRE-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ