### PR TITLE
fix(PHIRE-3313): preserve row order on QA doc duplication

### DIFF
--- a/scripts/create-qa-document/duplicateNotionTemplate.ts
+++ b/scripts/create-qa-document/duplicateNotionTemplate.ts
@@ -1,48 +1,25 @@
 import { notion, extractPageId } from "./notion"
 
 // ---------------------------------------------------------------------------
-// Notion has no "duplicate page" endpoint. This recreates a template page by
-// reading its title + block tree and rebuilding them as a new subpage at the
-// end of a destination page.
+// Duplicates the Mobile App QA Notion template into a new dated page.
+//
+// `POST /pages` takes a `template` parameter whose `template_id` may be *any*
+// page the integration can see, so Notion performs the duplication server-side.
+// That matters because a page's fidelity lives in places the create endpoints
+// can't reach: row order and column order are properties of a database *view*,
+// not of its data source, and `created_by` columns, formulas and Notion-hosted
+// images can't be authored through the API at all.
+//
+// An earlier version of this file rebuilt the page block-by-block instead. It
+// could only ever approximate the template — the regression table came out in
+// arbitrary row order, which matters because its test cases reference the row
+// above them ("Same as ☝️…"). Letting Notion do the copy removes that whole
+// class of problem, so there is deliberately no hand-rolled fallback: a wrong
+// QA document is worse than a failed job.
 //
 // Defaults to the Mobile App QA template → the Mobile App QA destination page
 // (both in constants.ts). Pass a template url/id to override the source.
 // ---------------------------------------------------------------------------
-
-// Block types that can't be re-created through the public API, or that need
-// bespoke structural handling we don't support yet. We copy everything else and
-// warn (loudly, never silently) for these so nothing looks like it succeeded.
-const UNSUPPORTED_BLOCK_TYPES = new Set([
-  "child_page",
-  "column_list",
-  "column",
-  "table",
-  "table_row",
-  "synced_block",
-  "link_preview",
-  "template",
-  "ai_block",
-  "unsupported",
-])
-
-// Property types we can't recreate in a database schema: system/computed values,
-// or types that require external references we can't reconstruct.
-const UNSUPPORTED_PROP_TYPE_LIST = [
-  "created_by",
-  "created_time",
-  "last_edited_by",
-  "last_edited_time",
-  "rollup",
-  "relation",
-  "status",
-  "unique_id",
-  "button",
-  "verification",
-]
-const UNSUPPORTED_PROP_TYPES = new Set(UNSUPPORTED_PROP_TYPE_LIST)
-
-// Property value types that can't be written when creating a row (computed).
-const READONLY_VALUE_TYPES = new Set([...UNSUPPORTED_PROP_TYPE_LIST, "formula"])
 
 interface RichText {
   type?: string
@@ -58,6 +35,20 @@ interface Block {
   [key: string]: unknown
 }
 
+interface PageProperty {
+  type: string
+  title?: RichText[]
+}
+
+interface Page {
+  id: string
+  url: string
+  parent: Record<string, unknown>
+  properties: Record<string, PageProperty>
+  icon?: Record<string, unknown> | null
+  cover?: Record<string, unknown> | null
+}
+
 // Strip read-only fields from rich text so the payload is accepted on write.
 const cleanRichText = (rich: RichText[] = []): RichText[] =>
   rich
@@ -69,54 +60,6 @@ const cleanRichText = (rich: RichText[] = []): RichText[] =>
       text: { content: r.text.content, link: r.text.link ?? null },
       annotations: r.annotations,
     }))
-
-// Recursively drop null-valued fields. The API returns blocks with fields like
-// `icon: null`, but the create endpoint rejects null (it wants an object or the
-// field absent); omitting a field means "use the default", which is what we want.
-const stripNulls = (value: unknown): unknown => {
-  if (Array.isArray(value)) return value.map(stripNulls)
-  if (value && typeof value === "object") {
-    const out: Record<string, unknown> = {}
-    for (const [k, v] of Object.entries(value)) {
-      if (v !== null) out[k] = stripNulls(v)
-    }
-    return out
-  }
-  return value
-}
-
-// Blocks that carry a file, which is either Notion-hosted (type "file", an
-// expiring URL we can't re-upload) or "external" (a plain URL we can copy).
-const FILE_BLOCK_TYPES = new Set(["image", "video", "file", "pdf", "audio"])
-
-// Turn a fetched block into a writable block payload (no ids/timestamps).
-// Returns null for block types we can't recreate.
-const cleanBlock = (block: Block): Record<string, unknown> | null => {
-  if (UNSUPPORTED_BLOCK_TYPES.has(block.type)) return null
-
-  const payload = { ...(block[block.type] as Record<string, unknown>) }
-
-  if (FILE_BLOCK_TYPES.has(block.type)) {
-    // Only external file URLs survive a copy; Notion-hosted files would need a
-    // fresh upload, so skip them rather than send an invalid payload.
-    if (payload.type !== "external" || !payload.external) return null
-    const clean: Record<string, unknown> = { type: "external", external: payload.external }
-    if (Array.isArray(payload.caption)) clean.caption = cleanRichText(payload.caption as RichText[])
-    return { object: "block", type: block.type, [block.type]: clean }
-  }
-
-  // rich_text is the common carrier of formatted content; clean it if present.
-  if (Array.isArray(payload.rich_text)) {
-    payload.rich_text = cleanRichText(payload.rich_text as RichText[])
-  }
-  // Children are appended separately (recursively), never inline here.
-  delete payload.children
-
-  return stripNulls({ object: "block", type: block.type, [block.type]: payload }) as Record<
-    string,
-    unknown
-  >
-}
 
 // Fetch every child block of a block/page, following pagination.
 const fetchAllChildren = async (blockId: string): Promise<Block[]> => {
@@ -133,224 +76,18 @@ const fetchAllChildren = async (blockId: string): Promise<Block[]> => {
   return blocks
 }
 
-const chunk = <T>(arr: T[], size: number): T[][] => {
-  const out: T[][] = []
-  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size))
-  return out
-}
-
-// Recursively copy the children of `sourceId` onto `destId`. `rootPageId` is the
-// nearest page ancestor in the destination — inline databases can only be
-// created under a page, so nested databases are placed there rather than in
-// their exact spot.
-//
-// We walk children in order, buffering plain blocks and flushing them right
-// before each embedded database, so databases keep their position relative to
-// surrounding content (e.g. sitting under their own heading).
-const copyChildren = async (
-  sourceId: string,
-  destId: string,
-  rootPageId: string
-): Promise<void> => {
-  const children = await fetchAllChildren(sourceId)
-  let buffer: { source: Block; cleaned: Record<string, unknown> }[] = []
-
-  const flush = async (): Promise<void> => {
-    if (buffer.length === 0) return
-    const batch = buffer
-    buffer = []
-    // Append in batches of 100 (API limit); created results come back in order.
-    const created: Block[] = []
-    for (const part of chunk(batch, 100)) {
-      const res = await notion<{ results: Block[] }>(`/blocks/${destId}/children`, {
-        method: "PATCH",
-        body: JSON.stringify({ children: part.map((e) => e.cleaned) }),
-      })
-      created.push(...res.results)
-    }
-    // Recurse for any block that had nested children.
-    for (let i = 0; i < batch.length; i++) {
-      if (batch[i].source.has_children && created[i]) {
-        await copyChildren(batch[i].source.id, created[i].id, rootPageId)
-      }
-    }
+// An icon/cover we can re-send on create. Emoji and external URLs are plain
+// values we can copy; a Notion-hosted file is an expiring URL that would need a
+// fresh upload, so it's dropped rather than sent as an invalid reference.
+export const copyableAsset = (
+  asset: Record<string, unknown> | null | undefined
+): Record<string, unknown> | null => {
+  if (!asset) return null
+  if (asset.type === "emoji" && asset.emoji) return { type: "emoji", emoji: asset.emoji }
+  if (asset.type === "external" && asset.external) {
+    return { type: "external", external: asset.external }
   }
-
-  for (const source of children) {
-    if (source.type === "child_database") {
-      await flush()
-      await copyDatabase(source.id, rootPageId)
-      continue
-    }
-    const cleaned = cleanBlock(source)
-    if (!cleaned) {
-      console.warn(`⚠️  Skipping non-copyable block: ${source.type}`)
-      continue
-    }
-    buffer.push({ source, cleaned })
-  }
-  await flush()
-}
-
-interface PropertyConfig {
-  type: string
-  [key: string]: unknown
-}
-
-// Build a create-database schema from a data source's property configs,
-// dropping property types we can't recreate.
-const buildSchema = (properties: Record<string, PropertyConfig>): Record<string, unknown> => {
-  const schema: Record<string, unknown> = {}
-  for (const [name, prop] of Object.entries(properties)) {
-    const type = prop.type
-    if (UNSUPPORTED_PROP_TYPES.has(type)) {
-      console.warn(`   ⚠️  skipping property "${name}" (${type} can't be created via API)`)
-      continue
-    }
-    const config = (prop[type] as Record<string, unknown>) ?? {}
-    if (type === "select" || type === "multi_select") {
-      const options = ((config.options as { name: string; color: string }[]) ?? []).map((o) => ({
-        name: o.name,
-        color: o.color,
-      }))
-      schema[name] = { type, [type]: { options } }
-    } else if (type === "formula") {
-      schema[name] = { type, formula: { expression: config.expression } }
-    } else if (type === "number") {
-      schema[name] = { type, number: { format: config.format ?? "number" } }
-    } else {
-      schema[name] = { type, [type]: {} }
-    }
-  }
-  return schema
-}
-
-// Build writable row properties from a source row's property values, skipping
-// computed values and any property not present in the new schema.
-const buildRowProperties = (
-  properties: Record<string, PropertyConfig>,
-  schema: Record<string, unknown>
-): Record<string, unknown> => {
-  const out: Record<string, unknown> = {}
-  for (const [name, prop] of Object.entries(properties)) {
-    if (!(name in schema) || READONLY_VALUE_TYPES.has(prop.type)) continue
-    const v = prop[prop.type] as never
-    switch (prop.type) {
-      case "title":
-      case "rich_text":
-        out[name] = { [prop.type]: cleanRichText(v) }
-        break
-      case "multi_select":
-        out[name] = {
-          multi_select: ((v as { name: string }[]) ?? []).map((o) => ({ name: o.name })),
-        }
-        break
-      case "select":
-        if (v) out[name] = { select: { name: (v as { name: string }).name } }
-        break
-      case "checkbox":
-        out[name] = { checkbox: Boolean(v) }
-        break
-      case "url":
-      case "email":
-      case "phone_number":
-        if (v) out[name] = { [prop.type]: v }
-        break
-      case "number":
-        if (v !== null && v !== undefined) out[name] = { number: v }
-        break
-      case "date":
-        if (v) {
-          const d = v as { start: string; end: string | null; time_zone: string | null }
-          out[name] = { date: { start: d.start, end: d.end, time_zone: d.time_zone } }
-        }
-        break
-      case "people":
-        out[name] = { people: ((v as { id: string }[]) ?? []).map((p) => ({ id: p.id })) }
-        break
-      case "files": {
-        // Notion-hosted files have expiring URLs that can't be re-uploaded via
-        // the API; only external file links can be copied.
-        const files = ((v as { type: string; name: string; external?: { url: string } }[]) ?? [])
-          .filter(
-            (f): f is { type: string; name: string; external: { url: string } } =>
-              f.type === "external" && !!f.external
-          )
-          .map((f) => ({ name: f.name, external: { url: f.external.url } }))
-        if (files.length) out[name] = { files }
-        break
-      }
-      default:
-        break
-    }
-  }
-  return out
-}
-
-// Rebuild an embedded database (schema + rows) as an inline database under a page.
-const copyDatabase = async (sourceDbId: string, destPageId: string): Promise<void> => {
-  const database = await notion<{
-    title: RichText[]
-    data_sources: { id: string; name: string }[]
-  }>(`/databases/${sourceDbId}`)
-  const sourceDs = database.data_sources[0]
-  if (!sourceDs) return
-
-  const source = await notion<{ properties: Record<string, PropertyConfig> }>(
-    `/data_sources/${sourceDs.id}`
-  )
-  const schema = buildSchema(source.properties)
-
-  console.log(`   Creating database "${sourceDs.name}"…`)
-  const newDb = await notion<{ id: string; data_sources: { id: string }[] }>("/databases", {
-    method: "POST",
-    body: JSON.stringify({
-      parent: { type: "page_id", page_id: destPageId },
-      title: cleanRichText(database.title),
-      is_inline: true,
-      initial_data_source: { properties: schema },
-    }),
-  })
-  const newDsId = newDb.data_sources[0].id
-
-  let cursor: string | undefined
-  let count = 0
-  do {
-    const res = await notion<{
-      results: { id: string; properties: Record<string, PropertyConfig> }[]
-      next_cursor: string | null
-      has_more: boolean
-    }>(`/data_sources/${sourceDs.id}/query`, {
-      method: "POST",
-      body: JSON.stringify({ start_cursor: cursor, page_size: 100 }),
-    })
-    for (const row of res.results) {
-      const newRow = await notion<{ id: string }>("/pages", {
-        method: "POST",
-        body: JSON.stringify({
-          parent: { type: "data_source_id", data_source_id: newDsId },
-          properties: buildRowProperties(row.properties, schema),
-        }),
-      })
-      // Rows can have page bodies of their own; copy them too.
-      await copyChildren(row.id, newRow.id, newRow.id)
-      count++
-    }
-    cursor = res.has_more ? res.next_cursor ?? undefined : undefined
-  } while (cursor)
-  console.log(`   → copied ${count} row(s) into "${sourceDs.name}"`)
-}
-
-interface PageProperty {
-  type: string
-  title?: RichText[]
-}
-
-interface Page {
-  id: string
-  url: string
-  parent: Record<string, unknown>
-  properties: Record<string, PageProperty>
+  return null
 }
 
 const getTitle = (page: Page): { key: string; rich: RichText[] } => {
@@ -436,6 +173,17 @@ const setCodeBlock = async (blockId: string, text: string): Promise<void> => {
   })
 }
 
+// Drop the changelog into the copy's changelog code block.
+const fillChangelog = async (pageId: string, changelog: string): Promise<void> => {
+  const codeBlockId = await findCodeBlock(pageId, CHANGELOG_PLACEHOLDER)
+  if (!codeBlockId) {
+    console.warn("⚠️  No code block found to fill with the changelog.")
+    return
+  }
+  console.log("Filling changelog code block…")
+  await setCodeBlock(codeBlockId, changelog)
+}
+
 // Idempotency guard: return the URL of an existing child page under the
 // destination whose title contains every string in `mustInclude` (e.g. the
 // version), or null if none exists.
@@ -453,6 +201,23 @@ export const findExistingCopy = async (
     }
   }
   return null
+}
+
+// Notion applies a template asynchronously: the create call returns immediately
+// and the page is briefly blank while the server fills it in. Poll until content
+// shows up (the docs' suggested alternative to subscribing to
+// `page.content_updated`).
+const TEMPLATE_POLL_INTERVAL_MS = 2_000
+const TEMPLATE_POLL_TIMEOUT_MS = 120_000
+
+const waitForTemplateContent = async (pageId: string): Promise<boolean> => {
+  const deadline = Date.now() + TEMPLATE_POLL_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const children = await fetchAllChildren(pageId)
+    if (children.length > 0) return true
+    await new Promise((r) => setTimeout(r, TEMPLATE_POLL_INTERVAL_MS))
+  }
+  return false
 }
 
 interface DuplicateOptions {
@@ -494,27 +259,37 @@ export const duplicateTemplate = async (
     newTitle = replaceInTitle(newTitle, ANDROID_BUILD_PLACEHOLDER, androidBuild)
   }
 
-  console.log(`Creating new page under destination ${destinationId}…`)
+  const icon = copyableAsset(template.icon)
+  const cover = copyableAsset(template.cover)
+
+  console.log(`Duplicating template into destination ${destinationId}…`)
   const newPage = await notion<Page>("/pages", {
     method: "POST",
     body: JSON.stringify({
       parent: { type: "page_id", page_id: destinationId },
       properties: { title: { title: newTitle } },
+      ...(icon ? { icon } : {}),
+      ...(cover ? { cover } : {}),
+      template: { type: "template_id", template_id: templateId },
     }),
   })
 
-  console.log("Copying block content…")
-  await copyChildren(templateId, newPage.id, newPage.id)
-
-  if (changelog) {
-    const codeBlockId = await findCodeBlock(newPage.id, CHANGELOG_PLACEHOLDER)
-    if (codeBlockId) {
-      console.log("Filling changelog code block…")
-      await setCodeBlock(codeBlockId, changelog)
-    } else {
-      console.warn("⚠️  No code block found to fill with the changelog.")
-    }
+  if (!(await waitForTemplateContent(newPage.id))) {
+    throw new Error(
+      `Template application timed out after ${
+        TEMPLATE_POLL_TIMEOUT_MS / 1000
+      }s; page left empty at ${newPage.url}`
+    )
   }
+
+  // Applying the template can overwrite the title we passed on create, so stamp
+  // the placeholders again now that the server is done.
+  await notion(`/pages/${newPage.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ properties: { title: { title: newTitle } } }),
+  })
+
+  if (changelog) await fillChangelog(newPage.id, changelog)
 
   console.log(`✅ Duplicated template → ${newPage.url}`)
   return newPage.url


### PR DESCRIPTION
This PR resolves [PHIRE-3313]

### Description

Fixes the row-ordering bug in the automated Mobile App QA Notion document by letting Notion duplicate the template server-side instead of rebuilding it block-by-block.

**The problem.** The QA doc generator rebuilt the template block-by-block, because the API has no duplicate-page endpoint. For the inline databases that meant reading rows with an unsorted `POST /data_sources/:id/query` and re-creating them one at a time. [Notion's docs][query] are explicit that "Notion doesn't guarantee any particular sort order when no sort parameters are provided", so rows landed in an arbitrary order that varied run to run. This mattered more than it sounds: the Regression QA checklist is manually ordered, and several of its test cases reference the row above them ("Same as ☝️, but when the app is completely closed", "After ☝️ with the conversation tab populated"). Shuffled, those steps are meaningless. The deeper issue is that manual row order isn't a property of the data source at all — it lives on the database's **view**, alongside column order, column visibility, and the table-vs-board layout. None of that was in the data being read, so no amount of sorting could have recovered it.

**The fix.** `POST /pages` accepts a [`template` parameter][templates] whose `template_id` can be any page the integration can access, and Notion performs the duplication server-side. Switching to it removed the whole problem class instead of patching one symptom, and deleted ~300 lines of reconstruction logic that could only ever approximate the template.

**Changes — `scripts/create-qa-document/duplicateNotionTemplate.ts` (521 → 296 lines):**

- Duplicates via `template: { type: "template_id", template_id }` on page create.
- Polls for content afterwards (template application is asynchronous), then re-stamps the title, since Notion can overwrite it while applying.
- Carries over the template's icon/cover.
- Removes the manual rebuild: `copyChildren`, `copyDatabase`, `buildSchema`, `buildRowProperties`, `cleanBlock`, `stripNulls`, and the whole `UNSUPPORTED_BLOCK_TYPES` / `UNSUPPORTED_PROP_TYPES` taxonomy.
- **No fallback.** If duplication is unavailable it throws. A plausible-looking QA doc with shuffled regression steps is worse than a failed job, and `notify-qa-failure` already alerts on this.

**What now survives the copy** that previously didn't:

| | Before | After |
|---|---|---|
| Regression QA row order | shuffled, ☝️ chain broken | 18/18 exact match |
| Regression QA columns | 4 of 10 visible | all 10, template order |
| Bugs view | table, group-by lost | board, grouped by Status |
| `Reporter` (`created_by`) | dropped | preserved |
| `Jira ticket created` (formula) | dropped | preserved |
| Image inside a row body | skipped | preserved |

**Test plan.** Verified against two real duplications into the shared Mobile App QA page (test docs since removed): row order compared position-by-position against the template, column order and visibility checked per view, Bugs confirmed as a board with `groupBy: Status / select / manual`. Also confirmed the copies' internal select-option ids are identical to the template's, which only a true server-side clone produces.

> [!IMPORTANT]
> **The QA template itself was edited, and that change is not in this diff.** Two of its views (Regression QA and Recent Changes QA) carried a sort referencing a property deleted long ago. Notion's UI silently ignores the dangling reference, but the Views API rejects any query through such a view (`400 Could not find sort property with name or id: y:Hd`) — which is what forced the old code down its unordered read path. Both sorts were cleared with a one-shot script that is deliberately not committed, since it isn't part of the automation. Row order was snapshotted before and after and is unchanged. This note is the only record, so if the symptom recurs, check the template's views for dangling sorts first.

### PR Checklist

- [ ] I have tested my changes on the following platforms: <!-- n/a: CI/Node script, no on-device code — see test plan in Description -->
  - [ ] **Android**.
  - [ ] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one. <!-- CI-only -->
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any. <!-- 31 unit tests passing; deleted tests covered deleted code -->
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device. <!-- n/a: verify with `RC_BRANCH=rc-v<version> yarn create-qa` against a scratch destination -->

<details><summary>Changelog updates</summary>

### Changelog updates

#### Dev changes

- The automated QA document is now duplicated by Notion server-side, so its tables keep the template's row order, column order and board layouts.

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code)

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md
[query]: https://developers.notion.com/reference/query-a-data-source
[templates]: https://developers.notion.com/guides/data-apis/creating-pages-from-templates
[PHIRE-3313]: https://artsyproduct.atlassian.net/browse/PHIRE-3313
