### PR TITLE
chore: use corresponding gravity flag for live nwfy rail

### DIFF
--- a/src/app/Scenes/HomeView/hooks/__tests__/useLiveHomeViewSectionIDs.tests.tsx
+++ b/src/app/Scenes/HomeView/hooks/__tests__/useLiveHomeViewSectionIDs.tests.tsx
@@ -26,16 +26,26 @@ const DISABLED: Variant = { name: "disabled", enabled: false }
 
 const setupFlags = ({
   gravity = true,
+  wtylGravity = gravity,
+  nwfyGravity = gravity,
   wtyl = DISABLED,
   nwfy = DISABLED,
 }: {
+  // Convenience default for both gravity flags; override per-couple with wtylGravity / nwfyGravity.
   gravity?: boolean
+  wtylGravity?: boolean
+  nwfyGravity?: boolean
   wtyl?: Variant
   nwfy?: Variant
 }) => {
-  mockUseExperimentFlag.mockImplementation((name: string) =>
-    name === "onyx_artwork-recommendations-gravity" ? gravity : false
-  )
+  mockUseExperimentFlag.mockImplementation((name: string) => {
+    // Each rail is gated by its own gravity flag, coupled with its own refresh experiment:
+    //   WTYL: onyx_artwork-recommendations-gravity + onyx_artwork-recommendations-refresh-eigen
+    //   NWFY: onyx_nwfy-gravity + onyx_nwfy-refresh-eigen
+    if (name === "onyx_artwork-recommendations-gravity") return wtylGravity
+    if (name === "onyx_nwfy-gravity") return nwfyGravity
+    return false
+  })
   mockUseExperimentVariant.mockImplementation((name: string) => {
     const variant =
       name === "onyx_artwork-recommendations-refresh-eigen"
@@ -66,8 +76,9 @@ describe("useEnableLiveHomeRecommendations", () => {
     expect(result.current.enabled).toBe(false)
   })
 
-  it("is disabled when Gravity is not ready, even for the treatment arm", () => {
-    setupFlags({ gravity: false, wtyl: { name: "variant", enabled: true } })
+  it("is disabled when its Gravity flag is not ready, even for the treatment arm", () => {
+    // WTYL's own gravity off, NWFY's gravity on — WTYL must still be disabled.
+    setupFlags({ wtylGravity: false, nwfyGravity: true, wtyl: { name: "variant", enabled: true } })
 
     const { result } = renderHook(() => useEnableLiveHomeRecommendations())
 
@@ -102,8 +113,13 @@ describe("useEnableLiveNewWorksForYou", () => {
     expect(result.current.enabled).toBe(false)
   })
 
-  it("is disabled when Gravity is not ready, even for the experiment arm", () => {
-    setupFlags({ gravity: false, nwfy: { name: "experiment", enabled: true } })
+  it("is disabled when its Gravity flag is not ready, even for the experiment arm", () => {
+    // NWFY's own gravity off, WTYL's gravity on — NWFY must still be disabled.
+    setupFlags({
+      nwfyGravity: false,
+      wtylGravity: true,
+      nwfy: { name: "experiment", enabled: true },
+    })
 
     const { result } = renderHook(() => useEnableLiveNewWorksForYou())
 
@@ -155,5 +171,29 @@ describe("useLiveHomeViewSectionIDs", () => {
     const { result } = renderHook(() => useLiveHomeViewSectionIDs())
 
     expect(result.current).toEqual([RECOMMENDED_ARTWORKS_SECTION_ID, NEW_WORKS_FOR_YOU_SECTION_ID])
+  })
+
+  it("requires each rail's own gravity flag — one couple's gravity does not enable the other", () => {
+    // Both refresh experiments in their enabled arm, but only WTYL's gravity flag is on.
+    setupFlags({
+      wtylGravity: true,
+      nwfyGravity: false,
+      wtyl: TREATMENT_WTYL,
+      nwfy: TREATMENT_NWFY,
+    })
+
+    const { result } = renderHook(() => useLiveHomeViewSectionIDs())
+
+    // Only WTYL goes live; NWFY stays off because onyx_nwfy-gravity is off.
+    expect(result.current).toEqual([RECOMMENDED_ARTWORKS_SECTION_ID])
+  })
+
+  it("does not enable a rail from gravity alone without its refresh experiment", () => {
+    // Both gravity flags on, but neither refresh experiment is in its enabled arm.
+    setupFlags({ wtylGravity: true, nwfyGravity: true, wtyl: DISABLED, nwfy: DISABLED })
+
+    const { result } = renderHook(() => useLiveHomeViewSectionIDs())
+
+    expect(result.current).toEqual([])
   })
 })

--- a/src/app/Scenes/HomeView/hooks/useLiveHomeViewSectionIDs.ts
+++ b/src/app/Scenes/HomeView/hooks/useLiveHomeViewSectionIDs.ts
@@ -15,7 +15,7 @@ export const useEnableLiveHomeRecommendations = (): { enabled: boolean } => {
 
 export const useEnableLiveNewWorksForYou = (): { enabled: boolean } => {
   const { variant } = useExperimentVariant("onyx_nwfy-refresh-eigen")
-  const enabledForGravity = useExperimentFlag("onyx_artwork-recommendations-gravity")
+  const enabledForGravity = useExperimentFlag("onyx_nwfy-gravity")
 
   const enabled = enabledForGravity && variant.enabled && variant.name === "experiment"
 

--- a/src/app/system/flags/experiments.ts
+++ b/src/app/system/flags/experiments.ts
@@ -11,7 +11,11 @@ export const experiments = {
   },
   "onyx_artwork-recommendations-gravity": {
     description:
-      "Enable Gravity-backed artwork recommendations for the Home screen recommendations rail",
+      "Enable Gravity-backed artwork recommendations for the Home screen We Think You'll Love recommendations rail",
+  },
+  "onyx_nwfy-gravity": {
+    description:
+      "Enable Gravity-backed artwork recommendations for the Home screen New Works for You rail",
   },
   "onyx_artwork-recommendations-refresh-eigen": {
     description: "Enable live-refreshing the Home screen recommendations rail in eigen",


### PR DESCRIPTION
This PR resolves [] <!-- eg [PROJECT-XXXX] -->

### Description

As discussed with Dejan, each frontend feature flag for live recs should have its own gravity flag

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [ ] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- use corresponding gravity flag for live nwfy rail - daria

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
