### PR TITLE
feat(DI-425): disable outbound navigation during onboarding

### DIFF
--- a/src/app/Components/PartnerListItemShort.tsx
+++ b/src/app/Components/PartnerListItemShort.tsx
@@ -14,6 +14,7 @@ import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 interface PartnerListItemShortProps {
   partner: PartnerListItemShort_partner$key
   disabledLocation?: boolean
+  disableNavigation?: boolean
   onPress?: () => void
 }
 
@@ -21,6 +22,7 @@ export const PartnerListItemShort: FC<PartnerListItemShortProps> = ({
   partner,
   onPress,
   disabledLocation,
+  disableNavigation,
 }) => {
   const data = useFragment(fragment, partner)
   const { location } = useLocation({ disabled: !!disabledLocation })
@@ -36,7 +38,11 @@ export const PartnerListItemShort: FC<PartnerListItemShortProps> = ({
     : locations
 
   return (
-    <RouterLink to={data.href} onPress={onPress} style={{ flex: 1 }}>
+    <RouterLink
+      to={!disableNavigation ? data.href : undefined}
+      onPress={onPress}
+      style={{ flex: 1 }}
+    >
       <EntityHeader
         avatarSize="sm"
         name={data.name}

--- a/src/app/Components/PartnerListItemShort.tsx
+++ b/src/app/Components/PartnerListItemShort.tsx
@@ -39,7 +39,8 @@ export const PartnerListItemShort: FC<PartnerListItemShortProps> = ({
 
   return (
     <RouterLink
-      to={!disableNavigation ? data.href : undefined}
+      to={data.href}
+      disableNavigation={disableNavigation}
       onPress={onPress}
       style={{ flex: 1 }}
     >

--- a/src/app/Components/constants.ts
+++ b/src/app/Components/constants.ts
@@ -12,6 +12,7 @@ export const HEART_ICON_SIZE = 22
  */
 export const DEFAULT_ICON_SIZE = 24
 export const ACCESSIBLE_DEFAULT_ICON_SIZE = 24 * PixelRatio.getFontScale()
+export const ACCESSIBLE_SMALL_ICON_SIZE = 18 * PixelRatio.getFontScale()
 export const ICON_HIT_SLOP = {
   top: 8,
   right: 6,

--- a/src/app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection.tsx
@@ -1,0 +1,138 @@
+import { Flex, FlexProps, Text, TextProps } from "@artsy/palette-mobile"
+import { ArtworkDetailSection_artwork$key } from "__generated__/ArtworkDetailSection_artwork.graphql"
+import { useArtworkDimensions } from "app/utils/hooks/useArtworkDimensions"
+import { FC } from "react"
+import { graphql, useFragment } from "react-relay"
+
+interface ArtworkDetailSectionProps {
+  artwork: ArtworkDetailSection_artwork$key
+}
+
+export const ArtworkDetailSection: FC<ArtworkDetailSectionProps> = ({ artwork }) => {
+  const data = useFragment(fragment, artwork)
+  const { regularDimensionText, framedDimensionText, hasFramedDimensions } = useArtworkDimensions({
+    dimensions: data.dimensions,
+    framedDimensions: data.framedDimensions,
+  })
+
+  const {
+    medium,
+    attributionClass,
+    mediumType,
+    condition,
+    signatureInfo,
+    certificateOfAuthenticity,
+    publisher,
+    isFramed,
+  } = data
+
+  return (
+    <Flex gap={1}>
+      <Flex flexDirection="row">
+        <Text {...labelStyle}>Materials</Text>
+        <Text {...valueStyle}>{medium}</Text>
+      </Flex>
+
+      {!!regularDimensionText && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Dimensions</Text>
+          <Text {...valueStyle}>{regularDimensionText}</Text>
+        </Flex>
+      )}
+
+      {!!hasFramedDimensions && !!framedDimensionText && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Framed Dimensions</Text>
+          <Text {...valueStyle}>{framedDimensionText}</Text>
+        </Flex>
+      )}
+
+      <Flex flexDirection="row">
+        <Text {...labelStyle}>Rarity</Text>
+        <Text {...valueStyle}>{attributionClass?.name}</Text>
+      </Flex>
+
+      {!!mediumType?.name && (
+        <Flex flexDirection="row" width="100%">
+          <Text {...labelStyle}>Medium</Text>
+          <Text {...valueStyle}>{mediumType.name}</Text>
+        </Flex>
+      )}
+
+      {!!condition?.displayText && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Condition</Text>
+          <Text {...valueStyle}>{condition.displayText}</Text>
+        </Flex>
+      )}
+
+      {!!signatureInfo?.details && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Signature</Text>
+          <Text {...valueStyle}>{signatureInfo.details}</Text>
+        </Flex>
+      )}
+
+      {!!certificateOfAuthenticity?.details && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Certificate of Authenticity</Text>
+          <Text {...valueStyle}>{certificateOfAuthenticity.details}</Text>
+        </Flex>
+      )}
+
+      {!!publisher && (
+        <Flex flexDirection="row">
+          <Text {...labelStyle}>Publisher</Text>
+          <Text {...valueStyle}>{publisher}</Text>
+        </Flex>
+      )}
+
+      <Flex flexDirection="row">
+        <Text {...labelStyle}>Frame</Text>
+        <Text {...valueStyle}>{isFramed ? "Frame included" : "Frame not included"}</Text>
+      </Flex>
+    </Flex>
+  )
+}
+
+const fragment = graphql`
+  fragment ArtworkDetailSection_artwork on Artwork {
+    medium
+    dimensions {
+      in
+      cm
+    }
+    framedDimensions {
+      in
+      cm
+    }
+    attributionClass {
+      name
+    }
+    mediumType {
+      name
+    }
+    condition {
+      displayText
+    }
+    signatureInfo {
+      details
+    }
+    certificateOfAuthenticity {
+      details
+    }
+    publisher
+    isFramed
+  }
+`
+
+export const labelStyle = {
+  width: "35%",
+  variant: "xs",
+  color: "mono60",
+} satisfies TextProps | FlexProps
+
+export const valueStyle = {
+  width: "65%",
+  variant: "xs",
+} satisfies TextProps | FlexProps

--- a/src/app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection.tsx
@@ -1,4 +1,4 @@
-import { Flex, FlexProps, Text, TextProps } from "@artsy/palette-mobile"
+import { Flex, Text } from "@artsy/palette-mobile"
 import { ArtworkDetailSection_artwork$key } from "__generated__/ArtworkDetailSection_artwork.graphql"
 import { useArtworkDimensions } from "app/utils/hooks/useArtworkDimensions"
 import { FC } from "react"
@@ -26,71 +26,33 @@ export const ArtworkDetailSection: FC<ArtworkDetailSectionProps> = ({ artwork })
     isFramed,
   } = data
 
+  const metadata = [
+    { label: "Materials", value: medium },
+    { label: "Dimensions", value: regularDimensionText },
+    { label: "Framed Dimensions", value: hasFramedDimensions ? framedDimensionText : null },
+    { label: "Rarity", value: attributionClass?.name },
+    { label: "Medium", value: mediumType?.name },
+    { label: "Condition", value: condition?.displayText },
+    { label: "Signature", value: signatureInfo?.details },
+    { label: "Certificate of Authenticity", value: certificateOfAuthenticity?.details },
+    { label: "Publisher", value: publisher },
+    { label: "Frame", value: isFramed ? "Frame included" : "Frame not included" },
+  ].filter(({ value }) => !!value)
+
   return (
     <Flex gap={1}>
-      <Flex flexDirection="row">
-        <Text {...labelStyle}>Materials</Text>
-        <Text {...valueStyle}>{medium}</Text>
-      </Flex>
-
-      {!!regularDimensionText && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Dimensions</Text>
-          <Text {...valueStyle}>{regularDimensionText}</Text>
+      {metadata.map(({ label, value }) => (
+        <Flex key={label} flexDirection="row">
+          <Flex width="35%">
+            <Text variant="xs" color="mono60">
+              {label}
+            </Text>
+          </Flex>
+          <Flex width="65%">
+            <Text variant="xs">{value}</Text>
+          </Flex>
         </Flex>
-      )}
-
-      {!!hasFramedDimensions && !!framedDimensionText && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Framed Dimensions</Text>
-          <Text {...valueStyle}>{framedDimensionText}</Text>
-        </Flex>
-      )}
-
-      <Flex flexDirection="row">
-        <Text {...labelStyle}>Rarity</Text>
-        <Text {...valueStyle}>{attributionClass?.name}</Text>
-      </Flex>
-
-      {!!mediumType?.name && (
-        <Flex flexDirection="row" width="100%">
-          <Text {...labelStyle}>Medium</Text>
-          <Text {...valueStyle}>{mediumType.name}</Text>
-        </Flex>
-      )}
-
-      {!!condition?.displayText && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Condition</Text>
-          <Text {...valueStyle}>{condition.displayText}</Text>
-        </Flex>
-      )}
-
-      {!!signatureInfo?.details && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Signature</Text>
-          <Text {...valueStyle}>{signatureInfo.details}</Text>
-        </Flex>
-      )}
-
-      {!!certificateOfAuthenticity?.details && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Certificate of Authenticity</Text>
-          <Text {...valueStyle}>{certificateOfAuthenticity.details}</Text>
-        </Flex>
-      )}
-
-      {!!publisher && (
-        <Flex flexDirection="row">
-          <Text {...labelStyle}>Publisher</Text>
-          <Text {...valueStyle}>{publisher}</Text>
-        </Flex>
-      )}
-
-      <Flex flexDirection="row">
-        <Text {...labelStyle}>Frame</Text>
-        <Text {...valueStyle}>{isFramed ? "Frame included" : "Frame not included"}</Text>
-      </Flex>
+      ))}
     </Flex>
   )
 }
@@ -125,14 +87,3 @@ const fragment = graphql`
     isFramed
   }
 `
-
-export const labelStyle = {
-  width: "35%",
-  variant: "xs",
-  color: "mono60",
-} satisfies TextProps | FlexProps
-
-export const valueStyle = {
-  width: "65%",
-  variant: "xs",
-} satisfies TextProps | FlexProps

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -234,7 +234,8 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
             <PartnerListItemShort
               disabledLocation
               partner={data.partner}
-              onPress={() => handleCollapse()}
+              onPress={handleCollapse}
+              disableNavigation={isNewUserOnboardingSession}
             />
             <Flex
               flexDirection="row"

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -24,6 +24,7 @@ import { PartnerListItemShort } from "app/Components/PartnerListItemShort"
 import { ContactGalleryButton } from "app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton"
 import { InfiniteDiscoveryCollectorSignal } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal"
 import { useSetArtworkAsRecentlyViewed } from "app/Scenes/InfiniteDiscovery/hooks/useSetArtworkAsRecentlyViewed"
+import { GlobalStore } from "app/store/GlobalStore"
 import { AnalyticsContextProvider } from "app/system/analytics/AnalyticsContext"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { Sentinel } from "app/utils/Sentinel"
@@ -50,6 +51,9 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
     framedDimensions: data?.framedDimensions,
   })
 
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
+
   if (!data) {
     return null
   }
@@ -65,6 +69,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
   }
 
   const handleCollapse = () => {
+    if (isNewUserOnboardingSession) return
     collapse()
   }
 
@@ -205,7 +210,8 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                   <ArtistListItemContainer
                     key={`artist-${index}`}
                     artist={artist}
-                    onPress={() => handleCollapse()}
+                    onPress={handleCollapse}
+                    disableNavigation={isNewUserOnboardingSession}
                   />
                 )
               })}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -91,13 +91,17 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                 <Flex flexDirection="row" gap={0.5} alignItems="center" testID="attribution">
                   <ArtworkIcon height={18} width={18} fill="mono60" />
                   {!!attributionClass[0] && <Text variant="xs">{attributionClass[0]}</Text>}
-                  <RouterLink
-                    to="/artwork-classifications"
-                    hasChildTouchable
-                    onPress={handleCollapse}
-                  >
-                    <LinkText variant="xs">{attributionClass[1]}</LinkText>
-                  </RouterLink>
+                  {isNewUserOnboardingSession ? (
+                    <Text variant="xs">{attributionClass[1]}</Text>
+                  ) : (
+                    <RouterLink
+                      to="/artwork-classifications"
+                      hasChildTouchable
+                      onPress={handleCollapse}
+                    >
+                      <LinkText variant="xs">{attributionClass[1]}</LinkText>
+                    </RouterLink>
+                  )}
                 </Flex>
               </Sentinel>
             )}
@@ -112,13 +116,17 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                 <CertificateIcon height={18} width={18} fill="mono60" testID="certificate-icon" />
                 <Flex flexDirection="row">
                   <Text variant="xs">Includes a </Text>
-                  <RouterLink
-                    to="/artwork-certificate-of-authenticity"
-                    hasChildTouchable
-                    onPress={handleCollapse}
-                  >
-                    <LinkText variant="xs">Certificate of Authenticity</LinkText>
-                  </RouterLink>
+                  {isNewUserOnboardingSession ? (
+                    <Text variant="xs">Certificate of Authenticity</Text>
+                  ) : (
+                    <RouterLink
+                      to="/artwork-certificate-of-authenticity"
+                      hasChildTouchable
+                      onPress={handleCollapse}
+                    >
+                      <LinkText variant="xs">Certificate of Authenticity</LinkText>
+                    </RouterLink>
+                  )}
                 </Flex>
               </Flex>
             )}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -237,26 +237,28 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
               onPress={handleCollapse}
               disableNavigation={isNewUserOnboardingSession}
             />
-            <Flex
-              flexDirection="row"
-              flexWrap="wrap"
-              justifyContent="space-between"
-              alignItems="center"
-            >
-              <Text variant="xs" color="mono60">
-                Questions about this piece?
-              </Text>
+            {!isNewUserOnboardingSession && (
+              <Flex
+                flexDirection="row"
+                flexWrap="wrap"
+                justifyContent="space-between"
+                alignItems="center"
+              >
+                <Text variant="xs" color="mono60">
+                  Questions about this piece?
+                </Text>
 
-              <Flex>
-                <ContactGalleryButton
-                  artwork={data}
-                  me={me}
-                  variant="outlineGray"
-                  size="small"
-                  icon={<EnvelopeIcon fill="mono100" width={16} height={16} />}
-                />
+                <Flex>
+                  <ContactGalleryButton
+                    artwork={data}
+                    me={me}
+                    variant="outlineGray"
+                    size="small"
+                    icon={<EnvelopeIcon fill="mono100" width={16} height={16} />}
+                  />
+                </Flex>
               </Flex>
-            </Flex>
+            )}
           </Flex>
         </Flex>
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryArtworkCard.tsx
@@ -8,6 +8,7 @@ import { InfiniteDiscoveryArtworkCardPopover } from "app/Scenes/InfiniteDiscover
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { useInfiniteDiscoveryCardSave } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryCardSave"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
+import { GlobalStore } from "app/store/GlobalStore"
 import { sizeToFit } from "app/utils/useSizeToFit"
 import { memo, useEffect, useRef, useState } from "react"
 import { FlatList, GestureResponderEvent, Text as RNText, ViewStyle } from "react-native"
@@ -42,6 +43,8 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
 
     const track = useInfiniteDiscoveryTracking()
     const color = useColor()
+    const isNewUserOnboardingSession =
+      GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
 
     const artwork = useFragment<InfiniteDiscoveryArtworkCard_artwork$key>(
       infiniteDiscoveryArtworkCardFragment,
@@ -158,6 +161,7 @@ export const InfiniteDiscoveryArtworkCard: React.FC<InfiniteDiscoveryArtworkCard
             contextModule={ContextModule.infiniteDiscoveryArtworkCard}
             contextScreenOwnerId={artwork.internalID}
             contextScreenOwnerSlug={artwork.slug}
+            disableNavigation={isNewUserOnboardingSession}
           />
         </Flex>
         <Flex alignItems="center" minHeight={adjustedMaxHeight} justifyContent="center">

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal.tsx
@@ -1,11 +1,10 @@
 import { Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { useCollectorSignal_artwork$key } from "__generated__/useCollectorSignal_artwork.graphql"
+import { ACCESSIBLE_SMALL_ICON_SIZE } from "app/Components/constants"
 import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { useCollectorSignal } from "app/utils/artwork/useCollectorSignal"
 import { FC } from "react"
-
-const ICON_SIZE = 18
 
 interface InfiniteDiscoveryCollectorSignalProps {
   artwork: useCollectorSignal_artwork$key
@@ -26,7 +25,11 @@ export const InfiniteDiscoveryCollectorSignal: FC<InfiniteDiscoveryCollectorSign
   return (
     <Flex>
       <Flex flexDirection="row" gap={0.5} alignItems="flex-end">
-        <SignalIcon fill="mono100" width={ICON_SIZE} height={ICON_SIZE} />
+        <SignalIcon
+          fill="mono100"
+          width={ACCESSIBLE_SMALL_ICON_SIZE}
+          height={ACCESSIBLE_SMALL_ICON_SIZE}
+        />
 
         <Text variant="xs" color="mono100">
           {signalTitle}
@@ -34,7 +37,7 @@ export const InfiniteDiscoveryCollectorSignal: FC<InfiniteDiscoveryCollectorSign
       </Flex>
 
       <Flex flex={1} flexDirection="row" gap={0.5}>
-        <Flex style={{ width: ICON_SIZE, height: ICON_SIZE }} />
+        <Flex style={{ width: ACCESSIBLE_SMALL_ICON_SIZE, height: ACCESSIBLE_SMALL_ICON_SIZE }} />
 
         {href && !isNewUserOnboardingSession ? (
           <RouterLink to={href} hasChildTouchable>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal.tsx
@@ -1,5 +1,6 @@
 import { Flex, LinkText, Text } from "@artsy/palette-mobile"
 import { useCollectorSignal_artwork$key } from "__generated__/useCollectorSignal_artwork.graphql"
+import { GlobalStore } from "app/store/GlobalStore"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { useCollectorSignal } from "app/utils/artwork/useCollectorSignal"
 import { FC } from "react"
@@ -15,6 +16,8 @@ export const InfiniteDiscoveryCollectorSignal: FC<InfiniteDiscoveryCollectorSign
 }) => {
   const { SignalIcon, signalTitle, signalDescription, href, hasCollectorSignal } =
     useCollectorSignal({ artwork })
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
 
   if (!hasCollectorSignal) {
     return null
@@ -33,7 +36,7 @@ export const InfiniteDiscoveryCollectorSignal: FC<InfiniteDiscoveryCollectorSign
       <Flex flex={1} flexDirection="row" gap={0.5}>
         <Flex style={{ width: ICON_SIZE, height: ICON_SIZE }} />
 
-        {href ? (
+        {href && !isNewUserOnboardingSession ? (
           <RouterLink to={href} hasChildTouchable>
             <LinkText variant="xs" color="mono100">
               {signalDescription}

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
@@ -1,8 +1,7 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { ArtworkIcon, CertificateIcon, EnvelopeIcon } from "@artsy/icons/native"
+import { ArtworkIcon, CertificateIcon } from "@artsy/icons/native"
 import {
   Flex,
-  LinkText,
   SimpleMessage,
   Skeleton,
   SkeletonBox,
@@ -11,20 +10,16 @@ import {
   Tabs,
   Text,
 } from "@artsy/palette-mobile"
-import { BottomSheetScrollView, useBottomSheet } from "@gorhom/bottom-sheet"
-import { InfiniteDiscoveryAboutTheWorkTabQuery } from "__generated__/InfiniteDiscoveryAboutTheWorkTabQuery.graphql"
-import { InfiniteDiscoveryAboutTheWorkTab_artwork$key } from "__generated__/InfiniteDiscoveryAboutTheWorkTab_artwork.graphql"
-import { MyProfileEditModal_me$key } from "__generated__/MyProfileEditModal_me.graphql"
-import { useSendInquiry_me$key } from "__generated__/useSendInquiry_me.graphql"
+import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
+import { NewUserOnboardingAboutTheWorkTabQuery } from "__generated__/NewUserOnboardingAboutTheWorkTabQuery.graphql"
+import { NewUserOnboardingAboutTheWorkTab_artwork$key } from "__generated__/NewUserOnboardingAboutTheWorkTab_artwork.graphql"
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { Divider } from "app/Components/Bidding/Components/Divider"
 import { PartnerListItemShort } from "app/Components/PartnerListItemShort"
-import { ContactGalleryButton } from "app/Scenes/Artwork/Components/CommercialButtons/ContactGalleryButton"
 import { ArtworkDetailSection } from "app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection"
 import { InfiniteDiscoveryCollectorSignal } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal"
 import { useSetArtworkAsRecentlyViewed } from "app/Scenes/InfiniteDiscovery/hooks/useSetArtworkAsRecentlyViewed"
 import { AnalyticsContextProvider } from "app/system/analytics/AnalyticsContext"
-import { RouterLink } from "app/system/navigation/RouterLink"
 import { Sentinel } from "app/utils/Sentinel"
 import { useCollectorSignal } from "app/utils/artwork/useCollectorSignal"
 import { withSuspense } from "app/utils/hooks/withSuspense"
@@ -32,14 +27,11 @@ import { FC } from "react"
 import { graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
 interface AboutTheWorkTabProps {
-  artwork: InfiniteDiscoveryAboutTheWorkTab_artwork$key
-  me: MyProfileEditModal_me$key & useSendInquiry_me$key
+  artwork: NewUserOnboardingAboutTheWorkTab_artwork$key
 }
 
-// TODO: export TAB_BAR_HEIGHT from palette-mobile
-export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
+const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
   const data = useFragment(fragment, artwork)
-  const { collapse } = useBottomSheet()
   const { setArtworkAsRecentlyViewed } = useSetArtworkAsRecentlyViewed(data?.internalID)
   const { signalTitle } = useCollectorSignal({ artwork: data })
 
@@ -57,10 +49,6 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
     }
   }
 
-  const handleCollapse = () => {
-    collapse()
-  }
-
   return (
     <BottomSheetScrollView>
       <AnalyticsContextProvider
@@ -70,7 +58,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
         contextScreenOwnerSlug={data.slug}
       >
         <Flex flex={1} px={2} gap={2}>
-          <Spacer y={4} />
+          <Spacer y={1} />
           <Flex gap={1} pt={1}>
             <InfiniteDiscoveryCollectorSignal artwork={data} />
 
@@ -79,13 +67,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                 <Flex flexDirection="row" gap={0.5} alignItems="center" testID="attribution">
                   <ArtworkIcon height={18} width={18} fill="mono60" />
                   {!!attributionClass[0] && <Text variant="xs">{attributionClass[0]}</Text>}
-                  <RouterLink
-                    to="/artwork-classifications"
-                    hasChildTouchable
-                    onPress={handleCollapse}
-                  >
-                    <LinkText variant="xs">{attributionClass[1]}</LinkText>
-                  </RouterLink>
+                  <Text variant="xs">{attributionClass[1]}</Text>
                 </Flex>
               </Sentinel>
             )}
@@ -100,13 +82,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                 <CertificateIcon height={18} width={18} fill="mono60" testID="certificate-icon" />
                 <Flex flexDirection="row">
                   <Text variant="xs">Includes a </Text>
-                  <RouterLink
-                    to="/artwork-certificate-of-authenticity"
-                    hasChildTouchable
-                    onPress={handleCollapse}
-                  >
-                    <LinkText variant="xs">Certificate of Authenticity</LinkText>
-                  </RouterLink>
+                  <Text variant="xs">Certificate of Authenticity</Text>
                 </Flex>
               </Flex>
             )}
@@ -134,7 +110,7 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                   <ArtistListItemContainer
                     key={`artist-${index}`}
                     artist={artist}
-                    onPress={handleCollapse}
+                    disableNavigation
                   />
                 )
               })}
@@ -146,44 +122,18 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
           <Flex gap={1}>
             <Text variant="sm-display">Gallery</Text>
 
-            <PartnerListItemShort
-              disabledLocation
-              partner={data.partner}
-              onPress={handleCollapse}
-            />
-            <Flex
-              flexDirection="row"
-              flexWrap="wrap"
-              justifyContent="space-between"
-              alignItems="center"
-            >
-              <Text variant="xs" color="mono60">
-                Questions about this piece?
-              </Text>
-
-              <Flex>
-                <ContactGalleryButton
-                  artwork={data}
-                  me={me}
-                  variant="outlineGray"
-                  size="small"
-                  icon={<EnvelopeIcon fill="mono100" width={16} height={16} />}
-                />
-              </Flex>
-            </Flex>
+            <PartnerListItemShort disabledLocation partner={data.partner} disableNavigation />
           </Flex>
         </Flex>
 
-        <Spacer y={12} />
-        <Spacer y={6} />
+        <Spacer y={4} />
       </AnalyticsContextProvider>
     </BottomSheetScrollView>
   )
 }
 
 const fragment = graphql`
-  fragment InfiniteDiscoveryAboutTheWorkTab_artwork on Artwork {
-    ...ContactGalleryButton_artwork
+  fragment NewUserOnboardingAboutTheWorkTab_artwork on Artwork {
     ...useCollectorSignal_artwork
     ...ArtworkDetailSection_artwork
 
@@ -206,46 +156,39 @@ const fragment = graphql`
   }
 `
 
-interface InfiniteDiscoveryAboutTheWorkTabProps {
+interface NewUserOnboardingAboutTheWorkTabProps {
   artworkID: string
 }
 
-const infiniteDiscoveryAboutTheWorkQuery = graphql`
-  query InfiniteDiscoveryAboutTheWorkTabQuery($id: String!) {
+const newUserOnboardingAboutTheWorkQuery = graphql`
+  query NewUserOnboardingAboutTheWorkTabQuery($id: String!) {
     artwork(id: $id) {
-      ...InfiniteDiscoveryAboutTheWorkTab_artwork
-    }
-    me {
-      ...useSendInquiry_me
-      ...MyProfileEditModal_me
-      ...BidButton_me
-      ...ArtworkCardBottomSheetFooter_me
+      ...NewUserOnboardingAboutTheWorkTab_artwork
     }
   }
 `
 
-export const InfiniteDiscoveryAboutTheWorkTab: FC<InfiniteDiscoveryAboutTheWorkTabProps> =
+export const NewUserOnboardingAboutTheWorkTab: FC<NewUserOnboardingAboutTheWorkTabProps> =
   withSuspense({
     Component: ({ artworkID }) => {
-      const data = useLazyLoadQuery<InfiniteDiscoveryAboutTheWorkTabQuery>(
-        infiniteDiscoveryAboutTheWorkQuery,
+      const data = useLazyLoadQuery<NewUserOnboardingAboutTheWorkTabQuery>(
+        newUserOnboardingAboutTheWorkQuery,
         {
           id: artworkID,
         }
       )
 
-      if (!data?.artwork || !data?.me) {
+      if (!data?.artwork) {
         return (
           <Tabs.ScrollView>
-            {/* This should never be the case, but we'll handle it anyway */}
             <SimpleMessage m={2}>No details available.</SimpleMessage>
           </Tabs.ScrollView>
         )
       }
 
-      return <AboutTheWorkTab artwork={data.artwork} me={data.me} />
+      return <AboutTheWorkTab artwork={data.artwork} />
     },
-    LoadingFallback: () => <InfiniteDiscoveryAboutTheWorkTabSkeleton />,
+    LoadingFallback: () => <NewUserOnboardingAboutTheWorkTabSkeleton />,
     ErrorFallback: () => {
       return (
         <Tabs.ScrollView contentContainerStyle={{ marginTop: 20 }}>
@@ -255,12 +198,12 @@ export const InfiniteDiscoveryAboutTheWorkTab: FC<InfiniteDiscoveryAboutTheWorkT
     },
   })
 
-export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
+const NewUserOnboardingAboutTheWorkTabSkeleton: FC = () => {
   return (
     <BottomSheetScrollView scrollEnabled={false}>
       <Skeleton>
         <Flex gap={2} px={2} flex={1}>
-          <Spacer y={4} />
+          <Spacer y={1} />
           <Flex gap={1} pt={1}>
             <Flex flexDirection="row" gap={0.5} alignItems="center">
               <SkeletonBox size={18} />
@@ -290,7 +233,7 @@ export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
                 <Flex width="35%">
                   <SkeletonText variant="xs">{label}</SkeletonText>
                 </Flex>
-                <SkeletonText variant="xs">{label + "a".repeat(Math.random() * 10)}</SkeletonText>
+                <SkeletonText variant="xs">{label}</SkeletonText>
               </Flex>
             ))}
           </Flex>
@@ -311,8 +254,6 @@ export const InfiniteDiscoveryAboutTheWorkTabSkeleton: FC = () => {
                 <SkeletonBox justifySelf="flex-end" height={30} width={90} borderRadius={25} />
               </Flex>
             </Flex>
-
-            <SkeletonText variant="xs">{"Biogr ".repeat(20)}</SkeletonText>
           </Flex>
         </Flex>
       </Skeleton>

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
@@ -16,6 +16,7 @@ import { NewUserOnboardingAboutTheWorkTab_artwork$key } from "__generated__/NewU
 import { ArtistListItemContainer } from "app/Components/ArtistListItem"
 import { Divider } from "app/Components/Bidding/Components/Divider"
 import { PartnerListItemShort } from "app/Components/PartnerListItemShort"
+import { ACCESSIBLE_SMALL_ICON_SIZE } from "app/Components/constants"
 import { ArtworkDetailSection } from "app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection"
 import { InfiniteDiscoveryCollectorSignal } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryCollectorSignal"
 import { useSetArtworkAsRecentlyViewed } from "app/Scenes/InfiniteDiscovery/hooks/useSetArtworkAsRecentlyViewed"
@@ -65,7 +66,11 @@ const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
             {!!attributionClass?.length && (
               <Sentinel onChange={handleOnVisible}>
                 <Flex flexDirection="row" gap={0.5} alignItems="center" testID="attribution">
-                  <ArtworkIcon height={18} width={18} fill="mono60" />
+                  <ArtworkIcon
+                    height={ACCESSIBLE_SMALL_ICON_SIZE}
+                    width={ACCESSIBLE_SMALL_ICON_SIZE}
+                    fill="mono60"
+                  />
                   {!!attributionClass[0] && <Text variant="xs">{attributionClass[0]}</Text>}
                   <Text variant="xs">{attributionClass[1]}</Text>
                 </Flex>
@@ -79,7 +84,12 @@ const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
                 alignItems="center"
                 testID="authenticity-certificate"
               >
-                <CertificateIcon height={18} width={18} fill="mono60" testID="certificate-icon" />
+                <CertificateIcon
+                  height={ACCESSIBLE_SMALL_ICON_SIZE}
+                  width={ACCESSIBLE_SMALL_ICON_SIZE}
+                  fill="mono60"
+                  testID="certificate-icon"
+                />
                 <Flex flexDirection="row">
                   <Text variant="xs">Includes a </Text>
                   <Text variant="xs">Certificate of Authenticity</Text>

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -1,0 +1,48 @@
+import { useColor } from "@artsy/palette-mobile"
+import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet"
+import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
+import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
+import { FC, useCallback } from "react"
+import { Dimensions } from "react-native"
+import { useSafeAreaInsets } from "react-native-safe-area-context"
+
+interface NewUserOnboardingArtworkCardBottomSheetProps {
+  artworkID: string
+}
+
+const { height } = Dimensions.get("screen")
+
+export const NewUserOnboardingArtworkCardBottomSheet: FC<
+  NewUserOnboardingArtworkCardBottomSheetProps
+> = ({ artworkID }) => {
+  const { bottom, top } = useSafeAreaInsets()
+  const color = useColor()
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        disappearsOnIndex={0}
+        appearsOnIndex={1}
+        pressBehavior="collapse"
+        style={[props.style, { marginTop: -top }]}
+      />
+    ),
+    [top]
+  )
+
+  return (
+    <BottomSheet
+      enableDynamicSizing={true}
+      enablePanDownToClose={false}
+      snapPoints={[bottom + 60]}
+      maxDynamicContentSize={height * 0.88}
+      index={0}
+      backdropComponent={renderBackdrop}
+      backgroundStyle={{ backgroundColor: color("mono0") }}
+      handleComponent={ArtworkCardBottomSheetHandle}
+    >
+      <NewUserOnboardingAboutTheWorkTab artworkID={artworkID} />
+    </BottomSheet>
+  )
+}

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet.tsx
@@ -1,20 +1,18 @@
-import { useColor } from "@artsy/palette-mobile"
+import { useColor, useScreenDimensions } from "@artsy/palette-mobile"
 import BottomSheet, { BottomSheetBackdrop, BottomSheetBackdropProps } from "@gorhom/bottom-sheet"
 import { ArtworkCardBottomSheetHandle } from "app/Components/ArtworkCard/ArtworkCardBottomSheetHandle"
 import { NewUserOnboardingAboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab" // pragma: allowlist secret
 import { FC, useCallback } from "react"
-import { Dimensions } from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface NewUserOnboardingArtworkCardBottomSheetProps {
   artworkID: string
 }
 
-const { height } = Dimensions.get("screen")
-
 export const NewUserOnboardingArtworkCardBottomSheet: FC<
   NewUserOnboardingArtworkCardBottomSheetProps
 > = ({ artworkID }) => {
+  const { height } = useScreenDimensions()
   const { bottom, top } = useSafeAreaInsets()
   const color = useColor()
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/ArtworkDetailSection.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/ArtworkDetailSection.tests.tsx
@@ -1,0 +1,100 @@
+import { screen } from "@testing-library/react-native"
+import { ArtworkDetailSectionTestQuery } from "__generated__/ArtworkDetailSectionTestQuery.graphql"
+import { ArtworkDetailSection } from "app/Scenes/InfiniteDiscovery/Components/ArtworkDetailSection"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("ArtworkDetailSection", () => {
+  const { renderWithRelay } = setupTestWrapper<ArtworkDetailSectionTestQuery>({
+    Component: ({ artwork }: any) => <ArtworkDetailSection artwork={artwork} />,
+    query: graphql`
+      query ArtworkDetailSectionTestQuery @relay_test_operation {
+        artwork(id: "artwork-id") {
+          ...ArtworkDetailSection_artwork
+        }
+      }
+    `,
+    preloaded: true,
+  })
+
+  it("renders all fields when data is available", () => {
+    const { mockResolveLastOperation } = renderWithRelay()
+    mockResolveLastOperation({ Artwork: () => artwork })
+
+    expect(screen.getByText("Oil on canvas")).toBeOnTheScreen()
+    expect(screen.getByText("20 × 24 in | 50.8 × 61 cm")).toBeOnTheScreen()
+    expect(screen.getByText("Unique")).toBeOnTheScreen()
+    expect(screen.getByText("Painting")).toBeOnTheScreen()
+    expect(screen.getByText("Excellent condition")).toBeOnTheScreen()
+    expect(screen.getByText("Signed and dated lower right")).toBeOnTheScreen()
+    expect(screen.getByText("Includes gallery certificate")).toBeOnTheScreen()
+    expect(screen.getByText("Test Publisher")).toBeOnTheScreen()
+    expect(screen.getByText("Frame included")).toBeOnTheScreen()
+  })
+
+  it("does not render optional rows when data is missing", () => {
+    const { mockResolveLastOperation } = renderWithRelay()
+    mockResolveLastOperation({
+      Artwork: () => ({
+        ...artwork,
+        mediumType: null,
+        condition: null,
+        signatureInfo: null,
+        certificateOfAuthenticity: null,
+        publisher: null,
+      }),
+    })
+
+    expect(screen.getByText("Oil on canvas")).toBeOnTheScreen()
+
+    expect(screen.queryByText("Medium")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Condition")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Signature")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Certificate of Authenticity")).not.toBeOnTheScreen()
+    expect(screen.queryByText("Publisher")).not.toBeOnTheScreen()
+  })
+
+  it("shows 'Frame not included' when isFramed is false", () => {
+    const { mockResolveLastOperation } = renderWithRelay()
+    mockResolveLastOperation({ Artwork: () => ({ ...artwork, isFramed: false }) })
+
+    expect(screen.getByText("Frame not included")).toBeOnTheScreen()
+  })
+
+  describe("framed dimensions", () => {
+    it("shows framed dimensions row when data is available", () => {
+      const { mockResolveLastOperation } = renderWithRelay()
+      mockResolveLastOperation({
+        Artwork: () => ({
+          ...artwork,
+          framedDimensions: { in: "24 × 28 in", cm: "61 × 71.1 cm" },
+        }),
+      })
+
+      expect(screen.getByText("20 × 24 in | 50.8 × 61 cm")).toBeOnTheScreen()
+      expect(screen.getByText("24 × 28 in | 61 × 71.1 cm")).toBeOnTheScreen()
+    })
+
+    it("does not show framed dimensions row when data is missing", () => {
+      const { mockResolveLastOperation } = renderWithRelay()
+      mockResolveLastOperation({ Artwork: () => ({ ...artwork, framedDimensions: null }) })
+
+      expect(screen.getByText("20 × 24 in | 50.8 × 61 cm")).toBeOnTheScreen()
+
+      expect(screen.queryByText("Framed Dimensions")).not.toBeOnTheScreen()
+    })
+  })
+})
+
+const artwork = {
+  medium: "Oil on canvas",
+  dimensions: { in: "20 × 24 in", cm: "50.8 × 61 cm" },
+  framedDimensions: null,
+  attributionClass: { name: "Unique" },
+  mediumType: { name: "Painting" },
+  condition: { displayText: "Excellent condition" },
+  signatureInfo: { details: "Signed and dated lower right" },
+  certificateOfAuthenticity: { details: "Includes gallery certificate" },
+  publisher: "Test Publisher",
+  isFramed: true,
+}

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -10,6 +10,7 @@ import {
   negativeSignalsQuery,
 } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryNegativeSignalsBottomSheet"
 import { InfiniteDiscoveryOnboarding } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding"
+import { NewUserOnboardingArtworkCardBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingArtworkCardBottomSheet"
 import { NewUserOnboardingCompletionBottomSheet } from "app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet"
 import { Swiper } from "app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
@@ -36,13 +37,15 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
 }) => {
   const track = useInfiniteDiscoveryTracking()
   const [commitMutation] = useCreateUserSeenArtwork()
-  const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
 
   const hasInteractedWithOnboarding = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.hasInteractedWithOnboarding
   )
   const isNewUserOnboardingSession =
     GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
+
+  const negativeSignalsEnabled =
+    useFeatureFlag("AREnabledDiscoverDailyNegativeSignals") && !isNewUserOnboardingSession
 
   const [topArtworkId, setTopArtworkId] = useState<string | null>(null)
   const topArtwork = useMemo(
@@ -194,12 +197,19 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
         />
         {!!topArtwork && (
           <>
-            <ArtworkCardBottomSheet
-              artworkID={topArtwork.internalID}
-              artworkSlug={topArtwork.slug}
-              artistIDs={topArtwork.artists.map((data) => data?.internalID ?? "")}
-              contextModule={ContextModule.infiniteDiscovery}
-            />
+            {isNewUserOnboardingSession ? (
+              <NewUserOnboardingArtworkCardBottomSheet
+                artworkID={topArtwork.internalID}
+                key={topArtwork.internalID}
+              />
+            ) : (
+              <ArtworkCardBottomSheet
+                artworkID={topArtwork.internalID}
+                artworkSlug={topArtwork.slug}
+                artistIDs={topArtwork.artists.map((data) => data?.internalID ?? "")}
+                contextModule={ContextModule.infiniteDiscovery}
+              />
+            )}
             {!!negativeSignalsEnabled && (
               <InfiniteDiscoveryNegativeSignalsBottomSheet
                 artworkID={topArtwork.internalID}


### PR DESCRIPTION
This PR resolves [DI-425](https://www.notion.so/DI-425)

### Description

This PR prevents the 8 ways that users can leave Infinite Discovery in "onboarding mode":

1. Tap on the artist name on the artwork card (disabled)
2. Tap on the attribution class link in the bottom sheet (unlinked)
3. Tap on the certificate of authenticity link in the bottom sheet (unlinked)
4. Tap on the artist name in the bottom sheet (disabled)
5. Tap on the gallery name in the bottom sheet (disabled)
6. Tap the contact gallery button in the bottom sheet (removed)
7. Tap on a commercial action button in the bottom sheet footer (removed)
8. Tap on an artwork in the bottom sheet "Other works" tab (removed)

7 and 8 were achieved by creating a new bottom sheet that looks a lot like the old artwork card sheet. I chose to do this instead of reusing the existing one because of the structural changes involved in removing tabs and the footer.

| mode | artwork card | bottom sheet A | bottom sheet A | bottom sheet B |
|-|-|-|-|-|
| onboarding | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 17 08" src="https://github.com/user-attachments/assets/cec4669d-801b-4998-86c4-a038938ef5f6" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 17 13" src="https://github.com/user-attachments/assets/4f9c032c-7739-4ebd-98ad-05f8480feb1f" /> | | |
| regular | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 17 59" src="https://github.com/user-attachments/assets/f93ec5bc-df66-4527-92e4-289c14bb7343" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 18 06" src="https://github.com/user-attachments/assets/eeb3171e-12a0-445a-b353-4455a480371e" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 19 14" src="https://github.com/user-attachments/assets/48f0f094-97f0-4342-88d8-6a9751a69eec" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 16 19 19" src="https://github.com/user-attachments/assets/d434b59c-0928-4441-be7e-5e0f90414f18" /> |





### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Disable links during new user onboarding to keep users in the discovery flow
<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)