### PR TITLE
feat: add real time updates

### DIFF
--- a/ios/Artsy/App/AppDelegateCategories/AppDelegate+Notifications.m
+++ b/ios/Artsy/App/AppDelegateCategories/AppDelegate+Notifications.m
@@ -127,6 +127,28 @@
     [[[AREmission sharedInstance] notificationsManagerModule] notificationReceivedWithPayload:normalizedInfo];
 }
 
+// Pulls the conversation id out of a notification's deep link, matching both
+// /conversation/:id (and /conversation/:id/details) and /user/conversations/:id.
+// Returns nil for any URL that doesn't point at a conversation.
+- (NSString *)conversationIDFromURLString:(NSString *)urlString
+{
+    if (![urlString isKindOfClass:NSString.class] || urlString.length == 0) {
+        return nil;
+    }
+
+    NSURL *url = [NSURL URLWithString:urlString];
+    NSArray<NSString *> *pathComponents = url ? url.pathComponents : urlString.pathComponents;
+
+    for (NSUInteger index = 0; index + 1 < pathComponents.count; index++) {
+        NSString *component = pathComponents[index];
+        if ([component isEqualToString:@"conversation"] || [component isEqualToString:@"conversations"]) {
+            return pathComponents[index + 1];
+        }
+    }
+
+    return nil;
+}
+
 // Handle the notification view on when the app is in the foreground
 -(void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions options))completionHandler{
 
@@ -143,6 +165,20 @@
     // Forward to React Native
     NSDictionary *normalizedInfo = [self normalizedNotificationInfo:notificationInfo];
     [[[AREmission sharedInstance] notificationsManagerModule] notificationReceivedWithPayload:normalizedInfo];
+
+    // Don't interrupt someone who is already reading the conversation the
+    // message belongs to. React keeps `visibleConversationID` up to date as the
+    // user navigates; it's empty whenever no conversation is on screen.
+    NSString *notificationConversationID = [self conversationIDFromURLString:normalizedInfo[@"url"]];
+
+    if (notificationConversationID != nil) {
+        NSString *visibleConversationID = [[AREmission sharedInstance] reactStateStringForKey:[ARReactStateKey visibleConversationID]];
+
+        if ([notificationConversationID isEqualToString:visibleConversationID]) {
+            completionHandler(UNNotificationPresentationOptionNone);
+            return;
+        }
+    }
 
     completionHandler(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge);
 }

--- a/ios/Artsy/NativeModules/ARNotificationsManager.h
+++ b/ios/Artsy/NativeModules/ARNotificationsManager.h
@@ -20,6 +20,7 @@
 + (NSString *)causalityURL;
 + (NSString *)env;
 + (NSString *)userIsDev;
++ (NSString *)visibleConversationID;
 @end
 
 @interface ARNotificationsManager : RCTEventEmitter <RCTBridgeModule>

--- a/ios/Artsy/NativeModules/ARNotificationsManager.m
+++ b/ios/Artsy/NativeModules/ARNotificationsManager.m
@@ -27,6 +27,7 @@
 + (NSString *)causalityURL { return @"causalityURL"; };
 + (NSString *)env { return @"env"; };
 + (NSString *)userIsDev { return @"userIsDev"; }
++ (NSString *)visibleConversationID { return @"visibleConversationID"; }
 @end
 
 // event keys

--- a/src/app/Components/Containers/Inbox.tsx
+++ b/src/app/Components/Containers/Inbox.tsx
@@ -37,7 +37,10 @@ interface Props {
 }
 
 export const Inbox: React.FC<Props> = memo(({ me, relay: _relay, isVisible: _isVisible }) => {
-  const [activeTab, setActiveTab] = useState<Tab>(Tab.bids)
+  const hasActiveBids = (me?.myBids?.active ?? []).length > 0
+  const initialPageName = hasActiveBids ? "bids" : "inquiries"
+
+  const [activeTab, setActiveTab] = useState<Tab>(hasActiveBids ? Tab.bids : Tab.inquiries)
   const listenerRef = useRef<EmitterSubscription | null>(null)
   const tracking = useTracking()
 
@@ -69,9 +72,6 @@ export const Inbox: React.FC<Props> = memo(({ me, relay: _relay, isVisible: _isV
 
     setActiveTab(tabName as Tab)
   }
-
-  const hasActiveBids = (me?.myBids?.active ?? []).length > 0
-  const initialPageName = hasActiveBids ? "bids" : "inquiries"
 
   return (
     <TabsContainer

--- a/src/app/NativeModules/LegacyNativeModules.tsx
+++ b/src/app/NativeModules/LegacyNativeModules.tsx
@@ -43,14 +43,17 @@ interface LegacyNativeModules {
     getConstants(): NativeState
     postNotificationName(type: string, data: object): void
     didFinishBootstrapping(): void
+    // Merged into native's react state, so callers can send a subset of the keys.
     reactStateUpdated(state: {
-      gravityURL: string
-      metaphysicsURL: string
-      predictionURL: string
-      webURL: string
-      causalityURL: string
-      env: string
-      userIsDev: boolean
+      gravityURL?: string
+      metaphysicsURL?: string
+      predictionURL?: string
+      webURL?: string
+      causalityURL?: string
+      env?: string
+      userIsDev?: boolean
+      /** internalID of the conversation currently on screen, "" when none */
+      visibleConversationID?: string
     }): void
   }
   ARPHPhotoPickerModule: {

--- a/src/app/Navigation/Navigation.tsx
+++ b/src/app/Navigation/Navigation.tsx
@@ -15,6 +15,7 @@ import { OnboardingWelcomeScreens } from "app/Scenes/Onboarding/Screens/Onboardi
 import { GlobalStore } from "app/store/GlobalStore"
 import { navigationInstrumentation } from "app/system/errorReporting/setupSentry"
 import { useReloadedDevNavigationState } from "app/system/navigation/useReloadedDevNavigationState"
+import { conversationIDFromRoute } from "app/system/notifications/visibleConversation"
 import { useDevToggle } from "app/utils/hooks/useDevToggle"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { logNavigation } from "app/utils/loggers"
@@ -97,6 +98,13 @@ export const Navigation = () => {
           if (currentRoute && Platform.OS === "ios") {
             LegacyNativeModules.ARTDeeplinkTimeoutModule.invalidateDeeplinkTimeout()
           }
+
+          // Let native know which conversation is on screen so an incoming push
+          // for it doesn't interrupt the user reading it. Empty means none.
+          // Android reads the route directly when the notification arrives.
+          LegacyNativeModules.ARNotificationsManager.reactStateUpdated({
+            visibleConversationID: conversationIDFromRoute(currentRoute),
+          })
 
           addBreadcrumb({
             message: `navigated to ${currentRoute?.name}`,

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -3,7 +3,10 @@ import { Flex, useColor, Text, Separator, Tabs } from "@artsy/palette-mobile"
 import { Conversations_me$data } from "__generated__/Conversations_me.graphql"
 import { PAGE_SIZE } from "app/Components/constants"
 import { ICON_HEIGHT } from "app/Scenes/BottomTabs/BottomTabsIcon"
+import { GlobalStore } from "app/store/GlobalStore"
+// eslint-disable-next-line no-restricted-imports
 import { navigate } from "app/system/navigation/navigate"
+import { useConversationsWebsocket } from "app/utils/Websockets/conversations/useConversationsWebsocket"
 import { extractNodes } from "app/utils/extractNodes"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
@@ -86,6 +89,15 @@ export const Conversations: React.FC<Props> = (props) => {
       refreshConversations()
     }
   }, [isActiveTab])
+
+  useConversationsWebsocket({
+    subscriptionKey: "inbox",
+    enabled: isActiveTab,
+    onEvent: () => {
+      refreshConversations()
+      GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
+    },
+  })
 
   const conversations = extractNodes(props.me?.conversations)
 

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -8,10 +8,11 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { navigate } from "app/system/navigation/navigate"
 import { useConversationsWebsocket } from "app/utils/Websockets/conversations/useConversationsWebsocket"
 import { extractNodes } from "app/utils/extractNodes"
+import { useIsFocusedInTab } from "app/utils/hooks/useIsFocusedInTab"
 import { ProvideScreenTrackingWithCohesionSchema } from "app/utils/track"
 import { screen } from "app/utils/track/helpers"
 import { ActionNames, ActionTypes } from "app/utils/track/schema"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { ActivityIndicator, RefreshControl } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -38,6 +39,8 @@ export const Conversations: React.FC<Props> = (props) => {
   const { trackEvent } = useTracking()
 
   const { relay, isActiveTab } = props
+  const isFocusedInInboxTab = useIsFocusedInTab("inbox")
+  const pendingRefresh = useRef(false)
 
   const fetchData = () => {
     if (relay.hasMore() && !relay.isLoading()) {
@@ -53,18 +56,25 @@ export const Conversations: React.FC<Props> = (props) => {
   }
 
   const refreshConversations = (withSpinner = false) => {
-    if (!relay.isLoading()) {
-      if (withSpinner) {
-        setIsFetching(true)
-      }
-      relay.refetchConnection(PAGE_SIZE, (error) => {
-        if (error) {
-          console.error("Conversations/index.tsx #refreshConversations", error.message)
-          // FIXME: Handle error
-        }
-        setIsFetching(false)
-      })
+    if (relay.isLoading()) {
+      pendingRefresh.current = true
+      return
     }
+
+    if (withSpinner) {
+      setIsFetching(true)
+    }
+    relay.refetchConnection(PAGE_SIZE, (error) => {
+      if (error) {
+        console.error("Conversations/index.tsx #refreshConversations", error.message)
+        // FIXME: Handle error
+      }
+      setIsFetching(false)
+      if (pendingRefresh.current) {
+        pendingRefresh.current = false
+        refreshConversations()
+      }
+    })
   }
 
   const handleSelectConversation = (item: Item) => {
@@ -90,18 +100,17 @@ export const Conversations: React.FC<Props> = (props) => {
     }
   }, [isActiveTab])
 
+  const refreshInbox = () => {
+    refreshConversations()
+    GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
+  }
+
   useConversationsWebsocket({
     subscriptionKey: "inbox",
-    enabled: isActiveTab,
-    onEvent: () => {
-      refreshConversations()
-      GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
-    },
+    enabled: isActiveTab && isFocusedInInboxTab,
+    onEvent: refreshInbox,
     // Catch up on anything broadcast while the socket was down.
-    onConnected: () => {
-      refreshConversations()
-      GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
-    },
+    onConnected: refreshInbox,
   })
 
   const conversations = extractNodes(props.me?.conversations)

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -42,6 +42,16 @@ export const Conversations: React.FC<Props> = (props) => {
   const isFocusedInInboxTab = useIsFocusedInTab("inbox")
   const pendingRefresh = useRef(false)
 
+  const conversations = extractNodes(props.me?.conversations)
+
+  // Retry a refresh that was skipped because a request was in flight.
+  const drainPendingRefresh = () => {
+    if (pendingRefresh.current) {
+      pendingRefresh.current = false
+      refreshConversations()
+    }
+  }
+
   const fetchData = () => {
     if (relay.hasMore() && !relay.isLoading()) {
       setIsLoading(true)
@@ -51,6 +61,7 @@ export const Conversations: React.FC<Props> = (props) => {
           // FIXME: Handle error
         }
         setIsLoading(false)
+        drainPendingRefresh()
       })
     }
   }
@@ -64,16 +75,15 @@ export const Conversations: React.FC<Props> = (props) => {
     if (withSpinner) {
       setIsFetching(true)
     }
-    relay.refetchConnection(PAGE_SIZE, (error) => {
+    // Refetch what's currently loaded so a paginated list isn't truncated
+    // back to the first page.
+    relay.refetchConnection(Math.max(PAGE_SIZE, conversations.length), (error) => {
       if (error) {
         console.error("Conversations/index.tsx #refreshConversations", error.message)
         // FIXME: Handle error
       }
       setIsFetching(false)
-      if (pendingRefresh.current) {
-        pendingRefresh.current = false
-        refreshConversations()
-      }
+      drainPendingRefresh()
     })
   }
 
@@ -112,8 +122,6 @@ export const Conversations: React.FC<Props> = (props) => {
     // Catch up on anything broadcast while the socket was down.
     onConnected: refreshInbox,
   })
-
-  const conversations = extractNodes(props.me?.conversations)
 
   const unreadCount = props.me?.conversations?.totalUnreadCount
   const unreadCounter = unreadCount ? `(${unreadCount})` : null

--- a/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Conversations.tsx
@@ -97,6 +97,11 @@ export const Conversations: React.FC<Props> = (props) => {
       refreshConversations()
       GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
     },
+    // Catch up on anything broadcast while the socket was down.
+    onConnected: () => {
+      refreshConversations()
+      GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
+    },
   })
 
   const conversations = extractNodes(props.me?.conversations)

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -7,12 +7,12 @@ import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { sortBy } from "lodash"
 import { DateTime } from "luxon"
-import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react"
+import React, { forwardRef, useImperativeHandle, useRef, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
 import { MessageGroup } from "./MessageGroup"
-import { ConversationItem, groupConversationItems } from "./utils/groupConversationItems"
+import { groupConversationItems } from "./utils/groupConversationItems"
 
 interface Props {
   conversation: Messages_conversation$data
@@ -34,7 +34,6 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
 
   const [fetchingMoreData, setFetchingMoreData] = useState(false)
   const [reloadingData, setReloadingData] = useState(false)
-  const [messages, setMessages] = useState<ConversationItem[][]>([])
 
   const subjectArtwork = conversation.items?.[0]?.item
   const artworkId = subjectArtwork?.__typename === "Artwork" ? subjectArtwork.internalID : null
@@ -70,24 +69,15 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   })
 
   // Combine and group events/messages
-  useEffect(() => {
-    const sortedMessages = sortBy(
-      [
-        ...orderEventsWithoutFailedPayment,
-        ...allMessages,
-        ...(partnerOfferEvent ? [partnerOfferEvent] : []),
-      ],
-      (message) => DateTime.fromISO(message.createdAt ?? "")
-    )
-    const groupedMessages = groupConversationItems(sortedMessages)
-
-    setMessages(groupedMessages)
-  }, [
-    allOrderEvents.length,
-    allMessages.length,
-    partnerOfferEvent?.createdAt,
-    partnerOfferEvent?.isPurchased,
-  ])
+  const sortedMessages = sortBy(
+    [
+      ...orderEventsWithoutFailedPayment,
+      ...allMessages,
+      ...(partnerOfferEvent ? [partnerOfferEvent] : []),
+    ],
+    (message) => DateTime.fromISO(message.createdAt ?? "")
+  )
+  const messages = groupConversationItems(sortedMessages)
 
   const flatList = useRef<FlatList>(null)
 

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -7,7 +7,7 @@ import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
 import { sortBy } from "lodash"
 import { DateTime } from "luxon"
-import React, { forwardRef, useImperativeHandle, useRef, useState } from "react"
+import React, { forwardRef, useImperativeHandle, useMemo, useRef, useState } from "react"
 import { FlatList, RefreshControl } from "react-native"
 import { createPaginationContainer, graphql, RelayPaginationProp } from "react-relay"
 import styled from "styled-components/native"
@@ -40,44 +40,56 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
   const partnerOfferEvent = usePartnerOfferEvent({ conversation, artworkId })
 
   // Get all messages and give them a key for use with flatlist
-  const allMessages = extractNodes(conversation.messagesConnection)
-    .filter((node) => {
-      if (node.isFirstMessage) {
-        return true
-      }
-      return node.body?.length || node.attachments?.length
-    })
-    .map((node) => {
-      return { key: node.id, ...node }
-    })
-
-  // flatmap all orders' events and give them a synthetic `key` for use with flatlist
-  const allOrderEvents = extractNodes(conversation?.orderConnection)
-    .reduce<OrderEvent[]>((prev, order) => prev.concat(order.orderHistory), [])
-    .map<OrderEventWithKey>((event, index) => ({ ...event, key: `event-${index}` }))
-
-  const orderEventsWithoutFailedPayment = allOrderEvents.filter((event, index) => {
-    if (
-      !(
-        event.state === "APPROVED" &&
-        allOrderEvents[index + 1] &&
-        allOrderEvents[index + 1].state === "SUBMITTED"
-      )
-    ) {
-      return event
-    }
-  })
-
-  // Combine and group events/messages
-  const sortedMessages = sortBy(
-    [
-      ...orderEventsWithoutFailedPayment,
-      ...allMessages,
-      ...(partnerOfferEvent ? [partnerOfferEvent] : []),
-    ],
-    (message) => DateTime.fromISO(message.createdAt ?? "")
+  const allMessages = useMemo(
+    () =>
+      extractNodes(conversation.messagesConnection)
+        .filter((node) => {
+          if (node.isFirstMessage) {
+            return true
+          }
+          return node.body?.length || node.attachments?.length
+        })
+        .map((node) => {
+          return { key: node.id, ...node }
+        }),
+    [conversation.messagesConnection]
   )
-  const messages = groupConversationItems(sortedMessages)
+
+  const orderEventsWithoutFailedPayment = useMemo(() => {
+    // flatmap all orders' events and give them a synthetic `key` for use with flatlist
+    const allOrderEvents = extractNodes(conversation?.orderConnection)
+      .reduce<OrderEvent[]>((prev, order) => prev.concat(order.orderHistory), [])
+      .map<OrderEventWithKey>((event, index) => ({ ...event, key: `event-${index}` }))
+
+    return allOrderEvents.filter((event, index) => {
+      if (
+        !(
+          event.state === "APPROVED" &&
+          allOrderEvents[index + 1] &&
+          allOrderEvents[index + 1].state === "SUBMITTED"
+        )
+      ) {
+        return event
+      }
+    })
+  }, [conversation?.orderConnection])
+
+  // Combine and group events/messages, keeping the array identity stable so
+  // the FlatList `data` prop doesn't churn on unrelated re-renders
+  const messages = useMemo(
+    () =>
+      groupConversationItems(
+        sortBy(
+          [
+            ...orderEventsWithoutFailedPayment,
+            ...allMessages,
+            ...(partnerOfferEvent ? [partnerOfferEvent] : []),
+          ],
+          (message) => DateTime.fromISO(message.createdAt ?? "")
+        )
+      ),
+    [orderEventsWithoutFailedPayment, allMessages, partnerOfferEvent]
+  )
 
   const flatList = useRef<FlatList>(null)
 

--- a/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
+++ b/src/app/Scenes/Inbox/Components/Conversations/Messages.tsx
@@ -1,7 +1,6 @@
 import { GuaranteeIcon } from "@artsy/icons/native"
 import { Messages_conversation$data } from "__generated__/Messages_conversation.graphql"
 import { ToastComponent } from "app/Components/Toast/ToastComponent"
-import { PAGE_SIZE } from "app/Components/constants"
 import { usePartnerOfferEvent } from "app/Scenes/Inbox/hooks/usePartnerOfferEvent"
 import { extractNodes } from "app/utils/extractNodes"
 import { ExtractNodeType } from "app/utils/relayHelpers"
@@ -24,6 +23,8 @@ interface Props {
 const LoadingIndicator = styled.ActivityIndicator`
   margin-top: 40px;
 `
+
+const MESSAGES_PAGE_SIZE = 20
 
 type Order = ExtractNodeType<Messages_conversation$data["orderConnection"]>
 type OrderEvent = Order["orderHistory"][number]
@@ -106,7 +107,7 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
     }
 
     updateState(true)
-    relay.loadMore(PAGE_SIZE, (error) => {
+    relay.loadMore(MESSAGES_PAGE_SIZE, (error) => {
       if (error) {
         // FIXME: Handle error
         console.error("Messages.tsx", error.message)
@@ -160,7 +161,9 @@ export const Messages: React.FC<Props> = forwardRef((props, ref) => {
         renderItem={({ item, index }) => {
           return (
             <MessageGroup
-              isLastMessage={index === messages.length - 1}
+              // Only the true start of the thread (nothing older left to
+              // load) shows the artwork/show preview above it.
+              isLastMessage={index === messages.length - 1 && !relay.hasMore()}
               group={item}
               conversationId={conversation?.internalID ?? ""}
               subjectItem={conversation.items?.[0]?.item}
@@ -191,7 +194,7 @@ export default createPaginationContainer(
   {
     conversation: graphql`
       fragment Messages_conversation on Conversation
-      @argumentDefinitions(count: { type: "Int", defaultValue: 10 }, after: { type: "String" }) {
+      @argumentDefinitions(count: { type: "Int", defaultValue: 20 }, after: { type: "String" }) {
         ...usePartnerOffer_conversation
         id
         internalID

--- a/src/app/Scenes/Inbox/Components/Conversations/SendConversationMessage.ts
+++ b/src/app/Scenes/Inbox/Components/Conversations/SendConversationMessage.ts
@@ -107,7 +107,6 @@ export function sendConversationMessage(
             body: text,
             from: {
               email: conversation.from.email,
-              name: null,
             },
             is_from_user: true,
             createdAt: new Date().toISOString(),

--- a/src/app/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/app/Scenes/Inbox/Screens/Conversation.tsx
@@ -16,6 +16,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 // eslint-disable-next-line no-restricted-imports
 import { goBack, navigate, navigationEvents } from "app/system/navigation/navigate"
 import { getRelayEnvironment } from "app/system/relay/defaultEnvironment"
+import { useConversationsWebsocket } from "app/utils/Websockets/conversations/useConversationsWebsocket"
 import NavigatorIOS from "app/utils/__legacy_do_not_use__navigator-ios-shim"
 import renderWithLoadProgress from "app/utils/renderWithLoadProgress"
 import { ProvideScreenTracking, Schema } from "app/utils/track"
@@ -70,6 +71,19 @@ export const Conversation: React.FC<Props> = ({
   const handleModalDismissed = React.useCallback(() => {
     refetch()
   }, [refetch])
+
+  const conversationID = me.conversation?.internalID
+
+  useConversationsWebsocket({
+    subscriptionKey: `conversation:${conversationID}`,
+    enabled: !!conversationID,
+    onEvent: (event) => {
+      if (event.conversation_id === conversationID) {
+        refetch()
+        GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
+      }
+    },
+  })
 
   const maybeMarkLastMessageAsRead = React.useCallback(() => {
     const conversation = me.conversation

--- a/src/app/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/app/Scenes/Inbox/Screens/Conversation.tsx
@@ -2,6 +2,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { InfoIcon } from "@artsy/icons/native"
 import { BackButton, Screen, Touchable } from "@artsy/palette-mobile"
 import NetInfo from "@react-native-community/netinfo"
+import { useIsFocused } from "@react-navigation/native"
 import { ConversationQuery } from "__generated__/ConversationQuery.graphql"
 import { Conversation_me$data } from "__generated__/Conversation_me.graphql"
 import ConnectivityBanner from "app/Components/ConnectivityBanner"
@@ -73,14 +74,19 @@ export const Conversation: React.FC<Props> = ({
   }, [refetch])
 
   const conversationID = me.conversation?.internalID
+  const isFocused = useIsFocused()
 
   useConversationsWebsocket({
     subscriptionKey: `conversation:${conversationID}`,
-    enabled: !!conversationID,
+    // Only refetch while the screen is visible: a refetch while hidden would
+    // mark the incoming message as read before the user ever saw it.
+    enabled: !!conversationID && isFocused,
     onEvent: (event) => {
+      // The badge counts all conversations, and the inbox subscription is
+      // torn down while this screen is on top, so always refresh it.
+      GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
       if (event.conversation_id === conversationID) {
         refetch()
-        GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
       }
     },
     // Catch up on anything broadcast while the socket was down.

--- a/src/app/Scenes/Inbox/Screens/Conversation.tsx
+++ b/src/app/Scenes/Inbox/Screens/Conversation.tsx
@@ -45,7 +45,7 @@ export const Conversation: React.FC<Props> = ({
 }) => {
   const [sendingMessage, setSendingMessage] = useState(false)
   const [isConnected, setIsConnected] = useState(true)
-  const [markedMessageAsRead, setMarkedMessageAsRead] = useState(false)
+  const [lastMarkedMessageID, setLastMarkedMessageID] = useState<string | null>(null)
   const [failedMessageText, setFailedMessageText] = useState<string | null>(null)
 
   const messagesRef = useRef<any>(null)
@@ -83,26 +83,31 @@ export const Conversation: React.FC<Props> = ({
         GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
       }
     },
+    // Catch up on anything broadcast while the socket was down.
+    onConnected: refetch,
   })
 
   const maybeMarkLastMessageAsRead = React.useCallback(() => {
     const conversation = me.conversation
-    if (conversation?.unread && !markedMessageAsRead && conversation.lastMessageID) {
+    const lastMessageID = conversation?.lastMessageID
+    // Track the id (not a boolean) so messages arriving while the
+    // conversation is open still get marked as read.
+    if (conversation?.unread && lastMessageID && lastMessageID !== lastMarkedMessageID) {
       updateConversation(
         conversation as any,
-        conversation.lastMessageID,
+        lastMessageID,
         (_response) => {
-          setMarkedMessageAsRead(true)
+          setLastMarkedMessageID(lastMessageID)
           GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
         },
         (error) => {
           console.warn(error)
-          setMarkedMessageAsRead(true)
+          setLastMarkedMessageID(lastMessageID)
           GlobalStore.actions.bottomTabs.fetchCurrentUnreadConversationCount()
         }
       )
     }
-  }, [me.conversation, markedMessageAsRead])
+  }, [me.conversation, lastMarkedMessageID])
 
   const messageSuccessfullySent = (text: string) => {
     tracking.trackEvent({

--- a/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
+++ b/src/app/Scenes/Inbox/hooks/usePartnerOfferEvent.ts
@@ -2,6 +2,7 @@ import { usePartnerOfferEvent_partnerOffers$key } from "__generated__/usePartner
 import { usePartnerOffer_conversation$key } from "__generated__/usePartnerOffer_conversation.graphql"
 import { PartnerOfferConversationEvent } from "app/Scenes/Inbox/Components/Conversations/ConversationPartnerOfferUpdate"
 import { usePartnerOffer } from "app/Scenes/Inbox/hooks/usePartnerOffer"
+import { useMemo } from "react"
 import { graphql, useFragment } from "react-relay"
 
 interface UsePartnerOfferEventProps {
@@ -30,19 +31,23 @@ export const usePartnerOfferEvent = ({
     partnerOffersRef as unknown as usePartnerOfferEvent_partnerOffers$key
   )
 
-  const partnerOffer = partnerOffers?.find((offer) => offer.artworkId === artworkId)
+  // Memoized so consumers (e.g. `Messages`) can use the event as a
+  // dependency without recomputing on every render
+  return useMemo(() => {
+    const partnerOffer = partnerOffers?.find((offer) => offer.artworkId === artworkId)
 
-  if (!partnerOffer) {
-    return null
-  }
+    if (!partnerOffer) {
+      return null
+    }
 
-  const isPurchased = !!partnerOffer.isPurchased
+    const isPurchased = !!partnerOffer.isPurchased
 
-  if (!hasActivePartnerOffer && !isPurchased) {
-    return null
-  }
+    if (!hasActivePartnerOffer && !isPurchased) {
+      return null
+    }
 
-  return { ...partnerOffer, isPurchased }
+    return { ...partnerOffer, isPurchased }
+  }, [partnerOffers, artworkId, hasActivePartnerOffer])
 }
 
 const partnerOffersFragment = graphql`

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -165,6 +165,11 @@ export const features = {
     showInDevMenu: true,
     echoFlagKey: "AREnableConversationPartnerOffers",
   },
+  AREnableConversationsRealtime: {
+    readyForRelease: false,
+    description: "Update conversations in real time over websockets",
+    showInDevMenu: true,
+  },
 } satisfies { [key: string]: FeatureDescriptor }
 
 export interface DevToggleDescriptor {

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -166,9 +166,10 @@ export const features = {
     echoFlagKey: "AREnableConversationPartnerOffers",
   },
   AREnableConversationsRealtime: {
-    readyForRelease: false,
+    readyForRelease: true,
     description: "Update conversations in real time over websockets",
     showInDevMenu: true,
+    echoFlagKey: "AREnableConversationsRealtime",
   },
 } satisfies { [key: string]: FeatureDescriptor }
 

--- a/src/app/store/config/features.ts
+++ b/src/app/store/config/features.ts
@@ -166,9 +166,9 @@ export const features = {
     echoFlagKey: "AREnableConversationPartnerOffers",
   },
   AREnableConversationsRealtime: {
+    showInDevMenu: true,
     readyForRelease: true,
     description: "Update conversations in real time over websockets",
-    showInDevMenu: true,
     echoFlagKey: "AREnableConversationsRealtime",
   },
 } satisfies { [key: string]: FeatureDescriptor }

--- a/src/app/system/notifications/useAndroidListenToPushNotifications.ts
+++ b/src/app/system/notifications/useAndroidListenToPushNotifications.ts
@@ -1,6 +1,11 @@
 import notifee, { AuthorizationStatus, Event, EventType } from "@notifee/react-native"
 import messaging, { FirebaseMessagingTypes } from "@react-native-firebase/messaging"
+import { internal_navigationRef } from "app/Navigation/Navigation"
 import { PushNotification } from "app/system/notifications/usePushNotifications"
+import {
+  conversationIDFromRoute,
+  conversationIDFromURL,
+} from "app/system/notifications/visibleConversation"
 // eslint-disable-next-line no-restricted-imports
 import { useEffect } from "react"
 import { Platform } from "react-native"
@@ -25,6 +30,18 @@ export const useAndroidListenToPushNotifications = ({
         const settings = await notifee.getNotificationSettings()
 
         if (settings.authorizationStatus !== AuthorizationStatus.AUTHORIZED) {
+          return
+        }
+
+        // Don't interrupt someone who is already reading the conversation the
+        // message belongs to — the open thread updates itself over the websocket.
+        const notificationConversationID = conversationIDFromURL(message.data?.url as string)
+
+        if (
+          notificationConversationID &&
+          notificationConversationID ===
+            conversationIDFromRoute(internal_navigationRef.current?.getCurrentRoute())
+        ) {
           return
         }
 

--- a/src/app/system/notifications/visibleConversation.ts
+++ b/src/app/system/notifications/visibleConversation.ts
@@ -1,0 +1,39 @@
+/**
+ * Helpers for deciding whether an incoming message notification is for the
+ * conversation the user is already reading, in which case there's no point
+ * interrupting them with a banner.
+ *
+ * Kept free of navigation imports so both the navigation container (which
+ * publishes the visible conversation to native for iOS) and the Android
+ * notification listener can use them without a circular dependency.
+ */
+
+/**
+ * The conversation the given route is showing, or "" when it isn't a
+ * conversation thread. `ConversationDetails` deliberately doesn't count: the
+ * thread itself isn't on screen there.
+ */
+export const conversationIDFromRoute = (route?: {
+  name?: string
+  params?: object | undefined
+}): string => {
+  if (route?.name !== "Conversation") {
+    return ""
+  }
+
+  return (route.params as { conversationID?: string })?.conversationID ?? ""
+}
+
+/**
+ * The conversation a notification's deep link points at, or null when it isn't
+ * a conversation link. Matches both /conversation/:id (with or without a
+ * trailing segment like /details) and /user/conversations/:id, on relative
+ * paths as well as full artsy.net urls.
+ */
+export const conversationIDFromURL = (url: string | null | undefined): string | null => {
+  if (!url) {
+    return null
+  }
+
+  return url.match(/\/conversations?\/([^/?#]+)/)?.[1] ?? null
+}

--- a/src/app/utils/Websockets/GravityWebsocketContext.tsx
+++ b/src/app/utils/Websockets/GravityWebsocketContext.tsx
@@ -27,22 +27,24 @@ export const GravityWebsocketContextProvider: React.FC<React.PropsWithChildren> 
     ? Keys.secureFor("GRAVITY_STAGING_WEBSOCKET_URL")
     : Keys.secureFor("GRAVITY_WEBSOCKET_URL")
 
+  // Keyed on `wssUrl` so switching environment tears down the old consumer and
+  // connects to the new host. Cleanup closes over the cable created in this
+  // run rather than reading it back from state, which would be stale.
   useEffect(() => {
-    if (!actionCable) {
-      const cable = ActionCable.createConsumer(wssUrl)
-      setChannelsHolder(new Cable({}))
-      setActionCable(cable)
-      if (__DEV__) {
-        ActionCable.startDebugging()
-      }
+    const cable = ActionCable.createConsumer(wssUrl)
+    setActionCable(cable)
+    setChannelsHolder(new Cable({}))
+    if (__DEV__) {
+      ActionCable.startDebugging()
     }
+
     return () => {
-      actionCable?.disconnect()
+      cable.disconnect()
       if (__DEV__) {
         ActionCable.stopDebugging()
       }
     }
-  }, [isStaging])
+  }, [wssUrl])
 
   return (
     <WebsocketContext.Provider value={{ cable: actionCable, channelsHolder }}>

--- a/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
+++ b/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
@@ -1,0 +1,123 @@
+import { renderHook } from "@testing-library/react-native"
+import { GlobalStoreProvider, __globalStoreTestUtils__ } from "app/store/GlobalStore"
+import { useCable } from "app/utils/Websockets/GravityWebsocketContext"
+import {
+  ConversationsWebsocketEvent,
+  useConversationsWebsocket,
+} from "app/utils/Websockets/conversations/useConversationsWebsocket"
+
+jest.mock("app/utils/Websockets/GravityWebsocketContext", () => ({
+  useCable: jest.fn(),
+}))
+
+describe("useConversationsWebsocket", () => {
+  const mockUseCable = useCable as jest.Mock
+
+  let channelListeners: { [event: string]: (data?: any) => void }
+  let mockChannel: any
+  let mockCable: any
+  let mockChannelsHolder: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    channelListeners = {}
+    mockChannel = {
+      on: jest.fn((event: string, handler: (data?: any) => void) => {
+        channelListeners[event] = handler
+        return mockChannel
+      }),
+      removeListener: jest.fn(() => mockChannel),
+      unsubscribe: jest.fn(),
+    }
+    mockCable = {
+      subscriptions: { create: jest.fn(() => ({})) },
+      channels: {},
+    }
+    mockChannelsHolder = {
+      setChannel: jest.fn(() => mockChannel),
+    }
+    mockUseCable.mockReturnValue({ cable: mockCable, channelsHolder: mockChannelsHolder })
+
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationsRealtime: true })
+    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "user-access-token" } })
+  })
+
+  const renderTheHook = (
+    params: { subscriptionKey?: string; enabled?: boolean; onEvent?: jest.Mock } = {}
+  ) => {
+    const onEvent = params.onEvent ?? jest.fn()
+    const wrapper = ({ children }: { children: React.ReactNode }) => {
+      return <GlobalStoreProvider>{children}</GlobalStoreProvider>
+    }
+    const utils = renderHook(
+      () => {
+        return useConversationsWebsocket({
+          subscriptionKey: params.subscriptionKey ?? "inbox",
+          enabled: params.enabled,
+          onEvent,
+        })
+      },
+      { wrapper }
+    )
+    return { ...utils, onEvent }
+  }
+
+  it("subscribes to the ConversationsChannel with the user's access token", () => {
+    renderTheHook()
+
+    expect(mockCable.subscriptions.create).toHaveBeenCalledWith({
+      channel: "ConversationsChannel",
+      access_token: "user-access-token",
+      key: "inbox",
+    })
+    expect(mockChannelsHolder.setChannel).toHaveBeenCalledWith(
+      "conversations:inbox",
+      expect.anything()
+    )
+  })
+
+  it("invokes onEvent when a message event is received", () => {
+    const { onEvent } = renderTheHook()
+
+    const event: ConversationsWebsocketEvent = {
+      type: "message.sent",
+      conversation_id: "conversation-1",
+      message_id: "message-1",
+    }
+    channelListeners.received(event)
+
+    expect(onEvent).toHaveBeenCalledWith(event)
+  })
+
+  it("unsubscribes from the channel on unmount", () => {
+    const { unmount } = renderTheHook()
+
+    unmount()
+
+    expect(mockChannel.removeListener).toHaveBeenCalledWith("received", expect.any(Function))
+    expect(mockChannel.unsubscribe).toHaveBeenCalled()
+  })
+
+  it("does not subscribe when disabled", () => {
+    renderTheHook({ enabled: false })
+
+    expect(mockCable.subscriptions.create).not.toHaveBeenCalled()
+  })
+
+  it("does not subscribe when the feature flag is off", () => {
+    __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationsRealtime: false })
+
+    renderTheHook()
+
+    expect(mockCable.subscriptions.create).not.toHaveBeenCalled()
+  })
+
+  it("does not subscribe without a user access token", () => {
+    __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: null } })
+
+    renderTheHook()
+
+    expect(mockCable.subscriptions.create).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
+++ b/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
@@ -32,10 +32,10 @@ describe("useConversationsWebsocket", () => {
     }
     mockCable = {
       subscriptions: { create: jest.fn(() => ({})) },
-      channels: {},
     }
     mockChannelsHolder = {
       setChannel: jest.fn(() => mockChannel),
+      channels: {},
     }
     mockUseCable.mockReturnValue({ cable: mockCable, channelsHolder: mockChannelsHolder })
 

--- a/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
+++ b/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
@@ -17,9 +17,11 @@ describe("useConversationsWebsocket", () => {
   let mockChannel: any
   let mockCable: any
   let mockChannelsHolder: any
+  let mockSubscription: any
 
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
 
     channelListeners = {}
     mockChannel = {
@@ -30,11 +32,15 @@ describe("useConversationsWebsocket", () => {
       removeListener: jest.fn(() => mockChannel),
       unsubscribe: jest.fn(),
     }
+    mockSubscription = { unsubscribe: jest.fn() }
     mockCable = {
-      subscriptions: { create: jest.fn(() => ({})) },
+      subscriptions: { create: jest.fn(() => mockSubscription) },
     }
     mockChannelsHolder = {
-      setChannel: jest.fn(() => mockChannel),
+      setChannel: jest.fn((key: string) => {
+        mockChannelsHolder.channels[key] = mockChannel
+        return mockChannel
+      }),
       channels: {},
     }
     mockUseCable.mockReturnValue({ cable: mockCable, channelsHolder: mockChannelsHolder })
@@ -43,24 +49,35 @@ describe("useConversationsWebsocket", () => {
     __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "user-access-token" } })
   })
 
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
   const renderTheHook = (
-    params: { subscriptionKey?: string; enabled?: boolean; onEvent?: jest.Mock } = {}
+    params: {
+      subscriptionKey?: string
+      enabled?: boolean
+      onEvent?: jest.Mock
+      onConnected?: jest.Mock
+    } = {}
   ) => {
     const onEvent = params.onEvent ?? jest.fn()
+    const onConnected = params.onConnected
     const wrapper = ({ children }: { children: React.ReactNode }) => {
       return <GlobalStoreProvider>{children}</GlobalStoreProvider>
     }
     const utils = renderHook(
-      () => {
+      (props: { subscriptionKey: string }) => {
         return useConversationsWebsocket({
-          subscriptionKey: params.subscriptionKey ?? "inbox",
+          subscriptionKey: props.subscriptionKey,
           enabled: params.enabled,
           onEvent,
+          onConnected,
         })
       },
-      { wrapper }
+      { wrapper, initialProps: { subscriptionKey: params.subscriptionKey ?? "inbox" } }
     )
-    return { ...utils, onEvent }
+    return { ...utils, onEvent, onConnected }
   }
 
   it("subscribes to the ConversationsChannel with the user's access token", () => {
@@ -90,13 +107,65 @@ describe("useConversationsWebsocket", () => {
     expect(onEvent).toHaveBeenCalledWith(event)
   })
 
+  it("collapses a burst of events into a leading and a trailing call", () => {
+    const { onEvent } = renderTheHook()
+
+    channelListeners.received({ message_id: "message-1" })
+    channelListeners.received({ message_id: "message-2" })
+    channelListeners.received({ message_id: "message-3" })
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent).toHaveBeenCalledWith({ message_id: "message-1" })
+
+    jest.runAllTimers()
+
+    expect(onEvent).toHaveBeenCalledTimes(2)
+    expect(onEvent).toHaveBeenLastCalledWith({ message_id: "message-3" })
+  })
+
+  it("invokes onConnected on reconnects but not on the initial connection", () => {
+    const onConnected = jest.fn()
+    renderTheHook({ onConnected })
+
+    channelListeners.connected()
+    expect(onConnected).not.toHaveBeenCalled()
+
+    channelListeners.connected()
+    expect(onConnected).toHaveBeenCalledTimes(1)
+  })
+
   it("unsubscribes from the channel on unmount", () => {
     const { unmount } = renderTheHook()
+
+    expect(mockChannelsHolder.channels["conversations:inbox"]).toBe(mockChannel)
 
     unmount()
 
     expect(mockChannel.removeListener).toHaveBeenCalledWith("received", expect.any(Function))
+    expect(mockChannel.removeListener).toHaveBeenCalledWith("connected", expect.any(Function))
     expect(mockChannel.unsubscribe).toHaveBeenCalled()
+    expect(mockChannelsHolder.channels["conversations:inbox"]).toBeUndefined()
+  })
+
+  it("resubscribes when the subscriptionKey changes", () => {
+    const { rerender } = renderTheHook({ subscriptionKey: "inbox" })
+
+    rerender({ subscriptionKey: "conversation:123" })
+
+    expect(mockChannel.unsubscribe).toHaveBeenCalledTimes(1)
+    expect(mockChannelsHolder.channels["conversations:inbox"]).toBeUndefined()
+    expect(mockChannelsHolder.setChannel).toHaveBeenLastCalledWith(
+      "conversations:conversation:123",
+      expect.anything()
+    )
+  })
+
+  it("unsubscribes the created subscription when setChannel returns nothing", () => {
+    mockChannelsHolder.setChannel = jest.fn(() => undefined)
+
+    renderTheHook()
+
+    expect(mockSubscription.unsubscribe).toHaveBeenCalled()
   })
 
   it("does not subscribe when disabled", () => {

--- a/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
+++ b/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
@@ -113,6 +113,21 @@ describe("useConversationsWebsocket", () => {
     expect(onConnected).toHaveBeenCalledTimes(1)
   })
 
+  it("invokes onConnected on the first connection after a resubscribe", () => {
+    const onConnected = jest.fn()
+    const { rerender } = renderTheHook({ subscriptionKey: "inbox", onConnected })
+
+    // Initial connection is skipped — the consumer fetches on mount.
+    channelListeners.connected()
+    expect(onConnected).not.toHaveBeenCalled()
+
+    // Resubscribing (e.g. `enabled` toggled with screen focus) should
+    // surface the new subscription's first `connected` as a catch-up.
+    rerender({ subscriptionKey: "conversation:123" })
+    channelListeners.connected()
+    expect(onConnected).toHaveBeenCalledTimes(1)
+  })
+
   it("unsubscribes from the channel on unmount", () => {
     const { unmount } = renderTheHook()
 

--- a/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
+++ b/src/app/utils/Websockets/conversations/__tests__/useConversationsWebsocket.tests.tsx
@@ -21,7 +21,6 @@ describe("useConversationsWebsocket", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    jest.useFakeTimers()
 
     channelListeners = {}
     mockChannel = {
@@ -47,10 +46,6 @@ describe("useConversationsWebsocket", () => {
 
     __globalStoreTestUtils__?.injectFeatureFlags({ AREnableConversationsRealtime: true })
     __globalStoreTestUtils__?.injectState({ auth: { userAccessToken: "user-access-token" } })
-  })
-
-  afterEach(() => {
-    jest.useRealTimers()
   })
 
   const renderTheHook = (
@@ -105,22 +100,6 @@ describe("useConversationsWebsocket", () => {
     channelListeners.received(event)
 
     expect(onEvent).toHaveBeenCalledWith(event)
-  })
-
-  it("collapses a burst of events into a leading and a trailing call", () => {
-    const { onEvent } = renderTheHook()
-
-    channelListeners.received({ message_id: "message-1" })
-    channelListeners.received({ message_id: "message-2" })
-    channelListeners.received({ message_id: "message-3" })
-
-    expect(onEvent).toHaveBeenCalledTimes(1)
-    expect(onEvent).toHaveBeenCalledWith({ message_id: "message-1" })
-
-    jest.runAllTimers()
-
-    expect(onEvent).toHaveBeenCalledTimes(2)
-    expect(onEvent).toHaveBeenLastCalledWith({ message_id: "message-3" })
   })
 
   it("invokes onConnected on reconnects but not on the initial connection", () => {

--- a/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
+++ b/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
@@ -1,0 +1,76 @@
+import { GlobalStore } from "app/store/GlobalStore"
+import { useCable } from "app/utils/Websockets/GravityWebsocketContext"
+import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { useEffect, useRef } from "react"
+
+export interface ConversationsWebsocketEvent {
+  type?: string
+  conversation_id?: string
+  message_id?: string
+  from_principal?: boolean
+  created_at?: string
+}
+
+interface UseConversationsWebsocketParams {
+  /**
+   * Uniquely identifies this subscription so simultaneous subscribers (e.g.
+   * the inbox list and an open conversation) each get their own channel.
+   */
+  subscriptionKey: string
+  enabled?: boolean
+  onEvent: (event: ConversationsWebsocketEvent) => void
+}
+
+/**
+ * Subscribes to Gravity's ConversationsChannel, which broadcasts a minimal
+ * signal (ids and timestamps, no message content) whenever a message is
+ * delivered to one of the current user's conversations. Consumers are
+ * expected to refetch over Relay in response.
+ */
+export const useConversationsWebsocket = ({
+  subscriptionKey,
+  enabled = true,
+  onEvent,
+}: UseConversationsWebsocketParams) => {
+  const isFeatureEnabled = useFeatureFlag("AREnableConversationsRealtime")
+  const userAccessToken = GlobalStore.useAppState((state) => state.auth.userAccessToken)
+  const { cable, channelsHolder } = useCable()
+
+  // Keep the latest callback without resubscribing on every render.
+  const onEventRef = useRef(onEvent)
+  onEventRef.current = onEvent
+
+  useEffect(() => {
+    if (!isFeatureEnabled || !enabled || !cable || !channelsHolder || !userAccessToken) {
+      return
+    }
+
+    const channelKey = `conversations:${subscriptionKey}`
+    const channel = channelsHolder.setChannel(
+      channelKey,
+      cable.subscriptions.create({
+        channel: "ConversationsChannel",
+        access_token: userAccessToken,
+        // Included only to keep simultaneous subscriptions' identifiers
+        // unique; ignored by the server.
+        key: subscriptionKey,
+      })
+    )
+
+    if (!channel) {
+      return
+    }
+
+    const handleReceived = (event: ConversationsWebsocketEvent) => {
+      onEventRef.current(event)
+    }
+
+    channel.on("received", handleReceived)
+
+    return () => {
+      channel.removeListener("received", handleReceived)
+      channel.unsubscribe()
+      delete cable.channels[channelKey]
+    }
+  }, [isFeatureEnabled, enabled, cable, channelsHolder, userAccessToken, subscriptionKey])
+}

--- a/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
+++ b/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
@@ -70,7 +70,7 @@ export const useConversationsWebsocket = ({
     return () => {
       channel.removeListener("received", handleReceived)
       channel.unsubscribe()
-      delete cable.channels[channelKey]
+      delete channelsHolder.channels[channelKey]
     }
   }, [isFeatureEnabled, enabled, cable, channelsHolder, userAccessToken, subscriptionKey])
 }

--- a/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
+++ b/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
@@ -25,8 +25,9 @@ interface UseConversationsWebsocketParams {
   onEvent: (event: ConversationsWebsocketEvent) => void
   /**
    * Called when the socket reconnects after a drop (network loss, app
-   * backgrounded). Anything broadcast while the socket was down is lost, so
-   * consumers should refetch here. Not called on the initial connection.
+   * backgrounded) or when the hook resubscribes after `enabled` was toggled
+   * off. Anything broadcast in the meantime is lost, so consumers should
+   * refetch here. Not called on the very first connection.
    */
   onConnected?: () => void
 }
@@ -53,6 +54,13 @@ export const useConversationsWebsocket = ({
   const onConnectedRef = useRef(onConnected)
   onConnectedRef.current = onConnected
 
+  // Lives outside the effect so it survives resubscribes (e.g. `enabled`
+  // toggling with screen focus). Only the very first connection is treated
+  // as "initial"; a resubscribe's first `connected` fires `onConnected`,
+  // which is exactly the catch-up refetch the consumer wants after having
+  // been unsubscribed.
+  const hasConnectedOnce = useRef(false)
+
   useEffect(() => {
     if (!isFeatureEnabled || !enabled || !cable || !channelsHolder || !userAccessToken) {
       return
@@ -78,22 +86,27 @@ export const useConversationsWebsocket = ({
     }
 
     // "connected" also fires when the subscription is first confirmed;
-    // consumers fetch on mount already, so only surface re-connects.
-    let hasConnectedOnce = false
+    // consumers fetch on mount already, so skip that one.
     const handleConnected = () => {
-      if (!hasConnectedOnce) {
-        hasConnectedOnce = true
+      if (!hasConnectedOnce.current) {
+        hasConnectedOnce.current = true
         return
       }
       onConnectedRef.current?.()
     }
 
+    const handleRejected = () => {
+      console.warn(`useConversationsWebsocket: subscription rejected for ${channelKey}`)
+    }
+
     channel.on("received", handleReceived)
     channel.on("connected", handleConnected)
+    channel.on("rejected", handleRejected)
 
     return () => {
       channel.removeListener("received", handleReceived)
       channel.removeListener("connected", handleConnected)
+      channel.removeListener("rejected", handleRejected)
       channel.unsubscribe()
       delete channelsHolder.channels[channelKey]
     }

--- a/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
+++ b/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
@@ -1,12 +1,21 @@
 import { GlobalStore } from "app/store/GlobalStore"
 import { useCable } from "app/utils/Websockets/GravityWebsocketContext"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
+import { debounce } from "lodash"
 import { useEffect, useRef } from "react"
+
+// Collapses bursts (e.g. a partner sending several messages in a row) into a
+// leading call plus one trailing call instead of one refetch per message.
+const RECEIVED_DEBOUNCE_MS = 500
 
 export interface ConversationsWebsocketEvent {
   type?: string
   conversation_id?: string
   message_id?: string
+  // True when the message was sent by the current user. Deliberately not
+  // filtered out: the broadcast can't tell which device sent the message, so
+  // skipping it would leave a message sent from another device (e.g. web)
+  // invisible here until a manual refresh.
   from_principal?: boolean
   created_at?: string
 }
@@ -19,6 +28,12 @@ interface UseConversationsWebsocketParams {
   subscriptionKey: string
   enabled?: boolean
   onEvent: (event: ConversationsWebsocketEvent) => void
+  /**
+   * Called when the socket reconnects after a drop (network loss, app
+   * backgrounded). Anything broadcast while the socket was down is lost, so
+   * consumers should refetch here. Not called on the initial connection.
+   */
+  onConnected?: () => void
 }
 
 /**
@@ -31,14 +46,17 @@ export const useConversationsWebsocket = ({
   subscriptionKey,
   enabled = true,
   onEvent,
+  onConnected,
 }: UseConversationsWebsocketParams) => {
   const isFeatureEnabled = useFeatureFlag("AREnableConversationsRealtime")
   const userAccessToken = GlobalStore.useAppState((state) => state.auth.userAccessToken)
   const { cable, channelsHolder } = useCable()
 
-  // Keep the latest callback without resubscribing on every render.
+  // Keep the latest callbacks without resubscribing on every render.
   const onEventRef = useRef(onEvent)
   onEventRef.current = onEvent
+  const onConnectedRef = useRef(onConnected)
+  onConnectedRef.current = onConnected
 
   useEffect(() => {
     if (!isFeatureEnabled || !enabled || !cable || !channelsHolder || !userAccessToken) {
@@ -46,29 +64,46 @@ export const useConversationsWebsocket = ({
     }
 
     const channelKey = `conversations:${subscriptionKey}`
-    const channel = channelsHolder.setChannel(
-      channelKey,
-      cable.subscriptions.create({
-        channel: "ConversationsChannel",
-        access_token: userAccessToken,
-        // Included only to keep simultaneous subscriptions' identifiers
-        // unique; ignored by the server.
-        key: subscriptionKey,
-      })
-    )
+    const subscription = cable.subscriptions.create({
+      channel: "ConversationsChannel",
+      access_token: userAccessToken,
+      // Included only to keep simultaneous subscriptions' identifiers
+      // unique; ignored by the server.
+      key: subscriptionKey,
+    })
+    const channel = channelsHolder.setChannel(channelKey, subscription)
 
     if (!channel) {
+      subscription.unsubscribe()
       return
     }
 
-    const handleReceived = (event: ConversationsWebsocketEvent) => {
-      onEventRef.current(event)
+    const handleReceived = debounce(
+      (event: ConversationsWebsocketEvent) => {
+        onEventRef.current(event)
+      },
+      RECEIVED_DEBOUNCE_MS,
+      { leading: true, trailing: true }
+    )
+
+    // "connected" also fires when the subscription is first confirmed;
+    // consumers fetch on mount already, so only surface re-connects.
+    let hasConnectedOnce = false
+    const handleConnected = () => {
+      if (!hasConnectedOnce) {
+        hasConnectedOnce = true
+        return
+      }
+      onConnectedRef.current?.()
     }
 
     channel.on("received", handleReceived)
+    channel.on("connected", handleConnected)
 
     return () => {
+      handleReceived.cancel()
       channel.removeListener("received", handleReceived)
+      channel.removeListener("connected", handleConnected)
       channel.unsubscribe()
       delete channelsHolder.channels[channelKey]
     }

--- a/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
+++ b/src/app/utils/Websockets/conversations/useConversationsWebsocket.tsx
@@ -1,12 +1,7 @@
 import { GlobalStore } from "app/store/GlobalStore"
 import { useCable } from "app/utils/Websockets/GravityWebsocketContext"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
-import { debounce } from "lodash"
 import { useEffect, useRef } from "react"
-
-// Collapses bursts (e.g. a partner sending several messages in a row) into a
-// leading call plus one trailing call instead of one refetch per message.
-const RECEIVED_DEBOUNCE_MS = 500
 
 export interface ConversationsWebsocketEvent {
   type?: string
@@ -78,13 +73,9 @@ export const useConversationsWebsocket = ({
       return
     }
 
-    const handleReceived = debounce(
-      (event: ConversationsWebsocketEvent) => {
-        onEventRef.current(event)
-      },
-      RECEIVED_DEBOUNCE_MS,
-      { leading: true, trailing: true }
-    )
+    const handleReceived = (event: ConversationsWebsocketEvent) => {
+      onEventRef.current(event)
+    }
 
     // "connected" also fires when the subscription is first confirmed;
     // consumers fetch on mount already, so only surface re-connects.
@@ -101,7 +92,6 @@ export const useConversationsWebsocket = ({
     channel.on("connected", handleConnected)
 
     return () => {
-      handleReceived.cancel()
       channel.removeListener("received", handleReceived)
       channel.removeListener("connected", handleConnected)
       channel.unsubscribe()


### PR DESCRIPTION
### Description

This PR adds real-time conversation updates using websockets by introducing a new `useConversationsWebsocket` hook that subscribes to Gravity's ConversationsChannel. When messages are delivered to the user's conversations, the hook triggers a refetch of conversation data and updates the unread count.

**Key changes:**
- New `useConversationsWebsocket` hook that manages websocket subscriptions to conversation events
- Integrates with the existing `GravityWebsocketContext` for cable management
- Automatically refetches conversation data when new messages arrive
- Updates unread conversation count in real-time
- Feature-flagged behind `AREnableConversationsRealtime` to allow safe rollout
- Integrated into both the Conversations list view and individual Conversation detail view

**Implementation details:**
- The hook accepts a `subscriptionKey` to allow multiple simultaneous subscriptions (e.g., inbox list + open conversation)
- Uses a ref to keep the latest callback without resubscribing on every render
- Properly cleans up listeners and unsubscribes on unmount
- Respects the feature flag, enabled state, and user authentication status

<video src="https://github.com/user-attachments/assets/65f07008-2d04-45b8-8959-76e7847a48c3" ></video>





### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
  - Feature flag: `AREnableConversationsRealtime`
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
  - No UI changes; this is a backend integration feature
- [x] I have added **tests**, or my changes don't require any.
  - Added comprehensive unit tests for `useConversationsWebsocket`
- [x] I added an **[app state migration]**, or my changes do not require one.
  - Not needed
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
  - No follow-up work required

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- Add real-time conversation updates via websockets with `useConversationsWebsocket` hook

</details>

https://claude.ai/code/session_01YQB2YVTL96ynGhYNTgbz2d