### PR TITLE
fix(DI-358): show real followed artists in the post-follow bottom sheet

### DIFF
--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -7,38 +7,22 @@ import {
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { GlobalStore } from "app/store/GlobalStore"
+import { OnboardingFollowedArtist } from "app/store/OnboardingModel"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform } from "react-native"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 
-interface DummyArtist {
-  id: string
-  name: string
-  imageUrl: string
-}
-
-const DUMMY_FOLLOWED_ARTISTS: DummyArtist[] = [
-  {
-    id: "1",
-    name: "Artist 1",
-    imageUrl: "https://d32dm0rphc51dk.cloudfront.net/8YQ9RcIGqoKC0ftglHMBeQ/large.jpg",
-  },
-  {
-    id: "2",
-    name: "Artist 2",
-    imageUrl: "https://d32dm0rphc51dk.cloudfront.net/fEdSbiBZs9MJftHqjyW3sA/square140.png",
-  },
-  {
-    id: "3",
-    name: "Artist 3",
-    imageUrl: "https://d32dm0rphc51dk.cloudfront.net/ENomMxabvEP15hIKHt5jmw/wide.jpg",
-  },
-]
+const hasImageUrl = (
+  artist: OnboardingFollowedArtist
+): artist is OnboardingFollowedArtist & { imageUrl: string } => !!artist.imageUrl
 
 export const ArtistSaveOnboardingBottomSheet = () => {
   const showFollowedArtistSummaryBottomSheet = GlobalStore.useAppState(
     (state) => state.onboarding.showFollowedArtistSummaryBottomSheet
+  )
+  const followedOnboardingArtists = GlobalStore.useAppState(
+    (state) => state.onboarding.followedOnboardingArtists
   )
   const isExperienceOnboardingEnabled = useFeatureFlag("AREnableExperienceBasedOnboarding")
   const [isVisible, setIsVisible] = useState(false)
@@ -103,27 +87,31 @@ export const ArtistSaveOnboardingBottomSheet = () => {
           <Spacer y={1} />
 
           <Flex flexDirection="row" justifyContent="center" alignItems="center">
-            {DUMMY_FOLLOWED_ARTISTS.slice(0, 3).map((artist, index) => (
-              <Flex
-                key={artist.id}
-                style={{
-                  marginLeft: index > 0 ? -10 : 0,
-                  zIndex: index,
-                  shadowColor: "#000",
-                  shadowOffset: { width: 0, height: 3 },
-                  shadowOpacity: 0.35,
-                  shadowRadius: 6,
-                  elevation: 8,
-                }}
-              >
-                <Image
-                  src={artist.imageUrl}
-                  width={75}
-                  height={75}
-                  style={{ borderRadius: 37.5 }}
-                />
-              </Flex>
-            ))}
+            {followedOnboardingArtists
+              .filter(hasImageUrl)
+              .slice(0, 3)
+              .map((artist, index) => (
+                <Flex
+                  key={artist.internalID}
+                  style={{
+                    marginLeft: index > 0 ? -10 : 0,
+                    zIndex: index,
+                    shadowColor: "#000",
+                    shadowOffset: { width: 0, height: 3 },
+                    shadowOpacity: 0.35,
+                    shadowRadius: 6,
+                    elevation: 8,
+                  }}
+                >
+                  <Image
+                    src={artist.imageUrl}
+                    blurhash={artist.blurhash}
+                    width={75}
+                    height={75}
+                    style={{ borderRadius: 37.5 }}
+                  />
+                </Flex>
+              ))}
           </Flex>
 
           <PagerView

--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -92,10 +92,10 @@ export const ArtistSaveOnboardingBottomSheet = () => {
                   marginLeft: index > 0 ? -10 : 0,
                   zIndex: index,
                   shadowColor: "#000",
-                  shadowOffset: { width: 0, height: 3 },
-                  shadowOpacity: 0.35,
-                  shadowRadius: 6,
-                  elevation: 8,
+                  shadowOffset: { width: 0, height: 2 },
+                  shadowOpacity: 0.08,
+                  shadowRadius: 4,
+                  elevation: 2,
                 }}
               >
                 <Avatar

--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -82,9 +82,11 @@ export const ArtistSaveOnboardingBottomSheet = () => {
           <Spacer y={1} />
 
           <Flex flexDirection="row" justifyContent="center" alignItems="center">
-            {followedOnboardingArtists.slice(0, 3).map((artist, index) => (
+            {followedOnboardingArtists.slice(-3).map((artist, index) => (
               <Flex
                 key={artist.internalID}
+                backgroundColor="mono0"
+                borderRadius={35}
                 style={{
                   marginLeft: index > 0 ? -10 : 0,
                   zIndex: index,

--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -36,6 +36,7 @@ export const ArtistSaveOnboardingBottomSheet = () => {
   const handleDismiss = () => {
     setIsVisible(false)
     GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(false)
+    GlobalStore.actions.onboarding.resetFollowedOnboardingArtists()
   }
 
   const handleButtonPress = () => {

--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Image, Spacer, Text } from "@artsy/palette-mobile"
+import { Avatar, Button, Flex, Image, Spacer, Text } from "@artsy/palette-mobile"
 import {
   BottomSheetBackdrop,
   BottomSheetBackdropProps,
@@ -7,15 +7,10 @@ import {
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/PaginationBars"
 import { GlobalStore } from "app/store/GlobalStore"
-import { OnboardingFollowedArtist } from "app/store/OnboardingModel"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform } from "react-native"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
-
-const hasImageUrl = (
-  artist: OnboardingFollowedArtist
-): artist is OnboardingFollowedArtist & { imageUrl: string } => !!artist.imageUrl
 
 export const ArtistSaveOnboardingBottomSheet = () => {
   const showFollowedArtistSummaryBottomSheet = GlobalStore.useAppState(
@@ -87,31 +82,27 @@ export const ArtistSaveOnboardingBottomSheet = () => {
           <Spacer y={1} />
 
           <Flex flexDirection="row" justifyContent="center" alignItems="center">
-            {followedOnboardingArtists
-              .filter(hasImageUrl)
-              .slice(0, 3)
-              .map((artist, index) => (
-                <Flex
-                  key={artist.internalID}
-                  style={{
-                    marginLeft: index > 0 ? -10 : 0,
-                    zIndex: index,
-                    shadowColor: "#000",
-                    shadowOffset: { width: 0, height: 3 },
-                    shadowOpacity: 0.35,
-                    shadowRadius: 6,
-                    elevation: 8,
-                  }}
-                >
-                  <Image
-                    src={artist.imageUrl}
-                    blurhash={artist.blurhash}
-                    width={75}
-                    height={75}
-                    style={{ borderRadius: 37.5 }}
-                  />
-                </Flex>
-              ))}
+            {followedOnboardingArtists.slice(0, 3).map((artist, index) => (
+              <Flex
+                key={artist.internalID}
+                style={{
+                  marginLeft: index > 0 ? -10 : 0,
+                  zIndex: index,
+                  shadowColor: "#000",
+                  shadowOffset: { width: 0, height: 3 },
+                  shadowOpacity: 0.35,
+                  shadowRadius: 6,
+                  elevation: 8,
+                }}
+              >
+                <Avatar
+                  src={artist.imageUrl ?? undefined}
+                  blurhash={artist.blurhash}
+                  initials={artist.initials ?? undefined}
+                  size="sm"
+                />
+              </Flex>
+            ))}
           </Flex>
 
           <PagerView

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -1,3 +1,4 @@
+import FastImage from "@d11/react-native-fast-image"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { ArtistSaveOnboardingBottomSheet } from "app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
@@ -12,6 +13,9 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(false)
+    ;["artist-1", "artist-2", "artist-3", "artist-4"].forEach((internalID) => {
+      GlobalStore.actions.onboarding.removeFollowedOnboardingArtist(internalID)
+    })
     ;(useFeatureFlag as jest.Mock).mockReturnValue(true)
   })
 
@@ -45,6 +49,71 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       expect(
         await screen.findByText("Your followed artists are saved to Favorites.")
       ).toBeOnTheScreen()
+    })
+  })
+
+  describe("Followed artist avatars", () => {
+    it("renders an avatar for each real followed artist, up to 3", async () => {
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-1",
+        imageUrl: "https://example.com/artist-1.jpg",
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-2",
+        imageUrl: "https://example.com/artist-2.jpg",
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-3",
+        imageUrl: "https://example.com/artist-3.jpg",
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-4",
+        imageUrl: "https://example.com/artist-4.jpg",
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+
+      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+
+      await screen.findByText("Your followed artists are saved to Favorites.")
+
+      const renderedImages = screen
+        .UNSAFE_getAllByType(FastImage)
+        .map((img) => img.props.source.uri)
+
+      expect(renderedImages.some((uri: string) => uri.includes("artist-1.jpg"))).toBe(true)
+      expect(renderedImages.some((uri: string) => uri.includes("artist-2.jpg"))).toBe(true)
+      expect(renderedImages.some((uri: string) => uri.includes("artist-3.jpg"))).toBe(true)
+      expect(renderedImages.some((uri: string) => uri.includes("artist-4.jpg"))).toBe(false)
+    })
+
+    it("skips followed artists without an image", async () => {
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-1",
+        imageUrl: null,
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-2",
+        imageUrl: "https://example.com/artist-2.jpg",
+        blurhash: null,
+      })
+      GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+
+      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+
+      await screen.findByText("Your followed artists are saved to Favorites.")
+
+      const avatarImages = screen
+        .UNSAFE_getAllByType(FastImage)
+        .map((img) => img.props.source.uri as string)
+        .filter((uri) => uri.includes("example.com"))
+
+      expect(avatarImages.some((uri) => uri.includes("artist-2.jpg"))).toBe(true)
+      expect(avatarImages).toHaveLength(1)
     })
   })
 

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -58,21 +58,25 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
         internalID: "artist-1",
         imageUrl: "https://example.com/artist-1.jpg",
         blurhash: null,
+        initials: "A",
       })
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-2",
         imageUrl: "https://example.com/artist-2.jpg",
         blurhash: null,
+        initials: "B",
       })
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-3",
         imageUrl: "https://example.com/artist-3.jpg",
         blurhash: null,
+        initials: "C",
       })
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-4",
         imageUrl: "https://example.com/artist-4.jpg",
         blurhash: null,
+        initials: "D",
       })
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
@@ -90,22 +94,26 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       expect(renderedImages.some((uri: string) => uri.includes("artist-4.jpg"))).toBe(false)
     })
 
-    it("skips followed artists without an image", async () => {
+    it("falls back to the artist's initials when there is no image", async () => {
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-1",
         imageUrl: null,
         blurhash: null,
+        initials: "A",
       })
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-2",
         imageUrl: "https://example.com/artist-2.jpg",
         blurhash: null,
+        initials: "B",
       })
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
       renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
+
+      expect(screen.getByText("A")).toBeOnTheScreen()
 
       const avatarImages = screen
         .UNSAFE_getAllByType(FastImage)

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -14,9 +14,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(false)
-    ;["artist-1", "artist-2", "artist-3", "artist-4"].forEach((internalID) => {
-      GlobalStore.actions.onboarding.removeFollowedOnboardingArtist(internalID)
-    })
+    GlobalStore.actions.onboarding.resetFollowedOnboardingArtists()
     ;(useFeatureFlag as jest.Mock).mockReturnValue(true)
   })
 

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -4,6 +4,7 @@ import { ArtistSaveOnboardingBottomSheet } from "app/Scenes/HomeView/Components/
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import PagerView from "react-native-pager-view"
 
 jest.mock("app/utils/hooks/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn(),
@@ -189,6 +190,29 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
         const state = __globalStoreTestUtils__!.getCurrentState()
         expect(state.onboarding.showFollowedArtistSummaryBottomSheet).toBe(false)
       }
+    })
+
+    it("clears followedOnboardingArtists once the sheet is dismissed", async () => {
+      GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
+        internalID: "artist-1",
+        imageUrl: "https://example.com/artist-1.jpg",
+        blurhash: null,
+        initials: "A",
+      })
+      GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+
+      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+
+      await screen.findByText("Your followed artists are saved to Favorites.")
+
+      const pagerView = screen.UNSAFE_getByType(PagerView)
+      pagerView.props.onPageScroll({ nativeEvent: { position: 1 } })
+
+      fireEvent.press(await screen.findByText("View For You"))
+
+      expect(
+        __globalStoreTestUtils__?.getCurrentState().onboarding.followedOnboardingArtists
+      ).toEqual([])
     })
   })
 })

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -53,7 +53,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
   })
 
   describe("Followed artist avatars", () => {
-    it("renders an avatar for each real followed artist, up to 3", async () => {
+    it("renders the last 3 followed artists when more than 3 were followed", async () => {
       GlobalStore.actions.onboarding.addFollowedOnboardingArtist({
         internalID: "artist-1",
         imageUrl: "https://example.com/artist-1.jpg",
@@ -88,10 +88,10 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
         .UNSAFE_getAllByType(FastImage)
         .map((img) => img.props.source.uri)
 
-      expect(renderedImages.some((uri: string) => uri.includes("artist-1.jpg"))).toBe(true)
+      expect(renderedImages.some((uri: string) => uri.includes("artist-1.jpg"))).toBe(false)
       expect(renderedImages.some((uri: string) => uri.includes("artist-2.jpg"))).toBe(true)
       expect(renderedImages.some((uri: string) => uri.includes("artist-3.jpg"))).toBe(true)
-      expect(renderedImages.some((uri: string) => uri.includes("artist-4.jpg"))).toBe(false)
+      expect(renderedImages.some((uri: string) => uri.includes("artist-4.jpg"))).toBe(true)
     })
 
     it("falls back to the artist's initials when there is no image", async () => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
@@ -69,7 +69,7 @@ const FollowArtistsOrderedSet: React.FC<FollowArtistsOrderedSetProps> = ({
                   internalID: item.internalID,
                   imageUrl: item.coverArtwork?.image?.cropped?.src ?? null,
                   blurhash: item.coverArtwork?.image?.blurhash ?? null,
-                  initials: item.firstInitial ?? null,
+                  initials: item.initials ?? null,
                 },
                 item.slug
               )
@@ -115,7 +115,7 @@ const FollowArtistsOrderedSetScreenQuery = graphql`
               internalID
               slug
               isFollowed
-              firstInitial: initials(length: 1)
+              initials
               coverArtwork {
                 image {
                   blurhash

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
@@ -69,6 +69,7 @@ const FollowArtistsOrderedSet: React.FC<FollowArtistsOrderedSetProps> = ({
                   internalID: item.internalID,
                   imageUrl: item.coverArtwork?.image?.cropped?.src ?? null,
                   blurhash: item.coverArtwork?.image?.blurhash ?? null,
+                  initials: item.firstInitial ?? null,
                 },
                 item.slug
               )
@@ -114,6 +115,7 @@ const FollowArtistsOrderedSetScreenQuery = graphql`
               internalID
               slug
               isFollowed
+              firstInitial: initials(length: 1)
               coverArtwork {
                 image {
                   blurhash

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -32,6 +32,7 @@ jest.mock("app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrde
             slug: "artist-slug",
             imageUrl: null,
             blurhash: null,
+            initials: null,
           })
         }
       >

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
@@ -85,7 +85,7 @@ const OnboardingSearchResults: React.FC<OnboardingSearchResultsProps> = ({
                       internalID: item.internalID,
                       imageUrl: item.coverArtwork?.image?.cropped?.src ?? null,
                       blurhash: item.coverArtwork?.image?.blurhash ?? null,
-                      initials: item.firstInitial ?? null,
+                      initials: item.initials ?? null,
                     },
                     item.slug
                   )
@@ -192,7 +192,7 @@ const OnboardingSearchResultsFragment = graphql`
             internalID
             slug
             isFollowed
-            firstInitial: initials(length: 1)
+            initials
             coverArtwork {
               image {
                 url

--- a/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
+++ b/src/app/Scenes/Onboarding/Screens/OnboardingQuiz/OnboardingSearchResults.tsx
@@ -85,6 +85,7 @@ const OnboardingSearchResults: React.FC<OnboardingSearchResultsProps> = ({
                       internalID: item.internalID,
                       imageUrl: item.coverArtwork?.image?.cropped?.src ?? null,
                       blurhash: item.coverArtwork?.image?.blurhash ?? null,
+                      initials: item.firstInitial ?? null,
                     },
                     item.slug
                   )
@@ -191,6 +192,7 @@ const OnboardingSearchResultsFragment = graphql`
             internalID
             slug
             isFollowed
+            firstInitial: initials(length: 1)
             coverArtwork {
               image {
                 url

--- a/src/app/store/OnboardingModel.ts
+++ b/src/app/store/OnboardingModel.ts
@@ -18,6 +18,7 @@ export interface OnboardingModel {
   setOnboardingState: Action<this, OnboardingState>
   addFollowedOnboardingArtist: Action<this, OnboardingFollowedArtist>
   removeFollowedOnboardingArtist: Action<this, string>
+  resetFollowedOnboardingArtists: Action<this>
   showFollowedArtistSummaryBottomSheet: boolean
   setShowFollowedArtistSummaryBottomSheet: Action<this, boolean>
 }
@@ -45,6 +46,9 @@ export const getOnboardingModel = (): OnboardingModel => ({
     state.followedOnboardingArtists = state.followedOnboardingArtists.filter(
       (a) => a.internalID !== internalID
     )
+  }),
+  resetFollowedOnboardingArtists: action((state) => {
+    state.followedOnboardingArtists = []
   }),
   setShowFollowedArtistSummaryBottomSheet: action((state, show) => {
     state.showFollowedArtistSummaryBottomSheet = show

--- a/src/app/store/OnboardingModel.ts
+++ b/src/app/store/OnboardingModel.ts
@@ -7,6 +7,7 @@ export interface OnboardingFollowedArtist {
   internalID: string
   imageUrl: string | null
   blurhash: string | null
+  initials: string | null
 }
 
 export interface OnboardingModel {

--- a/src/app/store/__tests__/migration.tests.ts
+++ b/src/app/store/__tests__/migration.tests.ts
@@ -1318,4 +1318,32 @@ describe("App version Versions.AddInfiniteDiscoveryModel", () => {
       expect(migratedState.onboarding.followedOnboardingArtists).toEqual([])
     })
   })
+  describe("App version Versions.AddInitialsToFollowedOnboardingArtists", () => {
+    it("should add initials to existing followedOnboardingArtists entries", () => {
+      const migrationToTest = Versions.AddInitialsToFollowedOnboardingArtists
+
+      const previousState = migrate({
+        state: { version: 0 },
+        toVersion: migrationToTest - 1,
+      }) as any
+
+      previousState.onboarding.followedOnboardingArtists = [
+        { internalID: "artist-1", imageUrl: "https://example.com/artist-1.jpg", blurhash: null },
+      ]
+
+      const migratedState = migrate({
+        state: previousState,
+        toVersion: migrationToTest,
+      }) as any
+
+      expect(migratedState.onboarding.followedOnboardingArtists).toEqual([
+        {
+          internalID: "artist-1",
+          imageUrl: "https://example.com/artist-1.jpg",
+          blurhash: null,
+          initials: null,
+        },
+      ])
+    })
+  })
 })

--- a/src/app/store/migration.ts
+++ b/src/app/store/migration.ts
@@ -70,9 +70,10 @@ export const Versions = {
   RemovePendingPushNotificationModel: 57,
   AddShowFollowedArtistSummaryBottomSheetToOnboardingModel: 58,
   AddFollowedOnboardingArtistsToOnboardingModel: 59,
+  AddInitialsToFollowedOnboardingArtists: 60,
 }
 
-export const CURRENT_APP_VERSION = Versions.AddFollowedOnboardingArtistsToOnboardingModel
+export const CURRENT_APP_VERSION = Versions.AddInitialsToFollowedOnboardingArtists
 
 export type Migrations = Record<number, (oldState: any) => any>
 export const artsyAppMigrations: Migrations = {
@@ -391,6 +392,11 @@ export const artsyAppMigrations: Migrations = {
   },
   [Versions.AddFollowedOnboardingArtistsToOnboardingModel]: (state) => {
     state.onboarding.followedOnboardingArtists = []
+  },
+  [Versions.AddInitialsToFollowedOnboardingArtists]: (state) => {
+    state.onboarding.followedOnboardingArtists.forEach((artist: any) => {
+      artist.initials = null
+    })
   },
 }
 


### PR DESCRIPTION
This PR resolves [DI-358](https://www.notion.so/375cab0764a08053a78ff91d1d342f74) and [DI-460](https://app.notion.com/p/artsy/Artists-without-an-avatar-should-still-appear-in-Post-Follow-Artists-modal-39ccab0764a080cdbf81eed0cd0898b8?v=5cbcab0764a082578d6388b3ee7cefda&source=copy_link)

### Description

The post-follow-artists bottom sheet (`ArtistSaveOnboardingBottomSheet`, shown after completing the "Follow Artists" onboarding step) displayed 3 hard-coded dummy artists instead of the artists the user actually just followed.

- The bottom sheet now shows the artists you actually followed during onboarding, instead of 3 placeholder artists.
- It shows the 3 artists you followed most recently, rather than the first 3.
- Artists without a profile photo now show a circle with their initials instead of being left out of the sheet entirely (DI-460).
- The followed-artists list is cleared from the app's saved state once the bottom sheet is dismissed, so it doesn't linger longer than it's needed.
- Added a data migration so this change works correctly for people who already have the app installed.

https://github.com/user-attachments/assets/a2f3ff69-dcb5-4f01-85a1-741cd125116f




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**. — Not tested; changes are cross-platform with no platform-specific code.
  - [ ] **iOS**. — Verified in the simulator.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — Already lives entirely within the existing `AREnableExperienceBasedOnboarding`-gated flow; no new flag needed.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — iOS-only; not attached here.
- [x] I have added **tests**, or my changes don't require any. — Added coverage for rendering real followed-artist avatars (last 3), the initials fallback, and clearing state on dismiss.
- [x] I added an **[app state migration]**, or my changes do not require one. — Added a migration backfilling `initials: null` on existing persisted `followedOnboardingArtists` entries.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. — Manual testing surfaced a separate bug (stale followed-artist data persisting across onboarding re-runs); that's being addressed in a follow-up PR.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device, on both iOS and Android.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Show the artists a user actually followed (most recent 3, with an initials fallback for missing photos) in the post-onboarding "followed artists" bottom sheet

#### Dev changes

- Add app state migration for the new `initials` field on `OnboardingFollowedArtist`

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)