### PR TITLE
chore(release): v9.14.0 RC

### DIFF
--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -21,15 +21,15 @@ export const durationSections = (duration: Duration, labels: [string, string, st
       label: labels[0],
     },
     {
-      time: padWithZero(d.hours),
+      time: padWithZero(Math.floor(d.hours)),
       label: labels[1],
     },
     {
-      time: padWithZero(d.minutes),
+      time: padWithZero(Math.floor(d.minutes)),
       label: labels[2],
     },
     {
-      time: padWithZero(d.seconds),
+      time: padWithZero(Math.floor(d.seconds)),
       label: labels[3],
     },
   ]

--- a/src/app/Components/Countdown/__tests__/Ticker.tests.tsx
+++ b/src/app/Components/Countdown/__tests__/Ticker.tests.tsx
@@ -42,6 +42,18 @@ describe("SimpleTicker", () => {
       })
     ).toBeTruthy()
   })
+
+  it("does not render fractional seconds / milliseconds", () => {
+    // 1s + 789ms — the fractional remainder that used to leak through
+    const fractional = Duration.fromMillis(1789)
+    renderWithWrappers(<SimpleTicker duration={fractional} separator="  " variant="sm-display" />)
+
+    expect(
+      screen.getByText("00d  00h  00m  01s", {
+        normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+      })
+    ).toBeTruthy()
+  })
 })
 
 describe("LabeledTicker", () => {

--- a/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
+++ b/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx
@@ -33,7 +33,7 @@ import { NoFallback, withSuspense } from "app/utils/hooks/withSuspense"
 import { isDislikeArtworksEnabledFor } from "app/utils/isDislikeArtworksEnabledFor"
 import { useMemoizedRandom } from "app/utils/placeholders"
 import { times } from "lodash"
-import { memo, useEffect, useRef } from "react"
+import { memo, useEffect, useState } from "react"
 import { fetchQuery, graphql, useFragment, useLazyLoadQuery } from "react-relay"
 
 interface HomeViewSectionArtworksProps extends FlexProps {
@@ -64,48 +64,58 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
 
   const isRailInViewport = viewableSections.includes(section.internalID)
 
-  // Ref so the async `complete` callback reads current visibility, not the value at kick-off.
-  const isRailInViewportRef = useRef(isRailInViewport)
-  isRailInViewportRef.current = isRailInViewport
+  // Set when a live refresh completes; cleared once we've re-fired railViewed for it. Lets us fire
+  // when the rail is on screen — now, or later when it's scrolled into view.
+  const [hasPendingRailViewed, setHasPendingRailViewed] = useState(false)
 
-  const { onViewableItemsChanged, viewabilityConfig, resetTracking } = useItemsImpressionsTracking({
-    // It is important here to tell if the rail is visible or not, because the viewability config
-    // default behavior, doesn't take into account the fact that the rail could be not visible
-    // on the screen because it's within a scrollable container.
-    isInViewport: isRailInViewport && section.trackItemImpressions,
-    contextModule,
-  })
-
-  // On a refetch bump, force-fetch this rail. This effect runs per-section, so every live rail
-  // (recommended, new works for you, and any future ones in liveSectionIDs) refetches — in view
-  // or not — so no live rail goes stale. On complete, reset the impression guard and re-fire
-  // railViewed only if the rail is on screen.
-  useEffect(() => {
-    if (!isLiveRefreshRail || liveRefetchKey === 0) {
-      return
-    }
-
-    const subscription = fetchQuery<HomeViewSectionArtworksQuery>(
-      getRelayEnvironment(),
-      homeViewSectionArtworksQuery,
-      { id: section.internalID, enableHidingDislikedArtworks },
-      { networkCacheConfig: { force: true } }
-    ).subscribe({
-      complete: () => {
-        resetTracking()
-
-        if (isRailInViewportRef.current) {
-          tracking.viewedSection(contextModule, index)
-        }
-      },
-      error: (error: Error) => {
-        console.error("Failed to refresh live artworks rail", error)
-      },
+  const { onViewableItemsChanged, viewabilityConfig, resetTracking, trackingKey } =
+    useItemsImpressionsTracking({
+      // It is important here to tell if the rail is visible or not, because the viewability config
+      // default behavior, doesn't take into account the fact that the rail could be not visible
+      // on the screen because it's within a scrollable container.
+      isInViewport: isRailInViewport && section.trackItemImpressions,
+      contextModule,
     })
 
-    return () => subscription.unsubscribe()
+  // On a refetch bump, flag that railViewed should re-fire for this refresh (the effect below
+  // fires it once the rail is on screen — now or when scrolled to), and force-fetch this rail. This
+  // effect runs per-section, so every live rail (recommended, new works for you, and any future
+  // ones in liveSectionIDs) refetches — in view or not — so no live rail goes stale. On complete we
+  // reset the per-item impression guard so items re-track against the fresh data.
+  useEffect(() => {
+    if (isLiveRefreshRail && liveRefetchKey > 0) {
+      setHasPendingRailViewed(true)
+
+      const subscription = fetchQuery<HomeViewSectionArtworksQuery>(
+        getRelayEnvironment(),
+        homeViewSectionArtworksQuery,
+        { id: section.internalID, enableHidingDislikedArtworks },
+        { networkCacheConfig: { force: true } }
+      ).subscribe({
+        complete: () => {
+          resetTracking()
+        },
+        error: (error: Error) => {
+          console.error("Failed to refresh live artworks rail", error)
+        },
+      })
+
+      return () => subscription.unsubscribe()
+    }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveRefetchKey])
+
+  // Re-fire railViewed after a live refresh, once the rail is on screen. Driven by the reactive
+  // `isRailInViewport` (from viewableSections, which updates on scroll), so a rail that was off
+  // screen at refresh time still re-fires when it's later scrolled into view.
+  useEffect(() => {
+    if (hasPendingRailViewed && isRailInViewport) {
+      tracking.viewedSection(contextModule, index)
+      setHasPendingRailViewed(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasPendingRailViewed, isRailInViewport])
 
   let artworks = extractNodes(section.artworksConnection)
 
@@ -182,6 +192,8 @@ export const HomeViewSectionArtworks: React.FC<HomeViewSectionArtworksProps> = (
           onArtworkPress={handleOnGridArtworkPress}
           trackItemImpressions={section.trackItemImpressions}
           contextModule={contextModule}
+          // We are using this key to force a re-render to track item impressions again
+          key={trackingKey}
         />
       ) : (
         <ArtworkRail

--- a/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
+++ b/src/app/Scenes/HomeView/Sections/__tests__/HomeViewSectionArtworks.tests.tsx
@@ -425,8 +425,8 @@ describe("HomeViewSectionArtworks", () => {
       setLiveSectionIDs([])
     })
 
-    it("re-fires railViewed only after the live refresh completes", () => {
-      const { env } = renderWithRelay({
+    it("re-fires railViewed as soon as the rail is refreshed", () => {
+      renderWithRelay({
         HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
       })
 
@@ -437,20 +437,6 @@ describe("HomeViewSectionArtworks", () => {
         homeViewStoreActions.bumpLiveRefetchKey()
       })
 
-      // Nothing fires yet — the refreshed data hasn't landed.
-      expect(mockTrackEvent).not.toHaveBeenCalledWith(
-        expect.objectContaining({ action: "railViewed" })
-      )
-
-      // Once the forced refetch completes, railViewed fires for the fresh data.
-      act(() => {
-        env.mock.resolveMostRecentOperation((operation) =>
-          MockPayloadGenerator.generate(operation, {
-            HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
-          })
-        )
-      })
-
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: "railViewed",
         context_module: "newWorksForYouRail",
@@ -459,8 +445,7 @@ describe("HomeViewSectionArtworks", () => {
       })
     })
 
-    it("does not re-fire railViewed on refresh when the WTYL rail is off screen", () => {
-      // The refresh-driven railViewed re-fire only happens while the rail is actually on screen.
+    it("re-fires railViewed once an off-screen rail is scrolled into view after a refresh", () => {
       const { env } = renderWithRelay({
         HomeViewSectionArtworks: () => RECOMMENDED_SECTION,
       })
@@ -480,10 +465,17 @@ describe("HomeViewSectionArtworks", () => {
         )
       })
 
-      // railViewed should not fire because the rail is off screen.
+      // Off screen at refresh time — nothing fires yet.
       expect(mockTrackEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ action: "railViewed" })
       )
+
+      // Scrolled into view afterwards — the pending refresh re-fires railViewed.
+      act(() => {
+        homeViewStoreActions.setViewableSections(["home-view-section-recommended-artworks"])
+      })
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(expect.objectContaining({ action: "railViewed" }))
     })
 
     it("re-fires railViewed on every refresh while the rail is in view", () => {
@@ -655,8 +647,8 @@ describe("HomeViewSectionArtworks", () => {
       setLiveSectionIDs([])
     })
 
-    it("re-fires railViewed only after the live refresh completes", () => {
-      const { env } = renderWithRelay({
+    it("re-fires railViewed as soon as the rail is refreshed", () => {
+      renderWithRelay({
         HomeViewSectionArtworks: () => NWFY_SECTION,
       })
 
@@ -665,19 +657,6 @@ describe("HomeViewSectionArtworks", () => {
 
       act(() => {
         homeViewStoreActions.bumpLiveRefetchKey()
-      })
-
-      // Nothing fires yet — the refreshed data hasn't landed.
-      expect(mockTrackEvent).not.toHaveBeenCalledWith(
-        expect.objectContaining({ action: "railViewed" })
-      )
-
-      act(() => {
-        env.mock.resolveMostRecentOperation((operation) =>
-          MockPayloadGenerator.generate(operation, {
-            HomeViewSectionArtworks: () => NWFY_SECTION,
-          })
-        )
       })
 
       expect(mockTrackEvent).toHaveBeenCalledWith({

--- a/src/app/Scenes/HomeView/hooks/useImpressionsTracking.ts
+++ b/src/app/Scenes/HomeView/hooks/useImpressionsTracking.ts
@@ -24,6 +24,7 @@ export const useItemsImpressionsTracking = ({
   // Use different state management for test vs production
   const renderedItems = useSharedValue<Array<TrackableItem>>([])
   const [testRenderedItems, setTestRenderedItems] = useState<Array<TrackableItem>>([])
+  const [key, setKey] = useState<number>(0)
 
   const trackedItems = useRef<Set<string>>(new Set()).current
 
@@ -106,18 +107,20 @@ export const useItemsImpressionsTracking = ({
         runOnJS(trackItems)(currentItems)
       }
     },
-    [enableItemsViewsTracking, isInViewport, contextScreenOwnerType, contextModule]
+    [enableItemsViewsTracking, isInViewport, contextScreenOwnerType, contextModule, key]
   )
 
   // Clears the per-item "already tracked" guard so itemViewed events become
   // eligible to fire again, e.g. after a forced data refresh of the rail.
   const resetTracking = useCallback(() => {
     trackedItems.clear()
-  }, [trackedItems])
+    setKey(key + 1)
+  }, [trackedItems, key])
 
   return {
     onViewableItemsChanged,
-    viewabilityConfig,
     resetTracking,
+    trackingKey: key,
+    viewabilityConfig,
   }
 }

--- a/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
+++ b/src/app/Scenes/MyProfile/MyProfileEditForm.tsx
@@ -209,7 +209,7 @@ export const MyProfileEditForm: React.FC<MyProfileEditFormProps> = () => {
         <Message
           variant="info"
           title="Complete your profile and make a great impression"
-          text="The information you provide here will be shared when you contact a gallery or make an offer."
+          text="The information you provide here will be shared when you contact a gallery, start an order, set an alert, or save an artwork."
           showCloseButton
         />
       )}


### PR DESCRIPTION
## Release Candidate 9.14.0

This branch was automatically created as the release candidate for version 9.14.0.

> ⚠️ Do not merge this PR. It is used for tracking the release and 🍒 cherry-picking fixes only.

## Changelog

### Cross-platform user-facing changes
- Add a progress bar to the Follow Artists and Discover Daily onboarding headers — iskounen (#13746)
- Allow continuing Discover Daily onboarding after the first 5 saves — iskounen (#13747)
- don't include cookies in auth requests to fix auth issues - brian — brainbicycle (#13751)
- Fix logo position/size and question step layout in the experience-based onboarding intro — iskounen (#13755)
- Show the artists a user actually followed (most recent 3, with an initials fallback for missing photos) in the post-onboarding "followed artists" bottom sheet — iskounen (#13756)
- Let the followed-artists bank in onboarding grow past 3 — iskounen (#13764)
- Fixed the Follow Artists onboarding completion sheet's backdrop tap and disabled swipe-to-dismiss — iskounen (#13777)
- Show a one-time tooltip pointing at the Favorites tab after new-user onboarding, and defer other Home tooltips to the next session to avoid back-to-back prompts — iskounen (#13783)
- Increase the home screen Viewing Rooms rail from 12 to 20 items — claude[bot] (#13795)
- Fix an intermittent iOS crash on screens with in-flight animations by upgrading react-native-reanimated to 4.3.2. — gkartalis (#13781)
- Fix missing "Clear" link on the Artists filter option so it matches other filters in the artwork filter modal — claude[bot] (#13796)
- Defer home tooltips to the next app session after Follow Artists onboarding flow — JanaeHijaz (#13801)
- allow linking to specific tabs in fairs screen - brian — brainbicycle (#13817)

### iOS user-facing changes
- nwfy rail live refresh - daria — dariakoko (#13787)
- Fix a crash when leaving or backgrounding the AR View in Room experience. — gkartalis (#13804)

### Dev changes
- Remove long-press tooltip and delay price range tooltip until after onboarding — JanaeHijaz (#13740)
- Fix `context_module`/`data_input` tracking gaps in onboarding and Infinite Discovery — iskounen (#13750)
- follow best patterns of actions - mounir — MounirDhahri (#13754)
- Add app state migration for the new `initials` field on `OnboardingFollowedArtist` — iskounen (#13756)
- Auto-generate the Mobile App QA Notion document (and Slack post) when a release-candidate PR is opened. — gkartalis (#13758)
- prevent MacOS detection during fastlane delivery by removing AWSCLI installer — gkartalis (#13761)
- Migrate FollowArtistsOrderedSet tests off deprecated Relay test utilities — iskounen (#13764)
- enable AI Claude Reviews - mounir — MounirDhahri (#13768)
- update getting started and troubleshooting — gkartalis (#13772)
- Updated copy across the new onboarding flow — iskounen (#13767)
- Renamed `ArtistSaveOnboardingBottomSheet` to `FollowArtistsOnboardingCompletionBottomSheet` — iskounen (#13776)
- add PR conventions to claude-review - mounir — MounirDhahri (#13779)
- build(deps): fix websocket-driver vulnerability by bumping — gkartalis (#13782)
- fix: mobile vitals link — gkartalis (#13784)
- fix: renames SENTRY_UPLOAD_AUTH_KEY to SENTRY_AUTH_TOKEN — gkartalis (#13785)
- Stabilize Maestro E2E tests (iOS + Android): non-fatal app-association prefetch, longer HomeView waits, per-flow retry, non-blocking deeplinks, suppressed rate-the-app prompt in E2E, Maestro 2.6.1 alignment across CI/local, and screenshot artifacts uploaded only on failure. — MounirDhahri (#13786)
- Reduced wasted re-renders in artwork grids: gate the hidden Create-Alert modal per grid cell, memoize the save icon, and stabilize the props passed to the masonry lists across the artwork grid screens. — gkartalis (#13771)
- Bump `react-native-reanimated` 4.2.1 → 4.3.2 and `react-native-worklets` 0.7.4 → 0.8.3. — gkartalis (#13781)
- default to stable react native and not experimental — gkartalis (#13800)
- Defer home tooltips to the next app session after Follow Artists onboarding flow — JanaeHijaz (#13801)
- fix hermes symbolication for iOS — gkartalis (#13805)
- Pin the onboarding intro sequence to `<Theme theme="v3light">` instead of theme-adaptive color tokens — iskounen (#13818)
- use corresponding gravity flag for live nwfy rail - daria — dariakoko (#13821)

#nochangelog