### PR TITLE
fix(ONYX-2169): fix wtyl rail tracking on back

### DIFF
--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -34,7 +34,7 @@ import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { isDislikeArtworksEnabledFor } from "app/utils/isDislikeArtworksEnabledFor"
 import { useMemoizedRandom } from "app/utils/placeholders"
 import { times } from "lodash"
-import { memo, useEffect } from "react"
+import { memo, useEffect, useRef } from "react"
 import { fetchQuery, graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
 interface HomeViewSectionArtworksProps extends FlexProps {
@@ -67,17 +67,25 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
   const shouldShowInGrid = section.component?.type === "ArtworksGrid"
   const contextModule = section.contextModule as ContextModule
 
+  const isRailInViewport = viewableSections.includes(section.internalID)
+
+  // Keep the latest visibility in a ref so the async `complete` callback below reads the current
+  // value rather than the stale one captured when the refetch was kicked off.
+  const isRailInViewportRef = useRef(isRailInViewport)
+  isRailInViewportRef.current = isRailInViewport
+
   const { onViewableItemsChanged, viewabilityConfig, resetTracking } = useItemsImpressionsTracking({
     // It is important here to tell if the rail is visible or not, because the viewability config
     // default behavior, doesn't take into account the fact that the rail could be not visible
     // on the screen because it's within a scrollable container.
-    isInViewport: viewableSections.includes(section.internalID) && section.trackItemImpressions,
+    isInViewport: isRailInViewport && section.trackItemImpressions,
     contextModule,
   })
 
   // When the live refetch key is bumped (returning to home or pull to refresh), force a fresh
-  // fetch of the rail's artworks. Impression tracking is re-fired in `complete` — once the new
-  // data is in the store — so railViewed/itemViewed reflect the new content, not the stale rail.
+  // fetch of the rail's artworks. On `complete` we reset the per-item impression guard so
+  // itemViewed can re-fire for the fresh content, and re-fire railViewed — but only if the rail
+  // is actually on screen, so returning to home while the rail is scrolled off doesn't fire it.
   useEffect(() => {
     if (!isLiveRecommendationsRail || liveRefetchKey === 0) {
       return
@@ -91,7 +99,10 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
     ).subscribe({
       complete: () => {
         resetTracking()
-        tracking.viewedSection(contextModule, index)
+
+        if (isRailInViewportRef.current) {
+          tracking.viewedSection(contextModule, index)
+        }
       },
       error: (error: Error) => {
         console.error("Failed to refresh live artworks rail", error)

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
@@ -460,6 +460,68 @@ describe("HomeViewSectionArtworks", () => {
       })
     })
 
+    it("does not re-fire railViewed on refresh when the WTYL rail is off screen", () => {
+      // The refresh-driven re-fire only applies to the live "We think you'll love" (WTYL) section
+      // (home-view-section-recommended-artworks); no other section takes this path.
+      const { env } = renderWithRelay({
+        HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
+      })
+
+      // Rail is not in the viewport.
+      homeViewStoreActions.setViewableSections([])
+      mockTrackEvent.mockClear()
+
+      // Request a refresh (focus return / pull to refresh).
+      act(() => {
+        homeViewStoreActions.bumpLiveRefetchKey()
+      })
+
+      // Complete the forced refetch.
+      act(() => {
+        env.mock.resolveMostRecentOperation((operation) =>
+          MockPayloadGenerator.generate(operation, {
+            HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
+          })
+        )
+      })
+
+      // railViewed should not fire because the rail is off screen.
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: "railViewed" })
+      )
+    })
+
+    it("re-fires railViewed on every refresh while the rail is in view", () => {
+      const { env } = renderWithRelay({
+        HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
+      })
+
+      homeViewStoreActions.setViewableSections(["home-view-section-recommended-artworks"])
+      mockTrackEvent.mockClear()
+
+      const refresh = () => {
+        act(() => {
+          homeViewStoreActions.bumpLiveRefetchKey()
+        })
+        act(() => {
+          env.mock.resolveMostRecentOperation((operation) =>
+            MockPayloadGenerator.generate(operation, {
+              HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
+            })
+          )
+        })
+      }
+
+      // Two separate returns to home, both with the rail in view.
+      refresh()
+      refresh()
+
+      const railViewedCalls = mockTrackEvent.mock.calls.filter(
+        (call) => (call[0] as any)?.action === "railViewed"
+      )
+      expect(railViewedCalls).toHaveLength(2)
+    })
+
     it("re-enables itemViewed tracking after the live refresh completes", async () => {
       const { env, UNSAFE_root } = renderWithRelay({
         HomeViewSectionArtworks: () => RECOMMENDED_SECTION,


### PR DESCRIPTION
This PR resolves [ONYX-2169] <!-- eg [PROJECT-XXXX] -->

### Description
WTYL `rail_viewed` was triggered on every back to home, even when the rail is not in the view - this was wrong

This PR changes the behavior - re-fire the `rail_viewed` on every back to home, but only if the rail is in the view


https://github.com/user-attachments/assets/6e0ec2fd-7300-4275-a078-5fa0b274a0cf



<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- fix wtyl rail tracking on back - daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[ONYX-2169]: https://artsyproduct.atlassian.net/browse/ONYX-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ