### PR TITLE
feat(DI-527): update interim question screen copy and remove skip-to-home

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Text } from "@artsy/palette-mobile"
+import { Button, Flex, Spacer, Text } from "@artsy/palette-mobile"
 import Animated, { Easing, FadeInRight } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { Logo } from "./Logo"
@@ -10,32 +10,32 @@ const BUTTONS_ENTERING_DELAY = 300
 
 interface BrowsePromptStepProps {
   onNext: () => void
-  onSkip: () => void
 }
 
-export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext, onSkip }) => {
+export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext }) => {
   const { bottom } = useSafeAreaInsets()
+
+  const enteringAnim = FadeInRight.duration(BUTTONS_ENTERING_DURATION)
+    .delay(BUTTONS_ENTERING_DELAY)
+    .easing(Easing.out(Easing.quad))
 
   return (
     <Flex flex={1} px={2} backgroundColor="mono0">
       <Logo fill="mono100" />
       <Flex flex={1} justifyContent="center">
         <Text variant="xl" color="mono100">
-          We’ll show you a selection of art. To get started, save 5 that speak to you.
+          What art are you drawn to?
         </Text>
+        <Spacer y={1} />
+        <AnimatedFlex entering={enteringAnim}>
+          <Text variant="lg-display" color="mono100">
+            Save the works that catch your eye.
+          </Text>
+        </AnimatedFlex>
       </Flex>
-      <AnimatedFlex
-        pb={`${bottom}px`}
-        gap={1}
-        entering={FadeInRight.duration(BUTTONS_ENTERING_DURATION)
-          .delay(BUTTONS_ENTERING_DELAY)
-          .easing(Easing.out(Easing.quad))}
-      >
+      <AnimatedFlex pb={`${bottom}px`} gap={1} entering={enteringAnim}>
         <Button variant="fillDark" block onPress={onNext}>
-          Start browsing
-        </Button>
-        <Button variant="fillLight" block onPress={onSkip}>
-          Skip to Home
+          Start Swiping
         </Button>
       </AnimatedFlex>
     </Flex>

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep.tsx
@@ -5,8 +5,8 @@ import { Logo } from "./Logo"
 
 const AnimatedFlex = Animated.createAnimatedComponent(Flex)
 
-const BUTTONS_ENTERING_DURATION = 500
-const BUTTONS_ENTERING_DELAY = 300
+const ENTERING_DURATION = 500
+const ENTERING_DELAY = 300
 
 interface BrowsePromptStepProps {
   onNext: () => void
@@ -15,8 +15,8 @@ interface BrowsePromptStepProps {
 export const BrowsePromptStep: React.FC<BrowsePromptStepProps> = ({ onNext }) => {
   const { bottom } = useSafeAreaInsets()
 
-  const enteringAnim = FadeInRight.duration(BUTTONS_ENTERING_DURATION)
-    .delay(BUTTONS_ENTERING_DELAY)
+  const enteringAnim = FadeInRight.duration(ENTERING_DURATION)
+    .delay(ENTERING_DELAY)
     .easing(Easing.out(Easing.quad))
 
   return (

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/BrowsePromptStep.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/__tests__/BrowsePromptStep.tests.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, screen } from "@testing-library/react-native"
+import { BrowsePromptStep } from "app/Scenes/Onboarding/Screens/Onboarding/Components/BrowsePromptStep"
+import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
+
+describe("BrowsePromptStep", () => {
+  it("renders the prompt and calls onNext", () => {
+    const onNext = jest.fn()
+    renderWithWrappers(<BrowsePromptStep onNext={onNext} />)
+
+    expect(screen.getByText("What art are you drawn to?")).toBeOnTheScreen()
+    expect(screen.getByText("Save the works that catch your eye.")).toBeOnTheScreen()
+
+    fireEvent.press(screen.getByText("Start Swiping"))
+    expect(onNext).toHaveBeenCalled()
+  })
+})

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Introduction.tsx
@@ -1,10 +1,8 @@
-import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Flex } from "@artsy/palette-mobile"
 import { useNavigation } from "@react-navigation/native"
 import { NativeStackNavigationProp } from "@react-navigation/native-stack"
 import { WelcomeStepQuery } from "__generated__/WelcomeStepQuery.graphql"
 import { useOnboardingTracking } from "app/Scenes/Onboarding/Screens/OnboardingQuiz/Hooks/useOnboardingTracking"
-import { GlobalStore } from "app/store/GlobalStore"
 import { AnimatePresence, MotiView } from "moti"
 import { useCallback, useEffect } from "react"
 import { useQueryLoader } from "react-relay"
@@ -26,12 +24,7 @@ export const Introduction: React.FC = () => {
   const { replace } = useNavigation<NativeStackNavigationProp<NavigationStack>>()
   const [welcomeQueryRef, loadWelcomeQuery] =
     useQueryLoader<WelcomeStepQuery>(WelcomeStepScreenQuery)
-  const {
-    trackStartedOnboarding,
-    trackCompletedOnboarding,
-    trackAnsweredExperienceQuestion,
-    trackTappedSkip,
-  } = useOnboardingTracking()
+  const { trackStartedOnboarding, trackAnsweredExperienceQuestion } = useOnboardingTracking()
 
   useEffect(() => {
     loadWelcomeQuery({}, { fetchPolicy: "network-only" })
@@ -53,12 +46,6 @@ export const Introduction: React.FC = () => {
     [replace]
   )
 
-  const handleSkipToHome = useCallback(() => {
-    trackTappedSkip(ContextModule.onboardingFlow, OwnerType.onboarding)
-    trackCompletedOnboarding()
-    GlobalStore.actions.onboarding.setOnboardingState("complete")
-  }, [trackCompletedOnboarding, trackTappedSkip])
-
   const { currentStep, next, selectExperience } = useConfig({ onDone: handleDone })
 
   const handleSelectExperience = (experience: Experience, label: string) => {
@@ -71,7 +58,7 @@ export const Introduction: React.FC = () => {
       case STEP_QUESTION:
         return <QuestionStep onSelect={handleSelectExperience} />
       case STEP_BROWSE_PROMPT:
-        return <BrowsePromptStep onNext={next} onSkip={handleSkipToHome} />
+        return <BrowsePromptStep onNext={next} />
       case STEP_ARTWORK_MONTAGE:
         return <ArtworkMontageStep onNext={next} />
       case STEP_WELCOME:

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/__tests__/Introduction.tests.tsx
@@ -1,7 +1,6 @@
-import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { ActionType, ContextModule } from "@artsy/cohesion"
 import { fireEvent, screen } from "@testing-library/react-native"
 import { Introduction } from "app/Scenes/Onboarding/Screens/Onboarding/Introduction"
-import { __globalStoreTestUtils__ } from "app/store/GlobalStore"
 import { mockTrackEvent } from "app/utils/tests/globallyMockedStuff"
 import { mockReplace } from "app/utils/tests/navigationMocks"
 import { renderWithWrappers } from "app/utils/tests/renderWithWrappers"
@@ -27,11 +26,8 @@ jest.mock("../Components/QuestionStep", () => {
 jest.mock("../Components/BrowsePromptStep", () => {
   const { Text } = require("react-native")
   return {
-    BrowsePromptStep: ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => (
-      <>
-        <Text onPress={onNext}>Browse next</Text>
-        <Text onPress={onSkip}>Browse skip</Text>
-      </>
+    BrowsePromptStep: ({ onNext }: { onNext: () => void }) => (
+      <Text onPress={onNext}>Browse next</Text>
     ),
   }
 })
@@ -118,35 +114,6 @@ describe("Introduction", () => {
 
       fireEvent.press(screen.getByText("Browse next"))
       expect(mockReplace).toHaveBeenCalledWith("InfiniteDiscovery")
-    })
-
-    it("completes onboarding when skipping from BrowsePromptStep", () => {
-      renderWithWrappers(<Introduction />)
-
-      fireEvent.press(screen.getByText("Montage next"))
-      fireEvent.press(screen.getByText("Welcome next"))
-      fireEvent.press(screen.getByText("Select beginner"))
-      fireEvent.press(screen.getByText("Browse skip"))
-
-      const state = __globalStoreTestUtils__?.getCurrentState()
-      expect(state?.onboarding.onboardingState).toBe("complete")
-      expect(mockTrackEvent).toHaveBeenCalledWith({ action: ActionType.completedOnboarding })
-    })
-
-    it("tracks the skip tap when skipping from BrowsePromptStep", () => {
-      renderWithWrappers(<Introduction />)
-
-      fireEvent.press(screen.getByText("Montage next"))
-      fireEvent.press(screen.getByText("Welcome next"))
-      fireEvent.press(screen.getByText("Select beginner"))
-      fireEvent.press(screen.getByText("Browse skip"))
-
-      expect(mockTrackEvent).toHaveBeenCalledWith({
-        action: ActionType.tappedSkip,
-        context_module: ContextModule.onboardingFlow,
-        context_screen_owner_type: OwnerType.onboarding,
-        subject: "Skip",
-      })
     })
   })
 })


### PR DESCRIPTION
This PR resolves [DI-527](https://www.notion.so/3adcab0764a08017a3d7ee1b8832ef41)

Assisted-by: Claude: Sonnet-5

### Description

Updates the "interim question" onboarding step (`BrowsePromptStep`) per DI-527:

- Removed the "Skip to Home" option — users can no longer bypass this step (also removed the now-dead `handleSkipToHome` tracking/state logic from `Introduction.tsx`, since onboarding completion is still tracked elsewhere in the flow, e.g. `FollowArtists`, `InfiniteDiscoveryHeader`, `NewUserOnboardingCompletionBottomSheet`).
- New copy:
  - Title: "What art are you drawn to?"
  - Body: "Save the works that catch your eye."
  - CTA: "Start Swiping"
- Background-to-white / text-to-black changes were already in place from prior work.
- Matched the entrance-animation pattern used on the equivalent `OnboardingWelcome.tsx` screen: the title appears immediately (static), while the body copy and CTA button fade in together (same `FadeInRight` timing), rather than the button animating in alone.

| OS | Before | After |
|-|-|-|
| Android | <img width="1080" height="2400" alt="Screenshot_1785429843" src="https://github.com/user-attachments/assets/ac77a037-cfb4-4006-b50d-d0fd855017c2" /> | <img width="1080" height="2400" alt="Screenshot_1785429823" src="https://github.com/user-attachments/assets/969f0735-deee-4d50-985a-1b9b3c770e13" /> |
| iOS | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 12 34 52" src="https://github.com/user-attachments/assets/7b2bc625-9edf-4bc0-bfeb-3dc3d03b60e6" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-30 at 12 34 25" src="https://github.com/user-attachments/assets/297201ba-97c2-4f42-a55b-9afb44d808e8" /> |




### PR Checklist

- [x] I have tested my changes on the following platforms:
  - [x] **Android**.
  - [x] **iOS**.
- [x] I hid my changes behind a **feature flag**, or they don't need one.
- [x] I have included **screenshots** or **videos** at least on **Android**, or I have not changed the UI.
- [x] I have added **tests**, or my changes don't require any.
- [x] I added an **app state migration**, or my changes do not require one.
- [x] I have documented any **follow-up work** that this PR will require, or it does not require any.
- [x] I have added a **changelog entry** below, or my changes do not require one.

### To the reviewers 👀

- [ ] I would like **at least one** of the reviewers to **run** this PR on the simulator or device.

<details><summary>Changelog updates</summary>

### Changelog updates

#### Cross-platform user-facing changes

- Updated copy on the onboarding "interim question" step and removed the "Skip to Home" option

#### iOS user-facing changes

-

#### Android user-facing changes

-

#### Dev changes

-

</details>