### PR TITLE
fix: Filter out orders that are abandoned or canceled when displaying upda…

### DIFF
--- a/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
+++ b/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
@@ -1,0 +1,106 @@
+import { screen } from "@testing-library/react-native"
+import { usePartnerOfferEvent_Test_Query } from "__generated__/usePartnerOfferEvent_Test_Query.graphql"
+import { ConversationPartnerOfferUpdate } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
+import { usePartnerOfferEvent } from "app/Scenes/Inbox/hooks/usePartnerOfferEvent"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+const futureISO = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
+
+const TestComponent = ({ me }: any) => {
+  const event = usePartnerOfferEvent({
+    me,
+    artworkId: "artwork-id",
+    conversation: me.conversation,
+  })
+
+  if (!event) {
+    return null
+  }
+
+  return <ConversationPartnerOfferUpdate partnerOffer={event} />
+}
+
+const { renderWithRelay } = setupTestWrapper<usePartnerOfferEvent_Test_Query>({
+  Component: ({ me }) => <TestComponent me={me} />,
+  query: graphql`
+    query usePartnerOfferEvent_Test_Query($conversationID: String!) @relay_test_operation {
+      me {
+        ...usePartnerOffer_me
+        conversation(id: $conversationID) {
+          ...usePartnerOfferEvent_conversation
+        }
+      }
+    }
+  `,
+  variables: { conversationID: "conversation-id" },
+})
+
+const activeOfferResolvers = (
+  orderOverrides: Record<string, unknown> = {},
+  offerOverrides: Record<string, unknown> = {}
+) => ({
+  Me: () => ({
+    partnerOffersConnection: {
+      edges: [
+        {
+          node: {
+            internalID: "partner-offer-id",
+            artworkId: "artwork-id",
+            endAt: futureISO(),
+            isAvailable: true,
+            priceWithDiscount: { display: "$450" },
+            ...offerOverrides,
+          },
+        },
+      ],
+    },
+    conversation: {
+      collectorOrdersConnection: {
+        edges: [
+          {
+            node: {
+              lineItems: [{ partnerOfferId: "partner-offer-id" }],
+              ...orderOverrides,
+            },
+          },
+        ],
+      },
+    },
+  }),
+})
+
+describe("usePartnerOfferEvent", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationPartnerOffers: true })
+  })
+
+  it("shows 'You purchased this artwork' when the order is SUBMITTED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "SUBMITTED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it("shows 'You purchased this artwork' when the order is APPROVED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "APPROVED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it("shows 'You purchased this artwork' when the order is COMPLETED", () => {
+    renderWithRelay(activeOfferResolvers({ buyerState: "COMPLETED" }))
+
+    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+  })
+
+  it.each(["INCOMPLETE", "CANCELED"])(
+    "does not show 'You purchased this artwork' when the order has buyerState %s",
+    (buyerState) => {
+      renderWithRelay(activeOfferResolvers({ buyerState }))
+
+      expect(screen.queryByText("You purchased this artwork")).toBeNull()
+      expect(screen.getByText("You received an offer for $450")).toBeTruthy()
+    }
+  )
+})

--- a/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
@@ -40,11 +40,14 @@ export const usePartnerOfferEvent = ({
     return null
   }
 
-  // The offer is fulfilled when one of the collector's orders has a line item
-  // tied to it; in that case we show a purchase confirmation instead of letting
-  // the offer expire after it ends.
+  // Only treat the offer as purchased if the order is in an active state
+  // (SUBMITTED, APPROVED, or COMPLETED) and has a line item tied to this offer.
+  // This prevents abandoned or canceled orders from showing a purchase confirmation.
+  const PURCHASED_BUYER_STATES = new Set(["SUBMITTED", "APPROVED", "COMPLETED"])
+
   const isPurchased = extractNodes(collectorOrdersConnection).some(
     (order) =>
+      PURCHASED_BUYER_STATES.has(order.buyerState ?? "") &&
       order.lineItems?.some((lineItem) => lineItem?.partnerOfferId === partnerOffer.internalID)
   )
 
@@ -70,6 +73,7 @@ const conversationFragment = graphql`
     collectorOrdersConnection(first: 10) {
       edges {
         node {
+          buyerState
           lineItems {
             partnerOfferId
           }


### PR DESCRIPTION
…tes for partner offer in convos

This PR resolves [Mobile QA bug](https://www.notion.so/artsy/I-am-displayed-You-purchased-this-artwork-for-all-artworks-I-have-had-an-offer-on-even-though-I-h-38bcab0764a080bf9103d996ec5ad422?source=copy_link) <!-- eg [PROJECT-XXXX] -->

### Description

Mirrors the behavior used in web's experience for partner offers, only display `You purchased this artwork` help text if an order is in a positive state


@cami-w was running into an issue where she saw this text but her order was abandonded.

Associated force changes: https://github.com/artsy/force/pull/17392
More discussion here: https://artsy.slack.com/archives/C0A5Z9S1BTJ/p1782482026539849


⚠️ Trying to get eigen up but its been a while and having some local issues ⚠️ Ill continue to debug

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [ ] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [ ] I have added **tests**, or my changes don't require any.
- [ ] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
