### PR TITLE
feat: track Skip button taps in onboarding

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
 import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
@@ -19,7 +20,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   useSavesSummaryToast()
   const negativeSignalsEnabled = useFeatureFlag("AREnabledDiscoverDailyNegativeSignals")
   const track = useInfiniteDiscoveryTracking()
-  const { trackCompletedOnboarding } = useOnboardingTracking()
+  const { trackCompletedOnboarding, trackTappedSkip } = useOnboardingTracking()
   const { setMoreInfoSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const hideRightButton = !topArtwork || !topArtwork.slug || !topArtwork.title
   const rightButtonLabel = negativeSignalsEnabled ? "More information" : "Share Artwork"
@@ -35,6 +36,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleSkipPressed = () => {
+    trackTappedSkip(ContextModule.infiniteDiscovery, OwnerType.infiniteDiscoveryArtwork)
     trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -1,4 +1,4 @@
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { InfiniteDiscoveryHeader } from "app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
@@ -155,6 +155,19 @@ describe("InfiniteDiscoveryHeader", () => {
 
       expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+    })
+
+    it("tracks the skip tap", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
+
+      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: ActionType.tappedSkip,
+        context_module: ContextModule.infiniteDiscovery,
+        context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
+        subject: "Skip",
+      })
     })
 
     it("suppresses the save summary toast when navigating away", () => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import {
   Box,
   Button,
@@ -28,7 +29,7 @@ const MIN_FOLLOWED = 3
 const SET_ID = "onboarding:suggested-artists"
 
 export const FollowArtists: React.FC = () => {
-  const { trackCompletedOnboarding } = useOnboardingTracking()
+  const { trackCompletedOnboarding, trackTappedSkip } = useOnboardingTracking()
   const [query, setQuery] = useState("")
   const [followedArtistRefs, setFollowedArtistRefs] = useState<ArtistRef[]>([])
 
@@ -67,6 +68,7 @@ export const FollowArtists: React.FC = () => {
             accessibilityRole="button"
             accessibilityLabel="Skip new user onboarding"
             onPress={() => {
+              trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
               trackCompletedOnboarding()
               GlobalStore.actions.onboarding.setOnboardingState("complete")
             }}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
@@ -24,8 +25,12 @@ export const Introduction: React.FC = () => {
   const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
-  const { trackStartedOnboarding, trackCompletedOnboarding, trackAnsweredExperienceQuestion } =
-    useOnboardingTracking()
+  const {
+    trackStartedOnboarding,
+    trackCompletedOnboarding,
+    trackAnsweredExperienceQuestion,
+    trackTappedSkip,
+  } = useOnboardingTracking()
 
   useEffect(() => {
     loadWelcomeQuery({}, { fetchPolicy: "network-only" })
@@ -48,9 +53,10 @@ export const Introduction: React.FC = () => {
   )
 
   const handleSkipToHome = useCallback(() => {
+    trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
     trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
-  }, [trackCompletedOnboarding])
+  }, [trackCompletedOnboarding, trackTappedSkip])
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -1,4 +1,4 @@
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { FollowArtists } from "app/Scenes/Onboarding/Screens/Onboarding/FollowArtists"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
@@ -195,6 +195,19 @@ describe("FollowArtists", () => {
         "complete"
       )
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+    })
+
+    it("tracks the skip tap", () => {
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: ActionType.tappedSkip,
+        context_module: ContextModule.onboardingFlow,
+        context_screen_owner_type: OwnerType.onboarding,
+        subject: "Skip",
+      })
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,4 +1,4 @@
-import { ActionType, ContextModule } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
@@ -125,6 +125,22 @@ describe("Introduction", () => {
       const state = __globalStoreTestUtils__?.getCurrentState()
       expect(state?.onboarding.onboardingState).toBe("complete")
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+    })
+
+    it("tracks the skip tap when skipping from BrowsePromptStep", () => {
+      renderWithWrappers(<Introduction />)
+
+      fireEvent.press(screen.getByText("Montage next"))
+      fireEvent.press(screen.getByText("Welcome next"))
+      fireEvent.press(screen.getByText("Select beginner"))
+      fireEvent.press(screen.getByText("Browse skip"))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: ActionType.tappedSkip,
+        context_module: ContextModule.onboardingFlow,
+        context_screen_owner_type: OwnerType.onboarding,
+        subject: "Skip",
+      })
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__mocks__/useOnboardingTracking.ts
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/__mocks__/useOnboardingTracking.ts
@@ -10,5 +10,6 @@ export const useOnboardingTracking = jest.fn().mockImplementation(() => {
     trackPartnerFollow: jest.fn(),
     trackGalleryFollow: jest.fn(),
     trackCompletedOnboarding: jest.fn(),
+    trackTappedSkip: jest.fn(),
   }
 })

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
@@ -7,7 +7,9 @@ import {
   FollowedPartner,
   OnboardingUserInputData,
   OwnerType,
+  ScreenOwnerType,
   StartedOnboarding,
+  TappedSkip,
   UnfollowedArtist,
   UnfollowedGene,
   UnfollowedPartner,
@@ -139,6 +141,24 @@ export const useOnboardingTracking = () => {
     trackEvent(payload)
   }
 
+  const trackTappedSkip = (
+    contextModule: ContextModule,
+    contextScreenOwnerType: ScreenOwnerType,
+    contextScreenOwnerId?: string,
+    contextScreenOwnerSlug?: string
+  ) => {
+    const payload: TappedSkip = {
+      action: ActionType.tappedSkip,
+      context_module: contextModule,
+      context_screen_owner_type: contextScreenOwnerType,
+      context_screen_owner_id: contextScreenOwnerId,
+      context_screen_owner_slug: contextScreenOwnerSlug,
+      subject: "Skip",
+    }
+
+    trackEvent(payload)
+  }
+
   return {
     trackStartedOnboarding,
     trackAnsweredQuestionOne,
@@ -149,5 +169,6 @@ export const useOnboardingTracking = () => {
     trackGalleryFollow,
     trackGeneFollow,
     trackCompletedOnboarding,
+    trackTappedSkip,
   }
 }


### PR DESCRIPTION
This PR partially resolves [DI-454](https://www.notion.so/396cab0764a080b5beb6dc5d4b3c71b9) by firing a `tappedSkip` event when the user skips onboarding.

From Follow Artists or the Intro Sequence's beginner path:

```
{
  "action": "tappedSkip",
  "context_module": "onboardingFlow",
  "context_screen_owner_type": "onboarding",
  "subject": "Skip"
}
```

From the onboarding-mode Infinite Discovery header:

```
{
  "action": "tappedSkip",
  "context_module": "infiniteDiscovery",
  "context_screen_owner_type": "infiniteDiscoveryArtwork",
  "subject": "Skip"
}
```

In this PR:

- Added `trackTappedSkip` to `useOnboardingTracking`.
- Wired it to the three Skip buttons: `FollowArtists`, `Introduction`'s `BrowsePromptStep` skip, and `InfiniteDiscoveryHeader`'s onboarding-mode Skip button.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — No UI or flag-gated behavior change.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — No UI change.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Track Skip button taps in onboarding

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)