### PR TITLE
feat(PartnerOffer): show the partner offer as purchased when collectors finalize the flow from a partner offer

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate.tsx
@@ -1,35 +1,47 @@
 import { MoneyFillIcon } from "@artsy/icons/native"
 import { Flex, Spacer } from "@artsy/palette-mobile"
+import { ConversationPartnerOfferUpdate_partnerOffer$key } from "__generated__/ConversationPartnerOfferUpdate_partnerOffer.graphql"
 import { ConversationEventRow } from "app/Scenes/Inbox/Components/Conversations/ConversationEventRow"
 import { TimeSince } from "app/Scenes/Inbox/Components/Conversations/TimeSince"
+import { graphql, useFragment } from "react-relay"
 
-/**
- * A synthetic, non-Relay event injected into the conversation timeline (see
- * `Messages`) to render a personalized partner offer — "You received an offer
- * for $X" — alongside the order-update events. The offer comes from
- * `me.partnerOffersConnection` (see `usePartnerOffer`), not from the order
- * history, which is why it is rendered separately from `OrderUpdate`.
- */
-export interface PartnerOfferConversationEvent {
-  __typename: "PartnerOfferEvent"
-  createdAt: string | null
-  amountDisplay: string | null
+export type PartnerOfferConversationEvent = ConversationPartnerOfferUpdate_partnerOffer$key & {
+  readonly __typename: "PartnerOfferToCollector"
+  readonly createdAt: string | null | undefined
+  readonly isPurchased: boolean
 }
 
 interface ConversationPartnerOfferUpdateProps {
-  event: PartnerOfferConversationEvent
+  partnerOffer: ConversationPartnerOfferUpdate_partnerOffer$key & { readonly isPurchased: boolean }
 }
 
 export const ConversationPartnerOfferUpdate: React.FC<ConversationPartnerOfferUpdateProps> = ({
-  event,
+  partnerOffer,
 }) => {
-  const message = event.amountDisplay
-    ? `You received an offer for ${event.amountDisplay}`
+  const data = useFragment(partnerOfferFragment, partnerOffer)
+
+  if (partnerOffer.isPurchased) {
+    return (
+      <Flex>
+        <ConversationEventRow
+          Icon={MoneyFillIcon}
+          iconFill="mono100"
+          message="You purchased this artwork"
+          textColor="mono100"
+        />
+        <Spacer y={2} />
+      </Flex>
+    )
+  }
+
+  const amountDisplay = data.priceWithDiscount?.display
+  const message = amountDisplay
+    ? `You received an offer for ${amountDisplay}`
     : "You received an offer"
 
   return (
     <Flex>
-      <TimeSince style={{ alignSelf: "center" }} time={event.createdAt} exact mb={1} />
+      <TimeSince style={{ alignSelf: "center" }} time={data.createdAt} exact mb={1} />
       <ConversationEventRow
         Icon={MoneyFillIcon}
         iconFill="mono100"
@@ -40,3 +52,12 @@ export const ConversationPartnerOfferUpdate: React.FC<ConversationPartnerOfferUp
     </Flex>
   )
 }
+
+const partnerOfferFragment = graphql`
+  fragment ConversationPartnerOfferUpdate_partnerOffer on PartnerOfferToCollector {
+    createdAt
+    priceWithDiscount {
+      display
+    }
+  }
+`

--- a/src/app/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/MessageGroup.tsx
@@ -115,14 +115,14 @@ export const MessageGroup: React.FC<MessageGroupProps> = ({
 
   // A partner offer isn't an order event; it's injected into the timeline by
   // `Messages` (only when the feature flag is on) and rendered on its own.
-  if (group[0].__typename === "PartnerOfferEvent") {
-    const onlyEvent = group[0] as PartnerOfferConversationEvent
+  if (group[0].__typename === "PartnerOfferToCollector") {
+    const onlyEvent = group[0]
     return (
       <>
         {!!isLastMessage && (
           <InitialMessage subjectItem={subjectItem} createdAt={onlyEvent.createdAt} />
         )}
-        <ConversationPartnerOfferUpdate event={onlyEvent} />
+        <ConversationPartnerOfferUpdate partnerOffer={onlyEvent} />
       </>
     )
   }

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -1,19 +1,17 @@
 import { GuaranteeIcon } from "@artsy/icons/native"
 import { Messages_conversation$data } from "__generated__/Messages_conversation.graphql"
-import { Messages_partnerOffers$key } from "__generated__/Messages_partnerOffers.graphql"
 import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
 import { ToastComponent } from "app/Components/Toast/ToastComponent"
 import { PAGE_SIZE } from "app/Components/constants"
-import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
+import { usePartnerOfferEvent } from "app/Scenes/Inbox/hooks/usePartnerOfferEvent"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { sortBy } from "lodash"
 import { DateTime } from "luxon"
 import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
-import { createPaginationContainer, graphql, RelayPaginationProp, useFragment } from "react-relay"
+import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
-import { PartnerOfferConversationEvent } from "./ConversationPartnerOfferUpdate"
 import { MessageGroup } from "./MessageGroup"
 import { ConversationItem, groupConversationItems } from "./utils/groupConversationItems"
 
@@ -42,26 +40,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
 
   const subjectArtwork = conversation.items?.[0]?.item
   const artworkId = subjectArtwork?.__typename === "Artwork" ? subjectArtwork.internalID : null
-  const { hasActivePartnerOffer, partnerOffers: partnerOffersRef } = usePartnerOffer({
-    me,
-    artworkId,
-  })
-  const partnerOffers = useFragment(
-    partnerOffersFragment,
-    partnerOffersRef as unknown as Messages_partnerOffers$key
-  )
-  const partnerOffer = partnerOffers?.find((offer) => offer.artworkId === artworkId)
-
-  const partnerOfferEvent: (PartnerOfferConversationEvent & { key: string; __id: string }) | null =
-    hasActivePartnerOffer && partnerOffer
-      ? {
-          __typename: "PartnerOfferEvent",
-          __id: "partner-offer-event",
-          key: "partner-offer-event",
-          createdAt: partnerOffer.createdAt ?? null,
-          amountDisplay: partnerOffer.priceWithDiscount?.display ?? null,
-        }
-      : null
+  const partnerOfferEvent = usePartnerOfferEvent({ me, artworkId, conversation })
 
   // Get all messages and give them a key for use with flatlist
   const allMessages = extractNodes(conversation.messagesConnection)
@@ -108,8 +87,8 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   }, [
     allOrderEvents.length,
     allMessages.length,
-    partnerOfferEvent?.__id,
     partnerOfferEvent?.createdAt,
+    partnerOfferEvent?.isPurchased,
   ])
 
   const flatList = useRef<FlatList>(null)
@@ -207,16 +186,6 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   )
 })
 
-const partnerOffersFragment = graphql`
-  fragment Messages_partnerOffers on PartnerOfferToCollector @relay(plural: true) {
-    artworkId
-    createdAt
-    priceWithDiscount {
-      display
-    }
-  }
-`
-
 export default createPaginationContainer(
   Messages,
   {
@@ -231,6 +200,7 @@ export default createPaginationContainer(
         to {
           name
         }
+        ...usePartnerOfferEvent_conversation
         orderConnection(first: 10, participantType: BUYER) {
           edges {
             node {

--- a/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationPartnerOfferUpdate.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationPartnerOfferUpdate.tests.tsx
@@ -1,33 +1,68 @@
 import { screen } from "@testing-library/react-native"
+import { ConversationPartnerOfferUpdateTestQuery } from "__generated__/ConversationPartnerOfferUpdateTestQuery.graphql"
 import { ConversationPartnerOfferUpdate } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+let isPurchased = false
+
+const { renderWithRelay } = setupTestWrapper<ConversationPartnerOfferUpdateTestQuery>({
+  Component: ({ artwork }) => (
+    <ConversationPartnerOfferUpdate
+      partnerOffer={{ ...artwork!.collectorSignals!.partnerOffer!, isPurchased }}
+    />
+  ),
+  query: graphql`
+    query ConversationPartnerOfferUpdateTestQuery @relay_test_operation {
+      artwork(id: "artwork-id") {
+        collectorSignals {
+          partnerOffer {
+            ...ConversationPartnerOfferUpdate_partnerOffer
+          }
+        }
+      }
+    }
+  `,
+})
 
 describe("ConversationPartnerOfferUpdate", () => {
+  beforeEach(() => {
+    isPurchased = false
+  })
+
   it("renders the offer message with the discounted price", () => {
-    renderWithWrappers(
-      <ConversationPartnerOfferUpdate
-        event={{
-          __typename: "PartnerOfferEvent",
-          createdAt: "2026-06-15T12:00:00Z",
-          amountDisplay: "US$450",
-        }}
-      />
-    )
+    renderWithRelay({
+      PartnerOfferToCollector: () => ({
+        createdAt: "2026-06-15T12:00:00Z",
+        priceWithDiscount: { display: "US$450" },
+      }),
+    })
 
     expect(screen.getByText("You received an offer for US$450")).toBeTruthy()
   })
 
   it("falls back to a generic message when there is no discounted price", () => {
-    renderWithWrappers(
-      <ConversationPartnerOfferUpdate
-        event={{
-          __typename: "PartnerOfferEvent",
-          createdAt: "2026-06-15T12:00:00Z",
-          amountDisplay: null,
-        }}
-      />
-    )
+    renderWithRelay({
+      PartnerOfferToCollector: () => ({
+        createdAt: "2026-06-15T12:00:00Z",
+        priceWithDiscount: null,
+      }),
+    })
 
     expect(screen.getByText("You received an offer")).toBeTruthy()
+  })
+
+  it("renders a purchase confirmation when the offer was fulfilled", () => {
+    isPurchased = true
+
+    renderWithRelay({
+      PartnerOfferToCollector: () => ({
+        createdAt: "2026-06-15T12:00:00Z",
+        priceWithDiscount: { display: "US$450" },
+      }),
+    })
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+    expect(screen.queryByText("You received an offer for US$450")).toBeNull()
   })
 })

--- a/src/app/Scenes/Inbox/hooks/usePartnerOffer.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOffer.ts
@@ -30,7 +30,7 @@ const fragment = graphql`
       edges {
         node {
           ...ConversationPartnerOfferCTA_partnerOffers
-          ...Messages_partnerOffers
+          ...usePartnerOfferEvent_partnerOffers
           internalID
           artworkId
           endAt

--- a/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
@@ -1,0 +1,80 @@
+import { usePartnerOfferEvent_conversation$key } from "__generated__/usePartnerOfferEvent_conversation.graphql"
+import { usePartnerOfferEvent_partnerOffers$key } from "__generated__/usePartnerOfferEvent_partnerOffers.graphql"
+import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
+import { PartnerOfferConversationEvent } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
+import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
+import { extractNodes } from "app/utils/extractNodes"
+import { graphql, useFragment } from "react-relay"
+
+interface UsePartnerOfferEventProps {
+  me: usePartnerOffer_me$key
+  artworkId?: string | null
+  conversation: usePartnerOfferEvent_conversation$key
+}
+
+/**
+ * Builds the partner-offer entry shown in the conversation timeline, hiding the
+ * Relay plumbing from `Messages`. It surfaces the matching offer when it is
+ * still active or once it has been fulfilled (purchased), and tags it with
+ * `isPurchased` so `ConversationPartnerOfferUpdate` can render the right state.
+ */
+export const usePartnerOfferEvent = ({
+  me,
+  artworkId,
+  conversation,
+}: UsePartnerOfferEventProps): PartnerOfferConversationEvent | null => {
+  const { hasActivePartnerOffer, partnerOffers: partnerOffersRef } = usePartnerOffer({
+    me,
+    artworkId,
+  })
+
+  const partnerOffers = useFragment(
+    partnerOffersFragment,
+    partnerOffersRef as unknown as usePartnerOfferEvent_partnerOffers$key
+  )
+  const { collectorOrdersConnection } = useFragment(conversationFragment, conversation)
+
+  const partnerOffer = partnerOffers?.find((offer) => offer.artworkId === artworkId)
+
+  if (!partnerOffer) {
+    return null
+  }
+
+  // The offer is fulfilled when one of the collector's orders has a line item
+  // tied to it; in that case we show a purchase confirmation instead of letting
+  // the offer expire after it ends.
+  const isPurchased = extractNodes(collectorOrdersConnection).some(
+    (order) =>
+      order.lineItems?.some((lineItem) => lineItem?.partnerOfferId === partnerOffer.internalID)
+  )
+
+  if (!hasActivePartnerOffer && !isPurchased) {
+    return null
+  }
+
+  return { ...partnerOffer, isPurchased }
+}
+
+const partnerOffersFragment = graphql`
+  fragment usePartnerOfferEvent_partnerOffers on PartnerOfferToCollector @relay(plural: true) {
+    __typename
+    internalID
+    artworkId
+    createdAt
+    ...ConversationPartnerOfferUpdate_partnerOffer
+  }
+`
+
+const conversationFragment = graphql`
+  fragment usePartnerOfferEvent_conversation on Conversation {
+    collectorOrdersConnection(first: 10) {
+      edges {
+        node {
+          lineItems {
+            partnerOfferId
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -171,9 +171,10 @@ export const features = {
     showInDevMenu: true,
   },
   AREnableConversationPartnerOffers: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Show partner offers in convos",
     showInDevMenu: true,
+    echoFlagKey: "AREnableConversationPartnerOffers",
   },
 } satisfies { [key: string]: FeatureDescriptor }
 


### PR DESCRIPTION
### Description

Shows a bubble as we do in Force in the convo when a partner offer leads to a completed purchase.
Also refactored the code in Messages.tsx around partner offer, abstracting the logic we use there into a hook wired with relay data.

| Platform |  |
|---|---|
| iOS | <img width="402" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-18 at 16 24 41" src="https://github.com/user-attachments/assets/551be5ee-a6de-4503-bc41-141155eecabb" /> |

cc @artsy/topaz-devs 


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: show a completed purchase bubble in convo when a partner offer leads to a purchase

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
