### PR TITLE
fix: background color incosistency on filters when on dark mode

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -1,5 +1,5 @@
 import { ActionType, ContextModule, OwnerType, TappedCreateAlert } from "@artsy/cohesion"
-import { Flex } from "@artsy/palette-mobile"
+import { Flex, useColor } from "@artsy/palette-mobile"
 import { NavigationContainer, NavigationIndependentTree } from "@react-navigation/native"
 import { TransitionPresets, createStackNavigator } from "@react-navigation/stack"
 import {
@@ -111,6 +111,7 @@ export type ArtworkFilterNavigationStack = {
 const Stack = createStackNavigator<ArtworkFilterNavigationStack>()
 
 export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
+  const color = useColor()
   const theme = useNavigationTheme()
   const insets = useSafeAreaInsets()
 
@@ -355,7 +356,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
                   ...TransitionPresets.SlideFromRightIOS,
                   headerShown: false,
                   cardStyle: {
-                    backgroundColor: "transparent",
+                    backgroundColor: color("mono0"),
                     paddingTop: Platform.OS === "ios" ? insets?.top : 0,
                   },
                 }}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Reported by applause https://platform.applause.com/company/13083/products/27922/community-issues/7182735

Fixes an inconsistency on background when on dark mode only. The issue was only visible on dark mode due to the cardStyle being "transparent" instead of `mono0`.

Now it changes dynamically depending on the mode.

Note: This issue was visible only on iOS

| Platform | Before | After |
|---|---|---|
| Dark Mode | <video src="https://github.com/user-attachments/assets/81a1691f-08ad-42f6-98d7-35f67cd67e79" width="400" /> | <video src="https://github.com/user-attachments/assets/b33ea8d0-6bce-4a92-890e-52f449aefca7" width="400" /> |
| Light Mode| <video src="https://github.com/user-attachments/assets/f6822b64-bbbe-434a-a96a-70e6f14432b2" width="400" /> | <video src="https://github.com/user-attachments/assets/c2f66ac3-6489-49cd-ba7d-258be1f5e806" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

- background color incosistency on filters when on dark mode

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

https://github.com/user-attachments/assets/81a1691f-08ad-42f6-98d7-35f67cd67e79

