### PR TITLE
feat: show curator notes on collection pages and rails

### DIFF
--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -1,4 +1,10 @@
-import { ActionType, ContextModule, OwnerType, TappedMainArtworkGrid } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  TappedCuratorNote,
+  TappedMainArtworkGrid,
+} from "@artsy/cohesion"
 import {
   Box,
   Flex,
@@ -232,6 +238,7 @@ export const Artwork: React.FC<ArtworkProps> = memo(
           destination_screen_owner_type: OwnerType.artwork,
           destination_screen_owner_id: artwork.internalID,
           destination_screen_owner_slug: artwork.slug,
+          has_curator_note: !!curatorNote,
           position: itemIndex,
           query: contextScreenQuery,
           sort: filterParams?.sort,
@@ -451,7 +458,26 @@ export const Artwork: React.FC<ArtworkProps> = memo(
                     />
                   )}
 
-                  {!!curatorNote && <CollectorNote note={curatorNote} />}
+                  {!!curatorNote && (
+                    <CollectorNote
+                      note={curatorNote}
+                      onTap={() => {
+                        if (!contextScreenOwnerType) {
+                          return
+                        }
+                        const noteTapEvent: TappedCuratorNote = {
+                          action: ActionType.tappedCuratorNote,
+                          context_module: contextModule || ContextModule.artworkGrid,
+                          context_screen_owner_type: contextScreenOwnerType,
+                          context_screen_owner_id: contextScreenOwnerId,
+                          context_screen_owner_slug: contextScreenOwnerSlug,
+                          artwork_id: artwork.internalID,
+                          artwork_slug: artwork.slug,
+                        }
+                        tracking.trackEvent(noteTapEvent)
+                      }}
+                    />
+                  )}
 
                   {!!displayArtworkSocialSignal && (
                     <ArtworkSocialSignal

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -20,6 +20,7 @@ import { ArtworksFiltersStore } from "app/Components/ArtworkFilter/ArtworkFilter
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
 import { ArtworkSaveIconWrapper } from "app/Components/ArtworkGrids/ArtworkSaveIconWrapper"
 import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
+import { CollectorNote } from "app/Components/ArtworkGrids/CollectorNote"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { ArtworkSaleMessage } from "app/Components/ArtworkRail/ArtworkSaleMessage"
 import { ContextMenuArtwork, trackLongPress } from "app/Components/ContextMenu/ContextMenuArtwork"
@@ -54,6 +55,8 @@ export interface ArtworkProps extends ArtworkActionTrackingProps {
   artistNamesTextStyle?: TextProps
   artwork: ArtworkGridItem_artwork$data
   artworkMetaStyle?: ViewProps["style"]
+  /** Curator's note for this artwork within a marketing collection (edge-level field) */
+  curatorNote?: string | null
   disableArtworksListPrompt?: boolean
   disableProgressiveOnboarding?: boolean
   /** Hide sale info */
@@ -90,6 +93,7 @@ export const Artwork: React.FC<ArtworkProps> = memo(
     artistNamesTextStyle,
     artwork,
     artworkMetaStyle,
+    curatorNote,
     contextModule,
     contextScreen,
     contextScreenOwnerId,
@@ -446,6 +450,8 @@ export const Artwork: React.FC<ArtworkProps> = memo(
                       hideRegisterBySignal={hideRegisterBySignal}
                     />
                   )}
+
+                  {!!curatorNote && <CollectorNote note={curatorNote} />}
 
                   {!!displayArtworkSocialSignal && (
                     <ArtworkSocialSignal

--- a/src/app/Components/ArtworkGrids/CollectorNote.tsx
+++ b/src/app/Components/ArtworkGrids/CollectorNote.tsx
@@ -1,0 +1,35 @@
+import { Flex, Text } from "@artsy/palette-mobile"
+
+interface CollectorNoteProps {
+  note: string
+  dark?: boolean
+}
+
+/**
+ * Renders a curator's note for an artwork within a marketing collection.
+ *
+ * The note is an edge-level field on `MarketingCollection.artworksConnection`
+ * (not a field on the `Artwork` node), so it is passed in as a plain string
+ * prop rather than via a Relay fragment. It is intentionally distinct from the
+ * collector social signal badge (`ArtworkSocialSignal`) and is meant to render
+ * directly above it.
+ */
+export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false }) => {
+  if (!note) {
+    return null
+  }
+
+  const primaryColor = dark ? "mono0" : "mono100"
+  const secondaryColor = dark ? "mono30" : "mono60"
+
+  return (
+    <Flex flexDirection="column">
+      <Text color={secondaryColor} variant="xs">
+        Curator’s note
+      </Text>
+      <Text color={primaryColor} variant="xs" numberOfLines={2} ellipsizeMode="tail">
+        {note}
+      </Text>
+    </Flex>
+  )
+}

--- a/src/app/Components/ArtworkGrids/CollectorNote.tsx
+++ b/src/app/Components/ArtworkGrids/CollectorNote.tsx
@@ -1,4 +1,8 @@
-import { Flex, Text } from "@artsy/palette-mobile"
+import { Flex, Text, Touchable } from "@artsy/palette-mobile"
+import { BottomSheetView } from "@gorhom/bottom-sheet"
+import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
+import { useState } from "react"
+import { Platform } from "react-native"
 
 interface CollectorNoteProps {
   note: string
@@ -11,10 +15,14 @@ interface CollectorNoteProps {
  * The note is an edge-level field on `MarketingCollection.artworksConnection`
  * (not a field on the `Artwork` node), so it is passed in as a plain string
  * prop rather than via a Relay fragment. It is intentionally distinct from the
- * collector social signal badge (`ArtworkSocialSignal`) and is meant to render
- * directly above it.
+ * collector social signal badge (`ArtworkSocialSignal`) and renders directly
+ * above it.
+ *
+ * The inline badge is truncated; tapping it opens a bottom sheet with the full note.
  */
 export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false }) => {
+  const [visible, setVisible] = useState(false)
+
   if (!note) {
     return null
   }
@@ -22,14 +30,44 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
   const primaryColor = dark ? "mono0" : "mono100"
   const secondaryColor = dark ? "mono30" : "mono60"
 
+  // The bottom sheet renders differently on iOS vs Android; mirror the pattern
+  // used elsewhere in the app (see AlertBottomSheet).
+  const bottomSheetViewStyles = Platform.OS === "ios" ? { flex: 1 } : {}
+
   return (
-    <Flex flexDirection="column">
-      <Text color={secondaryColor} variant="xs">
-        Curator’s note
-      </Text>
-      <Text color={primaryColor} variant="xs" numberOfLines={2} ellipsizeMode="tail">
-        {note}
-      </Text>
-    </Flex>
+    <>
+      <Touchable
+        accessibilityRole="button"
+        accessibilityLabel="Read the curator’s note"
+        onPress={() => setVisible(true)}
+      >
+        <Flex flexDirection="column">
+          <Text color={secondaryColor} variant="xs">
+            Curator’s note
+          </Text>
+          <Text color={primaryColor} variant="xs" numberOfLines={2} ellipsizeMode="tail">
+            {note}
+          </Text>
+        </Flex>
+      </Touchable>
+
+      {!!visible && (
+        <AutomountedBottomSheetModal
+          enableDynamicSizing
+          visible
+          name="CollectorNoteBottomSheet"
+          onDismiss={() => setVisible(false)}
+        >
+          <BottomSheetView style={bottomSheetViewStyles}>
+            <Flex mb={4} mx={2}>
+              <Text variant="sm-display" mb={1}>
+                Curator’s note
+              </Text>
+              <Text variant="sm">{note}</Text>
+            </Flex>
+          </BottomSheetView>
+        </AutomountedBottomSheetModal>
+      )}
+    </>
   )
 }

--- a/src/app/Components/ArtworkGrids/CollectorNote.tsx
+++ b/src/app/Components/ArtworkGrids/CollectorNote.tsx
@@ -1,12 +1,15 @@
 import { Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { BottomSheetView } from "@gorhom/bottom-sheet"
 import { AutomountedBottomSheetModal } from "app/Components/BottomSheet/AutomountedBottomSheetModal"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState } from "react"
 import { Platform } from "react-native"
 
 interface CollectorNoteProps {
   note: string
   dark?: boolean
+  /** Fired when the note is tapped, before the bottom sheet opens (for tracking). */
+  onTap?: () => void
 }
 
 /**
@@ -18,10 +21,11 @@ interface CollectorNoteProps {
  * label (styled like the collector signal labels) that invites a tap; tapping
  * opens a bottom sheet with the full note.
  */
-export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false }) => {
+export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false, onTap }) => {
   const [visible, setVisible] = useState(false)
+  const enableCuratorNotes = useFeatureFlag("AREnableCuratorNotes")
 
-  if (!note) {
+  if (!note || !enableCuratorNotes) {
     return null
   }
 
@@ -37,7 +41,10 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
       <Touchable
         accessibilityRole="button"
         accessibilityLabel="Read the curator’s note"
-        onPress={() => setVisible(true)}
+        onPress={() => {
+          onTap?.()
+          setVisible(true)
+        }}
       >
         <Flex
           flexDirection="row"

--- a/src/app/Components/ArtworkGrids/CollectorNote.tsx
+++ b/src/app/Components/ArtworkGrids/CollectorNote.tsx
@@ -9,6 +9,12 @@ interface CollectorNoteProps {
   dark?: boolean
 }
 
+// The inline badge shows at most 2 lines. Notes longer than this are very likely
+// to be truncated in the narrow grid/rail card, so we surface a "Read more" cue.
+// A length heuristic keeps layout stable (no measuring pass that could momentarily
+// render the full note) and is good enough for a fixed-width card.
+const READ_MORE_THRESHOLD = 80
+
 /**
  * Renders a curator's note for an artwork within a marketing collection.
  *
@@ -29,6 +35,8 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
 
   const primaryColor = dark ? "mono0" : "mono100"
   const secondaryColor = dark ? "mono30" : "mono60"
+  const linkColor = dark ? "mono0" : "blue100"
+  const showReadMore = note.length > READ_MORE_THRESHOLD
 
   // The bottom sheet renders differently on iOS vs Android; mirror the pattern
   // used elsewhere in the app (see AlertBottomSheet).
@@ -48,6 +56,11 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
           <Text color={primaryColor} variant="xs" numberOfLines={2} ellipsizeMode="tail">
             {note}
           </Text>
+          {!!showReadMore && (
+            <Text color={linkColor} variant="xs" underline>
+              Read more
+            </Text>
+          )}
         </Flex>
       </Touchable>
 

--- a/src/app/Components/ArtworkGrids/CollectorNote.tsx
+++ b/src/app/Components/ArtworkGrids/CollectorNote.tsx
@@ -9,22 +9,14 @@ interface CollectorNoteProps {
   dark?: boolean
 }
 
-// The inline badge shows at most 2 lines. Notes longer than this are very likely
-// to be truncated in the narrow grid/rail card, so we surface a "Read more" cue.
-// A length heuristic keeps layout stable (no measuring pass that could momentarily
-// render the full note) and is good enough for a fixed-width card.
-const READ_MORE_THRESHOLD = 80
-
 /**
  * Renders a curator's note for an artwork within a marketing collection.
  *
  * The note is an edge-level field on `MarketingCollection.artworksConnection`
  * (not a field on the `Artwork` node), so it is passed in as a plain string
- * prop rather than via a Relay fragment. It is intentionally distinct from the
- * collector social signal badge (`ArtworkSocialSignal`) and renders directly
- * above it.
- *
- * The inline badge is truncated; tapping it opens a bottom sheet with the full note.
+ * prop rather than via a Relay fragment. It renders as a compact, bordered
+ * label (styled like the collector signal labels) that invites a tap; tapping
+ * opens a bottom sheet with the full note.
  */
 export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false }) => {
   const [visible, setVisible] = useState(false)
@@ -34,9 +26,7 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
   }
 
   const primaryColor = dark ? "mono0" : "mono100"
-  const secondaryColor = dark ? "mono30" : "mono60"
-  const linkColor = dark ? "mono0" : "blue100"
-  const showReadMore = note.length > READ_MORE_THRESHOLD
+  const borderColor = dark ? "mono30" : "mono60"
 
   // The bottom sheet renders differently on iOS vs Android; mirror the pattern
   // used elsewhere in the app (see AlertBottomSheet).
@@ -49,18 +39,18 @@ export const CollectorNote: React.FC<CollectorNoteProps> = ({ note, dark = false
         accessibilityLabel="Read the curator’s note"
         onPress={() => setVisible(true)}
       >
-        <Flex flexDirection="column">
-          <Text color={secondaryColor} variant="xs">
+        <Flex
+          flexDirection="row"
+          alignItems="center"
+          alignSelf="flex-start"
+          borderWidth={1}
+          borderColor={borderColor}
+          borderRadius={3}
+          px={0.5}
+        >
+          <Text color={primaryColor} variant="xs">
             Curator’s note
           </Text>
-          <Text color={primaryColor} variant="xs" numberOfLines={2} ellipsizeMode="tail">
-            {note}
-          </Text>
-          {!!showReadMore && (
-            <Text color={linkColor} variant="xs" underline>
-              Read more
-            </Text>
-          )}
         </Flex>
       </Touchable>
 

--- a/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
@@ -15,4 +15,12 @@ describe("CollectorNote", () => {
 
     expect(screen.queryByText("Curator’s note")).not.toBeOnTheScreen()
   })
+
+  it("shows a Read more cue for long notes but not short ones", () => {
+    const { rerender } = renderWithWrappers(<CollectorNote note="A short note." />)
+    expect(screen.queryByText("Read more")).not.toBeOnTheScreen()
+
+    rerender(<CollectorNote note={"A much longer curator note ".repeat(6)} />)
+    expect(screen.getByText("Read more")).toBeOnTheScreen()
+  })
 })

--- a/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
@@ -3,24 +3,18 @@ import { CollectorNote } from "app/Components/ArtworkGrids/CollectorNote"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("CollectorNote", () => {
-  it("renders the note text and label", () => {
+  it("renders a tappable Curator's note label", () => {
     renderWithWrappers(<CollectorNote note="Chosen for its bold use of color" />)
 
+    // The inline representation is a compact label; the full note lives in the
+    // bottom sheet that opens on tap.
     expect(screen.getByText("Curator’s note")).toBeOnTheScreen()
-    expect(screen.getByText("Chosen for its bold use of color")).toBeOnTheScreen()
+    expect(screen.getByLabelText("Read the curator’s note")).toBeOnTheScreen()
   })
 
   it("renders nothing when the note is empty", () => {
     renderWithWrappers(<CollectorNote note="" />)
 
     expect(screen.queryByText("Curator’s note")).not.toBeOnTheScreen()
-  })
-
-  it("shows a Read more cue for long notes but not short ones", () => {
-    const { rerender } = renderWithWrappers(<CollectorNote note="A short note." />)
-    expect(screen.queryByText("Read more")).not.toBeOnTheScreen()
-
-    rerender(<CollectorNote note={"A much longer curator note ".repeat(6)} />)
-    expect(screen.getByText("Read more")).toBeOnTheScreen()
   })
 })

--- a/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
@@ -3,6 +3,10 @@ import { CollectorNote } from "app/Components/ArtworkGrids/CollectorNote"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 describe("CollectorNote", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCuratorNotes: true })
+  })
+
   it("renders a tappable Curator's note label", () => {
     renderWithWrappers(<CollectorNote note="Chosen for its bold use of color" />)
 
@@ -14,6 +18,14 @@ describe("CollectorNote", () => {
 
   it("renders nothing when the note is empty", () => {
     renderWithWrappers(<CollectorNote note="" />)
+
+    expect(screen.queryByText("Curator’s note")).not.toBeOnTheScreen()
+  })
+
+  it("renders nothing when the feature flag is off", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableCuratorNotes: false })
+
+    renderWithWrappers(<CollectorNote note="Chosen for its bold use of color" />)
 
     expect(screen.queryByText("Curator’s note")).not.toBeOnTheScreen()
   })

--- a/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
+++ b/src/app/Components/ArtworkGrids/__tests__/CollectorNote.tests.tsx
@@ -1,0 +1,18 @@
+import { screen } from "@testing-library/react-native"
+import { CollectorNote } from "app/Components/ArtworkGrids/CollectorNote"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("CollectorNote", () => {
+  it("renders the note text and label", () => {
+    renderWithWrappers(<CollectorNote note="Chosen for its bold use of color" />)
+
+    expect(screen.getByText("Curator’s note")).toBeOnTheScreen()
+    expect(screen.getByText("Chosen for its bold use of color")).toBeOnTheScreen()
+  })
+
+  it("renders nothing when the note is empty", () => {
+    renderWithWrappers(<CollectorNote note="" />)
+
+    expect(screen.queryByText("Curator’s note")).not.toBeOnTheScreen()
+  })
+})

--- a/src/app/Components/ArtworkRail/ArtworkRail.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRail.tsx
@@ -23,6 +23,12 @@ type Artwork = ArtworkRail_artworks$data[0]
 export interface ArtworkRailProps extends ArtworkActionTrackingProps {
   artworks: ArtworkRail_artworks$key
   onPress?: (artwork: ArtworkRail_artworks$data[0], index: number) => void
+  /**
+   * Curator's notes keyed by artwork `internalID`. Used to render a curator's note
+   * badge on marketing-collection rails. `note` is an edge-level field, so it can't
+   * ride along on the artwork node fragment and is threaded in via this map.
+   */
+  curatorNotes?: Record<string, string | null>
   dark?: boolean
   hideArtistName?: boolean
   hideCuratorsPickSignal?: boolean
@@ -60,6 +66,7 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
     onMorePress,
     hideIncreasedInterestSignal,
     hideCuratorsPickSignal,
+    curatorNotes,
     ...otherProps
   }) => {
     const artworks = useFragment(artworksFragment, otherProps.artworks)
@@ -80,11 +87,22 @@ export const ArtworkRail: React.FC<ArtworkRailProps> = memo(
             showSaveIcon={showSaveIcon}
             hideIncreasedInterestSignal={hideIncreasedInterestSignal}
             hideCuratorsPickSignal={hideCuratorsPickSignal}
+            curatorNote={curatorNotes?.[item.internalID]}
             {...otherProps}
           />
         )
       },
-      [hideArtistName, onPress, showPartnerName]
+      [
+        hideArtistName,
+        onPress,
+        showPartnerName,
+        curatorNotes,
+        dark,
+        showSaveIcon,
+        hideIncreasedInterestSignal,
+        hideCuratorsPickSignal,
+        itemHref,
+      ]
     )
 
     const listFooterComponent = useMemo(() => {

--- a/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCard.tsx
@@ -40,6 +40,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = memo(
     contextScreenOwnerId,
     contextScreenOwnerSlug,
     contextScreen,
+    curatorNote,
     dark = false,
     href,
     hideArtistName = false,
@@ -128,6 +129,7 @@ export const ArtworkRailCard: React.FC<ArtworkRailCardProps> = memo(
                     contextScreenOwnerId={contextScreenOwnerId}
                     contextScreenOwnerSlug={contextScreenOwnerSlug}
                     contextScreenOwnerType={contextScreenOwnerType}
+                    curatorNote={curatorNote}
                     dark={dark}
                     hideArtistName={hideArtistName}
                     hideCuratorsPickSignal={hideCuratorsPickSignal}

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -3,6 +3,7 @@ import { ArtworkRailCardMeta_artwork$key } from "__generated__/ArtworkRailCardMe
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
 import { ArtworkSaveIconWrapper } from "app/Components/ArtworkGrids/ArtworkSaveIconWrapper"
 import { ArtworkSocialSignal } from "app/Components/ArtworkGrids/ArtworkSocialSignal"
+import { CollectorNote } from "app/Components/ArtworkGrids/CollectorNote"
 import { useSaveArtworkToArtworkLists } from "app/Components/ArtworkLists/useSaveArtworkToArtworkLists"
 import { useMetaDataTextColor } from "app/Components/ArtworkRail/ArtworkRailUtils"
 import { ArtworkSaleMessage } from "app/Components/ArtworkRail/ArtworkSaleMessage"
@@ -20,6 +21,8 @@ import { useTracking } from "react-tracking"
 // These are the props that are shared between ArtworkRailCard and ArtworkRailCardMeta
 export interface ArtworkRailCardCommonProps extends ArtworkActionTrackingProps {
   dark?: boolean
+  /** Curator's note for this artwork within a marketing collection (edge-level field) */
+  curatorNote?: string | null
   hideArtistName?: boolean
   hideIncreasedInterestSignal?: boolean
   hideCuratorsPickSignal?: boolean
@@ -49,6 +52,7 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
   contextScreenOwnerId,
   contextScreenOwnerSlug,
   contextScreenOwnerType,
+  curatorNote,
   dark = false,
   hideArtistName = false,
   hideCuratorsPickSignal = false,
@@ -194,6 +198,8 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
         {!!displayAuctionSignal && !!collectorSignals && (
           <ArtworkAuctionTimer collectorSignals={collectorSignals} inRailCard />
         )}
+
+        {!!curatorNote && <CollectorNote note={curatorNote} dark={dark} />}
 
         {!!displayArtworkSocialSignal && (
           <ArtworkSocialSignal

--- a/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
+++ b/src/app/Components/ArtworkRail/ArtworkRailCardMeta.tsx
@@ -1,3 +1,4 @@
+import { ActionType, TappedCuratorNote } from "@artsy/cohesion"
 import { Flex, Text, Touchable } from "@artsy/palette-mobile"
 import { ArtworkRailCardMeta_artwork$key } from "__generated__/ArtworkRailCardMeta_artwork.graphql"
 import { ArtworkAuctionTimer } from "app/Components/ArtworkGrids/ArtworkAuctionTimer"
@@ -199,7 +200,27 @@ export const ArtworkRailCardMeta: React.FC<ArtworkRailCardMetaProps> = ({
           <ArtworkAuctionTimer collectorSignals={collectorSignals} inRailCard />
         )}
 
-        {!!curatorNote && <CollectorNote note={curatorNote} dark={dark} />}
+        {!!curatorNote && (
+          <CollectorNote
+            note={curatorNote}
+            dark={dark}
+            onTap={() => {
+              if (!contextModule || !contextScreenOwnerType) {
+                return
+              }
+              const noteTapEvent: TappedCuratorNote = {
+                action: ActionType.tappedCuratorNote,
+                context_module: contextModule,
+                context_screen_owner_type: contextScreenOwnerType,
+                context_screen_owner_id: contextScreenOwnerId,
+                context_screen_owner_slug: contextScreenOwnerSlug,
+                artwork_id: artwork.internalID,
+                artwork_slug: artwork.slug,
+              }
+              trackEvent(noteTapEvent)
+            }}
+          />
+        )}
 
         {!!displayArtworkSocialSignal && (
           <ArtworkSocialSignal

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -45,6 +45,19 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
     () => extractNodes(collection.collectionArtworks),
     [collection.collectionArtworks]
   )
+
+  // `note` is an edge-level field on the marketing collection's artworksConnection,
+  // so it can't ride along on the artwork node fragment. Build a lookup keyed by the
+  // node id and thread it into each grid item as a plain prop.
+  const curatorNotesByArtworkId = useMemo(() => {
+    const notes: Record<string, string> = {}
+    collection.collectionArtworks?.edges?.forEach((edge) => {
+      if (edge?.node?.id && edge?.note) {
+        notes[edge.node.id] = edge.note
+      }
+    })
+    return notes
+  }, [collection.collectionArtworks])
   const gridRef = useRef<FlashListRef<(typeof artworksList)[0]>>(null)
 
   const scrollToTop = () => {
@@ -120,11 +133,12 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
         contextScreenOwnerSlug={collection.slug}
         artwork={item}
         height={imgHeight}
+        curatorNote={curatorNotesByArtworkId[item.id]}
         hideCuratorsPickSignal={hideSignals}
         hideIncreasedInterestSignal={hideSignals}
       />
     )
-  }, [])
+  }, [collection.id, collection.slug, curatorNotesByArtworkId, width, space])
 
   return (
     <>
@@ -213,6 +227,7 @@ export const CollectionArtworksFragmentContainer = createPaginationContainer(
             total
           }
           edges {
+            note
             node {
               id
               slug

--- a/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
+++ b/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { ChevronRightIcon } from "@artsy/icons/native"
 import { Flex, Separator, Skeleton, SkeletonText, Spacer } from "@artsy/palette-mobile"
 import { ArtworkRail_artworks$data } from "__generated__/ArtworkRail_artworks.graphql"
@@ -39,7 +40,7 @@ export const CollectionRail: FC<CollectionRailProps> = ({
   }
 
   const handleArtworkPress = (artwork: ArtworkRail_artworks$data[0], index: number) => {
-    trackArtworkRailItemTap(artwork.internalID, index)
+    trackArtworkRailItemTap(artwork.internalID, index, !!curatorNotes[artwork.internalID])
   }
 
   const handleTitlePress = () => {
@@ -65,6 +66,9 @@ export const CollectionRail: FC<CollectionRailProps> = ({
           onPress={handleArtworkPress}
           artworks={artworks}
           curatorNotes={curatorNotes}
+          contextModule={ContextModule.collectionRail}
+          contextScreenOwnerType={OwnerType.collectionsCategory}
+          contextScreenOwnerSlug={collection.slug}
           showSaveIcon
           showPartnerName
         />

--- a/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
+++ b/src/app/Scenes/CollectionsByCategory/Components/CollectionRail.tsx
@@ -25,6 +25,15 @@ export const CollectionRail: FC<CollectionRailProps> = ({
 
   const artworks = extractNodes(collection?.artworksConnection)
 
+  // `note` is an edge-level field, so build a lookup keyed by artwork internalID and
+  // pass it to the rail, which threads each note down to its card as a plain prop.
+  const curatorNotes: Record<string, string | null> = {}
+  collection?.artworksConnection?.edges?.forEach((edge) => {
+    if (edge?.node?.internalID && edge?.note) {
+      curatorNotes[edge.node.internalID] = edge.note
+    }
+  })
+
   if (!collection || !artworks.length) {
     return null
   }
@@ -55,6 +64,7 @@ export const CollectionRail: FC<CollectionRailProps> = ({
         <ArtworkRail
           onPress={handleArtworkPress}
           artworks={artworks}
+          curatorNotes={curatorNotes}
           showSaveIcon
           showPartnerName
         />
@@ -71,6 +81,7 @@ const fragment = graphql`
 
     artworksConnection(first: 10, sort: "-decayed_merch") {
       edges {
+        note
         node {
           ...ArtworkRail_artworks
 

--- a/src/app/Scenes/CollectionsByCategory/hooks/useCollectionByCategoryTracking.ts
+++ b/src/app/Scenes/CollectionsByCategory/hooks/useCollectionByCategoryTracking.ts
@@ -23,13 +23,14 @@ export const useCollectionByCategoryTracking = () => {
     trackEvent(payload)
   }
 
-  const trackArtworkRailItemTap = (slug: string, index: number) => {
+  const trackArtworkRailItemTap = (slug: string, index: number, hasCuratorNote?: boolean) => {
     const payload: TappedArtworkGroup = {
       action: ActionType.tappedArtworkGroup,
       context_module: ContextModule.collectionRail,
       context_screen_owner_type: OwnerType.collectionsCategory,
       destination_screen_owner_slug: slug,
       destination_screen_owner_type: OwnerType.artwork,
+      has_curator_note: hasCuratorNote,
       horizontal_slide_position: index,
       type: "thumbnail",
     }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -50,6 +50,15 @@ export const HomeViewSectionFeaturedCollection: React.FC<
   const artworks = extractNodes(section.artworksConnection)
   const viewAllHref = getHomeViewSectionHref(viewAll?.href, section)
 
+  // `note` is an edge-level field, so build a lookup keyed by artwork internalID and
+  // pass it to the rail, which threads each note down to its card as a plain prop.
+  const curatorNotes: Record<string, string | null> = {}
+  section.artworksConnection?.edges?.forEach((edge) => {
+    if (edge?.node?.internalID && edge?.note) {
+      curatorNotes[edge.node.internalID] = edge.note
+    }
+  })
+
   const onHeaderPress = () => {
     tracking.tappedArtworkGroupViewAll(
       section.contextModule as ContextModule,
@@ -106,6 +115,7 @@ export const HomeViewSectionFeaturedCollection: React.FC<
           dark
           showPartnerName
           artworks={artworks}
+          curatorNotes={curatorNotes}
           onPress={handleOnArtworkPress}
           moreHref={viewAllHref}
           onMorePress={onSectionViewAll}
@@ -143,7 +153,9 @@ const fragment = graphql`
 
     artworksConnection(first: 10) {
       edges {
+        note
         node {
+          internalID
           ...ArtworkRail_artworks
         }
       }

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionFeaturedCollection.tsx
@@ -50,15 +50,6 @@ export const HomeViewSectionFeaturedCollection: React.FC<
   const artworks = extractNodes(section.artworksConnection)
   const viewAllHref = getHomeViewSectionHref(viewAll?.href, section)
 
-  // `note` is an edge-level field, so build a lookup keyed by artwork internalID and
-  // pass it to the rail, which threads each note down to its card as a plain prop.
-  const curatorNotes: Record<string, string | null> = {}
-  section.artworksConnection?.edges?.forEach((edge) => {
-    if (edge?.node?.internalID && edge?.note) {
-      curatorNotes[edge.node.internalID] = edge.note
-    }
-  })
-
   const onHeaderPress = () => {
     tracking.tappedArtworkGroupViewAll(
       section.contextModule as ContextModule,
@@ -115,7 +106,6 @@ export const HomeViewSectionFeaturedCollection: React.FC<
           dark
           showPartnerName
           artworks={artworks}
-          curatorNotes={curatorNotes}
           onPress={handleOnArtworkPress}
           moreHref={viewAllHref}
           onMorePress={onSectionViewAll}
@@ -153,9 +143,7 @@ const fragment = graphql`
 
     artworksConnection(first: 10) {
       edges {
-        note
         node {
-          internalID
           ...ArtworkRail_artworks
         }
       }

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -61,6 +61,12 @@ export const features = {
     readyForRelease: true,
     echoFlagKey: "AREnableNewAuctionsRailCard",
   },
+  AREnableCuratorNotes: {
+    description: "Show curator notes on collection artworks",
+    readyForRelease: true,
+    showInDevMenu: true,
+    echoFlagKey: "AREnableCuratorNotes",
+  },
   AREnableAdditionalSiftAndroidTracking: {
     description: "Send additional events to Sift on Android",
     readyForRelease: true,


### PR DESCRIPTION
### What

Surfaces the new **curator's note** (why an artwork was picked for a marketing collection) on:

- **Collection page grids** — `CollectionArtworks`
- **Collection rails** — `CollectionsByCategory` `CollectionRail` (e.g. Curators' Picks category rails)

The note renders as a distinct component, **directly above** the existing collector social signal badge.

| Surface | Component touched |
|---|---|
| New badge | `Components/ArtworkGrids/CollectorNote.tsx` |
| Grid item | `ArtworkGridItem` (new `curatorNote` prop) |
| Collection grid | `CollectionArtworks` (selects `edges { note }`, threads by node id) |
| Rail chain | `ArtworkRail` → `ArtworkRailCard` → `ArtworkRailCardMeta` (new `curatorNotes` map / `curatorNote` prop) |
| Collection rail | `CollectionRail` (selects `edges { note }`, passes per-artwork map) |

### Why it's threaded as a plain prop

The note is exposed by Metaphysics as an **edge-level** field on `MarketingCollection.artworksConnection` (`edges { note }`), not as a field on the `Artwork` node. So it cannot ride along on the `ArtworkGridItem_artwork` / `ArtworkRail_artworks` node fragments — instead the connection-owning screens read `edge.note`, build a lookup keyed by the artwork id, and pass it down as a plain `curatorNote` string.

### Dependencies

- Requires the companion Metaphysics change exposing `note` on `FilterArtworksEdge` (artsy/metaphysics#7756). The GraphQL selections here won't compile against a schema without it.

### Scope notes

- Only surfaces backed by `MarketingCollection.artworksConnection` are wired (the resolver only stamps notes there). Home-view collection rails read a different connection (`HomeViewSectionArtworks`) where `note` is not populated — intentionally left as a follow-up.

### ⚠️ Verification still needed (couldn't run in the authoring environment)

This branch was authored without `node_modules`, so the following were **not** run and must pass in CI / locally:

- [ ] `yarn relay` (relay-compiler) to regenerate `__generated__` types for the changed fragments
- [ ] `yarn type-check`
- [ ] `yarn jest` (incl. new `CollectorNote.tests.tsx`)

### Tests

- Added `CollectorNote.tests.tsx` (renders note + label; renders nothing when empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2iHtPiKHN91ghgcJWyJjC)_