### PR TITLE
feat: add Guess the Artist artwork game

### DIFF
--- a/src/app/Navigation/routes.tsx
+++ b/src/app/Navigation/routes.tsx
@@ -57,6 +57,7 @@ import {
 } from "app/Scenes/Artwork/Components/BrowseSimilarWorks/BrowseSimilarWorks"
 import { CertificateOfAuthenticity } from "app/Scenes/Artwork/Components/CertificateAuthenticity"
 import { UnlistedArtworksFAQScreen } from "app/Scenes/Artwork/Components/UnlistedArtworksFAQScreen"
+import { ArtworkArtistGame } from "app/Scenes/ArtworkArtistGame/ArtworkArtistGame"
 import {
   ArtworkAttributionClassFAQQueryRenderer,
   ArtworkAttributionClassFAQScreenQuery,
@@ -364,6 +365,17 @@ export const artsyDotNetRoutes = defineRoutes([
       },
     },
     queries: [ActivityItemQuery],
+  },
+  {
+    path: "/artwork-artist-game",
+    name: "ArtworkArtistGame",
+    Component: ArtworkArtistGame,
+    options: {
+      screenOptions: {
+        headerShown: false,
+      },
+      hidesBottomTabs: true,
+    },
   },
   {
     path: "/art-quiz",

--- a/src/app/Scenes/ArtworkArtistGame/ArtworkArtistGame.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/ArtworkArtistGame.tsx
@@ -1,0 +1,242 @@
+import { Button, Flex, Screen, Separator, Spacer, Text } from "@artsy/palette-mobile"
+import {
+  ArtworkArtistGamePlayQueryRenderer,
+  GameResult,
+} from "app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlay"
+import { ROUNDS_PER_GAME } from "app/Scenes/ArtworkArtistGame/utils/buildRounds"
+import {
+  addGameScore,
+  clearGameScores,
+  GameScoreRecord,
+  getGameScores,
+} from "app/Scenes/ArtworkArtistGame/utils/gameScoreHistory"
+import { goBack } from "app/system/navigation/navigate"
+import { MotiView } from "moti"
+import { useCallback, useEffect, useState } from "react"
+
+type Phase = "start" | "playing" | "results"
+
+export const ArtworkArtistGame: React.FC = () => {
+  const [phase, setPhase] = useState<Phase>("start")
+  // gameId changes each game so the play QueryRenderer remounts and refetches.
+  const [gameId, setGameId] = useState(0)
+  const [lastResult, setLastResult] = useState<GameResult | null>(null)
+  const [scores, setScores] = useState<GameScoreRecord[]>([])
+  const [progress, setProgress] = useState<{ current: number; total: number } | null>(null)
+
+  const refreshScores = async () => {
+    setScores(await getGameScores())
+  }
+
+  useEffect(() => {
+    refreshScores()
+  }, [])
+
+  const startGame = () => {
+    setGameId((id) => id + 1)
+    setLastResult(null)
+    setProgress(null)
+    setPhase("playing")
+  }
+
+  const handleFinish = async (result: GameResult) => {
+    const percentage = Math.round((result.correctCount / result.total) * 100)
+    const record: GameScoreRecord = {
+      correctCount: result.correctCount,
+      total: result.total,
+      percentage,
+      date: new Date().toISOString(),
+    }
+
+    setLastResult(result)
+    setPhase("results")
+    const updated = await addGameScore(record)
+    setScores(updated)
+  }
+
+  const handleProgress = useCallback((current: number, total: number) => {
+    setProgress({ current, total })
+  }, [])
+
+  const handleClearHistory = async () => {
+    await clearGameScores()
+    await refreshScores()
+  }
+
+  if (phase === "playing") {
+    return (
+      <Screen>
+        <Screen.Header
+          title="Who made this artwork?"
+          onBack={() => setPhase("start")}
+          rightElements={
+            progress ? (
+              <Text variant="sm" color="mono60">
+                {progress.current} / {progress.total}
+              </Text>
+            ) : undefined
+          }
+        />
+        <Screen.Body fullwidth>
+          <ArtworkArtistGamePlayQueryRenderer
+            key={gameId}
+            onFinish={handleFinish}
+            onProgress={handleProgress}
+          />
+        </Screen.Body>
+      </Screen>
+    )
+  }
+
+  if (phase === "results" && lastResult) {
+    return (
+      <Screen>
+        <Screen.AnimatedHeader title="Results" onBack={() => setPhase("start")} />
+        <Screen.Body>
+          <GameResults
+            correctCount={lastResult.correctCount}
+            total={lastResult.total}
+            onPlayAgain={startGame}
+            onBackToStart={() => setPhase("start")}
+          />
+        </Screen.Body>
+      </Screen>
+    )
+  }
+
+  return (
+    <Screen>
+      <Screen.Header onBack={goBack} />
+      <Screen.Body>
+        <Flex flex={1} py={2}>
+          <Text variant="lg-display" textAlign="center">
+            Guess the Artist
+          </Text>
+          <Spacer y={1} />
+          <Text variant="sm" color="mono60" textAlign="center">
+            You'll see {ROUNDS_PER_GAME} artworks. Pick the artist who made each one.
+          </Text>
+
+          <Spacer y={4} />
+
+          <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
+            <Text variant="md">Previous scores</Text>
+            {scores.length > 0 && (
+              <Text variant="xs" color="blue100" onPress={handleClearHistory}>
+                Clear
+              </Text>
+            )}
+          </Flex>
+          <Spacer y={1} />
+
+          <Flex flex={1}>
+            {scores.length === 0 ? (
+              <Text variant="sm" color="mono60">
+                No games played yet.
+              </Text>
+            ) : (
+              <Screen.ScrollView>
+                {scores.map((score, index) => (
+                  <Flex key={`${score.date}-${index}`}>
+                    <Flex flexDirection="row" justifyContent="space-between" py={1}>
+                      <Text variant="sm">{formatDate(score.date)}</Text>
+                      <Text variant="sm" weight="medium">
+                        {score.percentage}% ({score.correctCount}/{score.total})
+                      </Text>
+                    </Flex>
+                    <Separator />
+                  </Flex>
+                ))}
+              </Screen.ScrollView>
+            )}
+          </Flex>
+
+          <Spacer y={2} />
+          <Button block onPress={startGame}>
+            Play
+          </Button>
+          <Spacer y={2} />
+        </Flex>
+      </Screen.Body>
+    </Screen>
+  )
+}
+
+const formatDate = (iso: string): string => {
+  const date = new Date(iso)
+  if (isNaN(date.getTime())) return iso
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+}
+
+const COUNT_UP_DURATION = 600
+
+// Counts from 0 up to `target` over `duration` ms using requestAnimationFrame.
+const useCountUp = (target: number, duration: number = COUNT_UP_DURATION): number => {
+  const [value, setValue] = useState(0)
+
+  useEffect(() => {
+    let frame: number
+    let startTime: number | null = null
+
+    const step = (timestamp: number) => {
+      if (startTime === null) {
+        startTime = timestamp
+      }
+
+      const progress = Math.min((timestamp - startTime) / duration, 1)
+      setValue(Math.round(progress * target))
+
+      if (progress < 1) {
+        frame = requestAnimationFrame(step)
+      }
+    }
+
+    frame = requestAnimationFrame(step)
+
+    return () => cancelAnimationFrame(frame)
+  }, [target, duration])
+
+  return value
+}
+
+interface GameResultsProps {
+  correctCount: number
+  total: number
+  onPlayAgain: () => void
+  onBackToStart: () => void
+}
+
+const GameResults: React.FC<GameResultsProps> = ({
+  correctCount,
+  total,
+  onPlayAgain,
+  onBackToStart,
+}) => {
+  const percentage = Math.round((correctCount / total) * 100)
+  const displayPercentage = useCountUp(percentage)
+
+  return (
+    <MotiView
+      from={{ opacity: 0, translateY: 20 }}
+      animate={{ opacity: 1, translateY: 0 }}
+      transition={{ type: "timing", duration: 400 }}
+      style={{ flex: 1 }}
+    >
+      <Flex flex={1} justifyContent="center" alignItems="center">
+        <Text variant="xxl">{displayPercentage}%</Text>
+        <Spacer y={1} />
+        <Text variant="md" color="mono60">
+          You got {correctCount} out of {total} right
+        </Text>
+        <Spacer y={4} />
+        <Button block onPress={onPlayAgain}>
+          Play again
+        </Button>
+        <Spacer y={1} />
+        <Button block variant="outline" onPress={onBackToStart}>
+          Back to start
+        </Button>
+      </Flex>
+    </MotiView>
+  )
+}

--- a/src/app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlay.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlay.tsx
@@ -1,0 +1,294 @@
+import { Flex, Text, Touchable, useColor, useScreenDimensions } from "@artsy/palette-mobile"
+import FastImage from "@d11/react-native-fast-image"
+import { ArtworkArtistGamePlayQuery } from "__generated__/ArtworkArtistGamePlayQuery.graphql"
+import { LoadFailureView } from "app/Components/LoadFailureView"
+import { ArtworkArtistGamePlayPlaceholder } from "app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlayPlaceholder"
+import { GameArtworkImage } from "app/Scenes/ArtworkArtistGame/Components/GameArtworkImage"
+import {
+  buildRounds,
+  GameArtist,
+  GameArtwork,
+  GameRound,
+  ROUNDS_PER_GAME,
+} from "app/Scenes/ArtworkArtistGame/utils/buildRounds"
+import { extractNodes } from "app/utils/extractNodes"
+import { seededShuffle, useStableShuffle } from "app/utils/hooks/useStableShuffle"
+import { withSuspense } from "app/utils/hooks/withSuspense"
+import { sizeToFit } from "app/utils/useSizeToFit"
+import { MotiView } from "moti"
+import { useEffect, useRef, useState } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
+
+const REVEAL_ANIMATION_DURATION = 200
+const ROUND_TRANSITION_DURATION = 250
+
+export const REVEAL_DELAY = 1200
+
+export interface GameResult {
+  correctCount: number
+  total: number
+}
+
+interface ArtworkArtistGamePlayProps {
+  onFinish: (result: GameResult) => void
+  onProgress?: (current: number, total: number) => void
+}
+
+interface GamePlayProps {
+  rounds: GameRound[]
+  onFinish: (result: GameResult) => void
+  onProgress?: (current: number, total: number) => void
+}
+
+interface GameChoiceProps {
+  artist: GameArtist
+  answered: boolean
+  isCorrect: boolean
+  isSelected: boolean
+  onPress: () => void
+}
+
+// A single answer button. Once an answer is locked in, it animates its background
+// and border to the reveal colors, with a small scale "pop" on the correct choice.
+const GameChoice: React.FC<GameChoiceProps> = ({
+  artist,
+  answered,
+  isCorrect,
+  isSelected,
+  onPress,
+}) => {
+  const color = useColor()
+
+  const revealColor =
+    answered && isCorrect ? color("green100") : answered && isSelected ? color("red100") : null
+
+  const backgroundColor = revealColor ?? color("background")
+  const borderColor = revealColor ?? color("mono30")
+  const isHighlighted = answered && (isCorrect || isSelected)
+
+  return (
+    <Touchable accessibilityRole="button" disabled={answered} onPress={onPress}>
+      <MotiView
+        animate={{
+          backgroundColor,
+          borderColor,
+          // Array is a keyframe sequence — pop out then settle back.
+          scale: answered && isCorrect ? [1.04, 1] : 1,
+        }}
+        transition={{ type: "timing", duration: REVEAL_ANIMATION_DURATION }}
+        style={{ borderWidth: 1, borderRadius: 5 }}
+      >
+        <Flex py={1} px={2}>
+          <Text variant="sm" textAlign="center" color={isHighlighted ? "mono0" : "mono100"}>
+            {artist.name}
+          </Text>
+        </Flex>
+      </MotiView>
+    </Touchable>
+  )
+}
+
+// Presentational play component — receives prepared rounds and runs the game loop.
+export const GamePlay: React.FC<GamePlayProps> = ({ rounds, onFinish, onProgress }) => {
+  const { width, height, safeAreaInsets } = useScreenDimensions()
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [correctCount, setCorrectCount] = useState(0)
+  const [selectedArtistID, setSelectedArtistID] = useState<string | null>(null)
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeout.current) clearTimeout(timeout.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    onProgress?.(currentIndex + 1, rounds.length)
+  }, [currentIndex, rounds.length, onProgress])
+
+  // Warm the image cache for every round up front so later artworks appear instantly.
+  // Low priority so the currently-displayed artwork still loads first.
+  useEffect(() => {
+    const sources = rounds
+      .map((r) => r.artwork.imageURL)
+      .filter(Boolean)
+      .map((uri) => ({ uri, priority: FastImage?.priority?.low }))
+
+    try {
+      FastImage?.preload?.(sources)
+    } catch (error) {
+      // Prefetching is best-effort — never let it break the game (e.g. no native module in tests).
+      console.warn("Failed to prefetch game images", error)
+    }
+  }, [rounds])
+
+  const round = rounds[currentIndex]
+  const { shuffled: choices } = useStableShuffle({
+    items: round.choices,
+    seed: round.artwork.internalID,
+  })
+
+  const handlePick = (artistID: string) => {
+    if (selectedArtistID !== null) return
+
+    const isCorrect = artistID === round.correctArtistID
+    const newCorrectCount = correctCount + (isCorrect ? 1 : 0)
+
+    setSelectedArtistID(artistID)
+    setCorrectCount(newCorrectCount)
+
+    timeout.current = setTimeout(() => {
+      if (currentIndex + 1 >= rounds.length) {
+        onFinish({ correctCount: newCorrectCount, total: rounds.length })
+        return
+      }
+
+      setCurrentIndex(currentIndex + 1)
+      setSelectedArtistID(null)
+    }, REVEAL_DELAY)
+  }
+
+  const answered = selectedArtistID !== null
+
+  // Fit the artwork inside a bounding box (preserving aspect ratio) so it is never
+  // cropped, while leaving room for the choices above the safe area.
+  const container = { width: width - 32, height: height * 0.4 }
+  const displaySize = sizeToFit(
+    {
+      width: round.artwork.imageWidth || container.width,
+      height: round.artwork.imageHeight || container.height,
+    },
+    container
+  )
+
+  return (
+    <Flex flex={1} px={2} style={{ paddingBottom: safeAreaInsets.bottom + 8 }}>
+      {/* Keyed on the round so each new artwork + choices fades in as the previous fades away. */}
+      <MotiView
+        key={currentIndex}
+        from={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ type: "timing", duration: ROUND_TRANSITION_DURATION }}
+        style={{ flex: 1 }}
+      >
+        <Flex flex={1} justifyContent="center">
+          <GameArtworkImage
+            imageURL={round.artwork.imageURL}
+            width={displaySize.width}
+            height={displaySize.height}
+            blurhash={round.artwork.blurhash}
+            href={round.artwork.href}
+            artworkRef={round.artwork.saveArtworkRef}
+          />
+        </Flex>
+
+        <Flex gap={0.5}>
+          {choices.map((artist) => (
+            <GameChoice
+              key={artist.internalID}
+              artist={artist}
+              answered={answered}
+              isCorrect={artist.internalID === round.correctArtistID}
+              isSelected={artist.internalID === selectedArtistID}
+              onPress={() => handlePick(artist.internalID)}
+            />
+          ))}
+        </Flex>
+      </MotiView>
+    </Flex>
+  )
+}
+
+const artworkArtistGamePlayQuery = graphql`
+  query ArtworkArtistGamePlayQuery @relay_test_operation {
+    discoverArtworks(limit: 15) {
+      edges {
+        node {
+          internalID
+          title
+          href
+          image {
+            url(version: "large")
+            width
+            height
+            blurhash
+          }
+          artists(shallow: true) {
+            internalID
+            name
+          }
+          ...useSaveArtworkToArtworkLists_artwork
+        }
+      }
+    }
+    highlights {
+      popularArtists(size: 40) {
+        internalID
+        name
+      }
+    }
+  }
+`
+
+export const ArtworkArtistGamePlayQueryRenderer = withSuspense<ArtworkArtistGamePlayProps>({
+  Component: ({ onFinish, onProgress }) => {
+    const data = useLazyLoadQuery<ArtworkArtistGamePlayQuery>(
+      artworkArtistGamePlayQuery,
+      {},
+      { fetchPolicy: "network-only" }
+    )
+
+    const artworks = extractNodes(data.discoverArtworks).reduce<GameArtwork[]>((acc, node) => {
+      const artist = node.artists?.[0]
+      const imageURL = node.image?.url
+
+      if (artist?.internalID && artist.name && imageURL) {
+        acc.push({
+          internalID: node.internalID,
+          title: node.title,
+          href: node.href ?? null,
+          imageURL,
+          imageWidth: node.image?.width,
+          imageHeight: node.image?.height,
+          blurhash: node.image?.blurhash,
+          artist: { internalID: artist.internalID, name: artist.name },
+          saveArtworkRef: node,
+        })
+      }
+
+      return acc
+    }, [])
+
+    const artistPool = (data.highlights?.popularArtists ?? []).reduce<GameArtist[]>(
+      (acc, artist) => {
+        if (artist?.internalID && artist.name) {
+          acc.push({ internalID: artist.internalID, name: artist.name })
+        }
+        return acc
+      },
+      []
+    )
+
+    const rounds = buildRounds(artworks, artistPool, (items, seed) =>
+      seededShuffle(seed).shuffle(items)
+    )
+
+    if (rounds.length < ROUNDS_PER_GAME) {
+      return (
+        <Flex flex={1} justifyContent="center" alignItems="center" px={2}>
+          <Text variant="sm" textAlign="center" color="mono60">
+            Not enough artworks to start a game right now. Please try again later.
+          </Text>
+        </Flex>
+      )
+    }
+
+    return <GamePlay rounds={rounds} onFinish={onFinish} onProgress={onProgress} />
+  },
+  LoadingFallback: ArtworkArtistGamePlayPlaceholder,
+  ErrorFallback: () => (
+    <Flex flex={1}>
+      <LoadFailureView />
+    </Flex>
+  ),
+})

--- a/src/app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlayPlaceholder.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlayPlaceholder.tsx
@@ -1,0 +1,38 @@
+import {
+  Flex,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+  Spacer,
+  useScreenDimensions,
+} from "@artsy/palette-mobile"
+import { CHOICES_PER_ROUND } from "app/Scenes/ArtworkArtistGame/utils/buildRounds"
+
+export const ArtworkArtistGamePlayPlaceholder: React.FC = () => {
+  const { width } = useScreenDimensions()
+  const imageSize = width - 40
+
+  return (
+    <Skeleton>
+      <Flex flex={1} px={2}>
+        <Spacer y={1} />
+        <SkeletonText variant="sm">1 / 10</SkeletonText>
+        <Spacer y={1} />
+        <SkeletonText variant="lg-display">Who made this artwork?</SkeletonText>
+        <Spacer y={2} />
+
+        <Flex alignItems="center">
+          <SkeletonBox width={imageSize} height={imageSize} />
+        </Flex>
+
+        <Spacer y={2} />
+
+        <Flex gap={1}>
+          {Array.from({ length: CHOICES_PER_ROUND }).map((_, index) => (
+            <SkeletonBox key={index} height={52} borderRadius={5} />
+          ))}
+        </Flex>
+      </Flex>
+    </Skeleton>
+  )
+}

--- a/src/app/Scenes/ArtworkArtistGame/Components/GameArtworkImage.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/Components/GameArtworkImage.tsx
@@ -1,0 +1,147 @@
+import { HeartFillIcon } from "@artsy/icons/native"
+import { Flex, Image, Text, Touchable } from "@artsy/palette-mobile"
+import { useSaveArtworkToArtworkLists_artwork$key } from "__generated__/useSaveArtworkToArtworkLists_artwork.graphql"
+import { ArtworkSaveIconWrapper } from "app/Components/ArtworkGrids/ArtworkSaveIconWrapper"
+import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
+import { RouterLink } from "app/system/navigation/RouterLink"
+import { Gesture, GestureDetector } from "react-native-gesture-handler"
+import Haptic from "react-native-haptic-feedback"
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated"
+
+interface GameArtworkImageProps {
+  imageURL: string
+  width: number
+  height: number
+  blurhash?: string | null
+  href?: string | null
+  artworkRef: useSaveArtworkToArtworkLists_artwork$key
+}
+
+export const GameArtworkImage: React.FC<GameArtworkImageProps> = ({
+  imageURL,
+  width,
+  height,
+  blurhash,
+  href,
+  artworkRef,
+}) => {
+  const { isSaved, saveArtworkToLists } = useSaveArtworkToArtworkLists({
+    artworkFragmentRef: artworkRef,
+    saveToDefaultCollectionOnly: true,
+  })
+
+  const burstOpacity = useSharedValue(0)
+
+  const burstStyles = useAnimatedStyle(() => ({ opacity: burstOpacity.value }))
+
+  const playBurst = () => {
+    burstOpacity.value = withSequence(
+      withTiming(1, { duration: 200, easing: Easing.linear }),
+      withDelay(400, withTiming(0, { duration: 300, easing: Easing.linear }))
+    )
+  }
+
+  // Toggles the save state — used by the heart button.
+  const handleSavePress = () => {
+    if (!isSaved) {
+      Haptic.trigger("impactLight")
+      playBurst()
+    }
+    saveArtworkToLists()
+  }
+
+  // Double tap only ever saves (never un-saves), matching Infinite Discovery.
+  const handleDoubleTapSave = () => {
+    if (isSaved) return
+    Haptic.trigger("impactLight")
+    playBurst()
+    saveArtworkToLists()
+  }
+
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .maxDuration(250)
+    .onEnd(() => {
+      runOnJS(handleDoubleTapSave)()
+    })
+
+  return (
+    <Flex alignItems="center">
+      <GestureDetector gesture={doubleTap}>
+        <Flex width={width} height={height}>
+          {/* performResize=false so the fetched URL matches the one we prefetch (the raw
+              "large" version), guaranteeing a cache hit and avoiding on-the-fly resizing. */}
+          <Image
+            src={imageURL}
+            width={width}
+            height={height}
+            blurhash={blurhash ?? undefined}
+            performResize={false}
+          />
+
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              {
+                position: "absolute",
+                width: "100%",
+                height: "100%",
+                justifyContent: "center",
+                alignItems: "center",
+                zIndex: 100,
+              },
+              burstStyles,
+            ]}
+          >
+            <HeartFillIcon height={80} width={80} fill="mono0" />
+          </Animated.View>
+
+          <Flex position="absolute" top={10} right={10}>
+            <Touchable
+              accessibilityRole="button"
+              accessibilityLabel={isSaved ? "Saved" : "Save artwork"}
+              onPress={handleSavePress}
+            >
+              <Flex
+                flexDirection="row"
+                alignItems="center"
+                backgroundColor="mono0"
+                borderRadius={20}
+                borderWidth={1}
+                borderColor="mono10"
+                px={1}
+                py={0.5}
+              >
+                <ArtworkSaveIconWrapper isSaved={!!isSaved} testID="game-artwork-save-icon" />
+                <Text variant="xs" ml={0.5}>
+                  {isSaved ? "Saved" : "Save"}
+                </Text>
+              </Flex>
+            </Touchable>
+          </Flex>
+        </Flex>
+      </GestureDetector>
+
+      <Flex flexDirection="row" alignItems="center" mt={1} gap={1}>
+        <Text variant="xs" color="mono60">
+          Double tap the artwork to save it
+        </Text>
+        {!!href && (
+          <RouterLink to={href} accessibilityRole="link" testID="game-view-artwork-link">
+            <Text variant="xs" color="blue100">
+              View artwork
+            </Text>
+          </RouterLink>
+        )}
+      </Flex>
+    </Flex>
+  )
+}

--- a/src/app/Scenes/ArtworkArtistGame/Components/__tests__/ArtworkArtistGamePlay.tests.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/Components/__tests__/ArtworkArtistGamePlay.tests.tsx
@@ -1,0 +1,134 @@
+import { act, fireEvent, screen } from "@testing-library/react-native"
+import {
+  ArtworkArtistGamePlayQueryRenderer,
+  GamePlay,
+  REVEAL_DELAY,
+} from "app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlay"
+import { GameArtwork, GameRound } from "app/Scenes/ArtworkArtistGame/utils/buildRounds"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+
+// The artwork image (with its save mutation + gesture) is covered by its own test.
+jest.mock("app/Scenes/ArtworkArtistGame/Components/GameArtworkImage", () => ({
+  GameArtworkImage: () => {
+    const { Text } = require("@artsy/palette-mobile")
+    return <Text>Artwork Image</Text>
+  },
+}))
+
+const buildArtwork = (id: string): GameArtwork => ({
+  internalID: id,
+  title: `Artwork ${id}`,
+  href: `/artwork/${id}`,
+  imageURL: `https://example.com/${id}.jpg`,
+  imageWidth: 800,
+  imageHeight: 600,
+  blurhash: null,
+  artist: { internalID: `${id}-correct`, name: `Correct ${id}` },
+  saveArtworkRef: {} as GameArtwork["saveArtworkRef"],
+})
+
+const round = (id: string): GameRound => ({
+  artwork: buildArtwork(id),
+  correctArtistID: `${id}-correct`,
+  choices: [
+    { internalID: `${id}-correct`, name: `Correct ${id}` },
+    { internalID: `${id}-w1`, name: `Wrong ${id} A` },
+    { internalID: `${id}-w2`, name: `Wrong ${id} B` },
+    { internalID: `${id}-w3`, name: `Wrong ${id} C` },
+  ],
+})
+
+describe("GamePlay", () => {
+  beforeEach(() => jest.useFakeTimers())
+  afterEach(() => jest.useRealTimers())
+
+  it("shows the current round and reports progress", () => {
+    const onProgress = jest.fn()
+    renderWithWrappers(
+      <GamePlay
+        rounds={[round("aw1"), round("aw2")]}
+        onFinish={jest.fn()}
+        onProgress={onProgress}
+      />
+    )
+
+    expect(screen.getByText("Correct aw1")).toBeOnTheScreen()
+    expect(screen.getByText("Wrong aw1 A")).toBeOnTheScreen()
+    expect(onProgress).toHaveBeenCalledWith(1, 2)
+  })
+
+  it("scores correct answers and finishes after the last round", () => {
+    const onFinish = jest.fn()
+    const onProgress = jest.fn()
+    renderWithWrappers(
+      <GamePlay rounds={[round("aw1"), round("aw2")]} onFinish={onFinish} onProgress={onProgress} />
+    )
+
+    // Round 1: pick the correct answer
+    fireEvent.press(screen.getByText("Correct aw1"))
+    act(() => jest.advanceTimersByTime(REVEAL_DELAY))
+
+    // Round 2: pick a wrong answer
+    expect(onProgress).toHaveBeenLastCalledWith(2, 2)
+    fireEvent.press(screen.getByText("Wrong aw2 A"))
+    act(() => jest.advanceTimersByTime(REVEAL_DELAY))
+
+    expect(onFinish).toHaveBeenCalledWith({ correctCount: 1, total: 2 })
+  })
+
+  it("ignores taps after an answer is locked in", () => {
+    const onFinish = jest.fn()
+    renderWithWrappers(
+      <GamePlay rounds={[round("aw1")]} onFinish={onFinish} onProgress={jest.fn()} />
+    )
+
+    fireEvent.press(screen.getByText("Correct aw1"))
+    // second tap on a wrong answer should be ignored
+    fireEvent.press(screen.getByText("Wrong aw1 A"))
+    act(() => jest.advanceTimersByTime(REVEAL_DELAY))
+
+    expect(onFinish).toHaveBeenCalledWith({ correctCount: 1, total: 1 })
+  })
+})
+
+describe("ArtworkArtistGamePlayQueryRenderer", () => {
+  const { renderWithRelay } = setupTestWrapper({
+    Component: ArtworkArtistGamePlayQueryRenderer,
+  })
+
+  const resolvers = {
+    Query: () => ({
+      // 15 fully-specified artworks so buildRounds can make the 10 required rounds.
+      discoverArtworks: {
+        edges: Array.from({ length: 15 }, (_, i) => ({
+          node: {
+            internalID: `aw-${i}`,
+            image: { url: `https://example.com/${i}.jpg`, width: 800, height: 600, blurhash: null },
+            artists: [{ internalID: "correct-artist", name: "The Correct Artist" }],
+          },
+        })),
+      },
+      highlights: {
+        popularArtists: [
+          { internalID: "p1", name: "Distractor One" },
+          { internalID: "p2", name: "Distractor Two" },
+          { internalID: "p3", name: "Distractor Three" },
+          { internalID: "p4", name: "Distractor Four" },
+        ],
+      },
+    }),
+  }
+
+  it("renders the first round's choices from fetched data", async () => {
+    renderWithRelay(resolvers, { onFinish: jest.fn() })
+
+    // The QueryRenderer suspends; flush the boundary so the resolved content renders.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText("The Correct Artist")).toBeOnTheScreen()
+    expect(screen.getByText("Artwork Image")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/ArtworkArtistGame/Components/__tests__/GameArtworkImage.tests.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/Components/__tests__/GameArtworkImage.tests.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { GameArtworkImageTestQuery } from "__generated__/GameArtworkImageTestQuery.graphql"
+import { GameArtworkImage } from "app/Scenes/ArtworkArtistGame/Components/GameArtworkImage"
+import { navigate } from "app/system/navigation/navigate"
+import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { graphql } from "react-relay"
+
+describe("GameArtworkImage", () => {
+  const { renderWithRelay } = setupTestWrapper<GameArtworkImageTestQuery>({
+    Component: ({ artwork }) => (
+      <GameArtworkImage
+        imageURL="https://example.com/art.jpg"
+        width={200}
+        height={150}
+        href="/artwork/some-artwork"
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        artworkRef={artwork!}
+      />
+    ),
+    query: graphql`
+      query GameArtworkImageTestQuery @relay_test_operation {
+        artwork(id: "x") {
+          ...useSaveArtworkToArtworkLists_artwork
+        }
+      }
+    `,
+    wrapperProps: { includeArtworkLists: true },
+  })
+
+  it("shows the save affordance and the double-tap hint", () => {
+    renderWithRelay({ Artwork: () => ({ isSaved: false }) })
+
+    expect(screen.getByText("Save")).toBeOnTheScreen()
+    expect(screen.getByTestId("empty-heart-icon")).toBeOnTheScreen()
+    expect(screen.getByText("Double tap the artwork to save it")).toBeOnTheScreen()
+  })
+
+  it("renders the saved state when the artwork is already saved", () => {
+    renderWithRelay({ Artwork: () => ({ isSaved: true }) })
+
+    expect(screen.getByText("Saved")).toBeOnTheScreen()
+    expect(screen.getByTestId("filled-heart-icon")).toBeOnTheScreen()
+  })
+
+  it("saves the artwork when the heart button is pressed", () => {
+    renderWithRelay({ Artwork: () => ({ isSaved: false }) })
+
+    fireEvent.press(screen.getByLabelText("Save artwork"))
+
+    // Optimistic update flips the heart to the saved state.
+    expect(screen.getByText("Saved")).toBeOnTheScreen()
+  })
+
+  it("navigates to the artwork page", () => {
+    renderWithRelay({ Artwork: () => ({ isSaved: false }) })
+
+    fireEvent.press(screen.getByTestId("game-view-artwork-link"))
+
+    expect(navigate).toHaveBeenCalledWith("/artwork/some-artwork")
+  })
+})

--- a/src/app/Scenes/ArtworkArtistGame/__tests__/ArtworkArtistGame.tests.tsx
+++ b/src/app/Scenes/ArtworkArtistGame/__tests__/ArtworkArtistGame.tests.tsx
@@ -1,0 +1,56 @@
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import { fireEvent, screen } from "@testing-library/react-native"
+import { ArtworkArtistGame } from "app/Scenes/ArtworkArtistGame/ArtworkArtistGame"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+// Stub the Relay-backed play screen so we can drive the game flow deterministically.
+jest.mock("app/Scenes/ArtworkArtistGame/Components/ArtworkArtistGamePlay", () => ({
+  ArtworkArtistGamePlayQueryRenderer: ({
+    onFinish,
+  }: {
+    onFinish: (result: { correctCount: number; total: number }) => void
+  }) => {
+    const { Text } = require("@artsy/palette-mobile")
+    return <Text onPress={() => onFinish({ correctCount: 8, total: 10 })}>Finish Game</Text>
+  },
+}))
+
+describe("ArtworkArtistGame", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
+  it("renders the start screen with a play button and empty history", async () => {
+    renderWithWrappers(<ArtworkArtistGame />)
+
+    expect(screen.getByText("Play")).toBeOnTheScreen()
+    expect(await screen.findByText("No games played yet.")).toBeOnTheScreen()
+  })
+
+  it("plays a game, shows the score, and persists it to history", async () => {
+    renderWithWrappers(<ArtworkArtistGame />)
+
+    fireEvent.press(screen.getByText("Play"))
+    fireEvent.press(await screen.findByText("Finish Game"))
+
+    // Results screen
+    expect(await screen.findByText("80%")).toBeOnTheScreen()
+    expect(screen.getByText("You got 8 out of 10 right")).toBeOnTheScreen()
+
+    // Back to start — the score is now in history
+    fireEvent.press(screen.getByText("Back to start"))
+    expect(await screen.findByText("80% (8/10)")).toBeOnTheScreen()
+  })
+
+  it("clears history", async () => {
+    renderWithWrappers(<ArtworkArtistGame />)
+
+    fireEvent.press(screen.getByText("Play"))
+    fireEvent.press(await screen.findByText("Finish Game"))
+    fireEvent.press(await screen.findByText("Back to start"))
+
+    fireEvent.press(await screen.findByText("Clear"))
+
+    expect(await screen.findByText("No games played yet.")).toBeOnTheScreen()
+  })
+})

--- a/src/app/Scenes/ArtworkArtistGame/utils/__tests__/buildRounds.tests.ts
+++ b/src/app/Scenes/ArtworkArtistGame/utils/__tests__/buildRounds.tests.ts
@@ -1,0 +1,97 @@
+import {
+  buildRounds,
+  CHOICES_PER_ROUND,
+  GameArtist,
+  GameArtwork,
+} from "app/Scenes/ArtworkArtistGame/utils/buildRounds"
+
+const artist = (id: string, name: string): GameArtist => ({ internalID: id, name })
+
+const artwork = (id: string, artistID: string, artistName: string): GameArtwork => ({
+  internalID: id,
+  title: `Artwork ${id}`,
+  href: `/artwork/${id}`,
+  imageURL: `https://example.com/${id}.jpg`,
+  imageWidth: 800,
+  imageHeight: 600,
+  blurhash: null,
+  artist: artist(artistID, artistName),
+  saveArtworkRef: {} as GameArtwork["saveArtworkRef"],
+})
+
+const pool: GameArtist[] = [
+  artist("p1", "Distractor One"),
+  artist("p2", "Distractor Two"),
+  artist("p3", "Distractor Three"),
+  artist("p4", "Distractor Four"),
+]
+
+describe("buildRounds", () => {
+  it("builds a round per artwork with the correct artist plus distractors", () => {
+    const rounds = buildRounds([artwork("aw1", "c1", "Correct Artist")], pool)
+
+    expect(rounds).toHaveLength(1)
+    expect(rounds[0].correctArtistID).toBe("c1")
+    expect(rounds[0].choices).toHaveLength(CHOICES_PER_ROUND)
+    expect(rounds[0].choices.map((c) => c.internalID)).toContain("c1")
+  })
+
+  it("excludes the correct artist from the distractors", () => {
+    const poolIncludingCorrect = [artist("c1", "Correct Artist"), ...pool]
+    const rounds = buildRounds([artwork("aw1", "c1", "Correct Artist")], poolIncludingCorrect)
+
+    const correctOccurrences = rounds[0].choices.filter((c) => c.internalID === "c1")
+    expect(correctOccurrences).toHaveLength(1)
+  })
+
+  it("excludes distractors that share the correct artist's name", () => {
+    const poolWithNameClash = [artist("other-id", "Correct Artist"), ...pool]
+    const rounds = buildRounds([artwork("aw1", "c1", "Correct Artist")], poolWithNameClash)
+
+    const names = rounds[0].choices.map((c) => c.name.toLowerCase())
+    // "Correct Artist" should appear exactly once (the correct one)
+    expect(names.filter((n) => n === "correct artist")).toHaveLength(1)
+  })
+
+  it("skips artworks without enough distractors to fill the choices", () => {
+    const smallPool = [artist("p1", "Only One")]
+    const rounds = buildRounds([artwork("aw1", "c1", "Correct Artist")], smallPool)
+
+    expect(rounds).toHaveLength(0)
+  })
+
+  it("caps rounds at 10 even when given more artworks", () => {
+    const manyArtworks = Array.from({ length: 15 }).map((_, i) =>
+      artwork(`aw${i}`, `c${i}`, `Correct ${i}`)
+    )
+    const rounds = buildRounds(manyArtworks, pool)
+
+    expect(rounds).toHaveLength(10)
+  })
+
+  it("falls back to later artworks when earlier ones lack enough distractors", () => {
+    // With a pool of exactly CHOICES_PER_ROUND - 1 distractors, an artwork whose
+    // correct artist shares a pool name drops the eligible count below the
+    // threshold and is skipped — so a later artwork must fill the round instead.
+    const tightPool = [artist("p1", "Distractor One"), artist("p2", "Two"), artist("p3", "Three")]
+    const unbuildable = artwork("bad", "cbad", "Distractor One") // name clash → only 2 distractors left
+    const buildable = Array.from({ length: 10 }).map((_, i) =>
+      artwork(`aw${i}`, `c${i}`, `Correct ${i}`)
+    )
+
+    const rounds = buildRounds([unbuildable, ...buildable], tightPool)
+
+    expect(rounds).toHaveLength(10)
+    // the skipped artwork should not appear
+    expect(rounds.map((r) => r.artwork.internalID)).not.toContain("bad")
+  })
+
+  it("uses the provided seeded shuffle to vary distractors per artwork", () => {
+    const reversingShuffle = (items: GameArtist[]) => [...items].reverse()
+    const rounds = buildRounds([artwork("aw1", "c1", "Correct Artist")], pool, reversingShuffle)
+
+    // With the pool reversed, the first distractor should be the last pool entry.
+    const distractors = rounds[0].choices.filter((c) => c.internalID !== "c1")
+    expect(distractors[0].internalID).toBe("p4")
+  })
+})

--- a/src/app/Scenes/ArtworkArtistGame/utils/__tests__/gameScoreHistory.tests.ts
+++ b/src/app/Scenes/ArtworkArtistGame/utils/__tests__/gameScoreHistory.tests.ts
@@ -1,0 +1,64 @@
+import AsyncStorage from "@react-native-async-storage/async-storage"
+import {
+  addGameScore,
+  clearGameScores,
+  GAME_SCORES_KEY,
+  GameScoreRecord,
+  getGameScores,
+  MAX_STORED_SCORES,
+} from "app/Scenes/ArtworkArtistGame/utils/gameScoreHistory"
+
+const record = (percentage: number): GameScoreRecord => ({
+  correctCount: percentage / 10,
+  total: 10,
+  percentage,
+  date: new Date().toISOString(),
+})
+
+describe("gameScoreHistory", () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear()
+  })
+
+  it("returns an empty array when nothing is stored", async () => {
+    expect(await getGameScores()).toEqual([])
+  })
+
+  it("stores a score and reads it back", async () => {
+    await addGameScore(record(80))
+
+    const scores = await getGameScores()
+    expect(scores).toHaveLength(1)
+    expect(scores[0].percentage).toBe(80)
+  })
+
+  it("prepends newer scores", async () => {
+    await addGameScore(record(50))
+    await addGameScore(record(90))
+
+    const scores = await getGameScores()
+    expect(scores.map((s) => s.percentage)).toEqual([90, 50])
+  })
+
+  it("caps stored scores at MAX_STORED_SCORES", async () => {
+    for (let i = 0; i <= MAX_STORED_SCORES; i++) {
+      await addGameScore(record((i % 10) * 10))
+    }
+
+    const scores = await getGameScores()
+    expect(scores).toHaveLength(MAX_STORED_SCORES)
+  })
+
+  it("clears scores", async () => {
+    await addGameScore(record(70))
+    await clearGameScores()
+
+    expect(await getGameScores()).toEqual([])
+  })
+
+  it("returns an empty array when stored value is corrupt", async () => {
+    await AsyncStorage.setItem(GAME_SCORES_KEY, "not json")
+
+    expect(await getGameScores()).toEqual([])
+  })
+})

--- a/src/app/Scenes/ArtworkArtistGame/utils/buildRounds.ts
+++ b/src/app/Scenes/ArtworkArtistGame/utils/buildRounds.ts
@@ -1,0 +1,87 @@
+import { useSaveArtworkToArtworkLists_artwork$key } from "__generated__/useSaveArtworkToArtworkLists_artwork.graphql"
+
+export const ROUNDS_PER_GAME = 10
+export const CHOICES_PER_ROUND = 4
+
+export interface GameArtist {
+  internalID: string
+  name: string
+}
+
+export interface GameArtwork {
+  internalID: string
+  title: string | null | undefined
+  href: string | null
+  imageURL: string
+  imageWidth: number | null | undefined
+  imageHeight: number | null | undefined
+  blurhash: string | null | undefined
+  artist: GameArtist
+  /** Relay fragment ref used to save the artwork. */
+  saveArtworkRef: useSaveArtworkToArtworkLists_artwork$key
+}
+
+export interface GameRound {
+  artwork: GameArtwork
+  choices: GameArtist[]
+  correctArtistID: string
+}
+
+/**
+ * Optional shuffle applied to the distractor pool, keyed by a per-artwork seed,
+ * so each round draws a different set of wrong answers. Defaults to identity
+ * (deterministic) for easy testing.
+ */
+type SeededShuffle = (items: GameArtist[], seed: string) => GameArtist[]
+
+/**
+ * Builds up to ROUNDS_PER_GAME rounds. Each round pairs an artwork with
+ * CHOICES_PER_ROUND artist choices: the correct artist plus distractors drawn
+ * from `artistPool` (excluding the correct artist and duplicate names).
+ *
+ * The `correct` choice is always placed first — shuffle the final choice order
+ * at render time (seeded by artwork id) so it is stable across re-renders.
+ */
+export const buildRounds = (
+  artworks: GameArtwork[],
+  artistPool: GameArtist[],
+  shuffleWithSeed: SeededShuffle = (items) => items
+): GameRound[] => {
+  return artworks.reduce<GameRound[]>((rounds, artwork) => {
+    // Stop once we have a full game — later artworks are only used as fallback
+    // for any earlier ones that couldn't build a full set of choices.
+    if (rounds.length >= ROUNDS_PER_GAME) return rounds
+
+    const correct = artwork.artist
+
+    const eligible = artistPool
+      .filter(
+        (artist) =>
+          artist.internalID !== correct.internalID &&
+          artist.name.toLowerCase() !== correct.name.toLowerCase()
+      )
+      // de-dupe distractor names so choices never repeat
+      .filter(
+        (artist, index, self) =>
+          self.findIndex((a) => a.name.toLowerCase() === artist.name.toLowerCase()) === index
+      )
+
+    const distractors = shuffleWithSeed(eligible, artwork.internalID).slice(
+      0,
+      CHOICES_PER_ROUND - 1
+    )
+
+    // Skip artworks we can't build a full set of choices for.
+    if (distractors.length < CHOICES_PER_ROUND - 1) {
+      return rounds
+    }
+
+    rounds.push({
+      artwork,
+      choices: [correct, ...distractors],
+      correctArtistID: correct.internalID,
+    })
+
+    return rounds
+  }, [])
+}

--- a/src/app/Scenes/ArtworkArtistGame/utils/gameScoreHistory.ts
+++ b/src/app/Scenes/ArtworkArtistGame/utils/gameScoreHistory.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from "@react-native-async-storage/async-storage"
+
+export const GAME_SCORES_KEY = "ARTWORK_ARTIST_GAME_SCORES"
+export const MAX_STORED_SCORES = 20
+
+export interface GameScoreRecord {
+  correctCount: number
+  total: number
+  percentage: number
+  /** ISO date string of when the game was completed */
+  date: string
+}
+
+export const getGameScores = async (): Promise<GameScoreRecord[]> => {
+  try {
+    const json = await AsyncStorage.getItem(GAME_SCORES_KEY)
+
+    if (!json) return []
+
+    const scores = JSON.parse(json)
+
+    return Array.isArray(scores) ? scores : []
+  } catch (error) {
+    console.error("Failed to read game scores", error)
+    return []
+  }
+}
+
+export const addGameScore = async (record: GameScoreRecord): Promise<GameScoreRecord[]> => {
+  const scores = await getGameScores()
+  const updated = [record, ...scores].slice(0, MAX_STORED_SCORES)
+
+  await AsyncStorage.setItem(GAME_SCORES_KEY, JSON.stringify(updated))
+
+  return updated
+}
+
+export const clearGameScores = async (): Promise<void> => {
+  await AsyncStorage.removeItem(GAME_SCORES_KEY)
+}

--- a/src/app/system/devTools/DevMenu/Components/DevTools.tsx
+++ b/src/app/system/devTools/DevMenu/Components/DevTools.tsx
@@ -62,6 +62,12 @@ export const DevTools: React.FC<{}> = () => {
               dismissModal(() => navigate("/art-quiz"))
             }}
           />
+          <DevMenuButtonItem
+            title="Open Artist Guessing Game"
+            onPress={() => {
+              dismissModal(() => navigate("/artwork-artist-game"))
+            }}
+          />
           <Flex flexDirection="row" justifyContent="space-between" alignItems="center">
             <Flex>
               <MenuItem title="Migration version" />

--- a/src/app/utils/hooks/useStableShuffle.ts
+++ b/src/app/utils/hooks/useStableShuffle.ts
@@ -55,7 +55,7 @@ const mulberry32 = (a: number) => {
  * Returns a Fisher-Yates shuffle function seeded with seed value
  * https://stackoverflow.com/a/53758827/160937
  */
-const seededShuffle = (seed: string) => {
+export const seededShuffle = (seed: string) => {
   const hash = xmur3(seed)
   const random = mulberry32(hash())
 


### PR DESCRIPTION
### Description

Adds a **Guess the Artist** game, reachable from the Dev Menu. Players see 10 artworks and pick the artist who made each one; they can save any artwork, and per-game scores are kept in local history. Includes Moti reveal, round-transition, and results animations.

Dev-menu only — no user-facing routes or feature flag needed.

<video src="https://github.com/user-attachments/assets/4d1ae84c-08d6-4690-b382-65ad29873adf" width="500" />


### PR Checklist

- [x] I have added **tests**, or my changes don't require any.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one (dev-menu only).

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add a "Guess the Artist" game to the Dev Menu.

<!-- end_changelog_updates -->

</details>
