### PR TITLE
feat(DI-447): update progress pills copy/styling on Follow Artists and Infinite Discovery

### DIFF
--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -22,9 +22,7 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   total,
   unit,
 }) => {
-  const displayedCurrent = Math.min(current, total)
-
-  if (displayedCurrent >= total) {
+  if (current >= total) {
     return (
       <Text variant="sm-display" color="blue100">
         Complete
@@ -35,7 +33,7 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   return (
     <Text variant="sm-display" color="mono100" style={{ fontVariant: ["tabular-nums"] }}>
       <Text variant="sm-display" weight="medium" color="blue100">
-        {displayedCurrent}
+        {current}
       </Text>
       {` ${getProgressText(unit, total)}`}
     </Text>

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -31,7 +31,7 @@ export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = (
   }
 
   return (
-    <Text variant="sm-display" color="mono100" style={{ fontVariant: ["tabular-nums"] }}>
+    <Text variant="sm-display" color="mono100">
       <Text variant="sm-display" weight="medium" color="blue100">
         {current}
       </Text>

--- a/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
+++ b/src/app/Components/OnboardingProgressBadge/OnboardingProgressBadge.tsx
@@ -1,28 +1,43 @@
-import { Flex, Text } from "@artsy/palette-mobile"
+import { Text } from "@artsy/palette-mobile"
+
+export type OnboardingProgressUnit = "follows" | "saves"
+
+const getProgressText = (unit: OnboardingProgressUnit, total: number) => {
+  switch (unit) {
+    case "follows":
+      return `of ${total} follows`
+    case "saves":
+      return `of ${total} saves`
+  }
+}
 
 interface OnboardingProgressBadgeProps {
   current: number
   total: number
+  unit: OnboardingProgressUnit
 }
 
 export const OnboardingProgressBadge: React.FC<OnboardingProgressBadgeProps> = ({
   current,
   total,
+  unit,
 }) => {
-  return (
-    <Flex
-      backgroundColor="blue100"
-      borderRadius={30}
-      // paddingTop and paddingBottom are offset to center the text
-      style={{ paddingHorizontal: 15, paddingTop: 5, paddingBottom: 8 }}
-      alignItems="center"
-      justifyContent="center"
-      alignSelf="flex-start"
-    >
-      {/* tabular-nums keeps all digits equal width so the pill doesn't resize as the count changes */}
-      <Text color="mono0" variant="sm-display" style={{ fontVariant: ["tabular-nums"] }}>
-        {Math.min(current, total)}/{total}
+  const displayedCurrent = Math.min(current, total)
+
+  if (displayedCurrent >= total) {
+    return (
+      <Text variant="sm-display" color="blue100">
+        Complete
       </Text>
-    </Flex>
+    )
+  }
+
+  return (
+    <Text variant="sm-display" color="mono100" style={{ fontVariant: ["tabular-nums"] }}>
+      <Text variant="sm-display" weight="medium" color="blue100">
+        {displayedCurrent}
+      </Text>
+      {` ${getProgressText(unit, total)}`}
+    </Text>
   )
 }

--- a/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
+++ b/src/app/Components/OnboardingProgressBadge/__tests__/OnboardingProgressBadge.tests.tsx
@@ -3,21 +3,34 @@ import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("OnboardingProgressBadge", () => {
-  it("renders current and total", () => {
-    renderWithWrappers(<OnboardingProgressBadge current={2} total={5} />)
+  it("renders current and total for follows", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={2} total={5} unit="follows" />)
 
-    expect(screen.getByText("2/5")).toBeOnTheScreen()
+    expect(screen.getByText("2 of 5 follows")).toBeOnTheScreen()
+  })
+
+  it("renders current and total for saves", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={2} total={5} unit="saves" />)
+
+    expect(screen.getByText("2 of 5 saves")).toBeOnTheScreen()
   })
 
   it("renders zero state", () => {
-    renderWithWrappers(<OnboardingProgressBadge current={0} total={5} />)
+    renderWithWrappers(<OnboardingProgressBadge current={0} total={5} unit="saves" />)
 
-    expect(screen.getByText("0/5")).toBeOnTheScreen()
+    expect(screen.getByText("0 of 5 saves")).toBeOnTheScreen()
   })
 
-  it("caps the displayed count at total when current exceeds it", () => {
-    renderWithWrappers(<OnboardingProgressBadge current={7} total={5} />)
+  it("shows Complete once current reaches total", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={5} total={5} unit="saves" />)
 
-    expect(screen.getByText("5/5")).toBeOnTheScreen()
+    expect(screen.getByText("Complete")).toBeOnTheScreen()
+    expect(screen.queryByText("5 of 5 saves")).not.toBeOnTheScreen()
+  })
+
+  it("shows Complete when current exceeds total", () => {
+    renderWithWrappers(<OnboardingProgressBadge current={7} total={5} unit="saves" />)
+
+    expect(screen.getByText("Complete")).toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet.tsx
@@ -127,8 +127,13 @@ export const ArtistSaveOnboardingBottomSheet = () => {
 
               <Spacer y={1} />
 
-              <Text variant="xs" color="mono60" textAlign="center">
-                Find them anytime in the Favorites tab at the bottom of your screen.
+              <Text
+                variant="xs"
+                color="mono60"
+                textAlign="center"
+                style={{ width: 350, paddingHorizontal: 10 }}
+              >
+                Find them any time in the Favorites tab at the bottom of your screen.
               </Text>
 
               <Spacer y={2} />
@@ -151,9 +156,14 @@ export const ArtistSaveOnboardingBottomSheet = () => {
 
               <Spacer y={1} />
 
-              <Text variant="xs" color="mono60" textAlign="center">
-                When a new work by an artist you follow is added to Artsy, you'll see a notification
-                on the Alerts icon at the top of your For You page.
+              <Text
+                variant="xs"
+                color="mono60"
+                textAlign="center"
+                style={{ width: 350, paddingHorizontal: 10 }}
+              >
+                When there's a new work by an artist you follow, you'll see a notification at the
+                top of your For You page.
               </Text>
 
               <Spacer y={1} />

--- a/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/ArtistSaveOnboardingBottomSheet.tests.tsx
@@ -134,7 +134,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
         await screen.findByText("Your followed artists are saved to Favorites.")
       ).toBeOnTheScreen()
       expect(
-        screen.getByText("Find them anytime in the Favorites tab at the bottom of your screen.")
+        screen.getByText("Find them any time in the Favorites tab at the bottom of your screen.")
       ).toBeOnTheScreen()
     })
 
@@ -146,7 +146,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       expect(await screen.findByText("We'll let you know when new works arrive.")).toBeOnTheScreen()
       expect(
         screen.getByText(
-          /When a new work by an artist you follow is added to Artsy, you'll see a notification/
+          /When there's a new work by an artist you follow, you'll see a notification/
         )
       ).toBeOnTheScreen()
     })

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -119,7 +119,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
           }
         />
         <Flex px={2}>
-          <StepProgressBar current={newUserOnboardingSavedArtworkCount} total={5} />
+          <StepProgressBar current={displayedSavedArtworkCount} total={5} />
         </Flex>
       </Flex>
     )

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -1,5 +1,5 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { ChevronDownIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
+import { ChevronDownIcon, ChevronRightIcon, MoreIcon, ShareIcon } from "@artsy/icons/native"
 import { DEFAULT_HIT_SLOP, Flex, Screen, Text, Touchable } from "@artsy/palette-mobile"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
 import { getShareURL } from "app/Components/ShareSheet/helpers"
@@ -90,8 +90,10 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
     return (
       <Flex mb={1}>
         <Screen.Header
-          title="Discover Daily"
-          leftElements={<OnboardingProgressBadge current={displayedSavedArtworkCount} total={5} />}
+          hideTitle
+          leftElements={
+            <OnboardingProgressBadge current={displayedSavedArtworkCount} total={5} unit="saves" />
+          }
           rightElements={
             <Touchable
               accessibilityRole="button"
@@ -104,7 +106,10 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
               hitSlop={DEFAULT_HIT_SLOP}
               haptic
             >
-              <Text>{newUserOnboardingGoalReached ? "Exit" : "Skip"}</Text>
+              <Flex flexDirection="row" alignItems="center" gap={0.5}>
+                <Text>{newUserOnboardingGoalReached ? "Go to home" : "Skip to home"}</Text>
+                <ChevronRightIcon fill="onBackgroundHigh" />
+              </Flex>
             </Touchable>
           }
         />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -102,11 +102,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
           rightElements={
             <Touchable
               accessibilityRole="button"
-              accessibilityLabel={
-                hasChosenToContinueBrowsing
-                  ? "Exit new user onboarding"
-                  : "Skip new user onboarding"
-              }
+              accessibilityLabel={hasChosenToContinueBrowsing ? "Go to home" : "Skip to home"}
               onPress={handleSkipOrExitPressed}
               hitSlop={DEFAULT_HIT_SLOP}
               haptic

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -109,7 +109,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
             >
               <Flex flexDirection="row" alignItems="center" gap={0.5}>
                 <Text>{hasChosenToContinueBrowsing ? "Go to home" : "Skip to home"}</Text>
-                <ChevronRightIcon fill="onBackgroundHigh" />
+                <ChevronRightIcon fill="mono100" />
               </Flex>
             </Touchable>
           }

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -33,6 +33,11 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   const newUserOnboardingGoalReached = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalReached
   )
+  const newUserOnboardingCompletionBottomSheetVisible = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingCompletionBottomSheetVisible
+  )
+  const hasChosenToContinueBrowsing =
+    newUserOnboardingGoalReached && !newUserOnboardingCompletionBottomSheetVisible
   const displayedSavedArtworkCount = newUserOnboardingGoalReached
     ? 5
     : newUserOnboardingSavedArtworkCount
@@ -43,7 +48,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
   }
 
   const handleSkipOrExitPressed = () => {
-    if (!newUserOnboardingGoalReached) {
+    if (!hasChosenToContinueBrowsing) {
       trackTappedSkip(ContextModule.onboardingFlow, OwnerType.infiniteDiscoveryArtwork)
     }
     trackCompletedOnboarding()
@@ -98,7 +103,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
             <Touchable
               accessibilityRole="button"
               accessibilityLabel={
-                newUserOnboardingGoalReached
+                hasChosenToContinueBrowsing
                   ? "Exit new user onboarding"
                   : "Skip new user onboarding"
               }
@@ -107,7 +112,7 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
               haptic
             >
               <Flex flexDirection="row" alignItems="center" gap={0.5}>
-                <Text>{newUserOnboardingGoalReached ? "Go to home" : "Skip to home"}</Text>
+                <Text>{hasChosenToContinueBrowsing ? "Go to home" : "Skip to home"}</Text>
                 <ChevronRightIcon fill="onBackgroundHigh" />
               </Flex>
             </Touchable>

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -188,10 +188,6 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
                 </MotiView>
 
                 <Flex flex={1} px={2}>
-                  <Text>Welcome to Discover Daily</Text>
-
-                  <Spacer y={1} />
-
                   {isNewUserOnboardingSession ? (
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
                       Swipe to see the next artwork, tap the heart to save it.

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryOnboarding.tsx
@@ -194,11 +194,7 @@ export const InfiniteDiscoveryOnboarding: React.FC<InfiniteDiscoveryOnboardingPr
 
                   {isNewUserOnboardingSession ? (
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>
-                      Save{" "}
-                      <Text variant="lg-display" fontWeight="500">
-                        5
-                      </Text>{" "}
-                      different artworks to build your taste profile.
+                      Swipe to see the next artwork, tap the heart to save it.
                     </Text>
                   ) : (
                     <Text variant="lg-display" numberOfLines={2} adjustsFontSizeToFit>

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -128,7 +128,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
             </Button>
 
             <Button block variant="fillDark" onPress={handleTakeMeHome}>
-              Take Me Home
+              Go to home
             </Button>
           </Flex>
         </Flex>

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -200,29 +200,12 @@ describe("InfiniteDiscoveryHeader", () => {
         }
       })
 
-      it("shows a Go to home button instead of Skip, with the badge frozen at Complete", () => {
+      it("keeps showing Skip to home, with the badge frozen at Complete, until the user chooses to continue browsing", () => {
         renderWithWrappers(<InfiniteDiscoveryHeader />)
 
         expect(screen.getByText("Complete")).toBeOnTheScreen()
-        expect(screen.getByText("Go to home")).toBeOnTheScreen()
-        expect(screen.queryByText("Skip to home")).not.toBeOnTheScreen()
-      })
-
-      it("exits onboarding when Exit is pressed, without tracking a skip tap", () => {
-        const setOnboardingStateSpy = jest.spyOn(
-          GlobalStore.actions.onboarding,
-          "setOnboardingState"
-        )
-
-        renderWithWrappers(<InfiniteDiscoveryHeader />)
-
-        fireEvent.press(screen.getByLabelText("Exit new user onboarding"))
-
-        expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
-        expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
-        expect(mockTrackEvent).not.toHaveBeenCalledWith(
-          expect.objectContaining({ action: ActionType.tappedSkip })
-        )
+        expect(screen.getByText("Skip to home")).toBeOnTheScreen()
+        expect(screen.queryByText("Go to home")).not.toBeOnTheScreen()
       })
 
       it("keeps the badge frozen at Complete even if a saved artwork is removed", () => {
@@ -231,6 +214,38 @@ describe("InfiniteDiscoveryHeader", () => {
         renderWithWrappers(<InfiniteDiscoveryHeader />)
 
         expect(screen.getByText("Complete")).toBeOnTheScreen()
+      })
+
+      describe("and the user has chosen to continue browsing", () => {
+        beforeEach(() => {
+          GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(
+            false
+          )
+        })
+
+        it("shows a Go to home button instead of Skip", () => {
+          renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+          expect(screen.getByText("Go to home")).toBeOnTheScreen()
+          expect(screen.queryByText("Skip to home")).not.toBeOnTheScreen()
+        })
+
+        it("exits onboarding when Exit is pressed, without tracking a skip tap", () => {
+          const setOnboardingStateSpy = jest.spyOn(
+            GlobalStore.actions.onboarding,
+            "setOnboardingState"
+          )
+
+          renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+          fireEvent.press(screen.getByLabelText("Exit new user onboarding"))
+
+          expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
+          expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
+          expect(mockTrackEvent).not.toHaveBeenCalledWith(
+            expect.objectContaining({ action: ActionType.tappedSkip })
+          )
+        })
       })
     })
   })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -92,6 +92,12 @@ describe("InfiniteDiscoveryHeader", () => {
     expect(moreButton).toHaveAccessibleName("Share Artwork")
   })
 
+  it("shows the Discover Daily title outside of new user onboarding", () => {
+    renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
+
+    expect(screen.getByText("Discover Daily")).toBeOnTheScreen()
+  })
+
   it("shows toast when exiting with saved artworks", () => {
     GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
     GlobalStore.actions.infiniteDiscovery.incrementSavedArtworksCount()
@@ -118,10 +124,16 @@ describe("InfiniteDiscoveryHeader", () => {
       GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     })
 
+    it("hides the Discover Daily title", () => {
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      expect(screen.queryByText("Discover Daily")).not.toBeOnTheScreen()
+    })
+
     it("shows the progress badge instead of the exit chevron", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      expect(screen.getByText("0/5")).toBeOnTheScreen()
+      expect(screen.getByText("0 of 5 saves")).toBeOnTheScreen()
       expect(screen.queryByTestId("close-icon")).not.toBeOnTheScreen()
     })
 
@@ -136,13 +148,13 @@ describe("InfiniteDiscoveryHeader", () => {
       })
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      expect(screen.getByText("2/5")).toBeOnTheScreen()
+      expect(screen.getByText("2 of 5 saves")).toBeOnTheScreen()
     })
 
     it("shows a Skip button instead of the share/more button", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
 
-      expect(screen.getByText("Skip")).toBeOnTheScreen()
+      expect(screen.getByText("Skip to home")).toBeOnTheScreen()
       expect(screen.queryByTestId("top-right-icon")).not.toBeOnTheScreen()
     })
 
@@ -188,12 +200,12 @@ describe("InfiniteDiscoveryHeader", () => {
         }
       })
 
-      it("shows an Exit button instead of Skip, with the badge frozen at 5/5", () => {
+      it("shows a Go to home button instead of Skip, with the badge frozen at Complete", () => {
         renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-        expect(screen.getByText("5/5")).toBeOnTheScreen()
-        expect(screen.getByText("Exit")).toBeOnTheScreen()
-        expect(screen.queryByText("Skip")).not.toBeOnTheScreen()
+        expect(screen.getByText("Complete")).toBeOnTheScreen()
+        expect(screen.getByText("Go to home")).toBeOnTheScreen()
+        expect(screen.queryByText("Skip to home")).not.toBeOnTheScreen()
       })
 
       it("exits onboarding when Exit is pressed, without tracking a skip tap", () => {
@@ -213,12 +225,12 @@ describe("InfiniteDiscoveryHeader", () => {
         )
       })
 
-      it("keeps the badge frozen at 5/5 even if a saved artwork is removed", () => {
+      it("keeps the badge frozen at Complete even if a saved artwork is removed", () => {
         GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
 
         renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-        expect(screen.getByText("5/5")).toBeOnTheScreen()
+        expect(screen.getByText("Complete")).toBeOnTheScreen()
       })
     })
   })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -163,7 +163,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
       renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+      fireEvent.press(screen.getByLabelText("Skip to home"))
 
       expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
@@ -172,7 +172,7 @@ describe("InfiniteDiscoveryHeader", () => {
     it("tracks the skip tap", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
 
-      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+      fireEvent.press(screen.getByLabelText("Skip to home"))
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedSkip,
@@ -253,7 +253,7 @@ describe("InfiniteDiscoveryHeader", () => {
 
           renderWithWrappers(<InfiniteDiscoveryHeader />)
 
-          fireEvent.press(screen.getByLabelText("Exit new user onboarding"))
+          fireEvent.press(screen.getByLabelText("Go to home"))
 
           expect(setOnboardingStateSpy).toHaveBeenCalledWith("complete")
           expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -208,12 +208,13 @@ describe("InfiniteDiscoveryHeader", () => {
         expect(screen.queryByText("Go to home")).not.toBeOnTheScreen()
       })
 
-      it("keeps the badge frozen at Complete even if a saved artwork is removed", () => {
+      it("keeps the badge and progress bar frozen at Complete even if a saved artwork is removed", () => {
         GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
 
         renderWithWrappers(<InfiniteDiscoveryHeader />)
 
         expect(screen.getByText("Complete")).toBeOnTheScreen()
+        expect(screen.getByTestId("step-progress-bar-checkmark")).toBeOnTheScreen()
       })
 
       describe("and the user has chosen to continue browsing", () => {
@@ -228,6 +229,20 @@ describe("InfiniteDiscoveryHeader", () => {
 
           expect(screen.getByText("Go to home")).toBeOnTheScreen()
           expect(screen.queryByText("Skip to home")).not.toBeOnTheScreen()
+        })
+
+        it("keeps the badge and progress bar frozen at Complete even after unsaving and resaving artworks", () => {
+          GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-1")
+          GlobalStore.actions.infiniteDiscovery.removeNewUserOnboardingSavedArtwork("artwork-2")
+          GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+            internalID: "artwork-6",
+            url: "https://example.com/6.jpg",
+          })
+
+          renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+          expect(screen.getByText("Complete")).toBeOnTheScreen()
+          expect(screen.getByTestId("step-progress-bar-checkmark")).toBeOnTheScreen()
         })
 
         it("exits onboarding when Exit is pressed, without tracking a skip tap", () => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -35,7 +35,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
     it("shows the overlay immediately", () => {
       renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
 
-      expect(screen.getByText("Welcome to Discover Daily")).toBeOnTheScreen()
+      expect(screen.getByText("Tap to start swiping")).toBeOnTheScreen()
     })
 
     it("tracks the onboarding view", () => {
@@ -61,13 +61,13 @@ describe("InfiniteDiscoveryOnboarding", () => {
     it("shows the overlay after 1 second on first visit", () => {
       renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
 
-      expect(screen.queryByText("Welcome to Discover Daily")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Tap to get started")).not.toBeOnTheScreen()
 
       act(() => {
         jest.advanceTimersByTime(1000)
       })
 
-      expect(screen.getByText("Welcome to Discover Daily")).toBeOnTheScreen()
+      expect(screen.getByText("Tap to get started")).toBeOnTheScreen()
     })
 
     it("does not show the overlay for a returning visitor", () => {
@@ -78,7 +78,7 @@ describe("InfiniteDiscoveryOnboarding", () => {
         jest.runAllTimers()
       })
 
-      expect(screen.queryByText("Welcome to Discover Daily")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Tap to get started")).not.toBeOnTheScreen()
     })
   })
 })

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryOnboarding.tests.tsx
@@ -44,14 +44,16 @@ describe("InfiniteDiscoveryOnboarding", () => {
       expect(mockTrack.onboardingView).toHaveBeenCalled()
     })
 
-    it("shows the onboarding-specific save prompt", () => {
+    it("shows the onboarding-specific instructions", () => {
       renderWithWrappers(<InfiniteDiscoveryOnboarding artworks={[]} />)
 
       act(() => {
         jest.runAllTimers()
       })
 
-      expect(screen.getByText(/different artworks to build your taste profile/)).toBeOnTheScreen()
+      expect(
+        screen.getByText("Swipe to see the next artwork, tap the heart to save it.")
+      ).toBeOnTheScreen()
     })
   })
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -24,7 +24,7 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
 
     expect(screen.getByText("Five works is all it takes to start.")).toBeOnTheScreen()
     expect(screen.getByText("Continue Browsing")).toBeOnTheScreen()
-    expect(screen.getByText("Take Me Home")).toBeOnTheScreen()
+    expect(screen.getByText("Go to home")).toBeOnTheScreen()
   })
 
   it('"Continue Browsing" hides the sheet and keeps onboarding incomplete', () => {
@@ -42,13 +42,13 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
     expect(state?.onboarding.onboardingState).toBe("incomplete")
   })
 
-  it('"Take Me Home" hides the sheet and completes onboarding', () => {
+  it('"Go to home" hides the sheet and completes onboarding', () => {
     GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
 
     renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
 
-    fireEvent.press(screen.getByText("Take Me Home"))
+    fireEvent.press(screen.getByText("Go to home"))
 
     const state = __globalStoreTestUtils__?.getCurrentState()
     expect(

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
@@ -21,7 +21,7 @@ export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext, onSk
       <Logo />
       <Flex flex={1} justifyContent="center">
         <Text variant="xl" color="mono0">
-          Try our artwork browsing tool to start developing your tastes.
+          We'll show you a selection of art. To get started, save 5 that speak to you.
         </Text>
       </Flex>
       <AnimatedFlex
@@ -35,7 +35,7 @@ export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext, onSk
           Start browsing
         </Button>
         <Button variant="fillDark" block onPress={onSkip}>
-          Skip to homepage
+          Skip to home
         </Button>
       </AnimatedFlex>
     </Flex>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -8,10 +8,10 @@ import { Logo } from "./Logo"
 export type Experience = "experienced" | "beginner"
 
 const EXPERIENCE_OPTIONS: { label: string; experience: Experience }[] = [
-  { label: "I have collected many works (4 or more)", experience: "experienced" },
-  { label: "I have collected a few works (1-3)", experience: "experienced" },
-  { label: "I'm just starting out but have something in mind", experience: "beginner" },
-  { label: "I'm just starting out and want to explore", experience: "beginner" },
+  { label: "I'm an experienced collector (4+ works)", experience: "experienced" },
+  { label: "I've started my collection (1-3 works)", experience: "experienced" },
+  { label: "I'm new to collecting, but I have something in mind", experience: "beginner" },
+  { label: "I'm new to collecting and ready to explore", experience: "beginner" },
 ]
 
 const HORIZONTAL_MARGIN = 20
@@ -61,7 +61,7 @@ export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
         }}
       >
         <Text variant="lg-display" color="mono0">
-          What is your art collecting experience?
+          Where are you in your art collecting journey?
         </Text>
       </MotiView>
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -70,7 +70,7 @@ export const FollowArtists: React.FC = () => {
         rightElements={
           <Touchable
             accessibilityRole="button"
-            accessibilityLabel="Skip new user onboarding"
+            accessibilityLabel="Go to home"
             onPress={() => {
               trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
               trackCompletedOnboarding()

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -110,7 +110,7 @@ export const FollowArtists: React.FC = () => {
                 haptic
               >
                 <Text variant="sm-display" color="mono60">
-                  Cancel
+                  Clear
                 </Text>
               </Touchable>
             )}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -1,4 +1,5 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { ChevronRightIcon } from "@artsy/icons/native"
 import {
   Box,
   Button,
@@ -63,7 +64,9 @@ export const FollowArtists: React.FC = () => {
   return (
     <Screen>
       <Screen.Header
-        leftElements={<OnboardingProgressBadge current={count} total={MIN_FOLLOWED} />}
+        leftElements={
+          <OnboardingProgressBadge current={count} total={MIN_FOLLOWED} unit="follows" />
+        }
         rightElements={
           <Touchable
             accessibilityRole="button"
@@ -76,7 +79,10 @@ export const FollowArtists: React.FC = () => {
             hitSlop={DEFAULT_HIT_SLOP}
             haptic
           >
-            <Text>Skip</Text>
+            <Flex flexDirection="row" alignItems="center" gap={0.5}>
+              <Text>Go to home</Text>
+              <ChevronRightIcon fill="onBackgroundHigh" />
+            </Flex>
           </Touchable>
         }
       />
@@ -86,9 +92,8 @@ export const FollowArtists: React.FC = () => {
 
       <Screen.Body disableKeyboardAvoidance>
         <Box mt={2}>
-          <Text variant="lg-display">Tell us which artists you're interested in?</Text>
-          <Text variant="sm-display" color="mono60" mt={1}>
-            Follow {MIN_FOLLOWED} or more artists to see more of their work.
+          <Text variant="lg-display">
+            Show us what you're drawn to, follow {MIN_FOLLOWED} or more artists to get started.
           </Text>
         </Box>
         <Spacer y={2} />
@@ -137,6 +142,7 @@ export const FollowArtists: React.FC = () => {
         <KeyboardStickyView>
           <Flex p={2} backgroundColor="mono0">
             <Button
+              testID="continue-button"
               block
               disabled={count < MIN_FOLLOWED}
               onPress={() => {
@@ -145,7 +151,7 @@ export const FollowArtists: React.FC = () => {
                 GlobalStore.actions.onboarding.setOnboardingState("complete")
               }}
             >
-              Continue to Artsy
+              Go to home
             </Button>
           </Flex>
         </KeyboardStickyView>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -70,7 +70,7 @@ export const FollowArtists: React.FC = () => {
         rightElements={
           <Touchable
             accessibilityRole="button"
-            accessibilityLabel="Go to home"
+            accessibilityLabel="Skip to home"
             onPress={() => {
               trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
               trackCompletedOnboarding()
@@ -80,7 +80,7 @@ export const FollowArtists: React.FC = () => {
             haptic
           >
             <Flex flexDirection="row" alignItems="center" gap={0.5}>
-              <Text>Go to home</Text>
+              <Text>Skip to home</Text>
               <ChevronRightIcon fill="mono100" />
             </Flex>
           </Touchable>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -81,7 +81,7 @@ export const FollowArtists: React.FC = () => {
           >
             <Flex flexDirection="row" alignItems="center" gap={0.5}>
               <Text>Go to home</Text>
-              <ChevronRightIcon fill="onBackgroundHigh" />
+              <ChevronRightIcon fill="mono100" />
             </Flex>
           </Touchable>
         }

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -208,7 +208,7 @@ describe("FollowArtists", () => {
     it("sets onboardingState to complete", () => {
       renderWithWrappers(<FollowArtists />)
 
-      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+      fireEvent.press(screen.getByLabelText("Go to home"))
 
       expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
         "complete"
@@ -219,7 +219,7 @@ describe("FollowArtists", () => {
     it("tracks the skip tap", () => {
       renderWithWrappers(<FollowArtists />)
 
-      fireEvent.press(screen.getByLabelText("Skip new user onboarding"))
+      fireEvent.press(screen.getByLabelText("Go to home"))
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedSkip,

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -208,7 +208,7 @@ describe("FollowArtists", () => {
     it("sets onboardingState to complete", () => {
       renderWithWrappers(<FollowArtists />)
 
-      fireEvent.press(screen.getByLabelText("Go to home"))
+      fireEvent.press(screen.getByLabelText("Skip to home"))
 
       expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
         "complete"
@@ -219,7 +219,7 @@ describe("FollowArtists", () => {
     it("tracks the skip tap", () => {
       renderWithWrappers(<FollowArtists />)
 
-      fireEvent.press(screen.getByLabelText("Go to home"))
+      fireEvent.press(screen.getByLabelText("Skip to home"))
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.tappedSkip,

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -69,10 +69,10 @@ describe("FollowArtists", () => {
       expect(screen.queryByText("SearchResults")).not.toBeOnTheScreen()
     })
 
-    it("does not show the Cancel button when there is no query", () => {
+    it("does not show the Clear button when there is no query", () => {
       renderWithWrappers(<FollowArtists />)
 
-      expect(screen.queryByText("Cancel")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Clear")).not.toBeOnTheScreen()
     })
   })
 
@@ -95,32 +95,32 @@ describe("FollowArtists", () => {
       expect(screen.getByText("OrderedSet")).toBeOnTheScreen()
     })
 
-    it("shows Cancel button when query is non-empty", () => {
+    it("shows Clear button when query is non-empty", () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.changeText(screen.getByPlaceholderText("Search Artists"), "Banksy")
 
-      expect(screen.getByText("Cancel")).toBeOnTheScreen()
+      expect(screen.getByText("Clear")).toBeOnTheScreen()
     })
 
-    it("pressing Cancel clears the query and returns to ordered set", () => {
+    it("pressing Clear clears the query and returns to ordered set", () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.changeText(screen.getByPlaceholderText("Search Artists"), "Banksy")
       expect(screen.getByText("SearchResults")).toBeOnTheScreen()
 
-      fireEvent.press(screen.getByText("Cancel"))
+      fireEvent.press(screen.getByText("Clear"))
 
       expect(screen.queryByText("SearchResults")).not.toBeOnTheScreen()
       expect(screen.getByText("OrderedSet")).toBeOnTheScreen()
-      expect(screen.queryByText("Cancel")).not.toBeOnTheScreen()
+      expect(screen.queryByText("Clear")).not.toBeOnTheScreen()
     })
 
-    it("pressing Cancel dismisses the keyboard", () => {
+    it("pressing Clear dismisses the keyboard", () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.changeText(screen.getByPlaceholderText("Search Artists"), "Banksy")
-      fireEvent.press(screen.getByText("Cancel"))
+      fireEvent.press(screen.getByText("Clear"))
 
       expect(dismissSpy).toHaveBeenCalledTimes(1)
     })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/FollowArtists.tests.tsx
@@ -127,10 +127,10 @@ describe("FollowArtists", () => {
   })
 
   describe("progress badge", () => {
-    it("shows 0/3 initially", () => {
+    it("shows 0 of 3 follows initially", () => {
       renderWithWrappers(<FollowArtists />)
 
-      expect(screen.getByText("0/3")).toBeOnTheScreen()
+      expect(screen.getByText("0 of 3 follows")).toBeOnTheScreen()
     })
 
     it("reflects the number of followed artists", () => {
@@ -139,10 +139,10 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("2/3")).toBeOnTheScreen()
+      expect(screen.getByText("2 of 3 follows")).toBeOnTheScreen()
     })
 
-    it("caps badge display at 3/3 even with more than 3 followed artists", () => {
+    it("shows Complete once 3 or more artists are followed", () => {
       renderWithWrappers(<FollowArtists />)
 
       fireEvent.press(screen.getByText("OrderedSet"))
@@ -150,7 +150,7 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("3/3")).toBeOnTheScreen()
+      expect(screen.getByText("Complete")).toBeOnTheScreen()
     })
   })
 
@@ -175,7 +175,7 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("Continue to Artsy")).toBeDisabled()
+      expect(screen.getByTestId("continue-button")).toBeDisabled()
     })
 
     it("is enabled when 3 or more artists are followed", () => {
@@ -185,7 +185,7 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      expect(screen.getByText("Continue to Artsy")).not.toBeDisabled()
+      expect(screen.getByTestId("continue-button")).not.toBeDisabled()
     })
 
     it("sets onboardingState to complete when pressed", () => {
@@ -195,7 +195,7 @@ describe("FollowArtists", () => {
       fireEvent.press(screen.getByText("OrderedSet"))
       fireEvent.press(screen.getByText("OrderedSet"))
 
-      fireEvent.press(screen.getByText("Continue to Artsy"))
+      fireEvent.press(screen.getByTestId("continue-button"))
 
       expect(__globalStoreTestUtils__?.getCurrentState().onboarding.onboardingState).toBe(
         "complete"


### PR DESCRIPTION
This PR resolves [DI-447](https://www.notion.so/396cab0764a0802ebedefe38ee4cfd9d) and some other copy changes in the new onboarding flow.

What changed:
- The "5/5" and "3/3" pills are now plain text that reads like "2 of 3 follows" or "3 of 5 saves", with the number shown in blue. Once you hit the goal, it switches to "Complete" in blue.
- The "Skip" button now reads "Skip to home" (with a small arrow after it), and becomes "Go to home" once you've already reached the save/follow goal.
- The "Continue to Artsy" button on Follow Artists now reads "Go to home" to match.
- The intro copy at the top of Follow Artists was simplified to one line: "Show us what you're drawn to, follow 3 or more artists to get started."
- The onboarding overlay copy on Infinite Discovery (for brand-new users) now reads "Swipe to see the next artwork, tap the heart to save it." (the old "Welcome to Discover Daily" line was removed).
- On Infinite Discovery, "Skip to home" only flips to "Go to home" once the user explicitly chooses "Continue Browsing" on the completion sheet — reaching the 5-save goal alone no longer flips it, and the badge/progress bar stay frozen at "Complete" through any later unsave/resave.
- Accessible names (`accessibilityLabel`) now match the visible button copy across both flows, fixing a WCAG 2.5.3 (Label in Name) mismatch for Voice Control users.
- The Follow Artists header button stays "Skip to home" regardless of follow count (it's still functionally a skip), rather than switching to "Go to home" and colliding with the bottom continue button's label.
- The completion sheet's "Take Me Home" button is now "Go to home", matching the rest of onboarding's copy.
- Chevron icons next to "Skip to home"/"Go to home" use `mono100` instead of `onBackgroundHigh` for consistency with the rest of the codebase (same rendered color, just the conventional token).
- The intro sequence's Question step now asks "Where are you in your art collecting journey?" with refreshed answer copy: "I'm an experienced collector (4+ works)", "I've started my collection (1-3 works)", "I'm new to collecting, but I have something in mind", "I'm new to collecting and ready to explore".
- The intro sequence's Browse Prompt step now reads "We'll show you a selection of art. To get started, save 5 that speak to you.", with a "Skip to home" button (was "Skip to homepage").
- The Follow Artists search "Cancel" button is now "Clear".
- The Follow Artists completion modal's second step subtitle now reads "When there's a new work by an artist you follow, you'll see a notification at the top of your For You page.", and both steps' subtitles are now constrained to the same width as the image below them (with 10px horizontal padding) so they no longer wrap wider than the title/image.

| Intro | Experienced | Beginner |
|-|-|-|
| https://github.com/user-attachments/assets/47b55a35-c29e-42e9-8c66-608f47e2bc50 | https://github.com/user-attachments/assets/941e8e58-63c5-4c9f-a08c-597930701fd5 | https://github.com/user-attachments/assets/7c24207a-6255-49cf-abdb-65932edf1c4a |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Updated copy across the new onboarding flow

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
