### PR TITLE
feat(DI-452): let the followed artists bank grow past 3

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet.tsx
@@ -1,4 +1,4 @@
-import { Flex, Join, Spacer } from "@artsy/palette-mobile"
+import { Flex, Join, Separator, Spacer, Text } from "@artsy/palette-mobile"
 import { ArtistListItemNew_artist$key } from "__generated__/ArtistListItemNew_artist.graphql"
 import { FollowArtistsOrderedSetQuery } from "__generated__/FollowArtistsOrderedSetQuery.graphql"
 import { ArtistListItemPlaceholder } from "app/Components/ArtistListItem"
@@ -16,6 +16,7 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 
 interface FollowArtistsOrderedSetProps {
   id: string
+  hasFollowedArtists?: boolean
   hideFollowedArtists?: boolean
   listHeaderComponent?: React.ReactElement
   onArtistFollowed?: (
@@ -27,6 +28,7 @@ interface FollowArtistsOrderedSetProps {
 
 const FollowArtistsOrderedSet: React.FC<FollowArtistsOrderedSetProps> = ({
   id,
+  hasFollowedArtists,
   hideFollowedArtists,
   listHeaderComponent,
   onArtistFollowed,
@@ -52,7 +54,18 @@ const FollowArtistsOrderedSet: React.FC<FollowArtistsOrderedSetProps> = ({
     <FlatList
       showsVerticalScrollIndicator={false}
       contentContainerStyle={{ paddingBottom: SCROLLVIEW_PADDING_BOTTOM_OFFSET }}
-      ListHeaderComponent={listHeaderComponent}
+      ListHeaderComponent={
+        <>
+          {listHeaderComponent}
+          {nodes.length > 0 && (
+            <>
+              {!!hasFollowedArtists && <Separator my={2} />}
+              <Text variant="md">Leading artists on Artsy</Text>
+              <Spacer y={2} />
+            </>
+          )}
+        </>
+      }
       data={nodes}
       ItemSeparatorComponent={() => <Spacer y={2} />}
       renderItem={({ item }) => {

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank.tsx
@@ -1,4 +1,4 @@
-import { Join, Separator, Spacer } from "@artsy/palette-mobile"
+import { Join, Spacer } from "@artsy/palette-mobile"
 import { ArtistListItemNew_artist$key } from "__generated__/ArtistListItemNew_artist.graphql"
 import { ArtistListItemNew } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Components/ArtistListItem"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
@@ -23,21 +23,18 @@ export const FollowedArtistsBank: React.FC<FollowedArtistsBankProps> = ({
   if (artistRefs.length === 0) return null
 
   return (
-    <>
-      <Join separator={<Spacer y={2} />}>
-        {artistRefs.map(({ ref, internalID, slug }) => (
-          <ArtistListItemNew
-            key={internalID}
-            artist={ref}
-            onFollow={() => {}}
-            onUnfollow={() => {
-              trackArtistFollow(true, internalID, slug)
-              onArtistUnfollowed(internalID)
-            }}
-          />
-        ))}
-      </Join>
-      <Separator my={2} />
-    </>
+    <Join separator={<Spacer y={2} />}>
+      {artistRefs.map(({ ref, internalID, slug }) => (
+        <ArtistListItemNew
+          key={internalID}
+          artist={ref}
+          onFollow={() => {}}
+          onUnfollow={() => {
+            trackArtistFollow(true, internalID, slug)
+            onArtistUnfollowed(internalID)
+          }}
+        />
+      ))}
+    </Join>
   )
 }

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/FollowArtistsOrderedSet.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/FollowArtistsOrderedSet.tests.tsx
@@ -1,31 +1,26 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { Separator } from "@artsy/palette-mobile"
 import { fireEvent, screen, waitForElementToBeRemoved } from "@testing-library/react-native"
 import { FollowArtistsOrderedSetScreen } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
-import { renderWithHookWrappersTL } from "app/utils/tests/renderWithWrappers"
-import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
-import { createMockEnvironment } from "relay-test-utils"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 
 describe("FollowArtistsOrderedSet", () => {
-  let env: ReturnType<typeof createMockEnvironment>
-
-  beforeEach(() => {
-    env = createMockEnvironment()
+  const { renderWithRelay } = setupTestWrapper({
+    Component: FollowArtistsOrderedSetScreen,
   })
 
   it("tracks the artist's slug when followed", async () => {
-    renderWithHookWrappersTL(
-      <FollowArtistsOrderedSetScreen id="onboarding:suggested-artists" />,
-      env
+    const { mockResolveLastOperation } = renderWithRelay(
+      {
+        Artist: () => ({
+          internalID: "artist-internal-id",
+          slug: "banksy",
+          isFollowed: false,
+        }),
+      },
+      { id: "onboarding:suggested-artists" }
     )
-
-    resolveMostRecentRelayOperation(env, {
-      Artist: () => ({
-        internalID: "artist-internal-id",
-        slug: "banksy",
-        isFollowed: false,
-      }),
-    })
 
     await waitForElementToBeRemoved(() =>
       screen.queryByTestId("FollowArtistsOrderedSetPlaceholder")
@@ -33,7 +28,7 @@ describe("FollowArtistsOrderedSet", () => {
 
     fireEvent.press(screen.getAllByText("Follow")[0])
 
-    resolveMostRecentRelayOperation(env)
+    mockResolveLastOperation({})
 
     expect(mockTrackEvent).toHaveBeenCalledWith({
       action: ActionType.followedArtist,
@@ -42,6 +37,68 @@ describe("FollowArtistsOrderedSet", () => {
       owner_id: "artist-internal-id",
       owner_slug: "banksy",
       owner_type: OwnerType.artist,
+    })
+  })
+
+  describe("the 'Leading artists on Artsy' section", () => {
+    it("shows the heading and separator when there are followed artists and artists left to follow", async () => {
+      renderWithRelay(
+        {
+          Artist: () => ({
+            internalID: "artist-internal-id",
+            slug: "banksy",
+            isFollowed: false,
+          }),
+        },
+        { id: "onboarding:suggested-artists", hasFollowedArtists: true, hideFollowedArtists: true }
+      )
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId("FollowArtistsOrderedSetPlaceholder")
+      )
+
+      expect(screen.getByText("Leading artists on Artsy")).toBeOnTheScreen()
+      expect(screen.UNSAFE_queryAllByType(Separator)).toHaveLength(1)
+    })
+
+    it("shows the heading but not the separator when there are no followed artists yet", async () => {
+      renderWithRelay(
+        {
+          Artist: () => ({
+            internalID: "artist-internal-id",
+            slug: "banksy",
+            isFollowed: false,
+          }),
+        },
+        { id: "onboarding:suggested-artists", hideFollowedArtists: true }
+      )
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId("FollowArtistsOrderedSetPlaceholder")
+      )
+
+      expect(screen.getByText("Leading artists on Artsy")).toBeOnTheScreen()
+      expect(screen.UNSAFE_queryAllByType(Separator)).toHaveLength(0)
+    })
+
+    it("hides the heading and separator when every artist in the set has already been followed", async () => {
+      renderWithRelay(
+        {
+          Artist: () => ({
+            internalID: "artist-internal-id",
+            slug: "banksy",
+            isFollowed: true,
+          }),
+        },
+        { id: "onboarding:suggested-artists", hasFollowedArtists: true, hideFollowedArtists: true }
+      )
+
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId("FollowArtistsOrderedSetPlaceholder")
+      )
+
+      expect(screen.queryByText("Leading artists on Artsy")).not.toBeOnTheScreen()
+      expect(screen.UNSAFE_queryAllByType(Separator)).toHaveLength(0)
     })
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -122,17 +122,14 @@ export const FollowArtists: React.FC = () => {
           ) : (
             <FollowArtistsOrderedSetScreen
               id={SET_ID}
+              hasFollowedArtists={count > 0}
               hideFollowedArtists
               onArtistFollowed={handleArtistFollowed}
               listHeaderComponent={
-                <>
-                  <FollowedArtistsBank
-                    artistRefs={followedArtistRefs.slice(0, 3)}
-                    onArtistUnfollowed={handleArtistUnfollowed}
-                  />
-                  <Text variant="md">Leading artists on Artsy</Text>
-                  <Spacer y={2} />
-                </>
+                <FollowedArtistsBank
+                  artistRefs={followedArtistRefs}
+                  onArtistUnfollowed={handleArtistUnfollowed}
+                />
               }
             />
           )}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -1,5 +1,6 @@
 import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
+import { FollowedArtistsBank } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank"
 import { FollowArtists } from "app/Scenes/Onboarding/Screens/Onboarding/FollowArtists"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
@@ -18,26 +19,29 @@ jest.mock("app/utils/hooks/useDebouncedValue", () => ({
 }))
 
 jest.mock("app/Scenes/Onboarding/Screens/Onboarding/Components/FollowedArtistsBank", () => ({
-  FollowedArtistsBank: () => null,
+  FollowedArtistsBank: jest.fn(() => null),
 }))
 
 jest.mock("app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet", () => {
   const { Text } = require("react-native")
   return {
-    FollowArtistsOrderedSetScreen: ({ onArtistFollowed }: any) => (
-      <Text
-        onPress={() =>
-          onArtistFollowed?.({} as any, {
-            internalID: "artist-id",
-            slug: "artist-slug",
-            imageUrl: null,
-            blurhash: null,
-            initials: null,
-          })
-        }
-      >
-        OrderedSet
-      </Text>
+    FollowArtistsOrderedSetScreen: ({ onArtistFollowed, listHeaderComponent }: any) => (
+      <>
+        {listHeaderComponent}
+        <Text
+          onPress={() =>
+            onArtistFollowed?.({} as any, {
+              internalID: "artist-id",
+              slug: "artist-slug",
+              imageUrl: null,
+              blurhash: null,
+              initials: null,
+            })
+          }
+        >
+          OrderedSet
+        </Text>
+      </>
     ),
   }
 })
@@ -147,6 +151,20 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
 
       expect(screen.getByText("3/3")).toBeOnTheScreen()
+    })
+  })
+
+  describe("Followed artists bank", () => {
+    it("includes every followed artist", () => {
+      renderWithWrappers(<FollowArtists />)
+
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+      fireEvent.press(screen.getByText("OrderedSet"))
+
+      const lastCall = (FollowedArtistsBank as jest.Mock).mock.calls.at(-1)
+      expect(lastCall[0].artistRefs).toHaveLength(4)
     })
   })
 


### PR DESCRIPTION
This PR resolves [DI-452](https://www.notion.so/396cab0764a080378958f43d37a694f6)

The "bank" of followed artists shown while following artists during onboarding was capped at the last 3 artists followed. That cap was there to avoid pushing the "Leading artists on Artsy" suggestions down as the bank grew — but since newly-followed artists are added at the *top* of the bank, growing it doesn't disrupt the user's scroll position in the suggestions below.

- The bank now shows every artist followed so far in the session, not just the last 3, with the most recently followed artist still appearing at the top.
- The "Leading artists on Artsy" heading (and its separator from the bank) now only render when there's actually at least one un-followed artist left to suggest — previously they stayed visible even after a user had followed every artist in that list, leaving an empty section with just a heading and nothing under it.
- Migrated `FollowArtistsOrderedSet`'s tests off two utilities marked `@deprecated` in their own source (`renderWithHookWrappersTL`, `resolveMostRecentRelayOperation`) onto the recommended `setupTestWrapper`/`renderWithRelay`.

https://github.com/user-attachments/assets/cbd6eec8-91aa-45e9-ba6a-2778b5399eb5




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**. — Not tested; changes are cross-platform with no platform-specific code.
  - [ ] **iOS**. — Verified in the simulator.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — Lives entirely within the existing `AREnableExperienceBasedOnboarding`-gated flow; no new flag needed.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — iOS-only; not attached here.
- [x] I have added **tests**, or my changes don't require any. — Added coverage for the bank no longer capping at 3, and for the heading/separator only showing when artists remain to follow.
- [x] I added an **[app state migration]**, or my changes do not require one. — No state shape change.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any. — Two copy changes (a new "Skip to home" button label, and updated intro text on this screen) were considered alongside this but deliberately left out to ship as their own separate PR(s).
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device, on both iOS and Android.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Let the followed-artists bank in onboarding grow past 3

#### Dev changes

- Migrate FollowArtistsOrderedSet tests off deprecated Relay test utilities

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)