### PR TITLE
fix: bump vulnerable tar, xmldom, and brace-expansion transitive dependencies

### DIFF
--- a/bin/package.json
+++ b/bin/package.json
@@ -3,13 +3,17 @@
   "private": true,
   "dependenciesComments": {
     "form-data": "Pinned to fix GHSA-hmw2-7cc7-3qxx (CRLF injection). eas-cli exact-pins the vulnerable form-data@4.0.0 with no fixed release; remove this once eas-cli bumps it upstream.",
-    "minimatch": "Pinned to fix GHSA-7r86-cg39-jmmj (ReDoS). eas-cli exact-pins the vulnerable minimatch@5.1.2 with no fixed release; remove this once eas-cli bumps it upstream."
+    "minimatch": "Pinned to fix GHSA-7r86-cg39-jmmj (ReDoS). eas-cli exact-pins the vulnerable minimatch@5.1.2 with no fixed release; remove this once eas-cli bumps it upstream.",
+    "tar": "Pinned to fix multiple node-tar advisories (GHSA-9ppj-qmqm-q256, GHSA-qffp-2rhf-9h96, GHSA-83g3-92jg-28cx, GHSA-34x7-hfp2-rc4v, GHSA-r6q2-hw4h-h46w, GHSA-8qq5-rm4j-mr97). eas-cli exact-pins the vulnerable tar@6.2.1, which has no patched release on the 6.x line; remove this once eas-cli bumps past its exact pin (eas-cli@19+ already depends on tar 7.x).",
+    "@xmldom/xmldom": "Pinned to fix multiple xmldom advisories (GHSA-wh4c-j3r5-mjhp, GHSA-x6wf-f3px-wcqx, GHSA-f6ww-3ggp-fr8h, GHSA-j759-j44w-7fr8, GHSA-2v35-w6hq-6mfw). @expo/plist depends on the vulnerable @xmldom/xmldom@~0.7.7, which has no patched release on the 0.7.x line; remove this once @expo/plist bumps past 0.7.x."
   },
   "devDependencies": {
     "eas-cli": "16.9.0"
   },
   "resolutions": {
     "form-data": "4.0.6",
-    "minimatch@npm:5.1.2": "5.1.8"
+    "minimatch@npm:5.1.2": "5.1.8",
+    "tar@npm:6.2.1": "7.5.22",
+    "@xmldom/xmldom@npm:~0.7.7": "0.8.13"
   }
 }

--- a/bin/yarn.lock
+++ b/bin/yarn.lock
@@ -838,17 +838,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@xmldom/xmldom@npm:^0.8.8":
-  version: 0.8.11
-  resolution: "@xmldom/xmldom@npm:0.8.11"
-  checksum: 10c0/e768623de72c95d3dae6b5da8e33dda0d81665047811b5498d23a328d45b13feb5536fe921d0308b96a4a8dd8addf80b1f6ef466508051c0b581e63e0dc74ed5
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:~0.7.7":
-  version: 0.7.13
-  resolution: "@xmldom/xmldom@npm:0.7.13"
-  checksum: 10c0/cb02e4e8d986acf18578a5f25d1bce5e18d08718f40d8a0cdd922a4c112c8e00daf94de4e43f9556ed147c696b135f2ab81fa9a2a8a0416f60af15d156b60e40
+"@xmldom/xmldom@npm:0.8.13, @xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: 10c0/06405ee6fffba631abf715a305ace338420ebcea8baf1317f19f2752f5c505952b7df45159908e7be8451a42faa54326b780616ab4d08242b20477b2973da24b
   languageName: node
   linkType: hard
 
@@ -1158,16 +1151,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.2":
+"brace-expansion@npm:^2.0.1, brace-expansion@npm:^2.0.2":
   version: 2.1.2
   resolution: "brace-expansion@npm:2.1.2"
   dependencies:
@@ -1282,13 +1266,6 @@ __metadata:
   version: 0.0.2
   resolution: "charenc@npm:0.0.2"
   checksum: 10c0/a45ec39363a16799d0f9365c8dd0c78e711415113c6f14787a22462ef451f5013efae8a28f1c058f81fc01f2a6a16955f7a5fd0cd56247ce94a45349c89877d8
-  languageName: node
-  linkType: hard
-
-"chownr@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "chownr@npm:2.0.0"
-  checksum: 10c0/594754e1303672171cc04e50f6c398ae16128eb134a88f801bf5354fd96f205320f23536a045d9abd8b51024a149696e51231565891d4efdab8846021ecf88e6
   languageName: node
   linkType: hard
 
@@ -2050,15 +2027,6 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/9b808bd884beff5cb940773018179a6b94a966381d005479f00adda6b44e5e3d4abf765135773d849cc27efe68c349e4a7b86acd7d3306d5932c14f3a4b17a92
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "fs-minipass@npm:2.1.0"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10c0/703d16522b8282d7299337539c3ed6edddd1afe82435e4f5b76e34a79cd74e488a8a0e26a636afc2440e1a23b03878e2122e3a2cfe375a5cf63c37d92b86a004
   languageName: node
   linkType: hard
 
@@ -2987,13 +2955,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "minipass@npm:5.0.0"
-  checksum: 10c0/a91d8043f691796a8ac88df039da19933ef0f633e3d7f0d35dcd5373af49131cf2399bfc355f41515dc495e3990369c3858cd319e5c2722b4753c90bf3152462
-  languageName: node
-  linkType: hard
-
 "minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
   version: 7.1.2
   resolution: "minipass@npm:7.1.2"
@@ -3011,16 +2972,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "minizlib@npm:2.1.2"
-  dependencies:
-    minipass: "npm:^3.0.0"
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/64fae024e1a7d0346a1102bb670085b17b7f95bf6cfdf5b128772ec8faf9ea211464ea4add406a3a6384a7d87a0cd1a96263692134323477b4fb43659a6cab78
-  languageName: node
-  linkType: hard
-
 "minizlib@npm:^3.0.1":
   version: 3.0.2
   resolution: "minizlib@npm:3.0.2"
@@ -3030,21 +2981,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "mkdirp@npm:1.0.4"
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 10c0/46ea0f3ffa8bc6a5bc0c7081ffc3907777f0ed6516888d40a518c5111f8366d97d2678911ad1a6882bf592fa9de6c784fea32e1687bb94e1f4944170af48a5cf
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "mkdirp@npm:3.0.1"
-  bin:
-    mkdirp: dist/cjs/src/bin.js
-  checksum: 10c0/9f2b975e9246351f5e3a40dcfac99fcd0baa31fbfab615fe059fb11e51f10e4803c63de1f384c54d656e4db31d000e4767e9ef076a22e12a641357602e31d57d
+"minizlib@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "minizlib@npm:3.1.0"
+  dependencies:
+    minipass: "npm:^7.1.2"
+  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
   languageName: node
   linkType: hard
 
@@ -4027,31 +3969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:6.2.1":
-  version: 6.2.1
-  resolution: "tar@npm:6.2.1"
-  dependencies:
-    chownr: "npm:^2.0.0"
-    fs-minipass: "npm:^2.0.0"
-    minipass: "npm:^5.0.0"
-    minizlib: "npm:^2.1.1"
-    mkdirp: "npm:^1.0.3"
-    yallist: "npm:^4.0.0"
-  checksum: 10c0/a5eca3eb50bc11552d453488344e6507156b9193efd7635e98e867fab275d527af53d8866e2370cd09dfe74378a18111622ace35af6a608e5223a7d27fe99537
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.4.3":
-  version: 7.4.3
-  resolution: "tar@npm:7.4.3"
+"tar@npm:7.5.22, tar@npm:^7.4.3":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.0.1"
-    mkdirp: "npm:^3.0.1"
+    minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11634,11 +11634,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/8c919869b90f61d533b341d3340be5ee4413232ea89b8246cbc2f38eb014f1d8182785c98a006eaf6111d02dc9eeffefdc240d5ac158625b2ed084dccd4bbf9b
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 
@@ -25028,15 +25028,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3":
-  version: 7.5.20
-  resolution: "tar@npm:7.5.20"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4df4335c6d958b76adf1eaced55889dec3ca1c51f450658a074af80694bb0d9c154a8e93fdf4da617372d1575b121295379993961bbe4cd4b0867c0e5689846a
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR resolves [PHIRE-3321]

### Description

Follow-up to #13838. Addresses the remaining open Dependabot alerts for:

- **node-tar** (multiple CVEs, up to GHSA-r292-9mhp-454m)
- **@xmldom/xmldom** (up to GHSA-x6wf-f3px-wcqx)
- **brace-expansion** (GHSA-mh99-v99m-4gvg, GHSA-3jxr-9vmj-r5cp)

across both `yarn.lock` and `bin/yarn.lock` (the `eas-cli` tooling project).

Where a vulnerable version was reachable within its declared semver range, it was bumped in place with `yarn up` — no `resolutions` needed. Two dependencies required a `resolutions` override in `bin/package.json` (documented in `dependenciesComments`, following the existing `form-data`/`minimatch` pattern) because the requesting package pins them exactly/narrowly with no patched release on that line:

- `tar@6.2.1` — exact-pinned by `eas-cli@16.9.0`; resolved to `7.5.22`. **Note:** this crosses tar's 6→7 major version (dropped sync APIs, restructured options). `eas-cli`'s tar usage (artifact extraction during `eas build`/`eas submit`) isn't exercised by any test here — worth a real build/submit run before fully trusting this in CI.
- `@xmldom/xmldom@~0.7.7` — required by `@expo/plist`; resolved to `0.8.13`. Same caveat: no patched 0.7.x release exists, so this is also a minor-version jump in xmldom's API underneath code written against 0.7.x.

All 48 related Dependabot alerts (tar, @xmldom/xmldom, brace-expansion — fixed and previously-open) have been assigned to me for tracking.

<details><summary>Dependabot alerts addressed (48)</summary>

#### tar / node-tar

- [#444](https://github.com/artsy/eigen/security/dependabot/444) `yarn.lock` — GHSA-r292-9mhp-454m
- [#441](https://github.com/artsy/eigen/security/dependabot/441) `bin/yarn.lock` — GHSA-r292-9mhp-454m
- [#433](https://github.com/artsy/eigen/security/dependabot/433) `yarn.lock` — GHSA-w8wr-v893-vjvp
- [#423](https://github.com/artsy/eigen/security/dependabot/423) `bin/yarn.lock` — GHSA-w8wr-v893-vjvp
- [#432](https://github.com/artsy/eigen/security/dependabot/432) `yarn.lock` — GHSA-23hp-3jrh-7fpw
- [#422](https://github.com/artsy/eigen/security/dependabot/422) `bin/yarn.lock` — GHSA-23hp-3jrh-7fpw
- [#431](https://github.com/artsy/eigen/security/dependabot/431) `yarn.lock` — GHSA-8x88-c5mf-7j5w
- [#421](https://github.com/artsy/eigen/security/dependabot/421) `bin/yarn.lock` — GHSA-8x88-c5mf-7j5w
- [#430](https://github.com/artsy/eigen/security/dependabot/430) `yarn.lock` — GHSA-gvwx-54wh-qm9j
- [#420](https://github.com/artsy/eigen/security/dependabot/420) `bin/yarn.lock` — GHSA-gvwx-54wh-qm9j
- [#397](https://github.com/artsy/eigen/security/dependabot/397) `yarn.lock` — GHSA-vmf3-w455-68vh
- [#389](https://github.com/artsy/eigen/security/dependabot/389) `bin/yarn.lock` — GHSA-vmf3-w455-68vh
- [#287](https://github.com/artsy/eigen/security/dependabot/287) `yarn.lock` — GHSA-9ppj-qmqm-q256
- [#286](https://github.com/artsy/eigen/security/dependabot/286) `bin/yarn.lock` — GHSA-9ppj-qmqm-q256
- [#285](https://github.com/artsy/eigen/security/dependabot/285) `yarn.lock` — GHSA-qffp-2rhf-9h96
- [#283](https://github.com/artsy/eigen/security/dependabot/283) `bin/yarn.lock` — GHSA-qffp-2rhf-9h96
- [#258](https://github.com/artsy/eigen/security/dependabot/258) `yarn.lock` — GHSA-83g3-92jg-28cx
- [#255](https://github.com/artsy/eigen/security/dependabot/255) `bin/yarn.lock` — GHSA-83g3-92jg-28cx
- [#246](https://github.com/artsy/eigen/security/dependabot/246) `yarn.lock` — GHSA-34x7-hfp2-rc4v
- [#245](https://github.com/artsy/eigen/security/dependabot/245) `bin/yarn.lock` — GHSA-34x7-hfp2-rc4v
- [#241](https://github.com/artsy/eigen/security/dependabot/241) `yarn.lock` — GHSA-r6q2-hw4h-h46w
- [#240](https://github.com/artsy/eigen/security/dependabot/240) `bin/yarn.lock` — GHSA-r6q2-hw4h-h46w
- [#237](https://github.com/artsy/eigen/security/dependabot/237) `yarn.lock` — GHSA-8qq5-rm4j-mr97
- [#236](https://github.com/artsy/eigen/security/dependabot/236) `bin/yarn.lock` — GHSA-8qq5-rm4j-mr97

#### @xmldom/xmldom

- [#352](https://github.com/artsy/eigen/security/dependabot/352) `yarn.lock` — GHSA-2v35-w6hq-6mfw
- [#348](https://github.com/artsy/eigen/security/dependabot/348) `bin/yarn.lock` — GHSA-2v35-w6hq-6mfw
- [#351](https://github.com/artsy/eigen/security/dependabot/351) `yarn.lock` — GHSA-j759-j44w-7fr8
- [#347](https://github.com/artsy/eigen/security/dependabot/347) `bin/yarn.lock` — GHSA-j759-j44w-7fr8
- [#350](https://github.com/artsy/eigen/security/dependabot/350) `yarn.lock` — GHSA-x6wf-f3px-wcqx
- [#345](https://github.com/artsy/eigen/security/dependabot/345) `bin/yarn.lock` — GHSA-x6wf-f3px-wcqx
- [#349](https://github.com/artsy/eigen/security/dependabot/349) `yarn.lock` — GHSA-f6ww-3ggp-fr8h
- [#346](https://github.com/artsy/eigen/security/dependabot/346) `bin/yarn.lock` — GHSA-f6ww-3ggp-fr8h
- [#332](https://github.com/artsy/eigen/security/dependabot/332) `yarn.lock` — GHSA-wh4c-j3r5-mjhp
- [#333](https://github.com/artsy/eigen/security/dependabot/333) `bin/yarn.lock` — GHSA-wh4c-j3r5-mjhp
- [#103](https://github.com/artsy/eigen/security/dependabot/103) `yarn.lock` — GHSA-crh6-fp67-6883

#### brace-expansion

- [#445](https://github.com/artsy/eigen/security/dependabot/445) `yarn.lock` — GHSA-mh99-v99m-4gvg
- [#442](https://github.com/artsy/eigen/security/dependabot/442) `bin/yarn.lock` — GHSA-mh99-v99m-4gvg
- [#428](https://github.com/artsy/eigen/security/dependabot/428) `yarn.lock` — GHSA-3jxr-9vmj-r5cp
- [#427](https://github.com/artsy/eigen/security/dependabot/427) `yarn.lock` — GHSA-3jxr-9vmj-r5cp
- [#426](https://github.com/artsy/eigen/security/dependabot/426) `bin/yarn.lock` — GHSA-3jxr-9vmj-r5cp
- [#425](https://github.com/artsy/eigen/security/dependabot/425) `bin/yarn.lock` — GHSA-3jxr-9vmj-r5cp
- [#418](https://github.com/artsy/eigen/security/dependabot/418) `yarn.lock` — GHSA-3jxr-9vmj-r5cp
- [#328](https://github.com/artsy/eigen/security/dependabot/328) `yarn.lock` — GHSA-f886-m6hf-6m8v
- [#327](https://github.com/artsy/eigen/security/dependabot/327) `bin/yarn.lock` — GHSA-f886-m6hf-6m8v
- [#326](https://github.com/artsy/eigen/security/dependabot/326) `bin/yarn.lock` — GHSA-f886-m6hf-6m8v
- [#325](https://github.com/artsy/eigen/security/dependabot/325) `yarn.lock` — GHSA-f886-m6hf-6m8v
- [#197](https://github.com/artsy/eigen/security/dependabot/197) `yarn.lock` — GHSA-v6h2-p8h4-qcjw
- [#196](https://github.com/artsy/eigen/security/dependabot/196) `yarn.lock` — GHSA-v6h2-p8h4-qcjw

</details>

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**. <!-- dependency-only change, no platform-specific code -->
  - [x] **iOS**. <!-- dependency-only change, no platform-specific code -->
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

#nochangelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PHIRE-3321]: https://artsyproduct.atlassian.net/browse/PHIRE-3321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
