### PR TITLE
feat: fire startedOnboarding/completedOnboarding in experience-based onboarding

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -5,6 +5,7 @@ import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast"
+import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { GlobalStore } from "app/store/GlobalStore"
 import { goBack } from "app/system/navigation/navigate"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -18,6 +19,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   useSavesSummaryToast()
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
   const track = useInfiniteDiscoveryTracking()
+  const { trackCompletedOnboarding } = useOnboardingTracking()
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
@@ -33,6 +35,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleSkipPressed = () => {
+    trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -6,6 +6,7 @@ import {
 } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { ArtworkThumbnail } from "app/Scenes/InfiniteDiscovery/Components/ArtworkThumbnail"
+import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { GlobalStore } from "app/store/GlobalStore"
 import { useCallback } from "react"
 import { View } from "react-native"
@@ -44,6 +45,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   )
   const { setOnboardingState } = GlobalStore.actions.onboarding
   const { setNewUserOnboardingCompletionBottomSheetVisible } = GlobalStore.actions.infiniteDiscovery
+  const { trackCompletedOnboarding } = useOnboardingTracking()
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -71,6 +73,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
       handleComponent={null}
       backdropComponent={renderBackdrop}
       onDismiss={() => {
+        trackCompletedOnboarding()
         setOnboardingState("complete")
       }}
     >

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -1,7 +1,9 @@
+import { ActionType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { InfiniteDiscoveryHeader } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { GlobalStore, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import RNShare from "react-native-share"
 
@@ -152,6 +154,7 @@ describe("InfiniteDiscoveryHeader", () => {
       fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
 
       expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
+      expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
 
     it("suppresses the save summary toast when navigating away", () => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -16,6 +16,7 @@ import {
   ArtistRef,
   FollowedArtistsBank,
 } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank"
+import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { OnboardingSearchResultsScreen } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults"
 import { GlobalStore } from "app/store/GlobalStore"
 import { OnboardingFollowedArtist } from "app/store/OnboardingModel"
@@ -27,6 +28,7 @@ const MIN_FOLLOWED = 3
 const SET_ID = "onboarding:suggested-artists"
 
 export const FollowArtists: React.FC = () => {
+  const { trackCompletedOnboarding } = useOnboardingTracking()
   const [query, setQuery] = useState("")
   const storedFollowedArtists = GlobalStore.useAppState(
     (state) => state.onboarding.followedOnboardingArtists
@@ -67,7 +69,10 @@ export const FollowArtists: React.FC = () => {
           <Touchable
             accessibilityRole="button"
             accessibilityLabel="Skip new user onboarding"
-            onPress={() => GlobalStore.actions.onboarding.setOnboardingState("complete")}
+            onPress={() => {
+              trackCompletedOnboarding()
+              GlobalStore.actions.onboarding.setOnboardingState("complete")
+            }}
             hitSlop={DEFAULT_HIT_SLOP}
             haptic
           >
@@ -136,6 +141,7 @@ export const FollowArtists: React.FC = () => {
               block
               disabled={count < MIN_FOLLOWED}
               onPress={() => {
+                trackCompletedOnboarding()
                 GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
                 GlobalStore.actions.onboarding.setOnboardingState("complete")
               }}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -2,6 +2,7 @@ import { Flex } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { WelcomeStepQuery } from "__generated__/WelcomeStepQuery.graphql"
+import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
 import { GlobalStore } from "app/store/GlobalStore"
 import { AnimatePresence, MotiView } from "moti"
 import { useCallback, useEffect } from "react"
@@ -23,10 +24,16 @@ export const Introduction: React.FC = () => {
   const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
+  const { trackStartedOnboarding, trackCompletedOnboarding } = useOnboardingTracking()
 
   useEffect(() => {
     loadWelcomeQuery({}, { fetchPolicy: "network-only" })
   }, [loadWelcomeQuery])
+
+  useEffect(() => {
+    trackStartedOnboarding()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleDone = useCallback(
     (experience: Experience) => {
@@ -40,8 +47,9 @@ export const Introduction: React.FC = () => {
   )
 
   const handleSkipToHome = useCallback(() => {
+    trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
-  }, [])
+  }, [trackCompletedOnboarding])
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -1,6 +1,8 @@
+import { ActionType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { FollowArtists } from "app/Scenes/Onboarding/Screens/Onboarding/FollowArtists"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { KeyboardController } from "react-native-keyboard-controller"
 
@@ -196,6 +198,7 @@ describe("FollowArtists", () => {
       expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
         "complete"
       )
+      expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
   })
 
@@ -208,6 +211,7 @@ describe("FollowArtists", () => {
       expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
         "complete"
       )
+      expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,6 +1,8 @@
+import { ActionType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { mockReplace } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
@@ -56,6 +58,12 @@ describe("Introduction", () => {
     expect(screen.getByText("Montage next")).toBeOnTheScreen()
   })
 
+  it("fires startedOnboarding when it mounts", () => {
+    renderWithWrappers(<Introduction />)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.startedOnboarding })
+  })
+
   it("routes through ArtworkMontageStep → WelcomeStep → QuestionStep in order", () => {
     renderWithWrappers(<Introduction />)
 
@@ -102,6 +110,7 @@ describe("Introduction", () => {
 
       const state = __globalStoreTestUtils__?.getCurrentState()
       expect(state?.onboarding.onboardingState).toBe("complete")
+      expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
   })
 })


### PR DESCRIPTION
This PR partially resolves [DI-454](https://www.notion.so/396cab0764a080b5beb6dc5d4b3c71b9) by firing tracking events to signal that the onboarding flow has started and ended.

When the intro sequence begins:

```
{
  "action": "startedOnboarding"
}
```

When the user:

1. Clicks the _Continue to Artsy_ button after following 3 artists
2. Clicks the _Take me Home_ button after saving 5 artworks
3. Clicks the _Skip to homepage_ button in the intro sequence
4. Clicks the _Skip_ button instead of following 3 artists
5. Clicks the _Skip_ button instead of saving 5 artworks

```
{
  "action": "completedOnboarding"
}
```


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — Already behind the existing `AREnableExperienceBasedOnboarding` flag.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — No UI change.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. — See description above.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fire `startedOnboarding`/`completedOnboarding` analytics events in the experience-based onboarding flow

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)