### PR TITLE
feat: add step progress bar to onboarding headers

### DIFF
--- a/src/app/Components/StepProgressBar/StepProgressBar.tsx
+++ b/src/app/Components/StepProgressBar/StepProgressBar.tsx
@@ -1,0 +1,25 @@
+import { CheckmarkFillIcon } from "@artsy/icons/native"
+import { Flex, ProgressBar } from "@artsy/palette-mobile"
+
+interface StepProgressBarProps {
+  current: number
+  total: number
+}
+
+export const StepProgressBar: React.FC<StepProgressBarProps> = ({ current, total }) => {
+  const isComplete = current >= total
+  const progress = (Math.min(current, total) / total) * 100
+
+  return (
+    <Flex flexDirection="row" alignItems="center" gap={1} width="100%">
+      <ProgressBar
+        height={4}
+        trackColor={isComplete ? "green100" : "blue100"}
+        progress={progress}
+        style={{ flex: 1, borderRadius: 4 }}
+        progressBarStyle={{ borderRadius: 4 }}
+      />
+      {!!isComplete && <CheckmarkFillIcon testID="step-progress-bar-checkmark" fill="green100" />}
+    </Flex>
+  )
+}

--- a/src/app/Components/StepProgressBar/__tests__/StepProgressBar.tests.tsx
+++ b/src/app/Components/StepProgressBar/__tests__/StepProgressBar.tests.tsx
@@ -1,0 +1,29 @@
+import { screen } from "@testing-library/react-native"
+import { StepProgressBar } from "app/Components/StepProgressBar/StepProgressBar"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("StepProgressBar", () => {
+  it("does not show the checkmark before completion", () => {
+    renderWithWrappers(<StepProgressBar current={2} total={5} />)
+
+    expect(screen.queryByTestId("step-progress-bar-checkmark")).not.toBeOnTheScreen()
+  })
+
+  it("shows the checkmark once current reaches total", () => {
+    renderWithWrappers(<StepProgressBar current={5} total={5} />)
+
+    expect(screen.getByTestId("step-progress-bar-checkmark")).toBeOnTheScreen()
+  })
+
+  it("shows the checkmark when current exceeds total", () => {
+    renderWithWrappers(<StepProgressBar current={7} total={5} />)
+
+    expect(screen.getByTestId("step-progress-bar-checkmark")).toBeOnTheScreen()
+  })
+
+  it("renders the progress track", () => {
+    renderWithWrappers(<StepProgressBar current={0} total={5} />)
+
+    expect(screen.getByTestId("progress-bar-track")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -3,6 +3,7 @@ import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
 import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
+import { StepProgressBar } from "app/Components/StepProgressBar/StepProgressBar"
 import { InfiniteDiscoveryArtwork } from "app/Scenes/InfiniteDiscovery/InfiniteDiscovery"
 import { useInfiniteDiscoveryTracking } from "app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking"
 import { useSavesSummaryToast } from "app/Scenes/InfiniteDiscovery/hooks/useSavesSummaryToast"
@@ -97,6 +98,9 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
             </Touchable>
           }
         />
+        <Flex px={2}>
+          <StepProgressBar current={newUserOnboardingSavedArtworkCount} total={5} />
+        </Flex>
       </Flex>
     )
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/Swiper/Swiper.tsx
@@ -22,7 +22,7 @@ type SwiperProps = {
   cards: InfiniteDiscoveryArtwork[]
   cardStyle?: ViewStyle
   containerStyle?: ViewStyle
-  HeaderComponent?: () => React.ReactNode
+  HeaderComponent?: React.ReactNode
   isArtworkSaved?: (index: number) => boolean
   onNewCardReached?: (key: Key) => void
   onRewind: (key: Key) => void
@@ -205,7 +205,7 @@ export const Swiper = forwardRef<SwiperRefProps, SwiperProps>(
     return (
       <GestureDetector gesture={pan}>
         <View style={containerStyle}>
-          {!!HeaderComponent && <HeaderComponent />}
+          {HeaderComponent}
           <Flex>
             {cards.map((c, i) => {
               if (i < initialSliceIndex) {

--- a/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/InfiniteDiscovery.tsx
@@ -187,7 +187,7 @@ export const InfiniteDiscovery: React.FC<InfiniteDiscoveryProps> = ({
       */}
       <Screen.Body fullwidth style={{ marginTop: insets.top }} disableKeyboardAvoidance>
         <Swiper
-          HeaderComponent={() => <InfiniteDiscoveryHeader topArtwork={topArtwork} />}
+          HeaderComponent={<InfiniteDiscoveryHeader topArtwork={topArtwork} />}
           cards={artworks}
           onReachTriggerIndex={handleFetchMore}
           triggerIndex={2}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -12,6 +12,7 @@ import {
 } from "@artsy/palette-mobile"
 import { ArtistListItemNew_artist$key } from "__generated__/ArtistListItemNew_artist.graphql"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
+import { StepProgressBar } from "app/Components/StepProgressBar/StepProgressBar"
 import { FollowArtistsOrderedSetScreen } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet"
 import {
   ArtistRef,
@@ -79,6 +80,9 @@ export const FollowArtists: React.FC = () => {
           </Touchable>
         }
       />
+      <Flex px={2}>
+        <StepProgressBar current={count} total={MIN_FOLLOWED} />
+      </Flex>
 
       <Screen.Body disableKeyboardAvoidance>
         <Box mt={2}>


### PR DESCRIPTION
This PR adds a progress indicator to the headers for Follow Artists and Discover Daily in onboarding mode.

| Platform | Beginner | Experienced |
|-|-|-|
| iOS | https://github.com/user-attachments/assets/37d2c0a5-c201-4d16-be0d-c321b05e2e60 | https://github.com/user-attachments/assets/ef43e371-d0c9-4bac-9c43-07d7a88ddf01 |
| Android | https://github.com/user-attachments/assets/eeb01e83-a082-4c81-9847-6e1a9f62f070 | https://github.com/user-attachments/assets/cba233ec-b481-4cdc-8a4a-cc37c66cde5e |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — No flag needed.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Add a progress bar to the Follow Artists and Discover Daily onboarding headers

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)