### PR TITLE
feat(Conversation): use the new field to improve order fetching in a convo

### DIFF
--- a/src/app/Scenes/Inbox/Components/Conversations/Composer.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Composer.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex, useColor } from "@artsy/palette-mobile"
 import { themeGet } from "@styled-system/theme-get"
 import { Composer_conversation$key } from "__generated__/Composer_conversation.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
 import { KeyboardAvoidingContainer } from "app/utils/keyboard/KeyboardAvoidingContainer"
 import { Schema } from "app/utils/track"
 import React, { useEffect, useRef, useState } from "react"
@@ -34,12 +33,11 @@ interface Props {
   onSubmit?: (text: string) => any
   value?: string
   conversation: Composer_conversation$key
-  me: usePartnerOffer_me$key
 }
 
 export const Composer: React.FC<
   React.PropsWithChildren<Props & { forwardedRef?: React.Ref<TextInput> }>
-> = ({ disabled, onSubmit, value, conversation, me, children, forwardedRef }) => {
+> = ({ disabled, onSubmit, value, conversation, children, forwardedRef }) => {
   const data = useFragment(fragment, conversation)
   const { bottom } = useSafeAreaInsets()
   const [active, setActive] = useState(false)
@@ -98,7 +96,7 @@ export const Composer: React.FC<
     >
       {children}
       <Flex flexDirection="column">
-        <ConversationCTA show={!active} conversation={data} me={me} />
+        <ConversationCTA show={!active} conversation={data} />
         <Container active={active}>
           <TextInput
             accessibilityLabel="Text input field"

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationCTA.tsx
@@ -1,5 +1,4 @@
 import { ConversationCTA_conversation$key } from "__generated__/ConversationCTA_conversation.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
 import { ConversationPartnerOfferCTA } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferCTA"
 import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
 import { extractNodes } from "app/utils/extractNodes"
@@ -11,18 +10,17 @@ import { ReviewOfferButton, ReviewOfferCTAKind } from "./ReviewOfferButton"
 interface Props {
   show: boolean
   conversation: ConversationCTA_conversation$key
-  me: usePartnerOffer_me$key
 }
 
-export const ConversationCTA: React.FC<Props> = ({ conversation: _conversation, me, show }) => {
+export const ConversationCTA: React.FC<Props> = ({ conversation: _conversation, show }) => {
   const conversation = useFragment(conversationFragment, _conversation)
   const liveArtwork = conversation?.items?.[0]?.liveArtwork
   const { hasActivePartnerOffer } = usePartnerOffer({
-    me,
+    conversation,
     artworkId: liveArtwork?.__typename === "Artwork" ? liveArtwork.internalID : null,
   })
 
-  if (!conversation || !me || liveArtwork?.__typename !== "Artwork") {
+  if (!conversation || liveArtwork?.__typename !== "Artwork") {
     return null
   }
 
@@ -36,7 +34,7 @@ export const ConversationCTA: React.FC<Props> = ({ conversation: _conversation, 
     // When there's an active partner offer, the dedicated offer banner replaces
     // the inquiry transaction buttons.
     if (hasActivePartnerOffer) {
-      return <ConversationPartnerOfferCTA conversation={conversation} me={me} />
+      return <ConversationPartnerOfferCTA conversation={conversation} />
     }
 
     if (isOfferableFromInquiry || isOfferableConversationalBuyNow || conversationalBuyNow) {
@@ -101,6 +99,7 @@ export const ConversationCTA: React.FC<Props> = ({ conversation: _conversation, 
 const conversationFragment = graphql`
   fragment ConversationCTA_conversation on Conversation {
     ...ConversationPartnerOfferCTA_conversation
+    ...usePartnerOffer_conversation
 
     internalID
     items {

--- a/src/app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferCTA.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferCTA.tsx
@@ -2,7 +2,6 @@ import { ActionType, OwnerType, PartnerOfferInConversationViewed } from "@artsy/
 import { ChevronRightIcon, StopwatchIcon } from "@artsy/icons/native"
 import { Color, Flex, Text } from "@artsy/palette-mobile"
 import { ConversationPartnerOfferCTA_conversation$key } from "__generated__/ConversationPartnerOfferCTA_conversation.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
 import { formattedTimeLeftForPartnerOffer } from "app/Scenes/Artwork/utils/formattedTimeLeftForPartnerOffer"
 import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
 import { RouterLink } from "app/system/navigation/RouterLink"
@@ -14,7 +13,6 @@ import { useTracking } from "react-tracking"
 
 interface ConversationPartnerOfferCTAProps {
   conversation: ConversationPartnerOfferCTA_conversation$key
-  me: usePartnerOffer_me$key
 }
 
 /**
@@ -24,7 +22,6 @@ interface ConversationPartnerOfferCTAProps {
  */
 export const ConversationPartnerOfferCTA: React.FC<ConversationPartnerOfferCTAProps> = ({
   conversation: _conversation,
-  me,
 }) => {
   const { trackEvent } = useTracking()
   const conversation = useFragment(fragment, _conversation)
@@ -33,7 +30,7 @@ export const ConversationPartnerOfferCTA: React.FC<ConversationPartnerOfferCTAPr
   const artworkId = artwork?.__typename === "Artwork" ? artwork.internalID : null
 
   const { partnerOffers: _partnerOffers, hasActivePartnerOffer } = usePartnerOffer({
-    me,
+    conversation,
     artworkId,
   })
   const partnerOffers = useFragment(partnerOfferFragment, _partnerOffers)
@@ -128,6 +125,7 @@ const PartnerOfferExpiresIn: React.FC<{ endAt: string }> = ({ endAt }) => {
 
 const fragment = graphql`
   fragment ConversationPartnerOfferCTA_conversation on Conversation {
+    ...usePartnerOffer_conversation
     internalID
     items {
       item {

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -1,6 +1,5 @@
 import { GuaranteeIcon } from "@artsy/icons/native"
 import { Messages_conversation$data } from "__generated__/Messages_conversation.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
 import { ToastComponent } from "app/Components/Toast/ToastComponent"
 import { PAGE_SIZE } from "app/Components/constants"
 import { usePartnerOfferEvent } from "app/Scenes/Inbox/hooks/usePartnerOfferEvent"
@@ -17,7 +16,6 @@ import { ConversationItem, groupConversationItems } from "./utils/groupConversat
 
 interface Props {
   conversation: Messages_conversation$data
-  me: usePartnerOffer_me$key
   relay: RelayPaginationProp
   onDataFetching?: (loading: boolean) => void
   onRefresh?: () => void
@@ -32,7 +30,7 @@ type OrderEvent = Order["orderHistory"][number]
 type OrderEventWithKey = OrderEvent & { key: string }
 
 export const Messages: React.FC<Props> = forwardRef((props, ref) => {
-  const { conversation, me, relay, onDataFetching, onRefresh } = props
+  const { conversation, relay, onDataFetching, onRefresh } = props
 
   const [fetchingMoreData, setFetchingMoreData] = useState(false)
   const [reloadingData, setReloadingData] = useState(false)
@@ -40,7 +38,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
 
   const subjectArtwork = conversation.items?.[0]?.item
   const artworkId = subjectArtwork?.__typename === "Artwork" ? subjectArtwork.internalID : null
-  const partnerOfferEvent = usePartnerOfferEvent({ me, artworkId, conversation })
+  const partnerOfferEvent = usePartnerOfferEvent({ conversation, artworkId })
 
   // Get all messages and give them a key for use with flatlist
   const allMessages = extractNodes(conversation.messagesConnection)
@@ -192,6 +190,7 @@ export default createPaginationContainer(
     conversation: graphql`
       fragment Messages_conversation on Conversation
       @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+        ...usePartnerOffer_conversation
         id
         internalID
         from {
@@ -200,7 +199,6 @@ export default createPaginationContainer(
         to {
           name
         }
-        ...usePartnerOfferEvent_conversation
         orderConnection(first: 10, participantType: BUYER) {
           edges {
             node {

--- a/src/app/Scenes/Inbox/Components/Conversations/__tests__/Composer.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/__tests__/Composer.tests.tsx
@@ -16,13 +16,10 @@ const { renderWithRelay } = setupTestWrapper<
   ComposerTestsQuery,
   { disabled?: boolean; value?: string; onSubmit?: (text: string) => void }
 >({
-  Component: ({ me, ...props }) => (
-    <Composer conversation={me!.conversation!} me={me!} {...props} />
-  ),
+  Component: ({ me, ...props }) => <Composer conversation={me!.conversation!} {...props} />,
   query: graphql`
     query ComposerTestsQuery @relay_test_operation {
       me {
-        ...usePartnerOffer_me
         conversation(id: "whatever") {
           ...Composer_conversation
         }

--- a/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationCTA.tests.tsx
@@ -14,11 +14,10 @@ import { ComponentType } from "react"
 import { graphql } from "react-relay"
 
 const { renderWithRelay } = setupTestWrapper<ConversationCTATestsQuery>({
-  Component: ({ me }) => <ConversationCTA show conversation={me!.conversation!} me={me!} />,
+  Component: ({ me }) => <ConversationCTA show conversation={me!.conversation!} />,
   query: graphql`
     query ConversationCTATestsQuery($conversationID: String!) @relay_test_operation {
       me {
-        ...usePartnerOffer_me
         conversation(id: $conversationID) {
           ...ConversationCTA_conversation
         }
@@ -102,12 +101,7 @@ describe("conversation about an artwork with inquiry checkout enabled", () => {
       Conversation: () => ({
         items: [{ item: { __typename: "Artwork" }, liveArtwork: { __typename: "Artwork" } }],
         activeOrders: { edges: [] },
-      }),
-      // Ensures both `items.item` and `liveArtwork` resolve to the same artwork id
-      // that the offer below references.
-      Artwork: () => ({ internalID: "123", href: "/artwork/foo", isOfferableFromInquiry: true }),
-      Me: () => ({
-        partnerOffersConnection: {
+        collectorPartnerOffersConnection: {
           edges: [
             {
               node: {
@@ -121,6 +115,9 @@ describe("conversation about an artwork with inquiry checkout enabled", () => {
           ],
         },
       }),
+      // Ensures both `items.item` and `liveArtwork` resolve to the same artwork id
+      // that the offer below references.
+      Artwork: () => ({ internalID: "123", href: "/artwork/foo", isOfferableFromInquiry: true }),
     }
 
     it("replaces the inquiry buttons with the offer banner when the flag is on", () => {

--- a/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationPartnerOfferCTA.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/__tests__/ConversationPartnerOfferCTA.tests.tsx
@@ -11,11 +11,10 @@ const futureISO = (minutes = 60) => new Date(Date.now() + minutes * 60 * 1000).t
 const pastISO = () => new Date(Date.now() - 60 * 60 * 1000).toISOString()
 
 const { renderWithRelay } = setupTestWrapper<ConversationPartnerOfferCTA_Test_Query>({
-  Component: ({ me }) => <ConversationPartnerOfferCTA conversation={me!.conversation!} me={me!} />,
+  Component: ({ me }) => <ConversationPartnerOfferCTA conversation={me!.conversation!} />,
   query: graphql`
     query ConversationPartnerOfferCTA_Test_Query($conversationID: String!) @relay_test_operation {
       me {
-        ...usePartnerOffer_me
         conversation(id: $conversationID) {
           ...ConversationPartnerOfferCTA_conversation
         }
@@ -41,9 +40,7 @@ const offerResolvers = (
         },
       },
     ],
-  }),
-  Me: () => ({
-    partnerOffersConnection: {
+    collectorPartnerOffersConnection: {
       edges: [
         {
           node: {
@@ -90,8 +87,8 @@ describe("ConversationPartnerOfferCTA", () => {
     renderWithRelay({
       Conversation: () => ({
         items: [{ item: { __typename: "Artwork", internalID: "artwork-id", href: "/foo" } }],
+        collectorPartnerOffersConnection: { edges: [] },
       }),
-      Me: () => ({ partnerOffersConnection: { edges: [] } }),
     })
 
     expect(screen.queryByTestId("partnerOfferActionLink")).toBeNull()

--- a/src/app/Scenes/Inbox/Components/Conversations/__tests__/Messages.tests.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/__tests__/Messages.tests.tsx
@@ -33,13 +33,10 @@ afterEach(() => {
 const onRefresh = jest.fn()
 
 const { renderWithRelay } = setupTestWrapper<MessagesTestsQuery>({
-  Component: ({ me }) => (
-    <Messages conversation={me!.conversation!} me={me!} onRefresh={onRefresh} />
-  ),
+  Component: ({ me }) => <Messages conversation={me!.conversation!} onRefresh={onRefresh} />,
   query: graphql`
     query MessagesTestsQuery($conversationID: String!) @relay_test_operation {
       me {
-        ...usePartnerOffer_me
         conversation(id: $conversationID) {
           ...Messages_conversation
         }

--- a/src/app/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/app/Scenes/Inbox/Screens/Conversation.tsx
@@ -158,7 +158,6 @@ export const Conversation: React.FC<Props> = ({
     >
       <Composer
         conversation={conversation}
-        me={me}
         disabled={sendingMessage || !isConnected}
         // @ts-expect-error REACT_18_UPGRADE
         value={failedMessageText}
@@ -185,7 +184,6 @@ export const Conversation: React.FC<Props> = ({
           <Messages
             componentRef={(messages) => (messagesRef.current = messages)}
             conversation={conversation}
-            me={me}
             onRefresh={() => {
               relay.refetch(
                 { conversationID: conversation?.internalID },
@@ -210,8 +208,6 @@ export const ConversationFragmentContainer = createRefetchContainer(
   {
     me: graphql`
       fragment Conversation_me on Me {
-        ...usePartnerOffer_me
-
         conversation(id: $conversationID) {
           ...Composer_conversation
           ...Messages_conversation

--- a/src/app/Scenes/Inbox/Screens/__tests__/Conversation.tests.tsx
+++ b/src/app/Scenes/Inbox/Screens/__tests__/Conversation.tests.tsx
@@ -144,8 +144,11 @@ describe("partner offer banner priority", () => {
   const futureISO = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
 
   const offerResolvers = (activeOrderEdges: any[]) => ({
-    Me: () => ({
-      partnerOffersConnection: {
+    Conversation: () => ({
+      internalID: "conversation-id",
+      items: [{ item: { __typename: "Artwork" }, liveArtwork: { __typename: "Artwork" } }],
+      activeOrders: { edges: activeOrderEdges },
+      collectorPartnerOffersConnection: {
         edges: [
           {
             node: {
@@ -159,11 +162,6 @@ describe("partner offer banner priority", () => {
           },
         ],
       },
-    }),
-    Conversation: () => ({
-      internalID: "conversation-id",
-      items: [{ item: { __typename: "Artwork" }, liveArtwork: { __typename: "Artwork" } }],
-      activeOrders: { edges: activeOrderEdges },
     }),
     // Both `items.item` and `liveArtwork` resolve to the artwork the offer targets.
     Artwork: () => ({

--- a/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
+++ b/src/app/Scenes/Inbox/hooks/__tests__/usePartnerOfferEvent.tests.tsx
@@ -8,11 +8,10 @@ import { graphql } from "react-relay"
 
 const futureISO = () => new Date(Date.now() + 60 * 60 * 1000).toISOString()
 
-const TestComponent = ({ me }: any) => {
+const TestComponent = ({ conversation }: any) => {
   const event = usePartnerOfferEvent({
-    me,
+    conversation,
     artworkId: "artwork-id",
-    conversation: me.conversation,
   })
 
   if (!event) {
@@ -23,26 +22,21 @@ const TestComponent = ({ me }: any) => {
 }
 
 const { renderWithRelay } = setupTestWrapper<usePartnerOfferEvent_Test_Query>({
-  Component: ({ me }) => <TestComponent me={me} />,
+  Component: ({ me }) => <TestComponent conversation={me!.conversation} />,
   query: graphql`
-    query usePartnerOfferEvent_Test_Query($conversationID: String!) @relay_test_operation {
+    query usePartnerOfferEvent_Test_Query @relay_test_operation {
       me {
-        ...usePartnerOffer_me
-        conversation(id: $conversationID) {
-          ...usePartnerOfferEvent_conversation
+        conversation(id: "conversation-id") {
+          ...usePartnerOffer_conversation
         }
       }
     }
   `,
-  variables: { conversationID: "conversation-id" },
 })
 
-const activeOfferResolvers = (
-  orderOverrides: Record<string, unknown> = {},
-  offerOverrides: Record<string, unknown> = {}
-) => ({
-  Me: () => ({
-    partnerOffersConnection: {
+const activeOfferResolvers = (offerOverrides: Record<string, unknown> = {}) => ({
+  Conversation: () => ({
+    collectorPartnerOffersConnection: {
       edges: [
         {
           node: {
@@ -50,23 +44,12 @@ const activeOfferResolvers = (
             artworkId: "artwork-id",
             endAt: futureISO(),
             isAvailable: true,
+            isPurchased: false,
             priceWithDiscount: { display: "$450" },
             ...offerOverrides,
           },
         },
       ],
-    },
-    conversation: {
-      collectorOrdersConnection: {
-        edges: [
-          {
-            node: {
-              lineItems: [{ partnerOfferId: "partner-offer-id" }],
-              ...orderOverrides,
-            },
-          },
-        ],
-      },
     },
   }),
 })
@@ -76,31 +59,16 @@ describe("usePartnerOfferEvent", () => {
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationPartnerOffers: true })
   })
 
-  it("shows 'You purchased this artwork' when the order is SUBMITTED", () => {
-    renderWithRelay(activeOfferResolvers({ buyerState: "SUBMITTED" }))
+  it("shows 'You purchased this artwork' when the offer has been purchased", () => {
+    renderWithRelay(activeOfferResolvers({ isPurchased: true }))
 
     expect(screen.getByText("You purchased this artwork")).toBeTruthy()
   })
 
-  it("shows 'You purchased this artwork' when the order is APPROVED", () => {
-    renderWithRelay(activeOfferResolvers({ buyerState: "APPROVED" }))
+  it("shows the offer message when the offer has not been purchased", () => {
+    renderWithRelay(activeOfferResolvers({ isPurchased: false }))
 
-    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
+    expect(screen.queryByText("You purchased this artwork")).toBeNull()
+    expect(screen.getByText("You received an offer for $450")).toBeTruthy()
   })
-
-  it("shows 'You purchased this artwork' when the order is COMPLETED", () => {
-    renderWithRelay(activeOfferResolvers({ buyerState: "COMPLETED" }))
-
-    expect(screen.getByText("You purchased this artwork")).toBeTruthy()
-  })
-
-  it.each(["INCOMPLETE", "CANCELED"])(
-    "does not show 'You purchased this artwork' when the order has buyerState %s",
-    (buyerState) => {
-      renderWithRelay(activeOfferResolvers({ buyerState }))
-
-      expect(screen.queryByText("You purchased this artwork")).toBeNull()
-      expect(screen.getByText("You received an offer for $450")).toBeTruthy()
-    }
-  )
 })

--- a/src/app/Scenes/Inbox/hooks/usePartnerOffer.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOffer.ts
@@ -1,20 +1,20 @@
 import { ConversationPartnerOfferCTA_partnerOffers$key } from "__generated__/ConversationPartnerOfferCTA_partnerOffers.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
+import { usePartnerOffer_conversation$key } from "__generated__/usePartnerOffer_conversation.graphql"
 import { extractNodes } from "app/utils/extractNodes"
 import { getTimer } from "app/utils/getTimer"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { graphql, useFragment } from "react-relay"
 
 interface UsePartnerOfferProps {
-  me: usePartnerOffer_me$key
+  conversation: usePartnerOffer_conversation$key
   artworkId?: string | null
 }
 
-export const usePartnerOffer = ({ me, artworkId }: UsePartnerOfferProps) => {
-  const data = useFragment(fragment, me)
+export const usePartnerOffer = ({ conversation, artworkId }: UsePartnerOfferProps) => {
+  const data = useFragment(fragment, conversation)
   const isPartnerOfferConvoEnabled = useFeatureFlag("AREnableConversationPartnerOffers")
 
-  const partnerOffers = extractNodes(data?.partnerOffersConnection)
+  const partnerOffers = extractNodes(data?.collectorPartnerOffersConnection)
   const partnerOffer = partnerOffers.find((p) => p.artworkId === artworkId) ?? undefined
 
   return {
@@ -25,8 +25,8 @@ export const usePartnerOffer = ({ me, artworkId }: UsePartnerOfferProps) => {
 }
 
 const fragment = graphql`
-  fragment usePartnerOffer_me on Me {
-    partnerOffersConnection(first: 100, offerType: [PERSONALIZED]) {
+  fragment usePartnerOffer_conversation on Conversation {
+    collectorPartnerOffersConnection(first: 10, offerType: [PERSONALIZED]) {
       edges {
         node {
           ...ConversationPartnerOfferCTA_partnerOffers

--- a/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
@@ -1,30 +1,27 @@
-import { usePartnerOfferEvent_conversation$key } from "__generated__/usePartnerOfferEvent_conversation.graphql"
 import { usePartnerOfferEvent_partnerOffers$key } from "__generated__/usePartnerOfferEvent_partnerOffers.graphql"
-import { usePartnerOffer_me$key } from "__generated__/usePartnerOffer_me.graphql"
+import { usePartnerOffer_conversation$key } from "__generated__/usePartnerOffer_conversation.graphql"
 import { PartnerOfferConversationEvent } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
 import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
-import { extractNodes } from "app/utils/extractNodes"
 import { graphql, useFragment } from "react-relay"
 
 interface UsePartnerOfferEventProps {
-  me: usePartnerOffer_me$key
+  conversation: usePartnerOffer_conversation$key
   artworkId?: string | null
-  conversation: usePartnerOfferEvent_conversation$key
 }
 
 /**
  * Builds the partner-offer entry shown in the conversation timeline, hiding the
  * Relay plumbing from `Messages`. It surfaces the matching offer when it is
- * still active or once it has been fulfilled (purchased), and tags it with
- * `isPurchased` so `ConversationPartnerOfferUpdate` can render the right state.
+ * still active or once it has been purchased, and tags it with `isPurchased`
+ * (resolved server-side) so `ConversationPartnerOfferUpdate` can render the
+ * right state.
  */
 export const usePartnerOfferEvent = ({
-  me,
-  artworkId,
   conversation,
+  artworkId,
 }: UsePartnerOfferEventProps): PartnerOfferConversationEvent | null => {
   const { hasActivePartnerOffer, partnerOffers: partnerOffersRef } = usePartnerOffer({
-    me,
+    conversation,
     artworkId,
   })
 
@@ -32,7 +29,6 @@ export const usePartnerOfferEvent = ({
     partnerOffersFragment,
     partnerOffersRef as unknown as usePartnerOfferEvent_partnerOffers$key
   )
-  const { collectorOrdersConnection } = useFragment(conversationFragment, conversation)
 
   const partnerOffer = partnerOffers?.find((offer) => offer.artworkId === artworkId)
 
@@ -40,16 +36,7 @@ export const usePartnerOfferEvent = ({
     return null
   }
 
-  // Only treat the offer as purchased if the order is in an active state
-  // (SUBMITTED, APPROVED, or COMPLETED) and has a line item tied to this offer.
-  // This prevents abandoned or canceled orders from showing a purchase confirmation.
-  const PURCHASED_BUYER_STATES = new Set(["SUBMITTED", "APPROVED", "COMPLETED"])
-
-  const isPurchased = extractNodes(collectorOrdersConnection).some(
-    (order) =>
-      PURCHASED_BUYER_STATES.has(order.buyerState ?? "") &&
-      order.lineItems?.some((lineItem) => lineItem?.partnerOfferId === partnerOffer.internalID)
-  )
+  const isPurchased = !!partnerOffer.isPurchased
 
   if (!hasActivePartnerOffer && !isPurchased) {
     return null
@@ -64,21 +51,7 @@ const partnerOffersFragment = graphql`
     internalID
     artworkId
     createdAt
+    isPurchased
     ...ConversationPartnerOfferUpdate_partnerOffer
-  }
-`
-
-const conversationFragment = graphql`
-  fragment usePartnerOfferEvent_conversation on Conversation {
-    collectorOrdersConnection(first: 10) {
-      edges {
-        node {
-          buyerState
-          lineItems {
-            partnerOfferId
-          }
-        }
-      }
-    }
   }
 `


### PR DESCRIPTION
This PR resolves [TOP-325] <!-- eg [PROJECT-XXXX] -->

### Description

- Use `isPurchased` field for PartnerOfferCollectorType to check if an order was completed from it
- Use `collectorPartnerOffersConnection` instead of `me#partnerOffersConnection`, optimizing the data we fetch

No visual changes

@artsy/topaz-devs 

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- feat: use more efficient queries for orders in partner offer conversation context

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[TOP-325]: https://artsyproduct.atlassian.net/browse/TOP-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ