### PR TITLE
fix: track onboardingView and artistFollow context in Infinite Discovery

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab.tsx
@@ -135,6 +135,9 @@ export const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork, me }) => {
                     key={`artist-${index}`}
                     artist={artist}
                     onPress={handleCollapse}
+                    contextModule={ContextModule.infiniteDiscoveryDrawer}
+                    contextScreenOwnerId={data.internalID}
+                    contextScreenOwnerSlug={data.slug}
                   />
                 )
               })}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -72,8 +72,9 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
   useEffect(() => {
     if (isVisible) {
-      track.onboardingView
+      track.onboardingView()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isVisible])
 
   const showOnboardingAnimation = () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
@@ -121,6 +121,9 @@ const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
                     key={`artist-${index}`}
                     artist={artist}
                     disableNavigation
+                    contextModule={ContextModule.infiniteDiscoveryDrawer}
+                    contextScreenOwnerId={data.internalID}
+                    contextScreenOwnerSlug={data.slug}
                   />
                 )
               })}

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryAboutTheWorkTab.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryAboutTheWorkTab.tests.tsx
@@ -1,7 +1,9 @@
-import { screen, within } from "@testing-library/react-native"
+import { fireEvent, screen, within } from "@testing-library/react-native"
 import { InfiniteDiscoveryAboutTheWorkTabTestQuery } from "__generated__/InfiniteDiscoveryAboutTheWorkTabTestQuery.graphql"
 import { AboutTheWorkTab } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryAboutTheWorkTab"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { Schema } from "app/utils/track"
 import { Suspense } from "react"
 import { Text } from "react-native"
 import { graphql } from "react-relay"
@@ -139,6 +141,38 @@ describe("AboutTheWorkTab", () => {
       renderWithRelay({ Artwork: () => ({ ...artwork, isBiddable: true }) })
 
       expect(screen.queryByTestId("certificate-icon")).not.toBeOnTheScreen()
+    })
+  })
+
+  describe("artist follow tracking", () => {
+    it("tracks the artwork's context when an artist is followed", () => {
+      const { mockResolveLastOperation } = renderWithRelay()
+
+      mockResolveLastOperation({
+        Artwork: () => ({ ...artwork, internalID: "artwork-internal-id", slug: "artwork-slug" }),
+        Artist: () => ({
+          internalID: "artist-internal-id",
+          slug: "test-artist",
+          isFollowed: false,
+        }),
+      })
+
+      fireEvent.press(screen.getByText("Follow"))
+
+      mockResolveLastOperation({
+        Artist: () => ({ isFollowed: true }),
+      })
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action_name: Schema.ActionNames.ArtistFollow,
+        action_type: Schema.ActionTypes.Success,
+        owner_id: "artist-internal-id",
+        owner_slug: "test-artist",
+        owner_type: Schema.OwnerEntityTypes.Artist,
+        context_module: "infiniteDiscoveryDrawer",
+        context_screen_owner_id: "artwork-internal-id",
+        context_screen_owner_slug: "artwork-slug",
+      })
     })
   })
 })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -7,13 +7,18 @@ jest.mock("app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper", () => ({
   Swiper: () => null,
 }))
 
+const mockTrack = {
+  onboardingView: jest.fn(),
+}
+
 jest.mock("app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking", () => ({
-  useInfiniteDiscoveryTracking: () => ({ onboardingView: jest.fn() }),
+  useInfiniteDiscoveryTracking: () => mockTrack,
 }))
 
 describe("InfiniteDiscoveryOnboarding", () => {
   beforeEach(() => {
     jest.useFakeTimers()
+    jest.clearAllMocks()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
     GlobalStore.actions.infiniteDiscovery.setHasInteractedWithOnboarding(false)
   })
@@ -31,6 +36,12 @@ describe("InfiniteDiscoveryOnboarding", () => {
       renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
 
       expect(screen.getByText("Welcome to Discover Daily")).toBeOnTheScreen()
+    })
+
+    it("tracks the onboarding view", () => {
+      renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
+
+      expect(mockTrack.onboardingView).toHaveBeenCalled()
     })
 
     it("shows the onboarding-specific save prompt", () => {


### PR DESCRIPTION
This PR partially resolves [DI-454](https://www.notion.so/396cab0764a080b5beb6dc5d4b3c71b9) by firing the Infinite Discovery onboarding view event and including context on artist follow events fired from the About the Work drawer.

When the "Welcome to Discover Daily" overlay is shown:

```
{
  "action": "screen",
  "context_screen_owner_type": "infiniteDiscoveryOnboarding"
}
```

When an artist is followed from the About the Work drawer:

```
{
  "action_name": "artistFollow",
  "action_type": "success",
  "owner_id": "65c321d1e746cf000b834da6",
  "owner_slug": "callie-connors",
  "owner_type": "Artist",
  "context_module": "infiniteDiscoveryDrawer",
  "context_screen_owner_id": "67db5082938d41000fc90191",
  "context_screen_owner_slug": "callie-connors-dreams-of-summer"
}
```

In this PR:

- `track.onboardingView` was referenced but never called (missing parentheses), so it never fired. Fixed.
- `artistFollow`/`unfollowedArtist` events from the About the Work bottom sheet, in both the onboarding and regular Infinite Discovery flows, were missing `context_module`/`context_screen_owner_id`/`context_screen_owner_slug` entirely. Fixed in both flows.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — No UI or flag-gated behavior change.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — No UI change.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fix `onboardingView` and `artistFollow` tracking gaps in Infinite Discovery

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)