### PR TITLE
fix(PHIRE-3317): fix milliseconds showing in timers

### DIFF
--- a/src/app/Components/Countdown/Ticker.tsx
+++ b/src/app/Components/Countdown/Ticker.tsx
@@ -21,15 +21,15 @@ export const durationSections = (duration: Duration, labels: [string, string, st
       label: labels[0],
     },
     {
-      time: padWithZero(d.hours),
+      time: padWithZero(Math.floor(d.hours)),
       label: labels[1],
     },
     {
-      time: padWithZero(d.minutes),
+      time: padWithZero(Math.floor(d.minutes)),
       label: labels[2],
     },
     {
-      time: padWithZero(d.seconds),
+      time: padWithZero(Math.floor(d.seconds)),
       label: labels[3],
     },
   ]

--- a/src/app/Components/Countdown/__tests__/Ticker.tests.tsx
+++ b/src/app/Components/Countdown/__tests__/Ticker.tests.tsx
@@ -42,6 +42,18 @@ describe("SimpleTicker", () => {
       })
     ).toBeTruthy()
   })
+
+  it("does not render fractional seconds / milliseconds", () => {
+    // 1s + 789ms — the fractional remainder that used to leak through
+    const fractional = Duration.fromMillis(1789)
+    renderWithWrappers(<SimpleTicker duration={fractional} separator="  " variant="sm-display" />)
+
+    expect(
+      screen.getByText("00d  00h  00m  01s", {
+        normalizer: getDefaultNormalizer({ collapseWhitespace: false }),
+      })
+    ).toBeTruthy()
+  })
 })
 
 describe("LabeledTicker", () => {


### PR DESCRIPTION
This PR resolves [PHIRE-3317] <!-- eg [PROJECT-XXXX] -->

### Description
This PR fixes an issue where milliseconds are showing in timers in Artwork Lot, as well as Viewing Rooms

### Screenshots
#### Artwork Lot
| | Before | After |
|---|---|---|
| Android | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/9ffffaea-2094-4942-bb81-1f36e93365f2" /> | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/22c9fdba-163f-476a-ac8f-1a27b1e53409" /> |
| iOS | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/94afdf26-092b-4d6c-a75a-0b5d63510091" /> | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/957c9181-9f29-4d1c-aff9-b4a054372e71" /> |


#### Viewing Rooms
| | Before | After |
|---|---|---|
| Android | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/ceffffea-89b3-4bfc-873a-586bf7f44b33" /> | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/255b0bb7-7891-49c6-90fa-9b6bf7b27efb" /> |
| iOS | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/6c911e5d-d8b6-4983-8136-8c9d16de0cb4" /> | <img width="444" height="966" alt="image" src="https://github.com/user-attachments/assets/51f1338c-f01d-4c53-9e51-a6b7a10b3f3c" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- fix milliseconds showing in timers

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3317]: https://artsyproduct.atlassian.net/browse/PHIRE-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ