### PR TITLE
feat(DI-449): allow continuing Discover Daily onboarding past 5 saves

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -29,8 +29,8 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const newUserOnboardingSavedArtworkCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
   )
-  const newUserOnboardingCompleted = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingCompleted
+  const newUserOnboardingGoalReached = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalReached
   )
 
   const handleExitPressed = () => {
@@ -39,7 +39,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleSkipOrExitPressed = () => {
-    if (!newUserOnboardingCompleted) {
+    if (!newUserOnboardingGoalReached) {
       trackTappedSkip(ContextModule.infiniteDiscovery, OwnerType.infiniteDiscoveryArtwork)
     }
     trackCompletedOnboarding()
@@ -94,13 +94,15 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
             <Touchable
               accessibilityRole="button"
               accessibilityLabel={
-                newUserOnboardingCompleted ? "Exit new user onboarding" : "Skip new user onboarding"
+                newUserOnboardingGoalReached
+                  ? "Exit new user onboarding"
+                  : "Skip new user onboarding"
               }
               onPress={handleSkipOrExitPressed}
               hitSlop={DEFAULT_HIT_SLOP}
               haptic
             >
-              <Text>{newUserOnboardingCompleted ? "Exit" : "Skip"}</Text>
+              <Text>{newUserOnboardingGoalReached ? "Exit" : "Skip"}</Text>
             </Touchable>
           }
         />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -29,14 +29,19 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const newUserOnboardingSavedArtworkCount = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
   )
+  const newUserOnboardingCompleted = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingCompleted
+  )
 
   const handleExitPressed = () => {
     track.tappedExit()
     goBack()
   }
 
-  const handleSkipPressed = () => {
-    trackTappedSkip(ContextModule.infiniteDiscovery, OwnerType.infiniteDiscoveryArtwork)
+  const handleSkipOrExitPressed = () => {
+    if (!newUserOnboardingCompleted) {
+      trackTappedSkip(ContextModule.infiniteDiscovery, OwnerType.infiniteDiscoveryArtwork)
+    }
     trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
@@ -88,12 +93,14 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
           rightElements={
             <Touchable
               accessibilityRole="button"
-              accessibilityLabel="Skip new user onboarding"
-              onPress={handleSkipPressed}
+              accessibilityLabel={
+                newUserOnboardingCompleted ? "Exit new user onboarding" : "Skip new user onboarding"
+              }
+              onPress={handleSkipOrExitPressed}
               hitSlop={DEFAULT_HIT_SLOP}
               haptic
             >
-              <Text>Skip</Text>
+              <Text>{newUserOnboardingCompleted ? "Exit" : "Skip"}</Text>
             </Touchable>
           }
         />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -32,6 +32,9 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const newUserOnboardingGoalReached = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalReached
   )
+  const displayedSavedArtworkCount = newUserOnboardingGoalReached
+    ? 5
+    : newUserOnboardingSavedArtworkCount
 
   const handleExitPressed = () => {
     track.tappedExit()
@@ -87,9 +90,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
       <Flex mb={1}>
         <Screen.Header
           title="Discover Daily"
-          leftElements={
-            <OnboardingProgressBadge current={newUserOnboardingSavedArtworkCount} total={5} />
-          }
+          leftElements={<OnboardingProgressBadge current={displayedSavedArtworkCount} total={5} />}
           rightElements={
             <Touchable
               accessibilityRole="button"

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -47,6 +47,16 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   const { setNewUserOnboardingCompletionBottomSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const { trackCompletedOnboarding } = useOnboardingTracking()
 
+  const handleContinueBrowsing = () => {
+    setNewUserOnboardingCompletionBottomSheetVisible(false)
+  }
+
+  const handleTakeMeHome = () => {
+    trackCompletedOnboarding()
+    setOnboardingState("complete")
+    setNewUserOnboardingCompletionBottomSheetVisible(false)
+  }
+
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <BottomSheetBackdrop
@@ -72,10 +82,6 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
       enableContentPanningGesture={false}
       handleComponent={null}
       backdropComponent={renderBackdrop}
-      onDismiss={() => {
-        trackCompletedOnboarding()
-        setOnboardingState("complete")
-      }}
     >
       <BottomSheetView>
         <Flex px={2} pt={2} style={{ paddingBottom: safeAreaInsets.bottom + 16 }}>
@@ -104,27 +110,27 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
 
           <Flex gap={1} alignItems="center">
             <Text variant="lg-display" textAlign="center">
-              First five works saved!
+              Five works is all it takes to start.
             </Text>
             <Text variant="sm" textAlign="center">
-              We're starting to understand what draws you in.
+              We're beginning to see what moves you.
             </Text>
             <Text variant="xs" textAlign="center">
-              Visit your homepage to see what we've put together so far, or keep browsing.
+              Visit your For You page, or stay and keep exploring.
             </Text>
           </Flex>
 
           <Spacer y={2} />
 
-          <Button
-            block
-            variant="fillDark"
-            onPress={() => {
-              setNewUserOnboardingCompletionBottomSheetVisible(false)
-            }}
-          >
-            Take me home
-          </Button>
+          <Flex gap={1}>
+            <Button block variant="outline" onPress={handleContinueBrowsing}>
+              Continue Browsing
+            </Button>
+
+            <Button block variant="fillDark" onPress={handleTakeMeHome}>
+              Take Me Home
+            </Button>
+          </Flex>
         </Flex>
       </BottomSheetView>
     </AutomountedBottomSheetModal>

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -41,7 +41,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   const isNewUserOnboardingSession =
     GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
   const savedArtworks = GlobalStore.useAppState(
-    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalSnapshot
   )
   const { setOnboardingState } = GlobalStore.actions.onboarding
   const { setNewUserOnboardingCompletionBottomSheetVisible } = GlobalStore.actions.infiniteDiscovery

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -177,6 +177,50 @@ describe("InfiniteDiscoveryHeader", () => {
 
       expect(mockUseToast.show).not.toHaveBeenCalled()
     })
+
+    describe("once the 5-save milestone is completed", () => {
+      beforeEach(() => {
+        for (let i = 1; i <= 5; i++) {
+          GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+            internalID: `artwork-${i}`,
+            url: `https://example.com/${i}.jpg`,
+          })
+        }
+      })
+
+      it("shows an Exit button instead of Skip, with the badge frozen at 5/5", () => {
+        renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+        expect(screen.getByText("5/5")).toBeOnTheScreen()
+        expect(screen.getByText("Exit")).toBeOnTheScreen()
+        expect(screen.queryByText("Skip")).not.toBeOnTheScreen()
+      })
+
+      it("exits onboarding when Exit is pressed, without tracking a skip tap", () => {
+        const setOnboardingStateSpy = jest.spyOn(
+          GlobalStore.actions.onboarding,
+          "setOnboardingState"
+        )
+
+        renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+        fireEvent.press(screen.getByLabelText("Exit new user onboarding"))
+
+        expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
+        expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+        expect(mockTrackEvent).not.toHaveBeenCalledWith(
+          expect.objectContaining({ action: ActionType.tappedSkip })
+        )
+      })
+
+      it("keeps the badge frozen at 5/5 even if a saved artwork is removed", () => {
+        GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
+
+        renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+        expect(screen.getByText("5/5")).toBeOnTheScreen()
+      })
+    })
   })
 
   describe("when negative signals feature flag is enabled", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -22,22 +22,39 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
 
-    expect(screen.getByText("First five works saved!")).toBeOnTheScreen()
-    expect(screen.getByText("Take me home")).toBeOnTheScreen()
+    expect(screen.getByText("Five works is all it takes to start.")).toBeOnTheScreen()
+    expect(screen.getByText("Continue Browsing")).toBeOnTheScreen()
+    expect(screen.getByText("Take Me Home")).toBeOnTheScreen()
   })
 
-  it('"Take me home" hides the completion sheet', () => {
+  it('"Continue Browsing" hides the sheet and keeps onboarding incomplete', () => {
     GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
 
-    fireEvent.press(screen.getByText("Take me home"))
+    fireEvent.press(screen.getByText("Continue Browsing"))
 
-    const infiniteDiscoveryState = __globalStoreTestUtils__?.getCurrentState().infiniteDiscovery
-    expect(infiniteDiscoveryState?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(
-      false
-    )
+    const state = __globalStoreTestUtils__?.getCurrentState()
+    expect(
+      state?.infiniteDiscovery.sessionState.newUserOnboardingCompletionBottomSheetVisible
+    ).toBe(false)
+    expect(state?.onboarding.onboardingState).toBe("incomplete")
+  })
+
+  it('"Take Me Home" hides the sheet and completes onboarding', () => {
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
+
+    renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
+
+    fireEvent.press(screen.getByText("Take Me Home"))
+
+    const state = __globalStoreTestUtils__?.getCurrentState()
+    expect(
+      state?.infiniteDiscovery.sessionState.newUserOnboardingCompletionBottomSheetVisible
+    ).toBe(false)
+    expect(state?.onboarding.onboardingState).toBe("complete")
   })
 
   it("renders 5 artwork images from the store", () => {
@@ -48,6 +65,6 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
 
-    expect(screen.getByText("First five works saved!")).toBeOnTheScreen()
+    expect(screen.getByText("Five works is all it takes to start.")).toBeOnTheScreen()
   })
 })

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -14,6 +14,7 @@ export interface InfiniteDiscoveryModel {
     moreInfoSheetVisible: boolean
     newUserOnboardingSavedArtworks: NewUserOnboardingSavedArtwork[]
     newUserOnboardingCompletionBottomSheetVisible: boolean
+    newUserOnboardingCompleted: boolean
   }
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
@@ -35,6 +36,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
     moreInfoSheetVisible: false,
     newUserOnboardingSavedArtworks: [],
     newUserOnboardingCompletionBottomSheetVisible: false,
+    newUserOnboardingCompleted: false,
   },
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
@@ -48,6 +50,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   resetNewUserOnboardingSessionState: action((state) => {
     state.sessionState.newUserOnboardingSavedArtworks = []
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = false
+    state.sessionState.newUserOnboardingCompleted = false
   }),
   setHasInteractedWithOnboarding: action((state, payload) => {
     state.hasInteractedWithOnboarding = payload
@@ -62,6 +65,10 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = payload
   }),
   addNewUserOnboardingSavedArtwork: action((state, payload) => {
+    if (state.sessionState.newUserOnboardingCompleted) {
+      return
+    }
+
     const { newUserOnboardingSavedArtworks } = state.sessionState
     const alreadyAdded = newUserOnboardingSavedArtworks.some(
       (a) => a.internalID === payload.internalID
@@ -70,10 +77,15 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
       newUserOnboardingSavedArtworks.push(payload)
       if (newUserOnboardingSavedArtworks.length === 5) {
         state.sessionState.newUserOnboardingCompletionBottomSheetVisible = true
+        state.sessionState.newUserOnboardingCompleted = true
       }
     }
   }),
   removeNewUserOnboardingSavedArtwork: action((state, internalID) => {
+    if (state.sessionState.newUserOnboardingCompleted) {
+      return
+    }
+
     state.sessionState.newUserOnboardingSavedArtworks =
       state.sessionState.newUserOnboardingSavedArtworks.filter((a) => a.internalID !== internalID)
   }),

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -14,7 +14,7 @@ export interface InfiniteDiscoveryModel {
     moreInfoSheetVisible: boolean
     newUserOnboardingSavedArtworks: NewUserOnboardingSavedArtwork[]
     newUserOnboardingCompletionBottomSheetVisible: boolean
-    newUserOnboardingCompleted: boolean
+    newUserOnboardingGoalReached: boolean
   }
   incrementSavedArtworksCount: Action<this>
   decrementSavedArtworksCount: Action<this>
@@ -36,7 +36,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
     moreInfoSheetVisible: false,
     newUserOnboardingSavedArtworks: [],
     newUserOnboardingCompletionBottomSheetVisible: false,
-    newUserOnboardingCompleted: false,
+    newUserOnboardingGoalReached: false,
   },
   incrementSavedArtworksCount: action((state) => {
     state.savedArtworksCount += 1
@@ -50,7 +50,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   resetNewUserOnboardingSessionState: action((state) => {
     state.sessionState.newUserOnboardingSavedArtworks = []
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = false
-    state.sessionState.newUserOnboardingCompleted = false
+    state.sessionState.newUserOnboardingGoalReached = false
   }),
   setHasInteractedWithOnboarding: action((state, payload) => {
     state.hasInteractedWithOnboarding = payload
@@ -65,7 +65,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = payload
   }),
   addNewUserOnboardingSavedArtwork: action((state, payload) => {
-    if (state.sessionState.newUserOnboardingCompleted) {
+    if (state.sessionState.newUserOnboardingGoalReached) {
       return
     }
 
@@ -77,12 +77,12 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
       newUserOnboardingSavedArtworks.push(payload)
       if (newUserOnboardingSavedArtworks.length === 5) {
         state.sessionState.newUserOnboardingCompletionBottomSheetVisible = true
-        state.sessionState.newUserOnboardingCompleted = true
+        state.sessionState.newUserOnboardingGoalReached = true
       }
     }
   }),
   removeNewUserOnboardingSavedArtwork: action((state, internalID) => {
-    if (state.sessionState.newUserOnboardingCompleted) {
+    if (state.sessionState.newUserOnboardingGoalReached) {
       return
     }
 

--- a/src/app/store/InfiniteDiscoveryModel.ts
+++ b/src/app/store/InfiniteDiscoveryModel.ts
@@ -13,6 +13,7 @@ export interface InfiniteDiscoveryModel {
   sessionState: {
     moreInfoSheetVisible: boolean
     newUserOnboardingSavedArtworks: NewUserOnboardingSavedArtwork[]
+    newUserOnboardingGoalSnapshot: NewUserOnboardingSavedArtwork[]
     newUserOnboardingCompletionBottomSheetVisible: boolean
     newUserOnboardingGoalReached: boolean
   }
@@ -35,6 +36,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   sessionState: {
     moreInfoSheetVisible: false,
     newUserOnboardingSavedArtworks: [],
+    newUserOnboardingGoalSnapshot: [],
     newUserOnboardingCompletionBottomSheetVisible: false,
     newUserOnboardingGoalReached: false,
   },
@@ -49,6 +51,7 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
   }),
   resetNewUserOnboardingSessionState: action((state) => {
     state.sessionState.newUserOnboardingSavedArtworks = []
+    state.sessionState.newUserOnboardingGoalSnapshot = []
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = false
     state.sessionState.newUserOnboardingGoalReached = false
   }),
@@ -65,27 +68,28 @@ export const getInfiniteDiscoveryModel = (): InfiniteDiscoveryModel => ({
     state.sessionState.newUserOnboardingCompletionBottomSheetVisible = payload
   }),
   addNewUserOnboardingSavedArtwork: action((state, payload) => {
-    if (state.sessionState.newUserOnboardingGoalReached) {
-      return
-    }
-
     const { newUserOnboardingSavedArtworks } = state.sessionState
     const alreadyAdded = newUserOnboardingSavedArtworks.some(
       (a) => a.internalID === payload.internalID
     )
-    if (!alreadyAdded && newUserOnboardingSavedArtworks.length < 5) {
-      newUserOnboardingSavedArtworks.push(payload)
-      if (newUserOnboardingSavedArtworks.length === 5) {
-        state.sessionState.newUserOnboardingCompletionBottomSheetVisible = true
-        state.sessionState.newUserOnboardingGoalReached = true
-      }
-    }
-  }),
-  removeNewUserOnboardingSavedArtwork: action((state, internalID) => {
-    if (state.sessionState.newUserOnboardingGoalReached) {
+    if (alreadyAdded) {
       return
     }
 
+    newUserOnboardingSavedArtworks.push(payload)
+
+    if (
+      !state.sessionState.newUserOnboardingGoalReached &&
+      newUserOnboardingSavedArtworks.length === 5
+    ) {
+      state.sessionState.newUserOnboardingCompletionBottomSheetVisible = true
+      state.sessionState.newUserOnboardingGoalReached = true
+      // Keep a snapshot of the saved artworks when the onboarding goal was reached.
+      // Used in the post-onboarding animation in case the user goes back and unsaves them.
+      state.sessionState.newUserOnboardingGoalSnapshot = [...newUserOnboardingSavedArtworks]
+    }
+  }),
+  removeNewUserOnboardingSavedArtwork: action((state, internalID) => {
     state.sessionState.newUserOnboardingSavedArtworks =
       state.sessionState.newUserOnboardingSavedArtworks.filter((a) => a.internalID !== internalID)
   }),

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -62,6 +62,45 @@ describe("InfiniteDiscoveryModel", () => {
 
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(true)
     })
+
+    it("sets newUserOnboardingCompleted to true when the 5th artwork is added", () => {
+      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
+
+      for (let i = 1; i <= 4; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
+
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-5",
+        url: "https://example.com/5.jpg",
+      })
+
+      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(true)
+    })
+
+    it("does not add further artworks once completed", () => {
+      for (let i = 1; i <= 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-6",
+        url: "https://example.com/6.jpg",
+      })
+
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks.map((a) => a.internalID)).toEqual(
+        ["artwork-1", "artwork-2", "artwork-3", "artwork-4", "artwork-5"]
+      )
+    })
   })
 
   describe("setNewUserOnboardingCompletionBottomSheetVisible", () => {
@@ -91,6 +130,19 @@ describe("InfiniteDiscoveryModel", () => {
 
       expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(1)
       expect(state()?.sessionState.newUserOnboardingSavedArtworks[0].internalID).toBe("artwork-2")
+    })
+
+    it("does not remove artworks once onboarding is completed", () => {
+      for (let i = 1; i <= 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
+
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
     })
   })
 
@@ -132,6 +184,21 @@ describe("InfiniteDiscoveryModel", () => {
       GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
 
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(false)
+    })
+
+    it("clears newUserOnboardingCompleted", () => {
+      for (let i = 1; i <= 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(true)
+
+      GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+
+      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
     })
   })
 })

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -63,8 +63,8 @@ describe("InfiniteDiscoveryModel", () => {
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(true)
     })
 
-    it("sets newUserOnboardingCompleted to true when the 5th artwork is added", () => {
-      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
+    it("sets newUserOnboardingGoalReached to true when the 5th artwork is added", () => {
+      expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(false)
 
       for (let i = 1; i <= 4; i++) {
         GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
@@ -73,14 +73,14 @@ describe("InfiniteDiscoveryModel", () => {
         })
       }
 
-      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
+      expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(false)
 
       GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-5",
         url: "https://example.com/5.jpg",
       })
 
-      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(true)
+      expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(true)
     })
 
     it("does not add further artworks once completed", () => {
@@ -186,7 +186,7 @@ describe("InfiniteDiscoveryModel", () => {
       expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(false)
     })
 
-    it("clears newUserOnboardingCompleted", () => {
+    it("clears newUserOnboardingGoalReached", () => {
       for (let i = 1; i <= 5; i++) {
         GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
           internalID: `artwork-${i}`,
@@ -194,11 +194,11 @@ describe("InfiniteDiscoveryModel", () => {
         })
       }
 
-      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(true)
+      expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(true)
 
       GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
 
-      expect(state()?.sessionState.newUserOnboardingCompleted).toBe(false)
+      expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(false)
     })
   })
 })

--- a/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
+++ b/src/app/store/__tests__/InfiniteDiscoveryModel.tests.ts
@@ -22,15 +22,15 @@ describe("InfiniteDiscoveryModel", () => {
       })
     })
 
-    it("caps at 5 artworks", () => {
-      for (let i = 1; i <= 6; i++) {
+    it("keeps tracking saved artworks beyond 5 once the goal is reached", () => {
+      for (let i = 1; i <= 7; i++) {
         GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
           internalID: `artwork-${i}`,
           url: `https://example.com/${i}.jpg`,
         })
       }
 
-      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(7)
     })
 
     it("stores the blurhash when provided", () => {
@@ -83,7 +83,7 @@ describe("InfiniteDiscoveryModel", () => {
       expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(true)
     })
 
-    it("does not add further artworks once completed", () => {
+    it("captures an immutable snapshot of the first 5 artworks when the goal is reached", () => {
       for (let i = 1; i <= 5; i++) {
         GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
           internalID: `artwork-${i}`,
@@ -91,15 +91,58 @@ describe("InfiniteDiscoveryModel", () => {
         })
       }
 
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot.map((a) => a.internalID)).toEqual([
+        "artwork-1",
+        "artwork-2",
+        "artwork-3",
+        "artwork-4",
+        "artwork-5",
+      ])
+
       GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
         internalID: "artwork-6",
         url: "https://example.com/6.jpg",
       })
 
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(6)
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot.map((a) => a.internalID)).toEqual([
+        "artwork-1",
+        "artwork-2",
+        "artwork-3",
+        "artwork-4",
+        "artwork-5",
+      ])
+    })
+
+    it("does not re-trigger the completion sheet or overwrite the snapshot if the count dips below 5 and returns to 5", () => {
+      for (let i = 1; i <= 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+      GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(false)
+
+      GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
+      GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-2")
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-6",
+        url: "https://example.com/6.jpg",
+      })
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-7",
+        url: "https://example.com/7.jpg",
+      })
+
       expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
-      expect(state()?.sessionState.newUserOnboardingSavedArtworks.map((a) => a.internalID)).toEqual(
-        ["artwork-1", "artwork-2", "artwork-3", "artwork-4", "artwork-5"]
-      )
+      expect(state()?.sessionState.newUserOnboardingCompletionBottomSheetVisible).toBe(false)
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot.map((a) => a.internalID)).toEqual([
+        "artwork-1",
+        "artwork-2",
+        "artwork-3",
+        "artwork-4",
+        "artwork-5",
+      ])
     })
   })
 
@@ -132,7 +175,7 @@ describe("InfiniteDiscoveryModel", () => {
       expect(state()?.sessionState.newUserOnboardingSavedArtworks[0].internalID).toBe("artwork-2")
     })
 
-    it("does not remove artworks once onboarding is completed", () => {
+    it("keeps removing artworks after the goal is reached, without touching the first-five snapshot", () => {
       for (let i = 1; i <= 5; i++) {
         GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
           internalID: `artwork-${i}`,
@@ -142,7 +185,14 @@ describe("InfiniteDiscoveryModel", () => {
 
       GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
 
-      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(5)
+      expect(state()?.sessionState.newUserOnboardingSavedArtworks).toHaveLength(4)
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot.map((a) => a.internalID)).toEqual([
+        "artwork-1",
+        "artwork-2",
+        "artwork-3",
+        "artwork-4",
+        "artwork-5",
+      ])
     })
   })
 
@@ -199,6 +249,21 @@ describe("InfiniteDiscoveryModel", () => {
       GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
 
       expect(state()?.sessionState.newUserOnboardingGoalReached).toBe(false)
+    })
+
+    it("clears newUserOnboardingGoalSnapshot", () => {
+      for (let i = 1; i <= 5; i++) {
+        GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+          internalID: `artwork-${i}`,
+          url: `https://example.com/${i}.jpg`,
+        })
+      }
+
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot).toHaveLength(5)
+
+      GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+
+      expect(state()?.sessionState.newUserOnboardingGoalSnapshot).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
[DI-449](https://app.notion.com/p/artsy/Discover-Daily-continue-after-5-saves-396cab0764a080c1a99ff2bd4998fa66?v=5cbcab0764a082578d6388b3ee7cefda&source=copy_link)

This PR lets users continue in Discover Daily's onboarding mode after their first 5 saves, instead of being forced to exit onboarding. 

In this PR:

- The 5/5 onboarding badge now freezes permanently once reached — unsaving one of the first 5 artworks no longer drops the count back down.
- The header's "Skip" button becomes "Exit" once the milestone is completed (same underlying action — ends onboarding — just no longer semantically a skip).
- The completion bottom sheet has new copy and two buttons: **Continue Browsing** (dismisses the sheet, stays in onboarding mode, deck stays fully interactive) and **Take Me Home** (ends onboarding, as before).

| Platform | Screencap |
|-|-|
| iOS | https://github.com/user-attachments/assets/35c7c6e4-192a-40b2-a3db-e7b46c024bab |
| Android | https://github.com/user-attachments/assets/2763ec06-2bea-40a9-bd16-854833f58ef4 |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**. — Not yet run on a simulator; verified via `yarn tsc`, `yarn lint`, and Jest only so far.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — No flag; ships within the existing onboarding flow.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — Not yet captured; will add before taking this out of draft.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one. — `sessionState` isn't persisted, so no migration needed.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. — Favorites-tab tooltip, described above.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device — this is still pending on my end too, so please double check the badge-freeze, Skip/Exit swap, and both completion-sheet buttons before we merge.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Allow continuing Discover Daily onboarding after the first 5 saves

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
