### PR TITLE
poc(DI-498): pill that adjusts with accessibility font size

### DIFF
--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/AnswerOptionPill.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/AnswerOptionPill.tsx
@@ -1,0 +1,45 @@
+import { Flex, Text } from "@artsy/palette-mobile"
+import { MotiPressable } from "moti/interactions"
+import { useMemo, useState } from "react"
+
+interface AnswerOptionPillProps {
+  label: string
+  selected: boolean
+  onPress: () => void
+}
+
+export const AnswerOptionPill: React.FC<AnswerOptionPillProps> = ({ label, selected, onPress }) => {
+  const [isMultiline, setIsMultiline] = useState(false)
+
+  const animate = useMemo(() => {
+    return ({ hovered, pressed }: { hovered: boolean; pressed: boolean }) => {
+      "worklet"
+      return { opacity: hovered || pressed ? 0.5 : 1 }
+    }
+  }, [])
+
+  return (
+    <MotiPressable onPress={onPress} animate={animate}>
+      <Flex
+        alignSelf="flex-start"
+        alignItems="center"
+        justifyContent="center"
+        borderRadius={20}
+        borderWidth={1}
+        borderColor={selected ? "blue100" : "mono60"}
+        backgroundColor={selected ? "blue100" : undefined}
+        px="15px"
+        py="10px"
+      >
+        <Text
+          variant="xs"
+          color="mono0"
+          textAlign={isMultiline ? "left" : "center"}
+          onTextLayout={(event) => setIsMultiline(event.nativeEvent.lines.length > 1)}
+        >
+          {label}
+        </Text>
+      </Flex>
+    </MotiPressable>
+  )
+}

--- a/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
+++ b/src/app/Scenes/Onboarding/Screens/Onboarding/Components/QuestionStep.tsx
@@ -1,9 +1,10 @@
-import { Button, Flex, Pill, Spacer, Text, Theme, useScreenDimensions } from "@artsy/palette-mobile"
+import { Button, Flex, Spacer, Text, Theme, useScreenDimensions } from "@artsy/palette-mobile"
 import { ALWAYS_BLACK } from "app/utils/colors"
 import { MotiView } from "moti"
 import { useState } from "react"
 import Animated, { Easing, FadeInUp } from "react-native-reanimated"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
+import { AnswerOptionPill } from "./AnswerOptionPill"
 import { Logo } from "./Logo"
 
 export type Experience = "experienced" | "beginner"
@@ -111,16 +112,11 @@ export const QuestionStep: React.FC<QuestionStepProps> = ({ onSelect }) => {
                 const isSelected = selectedLabel === label
                 return (
                   <Flex key={label} alignSelf="flex-start">
-                    <Pill
-                      variant="onboarding"
+                    <AnswerOptionPill
+                      label={label}
                       selected={isSelected}
-                      alignSelf="flex-start"
                       onPress={() => setSelectedLabel(label)}
-                    >
-                      <Text variant="xs" color="mono0" textAlign="center">
-                        {label}
-                      </Text>
-                    </Pill>
+                    />
                     <Spacer y={2} />
                   </Flex>
                 )


### PR DESCRIPTION
This change is related to [DI-498](https://www.notion.so/3a5cab0764a08068b41dd5df27d2405a)
Assisted-by: Claude: Sonnet-5

**Description**

This PR is a proof-of-concept to document how Palette Mobile's pill will look when it is updated to adjust its height to match larger font sizes so that their text doesn't get clipped.

Next I will a Palette Mobile PR to make this change (and close this PR). That will also impact the old onboarding flow where the same clipping behavior exists. 

| Setting | Before | After |
|-|-|-|
| <img width="1080" height="2400" alt="and_default" src="https://github.com/user-attachments/assets/229ec41d-eb18-4bfc-8f5a-ba17abc53604" /> | <img width="1080" height="2400" alt="and_bef_default" src="https://github.com/user-attachments/assets/eebf4402-cb63-4a22-87e0-7586fb2da9d5" /> | <img width="1080" height="2400" alt="and_aft_default" src="https://github.com/user-attachments/assets/22fafd2b-6b1b-4208-8dba-d6948ee8a246" /> |
| <img width="1080" height="2400" alt="and_large" src="https://github.com/user-attachments/assets/e7e8b326-1212-4119-80c1-9029ded37b6b" /> | <img width="1080" height="2400" alt="and_bef_large" src="https://github.com/user-attachments/assets/71988d37-8bf4-492e-bf4b-358663b77bb0" /> | <img width="1080" height="2400" alt="and_aft_large" src="https://github.com/user-attachments/assets/6baac1c7-6c87-4ba1-a5ad-9d34c6eaa82c" /> |
| <img width="1080" height="2400" alt="and_larger" src="https://github.com/user-attachments/assets/10e699ac-a08e-47a5-b38b-bb19c581f721" /> | <img width="1080" height="2400" alt="and_bef_larger" src="https://github.com/user-attachments/assets/7b726833-18f7-4aa1-9de0-7e369b1e4982" /> | <img width="1080" height="2400" alt="and_aft_larger" src="https://github.com/user-attachments/assets/c00f7c63-1dcb-49c9-8948-6a4956227864" /> |
| <img width="1206" height="2622" alt="ios_default" src="https://github.com/user-attachments/assets/e09bf4e6-05e3-4cf5-b2c4-8d2f1341553c" /> | <img width="1206" height="2622" alt="ios_bef_default" src="https://github.com/user-attachments/assets/a568c75f-ef89-4f19-a42d-604a4d534e28" /> | <img width="1206" height="2622" alt="ios_aft_default" src="https://github.com/user-attachments/assets/8a90b3e0-5cc0-4ede-968d-d73d110ec472" /> |
| <img width="1206" height="2622" alt="ios_large" src="https://github.com/user-attachments/assets/dfb5269b-1b4f-433e-9fdd-88d5abf47dc6" /> | <img width="1206" height="2622" alt="ios_bef_large" src="https://github.com/user-attachments/assets/a157f0b5-8f9d-40e9-8944-9d342d5c5581" /> | <img width="1206" height="2622" alt="ios_aft_large" src="https://github.com/user-attachments/assets/6f0ec7e7-75a9-48fb-8958-fd7c6b290f92" /> |
| <img width="1206" height="2622" alt="ios_larger" src="https://github.com/user-attachments/assets/164c41d5-2f87-4bf5-999b-acbe9f0812c4" /> | <img width="1206" height="2622" alt="ios_bef_larger" src="https://github.com/user-attachments/assets/af263b5f-946c-414f-bf0b-ed96505953a3" /> | <img width="1206" height="2622" alt="ios_aft_larger" src="https://github.com/user-attachments/assets/8d63c1b1-b834-4feb-9ff1-a35ee523d708" /> | 



