### PR TITLE
fix(ONYX-2195): always enable Show Results button in artwork filter panel

### DIFF
--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -205,6 +205,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   }
 
   const handleApplyPress = () => {
+    if (selectedFiltersState.length === 0) {
+      exitModal?.()
+      return
+    }
+
     const appliedFiltersParams = filterArtworksParams(appliedFiltersState, filterTypeState)
     // TODO: Update to use cohesion
     switch (mode) {

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -205,8 +205,11 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
   }
 
   const handleApplyPress = () => {
+    // nothing staged to apply: treat the tap as a dismissal, reusing the same
+    // path as closing the panel — unlike exitModal, this lets consumers that
+    // only track dismissals (not applies) see this one.
     if (selectedFiltersState.length === 0) {
-      exitModal?.()
+      handleClosingModal()
       return
     }
 

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -130,9 +130,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
 
   const appliedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.appliedFilters)
   const selectedFiltersState = ArtworksFiltersStore.useStoreState((state) => state.selectedFilters)
-  const previouslyAppliedFiltersState = ArtworksFiltersStore.useStoreState(
-    (state) => state.previouslyAppliedFilters
-  )
   const filterTypeState = ArtworksFiltersStore.useStoreState((state) => state.filterType)
 
   const applyFiltersAction = ArtworksFiltersStore.useStoreActions(
@@ -206,10 +203,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
       ...(artworkQuery && { query: artworkQuery }),
     })
   }
-
-  const isApplyButtonEnabled =
-    selectedFiltersState.length > 0 ||
-    (previouslyAppliedFiltersState.length === 0 && appliedFiltersState.length > 0)
 
   const handleApplyPress = () => {
     const appliedFiltersParams = filterArtworksParams(appliedFiltersState, filterTypeState)
@@ -435,7 +428,7 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
               </Stack.Navigator>
 
               <ArtworkFilterApplyButton
-                disabled={!isApplyButtonEnabled}
+                disabled={false}
                 onPress={handleApplyPress}
                 onCreateAlertPress={handleCreateAlertPress}
                 shouldShowCreateAlertButton={shouldShowCreateAlertButton}

--- a/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
+++ b/src/app/Components/ArtworkFilter/ArtworkFilterNavigator.tsx
@@ -433,7 +433,6 @@ export const ArtworkFilterNavigator: React.FC<ArtworkFilterProps> = (props) => {
               </Stack.Navigator>
 
               <ArtworkFilterApplyButton
-                disabled={false}
                 onPress={handleApplyPress}
                 onCreateAlertPress={handleCreateAlertPress}
                 shouldShowCreateAlertButton={shouldShowCreateAlertButton}

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -380,6 +380,7 @@ describe("Clearing filters", () => {
 describe("Applying filters via Show Results", () => {
   beforeEach(() => {
     exitModalMock.mockClear()
+    closeModalMock.mockClear()
     mockTrackEvent.mockClear()
   })
 
@@ -412,6 +413,7 @@ describe("Applying filters via Show Results", () => {
     fireEvent.press(screen.getByText("Show Results"))
 
     expect(exitModalMock).toHaveBeenCalled()
+    expect(closeModalMock).not.toHaveBeenCalled()
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
     )

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -246,33 +246,6 @@ describe("Filter modal states", () => {
     expect(screen.getByText("Medium • 1")).toBeTruthy()
   })
 
-  it("displays the filter screen apply button as enabled when no filters are selected", () => {
-    renderWithWrappers(<MockFilterModalNavigator />)
-
-    expect(screen.getByText("Show Results")).not.toBeDisabled()
-  })
-
-  it("displays the filter screen apply button correctly when filters are selected", () => {
-    const injectedState: ArtworkFiltersState = {
-      selectedFilters: [{ displayText: "Price (Low to High)", paramName: FilterParamName.sort }],
-      appliedFilters: [],
-      previouslyAppliedFilters: [],
-      applyFilters: false,
-      aggregations: mockAggregations,
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-      showFilterArtworksModal: false,
-      sizeMetric: "cm",
-    }
-
-    renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
-
-    expect(screen.getByText("Show Results")).not.toBeDisabled()
-  })
-
   it("does not display default filters numbers on the Filter modal", () => {
     renderWithWrappers(<MockFilterScreen initialState={initialState} />)
 
@@ -327,6 +300,14 @@ describe("Filter modal states", () => {
 })
 
 describe("Clearing filters", () => {
+  beforeEach(() => {
+    exitModalMock.mockClear()
+    closeModalMock.mockClear()
+    // the global clearing in setupJest is skipped when ALLOW_CONSOLE_LOGS=true,
+    // so clear explicitly to keep the tracking assertions below reliable
+    mockTrackEvent.mockClear()
+  })
+
   it("allows users to clear all filters when selecting clear all", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [
@@ -378,21 +359,19 @@ describe("Clearing filters", () => {
       sizeMetric: "cm",
     }
 
-    exitModalMock.mockClear()
-
     renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
 
     fireEvent.press(screen.getByText("Clear All"))
 
     expect(screen.getByText("Sort By")).toBeTruthy()
     expect(screen.getByText("Rarity")).toBeTruthy()
-    expect(screen.getByText("Show Results")).not.toBeDisabled()
 
     fireEvent.press(screen.getByText("Show Results"))
 
-    expect(exitModalMock).toHaveBeenCalled()
-    // exitModal is also called when filters are applied, so additionally assert
-    // the tap was treated as a no-op: no filter-change event may be emitted
+    // the tap is a dismissal, not an apply: closeModal (which consumers may
+    // track as a close) rather than exitModal, and no filter-change event
+    expect(closeModalMock).toHaveBeenCalled()
+    expect(exitModalMock).not.toHaveBeenCalled()
     expect(mockTrackEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
     )
@@ -421,8 +400,6 @@ describe("Clearing filters", () => {
       showFilterArtworksModal: false,
       sizeMetric: "cm",
     }
-
-    exitModalMock.mockClear()
 
     renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
 

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -18,6 +18,7 @@ import {
   MockFilterScreen,
 } from "app/Components/ArtworkFilter/FilterTestHelper"
 import { CollectionArtworksFragmentContainer } from "app/Scenes/Collection/Screens/CollectionArtworks"
+import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { mockNavigate } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 import { resolveMostRecentRelayOperation } from "app/utils/tests/resolveMostRecentRelayOperation"
@@ -390,6 +391,11 @@ describe("Clearing filters", () => {
     fireEvent.press(screen.getByText("Show Results"))
 
     expect(exitModalMock).toHaveBeenCalled()
+    // exitModal is also called when filters are applied, so additionally assert
+    // the tap was treated as a no-op: no filter-change event may be emitted
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
+    )
   })
 })
 

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -26,7 +26,6 @@ import { graphql, QueryRenderer } from "react-relay"
 import { createMockEnvironment } from "relay-test-utils"
 
 const exitModalMock = jest.fn()
-const trackEvent = jest.fn()
 
 const mockAggregations: Aggregations = [
   {
@@ -341,7 +340,7 @@ describe("Clearing filters", () => {
     expect(screen.queryByText("• 1")).toBeFalsy()
   })
 
-  it("exits the modal when clear all button is pressed", () => {
+  it("closes the modal without applying when Show Results is pressed after clear all", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [],
       appliedFilters: [{ displayText: "Recently Added", paramName: FilterParamName.sort }],
@@ -376,9 +375,16 @@ describe("Clearing filters", () => {
       expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
     )
   })
+})
 
-  // counterpart to the no-op case above: with staged filters the same tap
-  // must go through the full apply path instead of the early return
+describe("Applying filters via Show Results", () => {
+  beforeEach(() => {
+    exitModalMock.mockClear()
+    mockTrackEvent.mockClear()
+  })
+
+  // counterpart to the no-op dismissal above: with staged filters the same
+  // tap must go through the full apply path instead of the early return
   it("applies filters and tracks the change when Show Results is pressed with staged filters", () => {
     const injectedState: ArtworkFiltersState = {
       selectedFilters: [
@@ -498,69 +504,6 @@ describe("Applying filters on Artworks", () => {
         "sort": null,
       }
     `)
-  })
-
-  it.skip("tracks changes in the filter state when a filter is applied", async () => {
-    const injectedState: ArtworkFiltersState = {
-      selectedFilters: [
-        {
-          displayText: "Works on Paper",
-          paramName: FilterParamName.medium,
-          paramValue: "work-on-paper",
-        },
-      ],
-      appliedFilters: [
-        {
-          displayText: "Recently Added",
-          paramName: FilterParamName.sort,
-          paramValue: "-decayed_merch",
-        },
-      ],
-      previouslyAppliedFilters: [
-        {
-          displayText: "Recently Added",
-          paramName: FilterParamName.sort,
-          paramValue: "-decayed_merch",
-        },
-      ],
-      applyFilters: true,
-      aggregations: mockAggregations,
-      filterType: "artwork",
-      counts: {
-        total: null,
-        followedArtists: null,
-      },
-      showFilterArtworksModal: false,
-      sizeMetric: "cm",
-    }
-
-    renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
-
-    resolveMostRecentRelayOperation(env)
-
-    fireEvent.press(screen.getByText("Show Results"))
-
-    expect(trackEvent).toHaveBeenCalledWith({
-      action_type: "commercialFilterParamsChanged",
-      changed: JSON.stringify({
-        medium: "work-on-paper",
-      }),
-      context_screen: "Artist",
-      context_screen_owner_id: "abc123",
-      context_screen_owner_slug: "some-artist",
-      context_screen_owner_type: "Artist",
-      current: JSON.stringify({
-        acquireable: false,
-        atAuction: false,
-        estimateRange: "",
-        includeArtworksByFollowedArtists: false,
-        inquireableOnly: false,
-        medium: "*",
-        offerable: false,
-        priceRange: "*-*",
-        sort: "-decayed_merch",
-      }),
-    })
   })
 })
 

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -397,6 +397,42 @@ describe("Clearing filters", () => {
       expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
     )
   })
+
+  // counterpart to the no-op case above: with staged filters the same tap
+  // must go through the full apply path instead of the early return
+  it("applies filters and tracks the change when Show Results is pressed with staged filters", () => {
+    const injectedState: ArtworkFiltersState = {
+      selectedFilters: [
+        {
+          displayText: "Works on Paper",
+          paramName: FilterParamName.medium,
+          paramValue: "work-on-paper",
+        },
+      ],
+      appliedFilters: [],
+      previouslyAppliedFilters: [],
+      applyFilters: false,
+      aggregations: mockAggregations,
+      filterType: "artwork",
+      counts: {
+        total: null,
+        followedArtists: null,
+      },
+      showFilterArtworksModal: false,
+      sizeMetric: "cm",
+    }
+
+    exitModalMock.mockClear()
+
+    renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
+
+    fireEvent.press(screen.getByText("Show Results"))
+
+    expect(exitModalMock).toHaveBeenCalled()
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action_type: "commercialFilterParamsChanged" })
+    )
+  })
 })
 
 describe("Applying filters on Artworks", () => {

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -245,10 +245,10 @@ describe("Filter modal states", () => {
     expect(screen.getByText("Medium • 1")).toBeTruthy()
   })
 
-  it("displays the filter screen apply button correctly when no filters are selected", () => {
+  it("displays the filter screen apply button as enabled when no filters are selected", () => {
     renderWithWrappers(<MockFilterModalNavigator />)
 
-    expect(screen.getByText("Show Results")).toBeDisabled()
+    expect(screen.getByText("Show Results")).not.toBeDisabled()
   })
 
   it("displays the filter screen apply button correctly when filters are selected", () => {
@@ -379,12 +379,11 @@ describe("Clearing filters", () => {
 
     renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
 
-    expect(screen.getByText("Show Results")).toBeDisabled()
-
     fireEvent.press(screen.getByText("Clear All"))
 
     expect(screen.getByText("Sort By")).toBeTruthy()
     expect(screen.getByText("Rarity")).toBeTruthy()
+    expect(screen.getByText("Show Results")).not.toBeDisabled()
   })
 })
 

--- a/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
+++ b/src/app/Components/ArtworkFilter/__tests__/FilterModal.tests.tsx
@@ -377,6 +377,8 @@ describe("Clearing filters", () => {
       sizeMetric: "cm",
     }
 
+    exitModalMock.mockClear()
+
     renderWithWrappers(<MockFilterModalNavigator initialData={injectedState} />)
 
     fireEvent.press(screen.getByText("Clear All"))
@@ -384,6 +386,10 @@ describe("Clearing filters", () => {
     expect(screen.getByText("Sort By")).toBeTruthy()
     expect(screen.getByText("Rarity")).toBeTruthy()
     expect(screen.getByText("Show Results")).not.toBeDisabled()
+
+    fireEvent.press(screen.getByText("Show Results"))
+
+    expect(exitModalMock).toHaveBeenCalled()
   })
 })
 

--- a/src/app/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/app/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -17,7 +17,7 @@ import { ResponsiveValue } from "styled-system"
 
 export interface ArtworkFilterApplyButtonProps {
   buttonText?: string
-  disabled: boolean
+  disabled?: boolean
   onCreateAlertPress?: () => void
   onPress: () => void
   shouldShowCreateAlertButton?: boolean
@@ -63,7 +63,7 @@ const InnerButton: React.FC<Button> = (props) => {
 export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
   const {
     buttonText,
-    disabled,
+    disabled = false,
     shouldShowCreateAlertButton,
     onCreateAlertPress,
     onPress,

--- a/src/app/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
+++ b/src/app/Components/ArtworkFilter/components/ArtworkFilterApplyButton.tsx
@@ -17,7 +17,6 @@ import { ResponsiveValue } from "styled-system"
 
 export interface ArtworkFilterApplyButtonProps {
   buttonText?: string
-  disabled?: boolean
   onCreateAlertPress?: () => void
   onPress: () => void
   shouldShowCreateAlertButton?: boolean
@@ -27,13 +26,12 @@ export interface ArtworkFilterApplyButtonProps {
 
 interface Button {
   label: string
-  disabled?: boolean
   icon?: React.ReactNode
   onPress: () => void
 }
 
 const InnerButton: React.FC<Button> = (props) => {
-  const { label, disabled, icon, onPress } = props
+  const { label, icon, onPress } = props
   const [isPressed, setIsPressed] = useState(false)
 
   return (
@@ -42,8 +40,7 @@ const InnerButton: React.FC<Button> = (props) => {
       onPressIn={() => setIsPressed(true)}
       onPressOut={() => setIsPressed(false)}
       onPress={onPress}
-      disabled={disabled}
-      style={{ flex: 1, opacity: disabled ? 0.4 : 1 }}
+      style={{ flex: 1 }}
     >
       <Box flex={1} flexDirection="row" alignItems="center" justifyContent="center">
         {icon}
@@ -63,7 +60,6 @@ const InnerButton: React.FC<Button> = (props) => {
 export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> = (props) => {
   const {
     buttonText,
-    disabled = false,
     shouldShowCreateAlertButton,
     onCreateAlertPress,
     onPress,
@@ -125,7 +121,7 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
                 <Box width="1" height={20} backgroundColor="mono0" mx={1} />
               </>
             )}
-            <InnerButton disabled={disabled} label="Show Results" onPress={onPress} />
+            <InnerButton label="Show Results" onPress={onPress} />
           </Box>
         </Box>
       </SafeAreaView>
@@ -137,7 +133,6 @@ export const ArtworkFilterApplyButton: React.FC<ArtworkFilterApplyButtonProps> =
       <Separator my={0} />
       <Box p={2} pb={pb}>
         <Button
-          disabled={disabled}
           onPress={onPress}
           block
           width={100}

--- a/src/app/Components/ArtworkFilter/components/__tests__/ArtworkFilterApplyButton.tests.tsx
+++ b/src/app/Components/ArtworkFilter/components/__tests__/ArtworkFilterApplyButton.tests.tsx
@@ -1,4 +1,4 @@
-import { fireEvent } from "@testing-library/react-native"
+import { fireEvent, screen } from "@testing-library/react-native"
 import {
   ArtworkFilterApplyButton,
   ArtworkFilterApplyButtonProps,
@@ -6,7 +6,6 @@ import {
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
 
 const defaultProps: ArtworkFilterApplyButtonProps = {
-  disabled: false,
   onCreateAlertPress: jest.fn,
   onPress: jest.fn,
 }
@@ -16,39 +15,28 @@ describe("ArtworkFilterApplyButton", () => {
     return <ArtworkFilterApplyButton {...defaultProps} {...props} />
   }
 
-  it("cannot press if disabled prop is passed", () => {
-    const onPressMock = jest.fn()
-    const { getByText } = renderWithWrappers(<TestWrapper disabled />)
-    const button = getByText("Show Results")
-
-    fireEvent.press(button)
-
-    expect(button).toBeDisabled()
-    expect(onPressMock).not.toBeCalled()
-  })
-
   it('should call "onPress" handler when it is pressed', () => {
     const onPressMock = jest.fn()
-    const { getByText } = renderWithWrappers(<TestWrapper onPress={onPressMock} />)
+    renderWithWrappers(<TestWrapper onPress={onPressMock} />)
 
-    fireEvent.press(getByText("Show Results"))
+    fireEvent.press(screen.getByText("Show Results"))
 
     expect(onPressMock).toBeCalled()
   })
 
   it('should show "Create Alert" button only when shouldShowCreateAlertButton prop is specified', () => {
-    const { getByText } = renderWithWrappers(<TestWrapper shouldShowCreateAlertButton />)
+    renderWithWrappers(<TestWrapper shouldShowCreateAlertButton />)
 
-    expect(getByText("Create Alert")).toBeTruthy()
+    expect(screen.getByText("Create Alert")).toBeTruthy()
   })
 
   it('should call "onCreateAlertPress" handler when "Create Alert" is pressed', () => {
     const onCreateAlertPressMock = jest.fn()
-    const { getByText } = renderWithWrappers(
+    renderWithWrappers(
       <TestWrapper shouldShowCreateAlertButton onCreateAlertPress={onCreateAlertPressMock} />
     )
 
-    fireEvent.press(getByText("Create Alert"))
+    fireEvent.press(screen.getByText("Create Alert"))
 
     expect(onCreateAlertPressMock).toBeCalled()
   })

--- a/src/app/Scenes/PriceDatabase/components/MediumOptions.tsx
+++ b/src/app/Scenes/PriceDatabase/components/MediumOptions.tsx
@@ -43,7 +43,6 @@ export const MediumOptions: React.FC<MediumOptionsScreenProps> = ({ navigation }
       />
 
       <ArtworkFilterApplyButton
-        disabled={false}
         onPress={navigation.goBack}
         buttonText="Apply"
         pb={2}

--- a/src/app/Scenes/PriceDatabase/components/SizesOptions.tsx
+++ b/src/app/Scenes/PriceDatabase/components/SizesOptions.tsx
@@ -45,7 +45,6 @@ export const SizesOptions: React.FC<OptionsScreenProps> = ({ navigation }) => {
       />
 
       <ArtworkFilterApplyButton
-        disabled={false}
         onPress={navigation.goBack}
         buttonText="Apply"
         pb={2}

--- a/src/app/Scenes/Tag/TagArtworks.tsx
+++ b/src/app/Scenes/Tag/TagArtworks.tsx
@@ -73,8 +73,8 @@ const TagArtworks: React.FC<TagArtworksProps> = ({ tag, relay }) => {
   const closeFilterArtworksModal = useCallback(() => {
     if (tag?.id && tag?.slug) {
       tracking.trackEvent(tracks.closeFilterWindow(tag.id, tag.slug))
-      setFilterArtworkModalVisible(false)
     }
+    setFilterArtworkModalVisible(false)
   }, [tracking, tag?.id, tag?.slug])
 
   const loadMore = useCallback(() => {


### PR DESCRIPTION
This PR resolves [ONYX-2195]

### Description

The "Show Results"/"Show all" button in the artwork filter panel stayed disabled after pressing "Clear All", leaving users stuck with only the back button to exit the panel. The root cause was in `isApplyButtonEnabled`'s condition (`ArtworkFilterNavigator.tsx`) — it never had a path back to `true` for the "everything just got cleared" state, since Clear All resets `selectedFilters`, `appliedFilters`, and `previouslyAppliedFilters` all to empty simultaneously.

Per product decision (made async in Slack, refinement time ran out): rather than patching that specific gap, the button is now **always enabled**, matching the UX in a competitor app we looked at. Users can always tap through to see all results or their filtered results.

Follow-up ticket [ONYX-2224] tracks a possible enhancement to show a live "Show X results" count instead of static text — deferred separately since it requires new debounced query work, not needed to ship this fix.

This is a shared component (`ArtworkFilterNavigator`) used by every artwork grid filter panel in the app (Artist, Search, Fair, Show, Sale, Partner, Collection, MyCollection, ArtistSeries, Collect, Tag) — the fix applies to all of them.

After: Button always enabled even when no filters are applied
<img width="424" height="928" alt="Screenshot 2026-07-31 at 15 09 04" src="https://github.com/user-attachments/assets/3ec2b101-5ec4-4914-be81-c57c5019f7e5" />


### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [ ] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **[feature flag]**, or they don't need one.
- [ ] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **[app state migration]**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [x] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Fix "Show Results" button in the artwork filter panel staying disabled after "Clear All"

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ONYX-2195]: https://artsyproduct.atlassian.net/browse/ONYX-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-2224]: https://artsyproduct.atlassian.net/browse/ONYX-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ