### PR TITLE
chore: try compare-two-pass-review on Claude PR reviews

### DIFF
--- a/.github/workflows/run-claude-review.yml
+++ b/.github/workflows/run-claude-review.yml
@@ -6,6 +6,12 @@ on:
 
 jobs:
   claude-review:
-    uses: artsy/duchamp/.github/workflows/claude-review.yml@main
+    # TEMPORARY: pinned to the trial branch instead of @main so this repo can
+    # try compare-two-pass-review before artsy/duchamp#110 merges. Once #110
+    # merges, revert this to `@main` and drop the `with:` block (or keep
+    # compare-two-pass-review: true if the trial goes well).
+    uses: artsy/duchamp/.github/workflows/claude-review.yml@claude/model-performance-comparison-n1wew6
     secrets:
       anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      compare-two-pass-review: true


### PR DESCRIPTION
### Description

Trial run of a new opt-in feature on the shared Claude PR review workflow.

This PR enables a two-pass Claude review comments from duchamp instead of one:

- **🅰️ Single-pass review (baseline)** — today's standard review, unchanged.
- **🅱️ Two-pass review (candidate)** — a "find" pass that lists every candidate issue without filtering, followed by a "filter" pass that verifies each claim against the diff/codebase and posts only what holds up. Intended to reduce false positives/noise compared to a single pass.

**The goal from this, is to evaluate for a week what's a better result and update/remove accordingly.**

### FYI: This doesn't make any changes, the only thing it does, is adding another comment for a week to compare the quality of both methods - hopefully, B wins


### PR Checklist

- [ ] I have tested my changes on the following platforms:
  - [x] N/A — CI workflow config only, no app code changed
- [x] My changes don't need a feature flag (this *is* a feature flag, but for the review CI, not the app).
- [x] I have not changed the UI — no screenshots needed.
- [x] My changes don't require tests — no app code changed.
- [x] My changes do not require an app state migration.
- [x] Follow-up work: revert `run-claude-review.yml`'s `uses:` ref to `@main` once `artsy/duchamp#110` merges.
- [x] My changes do not require a changelog entry — CI-only, not user-facing. #nochangelog

### To the reviewers 👀

- [ ] No simulator/device run needed — this only affects the PR review bot, not the app.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMY5kdBZaE9dGRWpcNytSV)_