### PR TITLE
ci: trigger AI PR review on label changes, not just push events

### DIFF
--- a/.github/workflows/run-claude-review.yml
+++ b/.github/workflows/run-claude-review.yml
@@ -2,7 +2,7 @@ name: 🤖 AI PR Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:
   claude-review:


### PR DESCRIPTION
This PR resolves []

### Description

Adds `labeled` and `unlabeled` to the `AI PR Review` workflow's trigger types so that adding/removing the `in-progress` label on a PR takes effect immediately, instead of waiting for the next push.

This pairs with [artsy/duchamp#103](https://github.com/artsy/duchamp/pull/103), which teaches the shared `claude-review.yml` workflow to skip AI review for PRs labeled `in-progress`. That skip logic already works on the existing `opened`/`synchronize`/`ready_for_review` triggers on its own; this change additionally makes label changes themselves re-evaluate the review immediately. Note: the skip behavior only takes effect here once the duchamp PR merges to `main`, since this workflow calls `artsy/duchamp/.github/workflows/claude-review.yml@main`.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**. N/A - CI workflow config only
  - [ ] **iOS**. N/A - CI workflow config only
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#nochangelog

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDFGEzhCLzkKBShZyHDRPh)_