### PR TITLE
fix: prevent Android back gesture from navigating back to onboarding introduction

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -20,7 +20,7 @@ import {
 } from "./config"
 
 export const Introduction: React.FC = () => {
-  const { navigate } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
+  const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
 
@@ -32,12 +32,12 @@ export const Introduction: React.FC = () => {
     (experience: Experience) => {
       if (experience === "beginner") {
         GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
-        navigate("InfiniteDiscovery")
+        replace("InfiniteDiscovery")
       } else {
-        navigate("FollowArtists")
+        replace("FollowArtists")
       }
     },
-    [navigate]
+    [replace]
   )
 
   const handleSkipToHome = useCallback(() => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { mockNavigate } from "app/utils/tests/navigationMocks"
+import { mockReplace } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 jest.mock("../Components/QuestionStep", () => {
@@ -79,7 +79,7 @@ describe("Introduction", () => {
       fireEvent.press(screen.getByText("Montage next"))
       fireEvent.press(screen.getByText("Welcome next"))
 
-      expect(mockNavigate).toHaveBeenCalledWith("InfiniteDiscovery")
+      expect(mockReplace).toHaveBeenCalledWith("InfiniteDiscovery")
     })
 
     it("completes onboarding when skipping to home from BrowsePromptStep", () => {
@@ -111,7 +111,7 @@ describe("Introduction", () => {
       fireEvent.press(screen.getByText("Montage next"))
       fireEvent.press(screen.getByText("Welcome next"))
 
-      expect(mockNavigate).toHaveBeenCalledWith("FollowArtists")
+      expect(mockReplace).toHaveBeenCalledWith("FollowArtists")
     })
   })
 })

--- a/src/app/utils/tests/navigationMocks.ts
+++ b/src/app/utils/tests/navigationMocks.ts
@@ -1,1 +1,2 @@
 export const mockNavigate = jest.fn()
+export const mockReplace = jest.fn()

--- a/src/setupJest.tsx
+++ b/src/setupJest.tsx
@@ -11,7 +11,7 @@ import { LegacyNativeModules } from "app/NativeModules/LegacyNativeModules"
 import { ScreenDimensionsWithSafeAreas } from "app/utils/hooks"
 import { mockPostEventToProviders, mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { mockFetchNotificationPermissions } from "app/utils/tests/mockFetchNotificationPermissions"
-import { mockNavigate } from "app/utils/tests/navigationMocks"
+import { mockNavigate, mockReplace } from "app/utils/tests/navigationMocks"
 import chalk from "chalk"
 import * as matchers from "jest-extended"
 import { NativeModules } from "react-native"
@@ -148,6 +148,7 @@ jest.mock("@react-navigation/native", () => {
     useIsFocused: () => jest.fn(),
     useNavigation: () => ({
       navigate: mockNavigate,
+      replace: mockReplace,
       dispatch: jest.fn(),
       addListener: jest.fn(),
       setOptions: jest.fn(),


### PR DESCRIPTION
On Android with gesture navigation, swiping from the left screen edge sends a `KEYCODE_BACK` event that React Navigation handles by popping the stack — this bypasses `gestureEnabled: false`, which only disables React Navigation's own swipe recognizer. When a user reaches `InfiniteDiscovery` via the onboarding `Introduction` screen, the back gesture would pop them back to the `WelcomeStep`.

The fix: use `replace` instead of `navigate` when advancing from `Introduction` to `InfiniteDiscovery` or `FollowArtists`. `replace` removes `Introduction` from the stack on the way out, so there is nothing to pop back to.

| Platform | Before | After |
|---|---|---|
| Android | https://github.com/user-attachments/assets/996c0fe5-9103-4bd9-ad12-6ac9002119bf | https://github.com/user-attachments/assets/6f5349c9-1131-4739-bb05-ec6a79bf7274 |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Android user-facing changes

- Fix: swiping back during onboarding no longer returns to a previous step.

<!-- end_changelog_updates -->

</details>

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

> This change is related to [DI-357](https://www.notion.so/375cab0764a0808a8746d73afc342d6e)