### PR TITLE
feat(DI-450): show a one-time Favorites tab tooltip after new-user onboarding

### DIFF
--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
@@ -10,10 +10,6 @@ import { switchTab } from "app/system/navigation/navigate"
 import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
 import { useTracking } from "react-tracking"
 
-export const PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE = "Your saves get stored here."
-export const PROGRESSIVE_ONBOARDING_FAVORITES_TAB_CONTENT =
-  "Visit your favorites at any time to see your saves and follows."
-
 const FAVORITES_TAB_ONBOARDING_POPOVER_DELAY = 1000
 
 export const ProgressiveOnboardingFavoritesTab: React.FC<React.PropsWithChildren> = ({
@@ -75,7 +71,7 @@ export const ProgressiveOnboardingFavoritesTab: React.FC<React.PropsWithChildren
       title={
         <Touchable accessibilityRole="button" noFeedback onPress={onPress}>
           <Text variant="xs" color="mono0" fontWeight="bold">
-            {PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE}
+            Your saves get stored here.
           </Text>
         </Touchable>
       }
@@ -83,7 +79,7 @@ export const ProgressiveOnboardingFavoritesTab: React.FC<React.PropsWithChildren
         <Touchable noFeedback accessibilityRole="button" onPress={onPress}>
           <Flex maxWidth={250}>
             <Text variant="xs" color="mono0">
-              {PROGRESSIVE_ONBOARDING_FAVORITES_TAB_CONTENT}
+              Visit your favorites at any time to see your saves and follows.
             </Text>
           </Flex>
         </Touchable>

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
@@ -1,0 +1,106 @@
+import { ActionType, ContextModule, OwnerType, TappedPopover } from "@artsy/cohesion"
+import { Flex, Popover, Text, Touchable } from "@artsy/palette-mobile"
+import { useProgressiveOnboardingTracking } from "app/Components/ProgressiveOnboarding/useProgressiveOnboardingTracking"
+import { useSetActivePopover } from "app/Components/ProgressiveOnboarding/useSetActivePopover"
+import { internal_navigationRef } from "app/Navigation/Navigation"
+import { GlobalStore } from "app/store/GlobalStore"
+import { PROGRESSIVE_ONBOARDING_FAVORITES_TAB } from "app/store/ProgressiveOnboardingModel"
+// eslint-disable-next-line no-restricted-imports
+import { switchTab } from "app/system/navigation/navigate"
+import { useDebouncedValue } from "app/utils/hooks/useDebouncedValue"
+import { useTracking } from "react-tracking"
+
+export const PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE = "Your saves get stored here."
+export const PROGRESSIVE_ONBOARDING_FAVORITES_TAB_CONTENT =
+  "Visit your favorites at any time to see your saves and follows."
+
+const FAVORITES_TAB_ONBOARDING_POPOVER_DELAY = 1000
+
+export const ProgressiveOnboardingFavoritesTab: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const tracking = useTracking()
+
+  const newUserOnboardingSavedArtworksCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
+  )
+  const {
+    isDismissed: isDismissedFn,
+    sessionState: { isReady },
+  } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
+
+  const { dismiss, setIsReady } = GlobalStore.actions.progressiveOnboarding
+
+  const { trackEvent } = useProgressiveOnboardingTracking({
+    name: PROGRESSIVE_ONBOARDING_FAVORITES_TAB,
+    contextScreenOwnerType: OwnerType.home,
+    contextModule: ContextModule.bottomTabs,
+  })
+
+  const currentRoute = internal_navigationRef.current?.getCurrentRoute()?.name
+
+  const isDismissed = isDismissedFn(PROGRESSIVE_ONBOARDING_FAVORITES_TAB).status
+
+  const isFavoritesTooltipDisplayable =
+    newUserOnboardingSavedArtworksCount >= 1 && !isDismissed && currentRoute === "Home" && isReady
+
+  const { isActive, clearActivePopover } = useSetActivePopover(isFavoritesTooltipDisplayable)
+
+  const debounceIsActive = useDebouncedValue({
+    value: isActive,
+    delay: FAVORITES_TAB_ONBOARDING_POPOVER_DELAY,
+  })
+
+  const handleDismiss = () => {
+    setIsReady(false)
+    dismiss(PROGRESSIVE_ONBOARDING_FAVORITES_TAB)
+  }
+
+  const isVisible = debounceIsActive.debouncedValue && !isDismissed
+
+  const onPress = () => {
+    handleDismiss()
+    tracking.trackEvent(tracks.onPopoverPress())
+    switchTab("favorites")
+  }
+
+  return (
+    <Popover
+      visible={isVisible}
+      onDismiss={handleDismiss}
+      onPressOutside={handleDismiss}
+      onCloseComplete={clearActivePopover}
+      onOpenComplete={trackEvent}
+      placement="top"
+      title={
+        <Touchable accessibilityRole="button" noFeedback onPress={onPress}>
+          <Text variant="xs" color="mono0" fontWeight="bold">
+            {PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE}
+          </Text>
+        </Touchable>
+      }
+      content={
+        <Touchable noFeedback accessibilityRole="button" onPress={onPress}>
+          <Flex maxWidth={250}>
+            <Text variant="xs" color="mono0">
+              {PROGRESSIVE_ONBOARDING_FAVORITES_TAB_CONTENT}
+            </Text>
+          </Flex>
+        </Touchable>
+      }
+    >
+      <Flex>{children}</Flex>
+    </Popover>
+  )
+}
+
+const tracks = {
+  onPopoverPress: (): TappedPopover => {
+    return {
+      action: ActionType.tappedPopover,
+      context_screen_owner_type: OwnerType.home,
+      context_module: ContextModule.bottomTabs,
+      type: PROGRESSIVE_ONBOARDING_FAVORITES_TAB,
+    }
+  },
+}

--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingPriceRangeHome.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingPriceRangeHome.tsx
@@ -24,7 +24,7 @@ export const ProgressiveOnboardingPriceRangeHome: React.FC<React.PropsWithChildr
 }) => {
   const {
     isDismissed: isDismissedFn,
-    sessionState: { isReady },
+    sessionState: { isReady, deferHomeTooltipsThisSession },
   } = GlobalStore.useAppState((state) => state.progressiveOnboarding)
 
   const showFollowedArtistSummaryBottomSheet = GlobalStore.useAppState(
@@ -58,7 +58,8 @@ export const ProgressiveOnboardingPriceRangeHome: React.FC<React.PropsWithChildr
     currentRoute === "Home" &&
     !isDismissed &&
     isReady &&
-    !showFollowedArtistSummaryBottomSheet
+    !showFollowedArtistSummaryBottomSheet &&
+    !deferHomeTooltipsThisSession
 
   const { isActive, clearActivePopover } = useSetActivePopover(isPriceRangePopoverDisplayable)
 

--- a/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
@@ -1,0 +1,121 @@
+import { screen } from "@testing-library/react-native"
+import { ProgressiveOnboardingFavoritesTab } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
+import { internal_navigationRef } from "app/Navigation/Navigation"
+import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { Text } from "react-native"
+
+jest.mock("@artsy/palette-mobile", () => ({
+  ...jest.requireActual("@artsy/palette-mobile"),
+  Popover: (props: any) => <MockedPopover {...props} />,
+}))
+
+jest.mock("app/utils/hooks/useDebouncedValue", () => {
+  return {
+    useDebouncedValue: ({ value }: { value: string }) => ({ debouncedValue: value }),
+  }
+})
+
+jest.mock("app/Navigation/Navigation", () => ({
+  ...jest.requireActual("app/Navigation/Navigation"),
+  internal_navigationRef: {
+    current: {
+      getCurrentRoute: () => ({
+        name: "Home",
+      }),
+    },
+  },
+}))
+
+describe("ProgressiveOnboardingFavoritesTab", () => {
+  beforeEach(() => {
+    __globalStoreTestUtils__?.injectState({
+      progressiveOnboarding: {
+        sessionState: { isReady: true },
+        dismissed: [],
+      },
+      infiniteDiscovery: {
+        sessionState: {
+          newUserOnboardingSavedArtworks: [{ internalID: "artwork-1", url: "https://example.com" }],
+        },
+      },
+    })
+
+    jest.spyOn(internal_navigationRef.current as any, "getCurrentRoute").mockReturnValue({
+      name: "Home",
+    } as any)
+  })
+
+  const render = () =>
+    renderWithWrappers(
+      <ProgressiveOnboardingFavoritesTab>
+        <Text>Content</Text>
+      </ProgressiveOnboardingFavoritesTab>
+    )
+
+  it("shows popover when at least one artwork was saved during onboarding", async () => {
+    render()
+
+    await flushPromiseQueue()
+
+    expect(screen.getByText("Popover")).toBeOnTheScreen()
+    expect(screen.getByText("Content")).toBeOnTheScreen()
+  })
+
+  it("does not show popover when no artworks were saved during onboarding", async () => {
+    __globalStoreTestUtils__?.injectState({
+      infiniteDiscovery: {
+        sessionState: { newUserOnboardingSavedArtworks: [] },
+      },
+    })
+
+    render()
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    expect(screen.getByText("Content")).toBeOnTheScreen()
+  })
+
+  it("does not show popover when the current route is not home", async () => {
+    jest.spyOn(internal_navigationRef.current as any, "getCurrentRoute").mockReturnValue({
+      name: "Search",
+    })
+
+    render()
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    expect(screen.getByText("Content")).toBeOnTheScreen()
+  })
+
+  it("does not show popover when it has already been dismissed", async () => {
+    __globalStoreTestUtils__?.injectState({
+      progressiveOnboarding: {
+        dismissed: [{ key: "favorites-tab", timestamp: Date.now() }],
+      },
+    })
+
+    render()
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    expect(screen.getByText("Content")).toBeOnTheScreen()
+  })
+})
+
+const MockedPopover: React.FC<any> = ({ children, onDismiss, visible }) => {
+  if (!visible) {
+    return <>{children}</>
+  }
+
+  return (
+    <>
+      <Text onPress={onDismiss}>Popover</Text>
+      <>{children}</>
+    </>
+  )
+}

--- a/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
@@ -1,10 +1,15 @@
-import { screen } from "@testing-library/react-native"
-import { ProgressiveOnboardingFavoritesTab } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
+import {
+  PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE,
+  ProgressiveOnboardingFavoritesTab,
+} from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { Text } from "react-native"
+
+const mockSwitchTab = jest.fn()
 
 jest.mock("@artsy/palette-mobile", () => ({
   ...jest.requireActual("@artsy/palette-mobile"),
@@ -26,6 +31,10 @@ jest.mock("app/Navigation/Navigation", () => ({
       }),
     },
   },
+}))
+
+jest.mock("app/system/navigation/navigate", () => ({
+  switchTab: (...args: any[]) => mockSwitchTab(...args),
 }))
 
 describe("ProgressiveOnboardingFavoritesTab", () => {
@@ -57,13 +66,13 @@ describe("ProgressiveOnboardingFavoritesTab", () => {
   it("shows popover when at least one artwork was saved during onboarding", async () => {
     render()
 
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Popover")).toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.getByText("Popover")).toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
-  it("does not show popover when no artworks were saved during onboarding", async () => {
+  it("does not show popover when no artworks were saved during onboarding", () => {
     __globalStoreTestUtils__?.injectState({
       infiniteDiscovery: {
         sessionState: { newUserOnboardingSavedArtworks: [] },
@@ -72,26 +81,22 @@ describe("ProgressiveOnboardingFavoritesTab", () => {
 
     render()
 
-    await flushPromiseQueue()
-
     expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
-  it("does not show popover when the current route is not home", async () => {
+  it("does not show popover when the current route is not home", () => {
     jest.spyOn(internal_navigationRef.current as any, "getCurrentRoute").mockReturnValue({
       name: "Search",
     })
 
     render()
 
-    await flushPromiseQueue()
-
     expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
-  it("does not show popover when it has already been dismissed", async () => {
+  it("does not show popover when it has already been dismissed", () => {
     __globalStoreTestUtils__?.injectState({
       progressiveOnboarding: {
         dismissed: [{ key: "favorites-tab", timestamp: Date.now() }],
@@ -100,14 +105,29 @@ describe("ProgressiveOnboardingFavoritesTab", () => {
 
     render()
 
-    await flushPromiseQueue()
-
     expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
+
+  it("dismisses the popover, switches to the favorites tab, and tracks the tap when pressed", async () => {
+    render()
+
+    await waitFor(() => {
+      expect(screen.getByText("Popover")).toBeOnTheScreen()
+    })
+
+    fireEvent.press(screen.getByText(PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE))
+
+    expect(mockSwitchTab).toHaveBeenCalledWith("favorites")
+    expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "favorites-tab" }))
+    expect(
+      __globalStoreTestUtils__?.getCurrentState().progressiveOnboarding.isDismissed("favorites-tab")
+        .status
+    ).toBe(true)
+  })
 })
 
-const MockedPopover: React.FC<any> = ({ children, onDismiss, visible }) => {
+const MockedPopover: React.FC<any> = ({ children, onDismiss, visible, title, content }) => {
   if (!visible) {
     return <>{children}</>
   }
@@ -115,6 +135,8 @@ const MockedPopover: React.FC<any> = ({ children, onDismiss, visible }) => {
   return (
     <>
       <Text onPress={onDismiss}>Popover</Text>
+      {title}
+      {content}
       <>{children}</>
     </>
   )

--- a/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingFavoritesTab.tests.tsx
@@ -1,8 +1,5 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react-native"
-import {
-  PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE,
-  ProgressiveOnboardingFavoritesTab,
-} from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
+import { ProgressiveOnboardingFavoritesTab } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
@@ -116,7 +113,7 @@ describe("ProgressiveOnboardingFavoritesTab", () => {
       expect(screen.getByText("Popover")).toBeOnTheScreen()
     })
 
-    fireEvent.press(screen.getByText(PROGRESSIVE_ONBOARDING_FAVORITES_TAB_TITLE))
+    fireEvent.press(screen.getByText("Your saves get stored here."))
 
     expect(mockSwitchTab).toHaveBeenCalledWith("favorites")
     expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "favorites-tab" }))

--- a/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingPriceRangeHome.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingPriceRangeHome.tests.tsx
@@ -1,8 +1,7 @@
-import { screen } from "@testing-library/react-native"
+import { screen, waitFor } from "@testing-library/react-native"
 import { ProgressiveOnboardingPriceRangeHome } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingPriceRangeHome"
 import { internal_navigationRef } from "app/Navigation/Navigation"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
-import { flushPromiseQueue } from "app/utils/tests/flushPromiseQueue"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
 import { useEffect } from "react"
 import { Text, View } from "react-native"
@@ -62,9 +61,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
   it("shows popover when all conditions are met", async () => {
     renderWithRelay(mockProps)
 
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Popover")).toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.getByText("Popover")).toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
@@ -75,9 +74,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
 
     renderWithRelay(mockProps)
 
-    await flushPromiseQueue()
-
-    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
@@ -88,9 +87,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
       }),
     })
 
-    await flushPromiseQueue()
-
-    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
@@ -106,9 +105,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
 
     renderWithRelay(mockProps)
 
-    await flushPromiseQueue()
-
-    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
@@ -125,9 +124,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
 
     renderWithRelay(mockProps)
 
-    await flushPromiseQueue()
-
-    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 
@@ -144,9 +143,9 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
 
     renderWithRelay(mockProps)
 
-    await flushPromiseQueue()
-
-    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    await waitFor(() => {
+      expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    })
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
 })

--- a/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingPriceRangeHome.tests.tsx
+++ b/src/app/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingPriceRangeHome.tests.tsx
@@ -130,6 +130,25 @@ describe("ProgressiveOnboardingPriceRangeHome", () => {
     expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
     expect(screen.getByText("Content")).toBeOnTheScreen()
   })
+
+  it("does not show popover when Home tooltips are deferred to the next session", async () => {
+    __globalStoreTestUtils__?.injectState({
+      progressiveOnboarding: {
+        sessionState: { isReady: true, deferHomeTooltipsThisSession: true },
+        dismissed: [],
+      },
+      onboarding: {
+        showFollowedArtistSummaryBottomSheet: false,
+      },
+    })
+
+    renderWithRelay(mockProps)
+
+    await flushPromiseQueue()
+
+    expect(screen.queryByText("Popover")).not.toBeOnTheScreen()
+    expect(screen.getByText("Content")).toBeOnTheScreen()
+  })
 })
 
 const mockProps = {

--- a/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
+++ b/src/app/Navigation/AuthenticatedRoutes/Tabs.tsx
@@ -4,6 +4,7 @@ import { createBottomTabNavigator } from "@react-navigation/bottom-tabs"
 import { PlatformPressable } from "@react-navigation/elements"
 import { EventArg } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
+import { ProgressiveOnboardingFavoritesTab } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab"
 import { ProgressiveOnboardingPriceRangeHome } from "app/Components/ProgressiveOnboarding/ProgressiveOnboardingPriceRangeHome"
 import { FavoritesTab } from "app/Navigation/AuthenticatedRoutes/FavoritesTab"
 import { HomeTab } from "app/Navigation/AuthenticatedRoutes/HomeTab"
@@ -140,7 +141,7 @@ const AppTabs: React.FC = () => {
               )
             }
 
-            const WrappedIcon = () => {
+            const WrappedProfileIcon = () => {
               return (
                 <ProgressiveOnboardingPriceRangeHome>
                   <Icon />
@@ -148,8 +149,20 @@ const AppTabs: React.FC = () => {
               )
             }
 
+            const WrappedFavoritesIcon = () => {
+              return (
+                <ProgressiveOnboardingFavoritesTab>
+                  <Icon />
+                </ProgressiveOnboardingFavoritesTab>
+              )
+            }
+
             if (route.name === "profile") {
-              return <WrappedIcon />
+              return <WrappedProfileIcon />
+            }
+
+            if (route.name === "favorites") {
+              return <WrappedFavoritesIcon />
             }
 
             return <Icon />

--- a/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/InfiniteDiscoveryHeader.tsx
@@ -52,6 +52,9 @@ export const InfiniteDiscoveryHeader: React.FC<InfiniteDiscoveryHeaderProps> = (
       trackTappedSkip(ContextModule.onboardingFlow, OwnerType.infiniteDiscoveryArtwork)
     }
     trackCompletedOnboarding()
+    if (newUserOnboardingSavedArtworkCount >= 1) {
+      GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
+    }
     GlobalStore.actions.onboarding.setOnboardingState("complete")
   }
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -43,6 +43,9 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
   const savedArtworks = GlobalStore.useAppState(
     (state) => state.infiniteDiscovery.sessionState.newUserOnboardingGoalSnapshot
   )
+  const newUserOnboardingSavedArtworkCount = GlobalStore.useAppState(
+    (state) => state.infiniteDiscovery.sessionState.newUserOnboardingSavedArtworks.length
+  )
   const { setOnboardingState } = GlobalStore.actions.onboarding
   const { setNewUserOnboardingCompletionBottomSheetVisible } = GlobalStore.actions.infiniteDiscovery
   const { trackCompletedOnboarding } = useOnboardingTracking()
@@ -53,7 +56,9 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
 
   const handleTakeMeHome = () => {
     trackCompletedOnboarding()
-    GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
+    if (newUserOnboardingSavedArtworkCount >= 1) {
+      GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
+    }
     setOnboardingState("complete")
     setNewUserOnboardingCompletionBottomSheetVisible(false)
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/NewUserOnboardingCompletionBottomSheet.tsx
@@ -53,6 +53,7 @@ export const NewUserOnboardingCompletionBottomSheet: React.FC = () => {
 
   const handleTakeMeHome = () => {
     trackCompletedOnboarding()
+    GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(true)
     setOnboardingState("complete")
     setNewUserOnboardingCompletionBottomSheetVisible(false)
   }

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/InfiniteDiscoveryHeader.tests.tsx
@@ -169,6 +169,38 @@ describe("InfiniteDiscoveryHeader", () => {
       expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
     })
 
+    it("does not defer Home tooltips when Skip is pressed without any saves", () => {
+      GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+      GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(false)
+
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      expect(
+        __globalStoreTestUtils__?.getCurrentState().progressiveOnboarding.sessionState
+          .deferHomeTooltipsThisSession
+      ).toBe(false)
+    })
+
+    it("defers Home tooltips to the next session when Skip is pressed after saving at least one", () => {
+      GlobalStore.actions.infiniteDiscovery.resetNewUserOnboardingSessionState()
+      GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(false)
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork({
+        internalID: "artwork-1",
+        url: "https://example.com/1.jpg",
+      })
+
+      renderWithWrappers(<InfiniteDiscoveryHeader />)
+
+      fireEvent.press(screen.getByLabelText("Skip to home"))
+
+      expect(
+        __globalStoreTestUtils__?.getCurrentState().progressiveOnboarding.sessionState
+          .deferHomeTooltipsThisSession
+      ).toBe(true)
+    })
+
     it("tracks the skip tap", () => {
       renderWithWrappers(<InfiniteDiscoveryHeader topArtwork={mockTopArtwork} />)
 

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -57,6 +57,19 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
     expect(state?.onboarding.onboardingState).toBe("complete")
   })
 
+  it('"Go to home" defers Home tooltips to the next session', () => {
+    GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(false)
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
+
+    renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
+
+    fireEvent.press(screen.getByText("Go to home"))
+
+    const state = __globalStoreTestUtils__?.getCurrentState()
+    expect(state?.progressiveOnboarding.sessionState.deferHomeTooltipsThisSession).toBe(true)
+  })
+
   it("renders 5 artwork images from the store", () => {
     GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     SAVED_ARTWORKS.forEach((artwork) => {

--- a/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/InfiniteDiscovery/Components/__tests__/NewUserOnboardingCompletionBottomSheet.tests.tsx
@@ -57,7 +57,23 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
     expect(state?.onboarding.onboardingState).toBe("complete")
   })
 
-  it('"Go to home" defers Home tooltips to the next session', () => {
+  it('"Go to home" defers Home tooltips to the next session when at least one artwork was saved', () => {
+    GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(false)
+    GlobalStore.actions.onboarding.setOnboardingState("incomplete")
+    SAVED_ARTWORKS.forEach((artwork) => {
+      GlobalStore.actions.infiniteDiscovery.addNewUserOnboardingSavedArtwork(artwork)
+    })
+    GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
+
+    renderWithWrappers(<NewUserOnboardingCompletionBottomSheet />)
+
+    fireEvent.press(screen.getByText("Go to home"))
+
+    const state = __globalStoreTestUtils__?.getCurrentState()
+    expect(state?.progressiveOnboarding.sessionState.deferHomeTooltipsThisSession).toBe(true)
+  })
+
+  it('"Go to home" does not defer Home tooltips when no artworks were saved', () => {
     GlobalStore.actions.progressiveOnboarding.setDeferHomeTooltipsThisSession(false)
     GlobalStore.actions.onboarding.setOnboardingState("incomplete")
     GlobalStore.actions.infiniteDiscovery.setNewUserOnboardingCompletionBottomSheetVisible(true)
@@ -67,7 +83,7 @@ describe("NewUserOnboardingCompletionBottomSheet", () => {
     fireEvent.press(screen.getByText("Go to home"))
 
     const state = __globalStoreTestUtils__?.getCurrentState()
-    expect(state?.progressiveOnboarding.sessionState.deferHomeTooltipsThisSession).toBe(true)
+    expect(state?.progressiveOnboarding.sessionState.deferHomeTooltipsThisSession).toBe(false)
   })
 
   it("renders 5 artwork images from the store", () => {

--- a/src/app/store/ProgressiveOnboardingModel.ts
+++ b/src/app/store/ProgressiveOnboardingModel.ts
@@ -23,9 +23,11 @@ export interface ProgressiveOnboardingModel {
     // we use this to control which popover is active, we cannot have 2 popovers
     // active at the same time
     activePopover?: string
+    deferHomeTooltipsThisSession: boolean
   }
   setIsReady: Action<this, boolean>
   setActivePopover: Action<this, string | undefined>
+  setDeferHomeTooltipsThisSession: Action<this, boolean>
   __clearDissmissed: Action<this>
   reset: Action<this>
 }
@@ -33,6 +35,7 @@ export interface ProgressiveOnboardingModel {
 export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => ({
   sessionState: {
     isReady: false,
+    deferHomeTooltipsThisSession: false,
   },
   dismissed: [],
   dismiss: action((state, key) => {
@@ -43,7 +46,10 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
       [...state.dismissed, ...keys.map((k) => ({ key: k, timestamp }))],
       (d) => d.key
     )
-    state.sessionState = { isReady: state.sessionState.isReady }
+    state.sessionState = {
+      isReady: state.sessionState.isReady,
+      deferHomeTooltipsThisSession: state.sessionState.deferHomeTooltipsThisSession,
+    }
   }),
   isDismissed: computed(({ dismissed }) => {
     return (key) => {
@@ -66,12 +72,15 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
   setActivePopover: action((state, id) => {
     state.sessionState.activePopover = id
   }),
+  setDeferHomeTooltipsThisSession: action((state, defer) => {
+    state.sessionState.deferHomeTooltipsThisSession = defer
+  }),
   __clearDissmissed: action((state) => {
     state.dismissed = []
   }),
   reset: action((state) => {
     state.dismissed = []
-    state.sessionState = { isReady: false }
+    state.sessionState = { isReady: false, deferHomeTooltipsThisSession: false }
   }),
 })
 
@@ -113,6 +122,8 @@ export const PROGRESSIVE_ONBOARDING_INFINITE_DISCOVERY_SAVE_REMINDER_2 =
 
 export const PROGRESSIVE_ONBOARDING_PRICE_RANGE_POPOVER_HOME = "price-range-popover-home"
 
+export const PROGRESSIVE_ONBOARDING_FAVORITES_TAB = "favorites-tab"
+
 export const PROGRESSIVE_ONBOARDING_KEYS = [
   PROGRESSIVE_ONBOARDING_SAVE_ARTWORK,
   PROGRESSIVE_ONBOARDING_ALERT_CREATE,
@@ -128,6 +139,7 @@ export const PROGRESSIVE_ONBOARDING_KEYS = [
   PROGRESSIVE_ONBOARDING_INFINITE_DISCOVERY_SAVE_REMINDER_2,
   PROGRESSIVE_ONBOARDING_DARK_MODE,
   PROGRESSIVE_ONBOARDING_PRICE_RANGE_POPOVER_HOME,
+  PROGRESSIVE_ONBOARDING_FAVORITES_TAB,
 ] as const
 
 export type ProgressiveOnboardingKey = (typeof PROGRESSIVE_ONBOARDING_KEYS)[number]

--- a/src/app/store/ProgressiveOnboardingModel.ts
+++ b/src/app/store/ProgressiveOnboardingModel.ts
@@ -47,10 +47,8 @@ export const getProgressiveOnboardingModel = (): ProgressiveOnboardingModel => (
       [...state.dismissed, ...keys.map((k) => ({ key: k, timestamp }))],
       (d) => d.key
     )
-    state.sessionState = {
-      isReady: state.sessionState.isReady,
-      deferHomeTooltipsThisSession: state.sessionState.deferHomeTooltipsThisSession,
-    }
+    const { activePopover: _activePopover, ...rest } = state.sessionState
+    state.sessionState = rest
   }),
   isDismissed: computed(({ dismissed }) => {
     return (key) => {

--- a/src/app/store/ProgressiveOnboardingModel.ts
+++ b/src/app/store/ProgressiveOnboardingModel.ts
@@ -23,6 +23,7 @@ export interface ProgressiveOnboardingModel {
     // we use this to control which popover is active, we cannot have 2 popovers
     // active at the same time
     activePopover?: string
+    // Each Home tooltip must check this itself; setting it doesn't block anything on its own
     deferHomeTooltipsThisSession: boolean
   }
   setIsReady: Action<this, boolean>


### PR DESCRIPTION
This PR resolves [DI-450](https://www.notion.so/396cab0764a08093a737dd9385f2c167)

### Description

Once a new user finishes Discover Daily onboarding having saved at least one artwork (whether they hit the 5-save goal or skipped out early) a tooltip points at the Favorites tab. It behaves like every other progressive-onboarding tooltip in the app: shows once, dismissible by tapping it, tapping outside it, or tapping through to Favorites.

In order to avoid showing back-to-back tooltips with the existing price range tooltip (since both can become eligible the moment a new user lands on Home), other Home tooltips now wait until the user's *next* app session before they're allowed to appear.

**How the "wait until next session" deferral works:**

When a new user finishes onboarding and lands on the Home tab, more than one progressive onboarding tooltip could be ready to show at the same moment — this new one pointing at Favorites, and an existing one about setting a price range. Rather than let two tips show one right after another, which will be annoying for users, the app now remembers "this person just finished onboarding" for the rest of that visit. While it remembers that, only the Favorites tooltip is allowed to show — every other tooltip on the Home screen waits until the next time the person opens the app. That memory clears itself automatically the next time they open the app, so from then on, tips behave exactly as they always have.

**How the new tooltip was plugged into the existing "one tip at a time" system:**

The app already has a system that makes sure only one progressive tooltip is ever on screen at once, no matter how many are technically eligible to show at that moment. Any tooltip that wants to appear has to be the first in line; if another tooltip is already holding being displayed, it just waits its turn until that one is dismissed. We plugged the new Favorites tip into that exact same system, so it behaves consistently with every other tooltip in the app: it takes its turn, shows once, and hands eligibility back once it's dismissed.


https://github.com/user-attachments/assets/f4a5aa4d-2cbd-4661-b3aa-eccadc7e9d7f



### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. — No flag; ships within the existing onboarding flow, same as its parent PR.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI. — To be added.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one. — Everything added lives under `sessionState`, which is exempt from migrations.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Show a one-time tooltip pointing at the Favorites tab after new-user onboarding, and defer other Home tooltips to the next session to avoid back-to-back prompts

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
