### PR TITLE
fix(DI-451): align onboarding intro logo and center question step layout

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -4,6 +4,7 @@ import { MotiView } from "moti"
 import { useEffect } from "react"
 import { Image } from "react-native"
 import { Easing } from "react-native-reanimated"
+import { Logo } from "./Logo"
 
 const IMG_DISPLAY_DURATION = 500
 const LAST_IMG_DISPLAY_DURATION = 600
@@ -45,6 +46,8 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
           <Image source={image} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
         </MotiView>
       ))}
+
+      <Logo />
     </Flex>
   )
 }

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/Logo.tsx
@@ -2,19 +2,11 @@ import { ArtsyLogoIcon } from "@artsy/icons/native"
 import { Box } from "@artsy/palette-mobile"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
-const LOGO_TOP_OFFSET = 44
-
 export const Logo: React.FC = () => {
   const { top } = useSafeAreaInsets()
   return (
-    <Box
-      position="absolute"
-      top={`${top + LOGO_TOP_OFFSET}px`}
-      left={0}
-      right={0}
-      alignItems="center"
-    >
-      <ArtsyLogoIcon height={32} width={94} fill="mono0" />
+    <Box position="absolute" top={`${top}px`} left={0} right={0} alignItems="center">
+      <ArtsyLogoIcon height={25} width={75} fill="mono0" />
     </Box>
   )
 }

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -16,8 +16,9 @@ const EXPERIENCE_OPTIONS: { label: string; experience: Experience }[] = [
 
 const HORIZONTAL_MARGIN = 20
 const QUESTION_HEIGHT = 64
-const QUESTION_TOP_OFFSET = 112
+const QUESTION_TOP_OFFSET = 70
 const QUESTION_SUBTITLE_GAP = 10
+const SUBTITLE_ANSWERS_GAP = 34
 
 interface QuestionStepProps {
   onSelect: (experience: Experience) => void
@@ -37,6 +38,9 @@ export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
   const questionEndTop = top + QUESTION_TOP_OFFSET
   const questionStartTop = screenHeight / 2 - QUESTION_HEIGHT / 2
   const translateYStart = questionStartTop - questionEndTop
+
+  const subtitleTop = questionEndTop + QUESTION_HEIGHT + QUESTION_SUBTITLE_GAP
+  const answersOffset = subtitleTop + SUBTITLE_ANSWERS_GAP
 
   return (
     <Flex flex={1} backgroundColor="mono100">
@@ -66,41 +70,70 @@ export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
           entering={FadeInUp.duration(400).easing(Easing.out(Easing.quad))}
           style={{
             position: "absolute",
-            top: questionEndTop + QUESTION_HEIGHT + QUESTION_SUBTITLE_GAP,
+            top: subtitleTop,
             left: HORIZONTAL_MARGIN,
             right: HORIZONTAL_MARGIN,
-            bottom: 0,
           }}
         >
-          <Flex flex={1} flexDirection="column">
-            <Text variant="xs" color="mono30">
-              Please select one answer
-            </Text>
-            <Flex flex={1} justifyContent="center">
-              {EXPERIENCE_OPTIONS.map(({ label }) => {
-                const isSelected = selectedLabel === label
-                return (
-                  <Flex key={label} alignSelf="flex-start">
-                    <Pill
-                      variant="onboarding"
-                      selected={isSelected}
-                      alignSelf="flex-start"
-                      onPress={() => setSelectedLabel(label)}
-                    >
-                      <Text variant="xs" color="mono0">
-                        {label}
-                      </Text>
-                    </Pill>
-                    <Spacer y={2} />
-                  </Flex>
-                )
-              })}
-            </Flex>
-            <Flex pb={`${bottom}px`}>
-              <Button variant="fillLight" block disabled={!selectedLabel} onPress={handleContinue}>
-                Continue
-              </Button>
-            </Flex>
+          <Text variant="xs" color="mono30">
+            Please select one answer
+          </Text>
+        </Animated.View>
+      )}
+
+      {!!questionSettled && (
+        <Animated.View
+          entering={FadeInUp.duration(400).easing(Easing.out(Easing.quad))}
+          style={{
+            position: "absolute",
+            top: answersOffset,
+            bottom: answersOffset,
+            left: HORIZONTAL_MARGIN,
+            right: HORIZONTAL_MARGIN,
+          }}
+        >
+          <Flex flex={1} justifyContent="center">
+            {EXPERIENCE_OPTIONS.map(({ label }) => {
+              const isSelected = selectedLabel === label
+              return (
+                <Flex key={label} alignSelf="flex-start">
+                  <Pill
+                    variant="onboarding"
+                    selected={isSelected}
+                    alignSelf="flex-start"
+                    onPress={() => setSelectedLabel(label)}
+                  >
+                    <Text variant="xs" color="mono0" textAlign="center">
+                      {label}
+                    </Text>
+                  </Pill>
+                  <Spacer y={2} />
+                </Flex>
+              )
+            })}
+          </Flex>
+        </Animated.View>
+      )}
+
+      {!!questionSettled && (
+        <Animated.View
+          entering={FadeInUp.duration(400).easing(Easing.out(Easing.quad))}
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: HORIZONTAL_MARGIN,
+            right: HORIZONTAL_MARGIN,
+          }}
+        >
+          <Flex pb={`${bottom}px`}>
+            <Button
+              variant={selectedLabel ? "fillLight" : "text"}
+              block
+              disabled={!selectedLabel}
+              onPress={handleContinue}
+            >
+              Continue
+            </Button>
           </Flex>
         </Animated.View>
       )}


### PR DESCRIPTION
This PR resolves [DI-451](https://www.notion.so/396cab0764a08091aeffe047c82c2003)

### Description

Fixes three layout issues in the new experience-based onboarding intro sequence (`Onboarding/Screens/Onboarding`, behind the `AREnableExperienceBasedOnboarding` flag):

- The Artsy logo now matches the auth flow's position and size (was offset ~44px lower and ~30% larger), and it's now also shown during the artwork montage step, where it was previously missing entirely.
- The collecting-experience question now sits closer to the logo, and the answer pills are positioned so their midpoint lands on the true vertical center of the screen, independent of the question/subtitle above and the Continue button below.
- The Continue button is transparent (just muted text) until an answer is selected, then becomes a solid white pill — previously it was a visible grey pill even while disabled.

| create account | montage | welcome | question |
|-|-|-|-|
| <img width="566" height="1099" alt="before0" src="https://github.com/user-attachments/assets/ffc2f70d-651f-4c62-a104-002b980c8c5a" /> | <img width="566" height="1099" alt="before1" src="https://github.com/user-attachments/assets/a39c6fe8-1ed5-4468-a8fa-6f06054e59df" /> | <img width="566" height="1099" alt="before2" src="https://github.com/user-attachments/assets/f6d56912-f58f-42d4-ad0f-083efeb68758" /> | <img width="566" height="1099" alt="before3" src="https://github.com/user-attachments/assets/6e803d98-f152-4b6d-8eeb-1b701964740c" /> |
| <img width="566" height="1099" alt="after0" src="https://github.com/user-attachments/assets/f97893ce-b839-4ede-a697-107fea4d2811" /> | <img width="566" height="1099" alt="after1" src="https://github.com/user-attachments/assets/451a0f52-b196-4919-95ef-66ca3d8d7cc8" /> | <img width="566" height="1099" alt="after2" src="https://github.com/user-attachments/assets/031ac792-f845-47b5-9071-ccb63a2e6e3e" /> | <img width="566" height="1099" alt="after3" src="https://github.com/user-attachments/assets/e1e0ecb5-dc2f-42f9-b04b-5ede4a6ec06a" /> |






### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**. — Not tested; changes are cross-platform layout/style with no platform-specific code.
  - [x] **iOS**. — Verified in the simulator.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — Already lives entirely within the existing `AREnableExperienceBasedOnboarding`-gated flow; no new flag needed.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — iOS-only screenshots reviewed during development; not attached here.
- [x] I have added **tests**, or my changes don't require any. — Layout/style only; existing `Introduction.tests.tsx` suite still passes.
- [x] I added an **[app state migration]**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device, on both iOS and Android.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix logo position/size and question step layout in the experience-based onboarding intro

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)