### PR TITLE
fix: onboarding artwork montage timing and Reduce Motion support

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -1,10 +1,20 @@
 import { Flex } from "@artsy/palette-mobile"
 import { useScreenDimensions } from "app/utils/hooks"
-import { MotiView } from "moti"
-import { useEffect } from "react"
-import { Image } from "react-native"
-import { Easing } from "react-native-reanimated"
+import { useEffect, useRef, useState } from "react"
+import { AccessibilityInfo, Image, ImageSourcePropType, ViewStyle } from "react-native"
+import Animated, {
+  cancelAnimation,
+  Easing,
+  runOnJS,
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated"
 import { Logo } from "./Logo"
+
+const AnimatedFlex = Animated.createAnimatedComponent(Flex)
 
 const IMG_DISPLAY_DURATION = 500
 const LAST_IMG_DISPLAY_DURATION = 600
@@ -17,34 +27,105 @@ const ONBOARDING_IMAGES = [
   require("images/OnboardingImage4AndyWarholCow.webp"),
 ]
 
-const ARTWORKS_DURATION =
-  ONBOARDING_IMAGES.length * IMG_DISPLAY_DURATION + LAST_IMG_DISPLAY_DURATION
-
 interface ArtworkMontageStepProps {
   onNext: () => void
 }
 
+const ImageFadeLayer = ({
+  index,
+  progress,
+  screenWidth,
+  source,
+}: {
+  index: number
+  progress: SharedValue<number>
+  screenWidth: number
+  source: ImageSourcePropType
+}) => {
+  const animatedStyle = useAnimatedStyle(() => {
+    "worklet"
+    return { opacity: progress.get() - (index + 1) }
+  })
+
+  return (
+    <AnimatedFlex
+      position="absolute"
+      height="100%"
+      width={screenWidth}
+      style={animatedStyle as ViewStyle}
+    >
+      <Image source={source} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
+    </AnimatedFlex>
+  )
+}
+
 export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }) => {
   const { width: screenWidth } = useScreenDimensions()
+  const progress = useSharedValue(1)
+  const onNextRef = useRef(onNext)
+  // null while we're checking; the montage only ever mounts once we know it's false
+  const [reduceMotionEnabled, setReduceMotionEnabled] = useState<boolean | null>(null)
 
   useEffect(() => {
-    const timer = setTimeout(onNext, ARTWORKS_DURATION)
-    return () => clearTimeout(timer)
+    onNextRef.current = onNext
   }, [onNext])
+
+  useEffect(() => {
+    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotionEnabled)
+  }, [])
+
+  useEffect(() => {
+    if (reduceMotionEnabled) {
+      onNextRef.current()
+    }
+  }, [reduceMotionEnabled])
+
+  useEffect(() => {
+    if (reduceMotionEnabled !== false) {
+      return
+    }
+
+    const timings = ONBOARDING_IMAGES.map((_, index) => {
+      const isLastImage = index === ONBOARDING_IMAGES.length - 1
+      const config = {
+        duration: isLastImage ? LAST_IMG_DISPLAY_DURATION : IMG_DISPLAY_DURATION,
+        easing: Easing.linear,
+      }
+
+      if (!isLastImage) {
+        return withTiming(index + 2, config)
+      }
+
+      return withTiming(index + 2, config, (finished) => {
+        if (finished) {
+          runOnJS(onNextRef.current)()
+        }
+      })
+    })
+
+    progress.set(() => withSequence(...timings))
+
+    return () => cancelAnimation(progress)
+  }, [reduceMotionEnabled])
+
+  if (reduceMotionEnabled !== false) {
+    return (
+      <Flex flex={1} backgroundColor="mono100">
+        <Logo />
+      </Flex>
+    )
+  }
 
   return (
     <Flex flex={1} backgroundColor="mono100">
       {ONBOARDING_IMAGES.map((image, index) => (
-        <MotiView
+        <ImageFadeLayer
           key={index}
-          from={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          delay={index * IMG_DISPLAY_DURATION}
-          transition={{ type: "timing", duration: IMG_DISPLAY_DURATION, easing: Easing.linear }}
-          style={{ position: "absolute", height: "100%", width: screenWidth }}
-        >
-          <Image source={image} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
-        </MotiView>
+          index={index}
+          progress={progress}
+          screenWidth={screenWidth}
+          source={image}
+        />
       ))}
 
       <Logo />

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -1,9 +1,9 @@
 import { Flex } from "@artsy/palette-mobile"
 import { useScreenDimensions } from "app/utils/hooks"
 import { MotiView } from "moti"
-import { useEffect, useState } from "react"
-import { AccessibilityInfo, Image } from "react-native"
-import { Easing } from "react-native-reanimated"
+import { useEffect } from "react"
+import { Image } from "react-native"
+import { Easing, useReducedMotion } from "react-native-reanimated"
 import { Logo } from "./Logo"
 
 const IMG_DISPLAY_DURATION = 500
@@ -17,10 +17,8 @@ const ONBOARDING_IMAGES = [
   require("images/OnboardingImage4AndyWarholCow.webp"),
 ]
 
-const ARTWORKS_DURATION =
+export const ARTWORKS_DURATION =
   ONBOARDING_IMAGES.length * IMG_DISPLAY_DURATION + LAST_IMG_DISPLAY_DURATION
-
-export const REDUCE_MOTION_CHECK_TIMEOUT = 1000
 
 interface ArtworkMontageStepProps {
   onNext: () => void
@@ -33,34 +31,13 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
   // montage look broken because it skips the transitions between each artwork and shows the last
   // artwork for the entire animation's duration.
   //
-  // We can tell whether a user has Reduce Motion enabled by calling
-  // AccessibilityInfo.isReduceMotionEnabled(), but it is an async function, so this component needs
-  // to handle (1) the time that it takes to get a response, (2) the case where we learn that the
-  // user has Reduce Motion enabled, or (3) the case where we learn that the user does not have it
-  // enabled.
-  //
-  // The way that it does this is by showing a black screen with the Artsy logo while racing the
-  // check for Reduce Motion against a short timeout. If the check times-out, we will assume that
-  // the user does not have it enabled and start the artwork montage. If the check completes before
-  // the timeout we will either start the artwork montage or skip it depending on the actual user's
-  // setting.
-  const [reduceMotionEnabled, setReduceMotionEnabled] = useState<boolean | null>(null)
+  // Reanimated's useReducedMotion() tells us whether the setting was on when the app launched.
+  // It's synchronous and cached, so we know on the very first render whether to skip the
+  // crossfade entirely — no async check, no loading state to juggle. The one thing it won't catch
+  // is the user toggling the setting mid-session, since it's only read once at launch.
+  const reduceMotionEnabled = useReducedMotion()
 
   useEffect(() => {
-    const giveUp = new Promise<boolean>((resolve) =>
-      setTimeout(() => resolve(false), REDUCE_MOTION_CHECK_TIMEOUT)
-    )
-
-    Promise.race([AccessibilityInfo.isReduceMotionEnabled(), giveUp])
-      .then(setReduceMotionEnabled)
-      .catch(() => setReduceMotionEnabled(false))
-  }, [])
-
-  useEffect(() => {
-    if (reduceMotionEnabled === null) {
-      return
-    }
-
     if (reduceMotionEnabled) {
       onNext()
       return
@@ -70,7 +47,7 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
     return () => clearTimeout(timer)
   }, [reduceMotionEnabled, onNext])
 
-  if (reduceMotionEnabled !== false) {
+  if (reduceMotionEnabled) {
     return (
       <Flex flex={1} backgroundColor="mono100">
         <Logo />

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -1,20 +1,10 @@
 import { Flex } from "@artsy/palette-mobile"
 import { useScreenDimensions } from "app/utils/hooks"
+import { MotiView } from "moti"
 import { useEffect, useRef, useState } from "react"
-import { AccessibilityInfo, Image, ImageSourcePropType, ViewStyle } from "react-native"
-import Animated, {
-  cancelAnimation,
-  Easing,
-  runOnJS,
-  SharedValue,
-  useAnimatedStyle,
-  useSharedValue,
-  withSequence,
-  withTiming,
-} from "react-native-reanimated"
+import { AccessibilityInfo, Image } from "react-native"
+import { Easing } from "react-native-reanimated"
 import { Logo } from "./Logo"
-
-const AnimatedFlex = Animated.createAnimatedComponent(Flex)
 
 const IMG_DISPLAY_DURATION = 500
 const LAST_IMG_DISPLAY_DURATION = 600
@@ -27,41 +17,15 @@ const ONBOARDING_IMAGES = [
   require("images/OnboardingImage4AndyWarholCow.webp"),
 ]
 
+const ARTWORKS_DURATION =
+  ONBOARDING_IMAGES.length * IMG_DISPLAY_DURATION + LAST_IMG_DISPLAY_DURATION
+
 interface ArtworkMontageStepProps {
   onNext: () => void
 }
 
-const ImageFadeLayer = ({
-  index,
-  progress,
-  screenWidth,
-  source,
-}: {
-  index: number
-  progress: SharedValue<number>
-  screenWidth: number
-  source: ImageSourcePropType
-}) => {
-  const animatedStyle = useAnimatedStyle(() => {
-    "worklet"
-    return { opacity: progress.get() - (index + 1) }
-  })
-
-  return (
-    <AnimatedFlex
-      position="absolute"
-      height="100%"
-      width={screenWidth}
-      style={animatedStyle as ViewStyle}
-    >
-      <Image source={source} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
-    </AnimatedFlex>
-  )
-}
-
 export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }) => {
   const { width: screenWidth } = useScreenDimensions()
-  const progress = useSharedValue(1)
   const onNextRef = useRef(onNext)
   // null while we're checking; the montage only ever mounts once we know it's false
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState<boolean | null>(null)
@@ -71,7 +35,9 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
   }, [onNext])
 
   useEffect(() => {
-    AccessibilityInfo.isReduceMotionEnabled().then(setReduceMotionEnabled)
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then(setReduceMotionEnabled)
+      .catch(() => setReduceMotionEnabled(false))
   }, [])
 
   useEffect(() => {
@@ -85,27 +51,8 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
       return
     }
 
-    const timings = ONBOARDING_IMAGES.map((_, index) => {
-      const isLastImage = index === ONBOARDING_IMAGES.length - 1
-      const config = {
-        duration: isLastImage ? LAST_IMG_DISPLAY_DURATION : IMG_DISPLAY_DURATION,
-        easing: Easing.linear,
-      }
-
-      if (!isLastImage) {
-        return withTiming(index + 2, config)
-      }
-
-      return withTiming(index + 2, config, (finished) => {
-        if (finished) {
-          runOnJS(onNextRef.current)()
-        }
-      })
-    })
-
-    progress.set(() => withSequence(...timings))
-
-    return () => cancelAnimation(progress)
+    const timer = setTimeout(() => onNextRef.current(), ARTWORKS_DURATION)
+    return () => clearTimeout(timer)
   }, [reduceMotionEnabled])
 
   if (reduceMotionEnabled !== false) {
@@ -119,13 +66,16 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
   return (
     <Flex flex={1} backgroundColor="mono100">
       {ONBOARDING_IMAGES.map((image, index) => (
-        <ImageFadeLayer
+        <MotiView
           key={index}
-          index={index}
-          progress={progress}
-          screenWidth={screenWidth}
-          source={image}
-        />
+          from={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          delay={index * IMG_DISPLAY_DURATION}
+          transition={{ type: "timing", duration: IMG_DISPLAY_DURATION, easing: Easing.linear }}
+          style={{ position: "absolute", height: "100%", width: screenWidth }}
+        >
+          <Image source={image} resizeMode="cover" style={{ height: "100%", width: screenWidth }} />
+        </MotiView>
       ))}
 
       <Logo />

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -1,7 +1,7 @@
 import { Flex } from "@artsy/palette-mobile"
 import { useScreenDimensions } from "app/utils/hooks"
 import { MotiView } from "moti"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { AccessibilityInfo, Image } from "react-native"
 import { Easing } from "react-native-reanimated"
 import { Logo } from "./Logo"
@@ -20,22 +20,38 @@ const ONBOARDING_IMAGES = [
 const ARTWORKS_DURATION =
   ONBOARDING_IMAGES.length * IMG_DISPLAY_DURATION + LAST_IMG_DISPLAY_DURATION
 
+export const REDUCE_MOTION_CHECK_TIMEOUT = 1000
+
 interface ArtworkMontageStepProps {
   onNext: () => void
 }
 
 export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }) => {
   const { width: screenWidth } = useScreenDimensions()
-  const onNextRef = useRef(onNext)
-  // null while we're checking; the montage only ever mounts once we know it's false
+
+  // Reduce Motion is an accessibility feature that users can enable, but it makes this artwork
+  // montage look broken because it skips the transitions between each artwork and shows the last
+  // artwork for the entire animation's duration.
+  //
+  // We can tell whether a user has Reduce Motion enabled by calling
+  // AccessibilityInfo.isReduceMotionEnabled(), but it is an async function, so this component needs
+  // to handle (1) the time that it takes to get a response, (2) the case where we learn that the
+  // user has Reduce Motion enabled, or (3) the case where we learn that the user does not have it
+  // enabled.
+  //
+  // The way that it does this is by showing a black screen with the Artsy logo while racing the
+  // check for Reduce Motion against a short timeout. If the check times-out, we will assume that
+  // the user does not have it enabled and start the artwork montage. If the check completes before
+  // the timeout we will either start the artwork montage or skip it depending on the actual user's
+  // setting.
   const [reduceMotionEnabled, setReduceMotionEnabled] = useState<boolean | null>(null)
 
   useEffect(() => {
-    onNextRef.current = onNext
-  }, [onNext])
+    const giveUp = new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(false), REDUCE_MOTION_CHECK_TIMEOUT)
+    )
 
-  useEffect(() => {
-    AccessibilityInfo.isReduceMotionEnabled()
+    Promise.race([AccessibilityInfo.isReduceMotionEnabled(), giveUp])
       .then(setReduceMotionEnabled)
       .catch(() => setReduceMotionEnabled(false))
   }, [])
@@ -46,13 +62,13 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
     }
 
     if (reduceMotionEnabled) {
-      onNextRef.current()
+      onNext()
       return
     }
 
-    const timer = setTimeout(() => onNextRef.current(), ARTWORKS_DURATION)
+    const timer = setTimeout(onNext, ARTWORKS_DURATION)
     return () => clearTimeout(timer)
-  }, [reduceMotionEnabled])
+  }, [reduceMotionEnabled, onNext])
 
   if (reduceMotionEnabled !== false) {
     return (

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep.tsx
@@ -41,13 +41,12 @@ export const ArtworkMontageStep: React.FC<ArtworkMontageStepProps> = ({ onNext }
   }, [])
 
   useEffect(() => {
+    if (reduceMotionEnabled === null) {
+      return
+    }
+
     if (reduceMotionEnabled) {
       onNextRef.current()
-    }
-  }, [reduceMotionEnabled])
-
-  useEffect(() => {
-    if (reduceMotionEnabled !== false) {
       return
     }
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
@@ -1,0 +1,82 @@
+import { act, screen } from "@testing-library/react-native"
+import { ArtworkMontageStep } from "app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { AccessibilityInfo, Image } from "react-native"
+import * as Reanimated from "react-native-reanimated"
+
+const actualReanimatedMock = jest.requireActual("react-native-reanimated/mock")
+
+jest.mock("react-native-reanimated", () => {
+  const actual = jest.requireActual("react-native-reanimated/mock")
+  return {
+    ...actual,
+    withTiming: jest.fn(actual.withTiming),
+    cancelAnimation: jest.fn(actual.cancelAnimation),
+  }
+})
+
+// Flushes the pending `AccessibilityInfo.isReduceMotionEnabled()` microtask, which in turn
+// triggers the effect that dispatches the animation sequence.
+const flushReduceMotionCheck = () => act(async () => await Promise.resolve())
+
+describe("ArtworkMontageStep", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(Reanimated.withTiming as jest.Mock).mockImplementation(actualReanimatedMock.withTiming)
+    jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(false)
+  })
+
+  it("renders all 5 onboarding images", async () => {
+    renderWithWrappers(<ArtworkMontageStep onNext={jest.fn()} />)
+    await flushReduceMotionCheck()
+
+    const images = screen.UNSAFE_getAllByType(Image)
+    expect(images).toHaveLength(5)
+  })
+
+  it("calls onNext exactly once when the sequence completes", async () => {
+    const onNext = jest.fn()
+    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+    await flushReduceMotionCheck()
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not call onNext when the sequence is cancelled", async () => {
+    ;(Reanimated.withTiming as jest.Mock).mockImplementation((toValue, _config, callback) => {
+      callback?.(false)
+      return toValue
+    })
+
+    const onNext = jest.fn()
+    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+    await flushReduceMotionCheck()
+
+    expect(onNext).not.toHaveBeenCalled()
+  })
+
+  it("cancels the animation on unmount and does not call onNext again afterward", async () => {
+    const cancelAnimationSpy = Reanimated.cancelAnimation as jest.Mock
+    const onNext = jest.fn()
+    const { unmount } = renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+    await flushReduceMotionCheck()
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    expect(cancelAnimationSpy).toHaveBeenCalled()
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips the montage and calls onNext immediately when Reduce Motion is enabled", async () => {
+    ;(AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockResolvedValue(true)
+
+    const onNext = jest.fn()
+    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+    await flushReduceMotionCheck()
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+    expect(screen.UNSAFE_queryAllByType(Image)).toHaveLength(0)
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
@@ -1,55 +1,54 @@
 import { act, screen } from "@testing-library/react-native"
 import {
+  ARTWORKS_DURATION,
   ArtworkMontageStep,
-  REDUCE_MOTION_CHECK_TIMEOUT,
 } from "app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
-import { AccessibilityInfo, Image } from "react-native"
+import { Image } from "react-native"
+import { useReducedMotion } from "react-native-reanimated"
 
-// Flushes the pending `AccessibilityInfo.isReduceMotionEnabled()` microtask, which in turn
-// triggers the effect that either starts the montage timer or fires `onNext` immediately.
-const flushReduceMotionCheck = () => act(async () => await Promise.resolve())
+jest.mock("react-native-reanimated", () => ({
+  ...jest.requireActual("react-native-reanimated"),
+  useReducedMotion: jest.fn(),
+}))
 
 describe("ArtworkMontageStep", () => {
-  let isReduceMotionEnabledMock: jest.SpyInstance
-
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
-    isReduceMotionEnabledMock = jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled")
-    isReduceMotionEnabledMock.mockResolvedValue(false)
+    ;(useReducedMotion as jest.Mock).mockReturnValue(false)
   })
 
   afterEach(() => {
     jest.useRealTimers()
   })
 
-  it("renders all 5 onboarding images", async () => {
+  it("renders all 5 onboarding images", () => {
     renderWithWrappers(<ArtworkMontageStep onNext={jest.fn()} />)
-    await flushReduceMotionCheck()
 
-    const images = screen.UNSAFE_getAllByType(Image)
-    expect(images).toHaveLength(5)
+    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(5)
   })
 
-  it("calls onNext once the montage duration elapses", async () => {
+  it("does not call onNext before the montage duration elapses, and does so right after", () => {
     const onNext = jest.fn()
     renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-    await flushReduceMotionCheck()
+
+    act(() => {
+      jest.advanceTimersByTime(ARTWORKS_DURATION - 1)
+    })
 
     expect(onNext).not.toHaveBeenCalled()
 
     act(() => {
-      jest.runAllTimers()
+      jest.advanceTimersByTime(1)
     })
 
     expect(onNext).toHaveBeenCalledTimes(1)
   })
 
-  it("clears the timer on unmount and does not call onNext afterward", async () => {
+  it("clears the timer on unmount and does not call onNext afterward", () => {
     const onNext = jest.fn()
     const { unmount } = renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-    await flushReduceMotionCheck()
 
     unmount()
 
@@ -60,51 +59,13 @@ describe("ArtworkMontageStep", () => {
     expect(onNext).not.toHaveBeenCalled()
   })
 
-  it("skips the montage and calls onNext immediately when Reduce Motion is enabled", async () => {
-    isReduceMotionEnabledMock.mockResolvedValue(true)
+  it("skips the montage and calls onNext immediately when Reduce Motion is enabled", () => {
+    ;(useReducedMotion as jest.Mock).mockReturnValue(true)
 
     const onNext = jest.fn()
     renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-    await flushReduceMotionCheck()
 
     expect(onNext).toHaveBeenCalledTimes(1)
     expect(screen.UNSAFE_queryAllByType(Image)).toHaveLength(0)
-  })
-
-  it("advances if the Reduce Motion check never settles, via the check's own timeout", async () => {
-    isReduceMotionEnabledMock.mockReturnValue(new Promise(() => {}))
-
-    const onNext = jest.fn()
-    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-
-    await act(async () => {
-      jest.advanceTimersByTime(REDUCE_MOTION_CHECK_TIMEOUT)
-      await Promise.resolve()
-    })
-
-    expect(onNext).not.toHaveBeenCalled()
-    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(5)
-
-    act(() => {
-      jest.runAllTimers()
-    })
-
-    expect(onNext).toHaveBeenCalledTimes(1)
-  })
-
-  it("falls back to showing the montage when the Reduce Motion check rejects", async () => {
-    isReduceMotionEnabledMock.mockRejectedValue(new Error("unavailable"))
-
-    const onNext = jest.fn()
-    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-    await flushReduceMotionCheck()
-
-    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(5)
-
-    act(() => {
-      jest.runAllTimers()
-    })
-
-    expect(onNext).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
@@ -8,7 +8,7 @@ import { Image } from "react-native"
 import { useReducedMotion } from "react-native-reanimated"
 
 jest.mock("react-native-reanimated", () => ({
-  ...jest.requireActual("react-native-reanimated"),
+  ...require("react-native-reanimated/mock"),
   useReducedMotion: jest.fn(),
 }))
 

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
@@ -2,28 +2,20 @@ import { act, screen } from "@testing-library/react-native"
 import { ArtworkMontageStep } from "app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { AccessibilityInfo, Image } from "react-native"
-import * as Reanimated from "react-native-reanimated"
-
-const actualReanimatedMock = jest.requireActual("react-native-reanimated/mock")
-
-jest.mock("react-native-reanimated", () => {
-  const actual = jest.requireActual("react-native-reanimated/mock")
-  return {
-    ...actual,
-    withTiming: jest.fn(actual.withTiming),
-    cancelAnimation: jest.fn(actual.cancelAnimation),
-  }
-})
 
 // Flushes the pending `AccessibilityInfo.isReduceMotionEnabled()` microtask, which in turn
-// triggers the effect that dispatches the animation sequence.
+// triggers the effect that either starts the montage timer or fires `onNext` immediately.
 const flushReduceMotionCheck = () => act(async () => await Promise.resolve())
 
 describe("ArtworkMontageStep", () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(Reanimated.withTiming as jest.Mock).mockImplementation(actualReanimatedMock.withTiming)
+    jest.useFakeTimers()
     jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it("renders all 5 onboarding images", async () => {
@@ -34,39 +26,32 @@ describe("ArtworkMontageStep", () => {
     expect(images).toHaveLength(5)
   })
 
-  it("calls onNext exactly once when the sequence completes", async () => {
-    const onNext = jest.fn()
-    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
-    await flushReduceMotionCheck()
-
-    expect(onNext).toHaveBeenCalledTimes(1)
-  })
-
-  it("does not call onNext when the sequence is cancelled", async () => {
-    ;(Reanimated.withTiming as jest.Mock).mockImplementation((toValue, _config, callback) => {
-      callback?.(false)
-      return toValue
-    })
-
+  it("calls onNext once the montage duration elapses", async () => {
     const onNext = jest.fn()
     renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
     await flushReduceMotionCheck()
 
     expect(onNext).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onNext).toHaveBeenCalledTimes(1)
   })
 
-  it("cancels the animation on unmount and does not call onNext again afterward", async () => {
-    const cancelAnimationSpy = Reanimated.cancelAnimation as jest.Mock
+  it("clears the timer on unmount and does not call onNext afterward", async () => {
     const onNext = jest.fn()
     const { unmount } = renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
     await flushReduceMotionCheck()
 
-    expect(onNext).toHaveBeenCalledTimes(1)
-
     unmount()
 
-    expect(cancelAnimationSpy).toHaveBeenCalled()
-    expect(onNext).toHaveBeenCalledTimes(1)
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
   })
 
   it("skips the montage and calls onNext immediately when Reduce Motion is enabled", async () => {
@@ -78,5 +63,23 @@ describe("ArtworkMontageStep", () => {
 
     expect(onNext).toHaveBeenCalledTimes(1)
     expect(screen.UNSAFE_queryAllByType(Image)).toHaveLength(0)
+  })
+
+  it("falls back to showing the montage when the Reduce Motion check rejects", async () => {
+    ;(AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockRejectedValue(
+      new Error("unavailable")
+    )
+
+    const onNext = jest.fn()
+    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+    await flushReduceMotionCheck()
+
+    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(5)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onNext).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/ArtworkMontageStep.tests.tsx
@@ -1,5 +1,8 @@
 import { act, screen } from "@testing-library/react-native"
-import { ArtworkMontageStep } from "app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep"
+import {
+  ArtworkMontageStep,
+  REDUCE_MOTION_CHECK_TIMEOUT,
+} from "app/Scenes/Onboarding/Screens/Onboarding/Components/ArtworkMontageStep"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { AccessibilityInfo, Image } from "react-native"
 
@@ -8,10 +11,13 @@ import { AccessibilityInfo, Image } from "react-native"
 const flushReduceMotionCheck = () => act(async () => await Promise.resolve())
 
 describe("ArtworkMontageStep", () => {
+  let isReduceMotionEnabledMock: jest.SpyInstance
+
   beforeEach(() => {
     jest.clearAllMocks()
     jest.useFakeTimers()
-    jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled").mockResolvedValue(false)
+    isReduceMotionEnabledMock = jest.spyOn(AccessibilityInfo, "isReduceMotionEnabled")
+    isReduceMotionEnabledMock.mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -55,7 +61,7 @@ describe("ArtworkMontageStep", () => {
   })
 
   it("skips the montage and calls onNext immediately when Reduce Motion is enabled", async () => {
-    ;(AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockResolvedValue(true)
+    isReduceMotionEnabledMock.mockResolvedValue(true)
 
     const onNext = jest.fn()
     renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
@@ -65,10 +71,29 @@ describe("ArtworkMontageStep", () => {
     expect(screen.UNSAFE_queryAllByType(Image)).toHaveLength(0)
   })
 
+  it("advances if the Reduce Motion check never settles, via the check's own timeout", async () => {
+    isReduceMotionEnabledMock.mockReturnValue(new Promise(() => {}))
+
+    const onNext = jest.fn()
+    renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)
+
+    await act(async () => {
+      jest.advanceTimersByTime(REDUCE_MOTION_CHECK_TIMEOUT)
+      await Promise.resolve()
+    })
+
+    expect(onNext).not.toHaveBeenCalled()
+    expect(screen.UNSAFE_getAllByType(Image)).toHaveLength(5)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onNext).toHaveBeenCalledTimes(1)
+  })
+
   it("falls back to showing the montage when the Reduce Motion check rejects", async () => {
-    ;(AccessibilityInfo.isReduceMotionEnabled as jest.Mock).mockRejectedValue(
-      new Error("unavailable")
-    )
+    isReduceMotionEnabledMock.mockRejectedValue(new Error("unavailable"))
 
     const onNext = jest.fn()
     renderWithWrappers(<ArtworkMontageStep onNext={onNext} />)


### PR DESCRIPTION
This PR resolves [DI-495](https://app.notion.com/p/artsy/a11y-Image-montage-does-not-play-when-Reduce-Motion-is-enabled-3a5cab0764a08009a027f7d6253fd2fb?v=5cbcab0764a082578d6388b3ee7cefda&source=copy_link)

Assisted-by: Claude: Sonnet-5

### Description

During QA for the new onboarding flow, I had Reduce Motion enabled on my iPhone, which caused the artwork montage in the intro sequence to (1) make sharp transitions instead of fade-in/outs, and (2) fast-forward to the last artwork in the montage and sit there for about 3 seconds.

The solution is to check whether the user has this feature enabled, and skip to the end of the artwork montage if it is.

| OS | Setting | Before | After | Disabled |
|-|-|-|-|-|
| iOS | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-28 at 11 16 25" src="https://github.com/user-attachments/assets/ec125775-0bcd-422c-bf30-300319b48d99" /> | https://github.com/user-attachments/assets/5babc850-9dea-43b1-a5ba-5a3042ab6927 | https://github.com/user-attachments/assets/0be81349-27af-42c4-b8a6-2a0be8e08f02 | https://github.com/user-attachments/assets/6a047e5b-b64e-46b5-be94-01cf32347de4 |
| Android | <img width="1080" height="2400" alt="Screenshot_1785251775" src="https://github.com/user-attachments/assets/9cd6a20d-f05f-4db1-bb50-a9f54bd688d2" /> | https://github.com/user-attachments/assets/a949940b-74e9-450c-83f9-075040ea4793 | https://github.com/user-attachments/assets/f401a071-fca0-42ff-ac40-f8f1017161d9 | https://github.com/user-attachments/assets/3c6f90ba-60dd-46e3-9fc6-f94cccb2f2f8 |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**
  - [x] **iOS**
- [x] I hid my changes behind a **[feature flag]**, or they don't need one
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI
- [x] I have added **tests**, or my changes don't require any
- [x] I added an **[app state migration]**, or my changes do not require one
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any
- [x] I have added a **changelog entry** below, or my changes do not require one

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Skip new onboarding artwork montage for users with Reduce Motion enabled

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md