### PR TITLE
fix(DI-519): hide background overlay on favorites tab onboarding tooltip

### DIFF
--- a/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
+++ b/src/app/Components/ProgressiveOnboarding/ProgressiveOnboardingFavoritesTab.tsx
@@ -67,6 +67,7 @@ export const ProgressiveOnboardingFavoritesTab: React.FC<React.PropsWithChildren
       onPressOutside={handleDismiss}
       onCloseComplete={clearActivePopover}
       onOpenComplete={trackEvent}
+      backgroundStyle={{ backgroundColor: "transparent" }}
       placement="top"
       title={
         <Touchable accessibilityRole="button" noFeedback onPress={onPress}>


### PR DESCRIPTION
This PR resolves [DI-519](https://www.notion.so/3aacab0764a08051a7aadbf6a53c5d83)

Assisted-by: Claude: Sonnet-5

### Description

The favorites tab tooltip that shows after completing onboarding (pointing out where saves are stored) had a dark background overlay. Per design, that dim should be off for this tooltip.

| Before | After |
|-|-|
| <img width="1206" height="2622" alt="ios_before" src="https://github.com/user-attachments/assets/782a2cc1-73d2-4666-822d-b49849acf338" /> | <img width="1206" height="2622" alt="ios_after" src="https://github.com/user-attachments/assets/ab9b69fa-a246-46dd-82d1-4e3a68c801ed" /> |
| <img width="1080" height="2400" alt="android_before" src="https://github.com/user-attachments/assets/ead79a56-1d6d-4e65-a7e4-c6887bb5d1e8" /> | <img width="1080" height="2400" alt="android_after" src="https://github.com/user-attachments/assets/594fdbd2-9d13-41af-86e9-0c11d676b07c" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Removed the background overlay on the "your saves get stored here" onboarding tooltip

</details>

[feature flag]: ../blob/main/docs/developing_a_feature.md
[app state migration]: ../blob/main/docs/adding_state_migrations.md