### PR TITLE
fix: avoid main-thread deadlock by dispatching reloadData asynchronously

### DIFF
--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListStickyCellCollectionViewLayout.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListStickyCellCollectionViewLayout.swift
@@ -25,8 +25,20 @@ extension PublicFunctions {
 
     func setActiveIndex(_ index: Int?) {
         currentIndex = index
-        invalidateLayout()
-        collectionView?.reloadData()
+
+        // `reloadData()` is dispatched asynchronously to avoid a fatal main-thread deadlock (EIGEN-AZ99).
+        // This method is called synchronously from inside an Interstellar `Observable.update` (via the
+        // `lotStateSignal` observer in `LiveAuctionLotListViewController`), which holds a non-recursive
+        // mutex while notifying its observers. `reloadData()` synchronously tears down cells, and
+        // `LotListCollectionViewCell`'s `deinit`/`prepareForReuse` calls `unsubscribe()` on that same
+        // signal — which would try to re-lock the already-held mutex on the same thread and deadlock.
+        // Deferring the reload lets `update` finish and release the lock before the cells are torn down.
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            self.invalidateLayout()
+            self.collectionView?.reloadData()
+        }
     }
 }
 

--- a/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListStickyCellCollectionViewLayout.swift
+++ b/ios/Artsy/View_Controllers/Live_Auctions/LiveAuctionLotListStickyCellCollectionViewLayout.swift
@@ -26,13 +26,7 @@ extension PublicFunctions {
     func setActiveIndex(_ index: Int?) {
         currentIndex = index
 
-        // `reloadData()` is dispatched asynchronously to avoid a fatal main-thread deadlock (EIGEN-AZ99).
-        // This method is called synchronously from inside an Interstellar `Observable.update` (via the
-        // `lotStateSignal` observer in `LiveAuctionLotListViewController`), which holds a non-recursive
-        // mutex while notifying its observers. `reloadData()` synchronously tears down cells, and
-        // `LotListCollectionViewCell`'s `deinit`/`prepareForReuse` calls `unsubscribe()` on that same
-        // signal — which would try to re-lock the already-held mutex on the same thread and deadlock.
-        // Deferring the reload lets `update` finish and release the lock before the cells are torn down.
+       // !! reloadData() is dispatched asynchronously to avoid a fatal main-thread deadlock (EIGEN-AZ99)
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
 


### PR DESCRIPTION
This PR resolves [PHIRE-3247] <!-- eg [PROJECT-XXXX] -->

### Description

Fixes a fatal main-thread deadlock in the native Live Auctions lot list. 
Sentry: 1,094 events / 398 users since Feb 2026 (Fatal App Hang Fully Blocked, culprit Mutex.lock).

Root cause — a reentrant lock in Interstellar.Observable:

- Observable.update(value) acquires a non-recursive pthread_mutex and notifies all observers while holding it.
- In the lot list, a lotStateSignal update (e.g. from a live-auction socket broadcast, or synchronously on subscribe) notifies the observer in LiveAuctionLotListViewController, which calls stickyCollectionViewLayout.setActiveIndex(...) → collectionView.reloadData().
- reloadData() synchronously tears down / recycles cells, and LotListCollectionViewCell.deinit / prepareForReuse call unsubscribe() on that same signal — which tries to re-lock the already-held mutex on the same thread → deadlock → watchdog kill.

Fix: defer the reloadData() in LiveAuctionLotListStickyCellCollectionViewLayout.setActiveIndex(_:) to the next main-runloop tick via DispatchQueue.main.async. currentIndex is still set synchronously (layout attributes stay correct); the reload — and therefore any cell teardown / unsubscribe() — now runs after Observable.update has released the lock. This breaks both the socket-driven path (unsubscribe-in-deinit) and the presentation-time path (subscribe-in-configureForViewModel).

How it was verified:

Reproduced and confirmed on an iPhone 17 simulator (iOS 26): before the fix, tapping the lot list hung the main thread (sample showed it parked in pthread_mutex_lock via Observable.unsubscribe); after the fix, the deadlock is gone and the deferred reload executes end-to-end. 

Also if we had the lot list open and any action was done in the auction operator i.e. move to a different lot the app was hanging there forever

| Platform | Before | After |
|---|---|---|
| iOS | <video src="https://github.com/user-attachments/assets/9021de5d-2320-4ebf-a958-84b7e291bc79" width="400" /> | <video src="https://github.com/user-attachments/assets/b3ec381d-a1f6-4d41-9a81-782bbe0390d7" width="400" /> |

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

- fix: avoid main-thread deadlock by dispatching reloadData asynchronously

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3247]: https://artsyproduct.atlassian.net/browse/PHIRE-3247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ