### PR TITLE
fix: artist bio rendering on artwork screen

### DIFF
--- a/src/app/Components/Artist/Biography.tsx
+++ b/src/app/Components/Artist/Biography.tsx
@@ -1,7 +1,5 @@
-import { Text } from "@artsy/palette-mobile"
 import { Biography_artist$key } from "__generated__/Biography_artist.graphql"
-import { HTML } from "app/Components/HTML"
-import { useState } from "react"
+import { ReadMore } from "app/Components/ReadMore"
 import { graphql, useFragment } from "react-relay"
 
 export const MAX_CHARS = 250
@@ -13,7 +11,6 @@ interface BiographyProps {
 }
 
 export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) => {
-  const [expanded, setExpanded] = useState(false)
   const data = useFragment(query, artist)
 
   if (!data || !data.biographyBlurb?.text) {
@@ -22,30 +19,21 @@ export const Biography: React.FC<BiographyProps> = ({ artist, variant = "sm" }) 
 
   const credit = data.biographyBlurb.credit
   const text = !!credit ? `${data.biographyBlurb.text} ${credit}` : data.biographyBlurb.text
-  const truncatedText = text.slice(0, MAX_CHARS)
-  const canExpand = text.length > MAX_CHARS
 
   return (
-    <>
-      <HTML
-        html={`${expanded ? text : truncatedText}${
-          text.length > MAX_CHARS && !expanded ? "... " : " "
-        }`}
-        variant={variant}
-      />
-
-      {!!canExpand && (
-        <Text underline onPress={() => setExpanded((e) => !e)} mt={-1} variant={variant}>
-          {expanded ? "Read Less" : "Read More"}
-        </Text>
-      )}
-    </>
+    <ReadMore
+      content={text}
+      maxChars={MAX_CHARS}
+      textVariant={variant}
+      linkTextVariant={variant}
+      showReadLessButton
+    />
   )
 }
 
 const query = graphql`
   fragment Biography_artist on Artist {
-    biographyBlurb(format: HTML) {
+    biographyBlurb(format: MARKDOWN) {
       text
       credit
     }

--- a/src/app/Components/Artist/__tests__/Biography.tests.tsx
+++ b/src/app/Components/Artist/__tests__/Biography.tests.tsx
@@ -105,7 +105,7 @@ describe("Biography", () => {
         }),
       })
 
-      expect(screen.getByText("Read More")).toBeOnTheScreen()
+      expect(screen.getByLabelText("Read More")).toBeOnTheScreen()
     })
 
     it("does not show Read More button when text is shorter than MAX_CHARS", () => {
@@ -120,7 +120,7 @@ describe("Biography", () => {
         }),
       })
 
-      expect(screen.queryByText("Read More")).toBeNull()
+      expect(screen.queryByLabelText("Read More")).toBeNull()
     })
 
     it("shows truncated text initially when text is long", () => {
@@ -151,7 +151,7 @@ describe("Biography", () => {
         }),
       })
 
-      fireEvent.press(screen.getByText("Read More"))
+      fireEvent.press(screen.getByLabelText("Read More"))
 
       expect(screen.getByText("Read Less")).toBeOnTheScreen()
       expect(screen.getByText(longText)).toBeOnTheScreen()
@@ -167,10 +167,10 @@ describe("Biography", () => {
         }),
       })
 
-      fireEvent.press(screen.getByText("Read More"))
+      fireEvent.press(screen.getByLabelText("Read More"))
       fireEvent.press(screen.getByText("Read Less"))
 
-      expect(screen.getByText("Read More")).toBeOnTheScreen()
+      expect(screen.getByLabelText("Read More")).toBeOnTheScreen()
       const truncatedText = longText.slice(0, 250)
       expect(screen.getByText(truncatedText, { exact: false })).toBeOnTheScreen()
     })
@@ -190,7 +190,7 @@ describe("Biography", () => {
         }),
       })
 
-      fireEvent.press(screen.getByText("Read More"))
+      fireEvent.press(screen.getByLabelText("Read More"))
 
       expect(screen.getByText(credit, { exact: false })).toBeOnTheScreen()
     })
@@ -205,7 +205,7 @@ describe("Biography", () => {
         }),
       })
 
-      expect(screen.getByText("Read More")).toBeOnTheScreen()
+      expect(screen.getByLabelText("Read More")).toBeOnTheScreen()
     })
   })
 })

--- a/src/app/Components/ReadMore.tsx
+++ b/src/app/Components/ReadMore.tsx
@@ -70,9 +70,6 @@ export const ReadMore = React.memo(
         ) => {
           return (
             <Flex key={state.key} mb={1}>
-              {!isExpanded && Number(state.key) > 0 ? (
-                <TextComponent {...textProps} color={color}>{` ${emdash} `}</TextComponent>
-              ) : null}
               {node.items.map((item: SimpleMarkdown.SingleASTNode, i: number) => (
                 <Flex key={i} flexDirection="row">
                   <TextComponent {...textProps} color={color}>

--- a/src/app/Components/ReadMore.tsx
+++ b/src/app/Components/ReadMore.tsx
@@ -6,6 +6,7 @@ import {
   Text as PaletteText,
   TextProps as PaletteTextProps,
   Color,
+  bullet,
 } from "@artsy/palette-mobile"
 import { navigate } from "app/system/navigation/navigate"
 import { plainTextFromTree } from "app/utils/plainTextFromTree"
@@ -61,17 +62,30 @@ export const ReadMore = React.memo(
     const rules = {
       ...basicRules,
       list: {
-        ...basicRules.paragraph,
+        ...basicRules.list,
         react: (
           node: SimpleMarkdown.SingleASTNode,
           output: SimpleMarkdown.Output<React.ReactNode>,
           state: SimpleMarkdown.State
         ) => {
           return (
-            <TextComponent {...textProps} color={color} key={state.key}>
-              {!isExpanded && Number(state.key) > 0 ? ` ${emdash} ` : null}
-              {output(node.content, state)}
-            </TextComponent>
+            <Flex key={state.key} mb={1}>
+              {!isExpanded && Number(state.key) > 0 ? (
+                <TextComponent {...textProps} color={color}>{` ${emdash} `}</TextComponent>
+              ) : null}
+              {node.items.map((item: SimpleMarkdown.SingleASTNode, i: number) => (
+                <Flex key={i} flexDirection="row">
+                  <TextComponent {...textProps} color={color}>
+                    {node.ordered ? `${(node.start ?? 1) + i}. ` : `${bullet} `}
+                  </TextComponent>
+                  <Flex flexShrink={1}>
+                    <TextComponent {...textProps} color={color}>
+                      {output(item, state)}
+                    </TextComponent>
+                  </Flex>
+                </Flex>
+              ))}
+            </Flex>
           )
         },
       },

--- a/src/app/Components/ReadMore.tsx
+++ b/src/app/Components/ReadMore.tsx
@@ -71,7 +71,7 @@ export const ReadMore = React.memo(
           return (
             <Flex key={state.key} mb={1}>
               {node.items.map((item: SimpleMarkdown.SingleASTNode, i: number) => (
-                <Flex key={i} flexDirection="row">
+                <Flex key={i} flexDirection="row" alignItems="flex-start">
                   <TextComponent {...textProps} color={color}>
                     {node.ordered ? `${(node.start ?? 1) + i}. ` : `${bullet} `}
                   </TextComponent>

--- a/src/app/Components/__tests__/ReadMore.tests.tsx
+++ b/src/app/Components/__tests__/ReadMore.tests.tsx
@@ -121,14 +121,17 @@ describe("ReadMore", () => {
 
     renderWithWrappers(<ReadMore maxChars={7} content={text} />)
 
-    // should display - first... Read more in the beginning
+    // this parses as a real markdown list, so the bullet and the truncated item content
+    // render as separate text nodes rather than one combined string
     expect(screen.queryByText(text)).toBeFalsy()
-    expect(screen.queryByText("- first... Read more")).toBeTruthy()
+    expect(screen.getByText("• ")).toBeTruthy()
+    expect(screen.getByText(/first/)).toBeTruthy()
 
     fireEvent.press(screen.getByText(/Read more/))
 
-    // after pressing read more, read more goes away and the full text is displayed
-    expect(screen.queryByText(text)).toBeTruthy()
+    // after pressing read more, read more goes away and the rest of the list items are displayed
+    expect(screen.getByText(/second/)).toBeTruthy()
+    expect(screen.getByText(/whatarethose/)).toBeTruthy()
     expect(screen.queryByText(/Read more/)).toBeFalsy()
   })
 })

--- a/src/app/Components/__tests__/ReadMore.tests.tsx
+++ b/src/app/Components/__tests__/ReadMore.tests.tsx
@@ -116,6 +116,19 @@ describe("ReadMore", () => {
     expect(navigate).toHaveBeenCalledWith("/artist/andy-warhol")
   })
 
+  it("renders ordered list numbering, including a custom start number", () => {
+    const content = "42. An item\n42. Another item\n42. Yet another item\n"
+
+    renderWithWrappers(<ReadMore maxChars={10000} content={content} />)
+
+    expect(screen.getByText("42.")).toBeTruthy()
+    expect(screen.getByText("43.")).toBeTruthy()
+    expect(screen.getByText("44.")).toBeTruthy()
+    expect(screen.getByText("An item")).toBeTruthy()
+    expect(screen.getByText("Another item")).toBeTruthy()
+    expect(screen.getByText("Yet another item")).toBeTruthy()
+  })
+
   it("doesn't break when it gets a text with dashes and special characters", () => {
     const text = "- first \n- second \n- third \n * star \n & another one \n ' whatarethose"
 

--- a/src/app/utils/__tests__/renderMarkdown.tests.tsx
+++ b/src/app/utils/__tests__/renderMarkdown.tests.tsx
@@ -27,6 +27,16 @@ describe("renderMarkdown", () => {
     expect(screen.getByText("This is a second paragraph")).toBeTruthy()
   })
 
+  it("renders an ATX (###-style) heading even without a trailing blank line", () => {
+    const componentList = renderMarkdown("### Heading\nBody text") as any
+
+    renderWithWrappers(<Flex>{componentList}</Flex>)
+
+    expect(screen.getByText("Heading")).toBeTruthy()
+    expect(screen.getByText("Body text")).toBeTruthy()
+    expect(screen.queryByText(/###/)).toBeNull()
+  })
+
   it("returns markdown for multiple paragraphs and links", () => {
     const componentList = renderMarkdown(
       "This is a [first](/artist/first) paragraph\n\nAnd that is a [second](/gene/second) paragraph"

--- a/src/app/utils/renderMarkdown.tsx
+++ b/src/app/utils/renderMarkdown.tsx
@@ -1,4 +1,4 @@
-import { LinkText, Separator, Text, TextProps } from "@artsy/palette-mobile"
+import { Flex, LinkText, Separator, Text, TextProps } from "@artsy/palette-mobile"
 import { ThemeAwareClassTheme } from "app/Components/DarkModeClassTheme"
 import { navigate } from "app/system/navigation/navigate"
 import { decode } from "html-entities"
@@ -131,7 +131,7 @@ export function defaultRules({
           } else {
             bullet = (
               <Text variant="sm" key={state.key}>
-                -{" "}
+                {"• "}
               </Text>
             )
           }
@@ -153,7 +153,7 @@ export function defaultRules({
             </View>
           )
         })
-        return <View>{items}</View>
+        return <Flex mb={1}>{items}</Flex>
       },
     },
 

--- a/src/app/utils/renderMarkdown.tsx
+++ b/src/app/utils/renderMarkdown.tsx
@@ -233,6 +233,13 @@ export function defaultRules({
   })
 }
 
+// simple-markdown's heading rule only matches ATX headings (`### foo`) that are followed by a
+// blank line, so a heading directly above its content (no blank line) falls through to the
+// paragraph rule and renders with the literal `###` still in the text.
+function ensureBlankLineAfterHeadings(markdown: string): string {
+  return markdown.replace(/^(#{1,6} .*)\n(?!\n)/gm, "$1\n\n")
+}
+
 export function renderMarkdown(
   markdown: string,
   rules: any = defaultRules({})
@@ -240,7 +247,7 @@ export function renderMarkdown(
   const parser = SimpleMarkdown.parserFor(rules)
   const writer = SimpleMarkdown.outputFor<any, any>(rules, "react")
 
-  const ast = parser(markdown, { inline: false })
+  const ast = parser(ensureBlankLineAfterHeadings(markdown), { inline: false })
 
   return writer(ast)
 }


### PR DESCRIPTION
This PR resolves [DI-346](https://www.notion.so/375cab0764a0815c9889ed7c6391ef79) <!-- eg [PROJECT-XXXX] -->

Assisted-by: Claude:Sonnet-5 

### Description

After getting bullied by Opus on https://github.com/artsy/eigen/pull/13842 I slept on it and decided on a different approach — fix the `ReadMore` component's Markdown rendering. This way the Artwork screen's `AboutArtist` component can benefit from that fix while remaining untouched itself.

In a nutshell:
- Make the parsing of headings more resilient to whitespace quirks in the user-supplied markdown
- Improve list rendering by adopting bullet markers and fixing layout issues
- (Bonus: we can undo a [two-year-old workaround](https://github.com/artsy/eigen/pull/9840) for the similar component on the Artist screen, by standardizing on the shared `ReadMore` component instead of relying on that one-off fix)

---

### Listed works

The common case:

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/a5259b61-7d06-47fd-b1e0-dcc086fbf183" height="300" /> | <img src="https://github.com/user-attachments/assets/6476d463-4107-42d3-ac05-3abfe80684df" height="300" /> |
| iOS | <img src="https://github.com/user-attachments/assets/5845c7ca-a1ba-4d44-ae4f-95b9cc4ad6ca" height="300" /> | <img src="https://github.com/user-attachments/assets/3b7f8794-528c-4432-9275-de5534fc544d" height="300" /> |

---

### Unlisted works

Are rendered inverted:

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/f25e1b24-234c-4ec9-b1aa-6a63781afab2" height="300" /> | <img src="https://github.com/user-attachments/assets/b5967eee-8a55-42bc-9c9d-f67faba17629" height="300" /> |
| iOS | <img src="https://github.com/user-attachments/assets/2c7dd3c6-04c8-4bfb-8231-c6b47fb4d550" height="300" /> | <img src="https://github.com/user-attachments/assets/acc7c6bf-a8ae-46b5-b049-e2ff009007b7" height="300" /> |

---

### Artist screen

The About tab of the artist screen has a similar expandable artist bio, and had been [patched with a one-off fix ](https://github.com/artsy/eigen/pull/9840)a couple of years ago. I also took this opportunity to standardize that on the `ReadMore` component.

| Platform | Before | After |
|---|---|---|
| Android | <img src="https://github.com/user-attachments/assets/b5a06c9b-b6d2-4a22-b556-64cfe87562fe" height="300" /> | <img src="https://github.com/user-attachments/assets/b2256c4b-ff7e-4193-a6e8-3a956ae528c2" height="300" /> |
| iOS | <img src="https://github.com/user-attachments/assets/851f4b4e-2c22-4360-9c85-9defc191da8b" height="300" /> | <img src="https://github.com/user-attachments/assets/e7cc357f-77e1-4970-be85-3123f5893fbf" height="300" /> |


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

- Improve rendering of artist bios on artwork pages.

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
