### PR TITLE
perf: reduce wasted re-renders in artwork grids

### DIFF
--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -66,6 +66,11 @@ import { useTracking } from "react-tracking"
 
 type ArtworkType = ExtractNodeType<ArtistArtworks_artist$data["artworks"]>
 
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render.
+const keyExtractor = (item: ArtworkType) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
+
 interface ArtworksGridProps extends InfiniteScrollGridProps, ArtistArtworksQueryRendererProps {
   artist: NonNullable<ArtistArtworksQuery$data["artist"]>
 }
@@ -159,16 +164,19 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     entityOwnerType: OwnerType.artist,
   })
 
-  const trackClear = (id: string, slug: string) => {
-    tracking.trackEvent({
-      action_name: "clearFilters",
-      context_screen: Schema.ContextModules.ArtworkGrid,
-      context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
-      context_screen_owner_id: id,
-      context_screen_owner_slug: slug,
-      action_type: Schema.ActionTypes.Tap,
-    })
-  }
+  const trackClear = useCallback(
+    (id: string, slug: string) => {
+      tracking.trackEvent({
+        action_name: "clearFilters",
+        context_screen: Schema.ContextModules.ArtworkGrid,
+        context_screen_owner_type: Schema.OwnerEntityTypes.Artist,
+        context_screen_owner_id: id,
+        context_screen_owner_slug: slug,
+        action_type: Schema.ActionTypes.Tap,
+      })
+    },
+    [tracking]
+  )
 
   const handleCompleteSavedSearch = () => {
     // TODO: Get the new count of the artist alerts
@@ -209,6 +217,57 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
       />
     ),
     [showCreateAlertAtEndOfList, isLoadingNext, hasNext, artist, setIsCreateAlertModalVisible]
+  )
+
+  const shouldShowCreateAlertReminder =
+    artworks.length >= CREATE_ALERT_REMINDER_ARTWORK_THRESHOLD &&
+    // We are intentionally temporarily disabling the create alert reminder on android until
+    // we can make the SubTabBar sticky.
+    Platform.OS !== "android"
+
+  const showCreateAlertModal = useCallback(() => {
+    if (shouldShowCreateAlertReminder) {
+      dismissAllCreateAlertReminder()
+    }
+
+    setIsCreateAlertModalVisible(true)
+  }, [shouldShowCreateAlertReminder, dismissAllCreateAlertReminder, setIsCreateAlertModalVisible])
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Box mb="80px" pt={2}>
+        <FilteredArtworkGridZeroState
+          id={artist.id}
+          slug={artist.slug}
+          trackClear={trackClear}
+          hideClearButton={!appliedFilters.length}
+        />
+      </Box>
+    ),
+    [artist.id, artist.slug, trackClear, appliedFilters.length]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <Flex flexDirection="row">
+            <ProgressiveOnboardingAlertReminder visible={!!shouldShowCreateAlertReminder} />
+            <Flex flex={1}>
+              <ArtistArtworksFilterHeader artist={artist} showCreateAlertModal={showCreateAlertModal} />
+            </Flex>
+          </Flex>
+        </Tabs.SubTabBar>
+        <Flex pt={1}>
+          <Text variant="xs" weight="medium">{`${artworksCount} Artwork${
+            artworksCount > 1 ? "s" : ""
+          }:`}</Text>
+        </Flex>
+      </Flex>
+    ),
+    [shouldShowCreateAlertReminder, artist, showCreateAlertModal, artworksCount]
   )
 
   if (!artist.statuses?.artworks) {
@@ -259,12 +318,6 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
     )
   }
 
-  const shouldShowCreateAlertReminder =
-    artworks.length >= CREATE_ALERT_REMINDER_ARTWORK_THRESHOLD &&
-    // We are intentionally temporarily disabling the create alert reminder on android until
-    // we can make the SubTabBar sticky.
-    Platform.OS !== "android"
-
   return (
     <Flex backgroundColor={color("mono0")} flex={1}>
       <Tabs.Masonry
@@ -272,50 +325,16 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
-        ListEmptyComponent={
-          <Box mb="80px" pt={2}>
-            <FilteredArtworkGridZeroState
-              id={artist.id}
-              slug={artist.slug}
-              trackClear={trackClear}
-              hideClearButton={!appliedFilters.length}
-            />
-          </Box>
-        }
-        keyExtractor={(item) => item.id}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
+        contentContainerStyle={contentContainerStyle}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <Flex flexDirection="row">
-                <ProgressiveOnboardingAlertReminder visible={!!shouldShowCreateAlertReminder} />
-                <Flex flex={1}>
-                  <ArtistArtworksFilterHeader
-                    artist={artist}
-                    showCreateAlertModal={() => {
-                      if (shouldShowCreateAlertReminder) {
-                        dismissAllCreateAlertReminder()
-                      }
-
-                      setIsCreateAlertModalVisible(true)
-                    }}
-                  />
-                </Flex>
-              </Flex>
-            </Tabs.SubTabBar>
-            <Flex pt={1}>
-              <Text variant="xs" weight="medium">{`${artworksCount} Artwork${
-                artworksCount > 1 ? "s" : ""
-              }:`}</Text>
-            </Flex>
-          </Flex>
-        }
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}
       />
 

--- a/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
+++ b/src/app/Components/Artist/ArtistArtworks/ArtistArtworks.tsx
@@ -66,11 +66,6 @@ import { useTracking } from "react-tracking"
 
 type ArtworkType = ExtractNodeType<ArtistArtworks_artist$data["artworks"]>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render.
-const keyExtractor = (item: ArtworkType) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 interface ArtworksGridProps extends InfiniteScrollGridProps, ArtistArtworksQueryRendererProps {
   artist: NonNullable<ArtistArtworksQuery$data["artist"]>
 }
@@ -256,7 +251,10 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
           <Flex flexDirection="row">
             <ProgressiveOnboardingAlertReminder visible={!!shouldShowCreateAlertReminder} />
             <Flex flex={1}>
-              <ArtistArtworksFilterHeader artist={artist} showCreateAlertModal={showCreateAlertModal} />
+              <ArtistArtworksFilterHeader
+                artist={artist}
+                showCreateAlertModal={showCreateAlertModal}
+              />
             </Flex>
           </Flex>
         </Tabs.SubTabBar>
@@ -326,14 +324,14 @@ const ArtworksGrid: React.FC<ArtworksGridProps> = ({
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         renderItem={renderItem}
         contentContainerStyle={contentContainerStyle}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}
       />

--- a/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkGridItem.tsx
@@ -482,11 +482,13 @@ export const Artwork: React.FC<ArtworkProps> = memo(
           </RouterLink>
         </ContextMenuArtwork>
 
-        <CreateArtworkAlertModal
-          artwork={artwork}
-          onClose={() => setShowCreateArtworkAlertModal(false)}
-          visible={showCreateArtworkAlertModal}
-        />
+        {!!showCreateArtworkAlertModal && (
+          <CreateArtworkAlertModal
+            artwork={artwork}
+            onClose={() => setShowCreateArtworkAlertModal(false)}
+            visible={showCreateArtworkAlertModal}
+          />
+        )}
       </Disappearable>
     )
   }

--- a/src/app/Components/ArtworkGrids/ArtworkSaveIconWrapper.tsx
+++ b/src/app/Components/ArtworkGrids/ArtworkSaveIconWrapper.tsx
@@ -1,5 +1,6 @@
 import { HeartFillIcon, HeartStrokeIcon } from "@artsy/icons/native"
 import { HEART_ICON_SIZE } from "app/Components/constants"
+import { memo } from "react"
 import { View } from "react-native"
 
 interface ArtworkSaveIconWrapperProps {
@@ -9,12 +10,15 @@ interface ArtworkSaveIconWrapperProps {
   fill?: string
 }
 
-export const ArtworkSaveIconWrapper: React.FC<ArtworkSaveIconWrapperProps> = ({
+// Memoized so it skips re-rendering the heart SVG when its (all-primitive) props are unchanged.
+// In grids this component re-renders on every FlashList recycle; since most artworks are unsaved,
+// the common `isSaved: false -> false` case now bails out instead of re-rendering the SVG.
+export const ArtworkSaveIconWrapper = memo(function ArtworkSaveIconWrapper({
   isSaved,
   testID,
   accessibilityLabel,
   fill,
-}) => {
+}: ArtworkSaveIconWrapperProps) {
   return (
     <View testID={testID} accessibilityLabel={accessibilityLabel}>
       {!!isSaved ? (
@@ -34,4 +38,4 @@ export const ArtworkSaveIconWrapper: React.FC<ArtworkSaveIconWrapperProps> = ({
       )}
     </View>
   )
-}
+})

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -24,7 +24,7 @@ import {
 import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Schema } from "app/utils/track"
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useMemo, useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -35,13 +35,18 @@ interface GeneArtworksContainerProps {
 
 type Artwork = ExtractNodeType<GeneArtworks_gene$data["artworks"]>
 
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it to fully re-render (and re-render all cells) on every container re-render.
+const keyExtractor = (item: Artwork) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
+
 export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ gene, relay }) => {
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const space = useSpace()
   const tracking = useTracking()
   const { width } = useScreenDimensions()
-  const artworks = extractNodes(gene.artworks)
+  const artworks = useMemo(() => extractNodes(gene.artworks), [gene.artworks])
   const shouldDisplaySpinner =
     !!isLoading && !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
 
@@ -55,17 +60,16 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
     pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
-  const trackClear = () => {
+  const trackClear = useCallback(() => {
     tracking.trackEvent(tracks.clearFilters(gene.id, gene.slug))
-  }
+  }, [tracking, gene.id, gene.slug])
 
   const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
-  const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
 
-  const openFilterArtworksModal = () => {
+  const openFilterArtworksModal = useCallback(() => {
     tracking.trackEvent(tracks.openFilterWindow(gene.id, gene.slug))
-    handleOpenFilterArtworksModal()
-  }
+    setFilterArtworkModalVisible(true)
+  }, [tracking, gene.id, gene.slug])
 
   const closeFilterArtworksModal = () => {
     tracking.trackEvent(tracks.closeFilterWindow(gene.id, gene.slug))
@@ -100,48 +104,62 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
     )
   }, [])
 
+  const listEmptyComponent = useMemo(
+    () =>
+      initialArtworksTotal ? (
+        <Box mt={1}>
+          <SimpleMessage>
+            There aren’t any works available in the category at this time.
+          </SimpleMessage>
+        </Box>
+      ) : (
+        <Box pt={1}>
+          <FilteredArtworkGridZeroState id={gene.id} slug={gene.slug} trackClear={trackClear} />
+        </Box>
+      ),
+    [gene.id, gene.slug, trackClear]
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <GeneArtworksFilterHeader openFilterArtworksModal={openFilterArtworksModal} />
+        </Tabs.SubTabBar>
+        <Flex pt={1}>
+          <Text variant="xs" color="mono60">
+            {`Showing ${artworksTotal} work${artworksTotal > 1 ? "s" : ""}`}
+          </Text>
+        </Flex>
+      </Flex>
+    ),
+    [openFilterArtworksModal, artworksTotal]
+  )
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
   return (
     <>
       <Tabs.Masonry
         data={artworks}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        ListEmptyComponent={
-          initialArtworksTotal ? (
-            <Box mt={1}>
-              <SimpleMessage>
-                There aren’t any works available in the category at this time.
-              </SimpleMessage>
-            </Box>
-          ) : (
-            <Box pt={1}>
-              <FilteredArtworkGridZeroState id={gene.id} slug={gene.slug} trackClear={trackClear} />
-            </Box>
-          )
-        }
-        keyExtractor={(item) => item.id}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <GeneArtworksFilterHeader openFilterArtworksModal={openFilterArtworksModal} />
-            </Tabs.SubTabBar>
-            <Flex pt={1}>
-              <Text variant="xs" color="mono60">
-                {`Showing ${artworksTotal} work${artworksTotal > 1 ? "s" : ""}`}
-              </Text>
-            </Flex>
-          </Flex>
-        }
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        contentContainerStyle={contentContainerStyle}
+        ListHeaderComponent={listHeaderComponent}
       />
       <ArtworkFilterNavigator
         id={gene.internalID}

--- a/src/app/Components/Gene/GeneArtworks.tsx
+++ b/src/app/Components/Gene/GeneArtworks.tsx
@@ -35,11 +35,6 @@ interface GeneArtworksContainerProps {
 
 type Artwork = ExtractNodeType<GeneArtworks_gene$data["artworks"]>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it to fully re-render (and re-render all cells) on every container re-render.
-const keyExtractor = (item: Artwork) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ gene, relay }) => {
   const [isFilterArtworksModalVisible, setFilterArtworkModalVisible] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
@@ -150,14 +145,14 @@ export const GeneArtworksContainer: React.FC<GeneArtworksContainerProps> = ({ ge
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         contentContainerStyle={contentContainerStyle}
         ListHeaderComponent={listHeaderComponent}
       />

--- a/src/app/Components/ProgressiveOnboarding/useDismissAlertReminder.tsx
+++ b/src/app/Components/ProgressiveOnboarding/useDismissAlertReminder.tsx
@@ -1,5 +1,6 @@
 import { useIsFocused } from "@react-navigation/native"
 import { GlobalStore } from "app/store/GlobalStore"
+import { useCallback } from "react"
 
 export const CREATE_ALERT_REMINDER_ARTWORK_THRESHOLD = 40
 const DAYS = 1000 * 60 * 60 * 24
@@ -22,7 +23,7 @@ export const useDismissAlertReminder = () => {
 
   const isDisplayable = isReady && (displayFirstTime || displaySecondTime) && isFocused
 
-  const dismissNextCreateAlertReminder = () => {
+  const dismissNextCreateAlertReminder = useCallback(() => {
     setIsReady(false)
 
     if (!isDismissed("alert-create-reminder-1").status) {
@@ -30,12 +31,12 @@ export const useDismissAlertReminder = () => {
     } else {
       dismiss("alert-create-reminder-2")
     }
-  }
+  }, [setIsReady, isDismissed, dismiss])
 
-  const dismissAllCreateAlertReminder = () => {
+  const dismissAllCreateAlertReminder = useCallback(() => {
     dismiss("alert-create-reminder-1")
     dismiss("alert-create-reminder-2")
-  }
+  }, [dismiss])
 
   return {
     isDisplayable,

--- a/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -28,11 +28,6 @@ const PAGE_SIZE = 10
 
 type Artworks = ExtractNodeType<ArtistSeriesArtworks_artistSeries$data["artistSeriesArtworks"]>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render.
-const keyExtractor = (item: Artworks) => item?.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries }) => {
   const { data, isLoadingNext, hasNext, loadNext, refetch } = usePaginationFragment(
     fragment,
@@ -160,13 +155,13 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item?.id}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         contentContainerStyle={contentContainerStyle}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}

--- a/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
+++ b/src/app/Scenes/ArtistSeries/ArtistSeriesArtworks.tsx
@@ -28,6 +28,11 @@ const PAGE_SIZE = 10
 
 type Artworks = ExtractNodeType<ArtistSeriesArtworks_artistSeries$data["artistSeriesArtworks"]>
 
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render.
+const keyExtractor = (item: Artworks) => item?.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
+
 export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ artistSeries }) => {
   const { data, isLoadingNext, hasNext, loadNext, refetch } = usePaginationFragment(
     fragment,
@@ -64,17 +69,17 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
     })
   }, [artworksTotal])
 
-  const openFilterArtworksModal = () => {
+  const openFilterArtworksModal = useCallback(() => {
     tracking.trackEvent(tracks.openFilterWindow(data.id, data.slug))
 
     setFilterArtworkModalVisible(true)
-  }
+  }, [tracking, data.id, data.slug])
 
-  const closeFilterArtworksModal = () => {
+  const closeFilterArtworksModal = useCallback(() => {
     tracking.trackEvent(tracks.closeFilterWindow(data.id, data.slug))
 
     setFilterArtworkModalVisible(false)
-  }
+  }, [tracking, data.id, data.slug])
 
   const loadMore = useCallback(() => {
     if (!isLoadingNext && hasNext) {
@@ -88,26 +93,63 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
     }
   }, [isLoadingNext, hasNext])
 
-  const trackClear = (id: string, slug: string) => {
-    tracking.trackEvent(tracks.clearFilters(id, slug))
-  }
+  const trackClear = useCallback(
+    (id: string, slug: string) => {
+      tracking.trackEvent(tracks.clearFilters(id, slug))
+    },
+    [tracking]
+  )
 
-  const renderItem: ListRenderItem<Artworks> = useCallback(({ item, index }) => {
-    const imgAspectRatio = item.image?.aspectRatio ?? 1
-    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-    const imgHeight = imgWidth / imgAspectRatio
+  const renderItem: ListRenderItem<Artworks> = useCallback(
+    ({ item, index }) => {
+      const imgAspectRatio = item.image?.aspectRatio ?? 1
+      const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+      const imgHeight = imgWidth / imgAspectRatio
 
-    return (
-      <ArtworkGridItem
-        itemIndex={index}
-        contextScreenOwnerType={OwnerType.artistSeries}
-        contextScreenOwnerId={data.internalID}
-        contextScreenOwnerSlug={data.slug}
-        artwork={item}
-        height={imgHeight}
-      />
-    )
-  }, [])
+      return (
+        <ArtworkGridItem
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.artistSeries}
+          contextScreenOwnerId={data.internalID}
+          contextScreenOwnerSlug={data.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      )
+    },
+    [width, space, data.internalID, data.slug]
+  )
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Box mb="80px" pt={2}>
+        <FilteredArtworkGridZeroState
+          id={data.internalID}
+          slug={data.slug}
+          trackClear={trackClear}
+        />
+      </Box>
+    ),
+    [data.internalID, data.slug, trackClear]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <HeaderArtworksFilterWithTotalArtworks onPress={openFilterArtworksModal} />
+        </Tabs.SubTabBar>
+      </Flex>
+    ),
+    [openFilterArtworksModal]
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
 
   return (
     <>
@@ -117,33 +159,17 @@ export const ArtistSeriesArtworks: React.FC<ArtistSeriesArtworksProps> = ({ arti
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
-        ListEmptyComponent={
-          <Box mb="80px" pt={2}>
-            <FilteredArtworkGridZeroState
-              id={data.internalID}
-              slug={data.slug}
-              trackClear={trackClear}
-            />
-          </Box>
-        }
-        keyExtractor={(item) => item?.id}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <HeaderArtworksFilterWithTotalArtworks onPress={openFilterArtworksModal} />
-            </Tabs.SubTabBar>
-          </Flex>
-        }
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        contentContainerStyle={contentContainerStyle}
+        ListHeaderComponent={listHeaderComponent}
+        ListFooterComponent={listFooterComponent}
       />
       <ArtworkFilterNavigator
         id={data.internalID}

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -31,6 +31,11 @@ export const CURATORS_PICKS_SLUGS = ["most-loved", "curators-picks"]
 
 type Artworks = ExtractNodeType<CollectionArtworks_collection$data["collectionArtworks"]>
 
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render.
+const keyExtractor = (item: Artworks) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
+
 export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collection, relay }) => {
   const { width } = useScreenDimensions()
   const space = useSpace()
@@ -63,13 +68,13 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
   const shouldDisplaySpinner =
     !!isLoading && !!artworksList.length && !!relay.isLoading() && !!relay.hasMore()
 
-  const handleFilterOpen = () => {
+  const handleFilterOpen = useCallback(() => {
     setFilterArtworkModalVisible(true)
-  }
+  }, [])
 
-  const handleFilterClose = () => {
+  const handleFilterClose = useCallback(() => {
     setFilterArtworkModalVisible(false)
-  }
+  }, [])
 
   const loadMore = () => {
     if (relay.hasMore() && !relay.isLoading()) {
@@ -94,37 +99,74 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
     setFiltersCountAction(filterCount)
   }, [artworksTotal])
 
-  const trackClear = (id: string, slug: string) => {
-    tracking.trackEvent({
-      action_name: "clearFilters",
-      context_screen: Schema.ContextModules.Collection,
-      context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
-      context_screen_owner_id: id,
-      context_screen_owner_slug: slug,
-      action_type: Schema.ActionTypes.Tap,
-    })
-  }
+  const trackClear = useCallback(
+    (id: string, slug: string) => {
+      tracking.trackEvent({
+        action_name: "clearFilters",
+        context_screen: Schema.ContextModules.Collection,
+        context_screen_owner_type: Schema.OwnerEntityTypes.Collection,
+        context_screen_owner_id: id,
+        context_screen_owner_slug: slug,
+        action_type: Schema.ActionTypes.Tap,
+      })
+    },
+    [tracking]
+  )
 
-  const renderItem: ListRenderItem<Artworks> = useCallback(({ item, index }) => {
-    const imgAspectRatio = item.image?.aspectRatio ?? 1
-    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-    const imgHeight = imgWidth / imgAspectRatio
+  const renderItem: ListRenderItem<Artworks> = useCallback(
+    ({ item, index }) => {
+      const imgAspectRatio = item.image?.aspectRatio ?? 1
+      const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+      const imgHeight = imgWidth / imgAspectRatio
 
-    const hideSignals = CURATORS_PICKS_SLUGS.includes(collection.slug)
+      const hideSignals = CURATORS_PICKS_SLUGS.includes(collection.slug)
 
-    return (
-      <ArtworkGridItem
-        itemIndex={index}
-        contextScreenOwnerType={OwnerType.collection}
-        contextScreenOwnerId={collection.id}
-        contextScreenOwnerSlug={collection.slug}
-        artwork={item}
-        height={imgHeight}
-        hideCuratorsPickSignal={hideSignals}
-        hideIncreasedInterestSignal={hideSignals}
-      />
-    )
-  }, [])
+      return (
+        <ArtworkGridItem
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.collection}
+          contextScreenOwnerId={collection.id}
+          contextScreenOwnerSlug={collection.slug}
+          artwork={item}
+          height={imgHeight}
+          hideCuratorsPickSignal={hideSignals}
+          hideIncreasedInterestSignal={hideSignals}
+        />
+      )
+    },
+    [width, space, collection.id, collection.slug]
+  )
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Box mb="80px" pt={2}>
+        <FilteredArtworkGridZeroState
+          id={collection.id}
+          slug={collection.slug}
+          trackClear={trackClear}
+        />
+      </Box>
+    ),
+    [collection.id, collection.slug, trackClear]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />
+        </Tabs.SubTabBar>
+      </Flex>
+    ),
+    [handleFilterOpen]
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
 
   return (
     <>
@@ -133,33 +175,17 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
-        ListEmptyComponent={
-          <Box mb="80px" pt={2}>
-            <FilteredArtworkGridZeroState
-              id={collection.id}
-              slug={collection.slug}
-              trackClear={trackClear}
-            />
-          </Box>
-        }
-        keyExtractor={(item) => item.id}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />
-            </Tabs.SubTabBar>
-          </Flex>
-        }
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        contentContainerStyle={contentContainerStyle}
+        ListHeaderComponent={listHeaderComponent}
+        ListFooterComponent={listFooterComponent}
       />
       <ArtworkFilterNavigator
         id={collection.id}

--- a/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
+++ b/src/app/Scenes/Collection/Screens/CollectionArtworks.tsx
@@ -31,11 +31,6 @@ export const CURATORS_PICKS_SLUGS = ["most-loved", "curators-picks"]
 
 type Artworks = ExtractNodeType<CollectionArtworks_collection$data["collectionArtworks"]>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render.
-const keyExtractor = (item: Artworks) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collection, relay }) => {
   const { width } = useScreenDimensions()
   const space = useSpace()
@@ -176,13 +171,13 @@ export const CollectionArtworks: React.FC<CollectionArtworksProps> = ({ collecti
         keyboardShouldPersistTaps="handled"
         innerRef={gridRef}
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         contentContainerStyle={contentContainerStyle}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -44,12 +44,6 @@ interface FairArtworksProps {
 
 type FairArtworkType = ExtractNodeType<NonNullable<FairArtworks_fair$data["fairArtworks"]>>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render. Profiling the Fair artworks
-// tab showed the filter header re-rendering once per pagination-driven container render.
-const keyExtractor = (item: FairArtworkType) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 export const FairArtworks: React.FC<FairArtworksProps> = ({
   fair,
   initiallyAppliedFilter,
@@ -189,14 +183,14 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
     <>
       <Tabs.Masonry
         data={filteredArtworks}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={contentContainerStyle}
         ListEmptyComponent={listEmptyComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         ListHeaderComponent={listHeaderComponent}
         ListFooterComponent={listFooterComponent}
         onEndReached={handleOnEndReached}
@@ -355,7 +349,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
     <>
       <FlashList
         data={filteredArtworks}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={contentContainerStyle}

--- a/src/app/Scenes/Fair/Components/FairArtworks.tsx
+++ b/src/app/Scenes/Fair/Components/FairArtworks.tsx
@@ -31,7 +31,7 @@ import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMaso
 import { PlaceholderGrid } from "app/utils/placeholderGrid"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Schema } from "app/utils/track"
-import React, { useCallback, useEffect, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 import { useTracking } from "react-tracking"
 
@@ -43,6 +43,12 @@ interface FairArtworksProps {
 }
 
 type FairArtworkType = ExtractNodeType<NonNullable<FairArtworks_fair$data["fairArtworks"]>>
+
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render. Profiling the Fair artworks
+// tab showed the filter header re-rendering once per pagination-driven container render.
+const keyExtractor = (item: FairArtworkType) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
 
 export const FairArtworks: React.FC<FairArtworksProps> = ({
   fair,
@@ -91,28 +97,27 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
     setFiltersCountAction({ ...counts, total: artworksTotal })
   }, [artworksTotal])
 
-  const renderItem: ListRenderItem<FairArtworkType> = useCallback(({ item, index }) => {
-    const imgAspectRatio = item.image?.aspectRatio ?? 1
-    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-    const imgHeight = imgWidth / imgAspectRatio
+  const renderItem: ListRenderItem<FairArtworkType> = useCallback(
+    ({ item, index }) => {
+      const imgAspectRatio = item.image?.aspectRatio ?? 1
+      const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+      const imgHeight = imgWidth / imgAspectRatio
 
-    return (
-      <ArtworkGridItem
-        itemIndex={index}
-        contextScreenOwnerType={OwnerType.fair}
-        contextScreenOwnerId={data.internalID}
-        contextScreenOwnerSlug={data.slug}
-        artwork={item}
-        height={imgHeight}
-      />
-    )
-  }, [])
+      return (
+        <ArtworkGridItem
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.fair}
+          contextScreenOwnerId={data.internalID}
+          contextScreenOwnerSlug={data.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      )
+    },
+    [width, space, data.internalID, data.slug]
+  )
 
-  if (!data) {
-    return null
-  }
-
-  const handleOnEndReached = () => {
+  const handleOnEndReached = useCallback(() => {
     if (!isLoadingNext && hasNext) {
       loadNext(FAIR2_ARTWORKS_PAGE_SIZE, {
         onComplete: (error) => {
@@ -122,56 +127,78 @@ export const FairArtworks: React.FC<FairArtworksProps> = ({
         },
       })
     }
-  }
+  }, [isLoadingNext, hasNext, loadNext])
 
-  const handleTrackClear = (id: string, slug: string) => {
-    tracking.trackEvent(tracks.trackClear(id, slug))
-  }
+  const handleTrackClear = useCallback(
+    (id: string, slug: string) => {
+      tracking.trackEvent(tracks.trackClear(id, slug))
+    },
+    [tracking]
+  )
 
-  const handleFilterOpen = () => {
+  const handleFilterOpen = useCallback(() => {
     setFilterArtworkModalVisible(true)
 
     tracking.trackEvent(tracks.openArtworksFilter(fair))
-  }
+  }, [tracking, fair])
 
-  const handleFilterClose = () => {
+  const handleFilterClose = useCallback(() => {
     setFilterArtworkModalVisible(false)
 
     tracking.trackEvent(tracks.closeArtworksFilter(fair))
-  }
+  }, [tracking, fair])
 
-  const filteredArtworks = extractNodes(data.fairArtworks)
+  const filteredArtworks = useMemo(() => extractNodes(data.fairArtworks), [data.fairArtworks])
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Flex mb={6}>
+        <FilteredArtworkGridZeroState
+          id={data.internalID}
+          slug={data.slug}
+          trackClear={handleTrackClear}
+        />
+      </Flex>
+    ),
+    [data.internalID, data.slug, handleTrackClear]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />
+        </Tabs.SubTabBar>
+      </Flex>
+    ),
+    [handleFilterOpen]
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={isLoadingNext} />,
+    [isLoadingNext]
+  )
+
+  if (!data) {
+    return null
+  }
 
   return (
     <>
       <Tabs.Masonry
         data={filteredArtworks}
-        keyExtractor={(item) => item.id}
+        keyExtractor={keyExtractor}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListEmptyComponent={
-          <Flex mb={6}>
-            <FilteredArtworkGridZeroState
-              id={data.internalID}
-              slug={data.slug}
-              trackClear={handleTrackClear}
-            />
-          </Flex>
-        }
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />
-            </Tabs.SubTabBar>
-          </Flex>
-        }
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={isLoadingNext} />
-        )}
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponent={listHeaderComponent}
+        ListFooterComponent={listFooterComponent}
         onEndReached={handleOnEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         renderItem={renderItem}
@@ -239,11 +266,7 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
     setFiltersCountAction({ ...counts, total: artworksTotal })
   }, [artworksTotal])
 
-  if (!data) {
-    return null
-  }
-
-  const handleOnEndReached = () => {
+  const handleOnEndReached = useCallback(() => {
     if (!isLoadingNext && hasNext) {
       loadNext(MASONRY_LIST_PAGE_SIZE, {
         onComplete: (error) => {
@@ -253,67 +276,95 @@ export const FairArtworksWithoutTabs: React.FC<FairArtworksProps> = ({
         },
       })
     }
-  }
+  }, [isLoadingNext, hasNext, loadNext])
 
-  const handleTrackClear = (id: string, slug: string) => {
-    tracking.trackEvent(tracks.trackClear(id, slug))
-  }
+  const handleTrackClear = useCallback(
+    (id: string, slug: string) => {
+      tracking.trackEvent(tracks.trackClear(id, slug))
+    },
+    [tracking]
+  )
 
-  const handleFilterOpen = () => {
+  const handleFilterOpen = useCallback(() => {
     setFilterArtworkModalVisible(true)
     tracking.trackEvent(tracks.openArtworksFilter(fair))
-  }
+  }, [tracking, fair])
 
-  const handleFilterClose = () => {
+  const handleFilterClose = useCallback(() => {
     setFilterArtworkModalVisible(false)
     tracking.trackEvent(tracks.closeArtworksFilter(fair))
-  }
+  }, [tracking, fair])
 
-  const filteredArtworks = extractNodes(data.fairArtworks)
+  const filteredArtworks = useMemo(() => extractNodes(data.fairArtworks), [data.fairArtworks])
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const renderItem: ListRenderItem<FairArtworkType> = useCallback(
+    ({ item, index }) => {
+      const imgAspectRatio = item.image?.aspectRatio ?? 1
+      const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+      const imgHeight = imgWidth / imgAspectRatio
+
+      return (
+        <ArtworkGridItem
+          itemIndex={index}
+          contextScreenOwnerType={OwnerType.fair}
+          contextScreenOwnerId={data.internalID}
+          contextScreenOwnerSlug={data.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      )
+    },
+    [width, space, data.internalID, data.slug]
+  )
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Flex mb={6} mt={4}>
+        <FilteredArtworkGridZeroState
+          id={data.internalID}
+          slug={data.slug}
+          trackClear={handleTrackClear}
+        />
+      </Flex>
+    ),
+    [data.internalID, data.slug, handleTrackClear]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => <HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />,
+    [handleFilterOpen]
+  )
+
+  const listFooterComponent = useMemo(
+    () =>
+      !!isLoadingNext ? (
+        <Flex my={4} flexDirection="row" justifyContent="center">
+          <Spinner />
+        </Flex>
+      ) : null,
+    [isLoadingNext]
+  )
+
+  if (!data) {
+    return null
+  }
 
   return (
     <>
       <FlashList
         data={filteredArtworks}
-        keyExtractor={(item) => item.id}
+        keyExtractor={keyExtractor}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListEmptyComponent={
-          <Flex mb={6} mt={4}>
-            <FilteredArtworkGridZeroState
-              id={data.internalID}
-              slug={data.slug}
-              trackClear={handleTrackClear}
-            />
-          </Flex>
-        }
-        ListHeaderComponent={<HeaderArtworksFilterWithTotalArtworks onPress={handleFilterOpen} />}
-        ListFooterComponent={() =>
-          !!isLoadingNext ? (
-            <Flex my={4} flexDirection="row" justifyContent="center">
-              <Spinner />
-            </Flex>
-          ) : null
-        }
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
+        ListHeaderComponent={listHeaderComponent}
+        ListFooterComponent={listFooterComponent}
         onEndReached={handleOnEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        renderItem={({ item, index }) => {
-          const imgAspectRatio = item.image?.aspectRatio ?? 1
-          const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-          const imgHeight = imgWidth / imgAspectRatio
-
-          return (
-            <ArtworkGridItem
-              itemIndex={index}
-              contextScreenOwnerType={OwnerType.fair}
-              contextScreenOwnerId={data.internalID}
-              contextScreenOwnerSlug={data.slug}
-              artwork={item}
-              height={imgHeight}
-            />
-          )
-        }}
+        renderItem={renderItem}
       />
       <ArtworkFilterNavigator
         visible={isFilterArtworksModalVisible}

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryMoreWorksTab.tsx
@@ -3,7 +3,10 @@ import { Button, SimpleMessage, Tabs, useScreenDimensions, useSpace } from "@art
 import { BottomSheetScrollView } from "@gorhom/bottom-sheet"
 import { ListRenderItem } from "@shopify/flash-list"
 import { InfiniteDiscoveryMoreWorksTabQuery } from "__generated__/InfiniteDiscoveryMoreWorksTabQuery.graphql"
-import { InfiniteDiscoveryMoreWorksTab_artworks$key } from "__generated__/InfiniteDiscoveryMoreWorksTab_artworks.graphql"
+import {
+  InfiniteDiscoveryMoreWorksTab_artworks$data,
+  InfiniteDiscoveryMoreWorksTab_artworks$key,
+} from "__generated__/InfiniteDiscoveryMoreWorksTab_artworks.graphql"
 import ArtworkGridItem from "app/Components/ArtworkGrids/ArtworkGridItem"
 import { PAGE_SIZE } from "app/Components/constants"
 import { extractNodes } from "app/utils/extractNodes"
@@ -12,7 +15,7 @@ import { NUM_COLUMNS_MASONRY, ON_END_REACHED_THRESHOLD_MASONRY } from "app/utils
 import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { PlaceholderGrid } from "app/utils/placeholderGrid"
 import { ExtractNodeType } from "app/utils/relayHelpers"
-import { FC, useCallback } from "react"
+import { FC, useCallback, useMemo } from "react"
 import { Platform } from "react-native"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 
@@ -20,12 +23,16 @@ interface MoreWorksTabProps {
   artworks: InfiniteDiscoveryMoreWorksTab_artworks$key
 }
 
+type MoreWorksArtwork = ExtractNodeType<
+  InfiniteDiscoveryMoreWorksTab_artworks$data["artworksConnection"]
+>
+
 export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => {
   const { data, hasNext, isLoadingNext, loadNext } = usePaginationFragment(fragment, _artworks)
   const space = useSpace()
   const { width } = useScreenDimensions()
 
-  const artworks = extractNodes(data.artworksConnection)
+  const artworks = useMemo(() => extractNodes(data.artworksConnection), [data.artworksConnection])
 
   const loadMore = useCallback(() => {
     if (hasNext && !isLoadingNext) {
@@ -33,7 +40,9 @@ export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => 
     }
   }, [hasNext, isLoadingNext, loadNext])
 
-  const renderItem: ListRenderItem<ExtractNodeType<typeof data.artworksConnection>> = useCallback(
+  const keyExtractor = useCallback((item: MoreWorksArtwork) => item?.internalID, [])
+
+  const renderItem: ListRenderItem<MoreWorksArtwork> = useCallback(
     ({ item, index }) => {
       const imgAspectRatio = item.image?.aspectRatio ?? 1
       const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
@@ -51,7 +60,36 @@ export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => 
         />
       )
     },
+    [width, space]
+  )
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => <SimpleMessage m={2}>There are no available works.</SimpleMessage>,
     []
+  )
+
+  const listFooterComponent = useMemo(
+    () =>
+      Platform.OS === "android" ? (
+        hasNext ? (
+          <Button
+            mt={2}
+            mb={4}
+            variant="fillGray"
+            size="large"
+            block
+            onPress={loadMore}
+            loading={isLoadingNext}
+          >
+            Show more
+          </Button>
+        ) : null
+      ) : (
+        <AnimatedMasonryListFooter shouldDisplaySpinner={!!hasNext && !!isLoadingNext} />
+      ),
+    [hasNext, isLoadingNext, loadMore]
   )
 
   const masonry = (
@@ -59,32 +97,14 @@ export const MoreWorksTab: FC<MoreWorksTabProps> = ({ artworks: _artworks }) => 
       data={artworks}
       numColumns={NUM_COLUMNS_MASONRY}
       keyboardShouldPersistTaps="handled"
-      contentContainerStyle={{ paddingHorizontal: space(1) }}
-      keyExtractor={(item) => item?.internalID}
-      ListEmptyComponent={<SimpleMessage m={2}>There are no available works.</SimpleMessage>}
+      contentContainerStyle={contentContainerStyle}
+      keyExtractor={keyExtractor}
+      ListEmptyComponent={listEmptyComponent}
       // Android: this Masonry is nested inside <BottomSheetScrollView>, which makes the inner
       // list believe it is fully visible on mount and fires onEndReached immediately regardless
       // of onEndReachedThreshold. We replace auto-pagination with an explicit "Show more" button
       // so loading more remains user-initiated on Android.
-      ListFooterComponent={() =>
-        Platform.OS === "android" ? (
-          hasNext ? (
-            <Button
-              mt={2}
-              mb={4}
-              variant="fillGray"
-              size="large"
-              block
-              onPress={loadMore}
-              loading={isLoadingNext}
-            >
-              Show more
-            </Button>
-          ) : null
-        ) : (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={!!hasNext && !!isLoadingNext} />
-        )
-      }
+      ListFooterComponent={listFooterComponent}
       // no-op on Android; see ListFooterComponent comment above
       onEndReached={Platform.OS === "ios" ? loadMore : undefined}
       onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}

--- a/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
+++ b/src/app/Scenes/MyCollection/MyCollectionArtworks.tsx
@@ -26,7 +26,7 @@ import {
   useRefreshControl,
   useRefreshFetchKey,
 } from "app/utils/refreshHelpers"
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 import { graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
 import {
   localSortAndFilterArtworks,
@@ -46,7 +46,10 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({ me }
 
   const { data, loadNext, isLoadingNext, hasNext, refetch } = usePaginationFragment(meFragment, me)
 
-  const artworks = extractNodes(data?.myCollectionConnection)
+  const artworks = useMemo(
+    () => extractNodes(data?.myCollectionConnection),
+    [data?.myCollectionConnection]
+  )
 
   useLocalArtworkFilter(artworks)
 
@@ -57,11 +60,9 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({ me }
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const filterOptions = ArtworksFiltersStore.useStoreState((state) => state.filterOptions)
 
-  const filteredArtworks = localSortAndFilterArtworks(
-    artworks as any,
-    appliedFiltersState,
-    filterOptions,
-    query
+  const filteredArtworks = useMemo(
+    () => localSortAndFilterArtworks(artworks as any, appliedFiltersState, filterOptions, query),
+    [artworks, appliedFiltersState, filterOptions, query]
   )
 
   useEffect(() => {
@@ -80,6 +81,32 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({ me }
     )
   }, [])
 
+  const keyExtractor = useCallback((item: (typeof filteredArtworks)[0]) => item.id, [])
+
+  const shouldDisplaySpinner = isLoadingNext && hasNext
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Box mb="80px" pt={2}>
+        <FilteredArtworkGridZeroState hideClearButton />
+      </Box>
+    ),
+    []
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
+
+  const onEndReached = useCallback(() => {
+    if (hasNext && !isLoadingNext) {
+      loadNext(PAGE_SIZE)
+    }
+  }, [hasNext, isLoadingNext, loadNext])
+
   const RefreshControl = useRefreshControl(refetch)
 
   if (!data.myCollectionConnection) {
@@ -94,8 +121,6 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({ me }
     return <MyCollectionZeroState RefreshControl={RefreshControl} />
   }
 
-  const shouldDisplaySpinner = isLoadingNext && hasNext
-
   return (
     <Flex flex={1}>
       <ArtworkFilterNavigator
@@ -108,23 +133,13 @@ export const MyCollectionArtworks: React.FC<MyCollectionArtworksProps> = ({ me }
         data={filteredArtworks}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListEmptyComponent={
-          <Box mb="80px" pt={2}>
-            <FilteredArtworkGridZeroState hideClearButton />
-          </Box>
-        }
-        keyExtractor={(item) => item.id}
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
-        onEndReached={() => {
-          if (hasNext && !isLoadingNext) {
-            loadNext(PAGE_SIZE)
-          }
-        }}
+        onEndReached={onEndReached}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListFooterComponent={listFooterComponent}
         refreshControl={RefreshControl}
       />
     </Flex>

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -23,12 +23,6 @@ import React, { useCallback, useMemo, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 type PartnerArtworkType = ExtractNodeType<NonNullable<PartnerArtwork_partner$data["artworks"]>>
-
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render. Profiling the artworks
-// scroll showed the filter header SVG re-rendering once per container (pagination) re-render.
-const keyExtractor = (item: PartnerArtworkType) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
 const EMPTY_TEXT =
   "There are no matching works from this gallery.\nTry changing your search filters"
 
@@ -122,14 +116,14 @@ export const PartnerArtwork: React.FC<{
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={contentContainerStyle}
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         ListHeaderComponent={listHeaderComponent}
       />
 

--- a/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
+++ b/src/app/Scenes/Partner/Components/PartnerArtwork.tsx
@@ -19,10 +19,18 @@ import {
 } from "app/utils/masonryHelpers"
 import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { ExtractNodeType } from "app/utils/relayHelpers"
-import React, { useCallback, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 
 type PartnerArtworkType = ExtractNodeType<NonNullable<PartnerArtwork_partner$data["artworks"]>>
+
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render. Profiling the artworks
+// scroll showed the filter header SVG re-rendering once per container (pagination) re-render.
+const keyExtractor = (item: PartnerArtworkType) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
+const EMPTY_TEXT =
+  "There are no matching works from this gallery.\nTry changing your search filters"
 
 export const PartnerArtwork: React.FC<{
   partner: PartnerArtwork_partner$data
@@ -41,7 +49,7 @@ export const PartnerArtwork: React.FC<{
   })
   const appliedFiltersCount = useSelectedFiltersCount()
 
-  const artworks = extractNodes(partner.artworks)
+  const artworks = useMemo(() => extractNodes(partner.artworks), [partner.artworks])
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
@@ -58,8 +66,7 @@ export const PartnerArtwork: React.FC<{
   const shouldDisplaySpinner =
     !!isLoading && !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
 
-  const emptyText =
-    "There are no matching works from this gallery.\nTry changing your search filters"
+  const openFilterArtworksModal = useCallback(() => setIsFilterArtworksModalVisible(true), [])
 
   const renderItem: ListRenderItem<PartnerArtworkType> = useCallback(({ item }) => {
     const imgAspectRatio = item.image?.aspectRatio ?? 1
@@ -77,38 +84,53 @@ export const PartnerArtwork: React.FC<{
     )
   }, [])
 
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () => (
+      <Box mb="80px" pt={2}>
+        <TabEmptyState text={EMPTY_TEXT} />
+      </Box>
+    ),
+    []
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <ArtworksFilterHeader
+            selectedFiltersCount={appliedFiltersCount}
+            onFilterPress={openFilterArtworksModal}
+          />
+        </Tabs.SubTabBar>
+      </Flex>
+    ),
+    [appliedFiltersCount, openFilterArtworksModal]
+  )
+
   return (
     <>
       <Tabs.Masonry
         data={artworks}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListEmptyComponent={
-          <Box mb="80px" pt={2}>
-            <TabEmptyState text={emptyText} />
-          </Box>
-        }
-        keyExtractor={(item) => item.id}
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <ArtworksFilterHeader
-                selectedFiltersCount={appliedFiltersCount}
-                onFilterPress={() => setIsFilterArtworksModalVisible(true)}
-              />
-            </Tabs.SubTabBar>
-          </Flex>
-        }
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponent={listHeaderComponent}
       />
 
       <ArtworkFilterNavigator

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -31,11 +31,6 @@ import { useTracking } from "react-tracking"
 
 type TagArtworkType = ExtractNodeType<NonNullable<TagArtworks_tag$data["artworks"]>>
 
-// Hoisted so their identity is stable across renders — passing new references to FlashList forces
-// it (and its header/footer) to re-render on every container re-render.
-const keyExtractor = (item: TagArtworkType) => item.id
-const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
-
 interface TagArtworksProps {
   tag?: TagArtworks_tag$data | null
   relay: RelayPaginationProp
@@ -158,14 +153,14 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
         keyboardShouldPersistTaps="handled"
         contentContainerStyle={contentContainerStyle}
         ListEmptyComponent={listEmptyComponent}
-        keyExtractor={keyExtractor}
+        keyExtractor={(item) => item.id}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
         ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponentStyle={{ zIndex: 1 }}
         ListHeaderComponent={listHeaderComponent}
       />
       <ArtworkFilterNavigator

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -25,11 +25,16 @@ import {
 import { AnimatedMasonryListFooter } from "app/utils/masonryHelpers/AnimatedMasonryListFooter"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { Schema } from "app/utils/track"
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useMemo, useRef, useState } from "react"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
 
 type TagArtworkType = ExtractNodeType<NonNullable<TagArtworks_tag$data["artworks"]>>
+
+// Hoisted so their identity is stable across renders — passing new references to FlashList forces
+// it (and its header/footer) to re-render on every container re-render.
+const keyExtractor = (item: TagArtworkType) => item.id
+const LIST_HEADER_COMPONENT_STYLE = { zIndex: 1 }
 
 interface TagArtworksProps {
   tag?: TagArtworks_tag$data | null
@@ -44,15 +49,15 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
   const { width } = useScreenDimensions()
   const artworksTotal = tag?.artworks?.counts?.total ?? 0
   const initialArtworksTotal = useRef(artworksTotal)
-  const artworks = extractNodes(tag?.artworks) ?? []
+  const artworks = useMemo(() => extractNodes(tag?.artworks) ?? [], [tag?.artworks])
   const shouldDisplaySpinner =
     !!isLoading && !!artworks.length && !!relay.isLoading() && !!relay.hasMore()
 
-  const trackClear = () => {
+  const trackClear = useCallback(() => {
     if (tag?.id && tag?.slug) {
       tracking.trackEvent(tracks.clearFilters(tag.id, tag.slug))
     }
-  }
+  }, [tracking, tag?.id, tag?.slug])
 
   useArtworkFilters({
     relay,
@@ -61,22 +66,21 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
     pageSize: MASONRY_LIST_PAGE_SIZE,
   })
 
-  const handleCloseFilterArtworksModal = () => setFilterArtworkModalVisible(false)
-  const handleOpenFilterArtworksModal = () => setFilterArtworkModalVisible(true)
+  const handleCloseFilterArtworksModal = useCallback(() => setFilterArtworkModalVisible(false), [])
 
-  const openFilterArtworksModal = () => {
+  const openFilterArtworksModal = useCallback(() => {
     if (tag?.id && tag?.slug) {
       tracking.trackEvent(tracks.openFilterWindow(tag.id, tag.slug))
-      handleOpenFilterArtworksModal()
+      setFilterArtworkModalVisible(true)
     }
-  }
+  }, [tracking, tag?.id, tag?.slug])
 
-  const closeFilterArtworksModal = () => {
+  const closeFilterArtworksModal = useCallback(() => {
     if (tag?.id && tag?.slug) {
       tracking.trackEvent(tracks.closeFilterWindow(tag.id, tag.slug))
-      handleCloseFilterArtworksModal()
+      setFilterArtworkModalVisible(false)
     }
-  }
+  }, [tracking, tag?.id, tag?.slug])
 
   const loadMore = useCallback(() => {
     if (relay.hasMore() && !relay.isLoading()) {
@@ -90,21 +94,61 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
     }
   }, [relay.hasMore(), relay.isLoading()])
 
-  const renderItem: ListRenderItem<TagArtworkType> = useCallback(({ item }) => {
-    const imgAspectRatio = item.image?.aspectRatio ?? 1
-    const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
-    const imgHeight = imgWidth / imgAspectRatio
+  const renderItem: ListRenderItem<TagArtworkType> = useCallback(
+    ({ item }) => {
+      const imgAspectRatio = item.image?.aspectRatio ?? 1
+      const imgWidth = width / NUM_COLUMNS_MASONRY - space(2) - space(1)
+      const imgHeight = imgWidth / imgAspectRatio
 
-    return (
-      <ArtworkGridItem
-        contextScreenOwnerType={OwnerType.tag}
-        contextScreenOwnerId={tag?.internalID}
-        contextScreenOwnerSlug={tag?.slug}
-        artwork={item}
-        height={imgHeight}
-      />
-    )
-  }, [])
+      return (
+        <ArtworkGridItem
+          contextScreenOwnerType={OwnerType.tag}
+          contextScreenOwnerId={tag?.internalID}
+          contextScreenOwnerSlug={tag?.slug}
+          artwork={item}
+          height={imgHeight}
+        />
+      )
+    },
+    [width, space, tag?.internalID, tag?.slug]
+  )
+
+  const contentContainerStyle = useMemo(() => ({ paddingHorizontal: space(1) }), [space])
+
+  const listEmptyComponent = useMemo(
+    () =>
+      initialArtworksTotal ? (
+        <Box mt={1}>
+          <SimpleMessage>There aren’t any works available in the tag at this time.</SimpleMessage>
+        </Box>
+      ) : (
+        <Box pt={1}>
+          <FilteredArtworkGridZeroState id={tag?.id} slug={tag?.slug} trackClear={trackClear} />
+        </Box>
+      ),
+    [tag?.id, tag?.slug, trackClear]
+  )
+
+  const listHeaderComponent = useMemo(
+    () => (
+      <Flex px={1}>
+        <Tabs.SubTabBar>
+          <TagArtworksFilterHeader openFilterArtworksModal={openFilterArtworksModal} />
+        </Tabs.SubTabBar>
+        <Flex pt={1} backgroundColor="mono0">
+          <Text variant="xs" color="mono60">
+            Showing {artworksTotal} works
+          </Text>
+        </Flex>
+      </Flex>
+    ),
+    [openFilterArtworksModal, artworksTotal]
+  )
+
+  const listFooterComponent = useMemo(
+    () => <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />,
+    [shouldDisplaySpinner]
+  )
 
   return (
     <>
@@ -112,42 +156,17 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
         data={artworks}
         numColumns={NUM_COLUMNS_MASONRY}
         keyboardShouldPersistTaps="handled"
-        contentContainerStyle={{ paddingHorizontal: space(1) }}
-        ListEmptyComponent={
-          initialArtworksTotal ? (
-            <Box mt={1}>
-              <SimpleMessage>
-                There aren’t any works available in the tag at this time.
-              </SimpleMessage>
-            </Box>
-          ) : (
-            <Box pt={1}>
-              <FilteredArtworkGridZeroState id={tag?.id} slug={tag?.slug} trackClear={trackClear} />
-            </Box>
-          )
-        }
-        keyExtractor={(item) => item.id}
+        contentContainerStyle={contentContainerStyle}
+        ListEmptyComponent={listEmptyComponent}
+        keyExtractor={keyExtractor}
         renderItem={renderItem}
         onEndReached={loadMore}
         onEndReachedThreshold={ON_END_REACHED_THRESHOLD_MASONRY}
-        ListFooterComponent={() => (
-          <AnimatedMasonryListFooter shouldDisplaySpinner={shouldDisplaySpinner} />
-        )}
+        ListFooterComponent={listFooterComponent}
         // need to pass zIndex: 1 here in order for the SubTabBar to
         // be visible above list content
-        ListHeaderComponentStyle={{ zIndex: 1 }}
-        ListHeaderComponent={
-          <Flex px={1}>
-            <Tabs.SubTabBar>
-              <TagArtworksFilterHeader openFilterArtworksModal={openFilterArtworksModal} />
-            </Tabs.SubTabBar>
-            <Flex pt={1} backgroundColor="mono0">
-              <Text variant="xs" color="mono60">
-                Showing {artworksTotal} works
-              </Text>
-            </Flex>
-          </Flex>
-        }
+        ListHeaderComponentStyle={LIST_HEADER_COMPONENT_STYLE}
+        ListHeaderComponent={listHeaderComponent}
       />
       <ArtworkFilterNavigator
         id={tag?.internalID}


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

**TL;DR:** Artwork grids do a lot of unnecessary re-rendering while you scroll. This PR removes that wasted work by (1) not mounting a hidden "Create Alert" modal inside every artwork cell, and (2) keeping the props we hand to the list stable so the header/footer/cells stop re-rendering on every scroll tick. No behavior or UI changes — pure re-render hygiene, verified with the React DevTools profiler.

#### What changed

**Cell-level (this is the one that actually helps scrolling):**
- **`ArtworkGridItem`** — the "Create Alert" modal (`CreateArtworkAlertModal` → `CreateSavedSearchModal`, which reads its own Relay fragment) used to be rendered inside **every** artwork tile even while hidden. It's now gated behind the "is it open?" flag, so that whole subtree isn't re-rendered as tiles recycle during scroll.
- **`ArtworkSaveIconWrapper`** — wrapped in `React.memo` so the heart/save SVG isn't re-rendered on every tile recycle when its (all-primitive) props haven't changed.

**Container-level (re-render hygiene across the grids):**
- Stabilized the props passed to the masonry list (`FlashList`) so it stops re-rendering its header/footer on every container update: hoisted `keyExtractor` and static style objects, `useMemo`'d the data + header/footer/empty elements + `contentContainerStyle`, `useCallback`'d handlers, and replaced the inline-arrow `ListFooterComponent={() => …}` (which React treats as a brand-new component type every render) with a stable memoized element.
- Applied to: `ArtistArtworks`, `FairArtworks` (both variants), `GeneArtworks`, `PartnerArtwork`, `CollectionArtworks`, `ArtistSeriesArtworks`, `TagArtworks`, `InfiniteDiscoveryMoreWorksTab`, `MyCollectionArtworks`.

**Supporting fix:**
- **`useDismissAlertReminder`** — its returned functions were recreated on every render, which silently defeated memoization in `ArtistArtworks`. Wrapped them in `useCallback`. (Without this, the `ArtistArtworks` change does nothing.)

#### Why

`FlashList` recycles a small pool of cells continuously as you scroll — so anything a cell re-renders, or any hidden subtree it mounts, is paid **on every recycle**. And when we pass freshly-created objects/functions/inline components to the list on each render, the list is forced to re-render its header/footer (and can remount them). Removing both kinds of waste makes each scroll tick cheaper.

#### Impact (measured with React DevTools Profiler on a physical device)

> How to read this: cell recycling on scroll is normal and expected — the goal is to cut *wasted* work. **Component re-render counts** below are the trustworthy, scroll-independent signal. (Raw totals like "sum duration" are **not** cited because they're dominated by how far/fast you happen to scroll in each run.)

**Cell-level — the real win (per scroll):**

| Component (re-renders during a scroll) | Before | After |
|---|---|---|
| `CreateArtworkAlertModal` (per artwork tile) | ~230 (≈1 per tile) | **0** |
| `CreateSavedSearchModal` | ~259 | **35** |
| `ArtworkSaveIconWrapper` (heart icon) | ~280 (≈1 per tile) | **0** |

→ The alert-modal subtree (incl. its Relay `useFragment`) and the save icon **no longer re-render as tiles recycle** — roughly **3 fewer component re-renders per recycled tile (~0.16 ms of render work/tile)**.

**Container-level — wasted header re-renders removed (per pagination):**

| Screen | Filter-header re-renders | Before → After |
|---|---|---|
| Fair → Artworks | per pagination | **17 → 0** |
| Collection → Artworks | per pagination | **19 → 0** |
| Artist → Artworks | per pagination | **29 → 13** (0.45× — header genuinely re-reads the paginating fragment, so it can't reach 0) |

**Honest scope:** the container-level changes are code-quality / wasted-render cleanup — they remove real re-renders but are too small to show up as an FPS change on their own. The measurable scroll win comes from the cell-level `ArtworkGridItem` change. The bigger future lever (out of scope here) is adopting the React Compiler.

<!-- No UI changes, so no screenshots/videos. -->

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one. _(no flag needed — behavior-preserving)_
- [x] I have included **screenshots** or **videos**, or I have not changed the UI. _(no UI change)_
- [x] I have added **tests**, or my changes don't require any. _(behavior-preserving; existing grid tests pass)_
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work**, or it does not require any. _(follow-up: shared `MasonryInfiniteScrollArtworkGrid` + React Compiler pilot)_
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

-

#### Dev changes

- Reduced wasted re-renders in artwork grids: gate the hidden Create-Alert modal per grid cell, memoize the save icon, and stabilize the props passed to the masonry lists across the artwork grid screens.

<!-- end_changelog_updates -->

</details>
