### PR TITLE
fix: early exit when userLocation is undefined

### DIFF
--- a/src/app/Scenes/Map/GlobalMap.tsx
+++ b/src/app/Scenes/Map/GlobalMap.tsx
@@ -116,10 +116,12 @@ export const GlobalMap: React.FC<Props> = (props) => {
     }
 
     const onPressUserPositionButton = () => {
-      // @ts-expect-error STRICTNESS_MIGRATION --- 🚨 Unsafe legacy code 🚨 Please delete this and fix any type errors if you have time 🙏
-      const { lat, lng } = userLocation
+      if (!isValidLatLng(userLocation)) {
+        return
+      }
+
       cameraRef.current?.setCamera({
-        centerCoordinate: [lng, lat],
+        centerCoordinate: [userLocation.lng, userLocation.lat],
         zoomLevel: DefaultZoomLevel,
         animationDuration: 500,
       })
@@ -146,7 +148,7 @@ export const GlobalMap: React.FC<Props> = (props) => {
                 isLoading={!viewer.city}
                 onPress={onPressCitySwitcherButton}
               />
-              {!!userLocation && (
+              {!!isValidLatLng(userLocation) && (
                 <Box style={{ marginLeft: 10 }}>
                   <UserPositionButton
                     highlight={userLocation === currentLocation}
@@ -337,11 +339,16 @@ export const GlobalMap: React.FC<Props> = (props) => {
   }
 
   const onUserLocationUpdate = (location: MapboxGL.Location) => {
-    if (!location || !location.coords) {
+    const coords = location?.coords
+
+    // The native side sends updates with an empty `coords` object before the first location fix
+    // lands (and for heading-only updates), which would otherwise leave us with a location made of
+    // `undefined`s and crash the camera.
+    if (typeof coords?.latitude !== "number" || typeof coords?.longitude !== "number") {
       return
     }
 
-    setUserLocation(longCoordsToLocation(location.coords))
+    setUserLocation(longCoordsToLocation(coords))
   }
 
   const onRegionIsChanging = async () => {
@@ -588,6 +595,14 @@ export const GlobalMap: React.FC<Props> = (props) => {
 /** Makes sure we're consistently using { lat, lng } internally */
 const longCoordsToLocation = (coords: { longitude: number; latitude: number }) => {
   return { lat: coords.latitude, lng: coords.longitude }
+}
+
+/**
+ * `city.coordinates` is nullable in the schema and location updates can arrive without coordinates,
+ * so make sure we actually have numbers before handing them over to the map.
+ */
+const isValidLatLng = (location: any): location is { lat: number; lng: number } => {
+  return typeof location?.lat === "number" && typeof location?.lng === "number"
 }
 
 const tracks = {


### PR DESCRIPTION
This PR resolves [PHIRE-3337] <!-- eg [PROJECT-XXXX] -->

### Description

No UI changes, this PR just protects the user location button on the maps from being called with undefined lon + lat.

Fixes this sentry issue https://artsynet.sentry.io/issues/7529680301/events/f15319ccfbf4490280c6ad21e606af80/

<!-- Info, implementation, how to get there, before & after screenshots & videos, follow-up work, etc -->

<!--  Please include screenshots or videos for visual changes, at least on Android -->
<!-- Screenshots template:
| Platform | Before | After |
|---|---|---|
| Android | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
| iOS | <img src="xxx" width="400" /> | <img src="xxx" width="400" /> |
-->
<!-- Videos template:
| Platform | Before | After |
|---|---|---|
| Android | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
| iOS | <video src="xxx" width="400" /> | <video src="xxx" width="400" /> |
-->

### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

<!-- 📝 Please fill out at least one of these sections. -->
<!-- ⓘ 'User-facing' changes will be published as release notes. -->
<!-- ⌫ Feel free to remove sections that don't apply. -->
<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
<!-- 📖 eg. `Enable lotsByFollowedArtists` or `Fix phone input misalignment`. -->
<!-- 🤷‍♂️ Replace this entire block with the hashtag `#nochangelog` to avoid updating the changelog. -->
<!-- ⚠️ Prefix with `[NEEDS EXTERNAL QA]` if a change requires external QA -->

#### Cross-platform user-facing changes

-

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

- early exit when userLocation is undefined

<!-- end_changelog_updates -->

</details>

Need help with something? Have a look at our [docs], or get in touch with us.

[app state migration]: ../blob/main/docs/adding_state_migrations.md
[feature flag]: ../blob/main/docs/developing_a_feature.md
[docs]: ../blob/main/docs/README.md


[PHIRE-3337]: https://artsyproduct.atlassian.net/browse/PHIRE-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ