### PR TITLE
feat: track the experience-selection answer in onboarding

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -24,7 +24,8 @@ export const Introduction: React.FC = () => {
   const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
-  const { trackStartedOnboarding, trackCompletedOnboarding } = useOnboardingTracking()
+  const { trackStartedOnboarding, trackCompletedOnboarding, trackAnsweredExperienceQuestion } =
+    useOnboardingTracking()
 
   useEffect(() => {
     loadWelcomeQuery({}, { fetchPolicy: "network-only" })
@@ -53,10 +54,15 @@ export const Introduction: React.FC = () => {
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
 
-  const renderStep = useCallback(() => {
+  const handleSelectExperience = (experience: Experience) => {
+    trackAnsweredExperienceQuestion(experience)
+    selectExperience(experience)
+  }
+
+  const renderStep = () => {
     switch (currentStep) {
       case STEP_QUESTION:
-        return <QuestionStep onSelect={selectExperience} />
+        return <QuestionStep onSelect={handleSelectExperience} />
       case STEP_BROWSE_PROMPT:
         return <BrowsePromptStep onNext={next} onSkip={handleSkipToHome} />
       case STEP_ARTWORK_MONTAGE:
@@ -66,7 +72,7 @@ export const Introduction: React.FC = () => {
       default:
         return null
     }
-  }, [currentStep, next, selectExperience, handleSkipToHome, welcomeQueryRef])
+  }
 
   return (
     <Flex flex={1} backgroundColor="mono100">

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,4 +1,4 @@
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ContextModule } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
@@ -84,6 +84,20 @@ describe("Introduction", () => {
       fireEvent.press(screen.getByText("Select experienced"))
 
       expect(mockReplace).toHaveBeenCalledWith("FollowArtists")
+    })
+
+    it("tracks the selected answer", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
+      fireEvent.press(screen.getByText("Select experienced"))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: ActionType.onboardingUserInputData,
+        context_module: ContextModule.onboardingCollectorLevel,
+        data_input: "experienced",
+      })
     })
   })
 

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__mocks__/useOnboardingTracking.ts
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__mocks__/useOnboardingTracking.ts
@@ -2,6 +2,7 @@ export const useOnboardingTracking = jest.fn().mockImplementation(() => {
   return {
     trackStartedOnboarding: jest.fn(),
     trackAnsweredQuestionOne: jest.fn(),
+    trackAnsweredExperienceQuestion: jest.fn(),
     trackAnsweredQuestionTwo: jest.fn(),
     trackAnsweredQuestionThree: jest.fn(),
     trackArtistFollow: jest.fn(),

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
@@ -35,6 +35,16 @@ export const useOnboardingTracking = () => {
     trackEvent(payload)
   }
 
+  const trackAnsweredExperienceQuestion = (experience: "experienced" | "beginner") => {
+    const payload: OnboardingUserInputData = {
+      action: ActionType.onboardingUserInputData,
+      context_module: ContextModule.onboardingCollectorLevel,
+      data_input: experience,
+    }
+
+    trackEvent(payload)
+  }
+
   const trackAnsweredQuestionTwo = (response: string[]) => {
     const payload: OnboardingUserInputData = {
       action: ActionType.onboardingUserInputData,
@@ -132,6 +142,7 @@ export const useOnboardingTracking = () => {
   return {
     trackStartedOnboarding,
     trackAnsweredQuestionOne,
+    trackAnsweredExperienceQuestion,
     trackAnsweredQuestionTwo,
     trackAnsweredQuestionThree,
     trackArtistFollow,


### PR DESCRIPTION
This PR partially resolves [DI-454](https://www.notion.so/396cab0764a080b5beb6dc5d4b3c71b9) by adding data tracking when users answer the experience question.

When one of the top two answers is selected:

```
{
  "action": "onboardingUserInputData",
  "context_module": "onboardingCollectorLevel",
  "data_input": "experienced"
}
```

When one of the bottom two answers is selected:
```
{
  "action": "onboardingUserInputData",
  "context_module": "onboardingCollectorLevel",
  "data_input": "beginner"
}
```

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — Already behind the existing `AREnableExperienceBasedOnboarding` flag.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — No UI change.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Track the experience-selection answer in the experience-based onboarding flow

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)