### PR TITLE
fix: correct context_module and data_input for onboarding analytics events

### DIFF
--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -44,7 +44,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
 
   const handleSkipOrExitPressed = () => {
     if (!newUserOnboardingGoalReached) {
-      trackTappedSkip(ContextModule.infiniteDiscovery, OwnerType.infiniteDiscoveryArtwork)
+      trackTappedSkip(ContextModule.onboardingFlow, OwnerType.infiniteDiscoveryArtwork)
     }
     trackCompletedOnboarding()
     GlobalStore.actions.onboarding.setOnboardingState("complete")

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingAboutTheWorkTab.tsx
@@ -53,7 +53,7 @@ const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
   return (
     <BottomSheetScrollView>
       <AnalyticsContextProvider
-        contextModule={ContextModule.infiniteDiscoveryDrawer}
+        contextModule={ContextModule.onboardingFlow}
         contextScreenOwnerType={OwnerType.infiniteDiscoveryArtwork}
         contextScreenOwnerId={data.internalID}
         contextScreenOwnerSlug={data.slug}
@@ -121,7 +121,7 @@ const AboutTheWorkTab: FC<AboutTheWorkTabProps> = ({ artwork }) => {
                     key={`artist-${index}`}
                     artist={artist}
                     disableNavigation
-                    contextModule={ContextModule.infiniteDiscoveryDrawer}
+                    contextModule={ContextModule.onboardingFlow}
                     contextScreenOwnerId={data.internalID}
                     contextScreenOwnerSlug={data.slug}
                   />

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -164,7 +164,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedSkip,
-        context_module: ContextModule.infiniteDiscovery,
+        context_module: ContextModule.onboardingFlow,
         context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
         subject: "Skip",
       })

--- a/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking.ts
+++ b/src/app/Scenes/InfiniteDiscovery/hooks/useInfiniteDiscoveryTracking.ts
@@ -7,11 +7,17 @@ import {
   TappedSeeFewerWorks,
   TappedShare,
 } from "@artsy/cohesion"
+import { GlobalStore } from "app/store/GlobalStore"
 import { Schema } from "app/utils/track"
 import { useTracking } from "react-tracking"
 
 export const useInfiniteDiscoveryTracking = () => {
   const { trackEvent } = useTracking()
+  const isNewUserOnboardingSession =
+    GlobalStore.useAppState((state) => state.onboarding.onboardingState) === "incomplete"
+
+  const getContextModule = (defaultContextModule: ContextModule) =>
+    isNewUserOnboardingSession ? ContextModule.onboardingFlow : defaultContextModule
 
   return {
     displayedNewArtwork: (artworkId: string, artworkSlug: string) => {
@@ -35,7 +41,7 @@ export const useInfiniteDiscoveryTracking = () => {
     swipedArtwork: (artworkId: string, artworkSlug: string) => {
       trackEvent({
         action: ActionType.swipedInfiniteDiscoveryArtwork,
-        context_module: ContextModule.infiniteDiscovery,
+        context_module: getContextModule(ContextModule.infiniteDiscovery),
         context_screen_owner_id: artworkId,
         context_screen_owner_slug: artworkSlug,
         context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
@@ -50,7 +56,7 @@ export const useInfiniteDiscoveryTracking = () => {
     tappedRewind: (artworkId: string, artworkSlug: string) => {
       trackEvent({
         action: ActionType.tappedRewind,
-        context_module: ContextModule.infiniteDiscovery,
+        context_module: getContextModule(ContextModule.infiniteDiscovery),
         context_screen_owner_id: artworkId,
         context_screen_owner_slug: artworkSlug,
         context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,
@@ -116,14 +122,14 @@ export const useInfiniteDiscoveryTracking = () => {
       trackEvent({
         action_name: Schema.ActionNames.ArtworkImageSwipe,
         action_type: Schema.ActionTypes.Swipe,
-        context_module: ContextModule.infiniteDiscoveryArtworkCard,
+        context_module: getContextModule(ContextModule.infiniteDiscoveryArtworkCard),
       })
     },
     savedArtwork: (isSaved: boolean, ownerId: string, ownerSlug: string) => {
       trackEvent({
         action_name: isSaved ? Schema.ActionNames.ArtworkSave : Schema.ActionNames.ArtworkUnsave,
         action_type: Schema.ActionTypes.Success,
-        context_module: ContextModule.infiniteDiscoveryArtworkCard,
+        context_module: getContextModule(ContextModule.infiniteDiscoveryArtworkCard),
         context_screen_owner_id: ownerId,
         context_screen_owner_slug: ownerSlug,
         context_screen_owner_type: OwnerType.infiniteDiscoveryArtwork,

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -20,7 +20,7 @@ const QUESTION_TOP_OFFSET = 112
 const QUESTION_SUBTITLE_GAP = 10
 
 interface QuestionStepProps {
-  onSelect: (experience: Experience) => void
+  onSelect: (experience: Experience, label: string) => void
 }
 
 export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
@@ -31,7 +31,7 @@ export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
 
   const handleContinue = () => {
     const option = EXPERIENCE_OPTIONS.find((o) => o.label === selectedLabel)
-    if (option) onSelect(option.experience)
+    if (option) onSelect(option.experience, option.label)
   }
 
   const questionEndTop = top + QUESTION_TOP_OFFSET

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -60,8 +60,8 @@ export const Introduction: React.FC = () => {
 
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
 
-  const handleSelectExperience = (experience: Experience) => {
-    trackAnsweredExperienceQuestion(experience)
+  const handleSelectExperience = (experience: Experience, label: string) => {
+    trackAnsweredExperienceQuestion(label)
     selectExperience(experience)
   }
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -9,10 +9,16 @@ import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 jest.mock("../Components/QuestionStep", () => {
   const { Text } = require("react-native")
   return {
-    QuestionStep: ({ onSelect }: { onSelect: (e: "beginner" | "experienced") => void }) => (
+    QuestionStep: ({
+      onSelect,
+    }: {
+      onSelect: (experience: "beginner" | "experienced", label: string) => void
+    }) => (
       <>
-        <Text onPress={() => onSelect("beginner")}>Select beginner</Text>
-        <Text onPress={() => onSelect("experienced")}>Select experienced</Text>
+        <Text onPress={() => onSelect("beginner", "Select beginner")}>Select beginner</Text>
+        <Text onPress={() => onSelect("experienced", "Select experienced")}>
+          Select experienced
+        </Text>
       </>
     ),
   }
@@ -96,7 +102,7 @@ describe("Introduction", () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.onboardingUserInputData,
         context_module: ContextModule.onboardingCollectorLevel,
-        data_input: "experienced",
+        data_input: "Select experienced",
       })
     })
   })

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking.ts
@@ -37,11 +37,11 @@ export const useOnboardingTracking = () => {
     trackEvent(payload)
   }
 
-  const trackAnsweredExperienceQuestion = (experience: "experienced" | "beginner") => {
+  const trackAnsweredExperienceQuestion = (buttonText: string) => {
     const payload: OnboardingUserInputData = {
       action: ActionType.onboardingUserInputData,
       context_module: ContextModule.onboardingCollectorLevel,
-      data_input: experience,
+      data_input: buttonText,
     }
 
     trackEvent(payload)


### PR DESCRIPTION
This PR further resolves [DI-454](https://www.notion.so/396cab0764a080b5beb6dc5d4b3c71b9) by correcting `context_module`/`data_input` values on several onboarding and Infinite Discovery analytics events.

When a user selects one of the 4 experience-level buttons on the intro question:

```
{
  "action": "onboardingUserInputData",
  "context_module": "onboardingCollectorLevel",
  "data_input": "I have collected many works (4 or more)"
}
```

(previously `data_input` was just `"experienced"` or `"beginner"`, not the button text)

When a card is swiped away during onboarding:

```
{
  "action": "swipedInfiniteDiscoveryArtwork",
  "context_module": "onboardingFlow",
  "context_screen_owner_id": "...",
  "context_screen_owner_slug": "...",
  "context_screen_owner_type": "infiniteDiscoveryArtwork"
}
```

(previously context_module was "infiniteDiscovery")

When an artwork is saved during onboarding:

```
{
  "action_name": "artworkSave",
  "action_type": "success",
  "context_module": "onboardingFlow",
  "context_screen_owner_id": "...",
  "context_screen_owner_slug": "...",
  "context_screen_owner_type": "infiniteDiscoveryArtwork"
}
```

(previously context_module was "infiniteDiscoveryArtworkCard")

When an artist is followed/unfollowed from the About the Work drawer during onboarding:

```
{
  "action_name": "artistFollow",
  "action_type": "success",
  "owner_id": "...",
  "owner_type": "Artist",
  "context_module": "onboardingFlow",
  "context_screen_owner_id": "...",
  "context_screen_owner_slug": "..."
}
```

(previously `context_module` was `"infiniteDiscoveryDrawer"`, even though this drawer only ever renders during onboarding)

When a user taps Skip from the onboarding-mode Infinite Discovery header:

```
{
  "action": "tappedSkip",
  "context_module": "onboardingFlow",
  "context_screen_owner_type": "infiniteDiscoveryArtwork",
  "subject": "Skip"
}
```

(previously `context_module` was `"infiniteDiscovery"`)

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [ ] **iOS**. — Not run on a simulator; verified via `yarn tsc`, `yarn lint`, and Jest only.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — No UI or flag-gated behavior change.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — No UI change.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. — `PartnerFollowButton`'s missing `context_module` (unrelated to onboarding, tracked separately) is not addressed here.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Fix `context_module`/`data_input` tracking gaps in onboarding and Infinite Discovery

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
