### PR TITLE
chore: fix Proxy handler is null crash in persistenceMiddleware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ android/                 # Android native code and Gradle project
 
 ## Workflow
 
+- When opening a pull request, always use the template at `docs/pull_request_template.md`
 - Do not import components/hooks/functions directly from a different Scene — extract shared code to `src/app/Components/` or `src/app/utils/`
 - When adding a screen with a corresponding artsy.net page, match the route path and enable deep linking (add to `AndroidManifest.xml` for Android)
 - Use independent `NavigationContainer` stacks for context-specific flows (multi-step forms, modal sequences) rather than adding global routes

--- a/src/app/store/__tests__/persistenceMiddleware.tests.ts
+++ b/src/app/store/__tests__/persistenceMiddleware.tests.ts
@@ -9,6 +9,9 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 
 const makeStore = (reducer: Reducer) => createStore(reducer, applyMiddleware(persistenceMiddleware))
 
+// Flushes RAF callbacks and the resulting promise chain
+const flushAll = () => jest.runAllTimersAsync()
+
 beforeEach(() => {
   jest.useFakeTimers()
   jest.clearAllMocks()
@@ -37,7 +40,7 @@ describe("persistenceMiddleware", () => {
     expect(result).toEqual({ type: "NOOP" })
   })
 
-  it("calls AsyncStorage.setItem after the next animation frame", () => {
+  it("calls AsyncStorage.setItem after the next animation frame", async () => {
     const store = makeStore((state: { value: string } = { value: "a" }, action) => {
       if (action.type === "SET") return { value: action.payload }
       return state
@@ -47,12 +50,12 @@ describe("persistenceMiddleware", () => {
 
     expect(AsyncStorage.setItem).not.toHaveBeenCalled()
 
-    jest.runAllTimers()
+    await flushAll()
 
     expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
   })
 
-  it("collapses multiple actions in the same frame into a single write", () => {
+  it("collapses multiple actions in the same frame into a single write", async () => {
     const store = makeStore((state: { count: number } = { count: 0 }, action) => {
       if (action.type === "INCREMENT") return { count: state.count + 1 }
       return state
@@ -62,12 +65,12 @@ describe("persistenceMiddleware", () => {
     store.dispatch({ type: "INCREMENT" })
     store.dispatch({ type: "INCREMENT" })
 
-    jest.runAllTimers()
+    await flushAll()
 
     expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
   })
 
-  it("persists the latest state when multiple actions fire before the frame", () => {
+  it("persists the latest state when multiple actions fire before the frame", async () => {
     const store = makeStore((state: { value: string } = { value: "a" }, action) => {
       if (action.type === "SET") return { value: action.payload }
       return state
@@ -76,9 +79,37 @@ describe("persistenceMiddleware", () => {
     store.dispatch({ type: "SET", payload: "b" })
     store.dispatch({ type: "SET", payload: "c" })
 
-    jest.runAllTimers()
+    await flushAll()
 
     const serialized = (AsyncStorage.setItem as jest.Mock).mock.calls[0][1]
     expect(JSON.parse(serialized)).toMatchObject({ value: "c" })
+  })
+
+  it("writes are serialised — a second write waits for the first to finish", async () => {
+    let resolveFirst!: () => void
+    const firstWrite = new Promise<void>((resolve) => {
+      resolveFirst = resolve
+    })
+    ;(AsyncStorage.setItem as jest.Mock)
+      .mockReturnValueOnce(firstWrite)
+      .mockResolvedValue(undefined)
+
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
+      return state
+    })
+
+    store.dispatch({ type: "SET", payload: "b" })
+    await flushAll()
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+
+    store.dispatch({ type: "SET", payload: "c" })
+    await flushAll()
+    // first write still in progress — second should not have started yet
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+
+    resolveFirst()
+    await flushAll()
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/app/store/__tests__/persistenceMiddleware.tests.ts
+++ b/src/app/store/__tests__/persistenceMiddleware.tests.ts
@@ -1,10 +1,7 @@
-import { captureException } from "@sentry/react-native"
+import AsyncStorage from "@react-native-async-storage/async-storage"
 import { persistenceMiddleware } from "app/store/persistence"
-import { action, createStore as createEasyPeasyStore } from "easy-peasy"
-import { Immer } from "immer"
 import { applyMiddleware, createStore, Reducer } from "redux"
 
-jest.mock("@sentry/react-native")
 jest.mock("@react-native-async-storage/async-storage", () => ({
   setItem: jest.fn().mockResolvedValue(undefined),
   getItem: jest.fn().mockResolvedValue(null),
@@ -12,32 +9,17 @@ jest.mock("@react-native-async-storage/async-storage", () => ({
 
 const makeStore = (reducer: Reducer) => createStore(reducer, applyMiddleware(persistenceMiddleware))
 
+beforeEach(() => {
+  jest.useFakeTimers()
+  jest.clearAllMocks()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
 describe("persistenceMiddleware", () => {
-  it("does not throw when a reducer throws", () => {
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw new Error("Proxy handler is null")
-      return state
-    })
-
-    expect(() => store.dispatch({ type: "THROW" })).not.toThrow()
-  })
-
-  it("reports the caught error to Sentry as handled", () => {
-    const error = new Error("Proxy handler is null")
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw error
-      return state
-    })
-
-    store.dispatch({ type: "THROW" })
-
-    expect(captureException).toHaveBeenCalledWith(error, {
-      level: "error",
-      tags: { handled: "true" },
-    })
-  })
-
-  it("passes successful actions through and updates state normally", () => {
+  it("passes actions through and updates state normally", () => {
     const store = makeStore((state: { count: number } = { count: 0 }, action) => {
       if (action.type === "INCREMENT") return { count: state.count + 1 }
       return state
@@ -55,56 +37,48 @@ describe("persistenceMiddleware", () => {
     expect(result).toEqual({ type: "NOOP" })
   })
 
-  it("returns undefined when a reducer throws", () => {
-    const store = makeStore((state = {}, action) => {
-      if (action.type === "THROW") throw new Error("boom")
+  it("calls AsyncStorage.setItem after the next animation frame", () => {
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
       return state
     })
 
-    const result = store.dispatch({ type: "THROW" })
-    expect(result).toBeUndefined()
+    store.dispatch({ type: "SET", payload: "b" })
+
+    expect(AsyncStorage.setItem).not.toHaveBeenCalled()
+
+    jest.runAllTimers()
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
   })
-})
 
-// Simulates the real EIGEN-AZR1 / EIGEN-AZA6 crash path:
-//   Hermes 0.14.1 on iOS 26 throws "TypeError: Proxy handler is null" inside
-//   immer's finishDraft() when revoking a Proxy — easy-peasy calls this after
-//   every action handler that mutates draft state (e.g. setIsReady).
-//   Without the try/catch in persistenceMiddleware the error propagates to
-//   RCTFatal → expo-updates recovery pipeline → intentional crash.
-describe("persistenceMiddleware — immer Proxy crash (EIGEN-AZR1 regression)", () => {
-  // Minimal model that mirrors the mutation pattern of the failing action:
-  //   ProgressiveOnboardingModel.setIsReady: action((state, v) => { state.sessionState.isReady = v })
-  const model = {
-    sessionState: { isReady: false },
-    setIsReady: action((state: any, value: boolean) => {
-      state.sessionState.isReady = value
-    }),
-  }
+  it("collapses multiple actions in the same frame into a single write", () => {
+    const store = makeStore((state: { count: number } = { count: 0 }, action) => {
+      if (action.type === "INCREMENT") return { count: state.count + 1 }
+      return state
+    })
 
-  it("does not throw and reports to Sentry when immer finishDraft throws during dispatch", () => {
-    const store = createEasyPeasyStore(model, { middleware: [persistenceMiddleware] })
+    store.dispatch({ type: "INCREMENT" })
+    store.dispatch({ type: "INCREMENT" })
+    store.dispatch({ type: "INCREMENT" })
 
-    // Warm up: dispatch once so easy-peasy creates its internal Immer instance
-    store.getActions().setIsReady(false)
+    jest.runAllTimers()
 
-    // Patch Immer.prototype.finishDraft to simulate "Proxy handler is null" (Hermes 0.14.1 bug)
-    const originalFinishDraft = Immer.prototype.finishDraft
-    const proxyError = new TypeError("Proxy handler is null")
-    Immer.prototype.finishDraft = () => {
-      throw proxyError
-    }
+    expect(AsyncStorage.setItem).toHaveBeenCalledTimes(1)
+  })
 
-    try {
-      // This must NOT propagate — persistenceMiddleware should swallow it
-      expect(() => store.getActions().setIsReady(true)).not.toThrow()
+  it("persists the latest state when multiple actions fire before the frame", () => {
+    const store = makeStore((state: { value: string } = { value: "a" }, action) => {
+      if (action.type === "SET") return { value: action.payload }
+      return state
+    })
 
-      expect(captureException).toHaveBeenCalledWith(proxyError, {
-        level: "error",
-        tags: { handled: "true" },
-      })
-    } finally {
-      Immer.prototype.finishDraft = originalFinishDraft
-    }
+    store.dispatch({ type: "SET", payload: "b" })
+    store.dispatch({ type: "SET", payload: "c" })
+
+    jest.runAllTimers()
+
+    const serialized = (AsyncStorage.setItem as jest.Mock).mock.calls[0][1]
+    expect(JSON.parse(serialized)).toMatchObject({ value: "c" })
   })
 })

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage"
-import { captureException } from "@sentry/react-native"
 import { State } from "easy-peasy"
-import { isArray, isBoolean, isNull, isNumber, isPlainObject, isString, throttle } from "lodash"
+import { isArray, isBoolean, isNull, isNumber, isPlainObject, isString } from "lodash"
 import { Middleware } from "redux"
 import { GlobalStoreModel } from "./GlobalStoreModel"
 import { migrate } from "./migration"
@@ -44,24 +43,30 @@ export function assignDeep(object: any, otherObject: any) {
   }
 }
 
-// Catches errors thrown by immer/reducers (e.g. the Hermes 0.14.1 "Proxy handler is null"
-// bug on iOS 26 — EIGEN-AZR1, EIGEN-AZA6) and reports them to Sentry without letting
-// them propagate to RCTFatal and crash the app. Also throttles state persistence.
+// Captures state synchronously after each action (while Immer Proxies are still alive),
+// then defers the AsyncStorage write to the next animation frame. Multiple actions in
+// the same frame collapse into a single write — mirroring easy-peasy's own persist middleware.
 export const persistenceMiddleware: Middleware = (api) => {
-  const throttledPersist = throttle(() => persist(api.getState()), 1000, {
-    leading: false,
-    trailing: true,
-  })
+  let rafHandle: ReturnType<typeof requestAnimationFrame> | null = null
 
   return (next) => (action) => {
-    try {
-      const result = next(action)
-      throttledPersist()
-      return result
-    } catch (e) {
-      captureException(e, { level: "error", tags: { handled: "true" } })
-      return undefined
+    const result = next(action)
+    const state = api.getState()
+
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle)
     }
+
+    rafHandle = requestAnimationFrame(() => {
+      persist(state).catch((e) => {
+        if (__DEV__) {
+          console.error("Failed to persist store state", e)
+        }
+      })
+      rafHandle = null
+    })
+
+    return result
   }
 }
 

--- a/src/app/store/persistence.ts
+++ b/src/app/store/persistence.ts
@@ -48,6 +48,7 @@ export function assignDeep(object: any, otherObject: any) {
 // the same frame collapse into a single write — mirroring easy-peasy's own persist middleware.
 export const persistenceMiddleware: Middleware = (api) => {
   let rafHandle: ReturnType<typeof requestAnimationFrame> | null = null
+  let writeChain = Promise.resolve()
 
   return (next) => (action) => {
     const result = next(action)
@@ -58,11 +59,13 @@ export const persistenceMiddleware: Middleware = (api) => {
     }
 
     rafHandle = requestAnimationFrame(() => {
-      persist(state).catch((e) => {
-        if (__DEV__) {
-          console.error("Failed to persist store state", e)
-        }
-      })
+      writeChain = writeChain
+        .then(() => persist(state))
+        .catch((e) => {
+          if (__DEV__) {
+            console.error("Failed to persist store state", e)
+          }
+        })
       rafHandle = null
     })
 


### PR DESCRIPTION
This PR resolves [PHIRE-3186]

### Description (written by me - fixed spelling and grammar by Claude)

Easy Peasy uses Immer under the hood, which wraps state in JavaScript Proxy objects during actions. As an optimisation, the JS engine can garbage collect these Proxies aggressively once it determines nothing holds a strong reference to them.

The previous implementation throttled the AsyncStorage write with a 1-second trailing delay, calling `api.getState()` inside the deferred callback. By then, the Immer Proxies could already be GC'd — causing an intermittent `TypeError: Proxy handler is null` crash.

The fix mirrors [easy-peasy's own persist middleware](https://github.com/ctrlplusb/easy-peasy/blob/master/src/create-store.js#L50-L51): capture `api.getState()` synchronously after `next(action)` while Proxies are still alive, then defer only the AsyncStorage write to the next animation frame via `requestAnimationFrame`.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fix intermittent `TypeError: Proxy handler is null` crash in `persistenceMiddleware` by capturing state synchronously and deferring only the AsyncStorage write via `requestAnimationFrame`

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

Assisted-by: Claude:Sonnet-4.6

[PHIRE-3186]: https://artsyproduct.atlassian.net/browse/PHIRE-3186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ