### PR TITLE
refactor: derive isNewUserOnboardingSession from onboardingState

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCardPopover.tsx
@@ -21,9 +21,8 @@ export const InfiniteDiscoveryArtworkCardPopover: React.FC<
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
 
   const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
 
   const showSaveAlertReminder1 =
     index === FIRST_REMINDER_SWIPES_COUNT &&

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -21,9 +21,8 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
   const newUserOnboardingSavedArtworkCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
   )
@@ -34,7 +33,6 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleSkipPressed = () => {
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -42,9 +42,8 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
 
   const [isVisible, setIsVisible] = useState(isNewUserOnboardingSession)
   const [enableTapToDismiss, setEnableTapToDismiss] = useState(false)

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -37,9 +37,8 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   const newUserOnboardingCompletionBottomSheetVisible = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingCompletionBottomSheetVisible
   )
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
   const savedArtworks = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks
   )

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -77,7 +77,7 @@ describe("InfiniteDiscoveryHeader", () => {
     jest.clearAllMocks()
     ;(mockAddListener as any).beforeRemoveCallback = undefined
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnabledDiscoverDailyNegativeSignals: false })
     ;(RNShare.open as jest.Mock).mockResolvedValue({ success: true, message: "shared" })
   })
@@ -113,7 +113,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
   describe("in new user onboarding mode", () => {
     beforeEach(() => {
-      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
+      GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     })
 
     it("shows the progress badge instead of the exit chevron", () => {
@@ -145,17 +145,12 @@ describe("InfiniteDiscoveryHeader", () => {
     })
 
     it("exits onboarding when Skip is pressed", () => {
-      const setIsNewUserOnboardingSessionSpy = jest.spyOn(
-        GlobalStore.actions.infiniteDiscovery,
-        "setIsNewUserOnboardingSession"
-      )
       const setOnboardingStateSpy = jest.spyOn(GlobalStore.actions.onboarding, "setOnboardingState")
 
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
       fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
 
-      expect(setIsNewUserOnboardingSessionSpy).toHaveBeenCalledWith(false)
       expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
     })
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -14,7 +14,7 @@ jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () 
 describe("InfiniteDiscoveryOnboarding", () => {
   beforeEach(() => {
     jest.useFakeTimers()
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
     GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(false)
   })
 
@@ -24,7 +24,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
 
   describe("in new user onboarding session", () => {
     beforeEach(() => {
-      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
+      GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     })
 
     it("shows the overlay immediately", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -12,7 +12,7 @@ const SAVED_ARTWORKS = Array.from({ length: 5 }, (_, i) => ({
 describe("NewUserOnboardingCompletionBottomSheet", () => {
   beforeEach(() => {
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(false)
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
+    GlobalStore.actions.onboarding.setOnboardingState("complete")
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
   })
 
@@ -21,7 +21,7 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
   })
 
   it("renders the sheet content when completionBottomSheetVisible is true", () => {
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
@@ -32,7 +32,7 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
   })
 
   it('"Take me home" completes onboarding, exiting the onboarding navigator to the home tab', () => {
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
@@ -44,7 +44,7 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
   })
 
   it("renders 5 artwork images from the store", () => {
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     SAVED_ARTWORKS.forEach((artwork) => {
       GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork(artwork)
     })

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -41,15 +41,8 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
-
-  useEffect(() => {
-    return () => {
-      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
-    }
-  }, [])
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
 
   const [topArtworkId, setTopArtworkId] = useState<string | null>(null)
   const topArtwork = useMemo(

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave.ts
@@ -26,9 +26,8 @@ export const useInfiniteDiscoveryCardSave = (
 
   const { hasSavedArtworks } = GlobalStore.useAppState((state) => state.infiniteDiscovery)
   const setHasSavedArtworks = GlobalStore.actions.infiniteDiscovery.setHasSavedArtworks
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
   const {
     incrementSavedArtworksCount,
     decrementSavedArtworksCount,

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast.tsx
@@ -14,9 +14,8 @@ export const useSavesSummaryToast = () => {
   const savedArtworksCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.savedArtworksCount
   )
-  const isNewUserOnboardingSession = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.isNewUserOnboardingSession
-  )
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
   const track = useInfiniteDiscoveryTracking()
 
   const showSavedCountToast = useCallback(() => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -31,7 +31,6 @@ export const Introduction: React.FC = () => {
   const handleDone = useCallback(
     (experience: Experience) => {
       if (experience === "beginner") {
-        GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(true)
         replace("InfiniteDiscovery")
       } else {
         replace("FollowArtists")

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -12,7 +12,6 @@ export interface InfiniteDiscoveryModel {
   savedArtworksCount: number
   sessionState: {
     moreInfoSheetVisible: boolean
-    isNewUserOnboardingSession: boolean
     newUserOnboardingSavedArtworks: NewUserOnboardingSavedArtwork[]
     newUserOnboardingCompletionBottomSheetVisible: boolean
   }
@@ -22,7 +21,6 @@ export interface InfiniteDiscoveryModel {
   setHasInteractedWithOnboarding: Action<this, boolean>
   setHasSavedArtworks: Action<this, boolean>
   setMoreInfoSheetVisible: Action<this, boolean>
-  setIsNewUserOnboardingSession: Action<this, boolean>
   setNewUserOnboardingCompletionBottomSheetVisible: Action<this, boolean>
   addNewUserOnboardingSavedArtwork: Action<this, NewUserOnboardingSavedArtwork>
   removeNewUserOnboardingSavedArtwork: Action<this, string>
@@ -34,7 +32,6 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   savedArtworksCount: 0,
   sessionState: {
     moreInfoSheetVisible: false,
-    isNewUserOnboardingSession: false,
     newUserOnboardingSavedArtworks: [],
     newUserOnboardingCompletionBottomSheetVisible: false,
   },
@@ -56,12 +53,6 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   setMoreInfoSheetVisible: action((state, payload) => {
     state.sessionState.moreInfoSheetVisible = payload
-  }),
-  setIsNewUserOnboardingSession: action((state, payload) => {
-    state.sessionState.isNewUserOnboardingSession = payload
-    if (!payload) {
-      state.sessionState.newUserOnboardingCompletionBottomSheetVisible = false
-    }
   }),
   setNewUserOnboardingCompletionBottomSheetVisible: action((state, payload) => {
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = payload

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -3,7 +3,6 @@ import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 describe("InfiniteDiscoveryModel", () => {
   beforeEach(() => {
     GlobalStore.actions.infiniteDiscovery.resetSavedArtworksCount()
-    GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
   })
 
   const state = () => __globalStoreTestUtils__?.getCurrentState().infiniteDiscovery
@@ -72,16 +71,6 @@ describe("InfiniteDiscoveryModel", () => {
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(true)
 
       GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(false)
-      expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(false)
-    })
-  })
-
-  describe("setIsNewUserOnboardingSession", () => {
-    it("clears newUserOnboardingCompletionBottomSheetVisible when set to false", () => {
-      GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
-      expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(true)
-
-      GlobalStore.actions.infiniteDiscovery.setIsNewUserOnboardingSession(false)
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(false)
     })
   })


### PR DESCRIPTION
### Description

This PR is a follow-up to #13673 that simplifies how Infinite Discovery determines whether it is in "onboarding mode" or not.

Previously, the onboarding flow used a `isNewUserOnboardingSession` global state variable to tell Infinite Discovery to open in "onboarding mode." However, now that Infinite Discovery has been brought into the onboarding flow, it can use the existing `onboardingState` to indicate that it is in "onboarding mode."

(The real motivation for this change was to allow developers to keep Infinite Discovery in "onboarding mode" between hot reloads because the `isNewUserOnboardingSession` would get reset.)

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Infinite Discovery onboarding session state is now derived from `onboardingState` directly
<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)