### PR TITLE
fix: gray button state on change password

### DIFF
--- a/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
+++ b/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
@@ -59,7 +59,13 @@ export const MyProfileScreenWrapper: React.FC<
             offset={{ opened: bottom + BOTTOM_TABS_HEIGHT }}
           >
             <Flex p={2} backgroundColor="mono0">
-              <Button block onPress={onPress} disabled={!isValid} loading={loading}>
+              <Button
+                key={`save-button-${isValid}`}
+                block
+                onPress={onPress}
+                disabled={!isValid}
+                loading={loading}
+              >
                 Save
               </Button>
             </Flex>

--- a/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
+++ b/src/app/Scenes/MyProfile/Components/MyProfileScreenWrapper.tsx
@@ -60,6 +60,8 @@ export const MyProfileScreenWrapper: React.FC<
           >
             <Flex p={2} backgroundColor="mono0">
               <Button
+                // Remount to fix a bug on validity change to clear a stale disabled (gray) state that
+                // lingered after pasting a password and toggling the input's secureTextEntry prop.
                 key={`save-button-${isValid}`}
                 block
                 onPress={onPress}


### PR DESCRIPTION
This PR resolves [PBRW-1767] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes an issue where the save button turned gray after pasting the password and flipping the secureTextEntry prop on the input

| Platform | Before | After |
|---|---|---|
| Android | <video src="https://github.com/user-attachments/assets/512ba26a-7c23-4124-9d0a-80bb00594721" width="400" /> | <video src="https://github.com/user-attachments/assets/81bd7caa-d641-42ad-8d56-60dd6c86a808" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix: gray button state on change password

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PBRW-1767]: https://artsyproduct.atlassian.net/browse/PBRW-1767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ