### PR TITLE
feat: automate the mobile QA doc creation and auto trigger betas from rc

### DIFF
--- a/.github/workflows/rc-release-automation.yml
+++ b/.github/workflows/rc-release-automation.yml
@@ -1,0 +1,162 @@
+name: RC Release Automation
+
+# When the release bot (artsyit) opens a release-candidate PR (head branch
+# `rc-v<version>`), this orchestrates the release-day automation:
+#   1. trigger-betas    — push the RC branch to beta-ios / beta-android, which
+#                          fires the 4 existing beta build workflows.
+#   2. wait-for-betas   — poll until all 4 beta builds complete; fail on any failure.
+#   3. create-qa-document — read the beta build numbers from the git tags, lift
+#                          the changelog out of the PR body, duplicate the Notion
+#                          QA template with all of it stamped in, and post to Slack.
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  guard:
+    # Only rc-v* PRs opened by the release bot.
+    if: startsWith(github.head_ref, 'rc-v') && github.event.pull_request.user.login == 'artsyit'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      sha: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Derive version from branch name
+        id: version
+        run: |
+          branch="${{ github.head_ref }}"
+          echo "version=${branch#rc-v}" >> "$GITHUB_OUTPUT"
+
+  trigger-betas:
+    needs: guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the RC branch
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.guard.outputs.sha }}
+          # Push with a PAT — a push made with the default GITHUB_TOKEN does NOT
+          # trigger the downstream beta build workflows (GitHub blocks recursion).
+          token: ${{ secrets.EIGEN_GITHUB_PAT_TOKEN }}
+
+      - name: Push to beta branches to trigger the 4 beta builds
+        run: |
+          git push origin HEAD:beta-ios -f --no-verify
+          git push origin HEAD:beta-android -f --no-verify
+
+  wait-for-betas:
+    needs: [guard, trigger-betas]
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SHA: ${{ needs.guard.outputs.sha }}
+    steps:
+      - name: Wait for all 4 beta builds to succeed
+        run: |
+          set -euo pipefail
+          workflows=(
+            build-deploy-ios-testflight.yml
+            build-deploy-ios-firebase.yml
+            build-deploy-android-playstore.yml
+            build-deploy-android-firebase.yml
+          )
+          # Overall deadline just under the job timeout.
+          deadline=$(( $(date +%s) + 115 * 60 ))
+          for wf in "${workflows[@]}"; do
+            echo "::group::Waiting for $wf (sha ${SHA})"
+            while true; do
+              if [ "$(date +%s)" -gt "$deadline" ]; then
+                echo "Timed out waiting for $wf"; exit 1
+              fi
+              run=$(gh run list --repo "$GITHUB_REPOSITORY" --workflow "$wf" --limit 30 \
+                --json headSha,status,conclusion \
+                --jq "[.[] | select(.headSha == \"${SHA}\")] | .[0]")
+              status=$(echo "$run" | jq -r '.status // empty')
+              conclusion=$(echo "$run" | jq -r '.conclusion // empty')
+              if [ -z "$status" ]; then
+                echo "  run not found yet; polling…"; sleep 30; continue
+              fi
+              if [ "$status" = "completed" ]; then
+                if [ "$conclusion" = "success" ]; then
+                  echo "  ✅ $wf succeeded"; break
+                fi
+                echo "  ❌ $wf concluded: $conclusion"; exit 1
+              fi
+              echo "  status=$status; polling…"; sleep 30
+            done
+            echo "::endgroup::"
+          done
+          echo "All 4 beta builds succeeded."
+
+  create-qa-document:
+    needs: [guard, wait-for-betas]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository (with tags)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch origin --tags --force
+
+      - name: Read beta build numbers from tags
+        id: builds
+        env:
+          VERSION: ${{ needs.guard.outputs.version }}
+        run: |
+          # Beta tags: ios-<version>-<build> / android-<version>-<code>
+          # (exclude -submission and -expo- OTA tags; newest by version sort).
+          ios_tag=$(git tag -l "ios-${VERSION}-*" | grep -v -- '-expo-' | grep -v -- '-submission' | sort -V | tail -1 || true)
+          android_tag=$(git tag -l "android-${VERSION}-*" | grep -v -- '-expo-' | grep -v -- '-submission' | sort -V | tail -1 || true)
+          echo "ios_build=${ios_tag#ios-${VERSION}-}" >> "$GITHUB_OUTPUT"
+          echo "android_build=${android_tag#android-${VERSION}-}" >> "$GITHUB_OUTPUT"
+          echo "iOS tag: ${ios_tag:-<none>} / Android tag: ${android_tag:-<none>}"
+
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+
+      - name: Install Node.js dependencies
+        run: yarn install --immutable
+
+      - name: Create Mobile App QA document in Notion
+        env:
+          NOTION_RELEASE_LOOKOUT_TOKEN: ${{ secrets.NOTION_RELEASE_LOOKOUT_TOKEN }}
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          RC_BRANCH: ${{ github.head_ref }}
+          IOS_BUILD: ${{ steps.builds.outputs.ios_build }}
+          ANDROID_BUILD: ${{ steps.builds.outputs.android_build }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: yarn create-qa
+
+  notify-qa-failure:
+    # Fires only when the betas succeeded (those have their own Slack alert) but
+    # creating the QA document failed — the one failure mode nothing else pings
+    # about. Skips cleanly for non-rc PRs (all jobs skipped ⇒ failure() is false)
+    # and for beta failures (wait-for-betas.result != 'success').
+    needs: [guard, wait-for-betas, create-qa-document]
+    if: failure() && needs.wait-for-betas.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post QA-document failure to Slack
+        env:
+          SLACK_URL: ${{ secrets.SLACK_URL }}
+          VERSION: ${{ needs.guard.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "${SLACK_URL:-}" ]; then
+            echo "No SLACK_URL set; skipping failure notification."
+            exit 0
+          fi
+          curl -sf -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\":rotating_light: QA document creation failed for v${VERSION} (betas were fine) — <${RUN_URL}|view run>\"}" \
+            "$SLACK_URL"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "deploy-beta": "./scripts/deploys/deploy-beta-both",
     "detect-secrets:hook": "scripts/detect-secrets/detect-secrets.sh hook",
     "detect-secrets:rebuild": "scripts/detect-secrets/detect-secrets.sh rebuild",
+    "create-qa": "tsx scripts/create-qa-document/createQaDocument.ts",
     "doctor": "./scripts/utils/doctor.js",
     "export-notion-to-jira": "tsx scripts/utils/exportNotionTicketsToJira.ts",
     "assign-team-labels-pbrw-tickets": "tsx scripts/utils/assignPBRWTicketsToTeams.ts",

--- a/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
+++ b/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
@@ -1,0 +1,177 @@
+import { DateTime } from "luxon"
+
+jest.mock("dotenv", () => ({ config: jest.fn() }))
+
+jest.mock("../duplicateNotionTemplate", () => ({
+  duplicateTemplate: jest.fn(),
+  findExistingCopy: jest.fn(),
+}))
+
+import { extractChangelogFromPrBody } from "../changelog"
+import { QA_DESTINATION_URL, QA_TEMPLATE_URL } from "../constants"
+import { createQaDocument } from "../createQaDocument"
+import { duplicateTemplate, findExistingCopy } from "../duplicateNotionTemplate"
+import { getVersionFromBranch } from "../version"
+
+const RC_BRANCH = "rc-v9.12.0"
+// 2026-08-13 so the title stamps a known date.
+const NOW = DateTime.fromISO("2026-08-13T10:00:00")
+const mockFetch = jest.fn().mockResolvedValue({ ok: true })
+
+describe("getVersionFromBranch", () => {
+  it("parses the version out of an rc-v branch", () => {
+    expect(getVersionFromBranch("rc-v9.12.0")).toEqual("9.12.0")
+    expect(getVersionFromBranch("rc-v10.0.1")).toEqual("10.0.1")
+  })
+
+  it("throws for a non-rc branch", () => {
+    expect(() => getVersionFromBranch("main")).toThrow(/rc-v<version>/)
+    expect(() => getVersionFromBranch("feature/rc-v1.2.3")).toThrow()
+  })
+})
+
+describe("extractChangelogFromPrBody", () => {
+  it("pulls the section between '## Changelog' and '#nochangelog'", () => {
+    const body = [
+      "## Release Candidate 9.13.0",
+      "",
+      "Some preamble.",
+      "",
+      "## Changelog",
+      "",
+      "### Cross-platform user-facing changes",
+      "- did a thing — someone (#1)",
+      "",
+      "#nochangelog",
+    ].join("\n")
+
+    expect(extractChangelogFromPrBody(body)).toEqual(
+      "### Cross-platform user-facing changes\n- did a thing — someone (#1)"
+    )
+  })
+
+  it("returns null when there is no changelog section", () => {
+    expect(extractChangelogFromPrBody("just a normal PR body")).toBeNull()
+    expect(extractChangelogFromPrBody("")).toBeNull()
+  })
+})
+
+describe("createQaDocument", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.spyOn(console, "log").mockImplementation(() => {})
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    jest.spyOn(console, "error").mockImplementation(() => {})
+    process.env.SLACK_URL = "https://hooks.slack.com/services/TEST"
+    delete process.env.IOS_BUILD
+    delete process.env.ANDROID_BUILD
+    delete process.env.PR_BODY
+    ;(global as any).fetch = mockFetch
+    ;(findExistingCopy as jest.Mock).mockResolvedValue(null)
+    ;(duplicateTemplate as jest.Mock).mockResolvedValue("https://notion.so/new-qa-page")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete process.env.SLACK_URL
+    delete process.env.IOS_BUILD
+    delete process.env.ANDROID_BUILD
+    delete process.env.PR_BODY
+  })
+
+  it("duplicates the template with today's date + version and posts to Slack", async () => {
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(duplicateTemplate).toHaveBeenCalledWith(QA_TEMPLATE_URL, QA_DESTINATION_URL, {
+      version: "9.12.0",
+      today: "2026-08-13",
+      iosBuild: undefined,
+      androidBuild: undefined,
+      changelog: undefined,
+    })
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://hooks.slack.com/services/TEST",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          text: ":notion: The mobile QA document for v9.12.0 was automatically created here: https://notion.so/new-qa-page",
+        }),
+      })
+    )
+  })
+
+  it("skips creation and re-posts the link when a doc already exists", async () => {
+    ;(findExistingCopy as jest.Mock).mockResolvedValue("https://notion.so/existing-qa-page")
+
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(duplicateTemplate).not.toHaveBeenCalled()
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://hooks.slack.com/services/TEST",
+      expect.objectContaining({
+        body: JSON.stringify({
+          text: "The mobile QA document for v9.12.0 already exists here: https://notion.so/existing-qa-page",
+        }),
+      })
+    )
+  })
+
+  it("checks idempotency by version", async () => {
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(findExistingCopy).toHaveBeenCalledWith(QA_DESTINATION_URL, ["9.12.0"])
+  })
+
+  it("passes the beta build numbers from env through to the duplicator", async () => {
+    process.env.IOS_BUILD = "2026.08.13.18"
+    process.env.ANDROID_BUILD = "2026081318"
+
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(duplicateTemplate).toHaveBeenCalledWith(
+      QA_TEMPLATE_URL,
+      QA_DESTINATION_URL,
+      expect.objectContaining({ iosBuild: "2026.08.13.18", androidBuild: "2026081318" })
+    )
+  })
+
+  it("extracts the changelog from PR_BODY and passes it to the duplicator", async () => {
+    process.env.PR_BODY =
+      "## Release Candidate\n\n## Changelog\n\n### Dev changes\n- did a thing (#1)\n\n#nochangelog"
+
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(duplicateTemplate).toHaveBeenCalledWith(
+      QA_TEMPLATE_URL,
+      QA_DESTINATION_URL,
+      expect.objectContaining({ changelog: "### Dev changes\n- did a thing (#1)" })
+    )
+  })
+
+  it("skips the Slack post (without throwing) when SLACK_URL is not set", async () => {
+    delete process.env.SLACK_URL
+
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(duplicateTemplate).toHaveBeenCalled()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it("does not fail the run when the Slack post errors (doc is the deliverable)", async () => {
+    // The document was already created; a Slack outage must not turn the run red.
+    ;(global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" })
+    await expect(createQaDocument(RC_BRANCH, NOW)).resolves.toBeUndefined()
+    expect(duplicateTemplate).toHaveBeenCalled()
+
+    // Also survives a thrown/network error from fetch.
+    ;(global as any).fetch = jest.fn().mockRejectedValue(new Error("network down"))
+    await expect(createQaDocument(RC_BRANCH, NOW)).resolves.toBeUndefined()
+  })
+
+  it("throws for a branch that is not an rc-v branch", async () => {
+    await expect(createQaDocument("main", NOW)).rejects.toThrow(/rc-v<version>/)
+    expect(duplicateTemplate).not.toHaveBeenCalled()
+  })
+})

--- a/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
+++ b/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
@@ -94,7 +94,7 @@ describe("createQaDocument", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          text: ":notion: The mobile QA document for v9.12.0 was automatically created here: https://notion.so/new-qa-page",
+          text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/new-qa-page",
         }),
       })
     )
@@ -110,7 +110,7 @@ describe("createQaDocument", () => {
       "https://hooks.slack.com/services/TEST",
       expect.objectContaining({
         body: JSON.stringify({
-          text: "The mobile QA document for v9.12.0 already exists here: https://notion.so/existing-qa-page",
+          text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/existing-qa-page",
         }),
       })
     )
@@ -158,7 +158,7 @@ describe("createQaDocument", () => {
       "https://hooks.slack.com/services/TEST",
       expect.objectContaining({
         body: JSON.stringify({
-          text: ":notion: The mobile QA document for v9.12.0 was automatically created here: https://notion.so/new-qa-page\n\n*Changelog*\n### Dev changes\n- did a thing (#1)",
+          text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/new-qa-page\n\n*Changelog*\n### Dev changes\n- did a thing (#1)",
         }),
       })
     )

--- a/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
+++ b/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
@@ -148,6 +148,22 @@ describe("createQaDocument", () => {
     )
   })
 
+  it("includes the changelog in the Slack message when present", async () => {
+    process.env.PR_BODY =
+      "## Release Candidate\n\n## Changelog\n\n### Dev changes\n- did a thing (#1)\n\n#nochangelog"
+
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://hooks.slack.com/services/TEST",
+      expect.objectContaining({
+        body: JSON.stringify({
+          text: ":notion: The mobile QA document for v9.12.0 was automatically created here: https://notion.so/new-qa-page\n\n*Changelog*\n### Dev changes\n- did a thing (#1)",
+        }),
+      })
+    )
+  })
+
   it("skips the Slack post (without throwing) when SLACK_URL is not set", async () => {
     delete process.env.SLACK_URL
 

--- a/scripts/create-qa-document/__tests__/duplicateNotionTemplate.tests.ts
+++ b/scripts/create-qa-document/__tests__/duplicateNotionTemplate.tests.ts
@@ -1,0 +1,44 @@
+import { splitForRichText } from "../duplicateNotionTemplate"
+
+describe("splitForRichText", () => {
+  it("returns a single chunk when the text is within the limit", () => {
+    expect(splitForRichText("short")).toEqual(["short"])
+    expect(splitForRichText("a".repeat(2000))).toHaveLength(1)
+  })
+
+  it("splits text over the limit into multiple chunks, each within the limit", () => {
+    const line = "x".repeat(500)
+    const text = Array.from({ length: 20 }, () => line).join("\n") // ~10k chars
+    const chunks = splitForRichText(text)
+
+    expect(chunks.length).toBeGreaterThan(1)
+    chunks.forEach((c) => expect(c.length).toBeLessThanOrEqual(2000))
+  })
+
+  it("reassembles to the original text byte-for-byte", () => {
+    const text = Array.from(
+      { length: 500 },
+      (_, i) => `- change number ${i} — someone (#${i})`
+    ).join("\n")
+    expect(splitForRichText(text).join("")).toEqual(text)
+  })
+
+  it("hard-splits a single line longer than the limit", () => {
+    const text = "y".repeat(5000) // one line, no newlines
+    const chunks = splitForRichText(text)
+
+    expect(chunks.length).toBe(3) // 2000 + 2000 + 1000
+    chunks.forEach((c) => expect(c.length).toBeLessThanOrEqual(2000))
+    expect(chunks.join("")).toEqual(text)
+  })
+
+  it("prefers to cut on a newline boundary", () => {
+    const first = "a".repeat(1990)
+    const second = "b".repeat(1990)
+    const [head] = splitForRichText(`${first}\n${second}`)
+
+    // Cut at the newline rather than mid-line, so the first chunk is the whole
+    // first line plus its trailing newline.
+    expect(head).toEqual(`${first}\n`)
+  })
+})

--- a/scripts/create-qa-document/__tests__/notion.tests.ts
+++ b/scripts/create-qa-document/__tests__/notion.tests.ts
@@ -1,0 +1,137 @@
+import { extractPageId, notion } from "../notion"
+
+describe("extractPageId", () => {
+  it("extracts the id from a full Notion URL whose slug is full of hex-like letters", () => {
+    // The "QA"/"App"/"cab" letters in the slug are valid hex chars; anchoring to
+    // the END of the path is what keeps them from shifting the match.
+    expect(
+      extractPageId(
+        "https://www.notion.so/artsy/2026-MM-DD-Mobile-App-QA-version-A-B-C-392cab0764a080a293abc71acfc2a54b"
+      )
+    ).toEqual("392cab07-64a0-80a2-93ab-c71acfc2a54b")
+  })
+
+  it("strips a query string and hash", () => {
+    expect(
+      extractPageId("https://www.notion.so/artsy/Page-392cab0764a080a293abc71acfc2a54b?pvs=4")
+    ).toEqual("392cab07-64a0-80a2-93ab-c71acfc2a54b")
+    expect(
+      extractPageId("https://www.notion.so/Page-392cab0764a080a293abc71acfc2a54b#heading")
+    ).toEqual("392cab07-64a0-80a2-93ab-c71acfc2a54b")
+  })
+
+  it("tolerates a trailing slash", () => {
+    expect(extractPageId("https://www.notion.so/Page-392cab0764a080a293abc71acfc2a54b/")).toEqual(
+      "392cab07-64a0-80a2-93ab-c71acfc2a54b"
+    )
+  })
+
+  it("accepts a raw 32-char id and canonicalises it into UUID form", () => {
+    expect(extractPageId("392cab0764a080a293abc71acfc2a54b")).toEqual(
+      "392cab07-64a0-80a2-93ab-c71acfc2a54b"
+    )
+  })
+
+  it("accepts an already-hyphenated UUID and returns it unchanged", () => {
+    expect(extractPageId("decba0c3-a57a-4508-b726-f3a8624ceca3")).toEqual(
+      "decba0c3-a57a-4508-b726-f3a8624ceca3"
+    )
+  })
+
+  it("throws when no id can be found", () => {
+    expect(() => extractPageId("https://www.notion.so/artsy/no-id-here")).toThrow(/Could not find/)
+    expect(() => extractPageId("")).toThrow(/Could not find/)
+  })
+})
+
+describe("notion (retry/backoff)", () => {
+  beforeEach(() => {
+    jest.spyOn(console, "warn").mockImplementation(() => {})
+    process.env.NOTION_RELEASE_LOOKOUT_TOKEN = "test-token"
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+    delete process.env.NOTION_RELEASE_LOOKOUT_TOKEN
+  })
+
+  const notOk = (status: number, retryAfter?: string) => ({
+    ok: false,
+    status,
+    headers: { get: (h: string) => (h === "Retry-After" ? retryAfter ?? null : null) },
+    text: async () => `body for ${status}`,
+  })
+
+  it("returns parsed JSON on a 2xx", async () => {
+    ;(global as any).fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) })
+    await expect(notion("/pages/x")).resolves.toEqual({ id: "1" })
+  })
+
+  it("throws immediately (no retry) on a non-retryable 4xx, including the body", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(notOk(400))
+    ;(global as any).fetch = fetchMock
+
+    await expect(notion("/pages/x")).rejects.toThrow(/Notion API error 400: body for 400/)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("retries a 5xx with backoff, then resolves on success", async () => {
+    jest.useFakeTimers()
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(notOk(500))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) })
+    ;(global as any).fetch = fetchMock
+
+    const p = notion("/pages/x")
+    await jest.advanceTimersByTimeAsync(500) // 2**0 * 500ms
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("honours the Retry-After header for the delay", async () => {
+    jest.useFakeTimers()
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(notOk(429, "2"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) })
+    ;(global as any).fetch = fetchMock
+
+    const p = notion("/pages/x")
+    await jest.advanceTimersByTimeAsync(1999)
+    expect(fetchMock).toHaveBeenCalledTimes(1) // still waiting on the 2s Retry-After
+    await jest.advanceTimersByTimeAsync(1)
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("retries a thrown network error / timeout, then resolves on success", async () => {
+    jest.useFakeTimers()
+    const fetchMock = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("The operation was aborted due to timeout"))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true }) })
+    ;(global as any).fetch = fetchMock
+
+    const p = notion("/pages/x")
+    await jest.advanceTimersByTimeAsync(500)
+    await expect(p).resolves.toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("gives up after MAX_RETRIES and throws", async () => {
+    jest.useFakeTimers()
+    const fetchMock = jest.fn().mockResolvedValue(notOk(503))
+    ;(global as any).fetch = fetchMock
+
+    const p = notion("/pages/x")
+    const assertion = expect(p).rejects.toThrow(/Notion API error 503/)
+    await jest.runAllTimersAsync()
+    await assertion
+    // initial attempt + 4 retries = 5 total
+    expect(fetchMock).toHaveBeenCalledTimes(5)
+  })
+})

--- a/scripts/create-qa-document/changelog.ts
+++ b/scripts/create-qa-document/changelog.ts
@@ -1,0 +1,21 @@
+// Extract the changelog region from the release-candidate PR body.
+//
+// The RC PR (opened by the `artsyit` bot) writes the changelog under a
+// "## Changelog" heading — a set of "### <section>" blocks with bullets — and
+// terminates the body with a "#nochangelog" marker. We take everything between
+// the heading and that marker so it can be dropped into the Notion code block.
+//
+// Returns null when the body has no changelog section (best-effort: a missing
+// changelog must never block QA document creation).
+export const extractChangelogFromPrBody = (body: string): string | null => {
+  const heading = "## Changelog"
+  const start = body.indexOf(heading)
+  if (start === -1) return null
+
+  const section = body
+    .slice(start + heading.length)
+    .replace(/#nochangelog\s*$/i, "") // drop the trailing marker
+    .trim()
+
+  return section || null
+}

--- a/scripts/create-qa-document/constants.ts
+++ b/scripts/create-qa-document/constants.ts
@@ -1,8 +1,6 @@
 // The Mobile App QA Notion template that gets duplicated for each release.
-// Uses the flat `392cab07…a54b` template so databases keep their layout
-// (the nested `023cb09f…` template lands them at the page bottom).
 export const QA_TEMPLATE_URL =
-  "https://www.notion.so/artsy/2026-MM-DD-Mobile-App-QA-version-A-B-C-iOS-build-2026-W-X-Y-Z-Android-build-XYZ-392cab0764a080a293abc71acfc2a54b"
+  "https://www.notion.so/artsy/2026-MM-DD-Mobile-App-QA-version-A-B-C-iOS-build-2026-W-X-Y-Z-Android-build-XYZ-023cb09f53494215ac465c2af8354add"
 
 // Where each duplicated QA page is created (as a subpage at the end of this
 // page). Must be shared with the NOTION_RELEASE_LOOKOUT_TOKEN integration.

--- a/scripts/create-qa-document/constants.ts
+++ b/scripts/create-qa-document/constants.ts
@@ -1,0 +1,10 @@
+// The Mobile App QA Notion template that gets duplicated for each release.
+// Uses the flat `392cab07…a54b` template so databases keep their layout
+// (the nested `023cb09f…` template lands them at the page bottom).
+export const QA_TEMPLATE_URL =
+  "https://www.notion.so/artsy/2026-MM-DD-Mobile-App-QA-version-A-B-C-iOS-build-2026-W-X-Y-Z-Android-build-XYZ-392cab0764a080a293abc71acfc2a54b"
+
+// Where each duplicated QA page is created (as a subpage at the end of this
+// page). Must be shared with the NOTION_RELEASE_LOOKOUT_TOKEN integration.
+export const QA_DESTINATION_URL =
+  "https://www.notion.so/artsy/Mobile-App-QA-decba0c3a57a4508b726f3a8624ceca3"

--- a/scripts/create-qa-document/createQaDocument.ts
+++ b/scripts/create-qa-document/createQaDocument.ts
@@ -59,27 +59,28 @@ export const createQaDocument = async (
   const changelog = extractChangelogFromPrBody(process.env.PR_BODY ?? "") ?? undefined
 
   // Idempotency: don't create a second doc if one for this version already
-  // exists (e.g. the RC PR was reopened or the job re-run).
+  // exists (e.g. the RC PR was reopened or the job re-run). Either way the
+  // channel just wants the link, so we announce it with the same message.
   const existing = await findExistingCopy(QA_DESTINATION_URL, [version])
+  let url: string
   if (existing) {
     console.log(`QA document already exists: ${existing}`)
-    await postToSlack(`The mobile QA document for v${version} already exists here: ${existing}`)
-    return
+    url = existing
+  } else {
+    url = await duplicateTemplate(QA_TEMPLATE_URL, QA_DESTINATION_URL, {
+      version,
+      today,
+      iosBuild,
+      androidBuild,
+      changelog,
+    })
+    console.log(`Successfully created QA document: ${url}`)
   }
-
-  const url = await duplicateTemplate(QA_TEMPLATE_URL, QA_DESTINATION_URL, {
-    version,
-    today,
-    iosBuild,
-    androidBuild,
-    changelog,
-  })
 
   const changelogSection = changelog ? `\n\n*Changelog*\n${changelog}` : ""
   await postToSlack(
-    `:notion: The mobile QA document for v${version} was automatically created here: ${url}${changelogSection}`
+    `:notion: The mobile QA document for v${version} is available here: ${url}${changelogSection}`
   )
-  console.log(`Successfully created QA document: ${url}`)
 }
 
 // Prevents auto-execution when imported in tests.

--- a/scripts/create-qa-document/createQaDocument.ts
+++ b/scripts/create-qa-document/createQaDocument.ts
@@ -1,7 +1,3 @@
-#!/usr/bin/env node
-/// <reference types="node" />
-"use strict"
-
 import { resolve } from "path"
 import { config } from "dotenv"
 import { DateTime } from "luxon"
@@ -79,8 +75,9 @@ export const createQaDocument = async (
     changelog,
   })
 
+  const changelogSection = changelog ? `\n\n*Changelog*\n${changelog}` : ""
   await postToSlack(
-    `:notion: The mobile QA document for v${version} was automatically created here: ${url}`
+    `:notion: The mobile QA document for v${version} was automatically created here: ${url}${changelogSection}`
   )
   console.log(`Successfully created QA document: ${url}`)
 }

--- a/scripts/create-qa-document/createQaDocument.ts
+++ b/scripts/create-qa-document/createQaDocument.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/// <reference types="node" />
+"use strict"
+
+import { resolve } from "path"
+import { config } from "dotenv"
+import { DateTime } from "luxon"
+
+config({ path: resolve(__dirname, "../../.env.releases") })
+
+import { extractChangelogFromPrBody } from "./changelog"
+import { QA_DESTINATION_URL, QA_TEMPLATE_URL } from "./constants"
+import { duplicateTemplate, findExistingCopy } from "./duplicateNotionTemplate"
+import { fetchWithTimeout } from "./notion"
+import { getVersionFromBranch } from "./version"
+
+// Post a simple message to Slack via the incoming webhook (same pattern as
+// scripts/utils/exportNotionTicketsToJira.ts). Best-effort and never fatal: the
+// QA document is the deliverable, so a Slack outage must not fail the job (which
+// would only report a false failure and, thanks to idempotency, keep failing on
+// every re-run while Slack is down).
+const postToSlack = async (text: string): Promise<void> => {
+  const slackUrl = process.env.SLACK_URL ?? ""
+  if (!slackUrl) {
+    console.warn("Missing SLACK_URL; skipping Slack notification.")
+    return
+  }
+  try {
+    const res = await fetchWithTimeout(
+      slackUrl,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      },
+      10_000
+    )
+    if (!res.ok) {
+      console.warn(`Failed to send Slack message: ${res.status} ${res.statusText}`)
+    }
+  } catch (error) {
+    console.warn(`Failed to send Slack message: ${error}`)
+  }
+}
+
+// Triggered by the release-candidate pull request (head branch `rc-v<version>`):
+// duplicates the Mobile App QA Notion template with the release version and
+// today's date stamped into the title, then posts the link to Slack.
+export const createQaDocument = async (
+  branch: string = process.env.RC_BRANCH ?? process.env.GITHUB_HEAD_REF ?? "",
+  now: DateTime = DateTime.now()
+): Promise<void> => {
+  const version = getVersionFromBranch(branch)
+  const today = now.toFormat("yyyy-MM-dd")
+
+  // Build numbers are read from the beta git tags by the workflow and passed in
+  // via env; empty when the betas haven't tagged yet (leaves the placeholder).
+  const iosBuild = process.env.IOS_BUILD || undefined
+  const androidBuild = process.env.ANDROID_BUILD || undefined
+
+  // Changelog is lifted from the RC PR body (passed in via env). Best-effort:
+  // a missing changelog must never block QA document creation.
+  const changelog = extractChangelogFromPrBody(process.env.PR_BODY ?? "") ?? undefined
+
+  // Idempotency: don't create a second doc if one for this version already
+  // exists (e.g. the RC PR was reopened or the job re-run).
+  const existing = await findExistingCopy(QA_DESTINATION_URL, [version])
+  if (existing) {
+    console.log(`QA document already exists: ${existing}`)
+    await postToSlack(`The mobile QA document for v${version} already exists here: ${existing}`)
+    return
+  }
+
+  const url = await duplicateTemplate(QA_TEMPLATE_URL, QA_DESTINATION_URL, {
+    version,
+    today,
+    iosBuild,
+    androidBuild,
+    changelog,
+  })
+
+  await postToSlack(
+    `:notion: The mobile QA document for v${version} was automatically created here: ${url}`
+  )
+  console.log(`Successfully created QA document: ${url}`)
+}
+
+// Prevents auto-execution when imported in tests.
+if (require.main === module) {
+  createQaDocument().catch((error) => {
+    console.error("Error creating QA document:", error)
+    process.exit(1)
+  })
+}

--- a/scripts/create-qa-document/duplicateNotionTemplate.ts
+++ b/scripts/create-qa-document/duplicateNotionTemplate.ts
@@ -1,0 +1,521 @@
+import { notion, extractPageId } from "./notion"
+
+// ---------------------------------------------------------------------------
+// Notion has no "duplicate page" endpoint. This recreates a template page by
+// reading its title + block tree and rebuilding them as a new subpage at the
+// end of a destination page.
+//
+// Defaults to the Mobile App QA template → the Mobile App QA destination page
+// (both in constants.ts). Pass a template url/id to override the source.
+// ---------------------------------------------------------------------------
+
+// Block types that can't be re-created through the public API, or that need
+// bespoke structural handling we don't support yet. We copy everything else and
+// warn (loudly, never silently) for these so nothing looks like it succeeded.
+const UNSUPPORTED_BLOCK_TYPES = new Set([
+  "child_page",
+  "column_list",
+  "column",
+  "table",
+  "table_row",
+  "synced_block",
+  "link_preview",
+  "template",
+  "ai_block",
+  "unsupported",
+])
+
+// Property types we can't recreate in a database schema: system/computed values,
+// or types that require external references we can't reconstruct.
+const UNSUPPORTED_PROP_TYPE_LIST = [
+  "created_by",
+  "created_time",
+  "last_edited_by",
+  "last_edited_time",
+  "rollup",
+  "relation",
+  "status",
+  "unique_id",
+  "button",
+  "verification",
+]
+const UNSUPPORTED_PROP_TYPES = new Set(UNSUPPORTED_PROP_TYPE_LIST)
+
+// Property value types that can't be written when creating a row (computed).
+const READONLY_VALUE_TYPES = new Set([...UNSUPPORTED_PROP_TYPE_LIST, "formula"])
+
+interface RichText {
+  type?: string
+  text?: { content: string; link: { url: string } | null }
+  annotations?: Record<string, unknown>
+  [key: string]: unknown
+}
+
+interface Block {
+  id: string
+  type: string
+  has_children: boolean
+  [key: string]: unknown
+}
+
+// Strip read-only fields from rich text so the payload is accepted on write.
+const cleanRichText = (rich: RichText[] = []): RichText[] =>
+  rich
+    .filter(
+      (r): r is RichText & { text: NonNullable<RichText["text"]> } => r.type === "text" && !!r.text
+    )
+    .map((r) => ({
+      type: "text",
+      text: { content: r.text.content, link: r.text.link ?? null },
+      annotations: r.annotations,
+    }))
+
+// Recursively drop null-valued fields. The API returns blocks with fields like
+// `icon: null`, but the create endpoint rejects null (it wants an object or the
+// field absent); omitting a field means "use the default", which is what we want.
+const stripNulls = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(stripNulls)
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      if (v !== null) out[k] = stripNulls(v)
+    }
+    return out
+  }
+  return value
+}
+
+// Blocks that carry a file, which is either Notion-hosted (type "file", an
+// expiring URL we can't re-upload) or "external" (a plain URL we can copy).
+const FILE_BLOCK_TYPES = new Set(["image", "video", "file", "pdf", "audio"])
+
+// Turn a fetched block into a writable block payload (no ids/timestamps).
+// Returns null for block types we can't recreate.
+const cleanBlock = (block: Block): Record<string, unknown> | null => {
+  if (UNSUPPORTED_BLOCK_TYPES.has(block.type)) return null
+
+  const payload = { ...(block[block.type] as Record<string, unknown>) }
+
+  if (FILE_BLOCK_TYPES.has(block.type)) {
+    // Only external file URLs survive a copy; Notion-hosted files would need a
+    // fresh upload, so skip them rather than send an invalid payload.
+    if (payload.type !== "external" || !payload.external) return null
+    const clean: Record<string, unknown> = { type: "external", external: payload.external }
+    if (Array.isArray(payload.caption)) clean.caption = cleanRichText(payload.caption as RichText[])
+    return { object: "block", type: block.type, [block.type]: clean }
+  }
+
+  // rich_text is the common carrier of formatted content; clean it if present.
+  if (Array.isArray(payload.rich_text)) {
+    payload.rich_text = cleanRichText(payload.rich_text as RichText[])
+  }
+  // Children are appended separately (recursively), never inline here.
+  delete payload.children
+
+  return stripNulls({ object: "block", type: block.type, [block.type]: payload }) as Record<
+    string,
+    unknown
+  >
+}
+
+// Fetch every child block of a block/page, following pagination.
+const fetchAllChildren = async (blockId: string): Promise<Block[]> => {
+  const blocks: Block[] = []
+  let cursor: string | undefined
+  do {
+    const query = cursor ? `?start_cursor=${cursor}&page_size=100` : "?page_size=100"
+    const res = await notion<{ results: Block[]; next_cursor: string | null; has_more: boolean }>(
+      `/blocks/${blockId}/children${query}`
+    )
+    blocks.push(...res.results)
+    cursor = res.has_more ? res.next_cursor ?? undefined : undefined
+  } while (cursor)
+  return blocks
+}
+
+const chunk = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
+  return out
+}
+
+// Recursively copy the children of `sourceId` onto `destId`. `rootPageId` is the
+// nearest page ancestor in the destination — inline databases can only be
+// created under a page, so nested databases are placed there rather than in
+// their exact spot.
+//
+// We walk children in order, buffering plain blocks and flushing them right
+// before each embedded database, so databases keep their position relative to
+// surrounding content (e.g. sitting under their own heading).
+const copyChildren = async (
+  sourceId: string,
+  destId: string,
+  rootPageId: string
+): Promise<void> => {
+  const children = await fetchAllChildren(sourceId)
+  let buffer: { source: Block; cleaned: Record<string, unknown> }[] = []
+
+  const flush = async (): Promise<void> => {
+    if (buffer.length === 0) return
+    const batch = buffer
+    buffer = []
+    // Append in batches of 100 (API limit); created results come back in order.
+    const created: Block[] = []
+    for (const part of chunk(batch, 100)) {
+      const res = await notion<{ results: Block[] }>(`/blocks/${destId}/children`, {
+        method: "PATCH",
+        body: JSON.stringify({ children: part.map((e) => e.cleaned) }),
+      })
+      created.push(...res.results)
+    }
+    // Recurse for any block that had nested children.
+    for (let i = 0; i < batch.length; i++) {
+      if (batch[i].source.has_children && created[i]) {
+        await copyChildren(batch[i].source.id, created[i].id, rootPageId)
+      }
+    }
+  }
+
+  for (const source of children) {
+    if (source.type === "child_database") {
+      await flush()
+      await copyDatabase(source.id, rootPageId)
+      continue
+    }
+    const cleaned = cleanBlock(source)
+    if (!cleaned) {
+      console.warn(`⚠️  Skipping non-copyable block: ${source.type}`)
+      continue
+    }
+    buffer.push({ source, cleaned })
+  }
+  await flush()
+}
+
+interface PropertyConfig {
+  type: string
+  [key: string]: unknown
+}
+
+// Build a create-database schema from a data source's property configs,
+// dropping property types we can't recreate.
+const buildSchema = (properties: Record<string, PropertyConfig>): Record<string, unknown> => {
+  const schema: Record<string, unknown> = {}
+  for (const [name, prop] of Object.entries(properties)) {
+    const type = prop.type
+    if (UNSUPPORTED_PROP_TYPES.has(type)) {
+      console.warn(`   ⚠️  skipping property "${name}" (${type} can't be created via API)`)
+      continue
+    }
+    const config = (prop[type] as Record<string, unknown>) ?? {}
+    if (type === "select" || type === "multi_select") {
+      const options = ((config.options as { name: string; color: string }[]) ?? []).map((o) => ({
+        name: o.name,
+        color: o.color,
+      }))
+      schema[name] = { type, [type]: { options } }
+    } else if (type === "formula") {
+      schema[name] = { type, formula: { expression: config.expression } }
+    } else if (type === "number") {
+      schema[name] = { type, number: { format: config.format ?? "number" } }
+    } else {
+      schema[name] = { type, [type]: {} }
+    }
+  }
+  return schema
+}
+
+// Build writable row properties from a source row's property values, skipping
+// computed values and any property not present in the new schema.
+const buildRowProperties = (
+  properties: Record<string, PropertyConfig>,
+  schema: Record<string, unknown>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [name, prop] of Object.entries(properties)) {
+    if (!(name in schema) || READONLY_VALUE_TYPES.has(prop.type)) continue
+    const v = prop[prop.type] as never
+    switch (prop.type) {
+      case "title":
+      case "rich_text":
+        out[name] = { [prop.type]: cleanRichText(v) }
+        break
+      case "multi_select":
+        out[name] = {
+          multi_select: ((v as { name: string }[]) ?? []).map((o) => ({ name: o.name })),
+        }
+        break
+      case "select":
+        if (v) out[name] = { select: { name: (v as { name: string }).name } }
+        break
+      case "checkbox":
+        out[name] = { checkbox: Boolean(v) }
+        break
+      case "url":
+      case "email":
+      case "phone_number":
+        if (v) out[name] = { [prop.type]: v }
+        break
+      case "number":
+        if (v !== null && v !== undefined) out[name] = { number: v }
+        break
+      case "date":
+        if (v) {
+          const d = v as { start: string; end: string | null; time_zone: string | null }
+          out[name] = { date: { start: d.start, end: d.end, time_zone: d.time_zone } }
+        }
+        break
+      case "people":
+        out[name] = { people: ((v as { id: string }[]) ?? []).map((p) => ({ id: p.id })) }
+        break
+      case "files": {
+        // Notion-hosted files have expiring URLs that can't be re-uploaded via
+        // the API; only external file links can be copied.
+        const files = ((v as { type: string; name: string; external?: { url: string } }[]) ?? [])
+          .filter(
+            (f): f is { type: string; name: string; external: { url: string } } =>
+              f.type === "external" && !!f.external
+          )
+          .map((f) => ({ name: f.name, external: { url: f.external.url } }))
+        if (files.length) out[name] = { files }
+        break
+      }
+      default:
+        break
+    }
+  }
+  return out
+}
+
+// Rebuild an embedded database (schema + rows) as an inline database under a page.
+const copyDatabase = async (sourceDbId: string, destPageId: string): Promise<void> => {
+  const database = await notion<{
+    title: RichText[]
+    data_sources: { id: string; name: string }[]
+  }>(`/databases/${sourceDbId}`)
+  const sourceDs = database.data_sources[0]
+  if (!sourceDs) return
+
+  const source = await notion<{ properties: Record<string, PropertyConfig> }>(
+    `/data_sources/${sourceDs.id}`
+  )
+  const schema = buildSchema(source.properties)
+
+  console.log(`   Creating database "${sourceDs.name}"…`)
+  const newDb = await notion<{ id: string; data_sources: { id: string }[] }>("/databases", {
+    method: "POST",
+    body: JSON.stringify({
+      parent: { type: "page_id", page_id: destPageId },
+      title: cleanRichText(database.title),
+      is_inline: true,
+      initial_data_source: { properties: schema },
+    }),
+  })
+  const newDsId = newDb.data_sources[0].id
+
+  let cursor: string | undefined
+  let count = 0
+  do {
+    const res = await notion<{
+      results: { id: string; properties: Record<string, PropertyConfig> }[]
+      next_cursor: string | null
+      has_more: boolean
+    }>(`/data_sources/${sourceDs.id}/query`, {
+      method: "POST",
+      body: JSON.stringify({ start_cursor: cursor, page_size: 100 }),
+    })
+    for (const row of res.results) {
+      const newRow = await notion<{ id: string }>("/pages", {
+        method: "POST",
+        body: JSON.stringify({
+          parent: { type: "data_source_id", data_source_id: newDsId },
+          properties: buildRowProperties(row.properties, schema),
+        }),
+      })
+      // Rows can have page bodies of their own; copy them too.
+      await copyChildren(row.id, newRow.id, newRow.id)
+      count++
+    }
+    cursor = res.has_more ? res.next_cursor ?? undefined : undefined
+  } while (cursor)
+  console.log(`   → copied ${count} row(s) into "${sourceDs.name}"`)
+}
+
+interface PageProperty {
+  type: string
+  title?: RichText[]
+}
+
+interface Page {
+  id: string
+  url: string
+  parent: Record<string, unknown>
+  properties: Record<string, PageProperty>
+}
+
+const getTitle = (page: Page): { key: string; rich: RichText[] } => {
+  const entry = Object.entries(page.properties).find(([, prop]) => prop.type === "title")
+  if (!entry) return { key: "title", rich: [] }
+  const [key, prop] = entry
+  return { key, rich: prop.title ?? [] }
+}
+
+// Placeholders in the template title that we fill on duplication. The title is:
+//   "2026-MM-DD Mobile App QA (version A.B.C, iOS build 2026.W.X.Y.Z Android build XYZ)"
+const DATE_PLACEHOLDER = /(?:\d{4}|YYYY)-MM-DD/g // e.g. "2026-MM-DD"
+const VERSION_PLACEHOLDER = /A\.B\.C/g // e.g. "version A.B.C"
+const IOS_BUILD_PLACEHOLDER = /\d{4}\.W\.X\.Y\.Z/g // e.g. "iOS build 2026.W.X.Y.Z"
+const ANDROID_BUILD_PLACEHOLDER = /XYZ/g // e.g. "Android build XYZ"
+
+// Replace a placeholder in the title's text segments with a concrete value.
+// (Notion's API rejects a dynamic "@today" mention outside of templates, so we
+// supply computed date/version/build strings instead.)
+const replaceInTitle = (rich: RichText[], pattern: RegExp, value: string): RichText[] =>
+  rich.map((seg) =>
+    seg.text?.content
+      ? { ...seg, text: { ...seg.text, content: seg.text.content.replace(pattern, value) } }
+      : seg
+  )
+
+const titleText = (rich: RichText[]): string => rich.map((seg) => seg.text?.content ?? "").join("")
+
+// The placeholder text in the template's changelog code block.
+const CHANGELOG_PLACEHOLDER = "Paste changelog here"
+
+// Find the id of the first code block under `blockId` (searched recursively)
+// whose text contains `match`; falls back to the first code block found.
+const findCodeBlock = async (blockId: string, match: string): Promise<string | null> => {
+  const children = await fetchAllChildren(blockId)
+  let fallback: string | null = null
+  for (const b of children) {
+    if (b.type === "code") {
+      const richText = (b.code as { rich_text?: { plain_text?: string }[] }).rich_text ?? []
+      const plain = richText.map((r) => r.plain_text ?? "").join("")
+      if (plain.includes(match)) return b.id
+      if (!fallback) fallback = b.id
+    } else if (b.has_children) {
+      const nested = await findCodeBlock(b.id, match)
+      if (nested) return nested
+    }
+  }
+  return fallback
+}
+
+// Notion caps a single rich-text object's `content` at 2000 chars. A long
+// changelog must therefore be split across multiple rich-text objects, which
+// Notion concatenates back together within the block. We prefer to cut on a
+// newline so lines stay intact, and hard-cut only when a single line exceeds
+// the limit. The pieces are consecutive substrings, so their concatenation is
+// byte-for-byte the original text regardless of where the cuts land.
+const NOTION_TEXT_LIMIT = 2000
+
+export const splitForRichText = (text: string, limit = NOTION_TEXT_LIMIT): string[] => {
+  if (text.length <= limit) return [text]
+  const chunks: string[] = []
+  let rest = text
+  while (rest.length > limit) {
+    const window = rest.slice(0, limit)
+    const nl = window.lastIndexOf("\n")
+    const cut = nl > 0 ? nl + 1 : limit // keep the newline with this chunk
+    chunks.push(rest.slice(0, cut))
+    rest = rest.slice(cut)
+  }
+  if (rest) chunks.push(rest)
+  return chunks
+}
+
+// Replace a code block's contents (language and everything else untouched).
+const setCodeBlock = async (blockId: string, text: string): Promise<void> => {
+  const rich_text = splitForRichText(text).map((content) => ({
+    type: "text",
+    text: { content },
+  }))
+  await notion(`/blocks/${blockId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ code: { rich_text } }),
+  })
+}
+
+// Idempotency guard: return the URL of an existing child page under the
+// destination whose title contains every string in `mustInclude` (e.g. the
+// version), or null if none exists.
+export const findExistingCopy = async (
+  destinationUrlOrId: string,
+  mustInclude: string[]
+): Promise<string | null> => {
+  const destId = extractPageId(destinationUrlOrId)
+  const children = await fetchAllChildren(destId)
+  for (const b of children) {
+    if (b.type !== "child_page") continue
+    const title = (b.child_page as { title?: string }).title ?? ""
+    if (mustInclude.every((s) => title.includes(s))) {
+      return `https://www.notion.so/${b.id.replace(/-/g, "")}`
+    }
+  }
+  return null
+}
+
+interface DuplicateOptions {
+  version?: string
+  today: string
+  // iOS build number, e.g. "2026.07.13.18" (fills the "2026.W.X.Y.Z" placeholder).
+  iosBuild?: string
+  // Android build number, e.g. "2026071318" (fills the "XYZ" placeholder).
+  androidBuild?: string
+  // Changelog markdown to drop into the template's changelog code block.
+  changelog?: string
+}
+
+export const duplicateTemplate = async (
+  templateUrlOrId: string,
+  destinationUrlOrId: string,
+  { version, today, iosBuild, androidBuild, changelog }: DuplicateOptions
+): Promise<string> => {
+  const templateId = extractPageId(templateUrlOrId)
+  const destinationId = extractPageId(destinationUrlOrId)
+  console.log(`Reading template ${templateId}…`)
+  const template = await notion<Page>(`/pages/${templateId}`)
+
+  // Copy the template's title, stamping today's date over the date placeholder
+  // and (when given) the release version + iOS/Android build numbers over their
+  // placeholders.
+  const { rich } = getTitle(template)
+  let newTitle: RichText[] = replaceInTitle(cleanRichText(rich), DATE_PLACEHOLDER, today)
+  if (version !== undefined) {
+    if (!titleText(newTitle).includes("A.B.C")) {
+      console.warn(`⚠️  No version placeholder (A.B.C) found in title to fill with ${version}.`)
+    }
+    newTitle = replaceInTitle(newTitle, VERSION_PLACEHOLDER, version)
+  }
+  if (iosBuild !== undefined) {
+    newTitle = replaceInTitle(newTitle, IOS_BUILD_PLACEHOLDER, iosBuild)
+  }
+  if (androidBuild !== undefined) {
+    newTitle = replaceInTitle(newTitle, ANDROID_BUILD_PLACEHOLDER, androidBuild)
+  }
+
+  console.log(`Creating new page under destination ${destinationId}…`)
+  const newPage = await notion<Page>("/pages", {
+    method: "POST",
+    body: JSON.stringify({
+      parent: { type: "page_id", page_id: destinationId },
+      properties: { title: { title: newTitle } },
+    }),
+  })
+
+  console.log("Copying block content…")
+  await copyChildren(templateId, newPage.id, newPage.id)
+
+  if (changelog) {
+    const codeBlockId = await findCodeBlock(newPage.id, CHANGELOG_PLACEHOLDER)
+    if (codeBlockId) {
+      console.log("Filling changelog code block…")
+      await setCodeBlock(codeBlockId, changelog)
+    } else {
+      console.warn("⚠️  No code block found to fill with the changelog.")
+    }
+  }
+
+  console.log(`✅ Duplicated template → ${newPage.url}`)
+  return newPage.url
+}

--- a/scripts/create-qa-document/notion.ts
+++ b/scripts/create-qa-document/notion.ts
@@ -1,0 +1,93 @@
+// Thin wrapper around the Notion REST API.
+// Requires a NOTION_RELEASE_LOOKOUT_TOKEN (an internal integration secret) with the template
+// page and its parent shared to the integration.
+const NOTION_VERSION = "2026-03-11"
+const MAX_RETRIES = 4
+// Abort a single request that stalls, so a hung connection can't wedge the job.
+const REQUEST_TIMEOUT_MS = 30_000
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// fetch with a hard per-request timeout, so a stalled connection aborts (and is
+// then retried) instead of hanging the job. Uses AbortController + setTimeout
+// for broad runtime support (AbortSignal.timeout isn't in our TS lib types).
+export const fetchWithTimeout = async (
+  url: string,
+  options: RequestInit = {},
+  timeoutMs = REQUEST_TIMEOUT_MS
+): Promise<Response> => {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { ...options, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export const notion = async <T = unknown>(path: string, options?: RequestInit): Promise<T> => {
+  for (let attempt = 0; ; attempt++) {
+    let res: Response
+    try {
+      res = await fetchWithTimeout(`https://api.notion.com/v1${path}`, {
+        ...options,
+        headers: {
+          Authorization: `Bearer ${process.env.NOTION_RELEASE_LOOKOUT_TOKEN ?? ""}`,
+          "Notion-Version": NOTION_VERSION,
+          "Content-Type": "application/json",
+          ...options?.headers,
+        },
+      })
+    } catch (error) {
+      // A timeout (AbortSignal) or network error throws here. Treat it as
+      // transient and retry with backoff, same as a 5xx.
+      if (attempt < MAX_RETRIES) {
+        const delay = 2 ** attempt * 500
+        console.warn(
+          `Notion request failed (${error}); retrying in ${delay}ms (attempt ${
+            attempt + 1
+          }/${MAX_RETRIES})`
+        )
+        await sleep(delay)
+        continue
+      }
+      throw error
+    }
+    if (res.ok) return res.json() as Promise<T>
+
+    // Retry rate limits (429) and transient server errors (5xx) with backoff.
+    const retryable = res.status === 429 || res.status >= 500
+    if (retryable && attempt < MAX_RETRIES) {
+      const retryAfter = Number(res.headers.get("Retry-After"))
+      const delay = retryAfter > 0 ? retryAfter * 1000 : 2 ** attempt * 500
+      console.warn(
+        `Notion API ${res.status}; retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES})`
+      )
+      await sleep(delay)
+      continue
+    }
+
+    const body = await res.text()
+    throw new Error(`Notion API error ${res.status}: ${body}`)
+  }
+}
+
+// Extracts the 32-char page ID from a Notion URL (or returns the input if it is
+// already an ID). URLs look like:
+//   https://www.notion.so/artsy/Some-Title-<32hexchars>?pvs=4
+// The ID is always the trailing token, so we anchor to the end of the path —
+// otherwise hex-like letters in the title slug (e.g. the "A" in "QA") shift the
+// match and yield the wrong ID.
+export const extractPageId = (urlOrId: string): string => {
+  const cleaned = urlOrId
+    .split(/[?#]/)[0] // drop query/hash
+    .replace(/\/+$/, "") // drop trailing slashes
+    .replace(/-/g, "") // drop hyphens (title separators + UUID dashes)
+  const match = cleaned.match(/[0-9a-f]{32}$/i)
+  if (!match) throw new Error(`Could not find a Notion page ID in: ${urlOrId}`)
+  const id = match[0]
+  // Re-hyphenate into the canonical UUID form the API expects.
+  return `${id.slice(0, 8)}-${id.slice(8, 12)}-${id.slice(12, 16)}-${id.slice(16, 20)}-${id.slice(
+    20
+  )}`
+}

--- a/scripts/create-qa-document/version.ts
+++ b/scripts/create-qa-document/version.ts
@@ -1,0 +1,11 @@
+// Parse the release version out of an RC branch name.
+//   "rc-v9.12.0" -> "9.12.0"
+// The QA document flow is triggered by the RC pull request, whose head branch
+// already encodes the target version, so we read it straight from there.
+export const getVersionFromBranch = (branch: string): string => {
+  const match = branch.match(/^rc-v(\d+(?:\.\d+)*)$/)
+  if (!match) {
+    throw new Error(`Expected an "rc-v<version>" branch, got: "${branch}"`)
+  }
+  return match[1]
+}


### PR DESCRIPTION
This PR resolves [PHIRE-3227] <!-- eg [PROJECT-XXXX] -->

### Description

Automates the release-day chore of hand-creating the **Mobile App QA** Notion document. When the release bot (`artsyit`) opens a release-candidate PR (`rc-v<version>`), a new GitHub Actions workflow triggers the beta builds, waits for them, then generates a fully-populated QA doc in Notion and posts the link to Slack.

**New workflow — `.github/workflows/rc-release-automation.yml`**

Runs on `pull_request: opened`, gated to `rc-v*` branches opened by `artsyit`. Five jobs:

| Job | What it does |
|---|---|
| `guard` | Gates on branch prefix + author; parses `rc-v9.14.0` → `9.14.0` |
| `trigger-betas` | Force-pushes the RC commit to `beta-ios` / `beta-android` (using the PAT, so downstream workflows fire), kicking off the 4 existing beta builds |
| `wait-for-betas` | Polls `gh run list` until all 4 beta builds for this SHA complete; fails on any failure (≤120 min) |
| `create-qa-document` | Reads beta build numbers from the git tags, lifts the changelog from the PR body, runs `yarn create-qa` |
| `notify-qa-failure` | On failure *after* betas succeeded, posts a run link to Slack (the one failure mode not already alerted) |

**New CLI — `scripts/create-qa-document/` (`yarn create-qa`)**

Notion has no "duplicate page" API, so the script rebuilds the template programmatically:
- Stamps the title placeholders — date → today, `A.B.C` → version, `2026.W.X.Y.Z` → iOS build, `XYZ` → Android build.
- Recreates the template's block tree and inline databases (schema + rows), preserving layout and skipping API-uncreatable block/property types with loud warnings.
- Fills the changelog code block, **split into ≤2000-char chunks** to respect Notion's rich-text limit.
- **Idempotent** — if a doc for the version already exists, it re-posts the link instead of creating a duplicate (safe on re-runs).
- All Notion calls go through a wrapper with **retry/backoff** (429/5xx/timeouts, honoring `Retry-After`) and a **30s per-request timeout**.
- Slack notification is **best-effort** — a Slack outage warns but never fails the job (the doc is the deliverable).

**`package.json`** — adds the `create-qa` script.

**Ops setup required before this runs** (not code):
- Add the `SLACK_URL` repo secret (`#practice-mobile` webhook). `NOTION_RELEASE_LOOKOUT_TOKEN` and `EIGEN_GITHUB_PAT_TOKEN` already exist.
- Share the `NOTION_RELEASE_LOOKOUT_TOKEN` integration with the QA template + destination pages.

> [!NOTE]  
>  opening an RC PR now *directly* deploys real betas (via the beta-branch push), intentionally skipping the interactive "build already running?" guard the manual flow has.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. — _CI/tooling only, no app change_
- [x] I have included **screenshots** or **videos**…, or I have not changed the UI. — _no UI change_
- [x] I have added **tests**, or my changes don't require any. — _29 unit tests across 3 suites_
- [x] I added an **app state migration**, or my changes do not require one. — _n/a_
- [x] I have documented any **follow-up work**…, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device. — _n/a, this is CI/tooling; happy to walk through a dry run_

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Auto-generate the Mobile App QA Notion document (and Slack post) when a release-candidate PR is opened.

<!-- end_changelog_updates -->

</details>



[PHIRE-3227]: https://artsyproduct.atlassian.net/browse/PHIRE-3227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ