### PR TITLE
feat: add follow support for Shows & Fairs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -584,35 +584,35 @@
         "filename": "src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx",
         "hashed_secret": "f1027d2a399ad325b12780b0ed8c7557bfea41db",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 87
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx",
         "hashed_secret": "71de11a26b02e42b44389dee26238733d3dfb4ea",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 104
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx",
         "hashed_secret": "4ce6a7a9f0859a760b917614e5f3467acb280885",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 128
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx",
         "hashed_secret": "62050713c51be285f18b693ff76fc17cc51cecdc",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 175
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx",
         "hashed_secret": "d295dad571802542c7462317749556de47cff20e",
         "is_verified": false,
-        "line_number": 188
+        "line_number": 191
       }
     ],
     "src/app/Scenes/Partner/Screens/__fixtures__/PartnerLocations-fixture.ts": [
@@ -1263,5 +1263,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-09T14:13:24Z"
+  "generated_at": "2026-07-14T12:48:20Z"
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
   },
   "dependencies": {
     "@artsy/changelog": "^0.1.0",
-    "@artsy/cohesion": "^4.360.0",
+    "@artsy/cohesion": "^4.386.1",
     "@artsy/icons": "3.67.0",
     "@artsy/palette-mobile": "23.12.0",
     "@artsy/to-title-case": "1.2.0",

--- a/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
+++ b/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
@@ -1,6 +1,7 @@
 import { ActionType, ContextModule, OwnerType, TappedShowGroup } from "@artsy/cohesion"
 import { ArtistShow_show$data, ArtistShow_show$key } from "__generated__/ArtistShow_show.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { hrefForPartialShow } from "app/utils/router"
 import { View, ViewStyle } from "react-native"
@@ -37,14 +38,19 @@ export const ArtistShow: React.FC<Props> = ({ styles, show, index, imageDimensio
   return (
     <RouterLink haptic onPress={handleTap} to={hrefForPartialShow(data)}>
       <View style={[styles?.container]}>
-        <View style={[styles?.imageMargin]}>
-          <ImageWithFallback
-            src={imageURL}
-            width={imageDimensions.width}
-            height={imageDimensions.height}
-            blurhash={image?.blurhash}
-            style={[{ overflow: "hidden", borderRadius: 2, flex: 0 }]}
-          />
+        <View style={{ position: "relative" }}>
+          <View style={[styles?.imageMargin]}>
+            <ImageWithFallback
+              src={imageURL}
+              width={imageDimensions.width}
+              height={imageDimensions.height}
+              blurhash={image?.blurhash}
+              style={[{ overflow: "hidden", borderRadius: 2, flex: 0 }]}
+            />
+          </View>
+          <View style={{ position: "absolute", top: 4, right: 4 }}>
+            <ShowFollowButton show={data} />
+          </View>
         </View>
         {/* this wrapper required to make numberOfLines work when parent is a row */}
         <View style={{ flex: 1 }}>
@@ -57,6 +63,7 @@ export const ArtistShow: React.FC<Props> = ({ styles, show, index, imageDimensio
 
 const query = graphql`
   fragment ArtistShow_show on Show {
+    ...ShowFollowButton_show
     internalID
     slug
     href

--- a/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
+++ b/src/app/Components/Artist/ArtistShows/ArtistShow.tsx
@@ -36,28 +36,30 @@ export const ArtistShow: React.FC<Props> = ({ styles, show, index, imageDimensio
   const imageURL = image && image.url
 
   return (
-    <RouterLink haptic onPress={handleTap} to={hrefForPartialShow(data)}>
-      <View style={[styles?.container]}>
-        <View style={{ position: "relative" }}>
-          <View style={[styles?.imageMargin]}>
-            <ImageWithFallback
-              src={imageURL}
-              width={imageDimensions.width}
-              height={imageDimensions.height}
-              blurhash={image?.blurhash}
-              style={[{ overflow: "hidden", borderRadius: 2, flex: 0 }]}
-            />
-          </View>
-          <View style={{ position: "absolute", top: 4, right: 4 }}>
-            <ShowFollowButton show={data} />
-          </View>
+    <View style={[styles?.container]}>
+      <RouterLink
+        haptic
+        onPress={handleTap}
+        to={hrefForPartialShow(data)}
+        style={{ flexDirection: "row", alignItems: "center", flex: 1 }}
+      >
+        <View style={[styles?.imageMargin]}>
+          <ImageWithFallback
+            src={imageURL}
+            width={imageDimensions.width}
+            height={imageDimensions.height}
+            blurhash={image?.blurhash}
+            style={[{ overflow: "hidden", borderRadius: 2, flex: 0 }]}
+          />
         </View>
         {/* this wrapper required to make numberOfLines work when parent is a row */}
         <View style={{ flex: 1 }}>
           <Metadata show={data} style={!!styles && styles.metadata} />
         </View>
-      </View>
-    </RouterLink>
+      </RouterLink>
+
+      <ShowFollowButton show={data} />
+    </View>
   )
 }
 

--- a/src/app/Components/Cards/CardWithMetaData.tsx
+++ b/src/app/Components/Cards/CardWithMetaData.tsx
@@ -74,9 +74,13 @@ export const CardWithMetaData: React.FC<CardWithMetaDataProps> = (props) => {
           ) : (
             <Box height={CARD_IMAGE_HEIGHT} width={CARD_IMAGE_WIDTH} />
           )}
+        </Flex>
+      </RouterLink>
 
-          <Spacer y={1} />
+      <Spacer y={1} />
 
+      <Flex flexDirection="row" alignItems="flex-start" justifyContent="space-between">
+        <RouterLink onPress={onPress} to={href} style={{ flex: 1 }}>
           {!!title && (
             <Text numberOfLines={2} ellipsizeMode="tail" variant="sm-display" mb={0.5}>
               {title}
@@ -92,14 +96,10 @@ export const CardWithMetaData: React.FC<CardWithMetaDataProps> = (props) => {
               {tag}
             </Text>
           )}
-        </Flex>
-      </RouterLink>
+        </RouterLink>
 
-      {!!actionElement && (
-        <Flex position="absolute" top={1} right={1}>
-          {actionElement}
-        </Flex>
-      )}
+        {!!actionElement && <Flex ml={1}>{actionElement}</Flex>}
+      </Flex>
     </Flex>
   )
 }

--- a/src/app/Components/Cards/CardWithMetaData.tsx
+++ b/src/app/Components/Cards/CardWithMetaData.tsx
@@ -35,10 +35,14 @@ interface CardWithMetaDataProps {
   tag: string | null | undefined
   onPress?: (event: GestureResponderEvent) => void
   testId?: string
+  // Rendered as an overlay in the top-right corner of the image, outside the card's
+  // RouterLink so it can be pressed independently (e.g. a follow/save button).
+  actionElement?: React.ReactNode
 }
 
 export const CardWithMetaData: React.FC<CardWithMetaDataProps> = (props) => {
-  const { isFluid, href, imageURL, title, subtitle, tag, onPress, imageComponent } = props
+  const { isFluid, href, imageURL, title, subtitle, tag, onPress, imageComponent, actionElement } =
+    props
   const numColumns = useNumColumns()
 
   const { space } = useTheme()
@@ -90,6 +94,12 @@ export const CardWithMetaData: React.FC<CardWithMetaDataProps> = (props) => {
           )}
         </Flex>
       </RouterLink>
+
+      {!!actionElement && (
+        <Flex position="absolute" top={1} right={1}>
+          {actionElement}
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/src/app/Components/Cards/CardWithMetaData.tsx
+++ b/src/app/Components/Cards/CardWithMetaData.tsx
@@ -80,24 +80,25 @@ export const CardWithMetaData: React.FC<CardWithMetaDataProps> = (props) => {
       <Spacer y={1} />
 
       <Flex flexDirection="row" alignItems="flex-start" justifyContent="space-between">
-        <RouterLink onPress={onPress} to={href} style={{ flex: 1 }}>
-          {!!title && (
-            <Text numberOfLines={2} ellipsizeMode="tail" variant="sm-display" mb={0.5}>
-              {title}
-            </Text>
-          )}
-          {!!subtitle && (
-            <Text color="mono60" variant="xs">
-              {subtitle}
-            </Text>
-          )}
-          {!!tag && (
-            <Text color="mono100" variant="xs">
-              {tag}
-            </Text>
-          )}
-        </RouterLink>
-
+        <Flex flex={1}>
+          <RouterLink onPress={onPress} to={href}>
+            {!!title && (
+              <Text numberOfLines={2} ellipsizeMode="tail" variant="sm-display" mb={0.5}>
+                {title}
+              </Text>
+            )}
+            {!!subtitle && (
+              <Text color="mono60" variant="xs">
+                {subtitle}
+              </Text>
+            )}
+            {!!tag && (
+              <Text color="mono100" variant="xs">
+                {tag}
+              </Text>
+            )}
+          </RouterLink>
+        </Flex>
         {!!actionElement && <Flex ml={1}>{actionElement}</Flex>}
       </Flex>
     </Flex>

--- a/src/app/Components/Cards/CardWithMetaData.tsx
+++ b/src/app/Components/Cards/CardWithMetaData.tsx
@@ -35,8 +35,8 @@ interface CardWithMetaDataProps {
   tag: string | null | undefined
   onPress?: (event: GestureResponderEvent) => void
   testId?: string
-  // Rendered as an overlay in the top-right corner of the image, outside the card's
-  // RouterLink so it can be pressed independently (e.g. a follow/save button).
+  // Rendered beside the title block, outside the card's RouterLink so it can be
+  // pressed independently (e.g. a follow/save button).
   actionElement?: React.ReactNode
 }
 

--- a/src/app/Components/FairFollowButton.tsx
+++ b/src/app/Components/FairFollowButton.tsx
@@ -1,0 +1,43 @@
+import { FollowButton } from "@artsy/palette-mobile"
+import { FairFollowButton_fair$key } from "__generated__/FairFollowButton_fair.graphql"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
+import { FC } from "react"
+import { graphql, useFragment } from "react-relay"
+
+interface FairFollowButtonProps {
+  fair: FairFollowButton_fair$key
+}
+
+export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
+  const data = useFragment(fragment, fair)
+  const { followProfile, isInFlight } = useFollowProfile({
+    id: data?.profile?.id ?? "",
+    internalID: data?.profile?.internalID ?? "",
+    isFollowed: !!data?.profile?.isFollowed,
+  })
+
+  if (!enableFollowShowsAndFairs || !data?.profile) {
+    return null
+  }
+
+  return (
+    <FollowButton
+      isFollowed={!!data.profile.isFollowed}
+      onPress={followProfile}
+      loading={isInFlight}
+    />
+  )
+}
+
+const fragment = graphql`
+  fragment FairFollowButton_fair on Fair {
+    internalID
+    profile {
+      id
+      internalID
+      isFollowed
+    }
+  }
+`

--- a/src/app/Components/FairFollowButton.tsx
+++ b/src/app/Components/FairFollowButton.tsx
@@ -21,6 +21,9 @@ export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
     id: data?.profile?.id ?? "",
     internalID: data?.profile?.internalID ?? "",
     isFollowed: !!data?.profile?.isFollowed,
+    onError: () => {
+      console.error("FairFollowButton: followProfile mutation failed")
+    },
   })
 
   if (!enableFollowShowsAndFairs || !data?.profile) {

--- a/src/app/Components/FairFollowButton.tsx
+++ b/src/app/Components/FairFollowButton.tsx
@@ -1,4 +1,4 @@
-import { FollowButton } from "@artsy/palette-mobile"
+import { Button } from "@artsy/palette-mobile"
 import { FairFollowButton_fair$key } from "__generated__/FairFollowButton_fair.graphql"
 import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
@@ -33,12 +33,15 @@ export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
   }
 
   return (
-    <FollowButton
-      isFollowed={!!data.profile.isFollowed}
+    <Button
+      variant={data.profile.isFollowed ? "outline" : "fillDark"}
+      size="small"
       onPress={handlePress}
       loading={isInFlight}
-      followText={data.profile.isFollowed ? "Saved" : "Save"}
-    />
+      longestText="Saved"
+    >
+      {data.profile.isFollowed ? "Saved" : "Save"}
+    </Button>
   )
 }
 

--- a/src/app/Components/FairFollowButton.tsx
+++ b/src/app/Components/FairFollowButton.tsx
@@ -1,9 +1,12 @@
 import { FollowButton } from "@artsy/palette-mobile"
 import { FairFollowButton_fair$key } from "__generated__/FairFollowButton_fair.graphql"
+import { AnalyticsContextProps, useAnalyticsContext } from "app/system/analytics/AnalyticsContext"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useFollowProfile } from "app/utils/mutations/useFollowProfile"
+import { ActionNames, ActionTypes, OwnerEntityTypes } from "app/utils/track/schema"
 import { FC } from "react"
 import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface FairFollowButtonProps {
   fair: FairFollowButton_fair$key
@@ -11,6 +14,8 @@ interface FairFollowButtonProps {
 
 export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
   const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
+  const analytics = useAnalyticsContext()
+  const { trackEvent } = useTracking()
   const data = useFragment(fragment, fair)
   const { followProfile, isInFlight } = useFollowProfile({
     id: data?.profile?.id ?? "",
@@ -22,10 +27,15 @@ export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
     return null
   }
 
+  const handlePress = () => {
+    trackEvent(tracks.trackFollowFair(data.internalID, !!data.profile?.isFollowed, analytics))
+    followProfile()
+  }
+
   return (
     <FollowButton
       isFollowed={!!data.profile.isFollowed}
-      onPress={followProfile}
+      onPress={handlePress}
       loading={isInFlight}
     />
   )
@@ -41,3 +51,15 @@ const fragment = graphql`
     }
   }
 `
+
+const tracks = {
+  trackFollowFair: (internalID: string, isFollowed: boolean, analytics: AnalyticsContextProps) => ({
+    action_name: isFollowed ? ActionNames.UnfollowFair : ActionNames.FollowFair,
+    action_type: ActionTypes.Tap,
+    owner_id: internalID,
+    owner_type: OwnerEntityTypes.Fair,
+    context_screen_owner_id: analytics.contextScreenOwnerId,
+    context_screen_owner_slug: analytics.contextScreenOwnerSlug,
+    context_screen_owner_type: analytics.contextScreenOwnerType,
+  }),
+}

--- a/src/app/Components/FairFollowButton.tsx
+++ b/src/app/Components/FairFollowButton.tsx
@@ -37,6 +37,7 @@ export const FairFollowButton: FC<FairFollowButtonProps> = ({ fair }) => {
       isFollowed={!!data.profile.isFollowed}
       onPress={handlePress}
       loading={isInFlight}
+      followText={data.profile.isFollowed ? "Saved" : "Save"}
     />
   )
 }

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -160,7 +160,7 @@ export const ShowItemRow: React.FC<Props> = ({
                 loading={isFollowedSaving}
                 longestText="Saved"
               >
-                {show.is_followed ? "Saved" : "Save"}
+                {show.is_followed ? "Followed" : "Follow"}
               </Button>
             )}
           </Flex>

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -74,7 +74,7 @@ export const ShowItemRow: React.FC<Props> = ({
         optimisticResponse: {
           followShow: {
             show: {
-              id: showID,
+              id: nodeID,
               slug: showSlug,
               internalID: showID,
               is_followed: !isShowFollowed,

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -8,6 +8,7 @@ import { exhibitionDates } from "app/Scenes/Map/exhibitionPeriodParser"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { hrefForPartialShow } from "app/utils/router"
 import { Schema } from "app/utils/track"
 import { debounce } from "lodash"
@@ -36,6 +37,7 @@ export const ShowItemRow: React.FC<Props> = ({
   const show = useFragment(showFragment, showProp)
   const [isFollowedSaving, setIsFollowedSaving] = useState(false)
   const { trackEvent } = useTracking()
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
 
   const handleTap = debounce((_slug: string, _internalID: string) => {
     const href = hrefForPartialShow(show)
@@ -158,9 +160,15 @@ export const ShowItemRow: React.FC<Props> = ({
                 size="small"
                 onPress={handleSave}
                 loading={isFollowedSaving}
-                longestText="Saved"
+                longestText={enableFollowShowsAndFairs ? "Followed" : "Saved"}
               >
-                {show.is_followed ? "Followed" : "Follow"}
+                {enableFollowShowsAndFairs
+                  ? show.is_followed
+                    ? "Followed"
+                    : "Follow"
+                  : show.is_followed
+                    ? "Saved"
+                    : "Save"}
               </Button>
             )}
           </Flex>

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -8,6 +8,7 @@ import { exhibitionDates } from "app/Scenes/Map/exhibitionPeriodParser"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { setShowFollowed } from "app/utils/mutations/setShowFollowed"
 import { hrefForPartialShow } from "app/utils/router"
 import { Schema } from "app/utils/track"
 import { debounce } from "lodash"
@@ -82,13 +83,7 @@ export const ShowItemRow: React.FC<Props> = ({
           },
         },
         updater: (store) => {
-          const show = store?.get(nodeID)
-          if (show) {
-            show.setValue(!isShowFollowed, "is_followed")
-            // Keep ShowFollowButton's unaliased `isFollowed` key in sync so any
-            // already-mounted surface using it doesn't show stale state until a refetch.
-            show.setValue(!isShowFollowed, "isFollowed")
-          }
+          setShowFollowed(store, nodeID, !isShowFollowed)
         },
       })
     }

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -85,6 +85,9 @@ export const ShowItemRow: React.FC<Props> = ({
           const show = store?.get(nodeID)
           if (show) {
             show.setValue(!isShowFollowed, "is_followed")
+            // Keep ShowFollowButton's unaliased `isFollowed` key in sync so any
+            // already-mounted surface using it doesn't show stale state until a refetch.
+            show.setValue(!isShowFollowed, "isFollowed")
           }
         },
       })

--- a/src/app/Components/Lists/ShowItemRow.tsx
+++ b/src/app/Components/Lists/ShowItemRow.tsx
@@ -8,7 +8,6 @@ import { exhibitionDates } from "app/Scenes/Map/exhibitionPeriodParser"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
-import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { hrefForPartialShow } from "app/utils/router"
 import { Schema } from "app/utils/track"
 import { debounce } from "lodash"
@@ -37,7 +36,6 @@ export const ShowItemRow: React.FC<Props> = ({
   const show = useFragment(showFragment, showProp)
   const [isFollowedSaving, setIsFollowedSaving] = useState(false)
   const { trackEvent } = useTracking()
-  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
 
   const handleTap = debounce((_slug: string, _internalID: string) => {
     const href = hrefForPartialShow(show)
@@ -76,6 +74,7 @@ export const ShowItemRow: React.FC<Props> = ({
         optimisticResponse: {
           followShow: {
             show: {
+              id: showID,
               slug: showSlug,
               internalID: showID,
               is_followed: !isShowFollowed,
@@ -160,15 +159,9 @@ export const ShowItemRow: React.FC<Props> = ({
                 size="small"
                 onPress={handleSave}
                 loading={isFollowedSaving}
-                longestText={enableFollowShowsAndFairs ? "Followed" : "Saved"}
+                longestText="Saved"
               >
-                {enableFollowShowsAndFairs
-                  ? show.is_followed
-                    ? "Followed"
-                    : "Follow"
-                  : show.is_followed
-                    ? "Saved"
-                    : "Save"}
+                {show.is_followed ? "Saved" : "Save"}
               </Button>
             )}
           </Flex>

--- a/src/app/Components/ShowCard.tsx
+++ b/src/app/Components/ShowCard.tsx
@@ -1,6 +1,7 @@
 import { toTitleCase } from "@artsy/to-title-case"
 import { ShowCard_show$data } from "__generated__/ShowCard_show.graphql"
 import { CardWithMetaData } from "app/Components/Cards/CardWithMetaData"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { compact } from "lodash"
 import { memo } from "react"
 import { GestureResponderEvent, ViewProps } from "react-native"
@@ -35,6 +36,7 @@ export const ShowCard: React.FC<ShowCardProps> = memo(({ show, isFluid, onPress 
       subtitle={show.partner?.name}
       tag={formattedCityAndDate}
       onPress={onPress}
+      actionElement={<ShowFollowButton show={show} />}
     />
   )
 })
@@ -78,6 +80,7 @@ export const getShowCity = ({
 export const ShowCardContainer = createFragmentContainer(ShowCard, {
   show: graphql`
     fragment ShowCard_show on Show {
+      ...ShowFollowButton_show
       name
       formattedStartAt: startAt(format: "MMM D")
       formattedEndAt: endAt(format: "MMM D")

--- a/src/app/Components/ShowCard.tsx
+++ b/src/app/Components/ShowCard.tsx
@@ -2,6 +2,7 @@ import { toTitleCase } from "@artsy/to-title-case"
 import { ShowCard_show$data } from "__generated__/ShowCard_show.graphql"
 import { CardWithMetaData } from "app/Components/Cards/CardWithMetaData"
 import { ShowFollowButton } from "app/Components/ShowFollowButton"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { compact } from "lodash"
 import { memo } from "react"
 import { GestureResponderEvent, ViewProps } from "react-native"
@@ -14,6 +15,7 @@ interface ShowCardProps extends ViewProps {
 }
 
 export const ShowCard: React.FC<ShowCardProps> = memo(({ show, isFluid, onPress }) => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
   const imageURL = show.metaImage?.url
 
   const showCity = getShowCity({
@@ -36,7 +38,7 @@ export const ShowCard: React.FC<ShowCardProps> = memo(({ show, isFluid, onPress 
       subtitle={show.partner?.name}
       tag={formattedCityAndDate}
       onPress={onPress}
-      actionElement={<ShowFollowButton show={show} />}
+      actionElement={enableFollowShowsAndFairs ? <ShowFollowButton show={show} /> : undefined}
     />
   )
 })

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -33,8 +33,16 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
 
       setIsFollowedSaving(true)
       commitMutation<ShowFollowButtonMutation>(getRelayEnvironment(), {
-        onCompleted: () => setIsFollowedSaving(false),
-        onError: () => setIsFollowedSaving(false),
+        onCompleted: (_response, errors) => {
+          setIsFollowedSaving(false)
+          if (errors?.length) {
+            console.error("ShowFollowButton: followShow mutation returned errors", errors)
+          }
+        },
+        onError: (error) => {
+          setIsFollowedSaving(false)
+          console.error("ShowFollowButton: followShow mutation failed", error)
+        },
         mutation: graphql`
           mutation ShowFollowButtonMutation($input: FollowShowInput!) {
             followShow(input: $input) {

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -1,0 +1,104 @@
+import { BoxProps, FollowButton } from "@artsy/palette-mobile"
+import { ShowFollowButtonMutation } from "__generated__/ShowFollowButtonMutation.graphql"
+import {
+  ShowFollowButton_show$data,
+  ShowFollowButton_show$key,
+} from "__generated__/ShowFollowButton_show.graphql"
+import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { Schema } from "app/utils/track"
+import { FC, useState } from "react"
+import { commitMutation, graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface ShowFollowButtonProps extends BoxProps {
+  show: ShowFollowButton_show$key
+}
+
+export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ...boxProps }) => {
+  const isFollowShowsAndFairsEnabled = useFeatureFlag("AREnableFollowShowsAndFairs")
+  const show = useFragment(showFragment, showProp)
+  const [isFollowedSaving, setIsFollowedSaving] = useState(false)
+  const { trackEvent } = useTracking()
+
+  if (!isFollowShowsAndFairsEnabled) {
+    return null
+  }
+
+  const handlePress = () => {
+    const { id: nodeID, internalID: showID, isFollowed: isShowFollowed } = show
+
+    if (showID && nodeID && !isFollowedSaving) {
+      trackEvent(tracks.trackSave(show))
+
+      setIsFollowedSaving(true)
+      commitMutation<ShowFollowButtonMutation>(getRelayEnvironment(), {
+        onCompleted: () => setIsFollowedSaving(false),
+        onError: () => setIsFollowedSaving(false),
+        mutation: graphql`
+          mutation ShowFollowButtonMutation($input: FollowShowInput!) {
+            followShow(input: $input) {
+              show {
+                slug
+                internalID
+                is_followed: isFollowed
+              }
+            }
+          }
+        `,
+        variables: {
+          input: {
+            partnerShowID: showID,
+            unfollow: isShowFollowed,
+          },
+        },
+        // @ts-ignore RELAY 12 MIGRATION
+        optimisticResponse: {
+          followShow: {
+            show: {
+              slug: show.slug,
+              internalID: showID,
+              is_followed: !isShowFollowed,
+            },
+          },
+        },
+        updater: (store) => {
+          const showRecord = store?.get(nodeID)
+          if (showRecord) {
+            showRecord.setValue(!isShowFollowed, "is_followed")
+          }
+        },
+      })
+    }
+  }
+
+  return (
+    <FollowButton
+      isFollowed={!!show.isFollowed}
+      onPress={handlePress}
+      loading={isFollowedSaving}
+      {...boxProps}
+    />
+  )
+}
+
+const showFragment = graphql`
+  fragment ShowFollowButton_show on Show {
+    id
+    internalID
+    slug
+    isFollowed
+  }
+`
+
+const tracks = {
+  trackSave: (show: ShowFollowButton_show$data) => {
+    return {
+      action_name: show.isFollowed ? Schema.ActionNames.UnsaveShow : Schema.ActionNames.SaveShow,
+      action_type: Schema.ActionTypes.Success,
+      owner_type: Schema.OwnerEntityTypes.Show,
+      owner_id: show.internalID,
+      owner_slug: show.slug,
+    } as any
+  },
+}

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -39,6 +39,7 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
           mutation ShowFollowButtonMutation($input: FollowShowInput!) {
             followShow(input: $input) {
               show {
+                id
                 slug
                 internalID
                 is_followed: isFollowed
@@ -56,6 +57,7 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
         optimisticResponse: {
           followShow: {
             show: {
+              id: nodeID,
               slug: show.slug,
               internalID: showID,
               is_followed: !isShowFollowed,

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -42,7 +42,7 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
                 id
                 slug
                 internalID
-                is_followed: isFollowed
+                isFollowed
               }
             }
           }
@@ -60,14 +60,14 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
               id: nodeID,
               slug: show.slug,
               internalID: showID,
-              is_followed: !isShowFollowed,
+              isFollowed: !isShowFollowed,
             },
           },
         },
         updater: (store) => {
           const showRecord = store?.get(nodeID)
           if (showRecord) {
-            showRecord.setValue(!isShowFollowed, "is_followed")
+            showRecord.setValue(!isShowFollowed, "isFollowed")
           }
         },
       })

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -76,6 +76,9 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
           const showRecord = store?.get(nodeID)
           if (showRecord) {
             showRecord.setValue(!isShowFollowed, "isFollowed")
+            // Keep ShowItemRow's aliased `is_followed` key in sync so Favorites/Map/City
+            // surfaces don't show stale follow state until a network refetch.
+            showRecord.setValue(!isShowFollowed, "is_followed")
           }
         },
       })

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -6,6 +6,7 @@ import {
 } from "__generated__/ShowFollowButton_show.graphql"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { setShowFollowed } from "app/utils/mutations/setShowFollowed"
 import { Schema } from "app/utils/track"
 import { FC, useState } from "react"
 import { commitMutation, graphql, useFragment } from "react-relay"
@@ -73,13 +74,7 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
           },
         },
         updater: (store) => {
-          const showRecord = store?.get(nodeID)
-          if (showRecord) {
-            showRecord.setValue(!isShowFollowed, "isFollowed")
-            // Keep ShowItemRow's aliased `is_followed` key in sync so Favorites/Map/City
-            // surfaces don't show stale follow state until a network refetch.
-            showRecord.setValue(!isShowFollowed, "is_followed")
-          }
+          setShowFollowed(store, nodeID, !isShowFollowed)
         },
       })
     }

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -87,6 +87,7 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
       isFollowed={!!show.isFollowed}
       onPress={handlePress}
       loading={isFollowedSaving}
+      followText={show.isFollowed ? "Saved" : "Save"}
       {...boxProps}
     />
   )

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -113,6 +113,6 @@ const tracks = {
       owner_type: Schema.OwnerEntityTypes.Show,
       owner_id: show.internalID,
       owner_slug: show.slug,
-    } as any
+    }
   },
 }

--- a/src/app/Components/ShowFollowButton.tsx
+++ b/src/app/Components/ShowFollowButton.tsx
@@ -1,4 +1,4 @@
-import { BoxProps, FollowButton } from "@artsy/palette-mobile"
+import { BoxProps, Button } from "@artsy/palette-mobile"
 import { ShowFollowButtonMutation } from "__generated__/ShowFollowButtonMutation.graphql"
 import {
   ShowFollowButton_show$data,
@@ -83,13 +83,16 @@ export const ShowFollowButton: FC<ShowFollowButtonProps> = ({ show: showProp, ..
   }
 
   return (
-    <FollowButton
-      isFollowed={!!show.isFollowed}
+    <Button
+      variant={show.isFollowed ? "outline" : "fillDark"}
       onPress={handlePress}
       loading={isFollowedSaving}
-      followText={show.isFollowed ? "Saved" : "Save"}
+      longestText="Saved"
       {...boxProps}
-    />
+      size="small"
+    >
+      {show.isFollowed ? "Saved" : "Save"}
+    </Button>
   )
 }
 

--- a/src/app/Components/ShowItem.tsx
+++ b/src/app/Components/ShowItem.tsx
@@ -1,5 +1,6 @@
-import { Button, Image, Text } from "@artsy/palette-mobile"
+import { Button, Flex, Image, Text } from "@artsy/palette-mobile"
 import { ShowItem_show$key } from "__generated__/ShowItem_show.graphql"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { hrefForPartialShow } from "app/utils/router"
 import { graphql, useFragment } from "react-relay"
@@ -8,10 +9,15 @@ const DEFAULT_CELL_WIDTH = 335
 
 interface ShowItemProps {
   displayViewShowButton?: boolean
+  shouldHideFollowButton?: boolean
   show: ShowItem_show$key
 }
 
-export const ShowItem: React.FC<ShowItemProps> = ({ displayViewShowButton = false, show }) => {
+export const ShowItem: React.FC<ShowItemProps> = ({
+  displayViewShowButton = false,
+  shouldHideFollowButton = false,
+  show,
+}) => {
   const data = useFragment(showGraphql, show)
 
   if (!data) {
@@ -26,13 +32,20 @@ export const ShowItem: React.FC<ShowItemProps> = ({ displayViewShowButton = fals
 
   return (
     <RouterLink to={href} style={{ width: DEFAULT_CELL_WIDTH }} testID="show-item-visit-show-link">
-      <Image
-        testID="show-cover"
-        src={data.coverImage?.url ?? ""}
-        blurhash={data.coverImage?.blurhash}
-        aspectRatio={1.3}
-        width={DEFAULT_CELL_WIDTH}
-      />
+      <Flex position="relative">
+        <Image
+          testID="show-cover"
+          src={data.coverImage?.url ?? ""}
+          blurhash={data.coverImage?.blurhash}
+          aspectRatio={1.3}
+          width={DEFAULT_CELL_WIDTH}
+        />
+        {!shouldHideFollowButton && (
+          <Flex position="absolute" top={1} right={1}>
+            <ShowFollowButton show={data} />
+          </Flex>
+        )}
+      </Flex>
 
       <Text variant="lg-display" mt={1}>
         {data.name}
@@ -55,6 +68,7 @@ export const ShowItem: React.FC<ShowItemProps> = ({ displayViewShowButton = fals
 
 const showGraphql = graphql`
   fragment ShowItem_show on Show {
+    ...ShowFollowButton_show
     slug
     href
     name

--- a/src/app/Components/ShowItem.tsx
+++ b/src/app/Components/ShowItem.tsx
@@ -31,8 +31,8 @@ export const ShowItem: React.FC<ShowItemProps> = ({
   })
 
   return (
-    <RouterLink to={href} style={{ width: DEFAULT_CELL_WIDTH }} testID="show-item-visit-show-link">
-      <Flex position="relative">
+    <Flex style={{ width: DEFAULT_CELL_WIDTH }}>
+      <RouterLink to={href} testID="show-item-visit-show-link">
         <Image
           testID="show-cover"
           src={data.coverImage?.url ?? ""}
@@ -40,29 +40,32 @@ export const ShowItem: React.FC<ShowItemProps> = ({
           aspectRatio={1.3}
           width={DEFAULT_CELL_WIDTH}
         />
+      </RouterLink>
+
+      <Flex flexDirection="row" alignItems="flex-start" justifyContent="space-between" mt={1}>
+        <RouterLink to={href} style={{ flex: 1 }}>
+          <Text variant="lg-display">{data.name}</Text>
+          <Text variant="sm-display">{data.partner?.name}</Text>
+          {!!data.exhibitionPeriod && (
+            <Text variant="sm-display" color="mono60">
+              {data.exhibitionPeriod}
+            </Text>
+          )}
+        </RouterLink>
+
         {!shouldHideFollowButton && (
-          <Flex position="absolute" top={1} right={1}>
+          <Flex ml={1}>
             <ShowFollowButton show={data} />
           </Flex>
         )}
       </Flex>
-
-      <Text variant="lg-display" mt={1}>
-        {data.name}
-      </Text>
-      <Text variant="sm-display">{data.partner?.name}</Text>
-      {!!data.exhibitionPeriod && (
-        <Text variant="sm-display" color="mono60">
-          {data.exhibitionPeriod}
-        </Text>
-      )}
 
       {!!displayViewShowButton && (
         <RouterLink hasChildTouchable to={href}>
           <Button my={2}>View Show</Button>
         </RouterLink>
       )}
-    </RouterLink>
+    </Flex>
   )
 }
 

--- a/src/app/Components/ShowItem.tsx
+++ b/src/app/Components/ShowItem.tsx
@@ -43,18 +43,20 @@ export const ShowItem: React.FC<ShowItemProps> = ({
       </RouterLink>
 
       <Flex flexDirection="row" alignItems="flex-start" justifyContent="space-between" mt={1}>
-        <RouterLink to={href} style={{ flex: 1 }}>
-          <Text variant="lg-display">{data.name}</Text>
-          <Text variant="sm-display">{data.partner?.name}</Text>
-          {!!data.exhibitionPeriod && (
-            <Text variant="sm-display" color="mono60">
-              {data.exhibitionPeriod}
-            </Text>
-          )}
-        </RouterLink>
+        <Flex flex={1}>
+          <RouterLink to={href}>
+            <Text variant="lg-display">{data.name}</Text>
+            <Text variant="sm-display">{data.partner?.name}</Text>
+            {!!data.exhibitionPeriod && (
+              <Text variant="sm-display" color="mono60">
+                {data.exhibitionPeriod}
+              </Text>
+            )}
+          </RouterLink>
+        </Flex>
 
         {!shouldHideFollowButton && (
-          <Flex ml={1}>
+          <Flex ml={0.5}>
             <ShowFollowButton show={data} />
           </Flex>
         )}

--- a/src/app/Components/ShowItem.tsx
+++ b/src/app/Components/ShowItem.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, Image, Text } from "@artsy/palette-mobile"
 import { ShowItem_show$key } from "__generated__/ShowItem_show.graphql"
 import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { RouterLink } from "app/system/navigation/RouterLink"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { hrefForPartialShow } from "app/utils/router"
 import { graphql, useFragment } from "react-relay"
 
@@ -18,6 +19,7 @@ export const ShowItem: React.FC<ShowItemProps> = ({
   shouldHideFollowButton = false,
   show,
 }) => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
   const data = useFragment(showGraphql, show)
 
   if (!data) {
@@ -55,7 +57,7 @@ export const ShowItem: React.FC<ShowItemProps> = ({
           </RouterLink>
         </Flex>
 
-        {!shouldHideFollowButton && (
+        {!shouldHideFollowButton && !!enableFollowShowsAndFairs && (
           <Flex ml={0.5}>
             <ShowFollowButton show={data} />
           </Flex>

--- a/src/app/Scenes/Activity/components/PartnerShowOpenedNotification.tsx
+++ b/src/app/Scenes/Activity/components/PartnerShowOpenedNotification.tsx
@@ -55,7 +55,12 @@ export const PartnerShowOpenedNotification: FC<PartnerShowOpenedNotificationProp
 
           <Flex flexDirection="column" alignItems="center">
             {shows.map((show) => (
-              <ShowItem displayViewShowButton show={show} key={show.internalID} />
+              <ShowItem
+                displayViewShowButton
+                shouldHideFollowButton
+                show={show}
+                key={show.internalID}
+              />
             ))}
           </Flex>
         </Flex>

--- a/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
+++ b/src/app/Scenes/Fair/Components/FairExhibitorRail.tsx
@@ -7,6 +7,7 @@ import {
 } from "__generated__/FairExhibitorRail_show.graphql"
 import { ArtworkRail, ArtworkRailPlaceholder } from "app/Components/ArtworkRail/ArtworkRail"
 import { SectionTitle } from "app/Components/SectionTitle"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 // eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
 import { extractNodes } from "app/utils/extractNodes"
@@ -36,17 +37,22 @@ export const FairExhibitorRail: React.FC<FairExhibitorRailProps> = memo(({ show:
 
   return (
     <>
-      <Flex px={2}>
-        <SectionTitle
-          title={partnerName}
-          subtitle={`${count} works`}
-          href={viewAllUrl}
-          onPress={() => {
-            if (!viewAllUrl) return
+      <Flex px={2} mb={2} flexDirection="row" alignItems="center" justifyContent="space-between">
+        <Flex flex={1}>
+          <SectionTitle
+            title={partnerName}
+            subtitle={`${count} works`}
+            href={viewAllUrl}
+            onPress={() => {
+              if (!viewAllUrl) return
 
-            trackEvent(tracks.tappedShow(show))
-          }}
-        />
+              trackEvent(tracks.tappedShow(show))
+            }}
+            mb={0}
+          />
+        </Flex>
+
+        <ShowFollowButton show={show} ml={1} />
       </Flex>
       <ArtworkRail
         artworks={artworks}
@@ -75,6 +81,7 @@ export const FairExhibitorRail: React.FC<FairExhibitorRailProps> = memo(({ show:
 
 const fairExhibitorRailFragment = graphql`
   fragment FairExhibitorRail_show on Show {
+    ...ShowFollowButton_show
     internalID
     slug
     href

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -11,6 +11,7 @@ import {
 import { FairQuery } from "__generated__/FairQuery.graphql"
 import { Fair_fair$data, Fair_fair$key } from "__generated__/Fair_fair.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { FairFollowButton } from "app/Components/FairFollowButton"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { useToast } from "app/Components/Toast/toastHook"
 import {
@@ -55,7 +56,14 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
   }, [data.internalID])
 
   const renderBelowHeaderComponent = useCallback(() => {
-    return <FairHeader fair={data} />
+    return (
+      <>
+        <FairHeader fair={data} />
+        <Flex px={2} pb={1}>
+          <FairFollowButton fair={data} />
+        </Flex>
+      </>
+    )
   }, [data])
 
   if (!data) {
@@ -157,6 +165,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
 const fragment = graphql`
   fragment Fair_fair on Fair {
     ...FairHeader_fair
+    ...FairFollowButton_fair
     internalID
     slug
     name

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -56,14 +56,7 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
   }, [data.internalID])
 
   const renderBelowHeaderComponent = useCallback(() => {
-    return (
-      <>
-        <FairHeader fair={data} />
-        <Flex px={2} pb={1}>
-          <FairFollowButton fair={data} />
-        </Flex>
-      </>
-    )
+    return <FairHeader fair={data} />
   }, [data])
 
   if (!data) {
@@ -125,15 +118,18 @@ export const Fair: React.FC<FairProps> = ({ fair }) => {
             onBack: goBack,
             hideTitle: true,
             rightElements: (
-              <TouchableOpacity
-                accessibilityRole="button"
-                accessibilityLabel="Share Fair"
-                onPress={() => {
-                  handleSharePress()
-                }}
-              >
-                <ShareIcon width={24} height={24} />
-              </TouchableOpacity>
+              <Flex flexDirection="row" alignItems="center" gap={1}>
+                <FairFollowButton fair={data} />
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessibilityLabel="Share Fair"
+                  onPress={() => {
+                    handleSharePress()
+                  }}
+                >
+                  <ShareIcon width={24} height={24} />
+                </TouchableOpacity>
+              </Flex>
             ),
           }}
         >

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -177,7 +177,7 @@ const fragment = graphql`
 `
 
 export const FairScreenQuery = graphql`
-  query FairQuery($fairID: String!) @cacheable {
+  query FairQuery($fairID: String!) {
     fair(id: $fairID) @required(action: THROW) {
       ...Fair_fair
     }

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -57,14 +57,7 @@ export const Fair: React.FC<FairProps> = ({ fair, initialTab = "Overview" }) => 
   }, [data.internalID])
 
   const renderBelowHeaderComponent = useCallback(() => {
-    return (
-      <>
-        <FairHeader fair={data} />
-        <Flex px={2} pb={1}>
-          <FairFollowButton fair={data} />
-        </Flex>
-      </>
-    )
+    return <FairHeader fair={data} />
   }, [data])
 
   if (!data) {
@@ -129,15 +122,18 @@ export const Fair: React.FC<FairProps> = ({ fair, initialTab = "Overview" }) => 
             onBack: goBack,
             hideTitle: true,
             rightElements: (
-              <TouchableOpacity
-                accessibilityRole="button"
-                accessibilityLabel="Share Fair"
-                onPress={() => {
-                  handleSharePress()
-                }}
-              >
-                <ShareIcon width={24} height={24} />
-              </TouchableOpacity>
+              <Flex flexDirection="row" alignItems="center" gap={1}>
+                <FairFollowButton fair={data} />
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessibilityLabel="Share Fair"
+                  onPress={() => {
+                    handleSharePress()
+                  }}
+                >
+                  <ShareIcon width={24} height={24} />
+                </TouchableOpacity>
+              </Flex>
             ),
           }}
         >

--- a/src/app/Scenes/Fair/Fair.tsx
+++ b/src/app/Scenes/Fair/Fair.tsx
@@ -11,6 +11,7 @@ import {
 import { FairQuery } from "__generated__/FairQuery.graphql"
 import { Fair_fair$data, Fair_fair$key } from "__generated__/Fair_fair.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
+import { FairFollowButton } from "app/Components/FairFollowButton"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
 import { useToast } from "app/Components/Toast/toastHook"
 import {
@@ -56,7 +57,14 @@ export const Fair: React.FC<FairProps> = ({ fair, initialTab = "Overview" }) => 
   }, [data.internalID])
 
   const renderBelowHeaderComponent = useCallback(() => {
-    return <FairHeader fair={data} />
+    return (
+      <>
+        <FairHeader fair={data} />
+        <Flex px={2} pb={1}>
+          <FairFollowButton fair={data} />
+        </Flex>
+      </>
+    )
   }, [data])
 
   if (!data) {
@@ -161,6 +169,7 @@ export const Fair: React.FC<FairProps> = ({ fair, initialTab = "Overview" }) => 
 const fragment = graphql`
   fragment Fair_fair on Fair {
     ...FairHeader_fair
+    ...FairFollowButton_fair
     internalID
     slug
     name

--- a/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
@@ -77,13 +77,13 @@ export const FollowedFairs: React.FC<Props> = ({ me }) => {
   )
 }
 
+const IMAGE_SIZE = 62
+
 interface FollowedFairRowProps {
   fair: FollowedFairs_fair$key
 }
 
 // Minimal, compact list row for a followed fair (image thumbnail + name + exhibition dates).
-// Intentionally does not include a follow/save button - that's handled separately by the
-// Fair follow button work happening in parallel.
 const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => {
   const color = useColor()
   const fair = useFragment(followedFairRowFragment, fairProp)
@@ -100,17 +100,25 @@ const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => 
       style={{ paddingHorizontal: 20, paddingVertical: 5 }}
     >
       <Flex flexDirection="row" alignItems="center">
-        <Box width={62} height={62} borderRadius={2} overflow="hidden" backgroundColor="mono10">
-          {!!fair.image?.url && <Image width={62} height={62} src={fair.image.url} />}
+        <Box
+          width={IMAGE_SIZE}
+          height={IMAGE_SIZE}
+          borderRadius={2}
+          overflow="hidden"
+          backgroundColor="mono10"
+        >
+          {!!fair.image?.url && (
+            <Image width={IMAGE_SIZE} height={IMAGE_SIZE} src={fair.image.url} />
+          )}
         </Box>
         <Flex flexDirection="column" flexGrow={1} ml="15px" mr={1}>
           {!!fair.name && (
-            <Text variant="sm" lineHeight="20px" color="mono100" weight="medium" numberOfLines={1}>
+            <Text variant="sm" color="mono100" weight="medium" numberOfLines={1}>
               {fair.name}
             </Text>
           )}
           {!!fair.exhibition_period && (
-            <Text variant="sm" lineHeight="20px" color={color("mono60")} numberOfLines={1}>
+            <Text variant="sm" color={color("mono60")} numberOfLines={1}>
               {fair.exhibition_period}
             </Text>
           )}

--- a/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
@@ -1,0 +1,191 @@
+import { Box, Flex, Image, Screen, Spacer, Text, Touchable, useColor } from "@artsy/palette-mobile"
+import { FollowedFairsQuery } from "__generated__/FollowedFairsQuery.graphql"
+import { FollowedFairs_fair$key } from "__generated__/FollowedFairs_fair.graphql"
+import { FollowedFairs_me$key } from "__generated__/FollowedFairs_me.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
+import Spinner from "app/Components/Spinner"
+import { ZeroState } from "app/Components/States/ZeroState"
+
+import { PAGE_SIZE } from "app/Components/constants"
+import { FavoritesContextStore } from "app/Scenes/Favorites/FavoritesContextStore"
+import { FollowOptionPicker } from "app/Scenes/Favorites/FollowsTab"
+// eslint-disable-next-line no-restricted-imports
+import { navigate } from "app/system/navigation/navigate"
+import { extractNodes } from "app/utils/extractNodes"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { useRefreshControl } from "app/utils/refreshHelpers"
+import React from "react"
+import { graphql, useFragment, useLazyLoadQuery, usePaginationFragment } from "react-relay"
+
+interface Props {
+  me: FollowedFairs_me$key
+}
+
+export const FollowedFairs: React.FC<Props> = ({ me }) => {
+  const { headerHeight } = FavoritesContextStore.useStoreState((state) => state)
+
+  const { data, loadNext, isLoadingNext, refetch, hasNext } = usePaginationFragment(
+    followedFairsFragment,
+    me
+  )
+
+  const fairs = extractNodes(data.followsAndSaves?.fairsConnection)
+
+  const RefreshControl = useRefreshControl(refetch, { progressViewOffset: headerHeight })
+
+  if (fairs.length === 0) {
+    return (
+      <Screen.ScrollView
+        refreshControl={RefreshControl}
+        contentContainerStyle={{ paddingTop: headerHeight }}
+      >
+        <FollowOptionPicker />
+        <ZeroState
+          title="You haven’t followed any fairs yet"
+          subtitle="When you follow fairs, they will show up here for future use."
+        />
+      </Screen.ScrollView>
+    )
+  }
+
+  return (
+    <Screen.FlatList
+      data={fairs}
+      onEndReached={() => {
+        loadNext(PAGE_SIZE)
+      }}
+      keyExtractor={(item, index) => item.id || index.toString()}
+      onEndReachedThreshold={0.2}
+      refreshControl={RefreshControl}
+      style={{ paddingHorizontal: 0 }}
+      contentContainerStyle={{ paddingTop: headerHeight }}
+      ListHeaderComponent={FollowOptionPicker}
+      ItemSeparatorComponent={() => <Spacer y={1} />}
+      ListFooterComponent={() =>
+        isLoadingNext && hasNext ? (
+          <Flex my={4} flexDirection="row" justifyContent="center">
+            <Spinner />
+          </Flex>
+        ) : (
+          <Spacer y={2} />
+        )
+      }
+      renderItem={({ item }) => {
+        return <FollowedFairRow fair={item} />
+      }}
+    />
+  )
+}
+
+interface FollowedFairRowProps {
+  fair: FollowedFairs_fair$key
+}
+
+// Minimal, compact list row for a followed fair (image thumbnail + name + exhibition dates).
+// Intentionally does not include a follow/save button - that's handled separately by the
+// Fair follow button work happening in parallel.
+const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => {
+  const color = useColor()
+  const fair = useFragment(followedFairRowFragment, fairProp)
+
+  const handleTap = () => {
+    navigate(`/fair/${fair.slug}`)
+  }
+
+  return (
+    <Touchable
+      accessibilityRole="button"
+      underlayColor={color("mono5")}
+      onPress={handleTap}
+      style={{ paddingHorizontal: 20, paddingVertical: 5 }}
+    >
+      <Flex flexDirection="row" alignItems="center">
+        <Box width={62} height={62} borderRadius={2} overflow="hidden" backgroundColor="mono10">
+          {!!fair.image?.url && <Image width={62} height={62} src={fair.image.url} />}
+        </Box>
+        <Flex flexDirection="column" flexGrow={1} ml="15px" mr={1}>
+          {!!fair.name && (
+            <Text variant="sm" lineHeight="20px" color="mono100" weight="medium" numberOfLines={1}>
+              {fair.name}
+            </Text>
+          )}
+          {!!fair.exhibition_period && (
+            <Text variant="sm" lineHeight="20px" color={color("mono60")} numberOfLines={1}>
+              {fair.exhibition_period}
+            </Text>
+          )}
+        </Flex>
+      </Flex>
+    </Touchable>
+  )
+}
+
+const followedFairRowFragment = graphql`
+  fragment FollowedFairs_fair on Fair {
+    internalID
+    slug
+    name
+    exhibition_period: exhibitionPeriod(format: SHORT)
+    image {
+      url(version: "square")
+    }
+  }
+`
+
+const followedFairsFragment = graphql`
+  fragment FollowedFairs_me on Me
+  @refetchable(queryName: "FollowedFairs_fairsConnectionRefetch")
+  @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, cursor: { type: "String" }) {
+    followsAndSaves {
+      fairsConnection(first: $count, after: $cursor)
+        @connection(key: "FollowedFairs_fairsConnection") {
+        edges {
+          node {
+            id
+            ...FollowedFairs_fair
+          }
+        }
+      }
+    }
+  }
+`
+
+const followedFairsQuery = graphql`
+  query FollowedFairsQuery($count: Int!, $cursor: String) {
+    me @required(action: NONE) {
+      ...FollowedFairs_me @arguments(count: $count, cursor: $cursor)
+    }
+  }
+`
+
+export const FollowedFairsQueryRenderer = withSuspense({
+  Component: ({}) => {
+    const data = useLazyLoadQuery<FollowedFairsQuery>(
+      followedFairsQuery,
+      {
+        count: PAGE_SIZE,
+      },
+      {
+        fetchPolicy: "store-and-network",
+      }
+    )
+
+    if (!data?.me) {
+      return null
+    }
+
+    return <FollowedFairs me={data?.me} />
+  },
+  LoadingFallback: () => <Spinner />,
+  ErrorFallback: (fallbackProps) => {
+    return (
+      <LoadFailureView
+        onRetry={fallbackProps.resetErrorBoundary}
+        showBackButton={false}
+        useSafeArea={false}
+        error={fallbackProps.error}
+        trackErrorBoundary={false}
+      />
+    )
+  },
+})

--- a/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Image, Screen, Spacer, Text, Touchable, useColor } from "@ar
 import { FollowedFairsQuery } from "__generated__/FollowedFairsQuery.graphql"
 import { FollowedFairs_fair$key } from "__generated__/FollowedFairs_fair.graphql"
 import { FollowedFairs_me$key } from "__generated__/FollowedFairs_me.graphql"
+import { FairFollowButton } from "app/Components/FairFollowButton"
 import { LoadFailureView } from "app/Components/LoadFailureView"
 import Spinner from "app/Components/Spinner"
 import { ZeroState } from "app/Components/States/ZeroState"
@@ -83,7 +84,7 @@ interface FollowedFairRowProps {
   fair: FollowedFairs_fair$key
 }
 
-// Minimal, compact list row for a followed fair (image thumbnail + name + exhibition dates).
+// Compact list row for a followed fair (image thumbnail + name + exhibition dates + follow button).
 const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => {
   const color = useColor()
   const fair = useFragment(followedFairRowFragment, fairProp)
@@ -123,6 +124,8 @@ const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => 
             </Text>
           )}
         </Flex>
+
+        <FairFollowButton fair={fair} />
       </Flex>
     </Touchable>
   )
@@ -130,6 +133,7 @@ const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => 
 
 const followedFairRowFragment = graphql`
   fragment FollowedFairs_fair on Fair {
+    ...FairFollowButton_fair
     internalID
     slug
     name

--- a/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
+++ b/src/app/Scenes/Favorites/Components/FollowedFairs.tsx
@@ -112,9 +112,9 @@ const FollowedFairRow: React.FC<FollowedFairRowProps> = ({ fair: fairProp }) => 
             <Image width={IMAGE_SIZE} height={IMAGE_SIZE} src={fair.image.url} />
           )}
         </Box>
-        <Flex flexDirection="column" flexGrow={1} ml="15px" mr={1}>
+        <Flex flex={1} flexGrow={1} ml="15px" mr={1}>
           {!!fair.name && (
-            <Text variant="sm" color="mono100" weight="medium" numberOfLines={1}>
+            <Text variant="sm" color="mono100" weight="medium" numberOfLines={2} lineHeight="20px">
               {fair.name}
             </Text>
           )}

--- a/src/app/Scenes/Favorites/FollowsTab.tsx
+++ b/src/app/Scenes/Favorites/FollowsTab.tsx
@@ -1,9 +1,11 @@
 import { OwnerType } from "@artsy/cohesion"
+import { SelectedFromDrawerSubject } from "@artsy/cohesion/dist/Schema/Events/Favorites"
 import { ChevronSmallDownIcon } from "@artsy/icons/native"
 import { Flex, Join, RadioButton, Spacer, Text, Touchable } from "@artsy/palette-mobile"
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
 import { FollowedArtistsQueryRenderer } from "app/Scenes/Favorites/Components/FollowedArtists"
+import { FollowedFairsQueryRenderer } from "app/Scenes/Favorites/Components/FollowedFairs"
 import { FollowedGalleriesQueryRenderer } from "app/Scenes/Favorites/Components/FollowedGalleries"
 import { FollowedShowsQueryRenderer } from "app/Scenes/Favorites/Components/FollowedShows"
 import { FavoritesContextStore } from "app/Scenes/Favorites/FavoritesContextStore"
@@ -12,12 +14,13 @@ import {
   useFavoritesTracking,
 } from "app/Scenes/Favorites/useFavoritesTracking"
 import { SNAP_POINTS } from "app/Scenes/MyCollection/Components/MyCollectionBottomSheetModals/MyCollectionBottomSheetModalArtistsPrompt"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import Haptic from "react-native-haptic-feedback"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
-export type FollowOption = "artists" | "shows" | "galleries"
+export type FollowOption = "artists" | "shows" | "galleries" | "fairs"
 
-const FOLLOW_OPTIONS: {
+const BASE_FOLLOW_OPTIONS: {
   value: FollowOption
   label: string
 }[] = [
@@ -35,9 +38,20 @@ const FOLLOW_OPTIONS: {
   },
 ]
 
+const useFollowOptions = () => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
+
+  if (enableFollowShowsAndFairs) {
+    return [...BASE_FOLLOW_OPTIONS, { value: "fairs" as const, label: "Fairs" }]
+  }
+
+  return BASE_FOLLOW_OPTIONS
+}
+
 export const FollowOptionPicker: React.FC<{}> = () => {
   const { followOption } = FavoritesContextStore.useStoreState((state) => state)
   const { setShowFollowsBottomSheet } = FavoritesContextStore.useStoreActions((actions) => actions)
+  const followOptions = useFollowOptions()
 
   return (
     <Flex px={2} pb={2}>
@@ -51,7 +65,7 @@ export const FollowOptionPicker: React.FC<{}> = () => {
       >
         <Flex flexDirection="row" alignItems="center">
           <Text variant="sm-display" mr={0.5}>
-            {FOLLOW_OPTIONS.find(({ value }) => value === followOption)?.label}
+            {followOptions.find(({ value }) => value === followOption)?.label}
           </Text>
           <ChevronSmallDownIcon
             style={{
@@ -79,12 +93,14 @@ export const FollowsTab = () => {
   )
 
   const { trackSelectedFromDrawer } = useFavoritesTracking()
+  const followOptions = useFollowOptions()
 
   return (
     <Flex flex={1}>
       {followOption === "artists" && <FollowedArtistsQueryRenderer />}
       {followOption === "shows" && <FollowedShowsQueryRenderer />}
       {followOption === "galleries" && <FollowedGalleriesQueryRenderer />}
+      {followOption === "fairs" && <FollowedFairsQueryRenderer />}
 
       <AutomountedBottomSheetModal
         visible={showFollowsBottomSheet}
@@ -104,7 +120,7 @@ export const FollowsTab = () => {
             <Spacer y={2} />
 
             <Join separator={<Spacer y={2} />}>
-              {FOLLOW_OPTIONS.map(({ value, label }) => (
+              {followOptions.map(({ value, label }) => (
                 <RadioButton
                   key={value}
                   block
@@ -115,7 +131,9 @@ export const FollowsTab = () => {
                     setTimeout(() => {
                       setShowFollowsBottomSheet(false)
                     }, 200)
-                    trackSelectedFromDrawer(value)
+                    // TODO: `SelectedFromDrawerSubject` (from @artsy/cohesion) does not yet include
+                    // "fairs" as a value. Cast until cohesion is updated to add it.
+                    trackSelectedFromDrawer(value as SelectedFromDrawerSubject)
                   }}
                   selected={followOption === value}
                   text={label}

--- a/src/app/Scenes/Favorites/FollowsTab.tsx
+++ b/src/app/Scenes/Favorites/FollowsTab.tsx
@@ -1,5 +1,4 @@
 import { OwnerType } from "@artsy/cohesion"
-import { SelectedFromDrawerSubject } from "@artsy/cohesion/dist/Schema/Events/Favorites"
 import { ChevronSmallDownIcon } from "@artsy/icons/native"
 import { Flex, Join, RadioButton, Spacer, Text, Touchable } from "@artsy/palette-mobile"
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
@@ -131,9 +130,7 @@ export const FollowsTab = () => {
                     setTimeout(() => {
                       setShowFollowsBottomSheet(false)
                     }, 200)
-                    // TODO: `SelectedFromDrawerSubject` (from @artsy/cohesion) does not yet include
-                    // "fairs" as a value. Cast until cohesion is updated to add it.
-                    trackSelectedFromDrawer(value as SelectedFromDrawerSubject)
+                    trackSelectedFromDrawer(value)
                   }}
                   selected={followOption === value}
                   text={label}

--- a/src/app/Scenes/HomeView/Sections/FairCard.tsx
+++ b/src/app/Scenes/HomeView/Sections/FairCard.tsx
@@ -2,6 +2,7 @@ import { bullet, useTheme } from "@artsy/palette-mobile"
 import { FairCard_fair$data, FairCard_fair$key } from "__generated__/FairCard_fair.graphql"
 import { CARD_WIDTH } from "app/Components/CardRail/CardRailCard"
 import { CardWithMetaData, useNumColumns } from "app/Components/Cards/CardWithMetaData"
+import { FairFollowButton } from "app/Components/FairFollowButton"
 import { MultipleImageLayout } from "app/Components/MultipleImageLayout"
 import { extractNodes } from "app/utils/extractNodes"
 import { compact, concat, take } from "lodash"
@@ -59,12 +60,14 @@ export const FairCard: FC<FairCardProps> = memo(({ fair: fairFragment, onPress, 
       onPress={() => {
         onPress?.(fair)
       }}
+      actionElement={<FairFollowButton fair={fair} />}
     />
   )
 })
 
 const fragment = graphql`
   fragment FairCard_fair on Fair {
+    ...FairFollowButton_fair
     internalID
     slug
     profile {

--- a/src/app/Scenes/HomeView/Sections/FairCard.tsx
+++ b/src/app/Scenes/HomeView/Sections/FairCard.tsx
@@ -5,6 +5,7 @@ import { CardWithMetaData, useNumColumns } from "app/Components/Cards/CardWithMe
 import { FairFollowButton } from "app/Components/FairFollowButton"
 import { MultipleImageLayout } from "app/Components/MultipleImageLayout"
 import { extractNodes } from "app/utils/extractNodes"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { compact, concat, take } from "lodash"
 import { FC, memo } from "react"
 import { useWindowDimensions } from "react-native"
@@ -17,6 +18,7 @@ interface FairCardProps {
 }
 
 export const FairCard: FC<FairCardProps> = memo(({ fair: fairFragment, onPress, isFluid }) => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
   const fair = useFragment(fragment, fairFragment)
 
   const numColumns = useNumColumns()
@@ -60,7 +62,7 @@ export const FairCard: FC<FairCardProps> = memo(({ fair: fairFragment, onPress, 
       onPress={() => {
         onPress?.(fair)
       }}
-      actionElement={<FairFollowButton fair={fair} />}
+      actionElement={enableFollowShowsAndFairs ? <FairFollowButton fair={fair} /> : undefined}
     />
   )
 })

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFairs.tsx
@@ -186,7 +186,7 @@ const HomeViewSectionFairsPlaceholder: React.FC<FlexProps> = (flexProps) => {
 }
 
 const homeViewSectionFairsQuery = graphql`
-  query HomeViewSectionFairsQuery($id: String!) @cacheable {
+  query HomeViewSectionFairsQuery($id: String!) {
     homeView {
       section(id: $id) {
         ...HomeViewSectionFairs_section

--- a/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
@@ -1,6 +1,7 @@
 import { Flex, Spacer, Text, useScreenDimensions } from "@artsy/palette-mobile"
 import { PartnerShowRailItem_show$data } from "__generated__/PartnerShowRailItem_show.graphql"
 import { ImageWithFallback } from "app/Components/ImageWithFallback/ImageWithFallback"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { exhibitionDates } from "app/Scenes/Map/exhibitionPeriodParser"
 import { RouterLink } from "app/system/navigation/RouterLink"
 import { Schema } from "app/utils/track"
@@ -28,31 +29,38 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
   const sectionWidth = windowWidth - 100
 
   return (
-    <RouterLink onPress={onPress} to={`/show/${props.show.slug}`}>
-      <Flex my="15px" mr={2} width={sectionWidth}>
-        <ImageWithFallback
-          height={200}
-          width={sectionWidth}
-          src={imageURL}
-          blurhash={coverImage?.blurhash}
-        />
-        <Spacer y={1} />
-        <Text variant="sm" numberOfLines={1}>
-          {name}
-        </Text>
-        {!!(exhibitionPeriod && endAt) && (
-          <Text variant="sm" color="mono60">
-            {exhibitionDates(exhibitionPeriod, endAt)}
+    <Flex my="15px" mr={2} width={sectionWidth}>
+      <RouterLink onPress={onPress} to={`/show/${props.show.slug}`}>
+        <Flex width={sectionWidth}>
+          <ImageWithFallback
+            height={200}
+            width={sectionWidth}
+            src={imageURL}
+            blurhash={coverImage?.blurhash}
+          />
+          <Spacer y={1} />
+          <Text variant="sm" numberOfLines={1}>
+            {name}
           </Text>
-        )}
+          {!!(exhibitionPeriod && endAt) && (
+            <Text variant="sm" color="mono60">
+              {exhibitionDates(exhibitionPeriod, endAt)}
+            </Text>
+          )}
+        </Flex>
+      </RouterLink>
+
+      <Flex position="absolute" top={1} right={1}>
+        <ShowFollowButton show={show} />
       </Flex>
-    </RouterLink>
+    </Flex>
   )
 }
 
 export const PartnerShowRailItemContainer = createFragmentContainer(PartnerShowRailItem, {
   show: graphql`
     fragment PartnerShowRailItem_show on Show {
+      ...ShowFollowButton_show
       internalID
       slug
       name

--- a/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerShowRailItem.tsx
@@ -31,14 +31,18 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
   return (
     <Flex my="15px" mr={2} width={sectionWidth}>
       <RouterLink onPress={onPress} to={`/show/${props.show.slug}`}>
-        <Flex width={sectionWidth}>
-          <ImageWithFallback
-            height={200}
-            width={sectionWidth}
-            src={imageURL}
-            blurhash={coverImage?.blurhash}
-          />
-          <Spacer y={1} />
+        <ImageWithFallback
+          height={200}
+          width={sectionWidth}
+          src={imageURL}
+          blurhash={coverImage?.blurhash}
+        />
+      </RouterLink>
+
+      <Spacer y={1} />
+
+      <Flex flexDirection="row" alignItems="flex-start" justifyContent="space-between">
+        <RouterLink onPress={onPress} to={`/show/${props.show.slug}`} style={{ flex: 1 }}>
           <Text variant="sm" numberOfLines={1}>
             {name}
           </Text>
@@ -47,11 +51,11 @@ export const PartnerShowRailItem: React.FC<Props> = (props) => {
               {exhibitionDates(exhibitionPeriod, endAt)}
             </Text>
           )}
-        </Flex>
-      </RouterLink>
+        </RouterLink>
 
-      <Flex position="absolute" top={1} right={1}>
-        <ShowFollowButton show={show} />
+        <Flex ml={1}>
+          <ShowFollowButton show={show} />
+        </Flex>
       </Flex>
     </Flex>
   )

--- a/src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx
+++ b/src/app/Scenes/Partner/Components/__tests__/PartnerShows.tests.tsx
@@ -82,6 +82,7 @@ const PartnerShowsFixture: PartnerShowsTestsQuery["rawResponse"]["partner"] = {
         node: {
           __typename: "Show",
           isDisplayable: true,
+          isFollowed: false,
           partner: null,
           id: "U2hvdzo1ZDY0MjBjZjJhNDFlNDAwMGYxYzAzYTE=",
           internalID: "5d6420cf2a41e4000f1c03a1",
@@ -98,6 +99,7 @@ const PartnerShowsFixture: PartnerShowsTestsQuery["rawResponse"]["partner"] = {
         node: {
           __typename: "Show",
           isDisplayable: true,
+          isFollowed: false,
           partner: null,
           id: "U2hvdzo1ZDY0MWJmMjAzNDliYTAwMTAxMzM4NmQ=",
           internalID: "5d641bf20349ba001013386d",
@@ -121,6 +123,7 @@ const PartnerShowsFixture: PartnerShowsTestsQuery["rawResponse"]["partner"] = {
         node: {
           __typename: "Show",
           isDisplayable: true,
+          isFollowed: false,
           partner: null,
           id: "U2hvdzo1ZDY0MjAwODEyZDI5MDAwMGUxZTVkMzU=",
           internalID: "5d64200812d290000e1e5d35",

--- a/src/app/Scenes/Show/Components/ShowHeader.tsx
+++ b/src/app/Scenes/Show/Components/ShowHeader.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, Spacer, Text } from "@artsy/palette-mobile"
 import { ShowHeader_show$data } from "__generated__/ShowHeader_show.graphql"
 import { ShowFollowButton } from "app/Components/ShowFollowButton"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useEventTiming } from "app/utils/useEventTiming"
 import { DateTime } from "luxon"
 import React, { useEffect, useState } from "react"
@@ -11,6 +12,7 @@ export interface ShowHeaderProps extends BoxProps {
 }
 
 export const ShowHeader: React.FC<ShowHeaderProps> = ({ show, ...rest }) => {
+  const enableFollowShowsAndFairs = useFeatureFlag("AREnableFollowShowsAndFairs")
   const [currentTime, setCurrentTime] = useState(DateTime.local().toString())
 
   const { formattedTime } = useEventTiming({
@@ -51,9 +53,13 @@ export const ShowHeader: React.FC<ShowHeaderProps> = ({ show, ...rest }) => {
         </Text>
       )}
 
-      <Spacer y={1} />
+      {!!enableFollowShowsAndFairs && (
+        <>
+          <Spacer y={1} />
 
-      <ShowFollowButton show={show} />
+          <ShowFollowButton show={show} />
+        </>
+      )}
     </Box>
   )
 }

--- a/src/app/Scenes/Show/Components/ShowHeader.tsx
+++ b/src/app/Scenes/Show/Components/ShowHeader.tsx
@@ -1,5 +1,6 @@
-import { Box, BoxProps, Text } from "@artsy/palette-mobile"
+import { Box, BoxProps, Spacer, Text } from "@artsy/palette-mobile"
 import { ShowHeader_show$data } from "__generated__/ShowHeader_show.graphql"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { useEventTiming } from "app/utils/useEventTiming"
 import { DateTime } from "luxon"
 import React, { useEffect, useState } from "react"
@@ -38,7 +39,7 @@ export const ShowHeader: React.FC<ShowHeaderProps> = ({ show, ...rest }) => {
         {show.formattedStartAt} – {show.formattedEndAt}
       </Text>
 
-      {!!show.startAt && !!show.endAt && (
+      {!!show.startAt && !!show.endAt && formattedTime !== null && (
         <Text variant="sm" color="mono60">
           {formattedTime}
         </Text>
@@ -49,6 +50,10 @@ export const ShowHeader: React.FC<ShowHeaderProps> = ({ show, ...rest }) => {
           {show.partner.name}
         </Text>
       )}
+
+      <Spacer y={1} />
+
+      <ShowFollowButton show={show} />
     </Box>
   )
 }
@@ -69,6 +74,7 @@ export const ShowHeaderFragmentContainer = createFragmentContainer(ShowHeader, {
           name
         }
       }
+      ...ShowFollowButton_show
     }
   `,
 })

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -4,6 +4,7 @@ import { Show_show$data } from "__generated__/Show_show.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
+import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -50,6 +51,8 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
 
   const sections: Section[] = [
     { key: "header", element: <ShowHeader show={show} mx={2} mt={2} /> },
+
+    { key: "follow-show", element: <ShowFollowButton show={show} mx={2} mt={1} /> },
 
     ...(Boolean(show.images?.length)
       ? [{ key: "install-shots", element: <ShowInstallShots show={show} /> }]
@@ -132,6 +135,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       internalID
       slug
       isActive
+      ...ShowFollowButton_show
       ...ShowHeader_show
       ...ShowInstallShots_show
       ...ShowInfo_show

--- a/src/app/Scenes/Show/Show.tsx
+++ b/src/app/Scenes/Show/Show.tsx
@@ -4,7 +4,6 @@ import { Show_show$data } from "__generated__/Show_show.graphql"
 import { ArtworkFiltersStoreProvider } from "app/Components/ArtworkFilter/ArtworkFilterStore"
 import { PlaceholderGrid } from "app/Components/ArtworkGrids/GenericGrid"
 import { HeaderArtworksFilterWithTotalArtworks as HeaderArtworksFilter } from "app/Components/HeaderArtworksFilter/HeaderArtworksFilterWithTotalArtworks"
-import { ShowFollowButton } from "app/Components/ShowFollowButton"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
 import { PlaceholderBox, PlaceholderText } from "app/utils/placeholders"
 import { renderWithPlaceholder } from "app/utils/renderWithPlaceholder"
@@ -51,8 +50,6 @@ export const Show: React.FC<ShowProps> = ({ show }) => {
 
   const sections: Section[] = [
     { key: "header", element: <ShowHeader show={show} mx={2} mt={2} /> },
-
-    { key: "follow-show", element: <ShowFollowButton show={show} mx={2} mt={1} /> },
 
     ...(Boolean(show.images?.length)
       ? [{ key: "install-shots", element: <ShowInstallShots show={show} /> }]
@@ -135,7 +132,6 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
       internalID
       slug
       isActive
-      ...ShowFollowButton_show
       ...ShowHeader_show
       ...ShowInstallShots_show
       ...ShowInfo_show
@@ -152,7 +148,7 @@ export const ShowFragmentContainer = createFragmentContainer(Show, {
 })
 
 export const ShowScreenQuery = graphql`
-  query ShowQuery($showID: String!) @cacheable {
+  query ShowQuery($showID: String!) {
     show(id: $showID) @principalField {
       ...Show_show
     }

--- a/src/app/Scenes/Shows/ShowsForYou.tsx
+++ b/src/app/Scenes/Shows/ShowsForYou.tsx
@@ -138,7 +138,7 @@ export const ShowsForYouScreenQuery = graphql`
     $after: String
     $near: Near
     $includeShowsNearIpBasedLocation: Boolean
-  ) @cacheable {
+  ) {
     me {
       ...ShowsForYou_showsConnection
         @arguments(

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -176,6 +176,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableConversationPartnerOffers",
   },
+  AREnableFollowShowsAndFairs: {
+    description: "Enable following Shows & Fairs (screen buttons + Favorites Fairs tab)",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableFollowShowsAndFairs",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -179,7 +179,7 @@ export const features = {
   },
   AREnableFollowShowsAndFairs: {
     description: "Enable following Shows & Fairs (screen buttons + Favorites Fairs tab)",
-    readyForRelease: false,
+    readyForRelease: true,
     showInDevMenu: true,
     echoFlagKey: "AREnableFollowShowsAndFairs",
   },

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -177,6 +177,12 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableTrendingSearchesInSearchModal",
   },
+  AREnableFollowShowsAndFairs: {
+    description: "Enable following Shows & Fairs (screen buttons + Favorites Fairs tab)",
+    readyForRelease: false,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableFollowShowsAndFairs",
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/utils/mutations/setShowFollowed.ts
+++ b/src/app/utils/mutations/setShowFollowed.ts
@@ -2,9 +2,10 @@ import { RecordSourceSelectorProxy } from "relay-runtime"
 
 /**
  * ShowFollowButton reads/writes the unaliased `isFollowed` field on Show,
- * while ShowItemRow reads/writes it aliased as `is_followed`. Relay stores
- * these under separate keys, so any mutation updater touching a Show's
- * follow state must write both to keep every surface in sync.
+ * while ShowItemRow aliases the same selection as `is_followed`. Relay only
+ * gives an aliased field its own storage key when it has arguments to
+ * disambiguate; a plain scalar alias like this one still normalizes under
+ * the field name, so a single write here already updates both surfaces.
  */
 export const setShowFollowed = (
   store: RecordSourceSelectorProxy<{}>,
@@ -16,5 +17,4 @@ export const setShowFollowed = (
   if (!show) return
 
   show.setValue(isFollowed, "isFollowed")
-  show.setValue(isFollowed, "is_followed")
 }

--- a/src/app/utils/mutations/setShowFollowed.ts
+++ b/src/app/utils/mutations/setShowFollowed.ts
@@ -1,0 +1,20 @@
+import { RecordSourceSelectorProxy } from "relay-runtime"
+
+/**
+ * ShowFollowButton reads/writes the unaliased `isFollowed` field on Show,
+ * while ShowItemRow reads/writes it aliased as `is_followed`. Relay stores
+ * these under separate keys, so any mutation updater touching a Show's
+ * follow state must write both to keep every surface in sync.
+ */
+export const setShowFollowed = (
+  store: RecordSourceSelectorProxy<{}>,
+  nodeID: string,
+  isFollowed: boolean
+) => {
+  const show = store.get(nodeID)
+
+  if (!show) return
+
+  show.setValue(isFollowed, "isFollowed")
+  show.setValue(isFollowed, "is_followed")
+}

--- a/src/app/utils/track/schema.ts
+++ b/src/app/utils/track/schema.ts
@@ -273,6 +273,8 @@ export enum ActionNames {
   AllBoothWorks = "allBoothWorks",
   BuyTickets = "buyTickets",
   FairSite = "fairSite",
+  FollowFair = "followFair",
+  UnfollowFair = "unfollowFair",
   FilterMedium = "filterMedium",
   FilterPrice = "filterPrice",
   GalleryFollow = "galleryFollow",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,12 +22,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:^4.360.0":
-  version: 4.360.0
-  resolution: "@artsy/cohesion@npm:4.360.0"
+"@artsy/cohesion@npm:^4.386.1":
+  version: 4.386.1
+  resolution: "@artsy/cohesion@npm:4.386.1"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/622d3790842c080606a9eff9d9f59a6df0aa2874d7132fb24a7416341c8739828bbbd8645b01d12d79b549de0b872fd2ea892e41074109ec2a69bc39021fd211
+  checksum: 10c0/ff6d026935b73f917f942cbb8ab4dc2a1a138a2dcc0bd68f3a67f2c199821e04f996f6420743172f4017d9c8fd10a46fb8135addee9fd82de7419893ec372449
   languageName: node
   linkType: hard
 
@@ -13362,7 +13362,7 @@ __metadata:
   resolution: "eigen@workspace:."
   dependencies:
     "@artsy/changelog": "npm:^0.1.0"
-    "@artsy/cohesion": "npm:^4.360.0"
+    "@artsy/cohesion": "npm:^4.386.1"
     "@artsy/icons": "npm:3.67.0"
     "@artsy/palette-mobile": "npm:23.12.0"
     "@artsy/to-title-case": "npm:1.2.0"


### PR DESCRIPTION
# This is behind a feature flag and we will follow up on it on Fireworks

This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Adds the ability to follow **Shows** and **Fairs** from their detail screens, and lists followed Fairs in the Favorites → Follows tab (mirroring the existing Shows option). 

### Screen recordings


https://github.com/user-attachments/assets/3d3e0f9d-ed28-4b24-8944-5e01e4040eea



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag** (`AREnableFollowShowsAndFairs`, dark/`readyForRelease: false`).
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any. <!-- existing Show/Fair/Favorites suites (108 tests) verified green; no new dedicated test files added for the new components -->
- [x] I added an **app state migration**, or my changes do not require one. <!-- no persisted state shape changed -->
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. <!-- see below -->
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Add follow fairs and shows - mounir

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- 

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[docs]: ../blob/main/docs/README.md


---
_Generated by [Claude Code](https://claude.ai/code/session_01N93KEHv3nKGRZXqwLTf2S9)_