### PR TITLE
fix: navigating to /favorites/saves now correctly opens the Saves tab

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -1587,7 +1587,7 @@ export const artsyDotNetRoutes = defineRoutes([
   },
   {
     path: "/favorites/follows",
-    name: "SavedArtworks",
+    name: "FollowedArtists",
     Component: SavedArtworks,
     options: {
       topTabsNavigatorOptions: {


### PR DESCRIPTION
### Description

Navigating to `/favorites/saves` (e.g. from the Infinite Discovery summary toast) was landing users on the Follows tab instead of Saves.

**Cause:** `/favorites/follows` and `/favorites/saves` both had `name: "SavedArtworks"` in `routes.tsx`. The `modules` registry [deduplicates by name](https://github.com/artsy/eigen/blob/7e20d9755dd708a9c29ad650d3e4236efb206ba3/src/app/Navigation/utils/modules.ts#L9-L12) via `uniqBy` (first-wins), so `modules["SavedArtworks"]` always held the follows route's options — meaning `topTabName` resolved to `"follows"` regardless of which path was navigated to.

**Fix:** Rename the `/favorites/follows` route to `"FollowedArtists"` so each path has a unique name and the correct `topTabName` is dispatched.

| Before | After |
|-|-|
| https://github.com/user-attachments/assets/16a05ed3-976b-4dc9-a3be-954fe61cef99 | https://github.com/user-attachments/assets/cd7d62e7-b12d-4608-9a42-66892547a3f5 |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix: tapping "Tap to see all of your saved artworks" now opens the Saves tab correctly.

<!-- end_changelog_updates -->

</details>

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md