### PR TITLE
fix: guard AR View in Room render callback against use-after-free

### DIFF
--- a/ios/Artsy/View_Controllers/ARVIR/VCs/ARAugmentedWallBasedVIRViewController.swift
+++ b/ios/Artsy/View_Controllers/ARVIR/VCs/ARAugmentedWallBasedVIRViewController.swift
@@ -467,8 +467,8 @@ extension ARAugmentedWallBasedVIRViewController: ARCoachingOverlayViewDelegate {
 
 extension ARAugmentedWallBasedVIRViewController: ARSCNViewDelegate, ARSessionDelegate {
     func renderer(_ renderer: SCNSceneRenderer, updateAtTime time: TimeInterval) {
-        DispatchQueue.main.async {
-            self.updateCursor()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateCursor()
         }
     }
 }


### PR DESCRIPTION
This PR resolves [EIGEN-AZTR](https://artsynet.sentry.io/issues/EIGEN-AZTR) [PHIRE-3293]

### Description

Fixes a recurring native `EXC_BAD_ACCESS` crash in the AR **View in Room** experience (`ARAugmentedWallBasedVIRViewController`), captured in Sentry as **EIGEN-AZTR** — 19 crashes / 19 users across app versions 9.9–9.13, on every device generation (iPhone 14 → 18) and multiple iOS versions.

**Root cause:** `renderer(_:updateAtTime:)` fires continuously on SceneKit's render thread and dispatches `updateCursor()` to the main queue while **strongly capturing `self`**:

```swift
DispatchQueue.main.async {
    self.updateCursor()
}
```

When the AR view is torn down — dismissed or backgrounded (the crashing events show `is_active: false`) — this races with the controller's deallocation on the main thread, leading to a retain on freed memory (`objc_retain` on a dangling pointer; random fault addresses per event).

**Fix:** capture `self` weakly so a callback that outlives teardown becomes a safe no-op instead of touching freed memory:

```swift
DispatchQueue.main.async { [weak self] in
    self?.updateCursor()
}
```

One-line, behavior-preserving change on the working path — when `self` is alive it behaves identically.

**Follow-up:** because this is a timing race, we'll monitor EIGEN-AZTR over the next release. If occurrences don't drop to zero, the escalation is to clear the `sceneView`/`session` delegates on teardown to stop the render thread from racing at all (safe given this VC's one-shot lifecycle).

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one.
- [x] I have included **screenshots** or **videos**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work**, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

Note for reviewers: iOS-only (native AR). To exercise the crash path pre-fix, run with **Zombie Objects** or **Address Sanitizer** enabled and repeatedly enter View in Room, then immediately dismiss or background the app mid-render.

<details><summary>Changelog updates</summary>

### Changelog updates

#### iOS user-facing changes

- Fix a crash when leaving or backgrounding the AR View in Room experience.

<!-- end_changelog_updates -->

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PHIRE-3293]: https://artsyproduct.atlassian.net/browse/PHIRE-3293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ