### PR TITLE
fix(DI-503): stop Follow Artists CTA from getting stuck on the wrong color

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsContinueButton.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsContinueButton.tsx
@@ -1,0 +1,97 @@
+import { Text, useColor } from "@artsy/palette-mobile"
+import { useEffect } from "react"
+import { Pressable } from "react-native"
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated"
+
+const ANIMATION_DURATION = 200
+
+// Color-state indices used with `interpolateColor` below.
+const DISABLED = 0
+const ENABLED = 1
+const PRESSED = 2
+
+interface FollowArtistsContinueButtonProps {
+  disabled: boolean
+  onPress: () => void
+  testID?: string
+  children: string
+}
+
+// A local, Reanimated-driven replacement for palette-mobile's <Button>, used only for this CTA.
+// palette-mobile's <Button> animates via react-spring, which can get permanently stuck showing
+// the wrong color when another Reanimated animation on this screen (StepProgressBar) fires from
+// the same state change at the same time. This component avoids that by using Reanimated too,
+// instead of mixing animation libraries.
+export const FollowArtistsContinueButton: React.FC<FollowArtistsContinueButtonProps> = ({
+  disabled,
+  onPress,
+  testID,
+  children,
+}) => {
+  const color = useColor()
+  // Resolved to plain strings here (regular JS), since `color()` isn't a worklet and can't be
+  // called from inside `useAnimatedStyle`, which runs on the UI thread.
+  const disabledColor = color("mono30")
+  const enabledColor = color("mono100")
+  const pressedColor = color("blue100")
+
+  const colorState = useSharedValue(disabled ? DISABLED : ENABLED)
+
+  useEffect(() => {
+    colorState.set(() =>
+      withTiming(disabled ? DISABLED : ENABLED, { duration: ANIMATION_DURATION })
+    )
+  }, [disabled, colorState])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: interpolateColor(
+      colorState.get(),
+      [DISABLED, ENABLED, PRESSED],
+      [disabledColor, enabledColor, pressedColor]
+    ),
+  }))
+
+  const handlePressIn = () => {
+    if (disabled) return
+    colorState.set(() => withTiming(PRESSED, { duration: ANIMATION_DURATION }))
+  }
+
+  const handlePressOut = () => {
+    if (disabled) return
+    colorState.set(() => withTiming(ENABLED, { duration: ANIMATION_DURATION }))
+  }
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      testID={testID}
+    >
+      <Animated.View
+        style={[
+          {
+            height: 50,
+            width: "100%",
+            borderRadius: 50,
+            alignItems: "center",
+            justifyContent: "center",
+          },
+          animatedStyle,
+        ]}
+      >
+        <Text variant="sm-display" color="mono0">
+          {children}
+        </Text>
+      </Animated.View>
+    </Pressable>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/FollowArtists.tsx
@@ -2,7 +2,6 @@ import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { ChevronRightIcon } from "@artsy/icons/native"
 import {
   Box,
-  Button,
   DEFAULT_HIT_SLOP,
   Flex,
   Screen,
@@ -14,6 +13,7 @@ import {
 import { ArtistListItemNew_artist$key } from "__generated__/ArtistListItemNew_artist.graphql"
 import { OnboardingProgressBadge } from "app/Components/OnboardingProgressBadge/OnboardingProgressBadge"
 import { StepProgressBar } from "app/Components/StepProgressBar/StepProgressBar"
+import { FollowArtistsContinueButton } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsContinueButton"
 import { FollowArtistsOrderedSetScreen } from "app/Scenes/Onboarding/Screens/Onboarding/Components/FollowArtistsOrderedSet"
 import {
   ArtistRef,
@@ -141,9 +141,8 @@ export const FollowArtists: React.FC = () => {
         </Flex>
         <KeyboardStickyView>
           <Flex p={2} backgroundColor="mono0">
-            <Button
+            <FollowArtistsContinueButton
               testID="continue-button"
-              block
               disabled={count < MIN_FOLLOWED}
               onPress={() => {
                 trackCompletedOnboarding()
@@ -153,7 +152,7 @@ export const FollowArtists: React.FC = () => {
               }}
             >
               Go to home
-            </Button>
+            </FollowArtistsContinueButton>
           </Flex>
         </KeyboardStickyView>
       </Screen.Body>


### PR DESCRIPTION
This PR resolves [DI-503](https://www.notion.so/3a5cab0764a080db82d3d884062b4ebb)

### Description

On the Follow Artists screen, the "Go to home" button turns black (enabled) correctly, then relapses to a stuck, incorrect dark-grey color a second or two later — and stays there, while remaining fully tappable.

**Root cause:** the button (palette-mobile's `<Button>`) animates its disabled ↔ enabled color transition via `react-spring`, which runs on the JS thread. On this screen, that transition and the progress bar (`StepProgressBar`)'s own Reanimated-driven completion animation are both triggered by the same `count` state change, so they fire at overlapping times. When that happens, react-spring's stepper can conclude prematurely that its animation is "at rest" mid-transition — confirmed directly via its internal `SpringPhase` flag (`isAnimating: false`) while the button sat at neither its start nor its target color — and it never updates again on its own.

This isn't about general JS-thread congestion: removing other synchronous re-render work from this screen didn't fix it, but removing (or merely freezing) the progress bar's own animation did. The trigger is specifically a react-spring transition and another Reanimated animation on the same screen firing concurrently from the same state change.

**Fix:** added `FollowArtistsContinueButton`, a small, local, Reanimated-driven stand-in for the shared `Button`, scoped to this one CTA. Driving its color on the UI thread avoids the conflict entirely, regardless of what else on the screen is animating.

**Follow-up note:** the same underlying react-spring behavior likely still exists in palette-mobile's shared `Button` component wherever a disabled ↔ enabled transition happens to fire concurrently with another Reanimated animation triggered by the same state change. Not urgent, but worth checking for first if a similar "button randomly looks wrong" report comes in on another screen.

| Before | After |
|-|-|
| https://github.com/user-attachments/assets/b76cac5a-363f-4c86-8e78-339e8bdde72b | https://github.com/user-attachments/assets/47b6a4a9-5fe4-4e7c-a917-2c78a5f102ce |
| https://github.com/user-attachments/assets/221dc11f-7213-4522-8d23-a28bfb014359 | https://github.com/user-attachments/assets/15e7a4b9-a2cf-4dae-b07b-b5b254619d5c |

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Added a local Reanimated-based CTA button for the Follow Artists onboarding screen to avoid a react-spring/Reanimated animation conflict

</details>

Assisted-by: Claude:Sonnet-5