### PR TITLE
feat: add tracking for live refresh of wtyl

### DIFF
--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -23,6 +23,7 @@ import { useHomeViewExperimentTracking } from "app/Scenes/HomeView/hooks/useHome
 import { useHomeViewTracking } from "app/Scenes/HomeView/hooks/useHomeViewTracking"
 import { Playground } from "app/Scenes/Playground/Playground"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
@@ -66,7 +67,10 @@ export const HomeView: React.FC = memo(() => {
   )
   const bumpLiveRefetchKey = HomeViewStore.useStoreActions((actions) => actions.bumpLiveRefetchKey)
 
-  const enableLiveRecommendations = useEnableLiveHomeRecommendations()
+  const { enabled: enableLiveRecommendations } = useEnableLiveHomeRecommendations()
+  const { trackExperiment: trackLiveRecommendationsExperiment } = useExperimentVariant(
+    "onyx_artwork-recommendations-refresh-eigen"
+  )
 
   const [isRefreshing, setIsRefreshing] = useState(false)
 
@@ -139,13 +143,16 @@ export const HomeView: React.FC = memo(() => {
     }, [])
   )
 
-  // Proactively refresh the recommended artworks rail whenever the user returns to
-  // the home screen (e.g. pressing back from another part of the app). We use
-  // `useFocusEffect` (a navigation focus-event subscription) rather than detecting
-  // focus inside the rail, because inactive screens are frozen/detached
-  // (detachInactiveScreens defaults to true) and wouldn't reliably observe the
-  // transition. The first focus is skipped since the initial mount already loads
-  // fresh data. Driven entirely by navigation, so it never polls on its own.
+  // Track the live-recommendations experiment exposure once on mount (no-op until Unleash
+  // has resolved a variant).
+  useEffect(() => {
+    trackLiveRecommendationsExperiment()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Refresh the recommended artworks rail when the user returns to home. We use
+  // `useFocusEffect` rather than detecting focus inside the rail, since inactive screens are
+  // frozen/detached and wouldn't observe the transition. The first (mount) focus is skipped.
   const hasFocusedHomeOnce = useRef(false)
   useFocusEffect(
     useCallback(() => {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -44,8 +44,7 @@ interface HomeViewSectionArtworksProps extends FlexProps {
 
 const GRID_MAX_ARTWORKS_COUNT = 4
 
-// The home view section id for the personalized recommended artworks rail, scoped
-// to the live-recommendations refresh behavior (forced refetch + analytics re-firing).
+// Section id for the recommended artworks rail (the rail with live-refresh behavior).
 const RECOMMENDED_ARTWORKS_SECTION_ID = "home-view-section-recommended-artworks"
 
 export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = ({
@@ -58,7 +57,7 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
   const section = useFragment(fragment, sectionProp)
   const viewableSections = HomeViewStore.useStoreState((state) => state.viewableSections)
 
-  const enableLiveRecommendations = useEnableLiveHomeRecommendations()
+  const { enabled: enableLiveRecommendations } = useEnableLiveHomeRecommendations()
   const enableHidingDislikedArtworks = useFeatureFlag("AREnableHidingDislikedArtworks")
   const liveRefetchKey = HomeViewStore.useStoreState((state) => state.liveRefetchKey)
 
@@ -76,12 +75,9 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     contextModule,
   })
 
-  // Live recommendations: when the live refetch key is bumped (returning to the home
-  // screen or pull to refresh), force a fresh fetch of the rail's artworks. We re-fire
-  // impression tracking only in the `complete` callback — i.e. once the refreshed data
-  // is actually in the store — so railViewed and itemViewed reflect the new content
-  // rather than the stale rail. The forced fetch writes to the store, so the rail's
-  // useLazyLoadQuery re-renders in place with the fresh data.
+  // When the live refetch key is bumped (returning to home or pull to refresh), force a fresh
+  // fetch of the rail's artworks. Impression tracking is re-fired in `complete` — once the new
+  // data is in the store — so railViewed/itemViewed reflect the new content, not the stale rail.
   useEffect(() => {
     if (!isLiveRecommendationsRail || liveRefetchKey === 0) {
       return
@@ -299,7 +295,7 @@ export const HomeViewSectionArtworksQueryRenderer: React.FC<SectionSharedProps> 
   withSuspense({
     Component: ({ sectionID, index, refetchKey, ...flexProps }) => {
       const enableHidingDislikedArtworks = useFeatureFlag("AREnableHidingDislikedArtworks")
-      const enableLiveRecommendations = useEnableLiveHomeRecommendations()
+      const { enabled: enableLiveRecommendations } = useEnableLiveHomeRecommendations()
 
       const isLiveRecommendationsRail =
         enableLiveRecommendations && sectionID === RECOMMENDED_ARTWORKS_SECTION_ID
@@ -311,9 +307,8 @@ export const HomeViewSectionArtworksQueryRenderer: React.FC<SectionSharedProps> 
           enableHidingDislikedArtworks,
         },
         {
-          // Live sections refresh via a forced fetchQuery in the component (so analytics
-          // can fire on completion), which writes to the store and re-renders this query
-          // in place. They therefore ignore the shared refetchKey to avoid a double fetch.
+          // Live sections refresh via their own forced fetchQuery, so they ignore the shared
+          // refetchKey to avoid a double fetch.
           fetchKey: isLiveRecommendationsRail ? undefined : refetchKey,
           fetchPolicy: "store-and-network",
         }

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
@@ -6,8 +6,8 @@ import {
   HomeViewStoreProvider,
 } from "app/Scenes/HomeView/HomeViewContext"
 import { HomeViewSectionArtworks } from "app/Scenes/HomeView/Sections/HomeViewSectionArtworks"
+import { useEnableLiveHomeRecommendations } from "app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { navigate } from "app/system/navigation/navigate"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
@@ -17,11 +17,18 @@ import { FlatList } from "react-native"
 import { graphql } from "react-relay"
 import { MockPayloadGenerator } from "relay-test-utils"
 
-jest.mock("app/system/flags/hooks/useExperimentFlag", () => ({
-  useExperimentFlag: jest.fn(),
+jest.mock("app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations", () => ({
+  useEnableLiveHomeRecommendations: jest.fn(),
 }))
 
-const mockUseExperimentFlag = useExperimentFlag as jest.Mock
+const mockUseEnableLiveHomeRecommendations = useEnableLiveHomeRecommendations as jest.Mock
+
+const setLiveRecommendationsEnabled = (enabled: boolean) => {
+  mockUseEnableLiveHomeRecommendations.mockReturnValue({
+    enabled,
+    trackExperiment: jest.fn(),
+  })
+}
 
 let homeViewStoreActions: Actions<HomeViewStoreModel>
 
@@ -40,6 +47,7 @@ const HomeViewStoreVisitor: React.FC = () => {
 describe("HomeViewSectionArtworks", () => {
   beforeEach(() => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableHidingDislikedArtworks: true })
+    setLiveRecommendationsEnabled(false)
   })
 
   const { renderWithRelay } = setupTestWrapper<HomeViewSectionArtworksTestsQuery>({
@@ -409,12 +417,12 @@ describe("HomeViewSectionArtworks", () => {
         AREnableHidingDislikedArtworks: true,
         ARImpressionsTrackingHomeItemViews: true,
       })
-      // Both Unleash flags (eigen + gravity) on
-      mockUseExperimentFlag.mockReturnValue(true)
+      // Treatment arm with Gravity ready (both Unleash flags effectively on)
+      setLiveRecommendationsEnabled(true)
     })
 
     afterEach(() => {
-      mockUseExperimentFlag.mockReturnValue(false)
+      setLiveRecommendationsEnabled(false)
     })
 
     it("re-fires railViewed only after the live refresh completes", () => {
@@ -495,7 +503,7 @@ describe("HomeViewSectionArtworks", () => {
     })
 
     it("does not re-fire analytics when the flags are off", () => {
-      mockUseExperimentFlag.mockReturnValue(false)
+      setLiveRecommendationsEnabled(false)
 
       renderWithRelay({
         HomeViewSectionArtworks: () => RECOMMENDED_SECTION,

--- a/src/app/Scenes/HomeView/hooks/__tests__/useEnableLiveHomeRecommendations.tests.tsx
+++ b/src/app/Scenes/HomeView/hooks/__tests__/useEnableLiveHomeRecommendations.tests.tsx
@@ -1,53 +1,65 @@
-import { screen } from "@testing-library/react-native"
+import { renderHook } from "@testing-library/react-native"
 import { useEnableLiveHomeRecommendations } from "app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations"
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
-import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { Text } from "react-native"
+import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 
 jest.mock("app/system/flags/hooks/useExperimentFlag", () => ({
   useExperimentFlag: jest.fn(),
 }))
 
+jest.mock("app/system/flags/hooks/useExperimentVariant", () => ({
+  useExperimentVariant: jest.fn(),
+}))
+
 const mockUseExperimentFlag = useExperimentFlag as jest.Mock
+const mockUseExperimentVariant = useExperimentVariant as jest.Mock
 
-const TestComponent: React.FC = () => {
-  const enabled = useEnableLiveHomeRecommendations()
-  return <Text>{enabled ? "enabled" : "disabled"}</Text>
-}
-
-const isEnabled = ({
-  eigenFlag,
+const setup = ({
   gravityFlag,
+  variantName,
+  variantEnabled,
 }: {
-  eigenFlag: boolean
   gravityFlag: boolean
-}): boolean => {
+  variantName: string
+  variantEnabled: boolean
+}) => {
   mockUseExperimentFlag.mockImplementation((name: string) =>
-    name === "onyx_artwork-recommendations-refresh-eigen" ? eigenFlag : gravityFlag
+    name === "onyx_artwork-recommendations-gravity" ? gravityFlag : false
   )
+  mockUseExperimentVariant.mockReturnValue({
+    variant: { name: variantName, enabled: variantEnabled },
+    trackExperiment: jest.fn(),
+  })
 
-  renderWithWrappers(<TestComponent />)
-  return screen.queryByText("enabled") !== null
+  return renderHook(() => useEnableLiveHomeRecommendations())
 }
 
 describe("useEnableLiveHomeRecommendations", () => {
   afterEach(() => {
-    mockUseExperimentFlag.mockReset()
+    jest.clearAllMocks()
   })
 
-  it("is enabled only when both Unleash flags are on", () => {
-    expect(isEnabled({ eigenFlag: true, gravityFlag: true })).toBe(true)
+  it("enables the behavior only for the treatment arm when Gravity is ready", () => {
+    const { result } = setup({ gravityFlag: true, variantName: "variant", variantEnabled: true })
+
+    expect(result.current.enabled).toBe(true)
   })
 
-  it("is disabled when only the eigen flag is on", () => {
-    expect(isEnabled({ eigenFlag: true, gravityFlag: false })).toBe(false)
+  it("does not enable the behavior for the control arm", () => {
+    const { result } = setup({ gravityFlag: true, variantName: "control", variantEnabled: true })
+
+    expect(result.current.enabled).toBe(false)
   })
 
-  it("is disabled when only the gravity flag is on", () => {
-    expect(isEnabled({ eigenFlag: false, gravityFlag: true })).toBe(false)
+  it("is disabled when Gravity is not ready, even for the treatment arm", () => {
+    const { result } = setup({ gravityFlag: false, variantName: "variant", variantEnabled: true })
+
+    expect(result.current.enabled).toBe(false)
   })
 
-  it("is disabled when both flags are off", () => {
-    expect(isEnabled({ eigenFlag: false, gravityFlag: false })).toBe(false)
+  it("is disabled when the user has not been assigned a variant", () => {
+    const { result } = setup({ gravityFlag: true, variantName: "disabled", variantEnabled: false })
+
+    expect(result.current.enabled).toBe(false)
   })
 })

--- a/src/app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations.ts
+++ b/src/app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations.ts
@@ -1,16 +1,22 @@
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
+import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
+
+// Treatment arm of the eigen experiment. Must match the variant name configured in Unleash.
+const TREATMENT_VARIANT_NAME = "variant"
 
 /**
- * Live home recommendations (forced refresh of the recommended artworks rail +
- * analytics re-firing) are gated behind BOTH Unleash flags:
- * - `onyx_artwork-recommendations-refresh-eigen` — the eigen frontend rollout, and
- * - `onyx_artwork-recommendations-gravity` — backend readiness.
- *
- * The behavior is only enabled when both are on.
+ * Whether live home recommendations (forced refresh of the recommended artworks rail) should
+ * run. Enabled only for the treatment arm of the eigen experiment and when Gravity is ready.
  */
-export const useEnableLiveHomeRecommendations = (): boolean => {
-  const enabledForEigen = useExperimentFlag("onyx_artwork-recommendations-refresh-eigen")
+export const useEnableLiveHomeRecommendations = (): {
+  enabled: boolean
+} => {
+  const { variant } = useExperimentVariant("onyx_artwork-recommendations-refresh-eigen")
   const enabledForGravity = useExperimentFlag("onyx_artwork-recommendations-gravity")
 
-  return enabledForEigen && enabledForGravity
+  const enabled = enabledForGravity && variant.enabled && variant.name === TREATMENT_VARIANT_NAME
+
+  return {
+    enabled,
+  }
 }

--- a/src/app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations.ts
+++ b/src/app/Scenes/HomeView/hooks/useEnableLiveHomeRecommendations.ts
@@ -1,20 +1,13 @@
 import { useExperimentFlag } from "app/system/flags/hooks/useExperimentFlag"
 import { useExperimentVariant } from "app/system/flags/hooks/useExperimentVariant"
 
-// Treatment arm of the eigen experiment. Must match the variant name configured in Unleash.
-const TREATMENT_VARIANT_NAME = "variant"
-
-/**
- * Whether live home recommendations (forced refresh of the recommended artworks rail) should
- * run. Enabled only for the treatment arm of the eigen experiment and when Gravity is ready.
- */
 export const useEnableLiveHomeRecommendations = (): {
   enabled: boolean
 } => {
   const { variant } = useExperimentVariant("onyx_artwork-recommendations-refresh-eigen")
   const enabledForGravity = useExperimentFlag("onyx_artwork-recommendations-gravity")
 
-  const enabled = enabledForGravity && variant.enabled && variant.name === TREATMENT_VARIANT_NAME
+  const enabled = enabledForGravity && variant.enabled && variant.name === "variant"
 
   return {
     enabled,

--- a/src/app/system/flags/hooks/useExperimentVariant.ts
+++ b/src/app/system/flags/hooks/useExperimentVariant.ts
@@ -21,6 +21,8 @@ export function useExperimentVariant(name: EXPERIMENT_NAME): {
   ) as { variant: IVariant; overrideApplied: boolean }
 
   const trackExperiment = (contextProps?: ContextProps) => {
+    console.log("LOGD in useExperimentVariant for experiment", variant)
+
     if (!variant.enabled || overrideApplied) {
       if (__DEV__) {
         console.warn(

--- a/src/app/system/flags/hooks/useExperimentVariant.ts
+++ b/src/app/system/flags/hooks/useExperimentVariant.ts
@@ -21,7 +21,6 @@ export function useExperimentVariant(name: EXPERIMENT_NAME): {
   ) as { variant: IVariant; overrideApplied: boolean }
 
   const trackExperiment = (contextProps?: ContextProps) => {
-    console.log("LOGD in useExperimentVariant for experiment", variant)
 
     if (!variant.enabled || overrideApplied) {
       if (__DEV__) {


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->
Adding missing tracking to the wtyl live refresh 

- Adde "experiment" variant to unleash feature flag https://unleash.artsy.net/projects/default/features/onyx_artwork
- Added only one variant to be able to use tracking and satisfy the rollout plan (gradual, starting with 5 %)
- The experiment should be treated as a feature flag
<img width="1172" height="578" alt="image" src="https://github.com/user-attachments/assets/fd7db95f-4b95-40b8-ba22-85a03791881d" />

```
{
  "action": "experiment_viewed",
  "experiment_name": "onyx_artwork-recommendations-refresh-eigen",
  "variant_name": "experiment",
  "service": "unleash"
}
```
| iOS | Android |
|---|---|
| <video src="https://github.com/user-attachments/assets/1169bb4b-1b7d-4997-adf9-d176cd535fa2" width="400" /> | <video src="https://github.com/user-attachments/assets/73c60cad-8586-44bb-8fdc-f193652eca40" width="400" /> |


<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos emplate:
| Platform | Before | After |
|---|---|---|

| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Add missing tracking to the wtyl live refresh -daria

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
