### PR TITLE
chore(release): v9.12.0 RC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ android/                 # Android native code and Gradle project
 
 ## Workflow
 
+- When opening a pull request, always use the template at `docs/pull_request_template.md`
 - Do not import components/hooks/functions directly from a different Scene — extract shared code to `src/app/Components/` or `src/app/utils/`
 - When adding a screen with a corresponding artsy.net page, match the route path and enable deep linking (add to `AndroidManifest.xml` for Android)
 - Use independent `NavigationContainer` stacks for context-specific flows (multi-step forms, modal sequences) rather than adding global routes

--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -1587,7 +1587,7 @@ export const artsyDotNetRoutes = defineRoutes([
   },
   {
     path: "/favorites/follows",
-    name: "SavedArtworks",
+    name: "FollowedArtists",
     Component: SavedArtworks,
     options: {
       topTabsNavigatorOptions: {

--- a/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
+++ b/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
@@ -1,0 +1,106 @@
+import { screen } from "@testing-library/react-native"
+import { usePartnerOfferEvent_Test_Query } from "__generated__/usePartnerOfferEvent_Test_Query.graphql"
+import { ConversationPartnerOfferUpdate } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
+import { usePartnerOfferEvent } from "app/Scenes/Inbox/hooks/usePartnerOfferEvent"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+const futureISO = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
+
+const TestComponent = ({ me }: any) => {
+  const event = usePartnerOfferEvent({
+    me,
+    artworkId: "artwork-id",
+    conversation: me.conversation,
+  })
+
+  if (!event) {
+    return null
+  }
+
+  return <ConversationPartnerOfferUpdate partnerOffer={event} />
+}
+
+const { renderWithRelay } = setupTestWrapper<usePartnerOfferEvent_Test_Query>({
+  Component: ({ me }) => <TestComponent me={me} />,
+  query: graphql`
+    query usePartnerOfferEvent_Test_Query($conversationID: String!) @relay_test_operation {
+      me {
+        ...usePartnerOffer_me
+        conversation(id: $conversationID) {
+          ...usePartnerOfferEvent_conversation
+        }
+      }
+    }
+  `,
+  variables: { conversationID: "conversation-id" },
+})
+
+const activeOfferResolvers = (
+  orderOverrides: Record<string, unknown> = {},
+  offerOverrides: Record<string, unknown> = {}
+) => ({
+  Me: () => ({
+    partnerOffersConnection: {
+      edges: [
+        {
+          node: {
+            internalID: "partner-offer-id",
+            artworkId: "artwork-id",
+            endAt: futureISO(),
+            isAvailable: true,
+            priceWithDiscount: { display: "$450" },
+            ...offerOverrides,
+          },
+        },
+      ],
+    },
+    conversation: {
+      collectorOrdersConnection: {
+        edges: [
+          {
+            node: {
+              lineItems: [{ partnerOfferId: "partner-offer-id" }],
+              ...orderOverrides,
+            },
+          },
+        ],
+      },
+    },
+  }),
+})
+
+describe("usePartnerOfferEvent", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationPartnerOffers: true })
+  })
+
+  it("shows 'You purchased this artwork' when the order is SUBMITTED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "SUBMITTED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it("shows 'You purchased this artwork' when the order is APPROVED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "APPROVED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it("shows 'You purchased this artwork' when the order is COMPLETED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "COMPLETED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it.each(["INCOMPLETE", "CANCELED"])(
+    "does not show 'You purchased this artwork' when the order has buyerState %s",
+    (buyerState) => {
+      renderWithRelay(activeOfferResolvers({ buyerState }))
+
+      expect(screen.queryByText("You purchased this artwork")).toBeNull()
+      expect(screen.getByText("You received an offer for $450")).toBeTruthy()
+    }
+  )
+})

--- a/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
@@ -40,11 +40,14 @@ export const usePartnerOfferEvent = ({
     return null
   }
 
-  // The offer is fulfilled when one of the collector's orders has a line item
-  // tied to it; in that case we show a purchase confirmation instead of letting
-  // the offer expire after it ends.
+  // Only treat the offer as purchased if the order is in an active state
+  // (SUBMITTED, APPROVED, or COMPLETED) and has a line item tied to this offer.
+  // This prevents abandoned or canceled orders from showing a purchase confirmation.
+  const PURCHASED_BUYER_STATES = new Set(["SUBMITTED", "APPROVED", "COMPLETED"])
+
   const isPurchased = extractNodes(collectorOrdersConnection).some(
     (order) =>
+      PURCHASED_BUYER_STATES.has(order.buyerState ?? "") &&
       order.lineItems?.some((lineItem) => lineItem?.partnerOfferId === partnerOffer.internalID)
   )
 
@@ -70,6 +73,7 @@ const conversationFragment = graphql`
     collectorOrdersConnection(first: 10) {
       edges {
         node {
+          buyerState
           lineItems {
             partnerOfferId
           }

--- a/src/app/store/__tests__/persistenceMiddleware.tests.ts
+++ b/src/app/store/__tests__/persistenceMiddleware.tests.ts
@@ -1,10 +1,7 @@
-import { captureException } from "@sentry/react-native"
+import AsyncStorage from "@react-native-async-storage/async-storage"
 import { persistenceMiddleware } from "app/store/persistence"
-import { action, createStore as createEasyPeasyStore } from "easy-peasy"
-import { Immer } from "immer"
 import { applyMiddleware, createStore, Reducer } from "redux"
 
-jest.mock("@sentry/react-native")
 jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn().mockResolvedValue(undefined),
   getItem: jest.fn().mockResolvedValue(null),
@@ -12,32 +9,20 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 
 const makeStore = (reducer: Reducer) => createStore(reducer, applyMiddleware(persistenceMiddleware))
 
+// Flushes RAF callbacks and the resulting promise chain
+const flushAll = () => jest.runAllTimersAsync()
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.clearAllMocks()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 describe("persistenceMiddleware", () => {
-  it("does not throw when a reducer throws", () => {
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw new Error("Proxy handler is null")
-      return state
-    })
-
-    expect(() => store.dispatch({ type: "THROW" })).not.toThrow()
-  })
-
-  it("reports the caught error to Sentry as handled", () => {
-    const error = new Error("Proxy handler is null")
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw error
-      return state
-    })
-
-    store.dispatch({ type: "THROW" })
-
-    expect(captureException).toHaveBeenCalledWith(error, {
-      level: "error",
-      tags: { handled: "true" },
-    })
-  })
-
-  it("passes successful actions through and updates state normally", () => {
+  it("passes actions through and updates state normally", () => {
     const store = makeStore((state: { count: number } = { count: 0 }, action) => {
       if (action.type === "INCREMENT") return { count: state.count + 1 }
       return state
@@ -55,56 +40,76 @@ describe("persistenceMiddleware", () => {
     expect(result).toEqual({ type: "NOOP" })
   })
 
-  it("returns undefined when a reducer throws", () => {
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw new Error("boom")
+  it("calls AsyncStorage.setItem after the next animation frame", async () => {
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
       return state
     })
 
-    const result = store.dispatch({ type: "THROW" })
-    expect(result).toBeUndefined()
+    store.dispatch({ type: "SET", payload: "b" })
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled()
+
+    await flushAll()
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
   })
-})
 
-// Simulates the real EIGEN-AZR1 / EIGEN-AZA6 crash path:
-//   Hermes 0.14.1 on iOS 26 throws "TypeError: Proxy handler is null" inside
-//   immer's finishDraft() when revoking a Proxy — easy-peasy calls this after
-//   every action handler that mutates draft state (e.g. setIsReady).
-//   Without the try/catch in persistenceMiddleware the error propagates to
-//   RCTFatal → expo-updates recovery pipeline → intentional crash.
-describe("persistenceMiddleware — immer Proxy crash (EIGEN-AZR1 regression)", () => {
-  // Minimal model that mirrors the mutation pattern of the failing action:
-  //   ProgressiveOnboardingModel.setIsReady: action((state, v) => { state.sessionState.isReady = v })
-  const model = {
-    sessionState: { isReady: false },
-    setIsReady: action((state: any, value: boolean) => {
-      state.sessionState.isReady = value
-    }),
-  }
+  it("collapses multiple actions in the same frame into a single write", async () => {
+    const store = makeStore((state: { count: number } = { count: 0 }, action) => {
+      if (action.type === "INCREMENT") return { count: state.count + 1 }
+      return state
+    })
 
-  it("does not throw and reports to Sentry when immer finishDraft throws during dispatch", () => {
-    const store = createEasyPeasyStore(model, { middleware: [persistenceMiddleware] })
+    store.dispatch({ type: "INCREMENT" })
+    store.dispatch({ type: "INCREMENT" })
+    store.dispatch({ type: "INCREMENT" })
 
-    // Warm up: dispatch once so easy-peasy creates its internal Immer instance
-    store.getActions().setIsReady(false)
+    await flushAll()
 
-    // Patch Immer.prototype.finishDraft to simulate "Proxy handler is null" (Hermes 0.14.1 bug)
-    const originalFinishDraft = Immer.prototype.finishDraft
-    const proxyError = new TypeError("Proxy handler is null")
-    Immer.prototype.finishDraft = () => {
-      throw proxyError
-    }
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+  })
 
-    try {
-      // This must NOT propagate — persistenceMiddleware should swallow it
-      expect(() => store.getActions().setIsReady(true)).not.toThrow()
+  it("persists the latest state when multiple actions fire before the frame", async () => {
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
+      return state
+    })
 
-      expect(captureException).toHaveBeenCalledWith(proxyError, {
-        level: "error",
-        tags: { handled: "true" },
-      })
-    } finally {
-      Immer.prototype.finishDraft = originalFinishDraft
-    }
+    store.dispatch({ type: "SET", payload: "b" })
+    store.dispatch({ type: "SET", payload: "c" })
+
+    await flushAll()
+
+    const serialized = (AsyncStorage.setItem as jest.Mock).mock.calls[0][1]
+    expect(JSON.parse(serialized)).toMatchObject({ value: "c" })
+  })
+
+  it("writes are serialised — a second write waits for the first to finish", async () => {
+    let resolveFirst!: () => void
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    ;(AsyncStorage.setItem as jest.Mock)
+      .mockReturnValueOnce(firstWrite)
+      .mockResolvedValue(undefined)
+
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
+      return state
+    })
+
+    store.dispatch({ type: "SET", payload: "b" })
+    await flushAll()
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+
+    store.dispatch({ type: "SET", payload: "c" })
+    await flushAll()
+    // first write still in progress — second should not have started yet
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+
+    resolveFirst()
+    await flushAll()
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import { captureException } from "@sentry/react-native"
 import { State } from "easy-peasy"
-import { isArray, isBoolean, isNull, isNumber, isPlainObject, isString, throttle } from "lodash"
+import { isArray, isBoolean, isNull, isNumber, isPlainObject, isString } from "lodash"
 import { Middleware } from "redux"
 import { GlobalStoreModel } from "./GlobalStoreModel"
 import { migrate } from "./migration"
@@ -44,24 +43,33 @@ export function assignDeep(object: any, otherObject: any) {
   }
 }
 
-// Catches errors thrown by immer/reducers (e.g. the Hermes 0.14.1 "Proxy handler is null"
-// bug on iOS 26 — EIGEN-AZR1, EIGEN-AZA6) and reports them to Sentry without letting
-// them propagate to RCTFatal and crash the app. Also throttles state persistence.
+// Captures state synchronously after each action (while Immer Proxies are still alive),
+// then defers the AsyncStorage write to the next animation frame. Multiple actions in
+// the same frame collapse into a single write — mirroring easy-peasy's own persist middleware.
 export const persistenceMiddleware: Middleware = (api) => {
-  const throttledPersist = throttle(() => persist(api.getState()), 1000, {
-    leading: false,
-    trailing: true,
-  })
+  let rafHandle: ReturnType<typeof requestAnimationFrame> | null = null
+  let writeChain = Promise.resolve()
 
   return (next) => (action) => {
-    try {
-      const result = next(action)
-      throttledPersist()
-      return result
-    } catch (e) {
-      captureException(e, { level: "error", tags: { handled: "true" } })
-      return undefined
+    const result = next(action)
+    const state = api.getState()
+
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle)
     }
+
+    rafHandle = requestAnimationFrame(() => {
+      writeChain = writeChain
+        .then(() => persist(state))
+        .catch((e) => {
+          if (__DEV__) {
+            console.error("Failed to persist store state", e)
+          }
+        })
+      rafHandle = null
+    })
+
+    return result
   }
 }
 


### PR DESCRIPTION
## Release Candidate 9.12.0

This branch was automatically created as the release candidate for version 9.12.0.

> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.

## Changelog

### Cross-platform user-facing changes
- feat: show partner offer in conversations — araujobarret (#13658)
- fix empty state for sale page - brian — brainbicycle (#13660)
- feat: track partner offer cta visibility in a conversation — araujobarret (#13664)
- feat: show a completed purchase bubble in convo when a partner offer leads to a purchase — araujobarret (#13676)
- Add missing tracking to the wtyl live refresh -daria — dariakoko (#13680)
- fix: smooth transitions between onboarding introduction steps — iskounen (#13677)
- adds a bottom sheet that notifies new users of their 5th saved artwork during onboarding — iskounen (#13681)

### iOS user-facing changes
- error message for limited login link failures - brian — brainbicycle (#13663)

### Android user-facing changes
- fix text cut off in onboarding - brian — brainbicycle (#13662)
- Fix: swiping back during onboarding no longer returns to a previous step. — iskounen (#13694)

### Dev changes
- Add experience-based onboarding shell behind `AREnableExperienceBasedOnboarding` flag — iskounen (#13646)
- Promote `AnimatedFadingPill` to `app/Components` (shared); remove local copy from `OnboardingQuiz` — iskounen (#13646)
- `InfiniteDiscovery` onboarding overlay now skips 1s delay when navigated from the new onboarding flow — iskounen (#13646)
- fix changelog missing merged prs - brian — brainbicycle (#13653)
- automate slack message for launch blockers - brian — brainbicycle (#13657)
- fix shell quote vulnerability — gkartalis (#13671)
- remove old sale artworks connection feature flag and associated code - brian — brainbicycle (#13661)
- Add onboarding mode to Infinite Discovery — iskounen (#13654)
- bump react-native-pager-view to latest — gkartalis (#13670)
- Beginner onboarding now transitions directly into Infinite Discovery via the Onboarding navigator, removing the HomeView relay and flash of home screen — iskounen (#13673)
- Tab bar visibility is now determined when the tab is mounted. — iskounen (#13673)
- remove obsolete patch for React Native — gkartalis (#13678)
- specify platform as 'ios' in deliver calls for beta promotion and version creation — gkartalis (#13684)
- bump macos gh runners from 15 to 26 — gkartalis (#13675)
- fix: iOS build adjust for XCode 26.5 — araujobarret (#13659)
- typeError proxy handler is null — MounirDhahri (#13687)
- revert app start errors from sentry — gkartalis (#13688)
- Extract save logic from `InfiniteDiscoveryArtworkCard` into `useInfiniteDiscoveryCardSave` hook. — iskounen (#13695)

#nochangelog
