### PR TITLE
fix(DI-448): address QA feedback on FollowArtistsOnboardingCompletionBottomSheet

### DIFF
--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -9,7 +9,7 @@ import { PaginationBars } from "app/Scenes/InfiniteDiscovery/Components/Paginati
 import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState, useRef, useCallback, useEffect } from "react"
-import { Platform } from "react-native"
+import { Platform, Pressable, StyleSheet } from "react-native"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 
 export const FollowArtistsOnboardingCompletionBottomSheet = () => {
@@ -39,13 +39,13 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
     GlobalStore.actions.onboarding.resetFollowedOnboardingArtists()
   }
 
-  const handleButtonPress = () => {
+  const handleButtonPress = useCallback(() => {
     if (activeStep === 0) {
       pagerViewRef.current?.setPage(1)
     } else {
       handleDismiss()
     }
-  }
+  }, [activeStep])
 
   const handleIndexChange = (e: PagerViewOnPageScrollEvent) => {
     if (e.nativeEvent.position !== undefined && e.nativeEvent.position !== -1) {
@@ -55,15 +55,26 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
-      <BottomSheetBackdrop
-        {...props}
-        appearsOnIndex={0}
-        disappearsOnIndex={-1}
-        opacity={0.5}
-        style={[props.style, { backgroundColor: "rgb(229,229,229)" }]}
-      />
+      <Pressable
+        onPress={handleButtonPress}
+        style={StyleSheet.absoluteFill}
+        accessibilityRole="button"
+        accessibilityLabel={
+          activeStep === 0 ? "Advance to the next step" : "Dismiss the onboarding sheet"
+        }
+      >
+        <BottomSheetBackdrop
+          {...props}
+          appearsOnIndex={0}
+          disappearsOnIndex={-1}
+          opacity={0.5}
+          pressBehavior="none"
+          enableTouchThrough
+          style={[props.style, { backgroundColor: "rgb(229,229,229)" }]}
+        />
+      </Pressable>
     ),
-    []
+    [handleButtonPress, activeStep]
   )
 
   if (!isVisible) {
@@ -77,10 +88,14 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
       name="FollowArtistsOnboardingCompletionBottomSheet"
       onDismiss={handleDismiss}
       backdropComponent={renderBackdrop}
+      enablePanDownToClose={false}
+      enableHandlePanningGesture={false}
+      enableContentPanningGesture={false}
+      handleComponent={null}
     >
       <BottomSheetView style={bottomSheetViewStyles}>
         <Flex mb={4} mx={2} alignItems="center">
-          <Spacer y={1} />
+          <Spacer y={2} />
 
           <Flex flexDirection="row" justifyContent="center" alignItems="center">
             {followedOnboardingArtists.slice(-3).map((artist, index) => (


### PR DESCRIPTION
This PR resolves [DI-448](https://www.notion.so/396cab0764a0804fa854d74528d3c4fc)

### Description

Addresses QA feedback on the Follow Artists onboarding completion sheet:

- **Backdrop tap now advances before it dismisses.** Previously, tapping the dimmed backdrop closed the sheet immediately, even on the first step. Now it reuses the same `handleButtonPress` logic as the visible button: first tap advances to step 2, second tap (once on step 2) dismisses the sheet.
- **Disabled swipe-to-dismiss entirely.** Added `enablePanDownToClose={false}`, `enableHandlePanningGesture={false}`, `enableContentPanningGesture={false}`, and `handleComponent={null}` (hides the drag handle) — matching how Infinite Discovery's `NewUserOnboardingCompletionBottomSheet` locks its equivalent sheet down.
- **Matched the spacing above the avatar row** to Infinite Discovery's spacing above its artwork fan (10px → 20px, via `<Spacer y={2} />`, keeping this repo's idiomatic `Spacer`-based spacing pattern rather than switching to container padding).

| You can't see the taps, but I'm using a combination of tapping the backdrop, swiping the cards, and tapping the button to advance the bottom sheet's content. |
|-|
| https://github.com/user-attachments/assets/827d3146-1b71-4cda-9dad-eec5fd36efd1 |




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

Note: the backdrop-tap behavior isn't covered by an automated test — the jest mock for `@gorhom/bottom-sheet` no-ops `BottomSheetBackdrop` and never invokes `backdropComponent`, so this needs manual/simulator verification.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fixed the Follow Artists onboarding completion sheet's backdrop tap and disabled swipe-to-dismiss

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md