### PR TITLE
feat(DI-350): reorder intro sequence and restyle QuestionStep

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
@@ -7,7 +7,13 @@ const LOGO_TOP_OFFSET = 44
 export const Logo: React.FC = () => {
   const { top } = useSafeAreaInsets()
   return (
-    <Box position="absolute" top={`${top + LOGO_TOP_OFFSET}px`} left={2}>
+    <Box
+      position="absolute"
+      top={`${top + LOGO_TOP_OFFSET}px`}
+      left={0}
+      right={0}
+      alignItems="center"
+    >
       <ArtsyLogoIcon height={32} width={94} fill="mono0" />
     </Box>
   )

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -1,12 +1,9 @@
-import { Button, Flex, Spacer, Screen, Text } from "@artsy/palette-mobile"
-import {
-  AnimatedFadingPill,
-  FADE_OUT_PILL_ANIMATION_DURATION,
-  PillCheckmarkIcon,
-  PillIconPlaceholder,
-} from "app/Components/AnimatedFadingPill/AnimatedFadingPill"
+import { Button, Flex, Pill, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
+import { MotiView } from "moti"
 import { useState } from "react"
+import Animated, { Easing, FadeInUp } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { Logo } from "./Logo"
 
 export type Experience = "experienced" | "beginner"
 
@@ -17,8 +14,10 @@ const EXPERIENCE_OPTIONS: { label: string; experience: Experience }[] = [
   { label: "I'm just starting out and want to explore", experience: "beginner" },
 ]
 
-const SHOW_TICK_DELAY = FADE_OUT_PILL_ANIMATION_DURATION + 200
-const NAVIGATE_DELAY = SHOW_TICK_DELAY + 500
+const HORIZONTAL_MARGIN = 20
+const QUESTION_HEIGHT = 64
+const QUESTION_TOP_OFFSET = 112
+const QUESTION_SUBTITLE_GAP = 10
 
 interface QuestionStepProps {
   onSelect: (experience: Experience) => void
@@ -26,54 +25,85 @@ interface QuestionStepProps {
 
 export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
   const [selectedLabel, setSelectedLabel] = useState<string | null>(null)
-  const [hideUnselectedPills, setHideUnselectedPills] = useState(false)
-  const [showPillTick, setShowPillTick] = useState(false)
-  const { bottom } = useSafeAreaInsets()
+  const [questionSettled, setQuestionSettled] = useState(false)
+  const { top, bottom } = useSafeAreaInsets()
+  const { height: screenHeight } = useScreenDimensions()
 
   const handleContinue = () => {
     const option = EXPERIENCE_OPTIONS.find((o) => o.label === selectedLabel)
-    if (!option) return
-
-    setHideUnselectedPills(true)
-    setTimeout(() => setShowPillTick(true), SHOW_TICK_DELAY)
-    setTimeout(() => onSelect(option.experience), NAVIGATE_DELAY)
+    if (option) onSelect(option.experience)
   }
 
-  return (
-    <Screen>
-      <Screen.Body>
-        <Flex flex={1} flexDirection="column">
-          <Spacer y={2} />
-          <Text variant="lg-display">What is your art collecting experience?</Text>
-          <Spacer y={2} />
-          {EXPERIENCE_OPTIONS.map(({ label }) => {
-            const isSelected = selectedLabel === label
-            const isVisible = !hideUnselectedPills || isSelected
-            const Icon = showPillTick && isSelected ? PillCheckmarkIcon : PillIconPlaceholder
+  const questionEndTop = top + QUESTION_TOP_OFFSET
+  const questionStartTop = screenHeight / 2 - QUESTION_HEIGHT / 2
+  const translateYStart = questionStartTop - questionEndTop
 
-            return (
-              <Flex key={label}>
-                <AnimatedFadingPill
-                  isVisible={isVisible}
-                  selected={isSelected}
-                  Icon={Icon}
-                  onPress={() => !hideUnselectedPills && setSelectedLabel(label)}
-                >
-                  <Text variant="sm" lineHeight="16px" color={isSelected ? "mono0" : "mono100"}>
-                    {label}
-                  </Text>
-                </AnimatedFadingPill>
-                {!!isVisible && <Spacer y={2} />}
-              </Flex>
-            )
-          })}
-        </Flex>
-        <Flex pb={`${bottom}px`}>
-          <Button block disabled={!selectedLabel || hideUnselectedPills} onPress={handleContinue}>
-            Continue
-          </Button>
-        </Flex>
-      </Screen.Body>
-    </Screen>
+  return (
+    <Flex flex={1} backgroundColor="mono100">
+      <Logo />
+
+      <MotiView
+        style={{
+          position: "absolute",
+          top: questionEndTop,
+          left: HORIZONTAL_MARGIN,
+          right: HORIZONTAL_MARGIN,
+        }}
+        from={{ translateY: translateYStart }}
+        animate={{ translateY: 0 }}
+        transition={{ type: "timing", duration: 600, easing: Easing.out(Easing.quad) }}
+        onDidAnimate={(key, finished) => {
+          if (key === "translateY" && finished) setQuestionSettled(true)
+        }}
+      >
+        <Text variant="lg-display" color="mono0">
+          What is your art collecting experience?
+        </Text>
+      </MotiView>
+
+      {!!questionSettled && (
+        <Animated.View
+          entering={FadeInUp.duration(400).easing(Easing.out(Easing.quad))}
+          style={{
+            position: "absolute",
+            top: questionEndTop + QUESTION_HEIGHT + QUESTION_SUBTITLE_GAP,
+            left: HORIZONTAL_MARGIN,
+            right: HORIZONTAL_MARGIN,
+            bottom: 0,
+          }}
+        >
+          <Flex flex={1} flexDirection="column">
+            <Text variant="xs" color="mono30">
+              Please select one answer
+            </Text>
+            <Flex flex={1} justifyContent="center">
+              {EXPERIENCE_OPTIONS.map(({ label }) => {
+                const isSelected = selectedLabel === label
+                return (
+                  <Flex key={label} alignSelf="flex-start">
+                    <Pill
+                      variant="onboarding"
+                      selected={isSelected}
+                      alignSelf="flex-start"
+                      onPress={() => setSelectedLabel(label)}
+                    >
+                      <Text variant="xs" color="mono0">
+                        {label}
+                      </Text>
+                    </Pill>
+                    <Spacer y={2} />
+                  </Flex>
+                )
+              })}
+            </Flex>
+            <Flex pb={`${bottom}px`}>
+              <Button variant="fillLight" block disabled={!selectedLabel} onPress={handleContinue}>
+                Continue
+              </Button>
+            </Flex>
+          </Flex>
+        </Animated.View>
+      )}
+    </Flex>
   )
 }

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -51,67 +51,57 @@ describe("Introduction", () => {
     jest.clearAllMocks()
   })
 
-  it("shows the question step initially", () => {
+  it("shows the artwork montage step initially", () => {
     renderWithWrappers(<Introduction />)
+    expect(screen.getByText("Montage next")).toBeOnTheScreen()
+  })
+
+  it("routes through ArtworkMontageStep → WelcomeStep → QuestionStep in order", () => {
+    renderWithWrappers(<Introduction />)
+
+    fireEvent.press(screen.getByText("Montage next"))
+    expect(screen.getByText("Welcome next")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText("Welcome next"))
     expect(screen.getByText("Select beginner")).toBeOnTheScreen()
     expect(screen.getByText("Select experienced")).toBeOnTheScreen()
   })
 
-  describe("beginner path", () => {
-    it("routes through BrowsePromptStep → ArtworkMontageStep → WelcomeStep in order", () => {
+  describe("experienced path", () => {
+    it("navigates directly to FollowArtists", () => {
       renderWithWrappers(<Introduction />)
 
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
+      fireEvent.press(screen.getByText("Select experienced"))
+
+      expect(mockReplace).toHaveBeenCalledWith("FollowArtists")
+    })
+  })
+
+  describe("beginner path", () => {
+    it("routes through BrowsePromptStep before navigating to InfiniteDiscovery", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
       fireEvent.press(screen.getByText("Select beginner"))
       expect(screen.getByText("Browse next")).toBeOnTheScreen()
 
       fireEvent.press(screen.getByText("Browse next"))
-      expect(screen.getByText("Montage next")).toBeOnTheScreen()
-
-      fireEvent.press(screen.getByText("Montage next"))
-      expect(screen.getByText("Welcome next")).toBeOnTheScreen()
-    })
-
-    it("navigates to InfiniteDiscovery when done", () => {
-      renderWithWrappers(<Introduction />)
-
-      fireEvent.press(screen.getByText("Select beginner"))
-      fireEvent.press(screen.getByText("Browse next"))
-      fireEvent.press(screen.getByText("Montage next"))
-      fireEvent.press(screen.getByText("Welcome next"))
-
       expect(mockReplace).toHaveBeenCalledWith("InfiniteDiscovery")
     })
 
-    it("completes onboarding when skipping to home from BrowsePromptStep", () => {
+    it("completes onboarding when skipping from BrowsePromptStep", () => {
       renderWithWrappers(<Introduction />)
 
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
       fireEvent.press(screen.getByText("Select beginner"))
       fireEvent.press(screen.getByText("Browse skip"))
 
       const state = __globalStoreTestUtils__?.getCurrentState()
       expect(state?.onboarding.onboardingState).toBe("complete")
-    })
-  })
-
-  describe("experienced path", () => {
-    it("skips BrowsePromptStep and routes ArtworkMontageStep → WelcomeStep", () => {
-      renderWithWrappers(<Introduction />)
-
-      fireEvent.press(screen.getByText("Select experienced"))
-      expect(screen.getByText("Montage next")).toBeOnTheScreen()
-
-      fireEvent.press(screen.getByText("Montage next"))
-      expect(screen.getByText("Welcome next")).toBeOnTheScreen()
-    })
-
-    it("navigates to FollowArtists when done", () => {
-      renderWithWrappers(<Introduction />)
-
-      fireEvent.press(screen.getByText("Select experienced"))
-      fireEvent.press(screen.getByText("Montage next"))
-      fireEvent.press(screen.getByText("Welcome next"))
-
-      expect(mockReplace).toHaveBeenCalledWith("FollowArtists")
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/config.ts
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/config.ts
@@ -1,13 +1,12 @@
-import { WorkflowEngine } from "app/utils/WorkflowEngine/WorkflowEngine"
 import { useCallback, useRef, useState } from "react"
 import { Experience } from "./Components/QuestionStep"
 
-export const STEP_QUESTION = "question"
-export const STEP_BROWSE_PROMPT = "browse_prompt"
 export const STEP_ARTWORK_MONTAGE = "artwork_montage"
 export const STEP_WELCOME = "welcome"
+export const STEP_QUESTION = "question"
+export const STEP_BROWSE_PROMPT = "browse_prompt"
 
-const CHECK_EXPERIENCE = "check_experience"
+const STEPS = [STEP_ARTWORK_MONTAGE, STEP_WELCOME, STEP_QUESTION, STEP_BROWSE_PROMPT]
 
 interface UseConfigProps {
   onDone: (experience: Experience) => void
@@ -15,41 +14,27 @@ interface UseConfigProps {
 
 export const useConfig = ({ onDone }: UseConfigProps) => {
   const experienceRef = useRef<Experience | null>(null)
-
-  const workflowEngine = useRef(
-    new WorkflowEngine({
-      workflow: [
-        STEP_QUESTION,
-        {
-          [CHECK_EXPERIENCE]: {
-            beginner: [STEP_BROWSE_PROMPT, STEP_ARTWORK_MONTAGE, STEP_WELCOME],
-            experienced: [STEP_ARTWORK_MONTAGE, STEP_WELCOME],
-          },
-        },
-      ],
-      conditions: {
-        [CHECK_EXPERIENCE]: () => experienceRef.current ?? "experienced",
-      },
-    })
-  )
-
-  const [currentStep, setCurrentStep] = useState(workflowEngine.current.current())
+  const [stepIndex, setStepIndex] = useState(0)
+  const currentStep = STEPS[stepIndex]
 
   const next = useCallback(() => {
-    if (workflowEngine.current.isEnd()) {
+    if (stepIndex >= STEPS.length - 1) {
       onDone(experienceRef.current ?? "experienced")
       return
     }
-    const nextStep = workflowEngine.current.next()
-    if (nextStep) setCurrentStep(nextStep)
-  }, [onDone])
+    setStepIndex((i) => i + 1)
+  }, [stepIndex, onDone])
 
   const selectExperience = useCallback(
     (experience: Experience) => {
       experienceRef.current = experience
-      next()
+      if (experience === "experienced") {
+        onDone(experience)
+      } else {
+        next()
+      }
     },
-    [next]
+    [next, onDone]
   )
 
   return { currentStep, next, selectExperience }


### PR DESCRIPTION
This PR resolves [DI-350]

The designs for the intro sequence are still being worked on, but I had some free time so I refactored it to match [the current state](https://www.figma.com/design/nEGB6nhwoAO43egClr4QPh/Onboarding?node-id=284-171329&t=ri60ynjNtlmnYY9I-4) of these designs.

| iOS | Android |
|-|-|
| https://github.com/user-attachments/assets/ececb7f9-5e53-48d1-a39e-c44f6746e9d6 | https://github.com/user-attachments/assets/3e8ee7bf-8274-4289-96ba-cedcd6cad2bd |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **iOS**.
  - [x] **Android**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### iOS user-facing changes

- Updated onboarding introduction sequence to match the latest designs.

<!-- end_changelog_updates -->

</details>

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

> This change is related to [DI-350](https://www.notion.so/DI-350)