### PR TITLE
ci(e2e): allow iOS and Android E2E jobs to run on manual dispatch

### DIFF
--- a/.github/workflows/android-e2e-maestro.yml
+++ b/.github/workflows/android-e2e-maestro.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run for manual/scheduled triggers, or only on a successful build when chained from the build workflow.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest # Use ubuntu-latest for better Android emulator support
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ios-e2e-maestro.yml
+++ b/.github/workflows/ios-e2e-maestro.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch: # Allows you to trigger the workflow manually from the Actions tab
 jobs:
   e2e-tests:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # Run for manual/scheduled triggers, or only on a successful build when chained from the build workflow.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: macos-26 # iOS simulators require macOS runners
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

Both the iOS and Android `E2E Tests (Maestro)` workflows already declare `workflow_dispatch`, but the `e2e-tests` job was gated on:

```yaml
if: ${{ github.event.workflow_run.conclusion == 'success' }}
```

For a `workflow_dispatch` (or `schedule`) event there is no `workflow_run` object, so this evaluates to `false` and the job is **skipped** — clicking "Run workflow" starts a run that does nothing.

This relaxes the guard to run the job for non-`workflow_run` events, while preserving the original behavior when chained from the build workflow (still only runs on a successful build):

```yaml
if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
```

After this, either suite can be triggered manually via **Actions → (iOS/Android) E2E Tests (Maestro) → Run workflow**, or `gh workflow run ios-e2e-maestro.yml --ref <branch>` / `gh workflow run android-e2e-maestro.yml --ref <branch>`.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Allow the iOS and Android Maestro E2E workflows to run on manual dispatch (the job previously skipped for non-build triggers).

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

Assisted-by: Claude:Opus-4.8
