### PR TITLE
fix(ONYX-2196): show checkbox instead of toggle for newly created artwork lists

### DIFF
--- a/src/app/Components/ArtworkLists/__tests__/ArtworkListsContext.tests.tsx
+++ b/src/app/Components/ArtworkLists/__tests__/ArtworkListsContext.tests.tsx
@@ -325,6 +325,8 @@ describe("ArtworkListsProvider", () => {
   describe("Newly created artwork list (regression: ONYX-2196)", () => {
     beforeEach(() => {
       __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkListOfferability: true })
+      // The form's "Save" button only renders on Android (iOS submits via the
+      // keyboard's return key), so force Android to drive submission here.
       Platform.OS = "android"
     })
 

--- a/src/app/Components/ArtworkLists/__tests__/ArtworkListsContext.tests.tsx
+++ b/src/app/Components/ArtworkLists/__tests__/ArtworkListsContext.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react-native"
+import { fireEvent, screen, waitFor } from "@testing-library/react-native"
 import { SelectArtworkListsForArtworkQuery } from "__generated__/SelectArtworkListsForArtworkQuery.graphql"
 import { ArtworkListsProvider } from "app/Components/ArtworkLists/ArtworkListsStore"
 import { ArtworkEntity } from "app/Components/ArtworkLists/types"
@@ -6,6 +6,8 @@ import * as utils from "app/Components/ArtworkLists/types"
 import { selectArtworkListsForArtworkQuery } from "app/Components/ArtworkLists/views/SelectArtworkListsForArtworkView/components/SelectArtworkListsForArtwork"
 import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { setupTestWrapper } from "app/utils/tests/setupTestWrapper"
+import { Platform } from "react-native"
+import { KeyboardController } from "react-native-keyboard-controller"
 
 describe("ArtworkListsProvider", () => {
   const initialStateSpy = jest.spyOn(utils, "getArtworkListsStoreInitialState")
@@ -317,6 +319,58 @@ describe("ArtworkListsProvider", () => {
           expect(screen.getByText("2 lists selected")).toBeOnTheScreen()
         })
       })
+    })
+  })
+
+  describe("Newly created artwork list (regression: ONYX-2196)", () => {
+    beforeEach(() => {
+      __globalStoreTestUtils__?.injectFeatureFlags({ AREnableArtworkListOfferability: true })
+      Platform.OS = "android"
+    })
+
+    afterEach(() => {
+      Platform.OS = "ios"
+    })
+
+    it("renders a checkbox, not a toggle, for a list just created from this flow", async () => {
+      const { mockResolveLastOperation } = renderWithRelay()
+      jest.spyOn(KeyboardController, "isVisible").mockReturnValue(false)
+
+      mockResolveLastOperation({
+        Me: () => ({ savedArtworksArtworkList, customArtworkLists: { edges: [] } }),
+      })
+
+      await screen.findByText("Saved Artworks")
+
+      fireEvent.press(screen.getByText("Create New List"))
+      fireEvent.changeText(screen.getByPlaceholderText("Name your list"), "My New List")
+      fireEvent.press(screen.getByText("Save"))
+
+      await waitFor(() => {
+        mockResolveLastOperation({
+          Mutation: () => ({
+            createCollection: {
+              responseOrError: {
+                __typename: "CreateCollectionSuccess",
+                collection: {
+                  internalID: "new-list-id",
+                  name: "My New List",
+                  // Mirrors the real mutation: it never selects `isSavedArtwork`.
+                  shareableWithPartners: true,
+                  artworksCount: 0,
+                },
+              },
+            },
+          }),
+        })
+      })
+
+      await screen.findByText("My New List")
+
+      // Before the fix, the missing `isSavedArtwork` field made this row look
+      // indistinguishable from an Offer Settings row, so it rendered a Switch.
+      expect(screen.queryAllByRole("switch")).toHaveLength(0)
+      expect(screen.getByTestId("artworkListItemSelectedIcon")).toBeOnTheScreen()
     })
   })
 

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListForm.tsx
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/components/CreateNewArtworkListForm.tsx
@@ -21,10 +21,11 @@ export const CreateNewArtworkListForm: FC = () => {
       setRecentlyAddedArtworkList: actions.setRecentlyAddedArtworkList,
       addOrRemoveArtworkList: actions.addOrRemoveArtworkList,
     }))
+  const artwork = ArtworkListsStore.useStoreState((state) => state.state.artwork)
   const { dismiss } = useBottomSheetModal()
   const analytics = useAnalyticsContext()
   const { trackEvent } = useTracking()
-  const [commitMutation] = useCreateNewArtworkList()
+  const [commitMutation] = useCreateNewArtworkList(artwork?.internalID)
   const AREnableArtworkListOfferability = useFeatureFlag("AREnableArtworkListOfferability")
 
   const setRecentlyAddedArtworkList = (artworkList: ArtworkListEntity) => {

--- a/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
+++ b/src/app/Components/ArtworkLists/views/CreateNewArtworkListView/useCreateNewArtworkList.ts
@@ -8,7 +8,7 @@ type CommitConfig = UseMutationConfig<useCreateNewArtworkListMutation>
 type Data = useCreateNewArtworkListMutation$data | null | undefined
 type Response = [(config: CommitConfig) => Disposable, boolean]
 
-export const useCreateNewArtworkList = (): Response => {
+export const useCreateNewArtworkList = (artworkID?: string): Response => {
   const [initialCommit, inProgress] = useMutation<useCreateNewArtworkListMutation>(
     CreateNewArtworkListMutation
   )
@@ -42,7 +42,7 @@ export const useCreateNewArtworkList = (): Response => {
       },
       updater: (store, data) => {
         config.updater?.(store, data)
-        updater(store, data)
+        updater(store, data, artworkID)
       },
     })
   }
@@ -52,7 +52,8 @@ export const useCreateNewArtworkList = (): Response => {
 
 const updater = (
   store: Parameters<NonNullable<UseMutationConfig<useCreateNewArtworkListMutation>["updater"]>>[0],
-  data: Data
+  data: Data,
+  artworkID?: string
 ) => {
   const response = data?.createCollection?.responseOrError
   const me = store.getRoot().getLinkedRecord("me")
@@ -69,6 +70,13 @@ const updater = (
 
   if (!customArtworkListsConnection || !createdCollection) {
     return
+  }
+
+  // A brand-new list can't contain the artwork yet. Seed `isSavedArtwork` so
+  // `ArtworkListItem` doesn't mistake this row for the Offer Settings screen
+  // (which never fetches `isSavedArtwork`) and render a toggle instead of a checkbox.
+  if (artworkID) {
+    createdCollection.setValue(false, "isSavedArtwork", { artworkID })
   }
 
   const createdCollectionEdge = ConnectionHandler.createEdge(


### PR DESCRIPTION
This PR resolves [ONYX-2196]

### Description

When saving an artwork and creating a new list on the fly from the "Save to lists" sheet, the new list's row rendered a `Switch` (toggle) instead of the checkbox every other list shows. 

Root cause: `ArtworkListItem` decides checkbox vs. toggle based on field presence — `shareableWithPartners !== undefined && isSavedArtwork === undefined` — to distinguish the artwork-picker context from the Offer Settings screen context (which never fetches `isSavedArtwork`). The `createCollection` mutation's Relay updater spliced the newly created list straight into the picker's connection without ever setting `isSavedArtwork` on that record, so it accidentally matched the Offer Settings branch and rendered a toggle.

Fix: the updater now seeds `isSavedArtwork: false` on the new record (keyed to the current artwork's ID) before inserting it into the connection — always correct, since a brand-new list can't already contain the artwork.

Assisted by: Claude Sonnet 5

Before
<img width="346" height="643" alt="Screenshot 2026-07-29 at 15 33 24" src="https://github.com/user-attachments/assets/a3260f82-ef84-4ffe-af17-96ae01238b76" />

After
<img width="418" height="880" alt="new-list-checkbox" src="https://github.com/user-attachments/assets/30d0b21d-11b0-4153-90e1-ae2c3c8179bb" />


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. (Existing `AREnableArtworkListOfferability` flag already gates this code path.)
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix newly created artwork lists showing a toggle instead of a checkbox in the "Save to lists" flow

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md

[ONYX-2196]: https://artsyproduct.atlassian.net/browse/ONYX-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ