### PR TITLE
fix: artist bio rendering on Artwork screen

### DIFF
--- a/src/app/Components/Artist/Biography.tsx
+++ b/src/app/Components/Artist/Biography.tsx
@@ -1,6 +1,7 @@
 import { Text } from "@artsy/palette-mobile"
 import { Biography_artist$key } from "__generated__/Biography_artist.graphql"
 import { HTML } from "app/Components/HTML"
+import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -22,15 +23,13 @@ export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) 
 
   const credit = data.biographyBlurb.credit
   const text = !!credit ? `${data.biographyBlurb.text} ${credit}` : data.biographyBlurb.text
-  const truncatedText = text.slice(0, MAX_CHARS)
-  const canExpand = text.length > MAX_CHARS
+  const canExpand = visibleHtmlTextLength(text) > MAX_CHARS
+  const truncatedText = truncateHtml(text, MAX_CHARS)
 
   return (
     <>
       <HTML
-        html={`${expanded ? text : truncatedText}${
-          text.length > MAX_CHARS && !expanded ? "... " : " "
-        }`}
+        html={`${expanded ? text : truncatedText}${canExpand && !expanded ? "... " : " "}`}
         variant={variant}
       />
 

--- a/src/app/Components/Artist/Biography.tsx
+++ b/src/app/Components/Artist/Biography.tsx
@@ -1,7 +1,7 @@
 import { Text } from "@artsy/palette-mobile"
 import { Biography_artist$key } from "__generated__/Biography_artist.graphql"
 import { HTML } from "app/Components/HTML"
-import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
+import { truncateHtml } from "app/utils/truncateHtml"
 import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -23,8 +23,7 @@ export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) 
 
   const credit = data.biographyBlurb.credit
   const text = !!credit ? `${data.biographyBlurb.text} ${credit}` : data.biographyBlurb.text
-  const canExpand = visibleHtmlTextLength(text) > MAX_CHARS
-  const truncatedText = truncateHtml(text, MAX_CHARS)
+  const { text: truncatedText, wasTruncated: canExpand } = truncateHtml(text, MAX_CHARS)
 
   return (
     <>

--- a/src/app/Components/HTML.tsx
+++ b/src/app/Components/HTML.tsx
@@ -50,6 +50,7 @@ export const HTML: React.FC<HTMLProps> = ({
       <RenderHtml
         contentWidth={contentWidth}
         source={{ html }}
+        baseStyle={{ color: color(textColor) }}
         systemFonts={[FONTS.regular, FONTS.italic, FONTS.medium, FONTS.mediumItalic]}
         renderers={{
           h2: CustomH2Renderer as CustomBlockRenderer,

--- a/src/app/Components/HTML.tsx
+++ b/src/app/Components/HTML.tsx
@@ -1,4 +1,5 @@
 import {
+  Color,
   Flex,
   FlexProps,
   TextProps,
@@ -15,6 +16,7 @@ import RenderHtml, { CustomBlockRenderer, MixedStyleRecord } from "react-native-
 
 interface HTMLProps extends FlexProps {
   html: string
+  color?: Color
   onLinkPress?: (href: string) => void
   tagStyles?: MixedStyleRecord
   variant?: TextProps["variant"]
@@ -29,6 +31,7 @@ export const FONTS = {
 
 export const HTML: React.FC<HTMLProps> = ({
   html,
+  color: textColor = "mono100",
   onLinkPress,
   tagStyles = {},
   variant = "sm",
@@ -71,25 +74,25 @@ export const HTML: React.FC<HTMLProps> = ({
           {
             a: {
               textDecorationLine: "underline",
-              textDecorationColor: color("mono100"),
-              color: color("mono100"),
+              textDecorationColor: color(textColor),
+              color: color(textColor),
               textDecorationStyle: "solid",
             },
             p: {
               fontFamily: FONTS.regular,
-              color: color("mono100"),
+              color: color(textColor),
               marginBottom: "1em",
               ...variantStyles,
             },
             li: {
               fontFamily: FONTS.regular,
-              color: color("mono100"),
+              color: color(textColor),
               marginBottom: "1em",
               ...omit(variantStyles, "lineHeight"), // to prevent mis-aligned markers
             },
             em: {
               fontFamily: FONTS.italic,
-              color: color("mono100"),
+              color: color(textColor),
             },
             h1: {
               fontFamily: FONTS.medium,
@@ -98,7 +101,7 @@ export const HTML: React.FC<HTMLProps> = ({
               letterSpacing: theme.textTreatments["xl"].letterSpacing,
               marginBottom: "1em",
               fontWeight: "normal",
-              color: color("mono100"),
+              color: color(textColor),
             },
             h2: {
               fontFamily: FONTS.medium,
@@ -107,7 +110,7 @@ export const HTML: React.FC<HTMLProps> = ({
               letterSpacing: theme.textTreatments["lg-display"].letterSpacing,
               marginBottom: "1em",
               fontWeight: "normal",
-              color: color("mono100"),
+              color: color(textColor),
             },
             h3: {
               fontFamily: FONTS.regular,
@@ -116,7 +119,7 @@ export const HTML: React.FC<HTMLProps> = ({
               letterSpacing: theme.textTreatments["md"].letterSpacing,
               marginBottom: "1em",
               fontWeight: "normal",
-              color: color("mono100"),
+              color: color(textColor),
             },
           },
           tagStyles

--- a/src/app/Components/__tests__/HTML.tests.tsx
+++ b/src/app/Components/__tests__/HTML.tests.tsx
@@ -1,0 +1,19 @@
+import { screen } from "@testing-library/react-native"
+import { HTML } from "app/Components/HTML"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("HTML", () => {
+  it("applies the color prop to bare text with no wrapping tag", () => {
+    renderWithWrappers(<HTML html="Bare text with no tag" color="mono0" />)
+
+    const node = screen.getByText("Bare text with no tag")
+    expect(node).toHaveStyle({ color: "#FFFFFF" })
+  })
+
+  it("applies the color prop to tags without an explicit tagsStyles entry", () => {
+    renderWithWrappers(<HTML html="<strong>Bold text</strong>" color="mono0" />)
+
+    const node = screen.getByText("Bold text")
+    expect(node).toHaveStyle({ color: "#FFFFFF" })
+  })
+})

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -4,7 +4,7 @@ import { ArtistListItemContainer as ArtistListItem } from "app/Components/Artist
 import { HTML } from "app/Components/HTML"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { Schema } from "app/utils/track"
-import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
+import { truncateHtml } from "app/utils/truncateHtml"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -35,8 +35,9 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
   const backgroundColor = artwork.isUnlisted ? "mono100" : "mono0"
   const textColor = artwork.isUnlisted ? "mono0" : "mono100"
 
-  const canExpand = !!text && visibleHtmlTextLength(text) > textLimit
-  const truncatedText = text ? truncateHtml(text, textLimit) : undefined
+  const { text: truncatedText, wasTruncated: canExpand } = text
+    ? truncateHtml(text, textLimit)
+    : { text: undefined, wasTruncated: false }
 
   const handleExpandPress = () => {
     if (!expanded) {

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -4,6 +4,7 @@ import { ArtistListItemContainer as ArtistListItem } from "app/Components/Artist
 import { HTML } from "app/Components/HTML"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { Schema } from "app/utils/track"
+import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -34,8 +35,8 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
   const backgroundColor = artwork.isUnlisted ? "mono100" : "mono0"
   const textColor = artwork.isUnlisted ? "mono0" : "mono100"
 
-  const truncatedText = text?.slice(0, textLimit)
-  const canExpand = !!text && text.length > textLimit
+  const canExpand = !!text && visibleHtmlTextLength(text) > textLimit
+  const truncatedText = text ? truncateHtml(text, textLimit) : undefined
 
   const handleExpandPress = () => {
     if (!expanded) {

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -1,16 +1,21 @@
-import { Spacer, Flex, Box, Text, Join, Screen } from "@artsy/palette-mobile"
+import { Spacer, Flex, Box, Text, LinkText, Join, Screen } from "@artsy/palette-mobile"
 import { AboutArtist_artwork$data } from "__generated__/AboutArtist_artwork.graphql"
 import { ArtistListItemContainer as ArtistListItem } from "app/Components/ArtistListItem"
-import { ReadMore } from "app/Components/ReadMore"
+import { HTML } from "app/Components/HTML"
 import { truncatedTextLimit } from "app/utils/hardware"
 import { Schema } from "app/utils/track"
+import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface AboutArtistProps {
   artwork: AboutArtist_artwork$data
 }
 
 export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
+  const tracking = useTracking()
+  const [expanded, setExpanded] = useState(false)
+
   const artists = artwork.artists || []
 
   const hasSingleArtist = artists && artists.length === 1
@@ -28,6 +33,21 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
 
   const backgroundColor = artwork.isUnlisted ? "mono100" : "mono0"
   const textColor = artwork.isUnlisted ? "mono0" : "mono100"
+
+  const truncatedText = text?.slice(0, textLimit)
+  const canExpand = !!text && text.length > textLimit
+
+  const handleExpandPress = () => {
+    if (!expanded) {
+      tracking.trackEvent({
+        action_name: Schema.ActionNames.ReadMore,
+        action_type: Schema.ActionTypes.Tap,
+        context_module: Schema.ContextModules.ArtistBiography,
+        flow: Schema.Flow.AboutTheArtist,
+      })
+    }
+    setExpanded((prev) => !prev)
+  }
 
   return (
     <Screen.FullWidthItem p={2} backgroundColor={backgroundColor}>
@@ -51,16 +71,16 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
       </Flex>
       {!!hasSingleArtist && !!text && !!artwork.displayArtistBio && (
         <Box mt={2} mb={artwork.isUnlisted ? 1 : 0}>
-          <ReadMore
-            content={text}
-            contextModule={Schema.ContextModules.ArtistBiography}
-            maxChars={textLimit}
-            textStyle="new"
-            trackingFlow={Schema.Flow.AboutTheArtist}
-            textVariant="sm"
-            linkTextVariant="sm-display"
+          <HTML
+            html={expanded ? text : `${truncatedText}${canExpand ? "... " : ""}`}
             color={textColor}
+            variant="sm"
           />
+          {!!canExpand && (
+            <LinkText variant="sm-display" color={textColor} onPress={handleExpandPress}>
+              {expanded ? "Read Less" : "Read More"}
+            </LinkText>
+          )}
         </Box>
       )}
     </Screen.FullWidthItem>
@@ -73,7 +93,7 @@ export const AboutArtistFragmentContainer = createFragmentContainer(AboutArtist,
       displayArtistBio
       artists(shallow: true) {
         id
-        biographyBlurb(partnerBio: false) {
+        biographyBlurb(format: HTML, partnerBio: false) {
           text
         }
 

--- a/src/app/Scenes/Artwork/Components/AboutArtist.tsx
+++ b/src/app/Scenes/Artwork/Components/AboutArtist.tsx
@@ -78,7 +78,12 @@ export const AboutArtist: React.FC<AboutArtistProps> = ({ artwork }) => {
             variant="sm"
           />
           {!!canExpand && (
-            <LinkText variant="sm-display" color={textColor} onPress={handleExpandPress}>
+            <LinkText
+              variant="sm-display"
+              color={textColor}
+              accessibilityRole="button"
+              onPress={handleExpandPress}
+            >
               {expanded ? "Read Less" : "Read More"}
             </LinkText>
           )}

--- a/src/app/Scenes/Artwork/Components/__tests__/AboutArtist.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/__tests__/AboutArtist.tests.tsx
@@ -85,7 +85,7 @@ describe("AboutArtist", () => {
       }),
     })
 
-    const readMoreLink = screen.getByText("Read more")
+    const readMoreLink = screen.getByText("Read More")
     fireEvent.press(readMoreLink)
     expect(mockTrackEvent).toBeCalledWith({
       action_name: "readMore",
@@ -93,5 +93,27 @@ describe("AboutArtist", () => {
       context_module: "ArtistBiography",
       flow: "AboutTheArtist",
     })
+  })
+
+  it("renders HTML-formatted bio content without raw markdown markers", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        isUnlisted: false,
+        displayArtistBio: true,
+        artists: [
+          {
+            biographyBlurb: {
+              text: "<h3>Key Exhibitions</h3><ul><li>David Hockney, The Metropolitan Museum of Art, 2017</li></ul>",
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(screen.getByText("Key Exhibitions")).toBeOnTheScreen()
+    expect(
+      screen.getByText("David Hockney, The Metropolitan Museum of Art, 2017")
+    ).toBeOnTheScreen()
+    expect(screen.queryByText(/###/)).not.toBeOnTheScreen()
   })
 })

--- a/src/app/Scenes/Artwork/Components/__tests__/AboutArtist.tests.tsx
+++ b/src/app/Scenes/Artwork/Components/__tests__/AboutArtist.tests.tsx
@@ -114,6 +114,6 @@ describe("AboutArtist", () => {
     expect(
       screen.getByText("David Hockney, The Metropolitan Museum of Art, 2017")
     ).toBeOnTheScreen()
-    expect(screen.queryByText(/###/)).not.toBeOnTheScreen()
+    expect(screen.queryByText(/<h3>/)).not.toBeOnTheScreen()
   })
 })

--- a/src/app/utils/__tests__/truncateHtml.tests.ts
+++ b/src/app/utils/__tests__/truncateHtml.tests.ts
@@ -1,75 +1,80 @@
-import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
-
-describe("visibleHtmlTextLength", () => {
-  it("returns the string length when there are no tags", () => {
-    expect(visibleHtmlTextLength("No tags here")).toEqual(12)
-  })
-
-  it("excludes tags from the count", () => {
-    expect(visibleHtmlTextLength("<p>Hello <em>world</em></p>")).toEqual(11)
-  })
-
-  it("returns zero for an empty string", () => {
-    expect(visibleHtmlTextLength("")).toEqual(0)
-  })
-
-  it("counts a named entity reference as a single visible character", () => {
-    expect(visibleHtmlTextLength("Hauser &amp; Wirth")).toEqual(14)
-  })
-
-  it("counts a numeric entity reference as a single visible character", () => {
-    expect(visibleHtmlTextLength("Rock &#38; Roll")).toEqual(11)
-  })
-})
+import { truncateHtml } from "app/utils/truncateHtml"
 
 describe("truncateHtml", () => {
   it("behaves like a plain slice when there is no markup", () => {
-    expect(truncateHtml("Hello world", 5)).toEqual("Hello")
+    const { text, wasTruncated } = truncateHtml("Hello world", 5)
+
+    expect(text).toEqual("Hello")
+    expect(wasTruncated).toBe(true)
   })
 
-  it("returns the entire string when the budget exceeds the visible text length", () => {
+  it("returns the entire string, untruncated, when the budget exceeds the visible text length", () => {
     const html = "<p>Hi</p>"
-    expect(truncateHtml(html, 100)).toEqual(html)
+    const { text, wasTruncated } = truncateHtml(html, 100)
+
+    expect(text).toEqual(html)
+    expect(wasTruncated).toBe(false)
   })
 
   it("does not count tag markup toward the visible character budget", () => {
     const html = "<p>Hello</p>"
-    expect(truncateHtml(html, 5)).toEqual("<p>Hello</p>")
+    const { text, wasTruncated } = truncateHtml(html, 5)
+
+    expect(text).toEqual("<p>Hello</p>")
+    expect(wasTruncated).toBe(false)
   })
 
   it("stops as soon as the visible character budget is reached, dropping trailing markup", () => {
     const html = "<p>Hello world</p>"
-    expect(truncateHtml(html, 5)).toEqual("<p>Hello")
+    const { text, wasTruncated } = truncateHtml(html, 5)
+
+    expect(text).toEqual("<p>Hello")
+    expect(wasTruncated).toBe(true)
   })
 
   it("never cuts in the middle of a tag or attribute", () => {
     const html =
       '<a href="https://www.artsy.net/artist/david-hockney">Hockney</a> retrospective'
 
-    const result = truncateHtml(html, 3)
+    const { text, wasTruncated } = truncateHtml(html, 3)
 
-    expect(result).toEqual('<a href="https://www.artsy.net/artist/david-hockney">Hoc')
-    expect(visibleHtmlTextLength(result)).toEqual(3)
+    expect(text).toEqual('<a href="https://www.artsy.net/artist/david-hockney">Hoc')
+    expect(wasTruncated).toBe(true)
   })
 
   it("does not cut in the middle of an entity reference", () => {
-    const result = truncateHtml("Arts &amp; Crafts", 7)
+    const { text } = truncateHtml("Arts &amp; Crafts", 7)
 
-    expect(result).toEqual("Arts &amp; ")
-    expect(visibleHtmlTextLength(result)).toEqual(7)
+    expect(text).toEqual("Arts &amp; ")
   })
 
   it("treats a bare ampersand that is not part of an entity as a normal character", () => {
-    expect(truncateHtml("Fish & Chips", 6)).toEqual("Fish &")
+    const { text } = truncateHtml("Fish & Chips", 6)
+
+    expect(text).toEqual("Fish &")
   })
 
   it("stops before a new tag opens once the budget is spent, without leaving it dangling open", () => {
     const html = "<p>abc</p><h3>Key Exhibitions</h3>"
-    expect(truncateHtml(html, 3)).toEqual("<p>abc</p>")
+    const { text } = truncateHtml(html, 3)
+
+    expect(text).toEqual("<p>abc</p>")
   })
 
   it("still emits closing tags for elements opened before the budget was spent", () => {
     const html = "<p>abc</p>"
-    expect(truncateHtml(html, 3)).toEqual(html)
+    const { text } = truncateHtml(html, 3)
+
+    expect(text).toEqual(html)
+  })
+
+  it("keeps the returned text and wasTruncated flag consistent even on malformed HTML", () => {
+    // An unterminated "<b" tag has no single answer for "how much is visible", but the
+    // scanner's own text and wasTruncated always agree with each other by construction,
+    // since both come from the same pass rather than two independently computed answers.
+    const { text, wasTruncated } = truncateHtml("Hi <b", 5)
+
+    expect(text).toEqual("Hi <b")
+    expect(wasTruncated).toBe(false)
   })
 })

--- a/src/app/utils/__tests__/truncateHtml.tests.ts
+++ b/src/app/utils/__tests__/truncateHtml.tests.ts
@@ -12,6 +12,14 @@ describe("visibleHtmlTextLength", () => {
   it("returns zero for an empty string", () => {
     expect(visibleHtmlTextLength("")).toEqual(0)
   })
+
+  it("counts a named entity reference as a single visible character", () => {
+    expect(visibleHtmlTextLength("Hauser &amp; Wirth")).toEqual(14)
+  })
+
+  it("counts a numeric entity reference as a single visible character", () => {
+    expect(visibleHtmlTextLength("Rock &#38; Roll")).toEqual(11)
+  })
 })
 
 describe("truncateHtml", () => {
@@ -42,5 +50,26 @@ describe("truncateHtml", () => {
 
     expect(result).toEqual('<a href="https://www.artsy.net/artist/david-hockney">Hoc')
     expect(visibleHtmlTextLength(result)).toEqual(3)
+  })
+
+  it("does not cut in the middle of an entity reference", () => {
+    const result = truncateHtml("Arts &amp; Crafts", 7)
+
+    expect(result).toEqual("Arts &amp; ")
+    expect(visibleHtmlTextLength(result)).toEqual(7)
+  })
+
+  it("treats a bare ampersand that is not part of an entity as a normal character", () => {
+    expect(truncateHtml("Fish & Chips", 6)).toEqual("Fish &")
+  })
+
+  it("stops before a new tag opens once the budget is spent, without leaving it dangling open", () => {
+    const html = "<p>abc</p><h3>Key Exhibitions</h3>"
+    expect(truncateHtml(html, 3)).toEqual("<p>abc</p>")
+  })
+
+  it("still emits closing tags for elements opened before the budget was spent", () => {
+    const html = "<p>abc</p>"
+    expect(truncateHtml(html, 3)).toEqual(html)
   })
 })

--- a/src/app/utils/__tests__/truncateHtml.tests.ts
+++ b/src/app/utils/__tests__/truncateHtml.tests.ts
@@ -1,0 +1,46 @@
+import { truncateHtml, visibleHtmlTextLength } from "app/utils/truncateHtml"
+
+describe("visibleHtmlTextLength", () => {
+  it("returns the string length when there are no tags", () => {
+    expect(visibleHtmlTextLength("No tags here")).toEqual(12)
+  })
+
+  it("excludes tags from the count", () => {
+    expect(visibleHtmlTextLength("<p>Hello <em>world</em></p>")).toEqual(11)
+  })
+
+  it("returns zero for an empty string", () => {
+    expect(visibleHtmlTextLength("")).toEqual(0)
+  })
+})
+
+describe("truncateHtml", () => {
+  it("behaves like a plain slice when there is no markup", () => {
+    expect(truncateHtml("Hello world", 5)).toEqual("Hello")
+  })
+
+  it("returns the entire string when the budget exceeds the visible text length", () => {
+    const html = "<p>Hi</p>"
+    expect(truncateHtml(html, 100)).toEqual(html)
+  })
+
+  it("does not count tag markup toward the visible character budget", () => {
+    const html = "<p>Hello</p>"
+    expect(truncateHtml(html, 5)).toEqual("<p>Hello</p>")
+  })
+
+  it("stops as soon as the visible character budget is reached, dropping trailing markup", () => {
+    const html = "<p>Hello world</p>"
+    expect(truncateHtml(html, 5)).toEqual("<p>Hello")
+  })
+
+  it("never cuts in the middle of a tag or attribute", () => {
+    const html =
+      '<a href="https://www.artsy.net/artist/david-hockney">Hockney</a> retrospective'
+
+    const result = truncateHtml(html, 3)
+
+    expect(result).toEqual('<a href="https://www.artsy.net/artist/david-hockney">Hoc')
+    expect(visibleHtmlTextLength(result)).toEqual(3)
+  })
+})

--- a/src/app/utils/truncateHtml.ts
+++ b/src/app/utils/truncateHtml.ts
@@ -1,14 +1,9 @@
 const ENTITY_PATTERN = "&(#\\d+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);"
 const ENTITY_REGEX = new RegExp(`^${ENTITY_PATTERN}`)
-const ENTITY_REGEX_GLOBAL = new RegExp(ENTITY_PATTERN, "g")
 
-/**
- * Strips tags to measure the length of the text a user would actually see.
- * Entity references (e.g. `&amp;`) count as a single character, matching how
- * they render.
- */
-export function visibleHtmlTextLength(html: string): number {
-  return html.replace(/<[^>]*>/g, "").replace(ENTITY_REGEX_GLOBAL, "&").length
+export interface TruncatedHtml {
+  text: string
+  wasTruncated: boolean
 }
 
 /**
@@ -16,11 +11,15 @@ export function visibleHtmlTextLength(html: string): number {
  * without ever cutting in the middle of a tag, an attribute, or an entity reference
  * (e.g. `&amp;`). Once the budget is spent, still emits any tags needed to close
  * elements that are already open, but stops before a new tag would open.
+ *
+ * `wasTruncated` and the returned `text` come from the same scan, so callers can't
+ * see them disagree about whether truncation happened.
  */
-export function truncateHtml(html: string, maxVisibleChars: number): string {
+export function truncateHtml(html: string, maxVisibleChars: number): TruncatedHtml {
   let result = ""
   let visibleCount = 0
   let inTag = false
+  let wasTruncated = false
 
   for (let i = 0; i < html.length; i++) {
     const char = html[i]
@@ -36,6 +35,7 @@ export function truncateHtml(html: string, maxVisibleChars: number): string {
     if (char === "<") {
       const isClosingTag = html[i + 1] === "/"
       if (visibleCount >= maxVisibleChars && !isClosingTag) {
+        wasTruncated = true
         break
       }
       inTag = true
@@ -47,6 +47,7 @@ export function truncateHtml(html: string, maxVisibleChars: number): string {
       const entityMatch = ENTITY_REGEX.exec(html.slice(i))
       if (entityMatch) {
         if (visibleCount >= maxVisibleChars) {
+          wasTruncated = true
           break
         }
         result += entityMatch[0]
@@ -57,6 +58,7 @@ export function truncateHtml(html: string, maxVisibleChars: number): string {
     }
 
     if (visibleCount >= maxVisibleChars) {
+      wasTruncated = true
       break
     }
 
@@ -64,5 +66,5 @@ export function truncateHtml(html: string, maxVisibleChars: number): string {
     visibleCount++
   }
 
-  return result
+  return { text: result, wasTruncated }
 }

--- a/src/app/utils/truncateHtml.ts
+++ b/src/app/utils/truncateHtml.ts
@@ -1,13 +1,21 @@
+const ENTITY_PATTERN = "&(#\\d+|#x[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);"
+const ENTITY_REGEX = new RegExp(`^${ENTITY_PATTERN}`)
+const ENTITY_REGEX_GLOBAL = new RegExp(ENTITY_PATTERN, "g")
+
 /**
  * Strips tags to measure the length of the text a user would actually see.
+ * Entity references (e.g. `&amp;`) count as a single character, matching how
+ * they render.
  */
 export function visibleHtmlTextLength(html: string): number {
-  return html.replace(/<[^>]*>/g, "").length
+  return html.replace(/<[^>]*>/g, "").replace(ENTITY_REGEX_GLOBAL, "&").length
 }
 
 /**
  * Truncates an HTML string to at most `maxVisibleChars` of visible (non-tag) text,
- * without ever cutting in the middle of a tag or attribute.
+ * without ever cutting in the middle of a tag, an attribute, or an entity reference
+ * (e.g. `&amp;`). Once the budget is spent, still emits any tags needed to close
+ * elements that are already open, but stops before a new tag would open.
  */
 export function truncateHtml(html: string, maxVisibleChars: number): string {
   let result = ""
@@ -17,18 +25,35 @@ export function truncateHtml(html: string, maxVisibleChars: number): string {
   for (let i = 0; i < html.length; i++) {
     const char = html[i]
 
-    if (char === "<") {
-      inTag = true
-      result += char
-      continue
-    }
-
     if (inTag) {
       result += char
       if (char === ">") {
         inTag = false
       }
       continue
+    }
+
+    if (char === "<") {
+      const isClosingTag = html[i + 1] === "/"
+      if (visibleCount >= maxVisibleChars && !isClosingTag) {
+        break
+      }
+      inTag = true
+      result += char
+      continue
+    }
+
+    if (char === "&") {
+      const entityMatch = ENTITY_REGEX.exec(html.slice(i))
+      if (entityMatch) {
+        if (visibleCount >= maxVisibleChars) {
+          break
+        }
+        result += entityMatch[0]
+        visibleCount++
+        i += entityMatch[0].length - 1
+        continue
+      }
     }
 
     if (visibleCount >= maxVisibleChars) {

--- a/src/app/utils/truncateHtml.ts
+++ b/src/app/utils/truncateHtml.ts
@@ -1,0 +1,43 @@
+/**
+ * Strips tags to measure the length of the text a user would actually see.
+ */
+export function visibleHtmlTextLength(html: string): number {
+  return html.replace(/<[^>]*>/g, "").length
+}
+
+/**
+ * Truncates an HTML string to at most `maxVisibleChars` of visible (non-tag) text,
+ * without ever cutting in the middle of a tag or attribute.
+ */
+export function truncateHtml(html: string, maxVisibleChars: number): string {
+  let result = ""
+  let visibleCount = 0
+  let inTag = false
+
+  for (let i = 0; i < html.length; i++) {
+    const char = html[i]
+
+    if (char === "<") {
+      inTag = true
+      result += char
+      continue
+    }
+
+    if (inTag) {
+      result += char
+      if (char === ">") {
+        inTag = false
+      }
+      continue
+    }
+
+    if (visibleCount >= maxVisibleChars) {
+      break
+    }
+
+    result += char
+    visibleCount++
+  }
+
+  return result
+}


### PR DESCRIPTION
This PR resolves [DI-346](https://www.notion.so/375cab0764a0815c9889ed7c6391ef79) <!-- eg [PROJECT-XXXX] -->

Assisted-by: Claude:Opus-5
Assisted-by: Claude:Sonnet-5 

### Description

Fixes a markdown rendering issue on Artwork screen artist bios by updating it to follow the established pattern from the Artist screen.

This is what you see when you expand the collapsed artist bio via the "Read more" link.

There are two variants to handle: listed works (the vast majority) and unlisted works (small number, but with inverted rendering — TIL)

### Listed works 

The common case…

| Platform | Before | After |
|---|---|---|
| Android (listed)| <img src="https://github.com/user-attachments/assets/3a75f969-de88-492d-bfde-1687688d7b6d" height="300" /> | <img src="https://github.com/user-attachments/assets/6551da61-f44b-49ab-83c6-324837b41c30" height="300" /> |
| iOS (listed) | <img src="https://github.com/user-attachments/assets/790c9ee1-4768-4547-bd50-e8157c774e45" height="300" /> | <img src="https://github.com/user-attachments/assets/b0d3af6c-ecdf-4525-b663-63cac46ede6f" height="300" /> |

---

### Unlisted works

Turns out that private aka unlisted works render with this component inverted.

 I would have easily missed this, thanks Claude 😅

| Platform | Before | After |
|---|---|---|
| Android (unlisted)| <img src="https://github.com/user-attachments/assets/6a4e8d9f-ac57-45f2-8eb4-36ef7bdda168" height="300" /> | <img src="https://github.com/user-attachments/assets/8ec30fff-a378-4646-9f20-64754a329543" height="300" /> |
| iOS (unlisted) | <img src="https://github.com/user-attachments/assets/8344d5d1-068b-4016-9164-b7c6e7cbc995" height="300" /> | <img src="https://github.com/user-attachments/assets/e12b2baa-b966-489c-b6f3-2b54a9ea583d" height="300" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Fixes text rendering on artwork screen's artist bio

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
