### PR TITLE
refactor: rename ArtistSaveOnboardingBottomSheet to FollowArtistsOnboardingCompletionBottomSheet

### DIFF
--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -12,7 +12,7 @@ import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform } from "react-native"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 
-export const ArtistSaveOnboardingBottomSheet = () => {
+export const FollowArtistsOnboardingCompletionBottomSheet = () => {
   const showFollowedArtistSummaryBottomSheet = GlobalStore.useAppState(
     (state) => state.onboarding.showFollowedArtistSummaryBottomSheet
   )
@@ -74,7 +74,7 @@ export const ArtistSaveOnboardingBottomSheet = () => {
     <AutomountedBottomSheetModal
       enableDynamicSizing
       visible={isVisible}
-      name="ArtistSaveOnboardingBottomSheet"
+      name="FollowArtistsOnboardingCompletionBottomSheet"
       onDismiss={handleDismiss}
       backdropComponent={renderBackdrop}
     >

--- a/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
@@ -1,6 +1,6 @@
 import FastImage from "@d11/react-native-fast-image"
 import { fireEvent, screen } from "@testing-library/react-native"
-import { ArtistSaveOnboardingBottomSheet } from "app/Scenes/HomeView/Components/ArtistSaveOnboardingBottomSheet"
+import { FollowArtistsOnboardingCompletionBottomSheet } from "app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet"
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
@@ -10,7 +10,7 @@ jest.mock("app/utils/hooks/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn(),
 }))
 
-describe("ArtistSaveOnboardingBottomSheet", () => {
+describe("FollowArtistsOnboardingCompletionBottomSheet", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(false)
@@ -22,7 +22,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("does not render content when showFollowedArtistSummaryBottomSheet is false", () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(false)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       expect(
         screen.queryByText("Your followed artists are saved to Favorites.")
@@ -33,7 +33,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       ;(useFeatureFlag as jest.Mock).mockReturnValue(false)
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       expect(
         screen.queryByText("Your followed artists are saved to Favorites.")
@@ -43,7 +43,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("renders the sheet content when both conditions are met", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       expect(
         await screen.findByText("Your followed artists are saved to Favorites.")
@@ -79,7 +79,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       })
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 
@@ -108,7 +108,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       })
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 
@@ -128,7 +128,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("renders page 1 content", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       expect(
         await screen.findByText("Your followed artists are saved to Favorites.")
@@ -141,7 +141,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("renders page 2 content", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       expect(await screen.findByText("We'll let you know when new works arrive.")).toBeOnTheScreen()
       expect(
@@ -156,7 +156,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("shows Next button on page 1", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       // Component starts on page 1 (activeStep = 0)
       expect(await screen.findByText("Next")).toBeOnTheScreen()
@@ -165,7 +165,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("shows View For You button on page 2", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 
@@ -176,7 +176,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
     it("dismisses and resets global state when View For You is pressed", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 
@@ -199,7 +199,7 @@ describe("ArtistSaveOnboardingBottomSheet", () => {
       })
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<ArtistSaveOnboardingBottomSheet />)
+      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 

--- a/src/app/Scenes/HomeView/HomeView.tsx
+++ b/src/app/Scenes/HomeView/HomeView.tsx
@@ -47,7 +47,7 @@ import {
   ViewToken,
 } from "react-native"
 import { fetchQuery, graphql, useLazyLoadQuery, usePaginationFragment } from "react-relay"
-import { ArtistSaveOnboardingBottomSheet } from "./Components/ArtistSaveOnboardingBottomSheet"
+import { FollowArtistsOnboardingCompletionBottomSheet } from "./Components/FollowArtistsOnboardingCompletionBottomSheet"
 
 export const NUMBER_OF_SECTIONS_TO_LOAD = 10
 
@@ -312,7 +312,7 @@ const HomeViewScreenComponent: React.FC = () => {
           </Sentry.TimeToInitialDisplay>
         </Suspense>
         <PortalHost name={`${OwnerType.home}-SearchOverlay`} />
-        <ArtistSaveOnboardingBottomSheet />
+        <FollowArtistsOnboardingCompletionBottomSheet />
       </RetryErrorBoundary>
     </HomeViewStoreProvider>
   )


### PR DESCRIPTION
### Description

Pure rename, no behavior change: `ArtistSaveOnboardingBottomSheet` → `FollowArtistsOnboardingCompletionBottomSheet`.

The old name didn't read as part of the `FollowArtists` family (`FollowArtists.tsx`, `FollowArtistsOrderedSet.tsx`, `FollowedArtistsBank.tsx`) it belongs to. The new name mirrors Infinite Discovery's `NewUserOnboardingCompletionBottomSheet` naming pattern for the equivalent sheet on that flow.

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- Renamed `ArtistSaveOnboardingBottomSheet` to `FollowArtistsOnboardingCompletionBottomSheet`

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md