### PR TITLE
 fix(DI-516): using TapGestureHandler to allow users to either tap or swipe within Follow Artists onboarding bottomsheet

### DIFF
--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -57,8 +57,10 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
   const tap = Gesture.Tap()
     .withTestId("tap-to-progress")
     .runOnJS(true)
-    .onEnd(() => {
-      handleButtonPress()
+    .onEnd((_event, success) => {
+      if (success) {
+        handleButtonPress()
+      }
     })
 
   const renderBackdrop = useCallback(

--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -10,7 +10,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform, Pressable, StyleSheet } from "react-native"
-import { TapGestureHandler, State } from "react-native-gesture-handler"
+import { Gesture, GestureDetector } from "react-native-gesture-handler"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 
 export const FollowArtistsOnboardingCompletionBottomSheet = () => {
@@ -54,14 +54,12 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
     }
   }
 
-  const handleTap = useCallback(
-    (event: any) => {
-      if (event.nativeEvent.state === State.END) {
-        handleButtonPress()
-      }
-    },
-    [handleButtonPress]
-  )
+  const tap = Gesture.Tap()
+    .withTestId("tap-to-progress")
+    .runOnJS(true)
+    .onEnd(() => {
+      handleButtonPress()
+    })
 
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
@@ -104,8 +102,8 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
       handleComponent={null}
     >
       <BottomSheetView style={bottomSheetViewStyles}>
-        <TapGestureHandler onHandlerStateChange={handleTap}>
-          <Flex mb={4} mx={2} alignItems="center">
+        <GestureDetector gesture={tap}>
+          <Flex pb={4} px={2} alignItems="center">
             <Spacer y={2} />
 
             <Flex flexDirection="row" justifyContent="center" alignItems="center">
@@ -211,7 +209,7 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
               {activeStep === 0 ? "Next" : "View For You"}
             </Button>
           </Flex>
-        </TapGestureHandler>
+        </GestureDetector>
       </BottomSheetView>
     </AutomountedBottomSheetModal>
   )

--- a/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
+++ b/src/app/Scenes/HomeView/Components/FollowArtistsOnboardingCompletionBottomSheet.tsx
@@ -10,6 +10,7 @@ import { GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { useState, useRef, useCallback, useEffect } from "react"
 import { Platform, Pressable, StyleSheet } from "react-native"
+import { TapGestureHandler, State } from "react-native-gesture-handler"
 import PagerView, { PagerViewOnPageScrollEvent } from "react-native-pager-view"
 
 export const FollowArtistsOnboardingCompletionBottomSheet = () => {
@@ -53,6 +54,15 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
     }
   }
 
+  const handleTap = useCallback(
+    (event: any) => {
+      if (event.nativeEvent.state === State.END) {
+        handleButtonPress()
+      }
+    },
+    [handleButtonPress]
+  )
+
   const renderBackdrop = useCallback(
     (props: BottomSheetBackdropProps) => (
       <Pressable
@@ -94,112 +104,114 @@ export const FollowArtistsOnboardingCompletionBottomSheet = () => {
       handleComponent={null}
     >
       <BottomSheetView style={bottomSheetViewStyles}>
-        <Flex mb={4} mx={2} alignItems="center">
-          <Spacer y={2} />
+        <TapGestureHandler onHandlerStateChange={handleTap}>
+          <Flex mb={4} mx={2} alignItems="center">
+            <Spacer y={2} />
 
-          <Flex flexDirection="row" justifyContent="center" alignItems="center">
-            {followedOnboardingArtists.slice(-3).map((artist, index) => (
-              <Flex
-                key={artist.internalID}
-                backgroundColor="mono0"
-                borderRadius={35}
-                style={{
-                  marginLeft: index > 0 ? -10 : 0,
-                  zIndex: index,
-                  shadowColor: "#000",
-                  shadowOffset: { width: 0, height: 2 },
-                  shadowOpacity: 0.08,
-                  shadowRadius: 4,
-                  elevation: 2,
-                }}
-              >
-                <Avatar
-                  src={artist.imageUrl ?? undefined}
-                  blurhash={artist.blurhash}
-                  initials={artist.initials ?? undefined}
-                  size="sm"
+            <Flex flexDirection="row" justifyContent="center" alignItems="center">
+              {followedOnboardingArtists.slice(-3).map((artist, index) => (
+                <Flex
+                  key={artist.internalID}
+                  backgroundColor="mono0"
+                  borderRadius={35}
+                  style={{
+                    marginLeft: index > 0 ? -10 : 0,
+                    zIndex: index,
+                    shadowColor: "#000",
+                    shadowOffset: { width: 0, height: 2 },
+                    shadowOpacity: 0.08,
+                    shadowRadius: 4,
+                    elevation: 2,
+                  }}
+                >
+                  <Avatar
+                    src={artist.imageUrl ?? undefined}
+                    blurhash={artist.blurhash}
+                    initials={artist.initials ?? undefined}
+                    size="sm"
+                  />
+                </Flex>
+              ))}
+            </Flex>
+
+            <PagerView
+              style={{ width: "100%", height: 200 }}
+              initialPage={0}
+              onPageScroll={handleIndexChange}
+              ref={pagerViewRef}
+              pageMargin={0}
+              overdrag={false}
+              offscreenPageLimit={1}
+            >
+              {/* Page 1 */}
+              <Flex key="page-0" alignItems="center" width="100%">
+                <Spacer y={2} />
+
+                <Text variant="sm-display" weight="medium" textAlign="center">
+                  Your followed artists are saved to Favorites.
+                </Text>
+
+                <Spacer y={1} />
+
+                <Text
+                  variant="xs"
+                  color="mono60"
+                  textAlign="center"
+                  style={{ width: 350, paddingHorizontal: 10 }}
+                >
+                  Find them any time in the Favorites tab at the bottom of your screen.
+                </Text>
+
+                <Spacer y={2} />
+
+                <Image
+                  src="https://files.artsy.net/images/nav-bar.png"
+                  height={75}
+                  width={350}
+                  resizeMode="contain"
                 />
               </Flex>
-            ))}
-          </Flex>
 
-          <PagerView
-            style={{ width: "100%", height: 200 }}
-            initialPage={0}
-            onPageScroll={handleIndexChange}
-            ref={pagerViewRef}
-            pageMargin={0}
-            overdrag={false}
-            offscreenPageLimit={1}
-          >
-            {/* Page 1 */}
-            <Flex key="page-0" alignItems="center" width="100%">
-              <Spacer y={2} />
+              {/* Page 2 */}
+              <Flex key="page-1" alignItems="center" width="100%">
+                <Spacer y={2} />
 
-              <Text variant="sm-display" weight="medium" textAlign="center">
-                Your followed artists are saved to Favorites.
-              </Text>
+                <Text variant="sm-display" weight="medium" textAlign="center">
+                  We'll let you know when new works arrive.
+                </Text>
 
-              <Spacer y={1} />
+                <Spacer y={1} />
 
-              <Text
-                variant="xs"
-                color="mono60"
-                textAlign="center"
-                style={{ width: 350, paddingHorizontal: 10 }}
-              >
-                Find them any time in the Favorites tab at the bottom of your screen.
-              </Text>
+                <Text
+                  variant="xs"
+                  color="mono60"
+                  textAlign="center"
+                  style={{ width: 350, paddingHorizontal: 10 }}
+                >
+                  When there's a new work by an artist you follow, you'll see a notification at the
+                  top of your For You page.
+                </Text>
 
-              <Spacer y={2} />
+                <Spacer y={1} />
 
-              <Image
-                src="https://files.artsy.net/images/nav-bar.png"
-                height={75}
-                width={350}
-                resizeMode="contain"
-              />
+                <Image
+                  src="https://files.artsy.net/images/search-bar.png"
+                  height={75}
+                  width={350}
+                  resizeMode="contain"
+                />
+              </Flex>
+            </PagerView>
+
+            <Flex mb={2} py={0.5}>
+              <PaginationBars currentIndex={activeStep} length={numberOfPages} />
             </Flex>
 
-            {/* Page 2 */}
-            <Flex key="page-1" alignItems="center" width="100%">
-              <Spacer y={2} />
-
-              <Text variant="sm-display" weight="medium" textAlign="center">
-                We'll let you know when new works arrive.
-              </Text>
-
-              <Spacer y={1} />
-
-              <Text
-                variant="xs"
-                color="mono60"
-                textAlign="center"
-                style={{ width: 350, paddingHorizontal: 10 }}
-              >
-                When there's a new work by an artist you follow, you'll see a notification at the
-                top of your For You page.
-              </Text>
-
-              <Spacer y={1} />
-
-              <Image
-                src="https://files.artsy.net/images/search-bar.png"
-                height={75}
-                width={350}
-                resizeMode="contain"
-              />
-            </Flex>
-          </PagerView>
-
-          <Flex mb={2} py={0.5}>
-            <PaginationBars currentIndex={activeStep} length={numberOfPages} />
+            <Button block onPress={handleButtonPress}>
+              {activeStep === 0 ? "Next" : "View For You"}
+            </Button>
           </Flex>
-
-          <Button block onPress={handleButtonPress}>
-            {activeStep === 0 ? "Next" : "View For You"}
-          </Button>
-        </Flex>
+        </TapGestureHandler>
       </BottomSheetView>
     </AutomountedBottomSheetModal>
   )

--- a/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
@@ -4,6 +4,7 @@ import { FollowArtistsOnboardingCompletionBottomSheet } from "app/Scenes/HomeVie
 import { __globalStoreTestUtils__, GlobalStore } from "app/store/GlobalStore"
 import { useFeatureFlag } from "app/utils/hooks/useFeatureFlag"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+import { fireGestureHandler, getByGestureTestId } from "react-native-gesture-handler/jest-utils"
 import PagerView from "react-native-pager-view"
 
 jest.mock("app/utils/hooks/useFeatureFlag", () => ({
@@ -230,14 +231,13 @@ describe("FollowArtistsOnboardingCompletionBottomSheet", () => {
       const setPageSpy = jest.spyOn(pagerView.props.ref.current, "setPage")
 
       // Simulate tap using gesture handler test utils
-      const {
-        fireGestureHandler,
-        getByGestureTestId,
-      } = require("react-native-gesture-handler/jest-utils")
       fireGestureHandler(getByGestureTestId("tap-to-progress"))
 
-      // Verify tap called setPage(1)
+      // Verify tap called setPage(1) and did not dismiss
       expect(setPageSpy).toHaveBeenCalledWith(1)
+      expect(
+        __globalStoreTestUtils__!.getCurrentState().onboarding.showFollowedArtistSummaryBottomSheet
+      ).toBe(true)
     })
 
     it("dismisses the sheet when tapping anywhere on page 1", async () => {
@@ -257,10 +257,6 @@ describe("FollowArtistsOnboardingCompletionBottomSheet", () => {
       expect(await screen.findByText("View For You")).toBeOnTheScreen()
 
       // Simulate tap gesture
-      const {
-        fireGestureHandler,
-        getByGestureTestId,
-      } = require("react-native-gesture-handler/jest-utils")
       fireGestureHandler(getByGestureTestId("tap-to-progress"))
 
       // Should dismiss and reset state

--- a/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
@@ -213,4 +213,60 @@ describe("FollowArtistsOnboardingCompletionBottomSheet", () => {
       ).toEqual([])
     })
   })
+
+  describe("Tap to progress behavior", () => {
+    it("advances from page 0 to page 1 when tapping anywhere on the sheet", async () => {
+      GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+
+      const { UNSAFE_getByType } = renderWithWrappers(
+        <FollowArtistsOnboardingCompletionBottomSheet />
+      )
+
+      await screen.findByText("Your followed artists are saved to Favorites.")
+      expect(screen.getByText("Next")).toBeOnTheScreen()
+
+      // Get PagerView and spy on setPage
+      const pagerView = UNSAFE_getByType(PagerView)
+      const setPageSpy = jest.spyOn(pagerView.props.ref.current, "setPage")
+
+      // Simulate tap using gesture handler test utils
+      const {
+        fireGestureHandler,
+        getByGestureTestId,
+      } = require("react-native-gesture-handler/jest-utils")
+      fireGestureHandler(getByGestureTestId("tap-to-progress"))
+
+      // Verify tap called setPage(1)
+      expect(setPageSpy).toHaveBeenCalledWith(1)
+    })
+
+    it("dismisses the sheet when tapping anywhere on page 1", async () => {
+      GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
+
+      const { UNSAFE_getByType } = renderWithWrappers(
+        <FollowArtistsOnboardingCompletionBottomSheet />
+      )
+
+      await screen.findByText("Your followed artists are saved to Favorites.")
+
+      // Navigate to page 1
+      const pagerView = UNSAFE_getByType(PagerView)
+      pagerView.props.onPageScroll({ nativeEvent: { position: 1 } })
+
+      // Should show "View For You" button on page 1
+      expect(await screen.findByText("View For You")).toBeOnTheScreen()
+
+      // Simulate tap gesture
+      const {
+        fireGestureHandler,
+        getByGestureTestId,
+      } = require("react-native-gesture-handler/jest-utils")
+      fireGestureHandler(getByGestureTestId("tap-to-progress"))
+
+      // Should dismiss and reset state
+      const state = __globalStoreTestUtils__!.getCurrentState()
+      expect(state.onboarding.showFollowedArtistSummaryBottomSheet).toBe(false)
+      expect(state.onboarding.followedOnboardingArtists).toEqual([])
+    })
+  })
 })

--- a/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
+++ b/src/app/Scenes/HomeView/Components/__tests__/FollowArtistsOnboardingCompletionBottomSheet.tests.tsx
@@ -177,18 +177,21 @@ describe("FollowArtistsOnboardingCompletionBottomSheet", () => {
     it("dismisses and resets global state when View For You is pressed", async () => {
       GlobalStore.actions.onboarding.setShowFollowedArtistSummaryBottomSheet(true)
 
-      renderWithWrappers(<FollowArtistsOnboardingCompletionBottomSheet />)
+      const { UNSAFE_getByType } = renderWithWrappers(
+        <FollowArtistsOnboardingCompletionBottomSheet />
+      )
 
       await screen.findByText("Your followed artists are saved to Favorites.")
 
-      const viewForYouButton = screen.queryByText("View For You")
+      // Navigate to page 1 to show "View For You" button
+      const pagerView = UNSAFE_getByType(PagerView)
+      pagerView.props.onPageScroll({ nativeEvent: { position: 1 } })
 
-      if (viewForYouButton) {
-        fireEvent.press(viewForYouButton)
+      const viewForYouButton = await screen.findByText("View For You")
+      fireEvent.press(viewForYouButton)
 
-        const state = __globalStoreTestUtils__!.getCurrentState()
-        expect(state.onboarding.showFollowedArtistSummaryBottomSheet).toBe(false)
-      }
+      const state = __globalStoreTestUtils__!.getCurrentState()
+      expect(state.onboarding.showFollowedArtistSummaryBottomSheet).toBe(false)
     })
 
     it("clears followedOnboardingArtists once the sheet is dismissed", async () => {


### PR DESCRIPTION
This PR resolves [DI-516](https://www.notion.so/3aacab0764a080e88844d1e0dc9ec827) <!-- eg [PROJECT-XXXX] -->

### Description

This PR adds the ability for users to tap anywhere on the Follow Artists onboarding bottom sheet to progress through tabs (page 0 → page 1) or dismiss (on page 1), matching the expected behavior for the experienced onboarding flow.

I initially tried to wrap the entire modal content in a `Pressable` component to capture tap events, but this blocked the `PagerView`'s swipe gestures so users could swipe forward but not backward between pages. So I switched to `TapGestureHandler` from `react-native-gesture-handler` which allows both tap-to-progress and swipe-to-navigate to work simultaneously in the same area without weird behavior. 

Now a user can progress through and also exit the bottom sheet by swiping, clicking the CTAs, or tapping either inside or outside of the bottom sheet itself. 

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

Before:

https://github.com/user-attachments/assets/cec55353-afeb-4142-b896-bcd296e89cb3

After:

https://github.com/user-attachments/assets/e2ea12a2-53f8-454b-94cc-9ee0a03a8f94


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- 

#### iOS user-facing changes

- 

#### Android user-facing changes

-

#### Dev changes

- using TapGestureHandler to allow users to either tap or swipe within Follow Artists bottomsheet

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
