### PR TITLE
fix(PHIRE-3314): fix rateLimitMiddleware getting stuck under sustained traffic

### DIFF
--- a/src/app/system/relay/middlewares/__tests__/rateLimitMiddleware.tests.ts
+++ b/src/app/system/relay/middlewares/__tests__/rateLimitMiddleware.tests.ts
@@ -100,4 +100,48 @@ describe("rateLimitMiddleware", () => {
 
     Date.now = now
   })
+
+  it("resets gradually under sustained traffic that never has a gap >= interval", async () => {
+    // Regression test: this scenario used to break the middleware, because resetting was
+    // previously based on the gap between consecutive requests rather than a sliding window.
+    // Requests arriving every 300ms (always < the 1000ms interval) meant the counter would
+    // climb indefinitely once traffic stayed continuous, causing recurring bursts of thrown
+    // errors instead of the window correctly expiring on schedule.
+    const now = Date.now
+    const logger = jest.fn()
+    const middleware = rateLimitMiddleware({ logger, limit: 3, interval: 1000 })
+
+    const timestamps = [0, 300, 600, 900, 1200]
+    const results: Array<"ok" | "throw"> = []
+
+    for (const timestamp of timestamps) {
+      Date.now = jest.fn(() => timestamp)
+
+      try {
+        await middleware(next)(request)
+        results.push("ok")
+      } catch {
+        results.push("throw")
+      }
+    }
+
+    // 0, 300, 600 fill the window (limit 3); 900 is still within 1000ms of t=0 so it throws;
+    // by 1200 the window starting at t=0 has fully expired, so the request succeeds again.
+    expect(results).toEqual(["ok", "ok", "ok", "throw", "ok"])
+
+    Date.now = now
+  })
+
+  it("respects the default limit/interval when constructed with no options", async () => {
+    const middleware = rateLimitMiddleware()
+
+    const requests = Array.from({ length: 101 }, async () => middleware(next)(request))
+    const results = await Promise.allSettled(requests)
+
+    const fulfilled = results.filter((result) => result.status === "fulfilled")
+    const rejected = results.filter((result) => result.status === "rejected")
+
+    expect(fulfilled).toHaveLength(100)
+    expect(rejected).toHaveLength(1)
+  })
 })

--- a/src/app/system/relay/middlewares/rateLimitMiddleware.ts
+++ b/src/app/system/relay/middlewares/rateLimitMiddleware.ts
@@ -8,6 +8,9 @@ interface RateLimitMiddlewareOpts {
   logger?: (...args: unknown[]) => void
 }
 
+// Minimum gap between captureMessage calls for a given rate-limited stream.
+const CAPTURE_SAMPLE_INTERVAL = 60_000
+
 export const rateLimitMiddleware = (
   {
     limit,
@@ -18,31 +21,37 @@ export const rateLimitMiddleware = (
     interval: 1000,
   }
 ): Middleware => {
-  let count = 0
-  let prevTimeElapsed = Date.now()
+  let requestTimestamps: number[] = []
+  let lastCaptureAt = 0
 
   return (next) => {
     return (req) => {
       const operationName = "id" in req ? req.operation.name : "UnknownOperation"
-      const timeElapsed = Date.now() - prevTimeElapsed
-      const isWithinInterval = timeElapsed < interval
-      const isOutsideInterval = timeElapsed >= interval
+      const now = Date.now()
 
-      if (isWithinInterval && count >= limit) {
+      // Drop timestamps that have aged out of the window instead of resetting the
+      // count based on the gap between requests, which never fires during sustained
+      // traffic (e.g. background prefetching) since every request keeps sliding the
+      // reference point forward.
+      requestTimestamps = requestTimestamps.filter((timestamp) => now - timestamp < interval)
+
+      if (requestTimestamps.length >= limit) {
         const message = `Rate limit exceeded: ${operationName}`
-        captureMessage(message)
+
+        // Hitting the limit is expected, self-inflicted, and not actionable per-event —
+        // sample so a sustained rate-limited stream doesn't flood Sentry with duplicates.
+        if (now - lastCaptureAt > CAPTURE_SAMPLE_INTERVAL) {
+          captureMessage(message)
+          lastCaptureAt = now
+        }
+
         throw new Error(message)
       }
 
-      if (isOutsideInterval) {
-        count = 0
-      }
-
-      count = count + 1
-      prevTimeElapsed = Date.now()
+      requestTimestamps.push(now)
 
       if (logOperation) {
-        logger(`${operationName}: request +${count}`)
+        logger(`${operationName}: request +${requestTimestamps.length}`)
       }
 
       return next(req)


### PR DESCRIPTION
This PR resolves [PHIRE-3314]

### Description

Fixes [EIGEN-AYTW](https://artsynet.sentry.io/issues/7022917940/) — `Rate limit exceeded: ArtistInsightsQuery` thrown from `rateLimitMiddleware.ts`, ~377k occurrences / ~9.5k users.

**Root cause:** the middleware reset its counter based on the gap between *consecutive* requests. Under sustained traffic (requests arriving faster than `interval` apart), that gap never fired, so the counter grew unboundedly. Once past `limit`, every subsequent request threw permanently — the limiter could never recover — and `captureMessage` fired on every single throw, flooding Sentry.

**Fix:**
- Replace the single-gap check with a sliding-window log: keep a list of recent request timestamps and drop the ones older than `interval` on each call. This lets the limiter recover naturally regardless of how densely-packed traffic is, instead of getting permanently stuck.
- Sample `captureMessage` to at most once per 60s per rate-limited stream, since hitting the limit is expected/self-inflicted and not actionable per-event.

Added a regression test reproducing the sustained-traffic scenario (requests every 300ms against a 1000ms interval), plus a test covering the default `limit`/`interval` when constructed with no options.

### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix Relay rate limiter getting stuck after sustained traffic, causing repeated "Rate limit exceeded" errors (e.g. on the Artist screen)

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

</details>

Need help with something? Have a look at our docs, or get in touch with us.

[PHIRE-3314]: https://artsyproduct.atlassian.net/browse/PHIRE-3314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ