### PR TITLE
feat(qa-doc): post release QA doc announcement via release-lookout's Slack bot

### DIFF
--- a/.github/workflows/rc-release-automation.yml
+++ b/.github/workflows/rc-release-automation.yml
@@ -130,7 +130,8 @@ jobs:
       - name: Create Mobile App QA document in Notion
         env:
           NOTION_RELEASE_LOOKOUT_TOKEN: ${{ secrets.NOTION_RELEASE_LOOKOUT_TOKEN }}
-          SLACK_URL: ${{ secrets.SLACK_URL }}
+          SLACK_TOKEN: ${{ secrets.RELEASE_LOOKOUT_SLACK_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           RC_BRANCH: ${{ github.head_ref }}
           IOS_BUILD: ${{ steps.builds.outputs.ios_build }}
           ANDROID_BUILD: ${{ steps.builds.outputs.android_build }}
@@ -149,14 +150,15 @@ jobs:
     steps:
       - name: Post QA-document failure to Slack
         env:
-          SLACK_URL: ${{ secrets.SLACK_URL }}
+          SLACK_TOKEN: ${{ secrets.RELEASE_LOOKOUT_SLACK_TOKEN }}
+          SLACK_CHANNEL: ${{ secrets.SLACK_CHANNEL }}
           VERSION: ${{ needs.guard.outputs.version }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ -z "${SLACK_URL:-}" ]; then
-            echo "No SLACK_URL set; skipping failure notification."
+          if [ -z "${SLACK_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL:-}" ]; then
+            echo "No SLACK_TOKEN/SLACK_CHANNEL set; skipping failure notification."
             exit 0
           fi
-          curl -sf -X POST -H 'Content-type: application/json' \
-            --data "{\"text\":\":rotating_light: QA document creation failed for v${VERSION} (betas were fine) — <${RUN_URL}|view run>\"}" \
-            "$SLACK_URL"
+          curl -sf -X POST -H 'Content-type: application/json' -H "Authorization: Bearer ${SLACK_TOKEN}" \
+            --data "{\"channel\":\"${SLACK_CHANNEL}\",\"text\":\":rotating_light: QA document creation failed for v${VERSION} (betas were fine) — <${RUN_URL}|view run>\"}" \
+            "https://slack.com/api/chat.postMessage"

--- a/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
+++ b/scripts/create-qa-document/__tests__/createQaDocument.tests.ts
@@ -16,7 +16,9 @@ import { getVersionFromBranch } from "../version"
 const RC_BRANCH = "rc-v9.12.0"
 // 2026-08-13 so the title stamps a known date.
 const NOW = DateTime.fromISO("2026-08-13T10:00:00")
-const mockFetch = jest.fn().mockResolvedValue({ ok: true })
+const mockFetch = jest
+  .fn()
+  .mockResolvedValue({ ok: true, json: async () => ({ ok: true, ts: "1000.1" }) })
 
 describe("getVersionFromBranch", () => {
   it("parses the version out of an rc-v branch", () => {
@@ -62,7 +64,8 @@ describe("createQaDocument", () => {
     jest.spyOn(console, "log").mockImplementation(() => {})
     jest.spyOn(console, "warn").mockImplementation(() => {})
     jest.spyOn(console, "error").mockImplementation(() => {})
-    process.env.SLACK_URL = "https://hooks.slack.com/services/TEST"
+    process.env.SLACK_TOKEN = "xoxb-test-token"
+    process.env.SLACK_CHANNEL = "C12345"
     delete process.env.IOS_BUILD
     delete process.env.ANDROID_BUILD
     delete process.env.PR_BODY
@@ -73,7 +76,8 @@ describe("createQaDocument", () => {
 
   afterEach(() => {
     jest.restoreAllMocks()
-    delete process.env.SLACK_URL
+    delete process.env.SLACK_TOKEN
+    delete process.env.SLACK_CHANNEL
     delete process.env.IOS_BUILD
     delete process.env.ANDROID_BUILD
     delete process.env.PR_BODY
@@ -90,10 +94,12 @@ describe("createQaDocument", () => {
       changelog: undefined,
     })
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://hooks.slack.com/services/TEST",
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer xoxb-test-token" }),
         body: JSON.stringify({
+          channel: "C12345",
           text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/new-qa-page",
         }),
       })
@@ -107,9 +113,10 @@ describe("createQaDocument", () => {
 
     expect(duplicateTemplate).not.toHaveBeenCalled()
     expect(mockFetch).toHaveBeenCalledWith(
-      "https://hooks.slack.com/services/TEST",
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         body: JSON.stringify({
+          channel: "C12345",
           text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/existing-qa-page",
         }),
       })
@@ -148,24 +155,43 @@ describe("createQaDocument", () => {
     )
   })
 
-  it("includes the changelog in the Slack message when present", async () => {
+  it("posts the changelog as a threaded reply under the main message", async () => {
     process.env.PR_BODY =
       "## Release Candidate\n\n## Changelog\n\n### Dev changes\n- did a thing (#1)\n\n#nochangelog"
 
     await createQaDocument(RC_BRANCH, NOW)
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://hooks.slack.com/services/TEST",
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://slack.com/api/chat.postMessage",
       expect.objectContaining({
         body: JSON.stringify({
-          text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/new-qa-page\n\n*Changelog*\n### Dev changes\n- did a thing (#1)",
+          channel: "C12345",
+          text: ":notion: The mobile QA document for v9.12.0 is available here: https://notion.so/new-qa-page",
+        }),
+      })
+    )
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://slack.com/api/chat.postMessage",
+      expect.objectContaining({
+        body: JSON.stringify({
+          channel: "C12345",
+          text: "*Changelog*\n### Dev changes\n- did a thing (#1)",
+          thread_ts: "1000.1",
         }),
       })
     )
   })
 
-  it("skips the Slack post (without throwing) when SLACK_URL is not set", async () => {
-    delete process.env.SLACK_URL
+  it("does not post a second Slack message when there is no changelog", async () => {
+    await createQaDocument(RC_BRANCH, NOW)
+
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("skips the Slack post (without throwing) when SLACK_TOKEN is not set", async () => {
+    delete process.env.SLACK_TOKEN
 
     await createQaDocument(RC_BRANCH, NOW)
 
@@ -177,7 +203,12 @@ describe("createQaDocument", () => {
     // The document was already created; a Slack outage must not turn the run red.
     ;(global as any).fetch = jest
       .fn()
-      .mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" })
+      .mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        json: async () => ({}),
+      })
     await expect(createQaDocument(RC_BRANCH, NOW)).resolves.toBeUndefined()
     expect(duplicateTemplate).toHaveBeenCalled()
 

--- a/scripts/create-qa-document/createQaDocument.ts
+++ b/scripts/create-qa-document/createQaDocument.ts
@@ -10,32 +10,48 @@ import { duplicateTemplate, findExistingCopy } from "./duplicateNotionTemplate"
 import { fetchWithTimeout } from "./notion"
 import { getVersionFromBranch } from "./version"
 
-// Post a simple message to Slack via the incoming webhook (same pattern as
-// scripts/utils/exportNotionTicketsToJira.ts). Best-effort and never fatal: the
-// QA document is the deliverable, so a Slack outage must not fail the job (which
+// Post via the release-lookout Slack bot (chat.postMessage), same auth model as
+// release-lookout/src/release-reminders.ts. Best-effort and never fatal: the QA
+// document is the deliverable, so a Slack outage must not fail the job (which
 // would only report a false failure and, thanks to idempotency, keep failing on
 // every re-run while Slack is down).
-const postToSlack = async (text: string): Promise<void> => {
-  const slackUrl = process.env.SLACK_URL ?? ""
-  if (!slackUrl) {
-    console.warn("Missing SLACK_URL; skipping Slack notification.")
-    return
+// Returns the posted message's `ts` (used to thread a follow-up reply under it),
+// or undefined if the post was skipped/failed.
+const postToSlack = async (text: string, threadTs?: string): Promise<string | undefined> => {
+  const slackToken = process.env.SLACK_TOKEN ?? ""
+  const slackChannel = process.env.SLACK_CHANNEL ?? ""
+  if (!slackToken || !slackChannel) {
+    console.warn("Missing SLACK_TOKEN or SLACK_CHANNEL; skipping Slack notification.")
+    return undefined
   }
   try {
     const res = await fetchWithTimeout(
-      slackUrl,
+      "https://slack.com/api/chat.postMessage",
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text }),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${slackToken}`,
+        },
+        body: JSON.stringify({
+          channel: slackChannel,
+          text,
+          ...(threadTs ? { thread_ts: threadTs } : {}),
+        }),
       },
       10_000
     )
-    if (!res.ok) {
-      console.warn(`Failed to send Slack message: ${res.status} ${res.statusText}`)
+    const body = await res.json().catch(() => null)
+    if (!res.ok || !body?.ok) {
+      console.warn(
+        `Failed to send Slack message: ${res.status} ${res.statusText} ${body?.error ?? ""}`
+      )
+      return undefined
     }
+    return body.ts
   } catch (error) {
     console.warn(`Failed to send Slack message: ${error}`)
+    return undefined
   }
 }
 
@@ -77,10 +93,15 @@ export const createQaDocument = async (
     console.log(`Successfully created QA document: ${url}`)
   }
 
-  const changelogSection = changelog ? `\n\n*Changelog*\n${changelog}` : ""
-  await postToSlack(
-    `:notion: The mobile QA document for v${version} is available here: ${url}${changelogSection}`
+  const parentTs = await postToSlack(
+    `:notion: The mobile QA document for v${version} is available here: ${url}`
   )
+
+  // Changelog goes as a threaded reply under the main announcement, rather than
+  // in the same message, so the channel stays scannable when it's long.
+  if (changelog) {
+    await postToSlack(`*Changelog*\n${changelog}`, parentTs)
+  }
 }
 
 // Prevents auto-execution when imported in tests.


### PR DESCRIPTION
This PR resolves [PHIRE-3311]

### Description

Switches the RC QA-document workflow's Slack notifications from an incoming webhook (`SLACK_URL`) to release-lookout's existing Slack bot (`chat.postMessage` with a bot token), so eigen posts as a real app identity instead of a channel-locked webhook. The changelog is now posted as a **threaded reply** under the QA doc announcement instead of being appended into the same message, keeping the channel scannable when the changelog is long.

The incoming webhook could only fire a message at one hardcoded channel with no way to thread, react, or reuse across channels. release-lookout already runs a Slack bot (`@slack/web-api`, scoped `chat:write`) for release-captain reminders — reusing its token gets eigen threading support and channel flexibility without standing up a new Slack app.

**Changes:**
- `scripts/create-qa-document/createQaDocument.ts`
  - `postToSlack` now calls `https://slack.com/api/chat.postMessage` with `Authorization: Bearer $SLACK_TOKEN` and `channel: $SLACK_CHANNEL`, instead of POSTing to a webhook URL.
  - Returns the posted message's `ts` so a second call can thread under it via `thread_ts`.
  - QA doc link is posted as the parent message; changelog (when present) is posted as a threaded reply.
- `.github/workflows/rc-release-automation.yml`
  - `create-qa-document` and `notify-qa-failure` jobs now read `secrets.RELEASE_LOOKOUT_SLACK_TOKEN` / `secrets.SLACK_CHANNEL` instead of `secrets.SLACK_URL`.
  - `notify-qa-failure`'s raw `curl` call updated to hit `chat.postMessage` with a bearer token instead of the webhook.
- `scripts/create-qa-document/__tests__/createQaDocument.tests.ts` — updated to assert the bot-token call shape, and to cover the new threaded-reply behavior.

`RELEASE_LOOKOUT_SLACK_TOKEN` and `SLACK_CHANNEL` secrets are already set up in the repo under GH ACTIONS SECRETS

<!-- Screenshots/videos: n/a — CI script + workflow config change, no UI -->

### PR Checklist

- [ ] I have tested my changes on the following platforms: <!-- n/a: CI/Node script + GitHub Actions workflow, no app-side/on-device code — see test plan in Description instead -->
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. <!-- CI-only, no feature flag needed -->
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any. <!-- unit tests updated: 14/14 passing -->
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device. <!-- n/a: not a simulator-testable change; verify by triggering the workflow or running `yarn create-qa` locally against a test channel -->

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- QA-document release automation now posts via release-lookout's Slack bot instead of a webhook, with the changelog threaded as a reply under the main announcement.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3311]: https://artsyproduct.atlassian.net/browse/PHIRE-3311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ