### PR TITLE
feat: add disableNavigation prop to RouterLink

### DIFF
--- a/src/app/Components/ArtistListItem.tsx
+++ b/src/app/Components/ArtistListItem.tsx
@@ -158,8 +158,8 @@ const ArtistListItem: React.FC<Props> = ({
   return (
     <RouterLink
       noFeedback={!withFeedback}
-      // Only navigate if there is an href and navigation is not disabled by passing `onPress` or
-      to={!disableNavigation ? href : undefined}
+      to={href}
+      disableNavigation={disableNavigation}
       onPress={() => callOnPress()}
       underlayColor={color("mono5")}
       style={containerStyle}

--- a/src/app/system/navigation/RouterLink.tsx
+++ b/src/app/system/navigation/RouterLink.tsx
@@ -11,6 +11,7 @@ import { Variables } from "relay-runtime"
 
 export interface RouterLinkProps {
   disablePrefetch?: boolean
+  disableNavigation?: boolean
   navigationProps?: NavigateOptions["passProps"]
   to?: string | null | undefined
   // Indicates whether the child component is a touchable element, preventing duplicate touch handlers
@@ -27,6 +28,7 @@ type PrefetchState = "started" | "complete" | null
  */
 export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   disablePrefetch,
+  disableNavigation,
   to,
   prefetchVariables,
   onPress,
@@ -45,7 +47,7 @@ export const RouterLink: React.FC<RouterLinkProps & TouchableProps> = ({
   const handlePress = (event: GestureResponderEvent) => {
     onPress?.(event)
 
-    if (!to) return
+    if (!to || disableNavigation) return
 
     if (navigationProps) {
       navigate(to, { passProps: navigationProps })

--- a/src/app/system/navigation/__tests__/RouterLink.tests.tsx
+++ b/src/app/system/navigation/__tests__/RouterLink.tests.tsx
@@ -1,4 +1,4 @@
-import { Text } from "@artsy/palette-mobile"
+import { Text, TouchableProps } from "@artsy/palette-mobile"
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { RouterLink, RouterLinkProps } from "app/system/navigation/RouterLink"
@@ -28,7 +28,7 @@ describe("RouterLink", () => {
     jest.clearAllMocks()
   })
 
-  const TestComponent = (props: Partial<RouterLinkProps>) => (
+  const TestComponent = (props: Partial<RouterLinkProps & TouchableProps>) => (
     <RouterLink to="/test-route" navigationProps={{ id: "test-id" }} {...props}>
       <Text>Test Link</Text>
     </RouterLink>
@@ -72,6 +72,25 @@ describe("RouterLink", () => {
 
     expect(navigate).toHaveBeenCalledExactlyOnceWith("/test-route", {
       passProps: { id: "test-id" },
+    })
+  })
+
+  describe("when disableNavigation is true", () => {
+    it("does not navigate on press", () => {
+      renderWithWrappers(<TestComponent disableNavigation />)
+
+      fireEvent.press(screen.getByText("Test Link"))
+
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it("still calls onPress", () => {
+      const onPress = jest.fn()
+      renderWithWrappers(<TestComponent disableNavigation onPress={onPress} />)
+
+      fireEvent.press(screen.getByText("Test Link"))
+
+      expect(onPress).toHaveBeenCalledTimes(1)
     })
   })
 


### PR DESCRIPTION
### Description

Adds a `disableNavigation` prop to `RouterLink` that prevents navigation on press while still allowing `onPress` to fire. Updates `ArtistListItem` to use it instead of the `to={!disableNavigation ? href : undefined}` pattern.

The motivation for this change was this PR review comment: https://github.com/artsy/eigen/pull/13710#discussion_r3504623420

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [ ] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add `disableNavigation` prop to `RouterLink`

<!-- end_changelog_updates -->

</details>